### PR TITLE
feat: improve gitignore and crushignore support

### DIFF
--- a/internal/csync/maps.go
+++ b/internal/csync/maps.go
@@ -56,6 +56,18 @@ func (m *Map[K, V]) Len() int {
 	return len(m.inner)
 }
 
+// GetOrSet gets and returns the key if it exists, otherwise, it executes the
+// given function, set its return value for the given key, and returns it.
+func (m *Map[K, V]) GetOrSet(key K, fn func() V) V {
+	got, ok := m.Get(key)
+	if ok {
+		return got
+	}
+	value := fn()
+	m.Set(key, value)
+	return value
+}
+
 // Take gets an item and then deletes it.
 func (m *Map[K, V]) Take(key K) (V, bool) {
 	m.mu.Lock()

--- a/internal/csync/maps_test.go
+++ b/internal/csync/maps_test.go
@@ -54,6 +54,16 @@ func TestMap_Set(t *testing.T) {
 	require.Equal(t, 1, m.Len())
 }
 
+func TestMap_GetOrSet(t *testing.T) {
+	t.Parallel()
+
+	m := NewMap[string, int]()
+
+	require.Equal(t, 42, m.GetOrSet("key1", func() int { return 42 }))
+	require.Equal(t, 42, m.GetOrSet("key1", func() int { return 99999 }))
+	require.Equal(t, 1, m.Len())
+}
+
 func TestMap_Get(t *testing.T) {
 	t.Parallel()
 

--- a/internal/fsext/ignore_test.go
+++ b/internal/fsext/ignore_test.go
@@ -25,20 +25,8 @@ func TestCrushIgnore(t *testing.T) {
 	// Create a .crushignore file that ignores .log files
 	require.NoError(t, os.WriteFile(".crushignore", []byte("*.log\n"), 0o644))
 
-	// Test DirectoryLister
-	t.Run("DirectoryLister respects .crushignore", func(t *testing.T) {
-		dl := NewDirectoryLister(tempDir)
-
-		// Test that .log files are ignored
-		require.True(t, dl.gitignore == nil, "gitignore should be nil")
-		require.NotNil(t, dl.crushignore, "crushignore should not be nil")
-	})
-
-	// Test FastGlobWalker
-	t.Run("FastGlobWalker respects .crushignore", func(t *testing.T) {
-		walker := NewFastGlobWalker(tempDir)
-
-		require.True(t, walker.gitignore == nil, "gitignore should be nil")
-		require.NotNil(t, walker.crushignore, "crushignore should not be nil")
-	})
+	dl := NewDirectoryLister(tempDir)
+	require.True(t, dl.shouldIgnore("test2.log", nil), ".log files should be ignored")
+	require.False(t, dl.shouldIgnore("test1.txt", nil), ".txt files should not be ignored")
+	require.True(t, dl.shouldIgnore("test3.tmp", nil), ".tmp files should be ignored by common patterns")
 }

--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -473,7 +473,7 @@ func (m *editorCmp) SetPosition(x, y int) tea.Cmd {
 }
 
 func (m *editorCmp) startCompletions() tea.Msg {
-	files, _, _ := fsext.ListDirectory(".", []string{}, 0)
+	files, _, _ := fsext.ListDirectory(".", nil, 0)
 	completionItems := make([]completions.Completion, 0, len(files))
 	for _, file := range files {
 		file = strings.TrimPrefix(file, "./")


### PR DESCRIPTION
git checks, in order:
- ./.gitignore, ../.gitignore, etc, until repo root
- ~/.config/git/ignore
- ~/.gitignore
                                                          
This check the following:
- the given ignorePatterns
- crush's commonIgnorePatterns
- ./.gitignore, ../.gitignore, etc, until dl.rootPath
- ./.crushignore, ../.crushignore, etc, until dl.rootPath
- ~/.config/git/ignore
- ~/.gitignore
- ~/.config/crush/ignore
