### PR TITLE
fix(tui): app: show error message when window is too small

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -414,7 +414,7 @@ func (a *appModel) View() tea.View {
 							Foreground(t.White).
 							BorderStyle(lipgloss.RoundedBorder()).
 							BorderForeground(t.Primary).
-							Render("Too small!"),
+							Render("Window too small!"),
 					),
 			),
 		)


### PR DESCRIPTION
<img width="467" height="304" alt="image" src="https://github.com/user-attachments/assets/b1519864-22e4-4925-b9c8-7c9ca00309ff" />
