### PR TITLE
sec: remove 'go' from safe programs

### DIFF
--- a/internal/llm/tools/safe.go
+++ b/internal/llm/tools/safe.go
@@ -52,21 +52,6 @@ var safeCommands = []string{
 	"git show",
 	"git status",
 	"git tag",
-
-	// Go
-	"go build",
-	"go clean",
-	"go doc",
-	"go env",
-	"go fmt",
-	"go help",
-	"go install",
-	"go list",
-	"go mod",
-	"go run",
-	"go test",
-	"go version",
-	"go vet",
 }
 
 func init() {


### PR DESCRIPTION
It could be used to prompt inject commands e.g. `go test -exec`.

Plus, we don't have other languages there, so I think we remove Go as well.

Ideally, we could ask haiku if the command is read only or not, and ask for perms based on that, but for now I think this will do.

Thanks Will Vandevanter for the report.
