### PR TITLE
fix: tui: properly calculate quit dialog size

### DIFF
--- a/internal/tui/components/dialog/quit.go
+++ b/internal/tui/components/dialog/quit.go
@@ -117,11 +117,14 @@ func (q *quitDialogCmp) View() string {
 		),
 	)
 
-	return baseStyle.Padding(1, 2).
+	quitDialogStyle := baseStyle.
+		Padding(1, 2).
 		Border(lipgloss.RoundedBorder()).
 		BorderBackground(t.Background()).
-		BorderForeground(t.TextMuted()).
-		Width(lipgloss.Width(content) + 4).
+		BorderForeground(t.TextMuted())
+
+	return quitDialogStyle.
+		Width(lipgloss.Width(content) + quitDialogStyle.GetHorizontalFrameSize()).
 		Render(content)
 }
 


### PR DESCRIPTION
This uses the style frame size to calculate the quit dialog width.

Before:
<img width="275" alt="image" src="https://github.com/user-attachments/assets/da738c0d-ca37-4f64-acc7-412203bf4b7c" />


After:
<img width="281" alt="image" src="https://github.com/user-attachments/assets/4aa177c5-1c97-4846-98c8-afdfe0c1d7f3" />
