### PR TITLE
fix(onboarding): fix onboarding screen "freezing" when on click on it

### DIFF
--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -177,6 +177,9 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return p, nil
 	case tea.MouseClickMsg:
+		if p.isOnboarding {
+			return p, nil
+		}
 		if p.compact {
 			msg.Y -= 1
 		}
@@ -203,6 +206,9 @@ func (p *chatPage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return p, nil
 	case tea.MouseReleaseMsg:
+		if p.isOnboarding {
+			return p, nil
+		}
 		if p.compact {
 			msg.Y -= 1
 		}

--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -697,7 +697,7 @@ func (p *chatPage) sendMessage(text string, attachments []message.Attachment) te
 		cmds = append(cmds, util.CmdHandler(chat.SessionSelectedMsg(session)))
 	}
 	if p.app.CoderAgent == nil {
-		return util.ReportError(fmt.Errorf("coder agent is not initialized - please check your configuration"))
+		return util.ReportError(fmt.Errorf("coder agent is not initialized"))
 	}
 	_, err := p.app.CoderAgent.Run(context.Background(), session.ID, text, attachments...)
 	if err != nil {


### PR DESCRIPTION
* Closes https://github.com/charmbracelet/crush/issues/812
* Follow-up of https://github.com/charmbracelet/crush/pull/817

To reproduce:

* `rm -rf ~/.config/crush; rm -rf ~/.local/share/crush`
* Open `crush` on onboarding
* Notice how you can navigate using arrows, filter, etc
* Click on the screen
* Not the onboarding screen will stop processing events properly (can't navigate, filter, choose model, etc)