### PR TITLE
fix(tui): renderer: replace tabs with spaces in plain content

### DIFF
--- a/internal/tui/components/chat/messages/renderer.go
+++ b/internal/tui/components/chat/messages/renderer.go
@@ -656,6 +656,7 @@ func joinHeaderBody(header, body string) string {
 func renderPlainContent(v *toolCallCmp, content string) string {
 	t := styles.CurrentTheme()
 	content = strings.ReplaceAll(content, "\r\n", "\n") // Normalize line endings
+	content = strings.ReplaceAll(content, "\t", "    ") // Replace tabs with spaces
 	content = strings.TrimSpace(content)
 	lines := strings.Split(content, "\n")
 


### PR DESCRIPTION
We need to ensure that tabs in plain text content are replaced with spaces otherwise they will be escaped and displayed as tab unicode picture characters.
