### PR TITLE
fix(lsp): return a copy of lsp diagnostics to avoid data race

### DIFF
--- a/internal/llm/tools/diagnostics.go
+++ b/internal/llm/tools/diagnostics.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"maps"
 	"sort"
 	"strings"
 	"time"
@@ -109,8 +108,7 @@ func waitForLspDiagnostics(ctx context.Context, filePath string, lsps map[string
 	diagChan := make(chan struct{}, 1)
 
 	for _, client := range lsps {
-		originalDiags := make(map[protocol.DocumentURI][]protocol.Diagnostic)
-		maps.Copy(originalDiags, client.GetDiagnostics())
+		originalDiags := client.GetDiagnostics()
 
 		handler := func(params json.RawMessage) {
 			lsp.HandleDiagnostics(client, params)

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -769,9 +769,7 @@ func (c *Client) GetDiagnostics() map[protocol.DocumentURI][]protocol.Diagnostic
 	c.diagnosticsMu.RLock()
 	defer c.diagnosticsMu.RUnlock()
 
-	diagnostics := make(map[protocol.DocumentURI][]protocol.Diagnostic, len(c.diagnostics))
-	maps.Copy(diagnostics, c.diagnostics)
-	return diagnostics
+	return maps.Clone(c.diagnostics)
 }
 
 // OpenFileOnDemand opens a file only if it's not already open

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -765,7 +766,12 @@ func (c *Client) GetFileDiagnostics(uri protocol.DocumentURI) []protocol.Diagnos
 
 // GetDiagnostics returns all diagnostics for all files
 func (c *Client) GetDiagnostics() map[protocol.DocumentURI][]protocol.Diagnostic {
-	return c.diagnostics
+	c.diagnosticsMu.RLock()
+	defer c.diagnosticsMu.RUnlock()
+
+	diagnostics := make(map[protocol.DocumentURI][]protocol.Diagnostic, len(c.diagnostics))
+	maps.Copy(diagnostics, c.diagnostics)
+	return diagnostics
 }
 
 // OpenFileOnDemand opens a file only if it's not already open


### PR DESCRIPTION
### Describe your changes

Return a copy of lsp diagnostics in `GetDiagnostics` to avoid data race.

Previously, the internal map is returned directly. Other goroutines can read it without lock.

### Related issue/discussion: 
- closes https://github.com/charmbracelet/crush/issues/676

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:

