### PR TITLE
fix: Delegate unhandled messages to the focused model

### DIFF
--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -299,40 +299,24 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			p.toggleDetails()
 			return p, nil
 		}
-
-		switch p.focusedPane {
-		case PanelTypeChat:
-			u, cmd := p.chat.Update(msg)
-			p.chat = u.(chat.MessageListCmp)
-			cmds = append(cmds, cmd)
-		case PanelTypeEditor:
-			u, cmd := p.editor.Update(msg)
-			p.editor = u.(editor.Editor)
-			cmds = append(cmds, cmd)
-		case PanelTypeSplash:
-			u, cmd := p.splash.Update(msg)
-			p.splash = u.(splash.Splash)
-			cmds = append(cmds, cmd)
-		}
-	case tea.PasteMsg:
-		switch p.focusedPane {
-		case PanelTypeEditor:
-			u, cmd := p.editor.Update(msg)
-			p.editor = u.(editor.Editor)
-			cmds = append(cmds, cmd)
-			return p, tea.Batch(cmds...)
-		case PanelTypeChat:
-			u, cmd := p.chat.Update(msg)
-			p.chat = u.(chat.MessageListCmp)
-			cmds = append(cmds, cmd)
-			return p, tea.Batch(cmds...)
-		case PanelTypeSplash:
-			u, cmd := p.splash.Update(msg)
-			p.splash = u.(splash.Splash)
-			cmds = append(cmds, cmd)
-			return p, tea.Batch(cmds...)
-		}
 	}
+
+	// Delegate other messages to the focused pane model
+	switch p.focusedPane {
+	case PanelTypeEditor:
+		u, cmd := p.editor.Update(msg)
+		p.editor = u.(editor.Editor)
+		cmds = append(cmds, cmd)
+	case PanelTypeChat:
+		u, cmd := p.chat.Update(msg)
+		p.chat = u.(chat.MessageListCmp)
+		cmds = append(cmds, cmd)
+	case PanelTypeSplash:
+		u, cmd := p.splash.Update(msg)
+		p.splash = u.(splash.Splash)
+		cmds = append(cmds, cmd)
+	}
+
 	return p, tea.Batch(cmds...)
 }
 


### PR DESCRIPTION
### Describe your changes

Currently, `chatPage` (the TUI root tea.Model) does not handle anything other than special events.
As a result, API/command responses from child models are passed to the
parent and processed without being communicated to the child (for
example, it is currently possible to open an external editor, but the
new text after closing the editor is not reflected in Crush's editor).
As an alternative solution, it is possible to export the child's tea.Msg
to the parent to address this issue, but we would prefer to handle the
logic closed in the child without communicating the details to the
parent as much as possible.

However, I am neither an expert on Elm Architecture nor Bubbletea. If there are any mistakes or areas for improvement, please let me know.

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
