### PR TITLE
Feature to display a request counter

### DIFF
--- a/internal/tui/components/chat/sidebar/sidebar.go
+++ b/internal/tui/components/chat/sidebar/sidebar.go
@@ -540,6 +540,12 @@ func formatTokensAndCost(tokens, contextWindow int64, cost float64) string {
 	return fmt.Sprintf("%s %s", formattedTokens, formattedCost)
 }
 
+func formatRequestCount(count int64) string {
+	t := styles.CurrentTheme()
+	requestCount := t.S().Base.Foreground(t.FgMuted).Render(fmt.Sprintf("%d requests", count))
+	return requestCount
+}
+
 func (s *sidebarCmp) currentModelBlock() string {
 	cfg := config.Get()
 	agentCfg := cfg.Agents["coder"]
@@ -584,6 +590,10 @@ func (s *sidebarCmp) currentModelBlock() string {
 				model.ContextWindow,
 				s.session.Cost,
 			),
+		)
+		parts = append(
+			parts,
+			"  "+formatRequestCount(s.session.MessageCount),
 		)
 	}
 	return lipgloss.JoinVertical(


### PR DESCRIPTION
### Describe your changes

This is a very simple feature; it only shows the total number of requests a session has made to the API. Useful for models that charge per request rather than per token (chutes.ai).

<img width="936" height="593" alt="image" src="https://github.com/user-attachments/assets/12d6cbf1-b768-4adc-8e0e-997e7ae9cad9" />

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
