### PR TITLE
feat(providers): enable bedrock

### DIFF
--- a/internal/tui/components/chat/splash/splash.go
+++ b/internal/tui/components/chat/splash/splash.go
@@ -109,6 +109,7 @@ func (s *splashCmp) SetOnboarding(onboarding bool) {
 		filteredProviders := []catwalk.Provider{}
 		simpleProviders := []string{
 			"anthropic",
+			"bedrock",
 			"openai",
 			"gemini",
 			"xai",

--- a/internal/tui/components/dialogs/models/models.go
+++ b/internal/tui/components/dialogs/models/models.go
@@ -101,6 +101,7 @@ func (m *modelDialogCmp) Init() tea.Cmd {
 		filteredProviders := []catwalk.Provider{}
 		simpleProviders := []string{
 			"anthropic",
+			"bedrock",
 			"openai",
 			"gemini",
 			"xai",


### PR DESCRIPTION
Bedrock models listed in catwalk weren't showing up in the onboarding screen.
Simply adding "bedrock" to the lists was enough to get it going.