### PR TITLE
feat: profiling

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -21,7 +21,7 @@ tasks:
   dev:
     desc: Run with profiling enabled
     env:
-      OPENCODE_PROFILE: true
+      CRUSH_PROFILE: true
     cmds:
       - go run .
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 		logging.ErrorPersist("Application terminated due to unhandled panic")
 	})
 
-	if os.Getenv("OPENCODE_PROFILE") != "" {
+	if os.Getenv("CRUSH_PROFILE") != "" {
 		go func() {
 			logging.Info("Serving pprof at localhost:6060")
 			if httpErr := http.ListenAndServe("localhost:6060", nil); httpErr != nil {


### PR DESCRIPTION
- starts pprof server if `OPENCODE_PROFILE` is set 
- adds a bunch of tasks to work with profiles