### PR TITLE
Copy selected text

### DIFF
--- a/internal/tui/components/chat/messages/messages.go
+++ b/internal/tui/components/chat/messages/messages.go
@@ -101,11 +101,14 @@ func (m *messageCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case tea.KeyPressMsg:
 		if key.Matches(msg, CopyKey) {
-			err := clipboard.WriteAll(m.message.Content().Text)
-			if err != nil {
-				return m, util.ReportError(fmt.Errorf("failed to copy message content to clipboard: %w", err))
-			}
-			return m, util.ReportInfo("Message copied to clipboard")
+			return m, tea.Sequence(
+				tea.SetClipboard(m.message.Content().Text),
+				func() tea.Msg {
+					_ = clipboard.WriteAll(m.message.Content().Text)
+					return nil
+				},
+				util.ReportInfo("Message copied to clipboard"),
+			)
 		}
 	}
 	return m, nil

--- a/internal/tui/components/chat/messages/messages.go
+++ b/internal/tui/components/chat/messages/messages.go
@@ -25,7 +25,8 @@ import (
 	"github.com/charmbracelet/crush/internal/tui/util"
 )
 
-var copyKey = key.NewBinding(key.WithKeys("c", "y", "C", "Y"), key.WithHelp("c/y", "copy"))
+// CopyKey is the key binding for copying message content to the clipboard.
+var CopyKey = key.NewBinding(key.WithKeys("c", "y", "C", "Y"), key.WithHelp("c/y", "copy"))
 
 // MessageCmp defines the interface for message components in the chat interface.
 // It combines standard UI model interfaces with message-specific functionality.
@@ -99,7 +100,7 @@ func (m *messageCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		}
 	case tea.KeyPressMsg:
-		if key.Matches(msg, copyKey) {
+		if key.Matches(msg, CopyKey) {
 			err := clipboard.WriteAll(m.message.Content().Text)
 			if err != nil {
 				return m, util.ReportError(fmt.Errorf("failed to copy message content to clipboard: %w", err))

--- a/internal/tui/components/chat/messages/tool.go
+++ b/internal/tui/components/chat/messages/tool.go
@@ -198,11 +198,14 @@ func (m *toolCallCmp) SetCancelled() {
 
 func (m *toolCallCmp) copyTool() tea.Cmd {
 	content := m.formatToolForCopy()
-	err := clipboard.WriteAll(content)
-	if err != nil {
-		return util.ReportError(fmt.Errorf("failed to copy tool content to clipboard: %w", err))
-	}
-	return util.ReportInfo("Tool content copied to clipboard")
+	return tea.Sequence(
+		tea.SetClipboard(content),
+		func() tea.Msg {
+			_ = clipboard.WriteAll(content)
+			return nil
+		},
+		util.ReportInfo("Tool content copied to clipboard"),
+	)
 }
 
 func (m *toolCallCmp) formatToolForCopy() string {

--- a/internal/tui/components/chat/messages/tool.go
+++ b/internal/tui/components/chat/messages/tool.go
@@ -165,7 +165,7 @@ func (m *toolCallCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Batch(cmds...)
 	case tea.KeyPressMsg:
-		if key.Matches(msg, copyKey) {
+		if key.Matches(msg, CopyKey) {
 			return m, m.copyTool()
 		}
 	}

--- a/internal/tui/exp/list/list.go
+++ b/internal/tui/exp/list/list.go
@@ -56,6 +56,7 @@ type List[T Item] interface {
 	SelectWord(col, line int)
 	SelectParagraph(col, line int)
 	GetSelectedText(paddingLeft int) string
+	HasSelection() bool
 }
 
 type direction int
@@ -286,30 +287,10 @@ func (l *list[T]) handleMouseWheel(msg tea.MouseWheelMsg) (tea.Model, tea.Cmd) {
 	return l, cmd
 }
 
-// View implements List.
-func (l *list[T]) View() string {
-	if l.height <= 0 || l.width <= 0 {
-		return ""
-	}
+// selectionView renders the highlighted selection in the view and returns it
+// as a string. If textOnly is true, it won't render any styles.
+func (l *list[T]) selectionView(view string, textOnly bool) string {
 	t := styles.CurrentTheme()
-	view := l.rendered
-	lines := strings.Split(view, "\n")
-
-	start, end := l.viewPosition()
-	viewStart := max(0, start)
-	viewEnd := min(len(lines), end+1)
-	lines = lines[viewStart:viewEnd]
-	if l.resize {
-		return strings.Join(lines, "\n")
-	}
-	view = t.S().Base.
-		Height(l.height).
-		Width(l.width).
-		Render(strings.Join(lines, "\n"))
-
-	if !l.hasSelection() {
-		return view
-	}
 	area := uv.Rect(0, 0, l.width, l.height)
 	scr := uv.NewScreenBuffer(area.Dx(), area.Dy())
 	uv.NewStyledString(view).Draw(scr, area)
@@ -397,6 +378,8 @@ func (l *list[T]) View() string {
 		lineTextBounds[y] = bounds
 	}
 
+	var selectedText strings.Builder
+
 	// Second pass: apply selection highlighting
 	for y := range scr.Height() {
 		selBounds := lineSelections[y]
@@ -421,14 +404,57 @@ func (l *list[T]) View() string {
 
 			cellStr := cell.String()
 			if len(cellStr) > 0 && !specialChars[cellStr] {
+				if textOnly {
+					// Collect selected text without styles
+					selectedText.WriteString(cell.String())
+					continue
+				}
+
 				cell = cell.Clone()
 				cell.Style = cell.Style.Background(t.BgOverlay).Foreground(t.White)
 				scr.SetCell(x, y, cell)
 			}
 		}
+
+		if textOnly {
+			// Make sure we add a newline after each line of selected text
+			selectedText.WriteByte('\n')
+		}
+	}
+
+	if textOnly {
+		return strings.TrimSpace(selectedText.String())
 	}
 
 	return scr.Render()
+}
+
+// View implements List.
+func (l *list[T]) View() string {
+	if l.height <= 0 || l.width <= 0 {
+		return ""
+	}
+	t := styles.CurrentTheme()
+	view := l.rendered
+	lines := strings.Split(view, "\n")
+
+	start, end := l.viewPosition()
+	viewStart := max(0, start)
+	viewEnd := min(len(lines), end+1)
+	lines = lines[viewStart:viewEnd]
+	if l.resize {
+		return strings.Join(lines, "\n")
+	}
+	view = t.S().Base.
+		Height(l.height).
+		Width(l.width).
+		Render(strings.Join(lines, "\n"))
+
+	if !l.hasSelection() {
+		return view
+	}
+
+	return l.selectionView(view, false)
 }
 
 func (l *list[T]) viewPosition() (int, int) {
@@ -1374,69 +1400,16 @@ func (l *list[T]) SelectParagraph(col, line int) {
 	l.selectionActive = false // Not actively selecting, just selected
 }
 
+// HasSelection returns whether there is an active selection.
+func (l *list[T]) HasSelection() bool {
+	return l.hasSelection()
+}
+
 // GetSelectedText returns the currently selected text.
 func (l *list[T]) GetSelectedText(paddingLeft int) string {
-	return ""
-	// if !l.hasSelection() {
-	// 	return ""
-	// }
-	//
-	// startLine := l.selectionStartLine
-	// endLine := l.selectionEndLine
-	// startCol := l.selectionStartCol
-	// endCol := l.selectionEndCol
-	//
-	// if l.direction == DirectionBackward {
-	// 	startLine = (lipgloss.Height(l.rendered) - 1) - startLine
-	// 	endLine = (lipgloss.Height(l.rendered) - 1) - endLine
-	// }
-	//
-	// if l.offset > 0 {
-	// 	if l.direction == DirectionBackward {
-	// 		startLine += l.offset
-	// 		endLine += l.offset
-	// 	} else {
-	// 		startLine -= l.offset
-	// 		endLine -= l.offset
-	// 	}
-	// }
-	//
-	// lines := strings.Split(l.rendered, "\n")
-	//
-	// if startLine < 0 || endLine < 0 || startLine >= len(lines) || endLine >= len(lines) {
-	// 	return ""
-	// }
-	//
-	// var result strings.Builder
-	// for i := range lines {
-	// 	lines[i] = ansi.Strip(lines[i])
-	// 	for _, icon := range styles.SelectionIgnoreIcons {
-	// 		lines[i] = strings.ReplaceAll(lines[i], icon, " ")
-	// 	}
-	//
-	// 	if i == startLine {
-	// 		if startCol < 0 || startCol >= len(lines[i]) {
-	// 			startCol = 0
-	// 		}
-	// 		if startCol < paddingLeft {
-	// 			startCol = paddingLeft
-	// 		}
-	// 		if i != endLine {
-	// 			endCol = len(lines[i])
-	// 		}
-	// 		result.WriteString(strings.TrimRightFunc(lines[i][startCol:endCol], unicode.IsSpace))
-	// 	} else if i > startLine && i < endLine {
-	// 		result.WriteString(strings.TrimRightFunc(lines[i][paddingLeft:], unicode.IsSpace))
-	// 	} else if i == endLine {
-	// 		if endCol < 0 || endCol >= len(lines[i]) {
-	// 			endCol = len(lines[i])
-	// 		}
-	// 		if endCol < paddingLeft {
-	// 			endCol = paddingLeft
-	// 		}
-	// 		result.WriteString(strings.TrimRightFunc(lines[i][paddingLeft:endCol], unicode.IsSpace))
-	// 	}
-	// }
-	//
-	// return result.String()
+	if !l.hasSelection() {
+		return ""
+	}
+
+	return l.selectionView(l.View(), true)
 }

--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -19,6 +19,7 @@ import (
 	"github.com/charmbracelet/crush/internal/tui/components/chat"
 	"github.com/charmbracelet/crush/internal/tui/components/chat/editor"
 	"github.com/charmbracelet/crush/internal/tui/components/chat/header"
+	"github.com/charmbracelet/crush/internal/tui/components/chat/messages"
 	"github.com/charmbracelet/crush/internal/tui/components/chat/sidebar"
 	"github.com/charmbracelet/crush/internal/tui/components/chat/splash"
 	"github.com/charmbracelet/crush/internal/tui/components/completions"
@@ -865,10 +866,7 @@ func (p *chatPage) Help() help.KeyMap {
 					key.WithKeys("up", "down"),
 					key.WithHelp("↑↓", "scroll"),
 				),
-				key.NewBinding(
-					key.WithKeys("c", "y"),
-					key.WithHelp("c/y", "copy"),
-				),
+				messages.CopyKey,
 			)
 			fullList = append(fullList,
 				[]key.Binding{

--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -172,10 +172,18 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return p, nil
 	case tea.MouseClickMsg:
+		if p.isMouseOverChat(msg.X, msg.Y) {
+			p.focusedPane = PanelTypeChat
+			p.chat.Focus()
+			p.editor.Blur()
+		} else {
+			p.focusedPane = PanelTypeEditor
+			p.editor.Focus()
+			p.chat.Blur()
+		}
 		u, cmd := p.chat.Update(msg)
 		p.chat = u.(chat.MessageListCmp)
 		return p, cmd
-		return p, nil
 	case tea.MouseMotionMsg:
 		if msg.Button == tea.MouseLeft {
 			u, cmd := p.chat.Update(msg)


### PR DESCRIPTION
This makes selected text copyable via `c` or `y` keybind.

To make it clear that we're in _copy mode_, we switch the focus to the messages list when the user start selecting text. Once some text is selected, using the copy keybind will copy the selected text then clear the selection on the screen. The user still needs to shift the focus back to the editor via click or the `tab` key.