### PR TITLE
Fix: Session Summarization Dialog Hanging Indefinitely

### DIFF
--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -754,7 +754,7 @@ func (a *agent) Summarize(ctx context.Context, sessionID string) error {
 			if r.Error != nil {
 				event = AgentEvent{
 					Type:  AgentEventTypeError,
-					Error: fmt.Errorf("failed to summarize: %w", err),
+					Error: fmt.Errorf("failed to summarize: %w", r.Error),
 					Done:  true,
 				}
 				a.Publish(pubsub.CreatedEvent, event)

--- a/internal/tui/components/dialogs/compact/compact.go
+++ b/internal/tui/components/dialogs/compact/compact.go
@@ -104,16 +104,23 @@ func (c *compactDialogCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case agent.AgentEvent:
-		if msg.Type == agent.AgentEventTypeSummarize {
+		switch msg.Type {
+		case agent.AgentEventTypeSummarize:
 			if msg.Error != nil {
 				c.state = stateError
 				c.progress = "Error: " + msg.Error.Error()
 			} else if msg.Done {
-				return c, util.CmdHandler(
-					dialogs.CloseDialogMsg{},
-				)
+				return c, util.CmdHandler(dialogs.CloseDialogMsg{})
 			} else {
 				c.progress = msg.Progress
+			}
+		case agent.AgentEventTypeError:
+			// Handle errors that occur during summarization but are sent as separate error events.
+			c.state = stateError
+			if msg.Error != nil {
+				c.progress = "Error: " + msg.Error.Error()
+			} else {
+				c.progress = "An unknown error occurred"
 			}
 		}
 		return c, nil


### PR DESCRIPTION
- Fixes a critical bug where the session summarization dialog would get stuck in "Generating Summary... Please wait..." state and never close
- Resolves error formatting issues that caused `%!w(<nil>)` display in error messages

## Problem

When users selected "Summarize Session" from the command menu, the dialog would:
1. Show "Generating Summary... Please wait..." 
2. Never disappear, even when errors occurred
3. Display malformed error messages like `Error: failed to summarize: %!w(<nil>)`

This left users unable to interact with the application and unclear about what went wrong.

## Root Cause

Two separate issues were causing this behavior:

1. **Incorrect error variable usage** in `agent.go`: The code was trying to format a `nil` error variable (`err`) instead of the actual response error (`r.Error`)
2. **Missing error event handling** in `compact.go`: The dialog only listened for `AgentEventTypeSummarize` events but ignored `AgentEventTypeError` events, so it never transitioned to error state

## Solution

### 1. Fixed Error Formatting (`internal/llm/agent/agent.go`)
```go
// Before: Used wrong error variable
Error: fmt.Errorf("failed to summarize: %w", err),

// After: Use actual response error
Error: fmt.Errorf("failed to summarize: %w", r.Error),
```

### 2. Added Error Event Handling (`internal/tui/components/dialogs/compact/compact.go`)
```go
// Before: Only handled summarize events
if msg.Type == agent.AgentEventTypeSummarize {
    // handle events
}

// After: Handle both summarize and error events
switch msg.Type {
case agent.AgentEventTypeSummarize:
    // handle summarize events
case agent.AgentEventTypeError:
    // handle error events and show proper error state
}
```

## Test Plan

- [x] Build succeeds without errors
- [x] All existing tests pass
- [x] Code formatted with gofmt
- [x] Manual testing shows dialog now properly displays errors instead of hanging

## Impact

- **User Experience**: Users will now see clear error messages instead of hanging dialogs
- **Reliability**: Session summarization failures are properly communicated
- **Debugging**: Error messages are now properly formatted and informative

💖 Generated with Crush

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
