### PR TITLE
fix(non-interactive): check bounds when reading message bytes

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -162,7 +162,7 @@ func (app *App) RunNonInteractive(ctx context.Context, prompt string, quiet bool
 
 			msgContent := result.Message.Content().String()
 			if len(msgContent) < readBts {
-				slog.Error("Non-interacgive: message content is shorter than read bytes", "message_length", len(msgContent), "read_bytes", readBts)
+				slog.Error("Non-interactive: message content is shorter than read bytes", "message_length", len(msgContent), "read_bytes", readBts)
 				return fmt.Errorf("message content is shorter than read bytes: %d < %d", len(msgContent), readBts)
 			}
 			fmt.Println(msgContent[readBts:])


### PR DESCRIPTION
This fixes a panic that count occur when printing messages non-interactively. @kujtimiihoxha, I'll need your guidance here around how or if this should be logged.