### PR TITLE
fix(tui): logo: make sure we truncate the logo if it exceeds the width

### DIFF
--- a/internal/tui/components/chat/sidebar/sidebar.go
+++ b/internal/tui/components/chat/sidebar/sidebar.go
@@ -250,6 +250,7 @@ func (m *sidebarCmp) logoBlock() string {
 		TitleColorB:  t.Primary,
 		CharmColor:   t.Secondary,
 		VersionColor: t.Primary,
+		Width:        m.width - 2,
 	})
 }
 

--- a/internal/tui/components/logo/logo.go
+++ b/internal/tui/components/logo/logo.go
@@ -98,7 +98,16 @@ func Render(version string, compact bool, o Opts) string {
 
 	// Return the wide version.
 	const hGap = " "
-	return lipgloss.JoinHorizontal(lipgloss.Top, leftField.String(), hGap, crush, hGap, rightField.String())
+	logo := lipgloss.JoinHorizontal(lipgloss.Top, leftField.String(), hGap, crush, hGap, rightField.String())
+	if o.Width > 0 {
+		// Truncate the logo to the specified width.
+		lines := strings.Split(logo, "\n")
+		for i, line := range lines {
+			lines[i] = ansi.Truncate(line, o.Width, "")
+		}
+		logo = strings.Join(lines, "\n")
+	}
+	return logo
 }
 
 // renderWord renders letterforms to fork a word.


### PR DESCRIPTION
Truncate each line of the logo to fit within the specified width.

<img width="347" height="898" alt="image" src="https://github.com/user-attachments/assets/6380266d-989f-42df-b26a-8f48bde6f9ae" />
