### PR TITLE
fix: fix three important bugs on windows

### DIFF
--- a/internal/fsext/fileutil.go
+++ b/internal/fsext/fileutil.go
@@ -233,3 +233,19 @@ func HasPrefix(path, prefix string) bool {
 	// If path is within prefix, Rel will not return a path starting with ".."
 	return !strings.HasPrefix(rel, "..")
 }
+
+// ToUnixLineEndings converts Windows line endings (CRLF) to Unix line endings (LF).
+func ToUnixLineEndings(content string) (string, bool) {
+	if strings.Contains(content, "\r\n") {
+		return strings.ReplaceAll(content, "\r\n", "\n"), true
+	}
+	return content, false
+}
+
+// ToWindowsLineEndings converts Unix line endings (LF) to Windows line endings (CRLF).
+func ToWindowsLineEndings(content string) (string, bool) {
+	if !strings.Contains(content, "\r\n") {
+		return strings.ReplaceAll(content, "\n", "\r\n"), true
+	}
+	return content, false
+}

--- a/internal/llm/tools/multiedit.go
+++ b/internal/llm/tools/multiedit.go
@@ -335,7 +335,7 @@ func (m *multiEditTool) processMultiEditExistingFile(ctx context.Context, params
 		return ToolResponse{}, fmt.Errorf("failed to read file: %w", err)
 	}
 
-	oldContent := string(content)
+	oldContent, isCrlf := fsext.ToUnixLineEndings(string(content))
 	currentContent := oldContent
 
 	// Apply all edits sequentially
@@ -375,6 +375,10 @@ func (m *multiEditTool) processMultiEditExistingFile(ctx context.Context, params
 	})
 	if !p {
 		return ToolResponse{}, permission.ErrorPermissionDenied
+	}
+
+	if isCrlf {
+		currentContent, _ = fsext.ToWindowsLineEndings(currentContent)
 	}
 
 	// Write the updated content

--- a/internal/tui/components/chat/sidebar/sidebar.go
+++ b/internal/tui/components/chat/sidebar/sidebar.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/csync"
 	"github.com/charmbracelet/crush/internal/diff"
+	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/history"
 	"github.com/charmbracelet/crush/internal/lsp"
 	"github.com/charmbracelet/crush/internal/pubsub"
@@ -190,8 +191,8 @@ func (m *sidebarCmp) handleFileHistoryEvent(event pubsub.Event[history.File]) te
 				// If the version is not greater than the latest, we ignore it
 				continue
 			}
-			before := existing.History.initialVersion.Content
-			after := existing.History.latestVersion.Content
+			before, _ := fsext.ToUnixLineEndings(existing.History.initialVersion.Content)
+			after, _ := fsext.ToUnixLineEndings(existing.History.latestVersion.Content)
 			path := existing.History.initialVersion.Path
 			cwd := config.Get().WorkingDir()
 			path = strings.TrimPrefix(path, cwd)
@@ -248,7 +249,9 @@ func (m *sidebarCmp) loadSessionFiles() tea.Msg {
 	for path, fh := range fileMap {
 		cwd := config.Get().WorkingDir()
 		path = strings.TrimPrefix(path, cwd)
-		_, additions, deletions := diff.GenerateDiff(fh.initialVersion.Content, fh.latestVersion.Content, path)
+		before, _ := fsext.ToUnixLineEndings(fh.initialVersion.Content)
+		after, _ := fsext.ToUnixLineEndings(fh.latestVersion.Content)
+		_, additions, deletions := diff.GenerateDiff(before, after, path)
 		sessionFiles = append(sessionFiles, SessionFile{
 			History:   fh,
 			FilePath:  path,

--- a/internal/tui/components/files/files.go
+++ b/internal/tui/components/files/files.go
@@ -3,6 +3,7 @@ package files
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -91,7 +92,9 @@ func RenderFileList(fileSlice []SessionFile, opts RenderOptions) []string {
 		extraContent := strings.Join(statusParts, " ")
 		cwd := config.Get().WorkingDir() + string(os.PathSeparator)
 		filePath := file.FilePath
-		filePath = strings.TrimPrefix(filePath, cwd)
+		if rel, err := filepath.Rel(cwd, filePath); err == nil {
+			filePath = rel
+		}
 		filePath = fsext.DirTrim(fsext.PrettyPath(filePath), 2)
 		filePath = ansi.Truncate(filePath, opts.MaxWidth-lipgloss.Width(extraContent)-2, "…")
 


### PR DESCRIPTION
* Closes #684

---

* `fix(tool): fix edit and multi-edit tools on windows`

We should convert the content to LF to apply the patch while still
 respecting the original line endings when saving the file on disk.

* `fix(sidebar): compute the right line count even on windows / crlf`

The diff library we're using assumes LF, so we need to convert CRLF to LF to ensure it works properly.

In the screenshots below, in both cases we had only 1 line removed and 3 added, but it was as if the whole files was changed before the fix.

<details><summary>Before</summary>
<p>

<img width="426" height="129" alt="Screenshot 2025-08-11 152224" src="https://github.com/user-attachments/assets/6a64d210-51de-4178-bbef-add848a973ff" />

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="443" height="116" alt="Screenshot 2025-08-11 153545" src="https://github.com/user-attachments/assets/02899f7e-6a3c-4732-b656-8f08c92ad36f" />

</p>
</details> 

* `fix(sidebar): fix full path appearing on sidebar on windows`

For some reason, this was only happening for OpenAI on Windows, and not for Anthropic.

<details><summary>Before</summary>
<p>

<img width="452" height="126" alt="Screenshot 2025-08-11 153720" src="https://github.com/user-attachments/assets/feb7306d-0153-43b9-9204-8a19c88f6bd0" />

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="442" height="127" alt="Screenshot 2025-08-11 161208" src="https://github.com/user-attachments/assets/3af6c4fb-d561-4843-bc24-c5c4666d099f" />

</p>
</details> 