### PR TITLE
fix(tui): Prevent dialog keymaps from being swallowed

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -372,6 +372,11 @@ func (a *appModel) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			return cmd
 		}
 	}
+	if a.dialog.HasDialogs() {
+		u, dialogCmd := a.dialog.Update(msg)
+		a.dialog = u.(dialogs.DialogCmp)
+		return dialogCmd
+	}
 	switch {
 	// help
 	case key.Matches(msg, a.keyMap.Help):
@@ -432,20 +437,14 @@ func (a *appModel) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		}
 		return tea.Suspend
 	default:
-		if a.dialog.HasDialogs() {
-			u, dialogCmd := a.dialog.Update(msg)
-			a.dialog = u.(dialogs.DialogCmp)
-			return dialogCmd
-		} else {
-			item, ok := a.pages[a.currentPage]
-			if !ok {
-				return nil
-			}
-
-			updated, cmd := item.Update(msg)
-			a.pages[a.currentPage] = updated.(util.Model)
-			return cmd
+		item, ok := a.pages[a.currentPage]
+		if !ok {
+			return nil
 		}
+
+		updated, cmd := item.Update(msg)
+		a.pages[a.currentPage] = updated.(util.Model)
+		return cmd
 	}
 }
 


### PR DESCRIPTION
### Describe your changes

This change checks for the presence of a dialog before checking for other handlers.

Now when pressing ctrl+p when a dialog is visible it will correctly navigate up the list. This restores the standard terminal behavior of using ctrl+n and ctrl+p.

How to reproduce:

1. ctrl+p to open for the command launcher
2. ctrl+n (or down) to move down one item
3. ctrl+p - command dialog closed

With this fix, step 3. will now correctly select the previous item in the dialog.

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
