### PR TITLE
chore: limit tool output

### DIFF
--- a/internal/llm/tools/tools.go
+++ b/internal/llm/tools/tools.go
@@ -28,9 +28,9 @@ const (
 	SessionIDContextKey sessionIDContextKey = "session_id"
 	MessageIDContextKey messageIDContextKey = "message_id"
 
-	MaxResponseWidth  = 3000
-	MaxResponseHeight = 5000
-	MaxResponseChars  = 50000
+	maxResponseWidth  = 3000
+	maxResponseHeight = 5000
+	maxResponseChars  = 50000
 )
 
 type ToolResponse struct {
@@ -48,13 +48,13 @@ func NewTextResponse(content string) ToolResponse {
 }
 
 func truncateContent(content string) string {
-	if len(content) <= MaxResponseChars {
+	if len(content) <= maxResponseChars {
 		return truncateWidthAndHeight(content)
 	}
 
-	truncated := content[:MaxResponseChars]
+	truncated := content[:maxResponseChars]
 
-	if lastNewline := strings.LastIndex(truncated, "\n"); lastNewline > MaxResponseChars/2 {
+	if lastNewline := strings.LastIndex(truncated, "\n"); lastNewline > maxResponseChars/2 {
 		truncated = truncated[:lastNewline]
 	}
 
@@ -67,12 +67,12 @@ func truncateWidthAndHeight(content string) string {
 	lines := strings.Split(content, "\n")
 
 	heightTruncated := false
-	if len(lines) > MaxResponseHeight {
-		keepLines := MaxResponseHeight - 3
+	if len(lines) > maxResponseHeight {
+		keepLines := maxResponseHeight - 3
 		firstHalf := keepLines / 2
 		secondHalf := keepLines - firstHalf
 
-		truncatedLines := make([]string, 0, MaxResponseHeight)
+		truncatedLines := make([]string, 0, maxResponseHeight)
 		truncatedLines = append(truncatedLines, lines[:firstHalf]...)
 		truncatedLines = append(truncatedLines, "")
 		truncatedLines = append(truncatedLines, fmt.Sprintf("... [%d lines truncated] ...", len(lines)-keepLines))
@@ -85,14 +85,14 @@ func truncateWidthAndHeight(content string) string {
 
 	widthTruncated := false
 	for i, line := range lines {
-		if len(line) > MaxResponseWidth {
-			if MaxResponseWidth > 20 {
-				keepChars := MaxResponseWidth - 10
+		if len(line) > maxResponseWidth {
+			if maxResponseWidth > 20 {
+				keepChars := maxResponseWidth - 10
 				firstHalf := keepChars / 2
 				secondHalf := keepChars - firstHalf
 				lines[i] = line[:firstHalf] + " ... " + line[len(line)-secondHalf:]
 			} else {
-				lines[i] = line[:MaxResponseWidth]
+				lines[i] = line[:maxResponseWidth]
 			}
 			widthTruncated = true
 		}

--- a/internal/llm/tools/tools.go
+++ b/internal/llm/tools/tools.go
@@ -101,7 +101,7 @@ func truncateWidthAndHeight(content string) string {
 	result := strings.Join(lines, "\n")
 
 	if heightTruncated || widthTruncated {
-		notices := []string{}
+		notices := make([]string, 0, 2)
 		if heightTruncated {
 			notices = append(notices, "height")
 		}


### PR DESCRIPTION
Should fix #375.

***

Editor’s note:

This limits the amount of tokens a tool call can use, avoiding cases where one line in a file is long enough that it could consume all of the available context. This adds a width and height limits on to messages and generally enforces a character limit.