### PR TITLE
fix(tui): copy textarea value to editor on open

### DIFF
--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -82,8 +82,10 @@ func (m *editorCmp) openEditor(value string) tea.Cmd {
 	if err != nil {
 		return util.ReportError(err)
 	}
-	_, _ = tmpfile.WriteString(value)
-	tmpfile.Close()
+	defer tmpfile.Close() //nolint:errcheck
+	if _, err := tmpfile.WriteString(value); err != nil {
+		return util.ReportError(err)
+	}
 	c := exec.Command(editor, tmpfile.Name())
 	c.Stdin = os.Stdin
 	c.Stdout = os.Stdout


### PR DESCRIPTION
This will copy the textarea value to the editor on open