### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ As an additional note, Crush also stores ephemeral data, such as application sta
 
 ```bash
 # Unix
-$HOME/.local/shared/crush/crush.json
+$HOME/.local/share/crush/crush.json
 
 # Windows
 %LOCALAPPDATA%\crush\crush.json


### PR DESCRIPTION
Typo fix in user data config directory on Unix

### Describe your changes

User data config is being written to `$HOME/.local/share/crush/`. README contains a typo in the standard directory path.


### Checklist before requesting a review

- [ x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x ] I have performed a self-review of my code

