### PR TITLE
docs: add crush installation by aqua (and mise)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ brew install charmbracelet/tap/crush
 # NPM
 npm install -g @charmland/crush
 
+# aqua or mise
+aqua generate -i charmbracelet/crush
+mise use -g aqua:charmbracelet/crush
+
 # Arch Linux (btw)
 yay -S crush-bin
 
@@ -39,7 +43,7 @@ nix run github:numtide/nix-ai-tools#crush
 
 <details>
 <summary><strong>Nix (NUR)</strong></summary>
-    
+
 Crush is available via [NUR](https://github.com/nix-community/NUR) in `nur.repos.charmbracelet.crush`.
 
 You can also try out Crush via `nix-shell`:


### PR DESCRIPTION
### Describe your changes

Crush is now available in [aqua](https://aquaproj.github.io/) or [mise](https://mise.jdx.dev/) (with [aqua backend](https://mise.jdx.dev/dev-tools/backends/aqua.html)).

[feat: add charmbracelet/crush by ras0q · Pull Request #39532 · aquaproj/aqua-registry](https://github.com/aquaproj/aqua-registry/pull/39532)

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
