### PR TITLE
refactor(agent): first step on splitting agent.go responsabilities

### DIFF
--- a/internal/llm/conversation/conversation.go
+++ b/internal/llm/conversation/conversation.go
@@ -1,0 +1,64 @@
+package conversation
+
+import (
+	"errors"
+
+	"github.com/charmbracelet/crush/internal/message"
+)
+
+type Conversation struct {
+	turns []message.Message
+}
+
+var ErrEmptyMessage = errors.New("message empty")
+
+// New creates a new Conversation containing the provided messages.
+// The input slice is copied to avoid sharing underlying arrays.
+func New(turns ...message.Message) Conversation {
+	return Conversation{turns: append([]message.Message(nil), turns...)}
+}
+
+// Len returns the number of messages in the conversation.
+func (c *Conversation) Len() int {
+	return len(c.turns)
+}
+
+// Messages returns a copy of all messages in the conversation.
+// The returned slice is a shallow copy to prevent external modification.
+func (c Conversation) Messages() []message.Message {
+	return append([]message.Message(nil), c.turns...)
+}
+
+// Add returns a new Conversation with the given message appended.
+// If the message has no content parts, ErrEmptyMessage is returned.
+func (c *Conversation) Add(m message.Message) (int, error) {
+	if len(m.Parts) == 0 {
+		return -1, ErrEmptyMessage
+	}
+	c.turns = append(c.turns, m)
+	return len(c.turns) - 1, nil
+}
+
+// WithRole returns a new Conversation containing only messages
+// that have the specified role. The order of messages is preserved.
+func (c Conversation) WithRole(role message.MessageRole) Conversation {
+	out := make([]message.Message, 0, len(c.turns))
+	for _, m := range c.turns {
+		if m.Role == role {
+			out = append(out, m)
+		}
+	}
+	return New(out...)
+}
+
+// First returns a new Conversation containing at most the first n messages.
+// If n is greater than the number of messages, the entire conversation is returned.
+func (c Conversation) First(n int) Conversation {
+	if n <= 0 {
+		return Conversation{turns: nil}
+	}
+	if n >= len(c.turns) {
+		return c
+	}
+	return New(c.turns[:n]...)
+}

--- a/internal/llm/conversation/loader.go
+++ b/internal/llm/conversation/loader.go
@@ -1,0 +1,41 @@
+package conversation
+
+import (
+	"context"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+)
+
+func LoadFromSession(
+	ctx context.Context,
+	session session.Session,
+	msgService message.Service,
+) (Conversation, error) {
+	messages, err := msgService.List(ctx, session.ID)
+	if err != nil {
+		return Conversation{}, err
+	}
+
+	var turns []message.Message
+	for _, msg := range messages {
+		afterSummary := false
+		role := message.MessageRole(msg.Role)
+
+		if session.SummaryMessageID == "" {
+			afterSummary = true
+		} else if msg.ID == session.SummaryMessageID {
+			afterSummary = true
+			role = message.User
+		}
+
+		if afterSummary {
+			turns = append(turns, message.Message{
+				Role:  message.MessageRole(role),
+				Parts: msg.Parts,
+			})
+		}
+	}
+
+	return New(turns...), nil
+}

--- a/internal/llm/conversation/loader_test.go
+++ b/internal/llm/conversation/loader_test.go
@@ -1,0 +1,87 @@
+package conversation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+type mockMessageService struct {
+	message.Service
+	listFunc func(ctx context.Context, sessionID string) ([]message.Message, error)
+}
+
+func (m *mockMessageService) List(ctx context.Context, sessionID string) ([]message.Message, error) {
+	return m.listFunc(ctx, sessionID)
+}
+
+func TestLoadFromSession(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s := session.Session{ID: "test-session"}
+
+	t.Run("should return a conversation with the correct messages", func(t *testing.T) {
+		t.Parallel()
+		service := getService(t)
+
+		conversation, err := LoadFromSession(ctx, s, service)
+		require.NoError(t, err)
+		require.Len(t, conversation.turns, 2)
+		require.Equal(t, message.User, conversation.turns[0].Role)
+		require.Equal(t, "hello", conversation.turns[0].Parts[0].(message.TextContent).Text)
+		require.Equal(t, message.Assistant, conversation.turns[1].Role)
+		require.Equal(t, "world", conversation.turns[1].Parts[0].(message.TextContent).Text)
+	})
+
+	t.Run("should return an error if the service fails to list messages", func(t *testing.T) {
+		t.Parallel()
+		service := &mockMessageService{
+			listFunc: func(ctx context.Context, sessionID string) ([]message.Message, error) {
+				return nil, errors.New("bork")
+			},
+		}
+
+		_, err := LoadFromSession(ctx, s, service)
+		require.Error(t, err)
+		require.Equal(t, "bork", err.Error())
+	})
+
+	t.Run("should ignore messages before the summary", func(t *testing.T) {
+		t.Parallel()
+		service := getService(t)
+		s = session.Session{ID: "test-session", SummaryMessageID: "1"}
+
+		conversation, err := LoadFromSession(ctx, s, service)
+		fmt.Println(conversation)
+		require.NoError(t, err)
+		require.Len(t, conversation.turns, 1)
+		require.Equal(t, message.User, conversation.turns[0].Role)
+		require.Equal(t, "hello", conversation.turns[0].Parts[0].(message.TextContent).Text)
+	})
+}
+
+func getService(t *testing.T) message.Service {
+	t.Helper()
+	service := &mockMessageService{
+		listFunc: func(ctx context.Context, sessionID string) ([]message.Message, error) {
+			return []message.Message{
+				{
+					ID:    "1",
+					Role:  "user",
+					Parts: []message.ContentPart{message.TextContent{Text: "hello"}},
+				},
+				{
+					ID:    "2",
+					Role:  "assistant",
+					Parts: []message.ContentPart{message.TextContent{Text: "world"}},
+				},
+			}, nil
+		},
+	}
+	return service
+}

--- a/internal/llm/title/generator.go
+++ b/internal/llm/title/generator.go
@@ -1,0 +1,49 @@
+package title
+
+import (
+	"context"
+	"strings"
+
+	"github.com/charmbracelet/crush/internal/llm/conversation"
+	"github.com/charmbracelet/crush/internal/llm/provider"
+	"github.com/charmbracelet/crush/internal/message"
+)
+
+type Strategy int
+
+const (
+	FromLastUser Strategy = iota
+	FromRecentContext
+)
+
+type Generator interface {
+	Generate(ctx context.Context, conv conversation.Conversation) (string, error)
+}
+
+type service struct {
+	provider provider.Provider
+}
+
+func NewGenerator(prov provider.Provider) Generator {
+	return &service{provider: prov}
+}
+
+func (s *service) Generate(ctx context.Context, conv conversation.Conversation) (string, error) {
+	msgs := conv.WithRole(message.User).First(1).Messages()
+	if len(msgs) == 0 {
+		return "", nil
+	}
+
+	stream := s.provider.StreamResponse(ctx, msgs, nil)
+	var final string
+	for ev := range stream {
+		if ev.Error != nil {
+			return "", ev.Error
+		}
+		if ev.Response != nil {
+			final = ev.Response.Content
+		}
+	}
+	title := strings.TrimSpace(strings.ReplaceAll(final, "\n", " "))
+	return title, nil
+}

--- a/internal/llm/title/generator_test.go
+++ b/internal/llm/title/generator_test.go
@@ -1,0 +1,92 @@
+package title
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/llm/conversation"
+	"github.com/charmbracelet/crush/internal/llm/provider"
+	"github.com/charmbracelet/crush/internal/llm/tools"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTitleGenerator(t *testing.T) {
+	t.Parallel()
+
+	t.Run("it should generate a title", func(t *testing.T) {
+		t.Parallel()
+
+		prov := &mockProvider{
+			response: "Test title",
+		}
+		gen := NewGenerator(prov)
+		conv := conversation.New(
+			message.Message{Role: message.Assistant, Parts: []message.ContentPart{message.TextContent{Text: "Hi"}}},
+			message.Message{Role: message.User, Parts: []message.ContentPart{message.TextContent{Text: "Hello"}}},
+		)
+
+		title, err := gen.Generate(context.Background(), conv)
+		require.NoError(t, err)
+		require.Equal(t, "Test title", title)
+	})
+
+	t.Run("it should return an empty title if no user messages are found", func(t *testing.T) {
+		t.Parallel()
+
+		prov := &mockProvider{}
+		gen := NewGenerator(prov)
+		conv := conversation.New(
+			message.Message{Role: message.Assistant, Parts: []message.ContentPart{message.TextContent{Text: "Hello"}}},
+		)
+
+		title, err := gen.Generate(context.Background(), conv)
+		require.NoError(t, err)
+		require.Equal(t, "", title)
+	})
+
+	t.Run("it should return an error if the provider returns an error", func(t *testing.T) {
+		t.Parallel()
+
+		prov := &mockProvider{
+			err: errors.New("provider error"),
+		}
+		gen := NewGenerator(prov)
+		conv := conversation.New(
+			message.Message{Role: message.User, Parts: []message.ContentPart{message.TextContent{Text: "Hello"}}},
+		)
+
+		_, err := gen.Generate(context.Background(), conv)
+		require.Error(t, err)
+		require.Equal(t, "provider error", err.Error())
+	})
+}
+
+type mockProvider struct {
+	response string
+	err      error
+}
+
+func (m *mockProvider) StreamResponse(ctx context.Context, messages []message.Message, tools []tools.BaseTool) <-chan provider.ProviderEvent {
+	ch := make(chan provider.ProviderEvent, 1)
+	if m.err != nil {
+		ch <- provider.ProviderEvent{Error: m.err}
+	} else {
+		ch <- provider.ProviderEvent{Response: &provider.ProviderResponse{Content: m.response}}
+	}
+	close(ch)
+	return ch
+}
+
+func (m *mockProvider) SendMessages(ctx context.Context, messages []message.Message, tools []tools.BaseTool) (*provider.ProviderResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &provider.ProviderResponse{Content: m.response}, nil
+}
+
+func (m *mockProvider) Model() catwalk.Model {
+	return catwalk.Model{}
+}


### PR DESCRIPTION
### Describe your changes

The goal of this PR is to simplify agent.go by redistributing its responsibilities into specialized, well-tested services.
In this case, the focus is on the session title generator.
The idea is to have a more modular code structure to improve reusability and make it easier to add future features—such as potential multi-agent support.

Happy to hear any thoughts, suggestions, or alternative ideas!

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
