### PR TITLE
Adds tmux detection to prevent background color override when running inside tmux

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -35,6 +35,8 @@ import (
 	"github.com/charmbracelet/lipgloss/v2"
 )
 
+const tmuxEnvVar = "TMUX"
+
 var lastMouseEvent time.Time
 
 func MouseEventFilter(m tea.Model, msg tea.Msg) tea.Msg {
@@ -476,7 +478,7 @@ func (a *appModel) moveToPage(pageID page.PageID) tea.Cmd {
 func (a *appModel) View() tea.View {
 	var view tea.View
 	t := styles.CurrentTheme()
-	if os.Getenv("TMUX") == "" {
+	if _, exists := os.LookupEnv(tmuxEnvVar); !exists {
 		view.BackgroundColor = t.BgBase
 	}
 	if a.wWidth < 25 || a.wHeight < 15 {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -475,7 +476,9 @@ func (a *appModel) moveToPage(pageID page.PageID) tea.Cmd {
 func (a *appModel) View() tea.View {
 	var view tea.View
 	t := styles.CurrentTheme()
-	view.BackgroundColor = t.BgBase
+	if os.Getenv("TMUX") == "" {
+		view.BackgroundColor = t.BgBase
+	}
 	if a.wWidth < 25 || a.wHeight < 15 {
 		view.Layer = lipgloss.NewCanvas(
 			lipgloss.NewLayer(


### PR DESCRIPTION
### Describe your changes

<img width="1680" height="1050" alt="Screenshot 2025-08-16 at 12 14 47" src="https://github.com/user-attachments/assets/0b4efb0c-e7e4-460b-ad0c-6ab61ae269ad" />


- Add tmux environment variable detection using `TMUX` env var
  - Conditionally set `view.BackgroundColor` only when tmux is not detected


### Checklist before requesting a review

- [ X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [ X] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
