### PR TITLE
Update OpenAI provider for error responses

### DIFF
--- a/internal/llm/provider/openai.go
+++ b/internal/llm/provider/openai.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -164,8 +165,23 @@ func (o *openaiClient) convertMessages(messages []message.Message) (openaiMessag
 
 		case message.Tool:
 			for _, result := range msg.ToolResults() {
+				content := result.Content
+				if result.IsError {
+					structured := struct {
+						Content string `json:"content"`
+						IsError bool   `json:"is_error"`
+					}{
+						Content: result.Content,
+						IsError: true,
+					}
+					if data, err := json.Marshal(structured); err == nil {
+						content = string(data)
+					} else {
+						slog.Warn("failed to marshal tool error", "err", err)
+					}
+				}
 				openaiMessages = append(openaiMessages,
-					openai.ToolMessage(result.Content, result.ToolCallID),
+					openai.ToolMessage(content, result.ToolCallID),
 				)
 			}
 		}

--- a/internal/llm/provider/openai_test.go
+++ b/internal/llm/provider/openai_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	_, err := config.Init("../../..", true)
+	_, err := config.Init(".", true)
 	if err != nil {
 		panic("Failed to initialize config: " + err.Error())
 	}


### PR DESCRIPTION
### Describe your changes
The OpenAI provider doesn't return the isError state to the LLM, leading to LLM confusion in many cases, such as where it requests and `edit` and it given only the error text. Crucially in this case, the error text isn't very clear, and doesn't explicitly say that an error occurred.

For example if the LLM says something like `edit` with `old_text` and `new_text` the same, the ToolResponse will say the two fields were the same without clearly stating it was an error.

In my observations, this led the LLM to frequently assume it succeeded... which is silly, but so it goes. This included relatively capable LLMs such as o3.

Inserting the isError into the response as a JSON blob should resolve this, and approximately matches what Anthropic does.

### Open Question

I chose to not format the response as JSON when there is no error, to preserve existing behavior and readability. But LLMs would be fine with JSON at all times, so that may be a desired state for consistency of response?

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code