### PR TITLE
feat(tui): toggle YOLO mode with Shift+Tab

### DIFF
--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -5,11 +5,12 @@ import (
 )
 
 type KeyMap struct {
-	Quit     key.Binding
-	Help     key.Binding
-	Commands key.Binding
-	Suspend  key.Binding
-	Sessions key.Binding
+	Quit       key.Binding
+	Help       key.Binding
+	Commands   key.Binding
+	Suspend    key.Binding
+	Sessions   key.Binding
+	ToggleYolo key.Binding
 
 	pageBindings []key.Binding
 }
@@ -35,6 +36,10 @@ func DefaultKeyMap() KeyMap {
 		Sessions: key.NewBinding(
 			key.WithKeys("ctrl+s"),
 			key.WithHelp("ctrl+s", "sessions"),
+		),
+		ToggleYolo: key.NewBinding(
+			key.WithKeys("shift+tab"),
+			key.WithHelp("shift+tab", "yolo mode"),
 		),
 	}
 }

--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -372,6 +372,8 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			p.changeFocus()
 			return p, nil
+		case key.Matches(msg, p.keyMap.ToggleYolo):
+			return p, util.CmdHandler(commands.ToggleYoloModeMsg{})
 		case key.Matches(msg, p.keyMap.Cancel):
 			if p.session.ID != "" && p.app.CoderAgent.IsBusy() {
 				return p, p.cancel()
@@ -850,6 +852,10 @@ func (p *chatPage) Help() help.KeyMap {
 			}
 			shortList = append(shortList, tabKey)
 			globalBindings = append(globalBindings, tabKey)
+			globalBindings = append(globalBindings, key.NewBinding(
+				key.WithKeys("shift+tab"),
+				key.WithHelp("shift+tab", "yolo mode"),
+			))
 		}
 		commandsBinding := key.NewBinding(
 			key.WithKeys("ctrl+p"),

--- a/internal/tui/page/chat/keys.go
+++ b/internal/tui/page/chat/keys.go
@@ -10,6 +10,7 @@ type KeyMap struct {
 	Cancel        key.Binding
 	Tab           key.Binding
 	Details       key.Binding
+	ToggleYolo    key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
@@ -33,6 +34,10 @@ func DefaultKeyMap() KeyMap {
 		Details: key.NewBinding(
 			key.WithKeys("ctrl+d"),
 			key.WithHelp("ctrl+d", "toggle details"),
+		),
+		ToggleYolo: key.NewBinding(
+			key.WithKeys("shift+tab"),
+			key.WithHelp("shift+tab", "yolo mode"),
 		),
 	}
 }


### PR DESCRIPTION
## Summary
- Add Shift+Tab keybinding to toggle YOLO mode (auto-approve permissions)
- Wire binding into app and chat page help; uses existing ToggleYoloModeMsg

## Test plan
- Launch TUI, press Shift+Tab to toggle YOLO; editor prompt/placeholder reflects YOLO mode
- Verify help shows Shift+Tab binding when in a session

💘 Generated with Crush