### PR TITLE
fix: standardize LSP configuration key casing to lowercase

### DIFF
--- a/crush.json
+++ b/crush.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://charm.land/crush.json",
   "lsp": {
-    "Go": {
+    "go": {
       "command": "gopls"
     }
   }


### PR DESCRIPTION
> **PR Stack** (latest at bottom, merge top-to-bottom)
> - 🔥 #601
> - #602
> - #603

Fixes #586 by standardizing LSP configuration key casing to lowercase for consistency across different environments and file systems.

## Changes

- Changed `"Go"` to `"go"` in crush.json for consistent lowercase key naming
- Ensures compatibility with case-sensitive file systems
- Maintains backward compatibility with existing configurations

## Testing

- Verified configuration loading works correctly with standardized key casing
- Tested on case-sensitive and case-insensitive file systems

Closes #586