### PR TITLE
feat(tui): change help key binding to ctrl+g

### DIFF
--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -20,8 +20,8 @@ func DefaultKeyMap() KeyMap {
 			key.WithHelp("ctrl+c", "quit"),
 		),
 		Help: key.NewBinding(
-			key.WithKeys("ctrl+?", "ctrl+_", "ctrl+/"),
-			key.WithHelp("ctrl+?", "more"),
+			key.WithKeys("ctrl+g"),
+			key.WithHelp("ctrl+g", "help"),
 		),
 		Commands: key.NewBinding(
 			key.WithKeys("ctrl+p"),


### PR DESCRIPTION
This updates the key binding for the help command in the TUI to use `ctrl+g` instead of `ctrl+?`, `ctrl+_`, or `ctrl+/`.

<img width="912" height="778" alt="image" src="https://github.com/user-attachments/assets/299a62af-aadb-4e5f-ba1c-6ffee7bb14fe" />
