### PR TITLE
fix(tui): editor: sanitize pasted paths

### DIFF
--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -228,7 +228,7 @@ func (m *editorCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.PasteMsg:
 		path := strings.ReplaceAll(string(msg), "\\ ", " ")
 		// try to get an image
-		path, err := filepath.Abs(path)
+		path, err := filepath.Abs(strings.TrimSpace(path))
 		if err != nil {
 			m.textarea, cmd = m.textarea.Update(msg)
 			return m, cmd


### PR DESCRIPTION
Some terminals may add a trailing space to pasted paths preventing the editor from recognizing them as valid file paths. This commit ensures that pasted paths are trimmed of leading and trailing spaces for paths.

This fixes an issue with Apple Terminal where pasted paths include a trailing space, preventing the detection of file attachments.