### PR TITLE
feat(tui): support adding newlines in chat editor

### DIFF
--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -145,6 +145,9 @@ func (m *editorCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	var cmds []tea.Cmd
 	switch msg := msg.(type) {
+	case tea.KeyboardEnhancementsMsg:
+		m.keyMap.keyboard = msg
+		return m, nil
 	case chat.SessionSelectedMsg:
 		if msg.ID != m.session.ID {
 			m.session = msg

--- a/internal/tui/components/chat/editor/keys.go
+++ b/internal/tui/components/chat/editor/keys.go
@@ -2,6 +2,7 @@ package editor
 
 import (
 	"github.com/charmbracelet/bubbles/v2/key"
+	tea "github.com/charmbracelet/bubbletea/v2"
 )
 
 type EditorKeyMap struct {
@@ -9,6 +10,8 @@ type EditorKeyMap struct {
 	SendMessage key.Binding
 	OpenEditor  key.Binding
 	Newline     key.Binding
+
+	keyboard tea.KeyboardEnhancementsMsg
 }
 
 func DefaultEditorKeyMap() EditorKeyMap {
@@ -27,18 +30,25 @@ func DefaultEditorKeyMap() EditorKeyMap {
 		),
 		Newline: key.NewBinding(
 			key.WithKeys("shift+enter", "ctrl+j"),
-			key.WithHelp("shift+enter", "newline"), key.WithHelp("ctrl+j", "newline"),
+			// "ctrl+j" is a common keybinding for newline in many editors. If
+			// the terminal supports "shift+enter", we substitute the help text
+			// to reflect that.
+			key.WithHelp("ctrl+j", "newline"),
 		),
 	}
 }
 
 // KeyBindings implements layout.KeyMapProvider
 func (k EditorKeyMap) KeyBindings() []key.Binding {
+	newline := k.Newline
+	if k.keyboard.SupportsKeyDisambiguation() {
+		newline.SetHelp("shift+enter", newline.Help().Desc)
+	}
 	return []key.Binding{
 		k.AddFile,
 		k.SendMessage,
 		k.OpenEditor,
-		k.Newline,
+		newline,
 	}
 }
 

--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -80,6 +80,10 @@ func (p *chatPage) cancelTimerCmd() tea.Cmd {
 func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
 	switch msg := msg.(type) {
+	case tea.KeyboardEnhancementsMsg:
+		m, cmd := p.layout.Update(msg)
+		p.layout = m.(layout.SplitPaneLayout)
+		return p, cmd
 	case CancelTimerExpiredMsg:
 		p.cancelPending = false
 		return p, nil

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -95,7 +95,14 @@ func (a *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyboardEnhancementsMsg:
-		return a, nil
+		for id, page := range a.pages {
+			m, pageCmd := page.Update(msg)
+			a.pages[id] = m.(util.Model)
+			if pageCmd != nil {
+				cmds = append(cmds, pageCmd)
+			}
+		}
+		return a, tea.Batch(cmds...)
 	case tea.WindowSizeMsg:
 		return a, a.handleWindowResize(msg.Width, msg.Height)
 


### PR DESCRIPTION
This adds support for inserting newlines in the chat editor using `shift+enter` (when supported) and `ctrl+j`. This allows users to write multi-line messages more easily, enhancing the chat experience.
