### PR TITLE
feat: create `.crush/.gitignore` automatically

### DIFF
--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
-	"os"
 	"path/filepath"
 
 	_ "github.com/ncruces/go-sqlite3/driver"
@@ -17,9 +16,6 @@ import (
 func Connect(ctx context.Context, dataDir string) (*sql.DB, error) {
 	if dataDir == "" {
 		return nil, fmt.Errorf("data.dir is not set")
-	}
-	if err := os.MkdirAll(dataDir, 0o700); err != nil {
-		return nil, fmt.Errorf("failed to create data directory: %w", err)
 	}
 	dbPath := filepath.Join(dataDir, "crush.db")
 	// Open the SQLite database

--- a/internal/llm/prompt/init.md
+++ b/internal/llm/prompt/init.md
@@ -7,4 +7,3 @@ The file you create will be given to agentic coding agents (such as yourself) th
 If there's already a **CRUSH.md**, improve it.
 
 If there are Cursor rules (in `.cursor/rules/` or `.cursorrules`) or Copilot rules (in `.github/copilot-instructions.md`), make sure to include them.
-Add the `.crush` directory to the `.gitignore` file if it's not already there.


### PR DESCRIPTION
This is a simple quality of life ™️ improvement:

* We won't be asking the LLM to update the project's `.gitignore` anymore
* We're automatically creating a `.crush/.gitignore` file with `*` to just ignore everything inside `.crush`
* We're creating that file as soon as we create the `.crush` directory
  * Before, since we were asking the LLM the update `.gitignore`, if the user chose NOT to initialize the repo, we were not ignoring `.crush` automatically at all (requiring the user to manually update `.gitignore`)

---

* Closes #588
* Closes #254
* Follow-up of #25

