### PR TITLE
fix(tui): chat: remove paste key binding from onboarding

### DIFF
--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -2,7 +2,6 @@ package chat
 
 import (
 	"context"
-	"runtime"
 	"time"
 
 	"github.com/charmbracelet/bubbles/v2/help"
@@ -615,26 +614,12 @@ func (a *chatPage) Help() help.KeyMap {
 			fullList = append(fullList, []key.Binding{v})
 		}
 	case a.isOnboarding && a.splash.IsShowingAPIKey():
-		var pasteKey key.Binding
-		if runtime.GOOS != "darwin" {
-			pasteKey = key.NewBinding(
-				key.WithKeys("ctrl+v"),
-				key.WithHelp("ctrl+v", "paste API key"),
-			)
-		} else {
-			pasteKey = key.NewBinding(
-				key.WithKeys("cmd+v"),
-				key.WithHelp("cmd+v", "paste API key"),
-			)
-		}
 		shortList = append(shortList,
 			// Go back
 			key.NewBinding(
 				key.WithKeys("esc"),
 				key.WithHelp("esc", "back"),
 			),
-			// Paste
-			pasteKey,
 			// Quit
 			key.NewBinding(
 				key.WithKeys("ctrl+c"),


### PR DESCRIPTION
The keybinding does not bind to any action in the app but rather assumes the terminal application's default paste behavior. We shouldn't assume that and instead leave it to the terminal emulator and user to handle pasting.

On most macOS terminals the default paste keybinding is `cmd+v` and on most Windows and Linux terminals it is `ctrl+shift+v`.
