### PR TITLE
chore: prevent switching the model while agent is working

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -180,6 +180,9 @@ func (a *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, a.handleWindowResize(a.wWidth, a.wHeight)
 	// Model Switch
 	case models.ModelSelectedMsg:
+		if a.app.CoderAgent.IsBusy() {
+			return a, util.ReportWarn("Agent is busy, please wait...")
+		}
 		config.Get().UpdatePreferredModel(msg.ModelType, msg.Model)
 
 		// Update the agent with the new model/provider configuration


### PR DESCRIPTION
This prevents a broken state when the model is busy