### PR TITLE
fix(gemini): retry at rate limit

### DIFF
--- a/internal/llm/provider/gemini.go
+++ b/internal/llm/provider/gemini.go
@@ -336,7 +336,7 @@ func (g *geminiClient) stream(ctx context.Context, messages []message.Message, t
 
 							return
 						case <-time.After(time.Duration(after) * time.Millisecond):
-							break
+							continue
 						}
 					} else {
 						eventChan <- ProviderEvent{Type: EventError, Error: err}


### PR DESCRIPTION
### Describe your changes

fix #467

Previously, Gemini API would silently terminate when reaching its rate limit.

Before|After
-|-
<img width="477" height="196" alt="image" src="https://github.com/user-attachments/assets/647ad827-4ab1-4492-8d28-a716150f94c2" />|<img width="690" height="148" alt="image" src="https://github.com/user-attachments/assets/b609b2b6-06c6-4805-97ed-f78a29e6fc89" />


### Related issue/discussion: https://github.com/charmbracelet/crush/issues/467

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
