### PR TITLE
fix(tui): escape control characters in tool call content

### DIFF
--- a/internal/tui/components/chat/messages/renderer.go
+++ b/internal/tui/components/chat/messages/renderer.go
@@ -789,7 +789,6 @@ func escapeContent(content string) string {
 		case r == ansi.DEL:
 			sb.WriteRune('\u2421')
 		default:
-			// Do we need to handle C1 control characters (0x80-0x9f) as well?
 			sb.WriteRune(r)
 		}
 	}


### PR DESCRIPTION
This will ensure that control characters are displayed correctly in the UI, preventing issues with rendering and user interaction.

<img width="856" height="1067" alt="image" src="https://github.com/user-attachments/assets/87a9459d-2c57-4e64-959c-05fcc341ec59" />


Fixes: https://github.com/charmbracelet/crush/pull/192