### PR TITLE
fix(tui): apply border styling to error messages in selected state

### DIFF
--- a/internal/tui/components/chat/messages/messages.go
+++ b/internal/tui/components/chat/messages/messages.go
@@ -188,8 +188,8 @@ func (m *messageCmp) renderAssistantMessage() string {
 		truncated := ansi.Truncate(finishedData.Message, m.textWidth()-2-lipgloss.Width(errTag), "...")
 		title := fmt.Sprintf("%s %s", errTag, t.S().Base.Foreground(t.FgHalfMuted).Render(truncated))
 		details := t.S().Base.Foreground(t.FgSubtle).Width(m.textWidth() - 2).Render(finishedData.Details)
-		// Handle error messages differently
-		return fmt.Sprintf("%s\n\n%s", title, details)
+		errorContent := fmt.Sprintf("%s\n\n%s", title, details)
+		return m.style().Render(errorContent)
 	}
 
 	if thinkingContent != "" {


### PR DESCRIPTION
## Summary
• Fix error messages not showing left border when selected/focused in chat interface
• Ensure consistent visual styling across all message types for better user experience

## Test plan
- [x] Verify error messages now show proper border styling when selected
- [x] Confirm no regressions in other message type styling
- [x] Run linting and tests to ensure code quality

💖 Generated with Crush