### PR TITLE
chore: fix golangci-lint locally

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -7,15 +7,26 @@ env:
   GOEXPERIMENT: greenteagc
 
 tasks:
+  lint:install:
+    desc: Install golangci-lint
+    cmds:
+      - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+    env:
+      GOTOOLCHAIN: go1.25.0
+
   lint:
     desc: Run base linters
     cmds:
       - golangci-lint run --path-mode=abs --config=".golangci.yml" --timeout=5m
+    env:
+      GOEXPERIMENT: null
 
   lint-fix:
     desc: Run base linters and fix issues
     cmds:
       - golangci-lint run --path-mode=abs --config=".golangci.yml" --timeout=5m --fix
+    env:
+      GOEXPERIMENT: null
 
   test:
     desc: Run tests


### PR DESCRIPTION
For some reason, golangci-lint is not behaving too well after we upgraded to Go 1.25 and enabled GreenTea GC.

After some debugging, I found out that we need to compile with Go 1.25 toolchain and run with the GreenTeaGC experiment _disabled_.

The build from Nix was built with Go 1.24, so that one doesn't work as expected.