### PR TITLE
feat(config): Add support for custom Gemini providers

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -246,7 +246,7 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 			c.Providers.Del(id)
 			continue
 		}
-		if providerConfig.Type != catwalk.TypeOpenAI && providerConfig.Type != catwalk.TypeAnthropic {
+		if providerConfig.Type != catwalk.TypeOpenAI && providerConfig.Type != catwalk.TypeAnthropic && providerConfig.Type != catwalk.TypeGemini {
 			slog.Warn("Skipping custom provider because the provider type is not supported", "provider", id, "type", providerConfig.Type)
 			c.Providers.Del(id)
 			continue

--- a/internal/llm/provider/gemini.go
+++ b/internal/llm/provider/gemini.go
@@ -43,6 +43,9 @@ func createGeminiClient(opts providerClientOptions) (*genai.Client, error) {
 	cc := &genai.ClientConfig{
 		APIKey:  opts.apiKey,
 		Backend: genai.BackendGeminiAPI,
+		HTTPOptions: genai.HTTPOptions{
+			BaseURL: opts.baseURL,
+		},
 	}
 	if config.Get().Options.Debug {
 		cc.HTTPClient = log.NewHTTPClient()


### PR DESCRIPTION
## Description

This PR enhances provider configuration by allowing users to define custom providers of `type: "gemini"` in `crush.json`.

This change enables users to connect to any Gemini-compatible API endpoint, such as a local proxy, a self-hosted model, or a third-party service. The custom provider is configured under the `providers` map, where users can specify a `base_url`, `api_key`, and a list of `models`.

This approach provides more flexibility than a simple global override.

## Example `crush.json` Configuration

```json
{
  "providers": {
    "gemini-proxy": {
      "name": "gemini-proxy",
      "type": "gemini",
      "base_url": "http://127.0.0.1:9300/gemini",
      "api_key": "your-api-key-here",
      "models": [
      {
        "name": "gemini-2.5-pro(proxied)",
        "id": "gemini-2.5-pro",
        "context_window": 1024000
        }
      ]
    }
  }
}
```

## How to Test

1.  Add a custom provider configuration to `crush.json` as shown in the example above.
2.  Select a model from the custom provider (e.g., via the TUI or by setting it as a default).
3.  Run `crush` and confirm that API requests are sent to the specified `base_url`.
