### PR TITLE
fix: Allow the `$schema` property in the JSON Schema

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -5,6 +5,10 @@
   "$defs": {
     "Config": {
       "properties": {
+        "$schema": {
+          "type": "string",
+          "format": "uri"
+        },
         "models": {
           "additionalProperties": {
             "$ref": "#/$defs/SelectedModel"


### PR DESCRIPTION
### Describe your changes

My JSON LSP complains when I edit my `crush.json` config at the `$schema` field. Since the `schema.json` file has `additionalProperties: false` and no `properties` entry for the `$schema` field that references the JSONSchema, I see an error. Rather than setting `additionalProperties` to `true`, just permitting the `$schema` field seems cleaner. This approach seems to be common [among schemas on GitHub](https://github.com/search?q=%22%5C%22%24schema%5C%22%3A+%7B%22+path%3Aschema.json&type=code).

#### Example

I used the `crush.json` from the README:

```json
{
  "$schema": "https://charm.land/crush.json",
  "lsp": {
    "go": {
      "command": "gopls"
    },
    "typescript": {
      "command": "typescript-language-server",
      "args": ["--stdio"]
    },
    "nix": {
      "command": "nil"
    }
  }
}
```

Here's me using the [jsonschema](https://github.com/santhosh-tekuri/jsonschema) tool to validate before the fix:

```bash
$ jv (jq '.["$schema"]' -r ~/.config/crush/crush.json) ~/.config/crush/crush.json
schema https://charm.land/crush.json: ok

instance /Users/smohr/.config/crush/crush.json: failed
jsonschema validation failed with 'https://charm.land/crush.json#'
- at '': additional properties '$schema' not allowed
```

And here's after the fix (with the new config in a local file, copied from the GitHub commit of this PR):

```bash
$ jv ~/dev/crush-jsonschema.json ~/.config/crush/crush.json
schema /Users/smohr/dev/crush-jsonschema.json: ok

instance /Users/smohr/.config/crush/crush.json: ok
```

### Checklist before requesting a review

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
