### PR TITLE
Display friendly message when offline

### DIFF
--- a/internal/fur/client/client.go
+++ b/internal/fur/client/client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/charmbracelet/crush/internal/fur/provider"
+	"github.com/charmbracelet/crush/internal/network"
 )
 
 const defaultURL = "https://fur.charmcli.dev"
@@ -46,6 +47,9 @@ func (c *Client) GetProviders() ([]provider.Provider, error) {
 
 	resp, err := c.httpClient.Get(url) //nolint:noctx
 	if err != nil {
+		if network.IsOfflineError(err) {
+			return nil, fmt.Errorf(network.GetFriendlyOfflineMessage())
+		}
 		return nil, fmt.Errorf("failed to make request: %w", err)
 	}
 	defer resp.Body.Close() //nolint:errcheck

--- a/internal/llm/tools/fetch.go
+++ b/internal/llm/tools/fetch.go
@@ -11,6 +11,7 @@ import (
 
 	md "github.com/JohannesKaufmann/html-to-markdown"
 	"github.com/PuerkitoBio/goquery"
+	"github.com/charmbracelet/crush/internal/network"
 	"github.com/charmbracelet/crush/internal/permission"
 )
 
@@ -167,6 +168,9 @@ func (t *fetchTool) Run(ctx context.Context, call ToolCall) (ToolResponse, error
 
 	resp, err := t.client.Do(req)
 	if err != nil {
+		if network.IsOfflineError(err) {
+			return NewTextErrorResponse(network.GetFriendlyOfflineMessage()), nil
+		}
 		return ToolResponse{}, fmt.Errorf("failed to fetch URL: %w", err)
 	}
 	defer resp.Body.Close()

--- a/internal/llm/tools/sourcegraph.go
+++ b/internal/llm/tools/sourcegraph.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/charmbracelet/crush/internal/network"
 )
 
 type SourcegraphParams struct {
@@ -233,6 +235,9 @@ func (t *sourcegraphTool) Run(ctx context.Context, call ToolCall) (ToolResponse,
 
 	resp, err := t.client.Do(req)
 	if err != nil {
+		if network.IsOfflineError(err) {
+			return NewTextErrorResponse(network.GetFriendlyOfflineMessage()), nil
+		}
 		return ToolResponse{}, fmt.Errorf("failed to fetch URL: %w", err)
 	}
 	defer resp.Body.Close()

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -1,0 +1,78 @@
+package network
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"strings"
+	"syscall"
+)
+
+// IsOfflineError checks if an error indicates the user is offline
+func IsOfflineError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check for common network error patterns
+	errorStr := strings.ToLower(err.Error())
+	
+	// Common offline indicators
+	offlinePatterns := []string{
+		"no such host",
+		"connection refused",
+		"network is unreachable",
+		"no route to host",
+		"host is down",
+		"connection timed out",
+		"dial tcp: no route to host",
+		"dial tcp: network is unreachable",
+		"temporary failure in name resolution",
+	}
+
+	for _, pattern := range offlinePatterns {
+		if strings.Contains(errorStr, pattern) {
+			return true
+		}
+	}
+
+	// Check for specific error types
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) && !dnsErr.Temporary() {
+		return true
+	}
+
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		if opErr.Op == "dial" || opErr.Op == "read" {
+			return true
+		}
+		
+		if syscallErr, ok := opErr.Err.(*net.AddrError); ok {
+			return syscallErr.Err == "no such host"
+		}
+		
+		if syscallErr, ok := opErr.Err.(syscall.Errno); ok {
+			return syscallErr == syscall.ECONNREFUSED || 
+				   syscallErr == syscall.ENETUNREACH ||
+				   syscallErr == syscall.EHOSTUNREACH
+		}
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return IsOfflineError(urlErr.Err)
+	}
+
+	return false
+}
+
+// GetFriendlyOfflineMessage returns a friendly message for offline scenarios
+func GetFriendlyOfflineMessage() string {
+	return "It seems you're offline, no donuts for you"
+}

--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -1,0 +1,80 @@
+package network
+
+import (
+	"errors"
+	"net"
+	"net/url"
+	"syscall"
+	"testing"
+)
+
+func TestIsOfflineError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "no such host error",
+			err:      errors.New("dial tcp: lookup example.com: no such host"),
+			expected: true,
+		},
+		{
+			name:     "connection refused error",
+			err:      errors.New("dial tcp 127.0.0.1:80: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "network unreachable error",
+			err:      errors.New("dial tcp: network is unreachable"),
+			expected: true,
+		},
+		{
+			name:     "timeout error",
+			err:      &net.OpError{Op: "dial", Err: syscall.ETIMEDOUT},
+			expected: true,
+		},
+		{
+			name:     "connection refused syscall",
+			err:      &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED},
+			expected: true,
+		},
+		{
+			name:     "url error with underlying network error",
+			err:      &url.Error{Op: "Get", URL: "http://example.com", Err: errors.New("no such host")},
+			expected: true,
+		},
+		{
+			name:     "generic error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+		{
+			name:     "server error (not offline)",
+			err:      errors.New("500 internal server error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsOfflineError(tt.err)
+			if result != tt.expected {
+				t.Errorf("IsOfflineError(%v) = %v, expected %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetFriendlyOfflineMessage(t *testing.T) {
+	msg := GetFriendlyOfflineMessage()
+	expected := "It seems you're offline, no donuts for you"
+	if msg != expected {
+		t.Errorf("GetFriendlyOfflineMessage() = %q, expected %q", msg, expected)
+	}
+}


### PR DESCRIPTION
## Summary
- Implements friendly offline message "It seems you're offline, no donuts for you" for network connectivity issues
- Adds new `internal/network` package to detect offline scenarios 
- Updates fetch, sourcegraph, and fur client tools to show friendly message instead of technical errors

## Test plan
- [x] Build successfully compiles
- [x] Unit tests pass for network detection logic
- [x] Manual testing can be done by disconnecting network and trying to use fetch tool

Fixes #168

🤖 Generated with [Claude Code](https://claude.ai/code)