### PR TITLE
feat: add command history navigation

### DIFF
--- a/internal/tui/components/chat/editor/keys.go
+++ b/internal/tui/components/chat/editor/keys.go
@@ -9,6 +9,8 @@ type EditorKeyMap struct {
 	SendMessage key.Binding
 	OpenEditor  key.Binding
 	Newline     key.Binding
+	Next        key.Binding
+	Previous    key.Binding
 }
 
 func DefaultEditorKeyMap() EditorKeyMap {
@@ -31,6 +33,14 @@ func DefaultEditorKeyMap() EditorKeyMap {
 			// the terminal supports "shift+enter", we substitute the help text
 			// to reflect that.
 			key.WithHelp("ctrl+j", "newline"),
+		),
+		Next: key.NewBinding(
+			key.WithKeys("shift+down"),
+			key.WithHelp("shift+↓", "down"),
+		),
+		Previous: key.NewBinding(
+			key.WithKeys("shift+up"),
+			key.WithHelp("shift+↑", "up"),
 		),
 	}
 }


### PR DESCRIPTION
This allows users to cycle through their command history with `shift+up` and `shift+down`. The way I'm adding a " " to the list means that the user has to hit up twice because that value gets added to the end of the list of commands. Feel free to scrap if you don't like the implementation. There's a demo below


https://github.com/user-attachments/assets/d6f09daf-b717-48bc-b544-f6133a7dba2c


