### PR TITLE
Remove Ripgrep and FZF warnings from stderr

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -52,15 +52,11 @@ func Load(workingDir string, debug bool) (*Config, error) {
 		cfg.Options.Debug = true
 	}
 
-	// Init logs
-	log.Init(
+	// Setup logs
+	log.Setup(
 		filepath.Join(cfg.Options.DataDirectory, "logs", fmt.Sprintf("%s.log", appName)),
 		cfg.Options.Debug,
 	)
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to load config: %w", err)
-	}
 
 	// Load known providers, this loads the config from fur
 	providers, err := LoadProviders(client.New())

--- a/internal/fsext/fileutil.go
+++ b/internal/fsext/fileutil.go
@@ -26,13 +26,13 @@ func init() {
 	var err error
 	rgPath, err = exec.LookPath("rg")
 	if err != nil {
-		if log.IsInitialized() {
+		if log.Initialized() {
 			slog.Warn("Ripgrep (rg) not found in $PATH. Some features might be limited or slower.")
 		}
 	}
 	fzfPath, err = exec.LookPath("fzf")
 	if err != nil {
-		if log.IsInitialized() {
+		if log.Initialized() {
 			slog.Warn("FZF not found in $PATH. Some features might be limited or slower.")
 		}
 	}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -17,7 +17,7 @@ var (
 	initialized atomic.Bool
 )
 
-func Init(logFile string, debug bool) {
+func Setup(logFile string, debug bool) {
 	initOnce.Do(func() {
 		logRotator := &lumberjack.Logger{
 			Filename:   logFile,
@@ -42,7 +42,7 @@ func Init(logFile string, debug bool) {
 	})
 }
 
-func IsInitialized() bool {
+func Initialized() bool {
 	return initialized.Load()
 }
 


### PR DESCRIPTION
This prevents the Ripgrep and FZF warnings from being printed on stderr, but not from the logfile.

EDIT: screenshot after removing the warnings

<img width="528" alt="image" src="https://github.com/user-attachments/assets/b14eeb94-5483-48e6-8047-f244186b9535" />
