### PR TITLE
Use default permissions of 0600 for crush.json

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -371,7 +371,7 @@ func (c *Config) SetConfigField(key string, value any) error {
 	if err != nil {
 		return fmt.Errorf("failed to set config field %s: %w", key, err)
 	}
-	if err := os.WriteFile(c.dataConfigDir, []byte(newValue), 0o644); err != nil {
+	if err := os.WriteFile(c.dataConfigDir, []byte(newValue), 0o600); err != nil {
 		return fmt.Errorf("failed to write config file: %w", err)
 	}
 	return nil


### PR DESCRIPTION
data that is stored in plain text (api keys, etc.)

closes #411

### Describe your changes

Simple change to default permissions of crush.json file. 

### Related issue/discussion: <insert link>

See Issue #411 

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [x] tests pass

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
