### PR TITLE
feat: read stdin

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -318,7 +318,7 @@ func maybePrependStdin(prompt string) (string, error) {
 	if err != nil {
 		return prompt, err
 	}
-	if fi.Size() == 0 {
+	if fi.Mode()&os.ModeNamedPipe == 0 {
 		return prompt, nil
 	}
 	bts, err := io.ReadAll(os.Stdin)


### PR DESCRIPTION
checks if STDIN is not a term, and if it's size is > 0, and if so, prepend it to the prompt to be used in non-interactive mode.

