### PR TITLE
fix(tui): permissions: ensure content viewport has a minimum height

### DIFF
--- a/internal/tui/components/dialogs/permissions/permissions.go
+++ b/internal/tui/components/dialogs/permissions/permissions.go
@@ -445,7 +445,11 @@ func (p *permissionDialogCmp) render() string {
 	contentFinal := p.getOrGenerateContent()
 
 	// Always set viewport content (the caching is handled in getOrGenerateContent)
-	contentHeight := min(p.height-9, lipgloss.Height(contentFinal))
+	const minContentHeight = 9
+	contentHeight := min(
+		max(minContentHeight, p.height-minContentHeight),
+		lipgloss.Height(contentFinal),
+	)
 	p.contentViewPort.SetHeight(contentHeight)
 	p.contentViewPort.SetContent(contentFinal)
 


### PR DESCRIPTION
Before:
<img width="1824" height="1480" alt="image" src="https://github.com/user-attachments/assets/54b3b3a1-accd-4a6e-b980-a7d612ddedf8" />


After:
<img width="809" height="627" alt="image" src="https://github.com/user-attachments/assets/4588663c-c79b-4571-950d-398bf4b1f336" />
