### PR TITLE
Improve `List` tool result preview

### DIFF
--- a/internal/llm/tools/ls.go
+++ b/internal/llm/tools/ls.go
@@ -274,7 +274,12 @@ func createFileTree(sortedPaths []string, rootPath string) []*TreeNode {
 func printTree(tree []*TreeNode, rootPath string) string {
 	var result strings.Builder
 
-	result.WriteString(fmt.Sprintf("- %s%s\n", rootPath, string(filepath.Separator)))
+	result.WriteString("- ")
+	result.WriteString(rootPath)
+	if rootPath[len(rootPath)-1] != '/' {
+		result.WriteByte(filepath.Separator)
+	}
+	result.WriteByte('\n')
 
 	for _, node := range tree {
 		printNode(&result, node, 1)


### PR DESCRIPTION
### Describe your changes

The List tool result should show the relative path from the root.

Before ( 9279e8580d634632c0650fcac91f11490c4ed818 )|After ( #335 )
-|-
<img width="780" height="705" alt="image" src="https://github.com/user-attachments/assets/205ea996-fe68-45f1-919f-9202f1c799df" />|<img width="845" height="761" alt="image" src="https://github.com/user-attachments/assets/891ca6d4-d994-47d2-8480-e610030ec350" />

### Related issue/discussion: resolve https://github.com/charmbracelet/crush/issues/334

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
