### PR TITLE
fix(mcp): handle multiple text content outputs properly

### DIFF
--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -122,14 +123,15 @@ func runTool(ctx context.Context, name, toolName string, input string) (tools.To
 		return tools.NewTextErrorResponse(err.Error()), nil
 	}
 
-	output := ""
+	var outputs []string
 	for _, v := range result.Content {
 		if v, ok := v.(mcp.TextContent); ok {
-			output = v.Text
+			outputs = append(outputs, v.Text)
 		} else {
-			output = fmt.Sprintf("%v", v)
+			outputs = append(outputs, fmt.Sprintf("%v", v))
 		}
 	}
+	output := strings.Join(outputs, "\n")
 
 	return tools.NewTextResponse(output), nil
 }


### PR DESCRIPTION
Collect all text content outputs from MCP tools and join them with newlines instead of only using the last output. This ensures all content is preserved when MCP tools return multiple text blocks.

🤖 Generated with [Claude Code](https://claude.ai/code)

### Describe your changes

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
