### PR TITLE
fix(mcp): append to output instead of replacing

### DIFF
--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -122,16 +123,16 @@ func runTool(ctx context.Context, name, toolName string, input string) (tools.To
 		return tools.NewTextErrorResponse(err.Error()), nil
 	}
 
-	output := ""
+	var output strings.Builder
 	for _, v := range result.Content {
 		if v, ok := v.(mcp.TextContent); ok {
-			output = v.Text
+			output.WriteString(v.Text)
 		} else {
-			output = fmt.Sprintf("%v", v)
+			_, _ = fmt.Fprintf(&output, "%v: ", v)
 		}
 	}
 
-	return tools.NewTextResponse(output), nil
+	return tools.NewTextResponse(output.String()), nil
 }
 
 func (b *McpTool) Run(ctx context.Context, params tools.ToolCall) (tools.ToolResponse, error) {


### PR DESCRIPTION
otherwise it'll only return the last message.

closes #604
