### PR TITLE
chore: if we're in the home dir top level show the full path

### DIFF
--- a/internal/tui/components/chat/sidebar/sidebar.go
+++ b/internal/tui/components/chat/sidebar/sidebar.go
@@ -509,9 +509,10 @@ func (s *sidebarCmp) currentModelBlock() string {
 func cwd() string {
 	cwd := config.WorkingDirectory()
 	t := styles.CurrentTheme()
-	// replace home directory with ~
+	// Replace home directory with ~, unless we're at the top level of the
+	// home directory).
 	homeDir, err := os.UserHomeDir()
-	if err == nil {
+	if err == nil && cwd != homeDir {
 		cwd = strings.ReplaceAll(cwd, homeDir, "~")
 	}
 	return t.S().Muted.Render(cwd)


### PR DESCRIPTION
Show the full path if you're in the home directory instead of the tilde, the thought being the tilde is too small and ambiguous in places like the sidebar.