### PR TITLE
fix: prevent header text jumping by aligning ctrl+d help text

### DIFF
--- a/internal/tui/components/chat/header/header.go
+++ b/internal/tui/components/chat/header/header.go
@@ -114,7 +114,7 @@ func (h *header) details() string {
 	if h.detailsOpen {
 		parts = append(parts, t.S().Muted.Render("ctrl+d")+t.S().Subtle.Render(" close"))
 	} else {
-		parts = append(parts, t.S().Muted.Render("ctrl+d")+t.S().Subtle.Render(" open"))
+		parts = append(parts, t.S().Muted.Render("ctrl+d")+t.S().Subtle.Render(" open "))
 	}
 	dot := t.S().Subtle.Render(" • ")
 	return strings.Join(parts, dot)


### PR DESCRIPTION
Just a tiny edit to keep the text in the small header bar from jumping around.