### PR TITLE
fix(models): Return APIKeyInputStateVerified if connection test failed

### DIFF
--- a/internal/tui/components/dialogs/models/models.go
+++ b/internal/tui/components/dialogs/models/models.go
@@ -149,7 +149,7 @@ func (m *modelDialogCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						if elapsed < 750*time.Millisecond {
 							time.Sleep(750*time.Millisecond - elapsed)
 						}
-						if err == nil {
+						if err != nil {
 							m.isAPIKeyValid = true
 							return APIKeyStateChangeMsg{
 								State: APIKeyInputStateVerified,


### PR DESCRIPTION
### Describe your changes

When the connection test with the LLM API is successful, an error status is returned. This is probably a typo.

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
