### PR TITLE
fix(tui): chat: adjust padding for message list

### DIFF
--- a/internal/tui/components/chat/chat.go
+++ b/internal/tui/components/chat/chat.go
@@ -107,7 +107,7 @@ func (m *messageListCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *messageListCmp) View() string {
 	t := styles.CurrentTheme()
 	return t.S().Base.
-		Padding(1).
+		Padding(1, 1, 0, 1).
 		Width(m.width).
 		Height(m.height).
 		Render(
@@ -508,7 +508,7 @@ func (m *messageListCmp) GetSize() (int, int) {
 func (m *messageListCmp) SetSize(width int, height int) tea.Cmd {
 	m.width = width
 	m.height = height
-	return m.listCmp.SetSize(width-2, height-2) // for padding
+	return m.listCmp.SetSize(width-2, height-1) // for padding
 }
 
 // Blur implements MessageListCmp.


### PR DESCRIPTION
The gap between the message list and the editor was too large. 3 lines of padding can be too much. 1 line gets added after each message list item as a "gap", there's the padding at the bottom of the message list, and there's the editor top padding.

In this commit, we removed the bottom padding of the message list, keeping both the gap that gets added after each message list item and the padding at the top of the editor.

<img width="843" height="678" alt="image" src="https://github.com/user-attachments/assets/e1f80bab-38de-438c-958d-dbfc4f18da0f" />
