### PR TITLE
fix(llm): set request timeout

### DIFF
--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -153,7 +153,6 @@ func (a *anthropicClient) convertMessages(messages []message.Message) (anthropic
 			}
 
 			if len(blocks) == 0 {
-				slog.Warn("There is a message without content, investigate, this should not happen")
 				continue
 			}
 			anthropicMessages = append(anthropicMessages, anthropic.NewAssistantMessage(blocks...))

--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -333,7 +333,7 @@ func (a *anthropicClient) stream(ctx context.Context, messages []message.Message
 			// Prepare messages on each attempt in case max_tokens was adjusted
 			preparedMessages := a.preparedMessages(a.convertMessages(messages), a.convertTools(tools))
 
-			var opts []option.RequestOption
+			opts := []option.RequestOption{option.WithRequestTimeout(time.Minute)}
 			if a.isThinkingEnabled() {
 				opts = append(opts, option.WithHeaderAdd("anthropic-beta", "interleaved-thinking-2025-05-14"))
 			}

--- a/internal/llm/provider/openai.go
+++ b/internal/llm/provider/openai.go
@@ -338,6 +338,7 @@ func (o *openaiClient) stream(ctx context.Context, messages []message.Message, t
 			openaiStream := o.client.Chat.Completions.NewStreaming(
 				ctx,
 				params,
+				option.WithRequestTimeout(time.Minute),
 			)
 
 			acc := openai.ChatCompletionAccumulator{}

--- a/internal/llm/provider/openai.go
+++ b/internal/llm/provider/openai.go
@@ -166,7 +166,6 @@ func (o *openaiClient) convertMessages(messages []message.Message) (openaiMessag
 				}
 			}
 			if !hasContent {
-				slog.Warn("There is a message without content, investigate, this should not happen")
 				continue
 			}
 


### PR DESCRIPTION
If the server is down, address don't resolve, or another myriad of reasons, currently, it'll get stuck.

This makes it so it times out after 1 minute.
