### PR TITLE
fix: fix two panic scenarios

### DIFF
--- a/internal/tui/exp/list/filterable.go
+++ b/internal/tui/exp/list/filterable.go
@@ -246,7 +246,7 @@ func (f *filterableList[T]) Filter(query string) tea.Cmd {
 	}
 
 	f.selectedItem = ""
-	if query == "" {
+	if query == "" || len(f.items) == 0 {
 		return f.list.SetItems(f.items)
 	}
 

--- a/internal/tui/exp/list/list.go
+++ b/internal/tui/exp/list/list.go
@@ -476,6 +476,7 @@ func (l *list[T]) viewPosition() (int, int) {
 		start = max(0, renderedLines-l.offset-l.height+1)
 		end = max(0, renderedLines-l.offset)
 	}
+	start = min(start, end)
 	return start, end
 }
 


### PR DESCRIPTION
* `fix: fix panic: start can't be greater than end`

Closes #649

<details><summary>Stacktrace</summary>

```
Caught panic:

runtime error: slice bounds out of range [27:10]

Restoring terminal...

goroutine 1 [running]:
runtime/debug.Stack()
        /opt/hostedtoolcache/go/1.24.6/x64/src/runtime/debug/stack.go:26 +0x64
github.com/charmbracelet/bubbletea/v2.(*Program).recoverFromPanic(0x140045d2c88, {0x101f2fb60, 0x140016420a8})
        /home/runner/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4.0.20250805190305-70e94a2e0b2d/tea.go:1233 +0x10c
github.com/charmbracelet/bubbletea/v2.(*Program).Run.func2()
        /home/runner/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4.0.20250805190305-70e94a2e0b2d/tea.go:946 +0xdc
panic({0x101f2fb60?, 0x140016420a8?})
        /opt/hostedtoolcache/go/1.24.6/x64/src/runtime/panic.go:792 +0x124
github.com/charmbracelet/crush/internal/tui/exp/list.(*list[...]).View(0x1020dd560)
        /home/runner/work/crush/crush/internal/tui/exp/list/list.go:453 +0x30c
github.com/charmbracelet/crush/internal/tui/exp/list.(*filterableList[...]).View(0x101364f7c?)
        /home/runner/work/crush/crush/internal/tui/exp/list/filterable.go:163 +0x44
github.com/charmbracelet/crush/internal/tui/components/completions.(*completionsCmp).View(0x14002e64800)
        /home/runner/work/crush/crush/internal/tui/components/completions/completions.go:264 +0x1d4
github.com/charmbracelet/crush/internal/tui.(*appModel).View(0x14002e64a00)
        /home/runner/work/crush/crush/internal/tui/tui.go:498 +0x9dc
github.com/charmbracelet/bubbletea/v2.(*Program).render(0x140045d2c88, {0x102094a70?, 0x14002e64a00})
        /home/runner/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4.0.20250805190305-70e94a2e0b2d/tea.go:876 +0x138
github.com/charmbracelet/bubbletea/v2.(*Program).eventLoop(0x140045d2c88, {0x102094a70?, 0x14002e64a00?}, 0x14004456310)
        /home/runner/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4.0.20250805190305-70e94a2e0b2d/tea.go:842 +0x1ae4
github.com/charmbracelet/bubbletea/v2.(*Program).Run(0x140045d2c88)
        /home/runner/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4.0.20250805190305-70e94a2e0b2d/tea.go:1102 +0xaf0
github.com/charmbracelet/crush/internal/cmd.init.func2(0x102ffe8e0, {0x10148ce74?, 0x7?, 0x101485389?})
        /home/runner/work/crush/crush/internal/cmd/root.go:74 +0x138
github.com/spf13/cobra.(*Command).execute(0x102ffe8e0, {0x1400003a060, 0x0, 0x0})
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0x844
github.com/spf13/cobra.(*Command).ExecuteC(0x102ffe8e0)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x384
github.com/spf13/cobra.(*Command).Execute(...)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        /home/runner/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1064
github.com/charmbracelet/fang.Execute({0x1020a5240, 0x103071380}, 0x102ffe8e0, {0x1400056dec8, 0x2, 0xd?})
        /home/runner/go/pkg/mod/github.com/charmbracelet/fang@v0.3.1-0.20250711140230-d5ebb8c1d674/fang.go:169 +0x2f8
github.com/charmbracelet/crush/internal/cmd.Execute()
        /home/runner/work/crush/crush/internal/cmd/root.go:83 +0xd0
main.main()
        /home/runner/work/crush/crush/main.go:30 +0x6c

t
   ERROR

  Tui error: program was killed: program experienced a panic.
```

</details> 

* `fix: fix panic: fuzzy library doesn't like empty lists`

This happened for me when I was trying to reproduce the first.

<details><summary>Stacktrace</summary>

```
Caught panic:

runtime error: index out of range [1] with length 1

Restoring terminal...

goroutine 1 [running]:
runtime/debug.Stack()
	/nix/store/f4a0g1p943l61wfvqnpdr73v9bsyfhf2-go-1.24.4/share/go/src/runtime/debug/stack.go:26 +0x64
github.com/charmbracelet/bubbletea/v2.(*Program).recoverFromPanic(0x1400031af08, {0x1044613c0, 0x14000cffea8})
	/Users/andrey/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4.0.20250805190305-70e94a2e0b2d/tea.go:1233 +0x10c
github.com/charmbracelet/bubbletea/v2.(*Program).Run.func2()
	/Users/andrey/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4.0.20250805190305-70e94a2e0b2d/tea.go:946 +0xdc
panic({0x1044613c0?, 0x14000cffea8?})
	/nix/store/f4a0g1p943l61wfvqnpdr73v9bsyfhf2-go-1.24.4/share/go/src/runtime/panic.go:792 +0x124
github.com/sahilm/fuzzy.FindFromNoSort({0x14003c2c699?, 0x4f00014000e67008?}, {0x1045cd7a8, 0x14003b2c258})
	/Users/andrey/go/pkg/mod/github.com/sahilm/fuzzy@v0.1.1/fuzzy.go:136 +0x6e0
github.com/sahilm/fuzzy.FindFrom({0x14003c2c699?, 0x2f4?}, {0x1045cd7a8?, 0x14003b2c258?})
	/Users/andrey/go/pkg/mod/github.com/sahilm/fuzzy@v0.1.1/fuzzy.go:99 +0x28
github.com/sahilm/fuzzy.Find({0x14003c2c699, 0x1}, {0x14000e67008?, 0x14000e56008?, 0x10420fd40?})
	/Users/andrey/go/pkg/mod/github.com/sahilm/fuzzy@v0.1.1/fuzzy.go:83 +0x4c
github.com/charmbracelet/crush/internal/tui/exp/list.(*filterableList[...]).Filter(0x1045fd200, {0x14003c2c699, 0x1})
	/Users/andrey/Developer/charm/crush/internal/tui/exp/list/filterable.go:258 +0x2e8
github.com/charmbracelet/crush/internal/tui/components/completions.(*completionsCmp).Update(0x14000c36200, {0x1043ffbc0?, 0x14000638390?})
	/Users/andrey/Developer/charm/crush/internal/tui/components/completions/completions.go:220 +0x154
github.com/charmbracelet/crush/internal/tui.(*appModel).Update(0x14000c36400, {0x1043ffbc0, 0x14000638390})
	/Users/andrey/Developer/charm/crush/internal/tui/tui.go:116 +0x1048
github.com/charmbracelet/bubbletea/v2.(*Program).eventLoop(0x1400031af08, {0x1045c9af8?, 0x14000c36400?}, 0x14003e360e0)
	/Users/andrey/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4.0.20250805190305-70e94a2e0b2d/tea.go:834 +0x1a6c
github.com/charmbracelet/bubbletea/v2.(*Program).Run(0x1400031af08)
	/Users/andrey/go/pkg/mod/github.com/charmbracelet/bubbletea/v2@v2.0.0-beta.4.0.20250805190305-70e94a2e0b2d/tea.go:1102 +0xaf0
github.com/charmbracelet/crush/internal/cmd.init.func2(0x10555fc00, {0x1039ac45c?, 0x7?, 0x1039a4903?})
	/Users/andrey/Developer/charm/crush/internal/cmd/root.go:74 +0x138
github.com/spf13/cobra.(*Command).execute(0x10555fc00, {0x1400003a070, 0x0, 0x0})
	/Users/andrey/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0x844
github.com/spf13/cobra.(*Command).ExecuteC(0x10555fc00)
	/Users/andrey/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x384
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/andrey/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/Users/andrey/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1064
github.com/charmbracelet/fang.Execute({0x1045da580, 0x1055d27c0}, 0x10555fc00, {0x14000579ec8, 0x2, 0xd?})
	/Users/andrey/go/pkg/mod/github.com/charmbracelet/fang@v0.3.1-0.20250711140230-d5ebb8c1d674/fang.go:169 +0x2f8
github.com/charmbracelet/crush/internal/cmd.Execute()
	/Users/andrey/Developer/charm/crush/internal/cmd/root.go:83 +0xd0
main.main()
	/Users/andrey/Developer/charm/crush/main.go:30 +0x6c
```

</details> 