### PR TITLE
feat(diffview): set tab width to 4

### DIFF
--- a/internal/tui/components/core/helpers.go
+++ b/internal/tui/components/core/helpers.go
@@ -151,6 +151,6 @@ func DiffFormatter() *diffview.DiffView {
 	t := styles.CurrentTheme()
 	formatDiff := diffview.New()
 	style := chroma.MustNewStyle("crush", styles.GetChromaTheme())
-	diff := formatDiff.ChromaStyle(style).Style(t.S().Diff)
+	diff := formatDiff.ChromaStyle(style).Style(t.S().Diff).TabWidth(4)
 	return diff
 }


### PR DESCRIPTION
The default is 8. 4 will give us some more space as it is critical for this use case, specially on split view.

Note that this only affects languages that uses tabs for spaces, like Go.