### PR TITLE
Add yolo mode for auto-accepting all permissions

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,6 +45,9 @@ to assist developers in writing, debugging, and understanding code directly from
 
   # Run a single non-interactive prompt with JSON output format
   crush -p "Explain the use of context in Go" -f json
+
+  # Run in dangerous mode (auto-accept all permissions)
+  crush -y
   `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Load the config
@@ -52,6 +55,7 @@ to assist developers in writing, debugging, and understanding code directly from
 		cwd, _ := cmd.Flags().GetString("cwd")
 		prompt, _ := cmd.Flags().GetString("prompt")
 		quiet, _ := cmd.Flags().GetBool("quiet")
+		yolo, _ := cmd.Flags().GetBool("yolo")
 
 		if cwd != "" {
 			err := os.Chdir(cwd)
@@ -71,6 +75,7 @@ to assist developers in writing, debugging, and understanding code directly from
 		if err != nil {
 			return err
 		}
+		cfg.Options.SkipPermissionsRequests = yolo
 
 		ctx := cmd.Context()
 
@@ -152,6 +157,7 @@ func init() {
 	rootCmd.Flags().BoolP("help", "h", false, "Help")
 	rootCmd.Flags().BoolP("debug", "d", false, "Debug")
 	rootCmd.Flags().StringP("prompt", "p", "", "Prompt to run in non-interactive mode")
+	rootCmd.Flags().BoolP("yolo", "y", false, "Automatically accept all permissions (dangerous mode)")
 
 	// Add quiet flag to hide spinner in non-interactive mode
 	rootCmd.Flags().BoolP("quiet", "q", false, "Hide spinner in non-interactive mode")

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -58,12 +58,13 @@ func New(ctx context.Context, conn *sql.DB, cfg *config.Config) (*App, error) {
 	sessions := session.NewService(q)
 	messages := message.NewService(q)
 	files := history.NewService(q, conn)
+	skipPermissionsRequests := cfg.Options != nil && cfg.Options.SkipPermissionsRequests
 
 	app := &App{
 		Sessions:    sessions,
 		Messages:    messages,
 		History:     files,
-		Permissions: permission.NewPermissionService(cfg.WorkingDir()),
+		Permissions: permission.NewPermissionService(cfg.WorkingDir(), skipPermissionsRequests),
 		LSPClients:  make(map[string]*lsp.Client),
 
 		globalCtx: ctx,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,13 +114,13 @@ type TUIOptions struct {
 }
 
 type Options struct {
-	ContextPaths         []string    `json:"context_paths,omitempty"`
-	TUI                  *TUIOptions `json:"tui,omitempty"`
-	Debug                bool        `json:"debug,omitempty"`
-	DebugLSP             bool        `json:"debug_lsp,omitempty"`
-	DisableAutoSummarize bool        `json:"disable_auto_summarize,omitempty"`
-	// Relative to the cwd
-	DataDirectory string `json:"data_directory,omitempty"`
+	ContextPaths            []string    `json:"context_paths,omitempty"`
+	TUI                     *TUIOptions `json:"tui,omitempty"`
+	Debug                   bool        `json:"debug,omitempty"`
+	DebugLSP                bool        `json:"debug_lsp,omitempty"`
+	DisableAutoSummarize    bool        `json:"disable_auto_summarize,omitempty"`
+	DataDirectory           string      `json:"data_directory,omitempty"` // Relative to the cwd
+	SkipPermissionsRequests bool        `json:"-"`                        // Automatically accept all permissions (YOLO mode)
 }
 
 type MCPs map[string]MCPConfig


### PR DESCRIPTION
## Summary
- Adds `-y/--yolo` flag to enable automatic acceptance of all permission requests
- Enables uninterrupted operation in trusted environments, useful for automation and CI/CD pipelines

Closes #161

## Test plan
- [ ] Run `crush -y` and verify all permissions are auto-accepted
- [ ] Run `crush` without flag and verify permissions still require manual approval
- [ ] Test with various commands that require permissions (file operations, shell commands, etc.)
- [ ] Verify the flag is properly documented in help text

💘 Generated with Crush