### PR TITLE
fix(onboarding): fix y/n key press on model list and api key field

### DIFF
--- a/internal/tui/components/chat/splash/splash.go
+++ b/internal/tui/components/chat/splash/splash.go
@@ -262,30 +262,34 @@ func (s *splashCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return s, nil
 			}
 		case key.Matches(msg, s.keyMap.Yes):
-			if s.isOnboarding {
-				return s, nil
-			}
 			if s.needsAPIKey {
 				u, cmd := s.apiKeyInput.Update(msg)
 				s.apiKeyInput = u.(*models.APIKeyInput)
 				return s, cmd
 			}
-
+			if s.isOnboarding {
+				u, cmd := s.modelList.Update(msg)
+				s.modelList = u
+				return s, cmd
+			}
 			if s.needsProjectInit {
 				return s, s.initializeProject()
 			}
 		case key.Matches(msg, s.keyMap.No):
-			if s.isOnboarding {
-				return s, nil
-			}
 			if s.needsAPIKey {
 				u, cmd := s.apiKeyInput.Update(msg)
 				s.apiKeyInput = u.(*models.APIKeyInput)
 				return s, cmd
 			}
-
-			s.selectedNo = true
-			return s, s.initializeProject()
+			if s.isOnboarding {
+				u, cmd := s.modelList.Update(msg)
+				s.modelList = u
+				return s, cmd
+			}
+			if s.needsProjectInit {
+				s.selectedNo = true
+				return s, s.initializeProject()
+			}
 		default:
 			if s.needsAPIKey {
 				u, cmd := s.apiKeyInput.Update(msg)


### PR DESCRIPTION
* Fixes https://github.com/charmbracelet/crush/issues/381
* Fixes https://github.com/charmbracelet/crush/issues/389
* Fixes https://github.com/charmbracelet/crush/issues/401

A bug on onboarding made it impossible to press "y" and "n" on onboarding, on both the model list and the API key field.

This also means that on some terminals, like the Windows Terminal, pasting an API key would supress all "y" and "n" chars present in the key, because these terminal receives an even for each character being pressed.

To reproduce:

* Run `rm -r ~/.local/share/crush` to delete config
* Run Crush to show onboarding
* Try to press <kbd>y</kbd> and <kbd>n</kbd> on model list and API key field

<img width="674" height="450" alt="Screenshot 2025-07-31 at 09 53 14" src="https://github.com/user-attachments/assets/dd635dc9-98ed-4aee-9845-e18c258f3a25" />

<img width="672" height="450" alt="Screenshot 2025-07-31 at 09 53 30" src="https://github.com/user-attachments/assets/b7e6817c-f4b4-446e-b986-838ef39510b6" />
