### PR TITLE
fix(tui): completions: close and reset completions on cancel key

### DIFF
--- a/internal/tui/components/completions/completions.go
+++ b/internal/tui/components/completions/completions.go
@@ -118,10 +118,7 @@ func (c *completionsCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				Value: selectedItem,
 			})
 		case key.Matches(msg, c.keyMap.Cancel):
-			if c.open {
-				c.open = false
-				return c, util.CmdHandler(CompletionsClosedMsg{})
-			}
+			return c, util.CmdHandler(CloseCompletionsMsg{})
 		}
 	case CloseCompletionsMsg:
 		c.open = false


### PR DESCRIPTION
This change ensures that when the cancel key is pressed, the completions component is closed and reset, preventing any lingering state that could affect subsequent interactions.
