### PR TITLE
fix: fix panic on onboarding when no model is selected on the list

### DIFF
--- a/internal/tui/components/chat/splash/splash.go
+++ b/internal/tui/components/chat/splash/splash.go
@@ -196,6 +196,9 @@ func (s *splashCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if s.isOnboarding && !s.needsAPIKey {
 				modelInx := s.modelList.SelectedIndex()
+				if modelInx == -1 {
+					return s, nil
+				}
 				items := s.modelList.Items()
 				selectedItem := items[modelInx].(completions.CompletionItem).Value().(models.ModelOption)
 				if s.isProviderConfigured(string(selectedItem.Provider.ID)) {


### PR DESCRIPTION
How to reproduce:

* `rm -r ~/.local/share/crush`
* run `crush`
* type something on the filter so no model is shown on the list
* press enter
* a panic happens

Fixes #285

<details><summary>Stacktrace</summary>

```
Caught panic:

runtime error: index out of range [-1]

Restoring terminal...

goroutine 1 [running]:
runtime/debug.Stack()
	/nix/store/f4a0g1p943l61wfvqnpdr73v9bsyfhf2-go-1.24.4/share/go/src/runtime/debug/stack.go:26 +0x64
github.com/charmbracelet/bubbletea/v2.(*Program).recoverFromPanic(0x14002e71188, {0x10265bf00, 0x140052b7e78})
	/Users/andrey/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4.0.20250717140350-bb75e8f6b6ac/tea.go:1233 +0x10c
github.com/charmbracelet/bubbletea/v2.(*Program).Run.func2()
	/Users/andrey/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4.0.20250717140350-bb75e8f6b6ac/tea.go:946 +0xdc
panic({0x10265bf00?, 0x140052b7e78?})
	/nix/store/f4a0g1p943l61wfvqnpdr73v9bsyfhf2-go-1.24.4/share/go/src/runtime/panic.go:792 +0x124
github.com/charmbracelet/crush/internal/tui/components/chat/splash.(*splashCmp).Update(0x14002e70a08, {0x1026cc4e0?, 0x14000474330?})
	/Users/andrey/Developer/charm/crush/internal/tui/components/chat/splash/splash.go:200 +0x148c
github.com/charmbracelet/crush/internal/tui/page/chat.(*chatPage).Update(0x14002e70f08, {0x1026cc4e0?, 0x14000474300?})
	/Users/andrey/Developer/charm/crush/internal/tui/page/chat/chat.go:311 +0xb14
github.com/charmbracelet/crush/internal/tui.(*appModel).handleKeyPressMsg(0x14000683880, {{0x0, 0x0}, 0x0, 0xd, 0x0, 0x0, 0x0})
	/Users/andrey/Developer/charm/crush/internal/tui/tui.go:395 +0x940
github.com/charmbracelet/crush/internal/tui.(*appModel).Update(0x14000683880, {0x1026cc4e0, 0x140004742a0})
	/Users/andrey/Developer/charm/crush/internal/tui/tui.go:265 +0x750
github.com/charmbracelet/bubbletea/v2.(*Program).eventLoop(0x14002e71188, {0x1027a9490?, 0x14000683880?}, 0x140004815e0)
	/Users/andrey/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4.0.20250717140350-bb75e8f6b6ac/tea.go:834 +0x1a54
github.com/charmbracelet/bubbletea/v2.(*Program).Run(0x14002e71188)
	/Users/andrey/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4.0.20250717140350-bb75e8f6b6ac/tea.go:1102 +0xaf0
github.com/charmbracelet/crush/internal/cmd.init.func2(0x103626ec0, {0x101c20144?, 0x7?, 0x101c1874f?})
	/Users/andrey/Developer/charm/crush/internal/cmd/root.go:119 +0x534
github.com/spf13/cobra.(*Command).execute(0x103626ec0, {0x1400003a090, 0x0, 0x0})
	/Users/andrey/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0x844
github.com/spf13/cobra.(*Command).ExecuteC(0x103626ec0)
	/Users/andrey/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x384
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/andrey/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/Users/andrey/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1064
github.com/charmbracelet/fang.Execute({0x1027b9430, 0x103698760}, 0x103626ec0, {0x14000555ec8, 0x2, 0xd?})
	/Users/andrey/go/pkg/mod/github.com/charmbracelet/fang@v0.3.1-0.20250711140230-d5ebb8c1d674/fang.go:169 +0x2f8
github.com/charmbracelet/crush/internal/cmd.Execute()
	/Users/andrey/Developer/charm/crush/internal/cmd/root.go:128 +0xd0
main.main()
	/Users/andrey/Developer/charm/crush/main.go:30 +0x6c
```

</details> 