### PR TITLE
fix: prevent nil pointer dereference in mcp tools parameters

### DIFF
--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -98,10 +98,14 @@ func (b *McpTool) Info() tools.ToolInfo {
 	if required == nil {
 		required = make([]string, 0)
 	}
+	parameters := b.tool.InputSchema.Properties
+	if parameters == nil {
+		parameters = make(map[string]any)
+	}
 	return tools.ToolInfo{
 		Name:        fmt.Sprintf("mcp_%s_%s", b.mcpName, b.tool.Name),
 		Description: b.tool.Description,
-		Parameters:  b.tool.InputSchema.Properties,
+		Parameters:  parameters,
 		Required:    required,
 	}
 }


### PR DESCRIPTION
### Describe your changes

This PR fixes a nil pointer dereference that occurs when MCP tools have no input schema properties defined. When using OpenAI-Compatible APIs like DeepSeek, the API expects function parameters to be a valid object schema, but was receiving null when MCP tools had no parameters, causing a 400 Bad Request error: `Invalid schema for function 'mcp_nvim_get_targets': null is not of type "object"`.

The fix ensures that the parameters field is always initialized to an empty map {} when b.tool.InputSchema.Properties is nil, satisfying the OpenAI function calling schema requirements.

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
