### PR TITLE
fix: address panic when deciding which model to use

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -301,6 +301,7 @@ func (cfg *Config) defaultModelSelection(knownProviders []provider.Provider) (la
 		defaultSmallModel := cfg.GetModel(string(p.ID), p.DefaultSmallModelID)
 		if defaultSmallModel == nil {
 			err = fmt.Errorf("default small model %s not found for provider %s", p.DefaultSmallModelID, p.ID)
+			return
 		}
 		smallModel = SelectedModel{
 			Provider:        string(p.ID),


### PR DESCRIPTION
I think this is the same issue reported on https://github.com/charmbracelet/crush/issues/162.

I now see this when trying to run Crush:

<img width="1664" height="274" alt="image" src="https://github.com/user-attachments/assets/864c5dd5-30b3-4fc1-9072-c2b69409bf7d" />
