### PR TITLE
fix(openai): 429 insuffice not retry

### DIFF
--- a/internal/llm/provider/openai_test.go
+++ b/internal/llm/provider/openai_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -86,5 +87,80 @@ func TestOpenAIClientStreamChoices(t *testing.T) {
 		if event.Type == EventError || event.Type == EventComplete {
 			break
 		}
+	}
+}
+
+func TestOpenAIClient429InsufficientQuotaError(t *testing.T) {
+	client := &openaiClient{
+		providerOptions: providerClientOptions{
+			modelType:     config.SelectedModelTypeLarge,
+			apiKey:        "test-key",
+			systemMessage: "test",
+			config: config.ProviderConfig{
+				ID:     "test-openai",
+				APIKey: "test-key",
+			},
+			model: func(config.SelectedModelType) catwalk.Model {
+				return catwalk.Model{
+					ID:   "test-model",
+					Name: "test-model",
+				}
+			},
+		},
+	}
+
+	// Test insufficient_quota error should not retry
+	apiErr := &openai.Error{
+		StatusCode: 429,
+		Message:    "You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.",
+		Type:       "insufficient_quota",
+		Code:       "insufficient_quota",
+	}
+
+	retry, _, err := client.shouldRetry(1, apiErr)
+	if retry {
+		t.Error("Expected shouldRetry to return false for insufficient_quota error, but got true")
+	}
+	if err == nil {
+		t.Error("Expected shouldRetry to return an error for insufficient_quota, but got nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "quota") {
+		t.Errorf("Expected error message to mention quota, got: %v", err)
+	}
+}
+
+func TestOpenAIClient429RateLimitError(t *testing.T) {
+	client := &openaiClient{
+		providerOptions: providerClientOptions{
+			modelType:     config.SelectedModelTypeLarge,
+			apiKey:        "test-key",
+			systemMessage: "test",
+			config: config.ProviderConfig{
+				ID:     "test-openai",
+				APIKey: "test-key",
+			},
+			model: func(config.SelectedModelType) catwalk.Model {
+				return catwalk.Model{
+					ID:   "test-model",
+					Name: "test-model",
+				}
+			},
+		},
+	}
+
+	// Test regular rate limit error should retry
+	apiErr := &openai.Error{
+		StatusCode: 429,
+		Message:    "Rate limit reached for requests",
+		Type:       "rate_limit_exceeded",
+		Code:       "rate_limit_exceeded",
+	}
+
+	retry, _, err := client.shouldRetry(1, apiErr)
+	if !retry {
+		t.Error("Expected shouldRetry to return true for rate_limit_exceeded error, but got false")
+	}
+	if err != nil {
+		t.Errorf("Expected shouldRetry to return nil error for rate_limit_exceeded, but got: %v", err)
 	}
 }


### PR DESCRIPTION
### Describe your changes

- Add better error handling for when OpenAI returns a 429 error with `insufficient_quota` type (indicating the API key has exceeded its usage quota).
- The current retry logic continues indefinitely instead of failing immediately. This causes user prompts to hang without any meaningful feedback.

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
