### PR TITLE
fix: return nil for empty tools slice to handle omitzero properly

### DIFF
--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -169,6 +169,9 @@ func (a *anthropicClient) convertMessages(messages []message.Message) (anthropic
 }
 
 func (a *anthropicClient) convertTools(tools []tools.BaseTool) []anthropic.ToolUnionParam {
+	if len(tools) == 0 {
+		return nil
+	}
 	anthropicTools := make([]anthropic.ToolUnionParam, len(tools))
 
 	for i, tool := range tools {


### PR DESCRIPTION
### Describe your changes

The anthropic.MessageNewParams uses omitzero tag, but an empty slice is not considered zero value. Return nil instead of empty slice when no tools are provided to ensure proper omitzero behavior.

This causes issues with Anthropic-compatible APIs (DeepSeek V3.1) that reject empty tools arrays. The current implementation returns an empty slice [] for tools when none are provided, but APIs expect the field to be omitted entirely when no tools are available.

```plain
{"time":"2025-08-22T16:20:39.19702+08:00","level":"DEBUG","source":{"function":"github.com/charmbracelet/crush/internal/log.(*HTTPRoundTripLogger).RoundTrip","file":"github.com/charmbracelet/crush/internal/log/http.go","line":46},"msg":"HTTP Request","method":"POST","url":{"Scheme":"https","Opaque":"","User":null,"Host":"api.deepseek.com","Path":"/anthropic/v1/messages","RawPath":"","OmitHost":false,"ForceQuery":false,"RawQuery":"","Fragment":"","RawFragment":""},"body":"{\"max_tokens\":5000,\"messages\":[{\"content\":[{\"text\":\"hello\",\"type\":\"text\"}],\"role\":\"user\"},{\"content\":[{\"text\":\"Hello! I'm Crush, your interactive CLI tool for software engineering tasks. I can help you with code editing, debugging, testing, and more. What would you like to work on today?\",\"cache_control\":{\"type\":\"ephemeral\"},\"type\":\"text\"}],\"role\":\"assistant\"},{\"content\":[{\"text\":\"Provide a detailed but concise summary of our conversation above. Focus on information that would be helpful for continuing the conversation, including what we did, what we're doing, which files we're working on, and what we're going to do next.\",\"cache_control\":{\"type\":\"ephemeral\"},\"type\":\"text\"}],\"role\":\"user\"}],\"model\":\"deepseek-chat\",\"temperature\":0,\"system\":[{\"text\":\"You are a helpful AI assistant tasked with summarizing conversations.\\n\\nWhen asked to summarize, provide a detailed but concise summary of the conversation.\\nFocus on information that would be helpful for continuing the conversation, including:\\n\\n- What was done\\n- What is currently being worked on\\n- Which files are being modified\\n- What needs to be done next\\n\\nYour summary should be comprehensive enough to provide context but concise enough to be quickly understood.\\n\",\"cache_control\":{\"type\":\"ephemeral\"},\"type\":\"text\"}],\"tools\":[],\"stream\":true}"}
{"time":"2025-08-22T16:20:39.25632+08:00","level":"DEBUG","source":{"function":"github.com/charmbracelet/crush/internal/log.(*HTTPRoundTripLogger).RoundTrip","file":"github.com/charmbracelet/crush/internal/log/http.go","line":68},"msg":"HTTP Response","status_code":400,"status":"400 Bad Request","headers":{"Access-Control-Allow-Credentials":["true"],"Connection":["keep-alive"],"Content-Length":["201"],"Content-Type":["application/json"],"Date":["Fri, 22 Aug 2025 08:20:39 GMT"],"Server":["CW"],"Set-Cookie":["HWWAFSESID=fc22f940e38367431b; path=/","HWWAFSESTIME=1755850835095; path=/"],"Strict-Transport-Security":["max-age=31536000; includeSubDomains; preload"],"Vary":["origin, access-control-request-method, access-control-request-headers"],"X-Content-Type-Options":["nosniff"],"X-Ds-Trace-Id":["b474e0158eeb7170bb3e6dfc2edac052"]},"body":"{\"error\":{\"message\":\"Invalid 'tools': empty array. Expected an array with minimum length 1, but got an empty array instead.\",\"type\":\"invalid_request_error\",\"param\":null,\"code\":\"invalid_request_error\"}}","content_length":201,"duration_ms":59,"error":null}
```

#### The example of omitzero behavior
https://go.dev/play/p/bVhfxDS89NK

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
