### PR TITLE
fix(gemini): tool-calling panic issue

### DIFF
--- a/internal/llm/provider/gemini.go
+++ b/internal/llm/provider/gemini.go
@@ -70,7 +70,7 @@ func (g *geminiClient) convertMessages(messages []message.Message) []*genai.Cont
 			}
 			history = append(history, &genai.Content{
 				Parts: parts,
-				Role:  "user",
+				Role:  genai.RoleUser,
 			})
 		case message.Assistant:
 			var assistantParts []*genai.Part
@@ -93,7 +93,7 @@ func (g *geminiClient) convertMessages(messages []message.Message) []*genai.Cont
 
 			if len(assistantParts) > 0 {
 				history = append(history, &genai.Content{
-					Role:  "model",
+					Role:  genai.RoleModel,
 					Parts: assistantParts,
 				})
 			}
@@ -127,7 +127,7 @@ func (g *geminiClient) convertMessages(messages []message.Message) []*genai.Cont
 							},
 						},
 					},
-					Role: "function",
+					Role: genai.RoleModel,
 				})
 			}
 		}


### PR DESCRIPTION
### Describe your changes
The issue was apparently that the go-genai module expects the roles in the chat history to be [either "user" or "model"](https://github.com/googleapis/go-genai/blob/main/chats.go#L93). Since the tool calls in the history were assigned the role "function", combined with the fact that the [chat creation errors were being ignored](https://github.com/charmbracelet/crush/blob/main/internal/llm/provider/gemini.go#L200), resulted in this cryptic/weird issue. This pr introduces a workaround by attributing the tool-call's output to the model.

Steps to validate the fix:
- make the llm perform any tool call.
- the main branch panics, while this branch does not.

PS: I'm not sure if this is a "proper fix", since the tool call results shouldn't most likely be attributed to the model in the history.

### Related issue/discussion: https://github.com/charmbracelet/crush/issues/768, https://github.com/charmbracelet/crush/issues/771

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
