### PR TITLE
chore(gitignore): ignore all .crush directories no matter where they are

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ Thumbs.db
 .env
 .env.local
 
-.crush/
+**/.crush/**
 
 crush
 


### PR DESCRIPTION
I accidentally committed a `.crush` directory in a subdirectory of the project. This prevents that from happening.