### PR TITLE
fix(tools): bash: add scp and ssh to banned commands

### DIFF
--- a/internal/llm/tools/bash.go
+++ b/internal/llm/tools/bash.go
@@ -55,6 +55,8 @@ var bannedCommands = []string{
 	"lynx",
 	"nc",
 	"safari",
+	"scp",
+	"ssh",
 	"telnet",
 	"w3m",
 	"wget",


### PR DESCRIPTION
Add `scp` and `ssh` to the list of banned commands to avoid security risks and UI issues when asking for user input in the terminal.
