### PR TITLE
fix(tui): permissions: properly pad command block

### DIFF
--- a/internal/tui/components/dialogs/permissions/permissions.go
+++ b/internal/tui/components/dialogs/permissions/permissions.go
@@ -323,7 +323,7 @@ func (p *permissionDialogCmp) generateBashContent() string {
 		for _, ln := range lines {
 			out = append(out, t.S().Muted.
 				Width(width).
-				Padding(0, 2).
+				Padding(0, 3).
 				Foreground(t.FgBase).
 				Background(t.BgSubtle).
 				Render(ln))


### PR DESCRIPTION
This change ensures the bash command block has 1 vertical padding and 2 horizontal paddings, improving the visual layout in the permissions dialog.

Before:
<img width="2452" height="1088" alt="image" src="https://github.com/user-attachments/assets/99342f8b-51ab-4cd9-8e01-c02d289ac37b" />

After:
<img width="968" height="1057" alt="image" src="https://github.com/user-attachments/assets/e2e6de27-f0e6-41d3-88ab-ccc91ff96a4c" />
