### PR TITLE
fix: fix "failed to generate title: context deadline exceeded" error

### DIFF
--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -241,7 +241,7 @@ func (a *agent) processGeneration(ctx context.Context, sessionID, content string
 				logging.ErrorPersist("panic while generating title")
 			})
 			titleErr := a.generateTitle(context.Background(), sessionID, content)
-			if titleErr != nil {
+			if titleErr != nil && !errors.Is(titleErr, context.Canceled) && !errors.Is(titleErr, context.DeadlineExceeded) {
 				logging.ErrorPersist(fmt.Sprintf("failed to generate title: %v", titleErr))
 			}
 		}()


### PR DESCRIPTION
This only happens on initializing a new project.

![Screenshot 2025-06-13 at 14 03 41](https://github.com/user-attachments/assets/f389b659-e4e1-4365-bfa8-abce7a46a278)
