### PR TITLE
refactor: rename `internal/fileutil` into `internal/fsutil`

### DIFF
--- a/internal/fsext/fileutil.go
+++ b/internal/fsext/fileutil.go
@@ -1,4 +1,4 @@
-package fileutil
+package fsext
 
 import (
 	"fmt"

--- a/internal/fsext/ls.go
+++ b/internal/fsext/ls.go
@@ -1,4 +1,4 @@
-package fileutil
+package fsext
 
 import (
 	"os"

--- a/internal/llm/tools/glob.go
+++ b/internal/llm/tools/glob.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/crush/internal/config"
-	"github.com/charmbracelet/crush/internal/fileutil"
+	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/logging"
 )
 
@@ -127,7 +127,7 @@ func (g *globTool) Run(ctx context.Context, call ToolCall) (ToolResponse, error)
 }
 
 func globFiles(pattern, searchPath string, limit int) ([]string, bool, error) {
-	cmdRg := fileutil.GetRgCmd(pattern)
+	cmdRg := fsext.GetRgCmd(pattern)
 	if cmdRg != nil {
 		cmdRg.Dir = searchPath
 		matches, err := runRipgrep(cmdRg, searchPath, limit)
@@ -137,7 +137,7 @@ func globFiles(pattern, searchPath string, limit int) ([]string, bool, error) {
 		logging.Warn(fmt.Sprintf("Ripgrep execution failed: %v. Falling back to doublestar.", err))
 	}
 
-	return fileutil.GlobWithDoubleStar(pattern, searchPath, limit)
+	return fsext.GlobWithDoubleStar(pattern, searchPath, limit)
 }
 
 func runRipgrep(cmd *exec.Cmd, searchRoot string, limit int) ([]string, error) {
@@ -158,7 +158,7 @@ func runRipgrep(cmd *exec.Cmd, searchRoot string, limit int) ([]string, error) {
 		if !filepath.IsAbs(absPath) {
 			absPath = filepath.Join(searchRoot, absPath)
 		}
-		if fileutil.SkipHidden(absPath) {
+		if fsext.SkipHidden(absPath) {
 			continue
 		}
 		matches = append(matches, absPath)

--- a/internal/llm/tools/grep.go
+++ b/internal/llm/tools/grep.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/crush/internal/config"
-	"github.com/charmbracelet/crush/internal/fileutil"
+	"github.com/charmbracelet/crush/internal/fsext"
 )
 
 // regexCache provides thread-safe caching of compiled regex patterns
@@ -342,7 +342,7 @@ func searchFilesWithRegex(pattern, rootPath, include string) ([]grepMatch, error
 			return nil // Skip directories
 		}
 
-		if fileutil.SkipHidden(path) {
+		if fsext.SkipHidden(path) {
 			return nil
 		}
 

--- a/internal/llm/tools/ls.go
+++ b/internal/llm/tools/ls.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/crush/internal/config"
-	"github.com/charmbracelet/crush/internal/fileutil"
+	"github.com/charmbracelet/crush/internal/fsext"
 )
 
 type LSParams struct {
@@ -108,7 +108,7 @@ func (l *lsTool) Run(ctx context.Context, call ToolCall) (ToolResponse, error) {
 		return NewTextErrorResponse(fmt.Sprintf("path does not exist: %s", searchPath)), nil
 	}
 
-	files, truncated, err := fileutil.ListDirectory(searchPath, params.Ignore, MaxLSFiles)
+	files, truncated, err := fsext.ListDirectory(searchPath, params.Ignore, MaxLSFiles)
 	if err != nil {
 		return ToolResponse{}, fmt.Errorf("error listing directory: %w", err)
 	}

--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -12,7 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/v2/textarea"
 	tea "github.com/charmbracelet/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/app"
-	"github.com/charmbracelet/crush/internal/fileutil"
+	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/logging"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/session"
@@ -327,7 +327,7 @@ func (m *editorCmp) SetPosition(x, y int) tea.Cmd {
 }
 
 func (m *editorCmp) startCompletions() tea.Msg {
-	files, _, _ := fileutil.ListDirectory(".", []string{}, 0)
+	files, _, _ := fsext.ListDirectory(".", []string{}, 0)
 	completionItems := make([]completions.Completion, 0, len(files))
 	for _, file := range files {
 		file = strings.TrimPrefix(file, "./")

--- a/internal/tui/components/chat/messages/renderer.go
+++ b/internal/tui/components/chat/messages/renderer.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/crush/internal/fileutil"
+	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/highlight"
 	"github.com/charmbracelet/crush/internal/llm/agent"
 	"github.com/charmbracelet/crush/internal/llm/tools"
@@ -208,7 +208,7 @@ func (vr viewRenderer) Render(v *toolCallCmp) string {
 		return vr.renderError(v, "Invalid view parameters")
 	}
 
-	file := fileutil.PrettyPath(params.FilePath)
+	file := fsext.PrettyPath(params.FilePath)
 	args := newParamBuilder().
 		addMain(file).
 		addKeyValue("limit", formatNonZero(params.Limit)).
@@ -248,7 +248,7 @@ func (er editRenderer) Render(v *toolCallCmp) string {
 		return er.renderError(v, "Invalid edit parameters")
 	}
 
-	file := fileutil.PrettyPath(params.FilePath)
+	file := fsext.PrettyPath(params.FilePath)
 	args := newParamBuilder().addMain(file).build()
 
 	return er.renderWithParams(v, "Edit", args, func() string {
@@ -258,8 +258,8 @@ func (er editRenderer) Render(v *toolCallCmp) string {
 		}
 
 		formatter := core.DiffFormatter().
-			Before(fileutil.PrettyPath(params.FilePath), meta.OldContent).
-			After(fileutil.PrettyPath(params.FilePath), meta.NewContent).
+			Before(fsext.PrettyPath(params.FilePath), meta.OldContent).
+			After(fsext.PrettyPath(params.FilePath), meta.NewContent).
 			Split().
 			Width(v.textWidth() - 2) // -2 for padding
 		return formatter.String()
@@ -282,7 +282,7 @@ func (wr writeRenderer) Render(v *toolCallCmp) string {
 		return wr.renderError(v, "Invalid write parameters")
 	}
 
-	file := fileutil.PrettyPath(params.FilePath)
+	file := fsext.PrettyPath(params.FilePath)
 	args := newParamBuilder().addMain(file).build()
 
 	return wr.renderWithParams(v, "Write", args, func() string {
@@ -412,7 +412,7 @@ func (lr lsRenderer) Render(v *toolCallCmp) string {
 	if path == "" {
 		path = "."
 	}
-	path = fileutil.PrettyPath(path)
+	path = fsext.PrettyPath(path)
 
 	args := newParamBuilder().addMain(path).build()
 

--- a/internal/tui/components/chat/sidebar/sidebar.go
+++ b/internal/tui/components/chat/sidebar/sidebar.go
@@ -9,7 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/diff"
-	"github.com/charmbracelet/crush/internal/fileutil"
+	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/history"
 	"github.com/charmbracelet/crush/internal/llm/models"
 	"github.com/charmbracelet/crush/internal/logging"
@@ -231,7 +231,7 @@ func (m *sidebarCmp) filesBlock() string {
 		}
 
 		extraContent := strings.Join(statusParts, " ")
-		filePath := fileutil.DirTrim(fileutil.PrettyPath(file.FilePath), 2)
+		filePath := fsext.DirTrim(fsext.PrettyPath(file.FilePath), 2)
 		filePath = ansi.Truncate(filePath, maxWidth-lipgloss.Width(extraContent)-2, "…")
 		fileList = append(fileList,
 			core.Status(

--- a/internal/tui/components/dialogs/permissions/permissions.go
+++ b/internal/tui/components/dialogs/permissions/permissions.go
@@ -8,7 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/v2/viewport"
 	tea "github.com/charmbracelet/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/diff"
-	"github.com/charmbracelet/crush/internal/fileutil"
+	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/llm/tools"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/tui/components/core"
@@ -170,7 +170,7 @@ func (p *permissionDialogCmp) renderHeader() string {
 	pathKey := t.S().Muted.Render("Path")
 	pathValue := t.S().Text.
 		Width(p.width - lipgloss.Width(pathKey)).
-		Render(fmt.Sprintf(" %s", fileutil.PrettyPath(p.permission.Path)))
+		Render(fmt.Sprintf(" %s", fsext.PrettyPath(p.permission.Path)))
 
 	headerParts := []string{
 		lipgloss.JoinHorizontal(
@@ -196,7 +196,7 @@ func (p *permissionDialogCmp) renderHeader() string {
 		fileKey := t.S().Muted.Render("File")
 		filePath := t.S().Text.
 			Width(p.width - lipgloss.Width(fileKey)).
-			Render(fmt.Sprintf(" %s", fileutil.PrettyPath(params.FilePath)))
+			Render(fmt.Sprintf(" %s", fsext.PrettyPath(params.FilePath)))
 		headerParts = append(headerParts,
 			lipgloss.JoinHorizontal(
 				lipgloss.Left,
@@ -211,7 +211,7 @@ func (p *permissionDialogCmp) renderHeader() string {
 		fileKey := t.S().Muted.Render("File")
 		filePath := t.S().Text.
 			Width(p.width - lipgloss.Width(fileKey)).
-			Render(fmt.Sprintf(" %s", fileutil.PrettyPath(params.FilePath)))
+			Render(fmt.Sprintf(" %s", fsext.PrettyPath(params.FilePath)))
 		headerParts = append(headerParts,
 			lipgloss.JoinHorizontal(
 				lipgloss.Left,
@@ -268,8 +268,8 @@ func (p *permissionDialogCmp) renderBashContent() string {
 func (p *permissionDialogCmp) renderEditContent() string {
 	if pr, ok := p.permission.Params.(tools.EditPermissionsParams); ok {
 		formatter := core.DiffFormatter().
-			Before(fileutil.PrettyPath(pr.FilePath), pr.OldContent).
-			After(fileutil.PrettyPath(pr.FilePath), pr.NewContent).
+			Before(fsext.PrettyPath(pr.FilePath), pr.OldContent).
+			After(fsext.PrettyPath(pr.FilePath), pr.NewContent).
 			Width(p.contentViewPort.Width()).
 			Split()
 


### PR DESCRIPTION
Asked Crush to do this while testing. Minor change, but worth to better match the Go's convention.

FYI: it's common to create "extension" packages to the standard library by naming them `[package]ext`. `io/fs` -> `fsext`.