### PR TITLE
fix(tui): renderer: line wrapping in chat

### DIFF
--- a/internal/tui/components/chat/messages/renderer.go
+++ b/internal/tui/components/chat/messages/renderer.go
@@ -124,9 +124,9 @@ func (br baseRenderer) makeNestedHeader(v *toolCallCmp, tool string, width int, 
 	} else if v.cancelled {
 		icon = t.S().Muted.Render(styles.ToolPending)
 	}
-	tool = t.S().Base.Foreground(t.FgHalfMuted).Render(tool) + " "
+	tool = t.S().Base.Foreground(t.FgHalfMuted).Render(tool)
 	prefix := fmt.Sprintf("%s %s ", icon, tool)
-	return prefix + renderParamList(true, width-lipgloss.Width(tool), params...)
+	return prefix + renderParamList(true, width-lipgloss.Width(prefix), params...)
 }
 
 // makeHeader builds "<Tool>: param (key=value)" and truncates as needed.


### PR DESCRIPTION
This fixes an issue where the tool call in nested headers don't wrap correctly when the tool name is long. The tool name is now rendered without an extra trailing space, and the parameter list is rendered with the correct width calculation.

Before
<img width="1504" height="2724" alt="image" src="https://github.com/user-attachments/assets/086701f1-2682-4301-a1d7-049a80e3dda9" />

After
<img width="673" height="795" alt="image" src="https://github.com/user-attachments/assets/1bdcb6a8-9bc2-4f94-ba8b-b0b894b6d59d" />
