### PR TITLE
feat: Add environment variable and tilde expansion support for command paths

### DIFF
--- a/internal/app/lsp.go
+++ b/internal/app/lsp.go
@@ -21,7 +21,7 @@ func (app *App) initLSPClients(ctx context.Context) {
 
 // createAndStartLSPClient creates a new LSP client, initializes it, and starts its workspace watcher
 func (app *App) createAndStartLSPClient(ctx context.Context, name string, config config.LSPConfig) {
-	slog.Info("Creating LSP client", "name", name, "command", config.Command, "fileTypes", config.FileTypes, "args", config.Args)
+	slog.Info("Creating LSP client", "name", name, "command", config.ResolvedCommand(), "fileTypes", config.FileTypes, "args", config.Args)
 
 	// Update state to starting
 	updateLSPState(name, lsp.StateStarting, nil, nil, 0)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -209,9 +209,7 @@ func (m MCPConfig) ResolvedHeaders() map[string]string {
 	return m.Headers
 }
 
-func (m MCPConfig) ResolvedCommand() string {
-	command := m.Command
-
+func resolveCommand(command, logContext string) string {
 	// Handle tilde expansion first
 	if strings.HasPrefix(command, "~/") {
 		homeDir, err := os.UserHomeDir()
@@ -229,36 +227,18 @@ func (m MCPConfig) ResolvedCommand() string {
 	resolver := NewShellVariableResolver(env.New())
 	resolved, err := resolver.ResolveValue(command)
 	if err != nil {
-		slog.Error("error resolving MCP command variable", "error", err, "command", m.Command)
+		slog.Error("error resolving command variable", "error", err, "command", command, "context", logContext)
 		return command
 	}
 	return resolved
 }
 
+func (m MCPConfig) ResolvedCommand() string {
+	return resolveCommand(m.Command, "MCP")
+}
+
 func (l LSPConfig) ResolvedCommand() string {
-	command := l.Command
-
-	// Handle tilde expansion first
-	if strings.HasPrefix(command, "~/") {
-		homeDir, err := os.UserHomeDir()
-		if err == nil {
-			command = filepath.Join(homeDir, command[2:])
-		}
-	} else if command == "~" {
-		homeDir, err := os.UserHomeDir()
-		if err == nil {
-			command = homeDir
-		}
-	}
-
-	// Then handle environment variable expansion
-	resolver := NewShellVariableResolver(env.New())
-	resolved, err := resolver.ResolveValue(command)
-	if err != nil {
-		slog.Error("error resolving LSP command variable", "error", err, "command", l.Command)
-		return command
-	}
-	return resolved
+	return resolveCommand(l.Command, "LSP")
 }
 
 type Agent struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -212,15 +212,11 @@ func (m MCPConfig) ResolvedHeaders() map[string]string {
 func resolveCommand(command, logContext string) string {
 	// Handle tilde expansion first
 	if strings.HasPrefix(command, "~/") {
-		homeDir, err := os.UserHomeDir()
-		if err == nil {
-			command = filepath.Join(homeDir, command[2:])
-		}
+		homeDir := HomeDir()
+		command = filepath.Join(homeDir, command[2:])
 	} else if command == "~" {
-		homeDir, err := os.UserHomeDir()
-		if err == nil {
-			command = homeDir
-		}
+		homeDir := HomeDir()
+		command = homeDir
 	}
 
 	// Then handle environment variable expansion

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/csync"
 	"github.com/charmbracelet/crush/internal/env"
+	"github.com/charmbracelet/crush/internal/home"
 	"github.com/tidwall/sjson"
 )
 
@@ -212,10 +213,10 @@ func (m MCPConfig) ResolvedHeaders() map[string]string {
 func resolveCommand(command, logContext string) string {
 	// Handle tilde expansion first
 	if strings.HasPrefix(command, "~/") {
-		homeDir := HomeDir()
+		homeDir := home.Dir()
 		command = filepath.Join(homeDir, command[2:])
 	} else if command == "~" {
-		homeDir := HomeDir()
+		homeDir := home.Dir()
 		command = homeDir
 	}
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -368,7 +368,7 @@ func applyDefaultLSPFileTypes(lspConfigs map[string]LSPConfig) {
 		if len(config.FileTypes) != 0 {
 			continue
 		}
-		bin := strings.ToLower(filepath.Base(config.Command))
+		bin := strings.ToLower(filepath.Base(config.ResolvedCommand()))
 		config.FileTypes = defaultLSPFileTypes[bin]
 		lspConfigs[name] = config
 	}

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -334,6 +334,9 @@ func TestNewEnvironmentVariableResolver(t *testing.T) {
 }
 
 func TestMCPConfig_ResolvedCommand(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
 	tests := []struct {
 		name     string
 		command  string
@@ -354,12 +357,12 @@ func TestMCPConfig_ResolvedCommand(t *testing.T) {
 		{
 			name:     "command with tilde expansion",
 			command:  "~/bin/gopls",
-			expected: filepath.Join(os.Getenv("HOME"), "bin/gopls"),
+			expected: filepath.Join(homeDir, "bin/gopls"),
 		},
 		{
 			name:     "command with just tilde",
 			command:  "~",
-			expected: os.Getenv("HOME"),
+			expected: homeDir,
 		},
 		{
 			name:     "command with braced variable",
@@ -387,6 +390,9 @@ func TestMCPConfig_ResolvedCommand(t *testing.T) {
 }
 
 func TestLSPConfig_ResolvedCommand(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
 	tests := []struct {
 		name     string
 		command  string
@@ -407,12 +413,12 @@ func TestLSPConfig_ResolvedCommand(t *testing.T) {
 		{
 			name:     "command with tilde expansion",
 			command:  "~/bin/gopls",
-			expected: filepath.Join(os.Getenv("HOME"), "bin/gopls"),
+			expected: filepath.Join(homeDir, "bin/gopls"),
 		},
 		{
 			name:     "command with just tilde",
 			command:  "~",
-			expected: os.Getenv("HOME"),
+			expected: homeDir,
 		},
 		{
 			name:     "command with XDG_CONFIG_HOME variable",

--- a/internal/config/resolve_test.go
+++ b/internal/config/resolve_test.go
@@ -3,11 +3,11 @@ package config
 import (
 	"context"
 	"errors"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/env"
+	"github.com/charmbracelet/crush/internal/home"
 	"github.com/stretchr/testify/require"
 )
 
@@ -334,8 +334,7 @@ func TestNewEnvironmentVariableResolver(t *testing.T) {
 }
 
 func TestMCPConfig_ResolvedCommand(t *testing.T) {
-	homeDir, err := os.UserHomeDir()
-	require.NoError(t, err)
+	homeDir := home.Dir()
 
 	tests := []struct {
 		name     string
@@ -390,8 +389,7 @@ func TestMCPConfig_ResolvedCommand(t *testing.T) {
 }
 
 func TestLSPConfig_ResolvedCommand(t *testing.T) {
-	homeDir, err := os.UserHomeDir()
-	require.NoError(t, err)
+	homeDir := home.Dir()
 
 	tests := []struct {
 		name     string

--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -355,7 +355,7 @@ func createMcpClient(m config.MCPConfig) (*client.Client, error) {
 			return nil, fmt.Errorf("mcp stdio config requires a non-empty 'command' field")
 		}
 		return client.NewStdioMCPClientWithOptions(
-			m.Command,
+			m.ResolvedCommand(),
 			m.ResolvedEnv(),
 			m.Args,
 			transport.WithCommandLogger(mcpLogger{}),

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -71,7 +71,7 @@ type Client struct {
 
 // NewClient creates a new LSP client.
 func NewClient(ctx context.Context, name string, config config.LSPConfig) (*Client, error) {
-	cmd := exec.CommandContext(ctx, config.Command, config.Args...)
+	cmd := exec.CommandContext(ctx, config.ResolvedCommand(), config.Args...)
 
 	// Copy env
 	cmd.Env = slices.Concat(os.Environ(), config.ResolvedEnv())

--- a/internal/tui/components/lsp/lsp.go
+++ b/internal/tui/components/lsp/lsp.go
@@ -58,7 +58,7 @@ func RenderLSPList(lspClients map[string]*lsp.Client, opts RenderOptions) []stri
 
 		// Determine icon color and description based on state
 		icon := t.ItemOfflineIcon
-		description := l.LSP.Command
+		description := l.LSP.ResolvedCommand()
 
 		if l.LSP.Disabled {
 			description = t.S().Subtle.Render("disabled")
@@ -69,7 +69,7 @@ func RenderLSPList(lspClients map[string]*lsp.Client, opts RenderOptions) []stri
 				description = t.S().Subtle.Render("starting...")
 			case lsp.StateReady:
 				icon = t.ItemOnlineIcon
-				description = l.LSP.Command
+				description = l.LSP.ResolvedCommand()
 			case lsp.StateError:
 				icon = t.ItemErrorIcon
 				if state.Error != nil {

--- a/internal/tui/components/mcp/mcp.go
+++ b/internal/tui/components/mcp/mcp.go
@@ -55,7 +55,7 @@ func RenderMCPList(opts RenderOptions) []string {
 
 		// Determine icon and color based on state
 		icon := t.ItemOfflineIcon
-		description := l.MCP.Command
+		description := l.MCP.ResolvedCommand()
 		extraContent := ""
 
 		if state, exists := mcpStates[l.Name]; exists {


### PR DESCRIPTION
## 📝 PR Summary

The PR includes:

• Complete implementation of variable resolution for MCP and LSP commands
• Support for  ~ ,  $HOME ,  $XDG_CONFIG_HOME , and other environment variables
• Tests covering scenarios

Checklist before requesting a review
 - [x] I have read [CONTRIBUTING.md](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
 - [x] I have performed a self-review of my code