### PR TITLE
fix(tui): chat: fix compact mode details toggle

### DIFF
--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -273,7 +273,7 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return p, p.cancel()
 			}
 		case key.Matches(msg, p.keyMap.Details):
-			p.showDetails()
+			p.toggleDetails()
 			return p, nil
 		}
 
@@ -415,12 +415,9 @@ func (p *chatPage) setCompactMode(compact bool) {
 	}
 	p.compact = compact
 	if compact {
-		p.compact = true
 		p.sidebar.SetCompactMode(true)
 	} else {
-		p.compact = false
-		p.showingDetails = false
-		p.sidebar.SetCompactMode(false)
+		p.setShowDetails(false)
 	}
 }
 
@@ -525,12 +522,19 @@ func (p *chatPage) cancel() tea.Cmd {
 	return cancelTimerCmd()
 }
 
-func (p *chatPage) showDetails() {
+func (p *chatPage) setShowDetails(show bool) {
+	p.showingDetails = show
+	p.header.SetDetailsOpen(p.showingDetails)
+	if !p.compact {
+		p.sidebar.SetCompactMode(false)
+	}
+}
+
+func (p *chatPage) toggleDetails() {
 	if p.session.ID == "" || !p.compact {
 		return
 	}
-	p.showingDetails = !p.showingDetails
-	p.header.SetDetailsOpen(p.showingDetails)
+	p.setShowDetails(!p.showingDetails)
 }
 
 func (p *chatPage) sendMessage(text string, attachments []message.Attachment) tea.Cmd {


### PR DESCRIPTION
If the details are open, then the window gets wider, the sidebar state doesn't get reset. This commit fixes the issue by ensuring that the sidebar is reset when the compact mode is toggled off.

Steps to reproduce:
1. Start a Crush session
2. Go into compact mode (narrow window size)
3. Toggle the details dialog (ctrl+d)
4. Make the window bigger (go out of compact mode) the dialog disappears as expected
5. Go back into compact mode
6. The dialog state should be reset i.e. it should say `ctrl+d open` instead of `ctrl+d close`


<img width="667" height="989" alt="image" src="https://github.com/user-attachments/assets/9a732d72-bd9b-431f-a53f-11325e301265" />

