### PR TITLE
fix(tui): permissions: set a maximum width for the dialog

### DIFF
--- a/internal/tui/components/dialogs/permissions/permissions.go
+++ b/internal/tui/components/dialogs/permissions/permissions.go
@@ -529,6 +529,9 @@ func (p *permissionDialogCmp) SetSize() tea.Cmd {
 	// Default to diff split mode when dialog is wide enough.
 	p.defaultDiffSplitMode = p.width >= 140
 
+	// Set a maximum width for the dialog
+	p.width = min(p.width, 180)
+
 	// Mark content as dirty if size changed
 	if oldWidth != p.width || oldHeight != p.height {
 		p.contentDirty = true


### PR DESCRIPTION
The dialog won't exceed 180 characters in width, ensuring it fits well within a wide terminal window.

Before:
<img width="5060" height="1690" alt="image" src="https://github.com/user-attachments/assets/54cb5217-5020-4c9a-9c79-6bacbaf1d5a1" />


After:
<img width="2208" height="1054" alt="image" src="https://github.com/user-attachments/assets/59989d24-d7d1-4e86-bd30-51160b72c2c1" />
