### PR TITLE
fix(tui): editor: change open editor key binding from ctrl+e to ctrl+v

### DIFF
--- a/internal/tui/components/chat/editor/keys.go
+++ b/internal/tui/components/chat/editor/keys.go
@@ -22,8 +22,8 @@ func DefaultEditorKeyMap() EditorKeyMap {
 			key.WithHelp("enter", "send"),
 		),
 		OpenEditor: key.NewBinding(
-			key.WithKeys("ctrl+e"),
-			key.WithHelp("ctrl+e", "open editor"),
+			key.WithKeys("ctrl+v"),
+			key.WithHelp("ctrl+v", "open editor"),
 		),
 		Newline: key.NewBinding(
 			key.WithKeys("shift+enter", "ctrl+j"),

--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -808,8 +808,8 @@ func (a *chatPage) Help() help.KeyMap {
 						key.WithHelp("/", "add file"),
 					),
 					key.NewBinding(
-						key.WithKeys("ctrl+e"),
-						key.WithHelp("ctrl+e", "open editor"),
+						key.WithKeys("ctrl+v"),
+						key.WithHelp("ctrl+v", "open editor"),
 					),
 				})
 		}


### PR DESCRIPTION
<img width="824" height="615" alt="image" src="https://github.com/user-attachments/assets/766d6a50-cbc0-478b-8899-b27783728e27" />
