### PR TITLE
fix(lint): check length before slicing to avoid a panic in list

### DIFF
--- a/internal/tui/exp/list/list.go
+++ b/internal/tui/exp/list/list.go
@@ -450,7 +450,12 @@ func (l *list[T]) View() string {
 	start, end := l.viewPosition()
 	viewStart := max(0, start)
 	viewEnd := min(len(lines), end+1)
+
+	if viewStart > viewEnd {
+		viewStart = viewEnd
+	}
 	lines = lines[viewStart:viewEnd]
+
 	if l.resize {
 		return strings.Join(lines, "\n")
 	}


### PR DESCRIPTION
Small one to fix a rogue panic that could happen when resizing.