### PR TITLE
Add message history navigation to editor component

### DIFF
--- a/internal/tui/components/chat/editor/keys.go
+++ b/internal/tui/components/chat/editor/keys.go
@@ -5,10 +5,12 @@ import (
 )
 
 type EditorKeyMap struct {
-	AddFile     key.Binding
-	SendMessage key.Binding
-	OpenEditor  key.Binding
-	Newline     key.Binding
+	AddFile         key.Binding
+	SendMessage     key.Binding
+	OpenEditor      key.Binding
+	Newline         key.Binding
+	PreviousMessage key.Binding
+	NextMessage     key.Binding
 }
 
 func DefaultEditorKeyMap() EditorKeyMap {
@@ -32,6 +34,14 @@ func DefaultEditorKeyMap() EditorKeyMap {
 			// to reflect that.
 			key.WithHelp("ctrl+j", "newline"),
 		),
+		PreviousMessage: key.NewBinding(
+			key.WithKeys("up", "ctrl+p"),
+			key.WithHelp("↑/ctrl+p", "previous message"),
+		),
+		NextMessage: key.NewBinding(
+			key.WithKeys("down", "ctrl+n"),
+			key.WithHelp("↓/ctrl+n", "next message"),
+		),
 	}
 }
 
@@ -42,6 +52,8 @@ func (k EditorKeyMap) KeyBindings() []key.Binding {
 		k.SendMessage,
 		k.OpenEditor,
 		k.Newline,
+		k.PreviousMessage,
+		k.NextMessage,
 		AttachmentsKeyMaps.AttachmentDeleteMode,
 		AttachmentsKeyMaps.DeleteAllAttachments,
 		AttachmentsKeyMaps.Escape,


### PR DESCRIPTION
Implements previous message editing functionality with comprehensive navigation:

Features:
- Navigate through message history with Up/Down arrows or Ctrl+P/Ctrl+N
- Stores up to 50 messages in local history with duplicate avoidance
- Empty message state as newest option for typing new messages
- Smart history mode exit when typing regular content
- Escape key exits history mode and restores original draft
- Preserves user draft when navigating through history

Navigation flow:
- Up arrow: Navigate to older messages
- Down arrow: Navigate to newer messages, ending at empty message state
- Typing: Automatically exits history mode
- Escape: Manual exit with draft restoration

Technical implementation:
- Added messageHistory, historyIndex, originalValue, inHistoryMode fields
- Extended EditorKeyMap with PreviousMessage and NextMessage bindings
- Implemented addToHistory(), navigateHistory(), exitHistoryMode() methods
- Enhanced key handling logic with history navigation support
- Maintains compatibility with existing editor functionality

🤖 Generated with [Claude Code](https://claude.ai/code)

### Describe your changes

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
