### PR TITLE
feat: open exit dialog on typing `exit` or `quit`

### DIFF
--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -18,7 +18,9 @@ import (
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/tui/components/chat"
 	"github.com/charmbracelet/crush/internal/tui/components/completions"
+	"github.com/charmbracelet/crush/internal/tui/components/dialogs"
 	"github.com/charmbracelet/crush/internal/tui/components/dialogs/filepicker"
+	"github.com/charmbracelet/crush/internal/tui/components/dialogs/quit"
 	"github.com/charmbracelet/crush/internal/tui/layout"
 	"github.com/charmbracelet/crush/internal/tui/styles"
 	"github.com/charmbracelet/crush/internal/tui/util"
@@ -118,6 +120,14 @@ func (m *editorCmp) send() tea.Cmd {
 	}
 
 	value := m.textarea.Value()
+	value = strings.TrimSpace(value)
+
+	switch value {
+	case "exit", "quit":
+		m.textarea.Reset()
+		return util.CmdHandler(dialogs.OpenDialogMsg{Model: quit.NewQuitDialog()})
+	}
+
 	m.textarea.Reset()
 	attachments := m.attachments
 


### PR DESCRIPTION
NOTE: This was implemented by Crush itself 😉 (just with minor adjustments)

<details><summary>Screenshots</summary>
<p>

![Screenshot 2025-06-13 at 17 03 28](https://github.com/user-attachments/assets/ff7dd32d-9e2a-4550-8676-af21b9d4c72e)

![Screenshot 2025-06-13 at 17 03 37](https://github.com/user-attachments/assets/8d9c35b5-4c4d-424e-b14e-889c91ae1a3b)

</p>
</details> 


