### PR TITLE
chore: fix custom headers and system prefix

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -145,16 +145,17 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 			maps.Copy(headers, config.ExtraHeaders)
 		}
 		prepared := ProviderConfig{
-			ID:           string(p.ID),
-			Name:         p.Name,
-			BaseURL:      p.APIEndpoint,
-			APIKey:       p.APIKey,
-			Type:         p.Type,
-			Disable:      config.Disable,
-			ExtraHeaders: headers,
-			ExtraBody:    config.ExtraBody,
-			ExtraParams:  make(map[string]string),
-			Models:       p.Models,
+			ID:                 string(p.ID),
+			Name:               p.Name,
+			BaseURL:            p.APIEndpoint,
+			APIKey:             p.APIKey,
+			Type:               p.Type,
+			Disable:            config.Disable,
+			SystemPromptPrefix: config.SystemPromptPrefix,
+			ExtraHeaders:       headers,
+			ExtraBody:          config.ExtraBody,
+			ExtraParams:        make(map[string]string),
+			Models:             p.Models,
 		}
 
 		switch p.ID {

--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -223,7 +223,6 @@ func (a *anthropicClient) preparedMessages(messages []anthropic.MessageParam, to
 	}
 
 	systemBlocks := []anthropic.TextBlockParam{}
-	slog.Info("Testing", "prefix", a.providerOptions.systemPromptPrefix)
 
 	// Add custom system prompt prefix if configured
 	if a.providerOptions.systemPromptPrefix != "" {

--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -67,8 +67,8 @@ func createAnthropicClient(opts providerClientOptions, useBedrock bool) anthropi
 	if useBedrock {
 		anthropicClientOptions = append(anthropicClientOptions, bedrock.WithLoadDefaultConfig(context.Background()))
 	}
-	for _, header := range opts.extraHeaders {
-		anthropicClientOptions = append(anthropicClientOptions, option.WithHeaderAdd(header, opts.extraHeaders[header]))
+	for key, header := range opts.extraHeaders {
+		anthropicClientOptions = append(anthropicClientOptions, option.WithHeaderAdd(key, header))
 	}
 	for key, value := range opts.extraBody {
 		anthropicClientOptions = append(anthropicClientOptions, option.WithJSONSet(key, value))
@@ -223,6 +223,7 @@ func (a *anthropicClient) preparedMessages(messages []anthropic.MessageParam, to
 	}
 
 	systemBlocks := []anthropic.TextBlockParam{}
+	slog.Info("Testing", "prefix", a.providerOptions.systemPromptPrefix)
 
 	// Add custom system prompt prefix if configured
 	if a.providerOptions.systemPromptPrefix != "" {


### PR DESCRIPTION
This was a bug that prevented custom headers to be added to anthropic providers 