### PR TITLE
Add pixi to supported package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ nix run github:numtide/nix-ai-tools#crush
 # Scoop
 scoop bucket add charm https://github.com/charmbracelet/scoop-bucket.git
 scoop install crush
+
+# Conda-forge
+pixi global install crush
 ```
 
 <details>


### PR DESCRIPTION
### Describe your changes

[pixi](https://pixi.sh) is a modern package manager for the conda ecosystem that works on macOS, Linux and Windows.
Crush is also packaged on conda-forge: https://prefix.dev/channels/conda-forge/packages/crush

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
