### PR TITLE
Add compatibiliy with Qwen3 Coder 480B from Cerebras

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,7 +90,7 @@ type ProviderConfig struct {
 	ExtraBody map[string]any `json:"extra_body,omitempty" jsonschema:"description=Additional fields to include in request bodies"`
 
 	// Used to pass extra parameters to the provider.
-	ExtraParams map[string]string `json:"-"`
+	ExtraParams map[string]string `json:"extra_params,omitempty" jsonschema:"description=Additional parameters to pass to the provider"`
 
 	// The provider models
 	Models []catwalk.Model `json:"models,omitempty" jsonschema:"description=List of models available from this provider"`

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -144,6 +144,12 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 		if len(config.ExtraHeaders) > 0 {
 			maps.Copy(headers, config.ExtraHeaders)
 		}
+		extraParams := make(map[string]string)
+		// Copy extra_params from user configuration
+		if len(config.ExtraParams) > 0 {
+			maps.Copy(extraParams, config.ExtraParams)
+		}
+		
 		prepared := ProviderConfig{
 			ID:                 string(p.ID),
 			Name:               p.Name,
@@ -154,7 +160,7 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 			SystemPromptPrefix: config.SystemPromptPrefix,
 			ExtraHeaders:       headers,
 			ExtraBody:          config.ExtraBody,
-			ExtraParams:        make(map[string]string),
+			ExtraParams:        extraParams,
 			Models:             p.Models,
 		}
 
@@ -168,8 +174,12 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 				}
 				continue
 			}
-			prepared.ExtraParams["project"] = env.Get("VERTEXAI_PROJECT")
-			prepared.ExtraParams["location"] = env.Get("VERTEXAI_LOCATION")
+			if prepared.ExtraParams["project"] == "" {
+				prepared.ExtraParams["project"] = env.Get("VERTEXAI_PROJECT")
+			}
+			if prepared.ExtraParams["location"] == "" {
+				prepared.ExtraParams["location"] = env.Get("VERTEXAI_LOCATION")
+			}
 		case catwalk.InferenceProviderAzure:
 			endpoint, err := resolver.ResolveValue(p.APIEndpoint)
 			if err != nil || endpoint == "" {
@@ -180,7 +190,9 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 				continue
 			}
 			prepared.BaseURL = endpoint
-			prepared.ExtraParams["apiVersion"] = env.Get("AZURE_OPENAI_API_VERSION")
+			if prepared.ExtraParams["apiVersion"] == "" {
+				prepared.ExtraParams["apiVersion"] = env.Get("AZURE_OPENAI_API_VERSION")
+			}
 		case catwalk.InferenceProviderBedrock:
 			if !hasAWSCredentials(env) {
 				if configExists {
@@ -189,7 +201,9 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 				}
 				continue
 			}
-			prepared.ExtraParams["region"] = env.Get("AWS_REGION")
+			if prepared.ExtraParams["region"] == "" {
+				prepared.ExtraParams["region"] = env.Get("AWS_REGION")
+			}
 			if prepared.ExtraParams["region"] == "" {
 				prepared.ExtraParams["region"] = env.Get("AWS_DEFAULT_REGION")
 			}

--- a/internal/llm/provider/openai.go
+++ b/internal/llm/provider/openai.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -236,8 +235,6 @@ func (o *openaiClient) preparedParams(messages []openai.ChatCompletionMessagePar
 		params.Tools = nil
 	}
 
-	// Note: Stream parameter is controlled by calling NewStreaming vs New on the client
-
 	maxTokens := model.DefaultMaxTokens
 	if modelConfig.MaxTokens > 0 {
 		maxTokens = modelConfig.MaxTokens
@@ -377,19 +374,10 @@ func (o *openaiClient) sendCompatible(ctx context.Context, messages []message.Me
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, resp.Status)
 	}
 	
-	// Read the raw response body for debugging
+	// Read the response body
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-	
-	// Debug: log the raw response
-	if cfg.Options.Debug {
-		debugFile, _ := os.OpenFile("/tmp/crush-debug.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if debugFile != nil {
-			fmt.Fprintf(debugFile, "DEBUG: Raw Cerebras response: %s\n", string(bodyBytes))
-			debugFile.Close()
-		}
 	}
 	
 	// Use flexible JSON parsing for compatibility mode
@@ -398,14 +386,6 @@ func (o *openaiClient) sendCompatible(ctx context.Context, messages []message.Me
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 	
-	// Debug: log parsed response structure
-	if cfg.Options.Debug {
-		debugFile, _ := os.OpenFile("/tmp/crush-debug.log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if debugFile != nil {
-			fmt.Fprintf(debugFile, "DEBUG: Successfully parsed generic response\n")
-			debugFile.Close()
-		}
-	}
 	
 	// Extract choices
 	choicesInterface, ok := genericResponse["choices"]


### PR DESCRIPTION
Why? Because Qwen 3 Coder there is faaaaaast https://www.cerebras.ai/blog/qwen3-coder-480b-is-live-on-cerebras

This PR introduces a compatibility mode that provides a clean fallback for providers with OpenAI client incompatibilities:
This is horribly vibed, you likely want a different solution, I let Claude do it's thing in a loop till it worked.

  Key Changes

  1. Compatibility Mode Toggle
  "extra_params": {
    "compatibility_mode": "true"
  }
  2. Custom HTTP Implementation
    - Bypasses OpenAI Go client for both streaming and non-streaming requests
    - Uses only essential parameters (model, messages, max_tokens, stream)
    - Avoids problematic max_completion_tokens parameter entirely
  3. Flexible JSON Parsing
    - Uses generic map[string]interface{} instead of rigid OpenAI structs
    - Gracefully handles provider-specific response fields
    - Maintains compatibility with standard OpenAI response format
  4. Full Streaming Support
    - Implements Server-Sent Events (SSE) parsing with bufio.Scanner
    - Parses data: lines and extracts content deltas in real-time
    - Emits proper EventContentDelta events for smooth streaming UX

  Configuration Loading Fix

  Also fixes extra_params configuration loading:
  - Changes json:"-" to json:"extra_params,omitempty" in config structs
  - Ensures user-configured parameters are preserved during config loading

  Testing

  - ✅ Non-streaming: Cerebras API calls succeed without 422 errors
  - ✅ Streaming: Real-time content deltas work properly (tested via curl)
  - ✅ Backward compatibility: Standard OpenAI providers unaffected
  - ✅ Configuration: extra_params correctly loaded from JSON config

  Impact

  - Enables Cerebras support in Crush with full streaming capabilities
  - Provides framework for other OpenAI-compatible providers with similar issues
  - Zero impact on existing OpenAI, Anthropic, or other standard providers
  - Minimal code changes - compatibility mode is opt-in via configuration

  This solution transforms Cerebras from completely broken (422 errors) to fully functional with streaming
  support, while maintaining clean separation from the standard OpenAI client code path.

<img width="912" height="740" alt="Screenshot 2025-08-01 at 23 49 17" src="https://github.com/user-attachments/assets/e8064605-da7d-442f-a96e-4ecd8c599748" />
