### PR TITLE
fix(mcp): give a time limit for startup

### DIFF
--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -274,7 +274,7 @@ func doGetMCPTools(ctx context.Context, permissions permission.Service, cfg *con
 				}
 			}()
 
-			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 			defer cancel()
 			c, err := createMcpClient(m)
 			if err != nil {

--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -274,6 +274,8 @@ func doGetMCPTools(ctx context.Context, permissions permission.Service, cfg *con
 				}
 			}()
 
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
 			c, err := createMcpClient(m)
 			if err != nil {
 				updateMCPState(name, MCPStateError, err, nil, 0)


### PR DESCRIPTION
If a MCP gets stuck starting/connecting, chatting will not work.

This makes it so it'll timeout after 5s (we can discuss the time), and then everything works accordingly.
