### PR TITLE
fix nil pointer dereference when there's no provider for specific model

### DIFF
--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -859,7 +859,7 @@ func (a *agent) UpdateModel() error {
 
 	// Get current provider configuration
 	currentProviderCfg := cfg.GetProviderForModel(a.agentCfg.Model)
-	if currentProviderCfg.ID == "" {
+	if currentProviderCfg == nil || currentProviderCfg.ID == "" {
 		return fmt.Errorf("provider for agent %s not found in config", a.agentCfg.Name)
 	}
 


### PR DESCRIPTION
### Describe your changes
Add nil pointer check after getting provider for a model.
### Related issue/discussion: <insert link>
How to reproduce: 
* on main 
* run crush without setting any env var to select provider or config
* CTRL+P to change provider
* select any of the anthropic ones
* panic
<img width="875" height="225" alt="image" src="https://github.com/user-attachments/assets/21025ea2-ffcd-4635-a30a-05c1d94d9956" />



### Checklist before requesting a review

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
