### PR TITLE
fix(tui): completions should not close on no results

### DIFF
--- a/internal/tui/components/completions/completions.go
+++ b/internal/tui/components/completions/completions.go
@@ -157,10 +157,6 @@ func (c *completionsCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		itemsLen := len(c.list.Items())
 		c.height = max(min(maxCompletionsHeight, itemsLen), 1)
 		cmds = append(cmds, c.list.SetSize(c.width, c.height))
-		if itemsLen == 0 {
-			// Close completions if no items match the query
-			cmds = append(cmds, util.CmdHandler(CloseCompletionsMsg{}))
-		}
 		return c, tea.Batch(cmds...)
 	}
 	return c, nil


### PR DESCRIPTION
currently, if you `/filter` until there are no results, and eventually want to backspace back to a filter that yields results, it won't work.

this fixes it:

### before

https://github.com/user-attachments/assets/17871190-e8bd-4856-8ab5-1d47ecc14e00


### after

https://github.com/user-attachments/assets/7133b2ce-d0ae-49d8-8f12-3838a5e2fc0c

