### PR TITLE
revert "refactor(mouse): delegate mouse actions to terminal emulator"

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,6 +106,8 @@ to assist developers in writing, debugging, and understanding code directly from
 			tui.New(app),
 			tea.WithAltScreen(),
 			tea.WithContext(ctx),
+			tea.WithMouseCellMotion(),            // Use cell motion instead of all motion to reduce event flooding
+			tea.WithFilter(tui.MouseEventFilter), // Filter mouse events based on focus state
 		)
 
 		go app.Subscribe(program)

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -32,6 +32,29 @@ import (
 	"github.com/charmbracelet/lipgloss/v2"
 )
 
+// MouseEventFilter filters mouse events based on the current focus state
+// This is used with tea.WithFilter to prevent mouse scroll events from
+// interfering with typing performance in the editor
+func MouseEventFilter(m tea.Model, msg tea.Msg) tea.Msg {
+	// Only filter mouse events
+	switch msg.(type) {
+	case tea.MouseWheelMsg, tea.MouseMotionMsg:
+		// Check if we have an appModel and if editor is focused
+		if appModel, ok := m.(*appModel); ok {
+			if appModel.currentPage == chat.ChatPageID {
+				if chatPage, ok := appModel.pages[appModel.currentPage].(chat.ChatPage); ok {
+					// If editor is focused (not chatFocused), filter out mouse wheel/motion events
+					if !chatPage.IsChatFocused() {
+						return nil // Filter out the event
+					}
+				}
+			}
+		}
+	}
+	// Allow all other events to pass through
+	return msg
+}
+
 // appModel represents the main application model that manages pages, dialogs, and UI state.
 type appModel struct {
 	wWidth, wHeight int // Window dimensions
@@ -66,6 +89,8 @@ func (a appModel) Init() tea.Cmd {
 
 	cmd = a.status.Init()
 	cmds = append(cmds, cmd)
+
+	cmds = append(cmds, tea.EnableMouseAllMotion)
 
 	return tea.Batch(cmds...)
 }


### PR DESCRIPTION
This revision reverts charmbracelet/crush#218.

We're reverting as it breaks the experience in several terminals and, can prints ANSI artifacts in the input area, and can flood the application with events causing lock up.