### PR TITLE
fix: display URL in permission popup path field for fetch operations

### DIFF
--- a/internal/tui/components/dialogs/permissions/permissions.go
+++ b/internal/tui/components/dialogs/permissions/permissions.go
@@ -220,19 +220,9 @@ func (p *permissionDialogCmp) renderHeader() string {
 		Render(fmt.Sprintf(" %s", p.permission.ToolName))
 
 	pathKey := t.S().Muted.Render("Path")
-	var pathDisplayValue string
-	if p.permission.ToolName == tools.FetchToolName {
-		if params, ok := p.permission.Params.(tools.FetchPermissionsParams); ok {
-			pathDisplayValue = params.URL
-		} else {
-			pathDisplayValue = p.permission.Path
-		}
-	} else {
-		pathDisplayValue = fsext.PrettyPath(p.permission.Path)
-	}
 	pathValue := t.S().Text.
 		Width(p.width - lipgloss.Width(pathKey)).
-		Render(fmt.Sprintf(" %s", pathDisplayValue))
+		Render(fmt.Sprintf(" %s", fsext.PrettyPath(p.permission.Path)))
 
 	headerParts := []string{
 		lipgloss.JoinHorizontal(
@@ -241,12 +231,18 @@ func (p *permissionDialogCmp) renderHeader() string {
 			toolValue,
 		),
 		baseStyle.Render(strings.Repeat(" ", p.width)),
-		lipgloss.JoinHorizontal(
-			lipgloss.Left,
-			pathKey,
-			pathValue,
-		),
-		baseStyle.Render(strings.Repeat(" ", p.width)),
+	}
+
+	// Only show Path field for non-fetch tools
+	if p.permission.ToolName != tools.FetchToolName {
+		headerParts = append(headerParts,
+			lipgloss.JoinHorizontal(
+				lipgloss.Left,
+				pathKey,
+				pathValue,
+			),
+			baseStyle.Render(strings.Repeat(" ", p.width)),
+		)
 	}
 
 	// Add tool-specific header information

--- a/internal/tui/components/dialogs/permissions/permissions.go
+++ b/internal/tui/components/dialogs/permissions/permissions.go
@@ -405,6 +405,20 @@ func (p *permissionDialogCmp) generateWriteContent() string {
 }
 
 func (p *permissionDialogCmp) generateFetchContent() string {
+	t := styles.CurrentTheme()
+	baseStyle := t.S().Base.Background(t.BgSubtle)
+	if pr, ok := p.permission.Params.(tools.FetchPermissionsParams); ok {
+		// Show format info instead of duplicating URL
+		content := fmt.Sprintf("Format: %s", pr.Format)
+		if pr.Timeout > 0 {
+			content += fmt.Sprintf("\nTimeout: %d seconds", pr.Timeout)
+		}
+		finalContent := baseStyle.
+			Padding(1, 2).
+			Width(p.contentViewPort.Width()).
+			Render(content)
+		return finalContent
+	}
 	return ""
 }
 

--- a/internal/tui/components/dialogs/permissions/permissions.go
+++ b/internal/tui/components/dialogs/permissions/permissions.go
@@ -405,20 +405,6 @@ func (p *permissionDialogCmp) generateWriteContent() string {
 }
 
 func (p *permissionDialogCmp) generateFetchContent() string {
-	t := styles.CurrentTheme()
-	baseStyle := t.S().Base.Background(t.BgSubtle)
-	if pr, ok := p.permission.Params.(tools.FetchPermissionsParams); ok {
-		// Show format info instead of duplicating URL
-		content := fmt.Sprintf("Format: %s", pr.Format)
-		if pr.Timeout > 0 {
-			content += fmt.Sprintf("\nTimeout: %d seconds", pr.Timeout)
-		}
-		finalContent := baseStyle.
-			Padding(1, 2).
-			Width(p.contentViewPort.Width()).
-			Render(content)
-		return finalContent
-	}
 	return ""
 }
 

--- a/internal/tui/components/dialogs/permissions/permissions.go
+++ b/internal/tui/components/dialogs/permissions/permissions.go
@@ -283,7 +283,20 @@ func (p *permissionDialogCmp) renderHeader() string {
 			baseStyle.Render(strings.Repeat(" ", p.width)),
 		)
 	case tools.FetchToolName:
-		headerParts = append(headerParts, t.S().Muted.Width(p.width).Bold(true).Render("URL"))
+		if params, ok := p.permission.Params.(tools.FetchPermissionsParams); ok {
+			urlKey := t.S().Muted.Render("URL")
+			urlValue := t.S().Text.
+				Width(p.width - lipgloss.Width(urlKey)).
+				Render(fmt.Sprintf(" %s", params.URL))
+			headerParts = append(headerParts,
+				lipgloss.JoinHorizontal(
+					lipgloss.Left,
+					urlKey,
+					urlValue,
+				),
+				baseStyle.Render(strings.Repeat(" ", p.width)),
+			)
+		}
 	}
 
 	return baseStyle.Render(lipgloss.JoinVertical(lipgloss.Left, headerParts...))

--- a/internal/tui/components/dialogs/permissions/permissions.go
+++ b/internal/tui/components/dialogs/permissions/permissions.go
@@ -409,15 +409,6 @@ func (p *permissionDialogCmp) generateWriteContent() string {
 }
 
 func (p *permissionDialogCmp) generateFetchContent() string {
-	t := styles.CurrentTheme()
-	baseStyle := t.S().Base.Background(t.BgSubtle)
-	if pr, ok := p.permission.Params.(tools.FetchPermissionsParams); ok {
-		finalContent := baseStyle.
-			Padding(1, 2).
-			Width(p.contentViewPort.Width()).
-			Render(pr.URL)
-		return finalContent
-	}
 	return ""
 }
 

--- a/internal/tui/components/dialogs/permissions/permissions.go
+++ b/internal/tui/components/dialogs/permissions/permissions.go
@@ -220,9 +220,19 @@ func (p *permissionDialogCmp) renderHeader() string {
 		Render(fmt.Sprintf(" %s", p.permission.ToolName))
 
 	pathKey := t.S().Muted.Render("Path")
+	var pathDisplayValue string
+	if p.permission.ToolName == tools.FetchToolName {
+		if params, ok := p.permission.Params.(tools.FetchPermissionsParams); ok {
+			pathDisplayValue = params.URL
+		} else {
+			pathDisplayValue = p.permission.Path
+		}
+	} else {
+		pathDisplayValue = fsext.PrettyPath(p.permission.Path)
+	}
 	pathValue := t.S().Text.
 		Width(p.width - lipgloss.Width(pathKey)).
-		Render(fmt.Sprintf(" %s", fsext.PrettyPath(p.permission.Path)))
+		Render(fmt.Sprintf(" %s", pathDisplayValue))
 
 	headerParts := []string{
 		lipgloss.JoinHorizontal(


### PR DESCRIPTION
## Summary
- Fixed bug where permission popup for fetch operations showed working directory instead of URL in the path field
- Removed duplicate URL display in fetch permission popups
- Hide Path field for fetch tools since working directory is not relevant for URL fetching

Closes #163

## Changes Made
- Display URL from `FetchPermissionsParams` in dedicated URL field for fetch operations
- Remove Path field entirely for fetch tools (preserve original behavior for other tools)
- Remove duplicate URL content in fetch popup content area

## Test plan
- [x] Build compiles successfully
- [ ] Test fetch operation permission popup shows URL in header with no Path field
- [ ] Test fetch popup has no duplicate URL in content area
- [ ] Verify other tools (bash, edit, write) still show correct Path field behavior

🤖 Generated with [Claude Code](https://claude.ai/code)