### PR TITLE
Windows Search Improvements

### DIFF
--- a/internal/llm/tools/rg.go
+++ b/internal/llm/tools/rg.go
@@ -42,8 +42,8 @@ func getRgSearchCmd(ctx context.Context, pattern, path, include string) *exec.Cm
 	if name == "" {
 		return nil
 	}
-	// Use -n to show line numbers and include the matched line
-	args := []string{"-H", "-n", pattern}
+	// Use JSON output to avoid platform-specific path parsing issues (e.g., Windows drive letters)
+	args := []string{"--json", "-n", "-H", pattern}
 	if include != "" {
 		args = append(args, "--glob", include)
 	}

--- a/internal/tui/components/dialogs/models/apikey.go
+++ b/internal/tui/components/dialogs/models/apikey.go
@@ -57,6 +57,14 @@ func NewAPIKeyInput() *APIKeyInput {
 	}
 }
 
+func (a *APIKeyInput) SetValue(value string) {
+	a.input.SetValue(value)
+}
+
+func (a *APIKeyInput) SetTitle(title string) {
+	a.title = title
+}
+
 func (a *APIKeyInput) SetProviderName(name string) {
 	a.providerName = name
 	a.updateStatePresentation()

--- a/internal/tui/components/dialogs/models/keys.go
+++ b/internal/tui/components/dialogs/models/keys.go
@@ -6,6 +6,7 @@ import (
 
 type KeyMap struct {
 	Select,
+	EditAPIKey,
 	Next,
 	Previous,
 	Tab,
@@ -20,6 +21,10 @@ func DefaultKeyMap() KeyMap {
 		Select: key.NewBinding(
 			key.WithKeys("enter", "ctrl+y"),
 			key.WithHelp("enter", "confirm"),
+		),
+		EditAPIKey: key.NewBinding(
+			key.WithKeys("ctrl+enter"),
+			key.WithHelp("ctrl+enter", "edit api key"),
 		),
 		Next: key.NewBinding(
 			key.WithKeys("down", "ctrl+n"),
@@ -44,6 +49,7 @@ func DefaultKeyMap() KeyMap {
 func (k KeyMap) KeyBindings() []key.Binding {
 	return []key.Binding{
 		k.Select,
+		k.EditAPIKey,
 		k.Next,
 		k.Previous,
 		k.Tab,
@@ -73,7 +79,7 @@ func (k KeyMap) ShortHelp() []key.Binding {
 			k.Select,
 		}
 	}
-	return []key.Binding{
+	help := []key.Binding{
 		key.NewBinding(
 			key.WithKeys("down", "up"),
 			key.WithHelp("↑↓", "choose"),
@@ -82,4 +88,8 @@ func (k KeyMap) ShortHelp() []key.Binding {
 		k.Select,
 		k.Close,
 	}
+	if !k.isAPIKeyHelp {
+		help = append(help, k.EditAPIKey)
+	}
+	return help
 }


### PR DESCRIPTION
### This PR improves Windows compatibility for the search functionality by switching ripgrep to JSON output format. This change addresses path parsing issues that occur on Windows systems, particularly with drive letters and special characters in file paths.

**Key changes:**
- Updated `rg.go` and `grep.go` to use ripgrep's `--json` output for robust, cross-platform parsing
- Refactored `grep.go` to parse JSON output from ripgrep instead of colon-delimited text
- Eliminates Windows-specific path parsing issues (e.g., "C:" being incorrectly parsed as a separator)

This ensures consistent search behavior across all platforms and improves reliability on Windows systems.

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment: