### PR TITLE
feat: add API key logging with masking

### DIFF
--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -18,6 +18,7 @@ import (
 	"github.com/charmbracelet/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/llm/tools"
+	"github.com/charmbracelet/crush/internal/log"
 	"github.com/charmbracelet/crush/internal/message"
 )
 
@@ -272,6 +273,12 @@ func (a *anthropicClient) send(ctx context.Context, messages []message.Message, 
 		if a.isThinkingEnabled() {
 			opts = append(opts, option.WithHeaderAdd("anthropic-beta", "interleaved-thinking-2025-05-14"))
 		}
+		
+		slog.Info("Making Anthropic API request", 
+			"api_key", log.MaskAPIKey(a.providerOptions.apiKey),
+			"model", preparedMessages.Model,
+			"attempt", attempts)
+		
 		anthropicResponse, err := a.client.Messages.New(
 			ctx,
 			preparedMessages,
@@ -329,6 +336,11 @@ func (a *anthropicClient) stream(ctx context.Context, messages []message.Message
 			if a.isThinkingEnabled() {
 				opts = append(opts, option.WithHeaderAdd("anthropic-beta", "interleaved-thinking-2025-05-14"))
 			}
+
+			slog.Info("Making Anthropic streaming API request", 
+				"api_key", log.MaskAPIKey(a.providerOptions.apiKey),
+				"model", preparedMessages.Model,
+				"attempt", attempts)
 
 			anthropicStream := a.client.Messages.NewStreaming(
 				ctx,

--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -274,7 +274,7 @@ func (a *anthropicClient) send(ctx context.Context, messages []message.Message, 
 			opts = append(opts, option.WithHeaderAdd("anthropic-beta", "interleaved-thinking-2025-05-14"))
 		}
 		
-		slog.Info("Making Anthropic API request", 
+		slog.Debug("Making Anthropic API request", 
 			"api_key", log.MaskAPIKey(a.providerOptions.apiKey),
 			"model", preparedMessages.Model,
 			"attempt", attempts)
@@ -337,7 +337,7 @@ func (a *anthropicClient) stream(ctx context.Context, messages []message.Message
 				opts = append(opts, option.WithHeaderAdd("anthropic-beta", "interleaved-thinking-2025-05-14"))
 			}
 
-			slog.Info("Making Anthropic streaming API request", 
+			slog.Debug("Making Anthropic streaming API request", 
 				"api_key", log.MaskAPIKey(a.providerOptions.apiKey),
 				"model", preparedMessages.Model,
 				"attempt", attempts)

--- a/internal/llm/provider/gemini.go
+++ b/internal/llm/provider/gemini.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/llm/tools"
+	"github.com/charmbracelet/crush/internal/log"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/google/uuid"
 	"google.golang.org/genai"
@@ -198,6 +199,11 @@ func (g *geminiClient) send(ctx context.Context, messages []message.Message, too
 	attempts := 0
 	for {
 		attempts++
+		slog.Info("Making Gemini API request", 
+			"api_key", log.MaskAPIKey(g.providerOptions.apiKey),
+			"model", model.ID,
+			"attempt", attempts)
+		
 		var toolCalls []message.ToolCall
 
 		var lastMsgParts []genai.Part
@@ -307,6 +313,11 @@ func (g *geminiClient) stream(ctx context.Context, messages []message.Message, t
 
 		for {
 			attempts++
+			
+			slog.Info("Making Gemini streaming API request", 
+				"api_key", log.MaskAPIKey(g.providerOptions.apiKey),
+				"model", model.ID,
+				"attempt", attempts)
 
 			currentContent := ""
 			toolCalls := []message.ToolCall{}

--- a/internal/llm/provider/gemini.go
+++ b/internal/llm/provider/gemini.go
@@ -199,7 +199,7 @@ func (g *geminiClient) send(ctx context.Context, messages []message.Message, too
 	attempts := 0
 	for {
 		attempts++
-		slog.Info("Making Gemini API request", 
+		slog.Debug("Making Gemini API request", 
 			"api_key", log.MaskAPIKey(g.providerOptions.apiKey),
 			"model", model.ID,
 			"attempt", attempts)
@@ -314,7 +314,7 @@ func (g *geminiClient) stream(ctx context.Context, messages []message.Message, t
 		for {
 			attempts++
 			
-			slog.Info("Making Gemini streaming API request", 
+			slog.Debug("Making Gemini streaming API request", 
 				"api_key", log.MaskAPIKey(g.providerOptions.apiKey),
 				"model", model.ID,
 				"attempt", attempts)

--- a/internal/llm/provider/openai.go
+++ b/internal/llm/provider/openai.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/llm/tools"
+	"github.com/charmbracelet/crush/internal/log"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -258,6 +259,11 @@ func (o *openaiClient) send(ctx context.Context, messages []message.Message, too
 	attempts := 0
 	for {
 		attempts++
+		slog.Info("Making OpenAI API request", 
+			"api_key", log.MaskAPIKey(o.providerOptions.apiKey),
+			"model", params.Model,
+			"attempt", attempts)
+		
 		openaiResponse, err := o.client.Chat.Completions.New(
 			ctx,
 			params,
@@ -327,6 +333,12 @@ func (o *openaiClient) stream(ctx context.Context, messages []message.Message, t
 			if len(params.Tools) == 0 {
 				params.Tools = nil
 			}
+			
+			slog.Info("Making OpenAI streaming API request", 
+				"api_key", log.MaskAPIKey(o.providerOptions.apiKey),
+				"model", params.Model,
+				"attempt", attempts)
+			
 			openaiStream := o.client.Chat.Completions.NewStreaming(
 				ctx,
 				params,

--- a/internal/llm/provider/openai.go
+++ b/internal/llm/provider/openai.go
@@ -259,7 +259,7 @@ func (o *openaiClient) send(ctx context.Context, messages []message.Message, too
 	attempts := 0
 	for {
 		attempts++
-		slog.Info("Making OpenAI API request", 
+		slog.Debug("Making OpenAI API request", 
 			"api_key", log.MaskAPIKey(o.providerOptions.apiKey),
 			"model", params.Model,
 			"attempt", attempts)
@@ -334,7 +334,7 @@ func (o *openaiClient) stream(ctx context.Context, messages []message.Message, t
 				params.Tools = nil
 			}
 			
-			slog.Info("Making OpenAI streaming API request", 
+			slog.Debug("Making OpenAI streaming API request", 
 				"api_key", log.MaskAPIKey(o.providerOptions.apiKey),
 				"model", params.Model,
 				"attempt", attempts)

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -44,6 +45,28 @@ func Setup(logFile string, debug bool) {
 
 func Initialized() bool {
 	return initialized.Load()
+}
+
+// MaskAPIKey masks an API key by showing only the first and last 5 characters.
+// For keys shorter than 10 characters, it shows first 2 and last 2 characters.
+// Returns "***EMPTY***" for empty strings.
+func MaskAPIKey(apiKey string) string {
+	if apiKey == "" {
+		return "***EMPTY***"
+	}
+	
+	// Remove common prefixes
+	key := strings.TrimPrefix(apiKey, "Bearer ")
+	key = strings.TrimPrefix(key, "sk-")
+	
+	keyLen := len(key)
+	if keyLen <= 4 {
+		return strings.Repeat("*", keyLen)
+	} else if keyLen <= 10 {
+		return key[:2] + strings.Repeat("*", keyLen-4) + key[keyLen-2:]
+	} else {
+		return key[:5] + strings.Repeat("*", keyLen-10) + key[keyLen-5:]
+	}
 }
 
 func RecoverPanic(name string, cleanup func()) {


### PR DESCRIPTION
- Add MaskAPIKey utility function to log package that shows first/last 5 chars
- Add request logging to all provider implementations (Anthropic, OpenAI, Gemini)
- Log masked API key, model name, and attempt number for each request
- Supports various key formats (Bearer tokens, sk- prefixes, etc.)
- Azure, Bedrock, and VertexAI inherit logging from their base providers

This provides visibility into which API keys are being used for requests
while maintaining security by masking sensitive parts of the keys.