### PR TITLE
fix(tui): underline quit dialog buttons

### DIFF
--- a/internal/tui/components/dialogs/quit/quit.go
+++ b/internal/tui/components/dialogs/quit/quit.go
@@ -80,8 +80,10 @@ func (q *quitDialogCmp) View() string {
 	}
 
 	const horizontalPadding = 3
-	yesButton := yesStyle.Padding(0, horizontalPadding).Render("Yep!")
-	noButton := noStyle.Padding(0, horizontalPadding).Render("Nope")
+	yesButton := yesStyle.PaddingLeft(horizontalPadding).Underline(true).Render("Y") +
+		yesStyle.PaddingRight(horizontalPadding).Render("ep!")
+	noButton := noStyle.PaddingLeft(horizontalPadding).Underline(true).Render("N") +
+		noStyle.PaddingRight(horizontalPadding).Render("ope")
 
 	buttons := baseStyle.Width(lipgloss.Width(question)).Align(lipgloss.Right).Render(
 		lipgloss.JoinHorizontal(lipgloss.Center, yesButton, "  ", noButton),


### PR DESCRIPTION
This underlines the "Y" and "N" in "Yep!" and "Nope" of the quit dialog to make it consistent with other dialogs and indicates that these buttons can be activated by a key press.

Before:
<img width="912" height="778" alt="image" src="https://github.com/user-attachments/assets/06224da1-416c-4c7f-871c-522f1df4f1dc" />


After:
<img width="912" height="778" alt="image" src="https://github.com/user-attachments/assets/dea65cea-21d5-472d-9c77-3c3852ddb831" />
