### PR TITLE
fix(permission): resolve issue with permission requests hanging

### DIFF
--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -179,15 +179,6 @@ func (s *permissionService) Request(opts CreatePermissionRequest) bool {
 	}
 	s.sessionPermissionsMu.RUnlock()
 
-	s.sessionPermissionsMu.RLock()
-	for _, p := range s.sessionPermissions {
-		if p.ToolName == permission.ToolName && p.Action == permission.Action && p.SessionID == permission.SessionID && p.Path == permission.Path {
-			s.sessionPermissionsMu.RUnlock()
-			return true
-		}
-	}
-	s.sessionPermissionsMu.RUnlock()
-
 	s.activeRequest = &permission
 
 	respCh := make(chan bool, 1)

--- a/internal/tui/components/dialogs/permissions/permissions.go
+++ b/internal/tui/components/dialogs/permissions/permissions.go
@@ -156,13 +156,13 @@ func (p *permissionDialogCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				p.contentDirty = true // Mark content as dirty when scrolling
 				return p, nil
 			}
-		default:
-			// Pass other keys to viewport
-			viewPort, cmd := p.contentViewPort.Update(msg)
-			p.contentViewPort = viewPort
-			cmds = append(cmds, cmd)
 		}
 	}
+
+	// Pass other keys to viewport
+	viewPort, cmd := p.contentViewPort.Update(msg)
+	p.contentViewPort = viewPort
+	cmds = append(cmds, cmd)
 
 	return p, tea.Batch(cmds...)
 }


### PR DESCRIPTION
This commit addresses a bug where the application would hang when a permission request was displayed. The root cause was twofold:

1.  An issue in the TUI component for permissions (`internal/tui/components/dialogs/permissions/permissions.go`) where unhandled keypress events were being swallowed by the viewport, preventing the permission response from being sent. This has been corrected by ensuring that all keypresses are appropriately handled or allowed to bubble up.

2.  A duplicated block of code in the permission service (`internal/permission/permission.go`) that checked for existing session permissions twice. This has been removed to improve efficiency.

These changes ensure that the permission dialog correctly handles user input and that the permission service operates as expected, resolving the hanging issue and improving code quality.

### Describe your changes

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
