### PR TITLE
fix(editor): better sorting of files when completing with /

### DIFF
--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -481,6 +481,9 @@ func (m *editorCmp) SetPosition(x, y int) tea.Cmd {
 
 func (m *editorCmp) startCompletions() tea.Msg {
 	files, _, _ := fsext.ListDirectory(".", nil, 0)
+	slices.SortFunc(files, func(a, b string) int {
+		return strings.Compare(a, b)
+	})
 	completionItems := make([]completions.Completion, 0, len(files))
 	for _, file := range files {
 		file = strings.TrimPrefix(file, "./")

--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -481,9 +481,7 @@ func (m *editorCmp) SetPosition(x, y int) tea.Cmd {
 
 func (m *editorCmp) startCompletions() tea.Msg {
 	files, _, _ := fsext.ListDirectory(".", nil, 0)
-	slices.SortFunc(files, func(a, b string) int {
-		return strings.Compare(a, b)
-	})
+	slices.Sort(files)
 	completionItems := make([]completions.Completion, 0, len(files))
 	for _, file := range files {
 		file = strings.TrimPrefix(file, "./")


### PR DESCRIPTION
Basically, show shorter paths first.

Before:

<img width="1374" height="552" alt="CleanShot 2025-08-12 at 12 08 19@2x" src="https://github.com/user-attachments/assets/30ba2617-5377-4c56-82d5-ec7d080c91ba" />


Now:

<img width="862" height="536" alt="CleanShot 2025-08-12 at 12 07 34@2x" src="https://github.com/user-attachments/assets/3f586a89-92ce-45aa-82f2-a10daf883c3d" />
