### PR TITLE
fix: do not init MCP client on every tool request

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -267,6 +267,10 @@ func (app *App) InitCoderAgent() error {
 		slog.Error("Failed to create coder agent", "err", err)
 		return err
 	}
+
+	// Add MCP client cleanup to shutdown process
+	app.cleanupFuncs = append(app.cleanupFuncs, agent.CloseMCPClients)
+
 	setupSubscriber(app.eventsCtx, app.serviceEventsWG, "coderAgent", app.CoderAgent.Subscribe, app.events)
 	return nil
 }

--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -23,19 +23,9 @@ import (
 type mcpTool struct {
 	mcpName     string
 	tool        mcp.Tool
-	client      MCPClient
+	client      *client.Client
 	permissions permission.Service
 	workingDir  string
-}
-
-type MCPClient interface {
-	Initialize(
-		ctx context.Context,
-		request mcp.InitializeRequest,
-	) (*mcp.InitializeResult, error)
-	ListTools(ctx context.Context, request mcp.ListToolsRequest) (*mcp.ListToolsResult, error)
-	CallTool(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error)
-	Close() error
 }
 
 func (b *mcpTool) Name() string {
@@ -55,7 +45,7 @@ func (b *mcpTool) Info() tools.ToolInfo {
 	}
 }
 
-func runTool(ctx context.Context, c MCPClient, toolName string, input string) (tools.ToolResponse, error) {
+func runTool(ctx context.Context, c *client.Client, toolName string, input string) (tools.ToolResponse, error) {
 	toolRequest := mcp.CallToolRequest{}
 	toolRequest.Params.Name = toolName
 	var args map[string]any
@@ -104,7 +94,7 @@ func (b *mcpTool) Run(ctx context.Context, params tools.ToolCall) (tools.ToolRes
 	return runTool(ctx, b.client, b.tool.Name, params.Input)
 }
 
-func NewMcpTool(name string, tool mcp.Tool, client MCPClient, permissions permission.Service, workingDir string) tools.BaseTool {
+func NewMcpTool(name string, tool mcp.Tool, client *client.Client, permissions permission.Service, workingDir string) tools.BaseTool {
 	return &mcpTool{
 		mcpName:     name,
 		tool:        tool,
@@ -114,7 +104,7 @@ func NewMcpTool(name string, tool mcp.Tool, client MCPClient, permissions permis
 	}
 }
 
-func getTools(ctx context.Context, name string, permissions permission.Service, c MCPClient, workingDir string) []tools.BaseTool {
+func getTools(ctx context.Context, name string, permissions permission.Service, c *client.Client, workingDir string) []tools.BaseTool {
 	var mcpTools []tools.BaseTool
 	initRequest := mcp.InitializeRequest{}
 	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION


### PR DESCRIPTION
this is wasting resources/time.

- This new implementation holds initialized clients in a `csync.Map` and reuses it
- Added a shutdown that closes the clients only once
- Remove an unneeded interface
- `mcpTool` don't need to hold a reference to a `MCPConfig` anymore