### PR TITLE
feat: allow to disable catwalk / "offline mode"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/charlievieth/fastwalk v1.0.12
 	github.com/charmbracelet/bubbles/v2 v2.0.0-beta.1.0.20250820203609-601216f68ee2
 	github.com/charmbracelet/bubbletea/v2 v2.0.0-beta.4.0.20250813213544-5cc219db8892
-	github.com/charmbracelet/catwalk v0.4.12
+	github.com/charmbracelet/catwalk v0.5.0
 	github.com/charmbracelet/fang v0.3.1-0.20250711140230-d5ebb8c1d674
 	github.com/charmbracelet/glamour/v2 v2.0.0-20250811143442-a27abb32f018
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.3.0.20250721205738-ea66aa652ee0

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/charmbracelet/bubbles/v2 v2.0.0-beta.1.0.20250820203609-601216f68ee2 
 github.com/charmbracelet/bubbles/v2 v2.0.0-beta.1.0.20250820203609-601216f68ee2/go.mod h1:6HamsBKWqEC/FVHuQMHgQL+knPyvHH55HwJDHl/adMw=
 github.com/charmbracelet/bubbletea/v2 v2.0.0-beta.4.0.20250813213544-5cc219db8892 h1:lqoYD2DrKhSdC9xCr59JMXtbbdR5/AZ6xfd/G8eOQJM=
 github.com/charmbracelet/bubbletea/v2 v2.0.0-beta.4.0.20250813213544-5cc219db8892/go.mod h1:TUpoECaG4/3CwFx5lTlXNpR87Yo7gOwGqucnHGfAm20=
-github.com/charmbracelet/catwalk v0.4.12 h1:HN7l/VVH+ecJbropJSoODeAawPuWk2mBApn99fs1MGM=
-github.com/charmbracelet/catwalk v0.4.12/go.mod h1:WnKgNPmQHuMyk7GtwAQwl+ezHusfH40IvzML2qwUGwc=
+github.com/charmbracelet/catwalk v0.5.0 h1:RTDWSuQNgt2M/wLPmYXp8jFiIgt+4hIn/dcnLTYgojA=
+github.com/charmbracelet/catwalk v0.5.0/go.mod h1:WnKgNPmQHuMyk7GtwAQwl+ezHusfH40IvzML2qwUGwc=
 github.com/charmbracelet/colorprofile v0.3.2 h1:9J27WdztfJQVAQKX2WOlSSRB+5gaKqqITmrvb1uTIiI=
 github.com/charmbracelet/colorprofile v0.3.2/go.mod h1:mTD5XzNeWHj8oqHb+S1bssQb7vIHbepiebQ2kPKVKbI=
 github.com/charmbracelet/fang v0.3.1-0.20250711140230-d5ebb8c1d674 h1:+Cz+VfxD5DO+JT1LlswXWhre0HYLj6l2HW8HVGfMuC0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,6 +143,7 @@ type Options struct {
 	DebugLSP             bool        `json:"debug_lsp,omitempty" jsonschema:"description=Enable debug logging for LSP servers,default=false"`
 	DisableAutoSummarize bool        `json:"disable_auto_summarize,omitempty" jsonschema:"description=Disable automatic conversation summarization,default=false"`
 	DataDirectory        string      `json:"data_directory,omitempty" jsonschema:"description=Directory for storing application data (relative to working directory),default=.crush,example=.crush"` // Relative to the cwd
+	DisableCatwalk       bool        `json:"disable_catwalk,omitempty" jsonschema:"description=Skip HTTP request to update providers automatically,default=false"`
 }
 
 type MCPs map[string]MCPConfig

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/catwalk/pkg/catwalk"
@@ -65,7 +66,7 @@ func Load(workingDir, dataDir string, debug bool) (*Config, error) {
 	)
 
 	// Load known providers, this loads the config from catwalk
-	providers, err := Providers()
+	providers, err := Providers(cfg)
 	if err != nil || len(providers) == 0 {
 		return nil, fmt.Errorf("failed to load providers: %w", err)
 	}
@@ -75,7 +76,7 @@ func Load(workingDir, dataDir string, debug bool) (*Config, error) {
 	// Configure providers
 	valueResolver := NewShellVariableResolver(env)
 	cfg.resolver = valueResolver
-	if err := cfg.configureProviders(env, valueResolver, providers); err != nil {
+	if err := cfg.configureProviders(env, valueResolver, cfg.knownProviders); err != nil {
 		return nil, fmt.Errorf("failed to configure providers: %w", err)
 	}
 
@@ -84,7 +85,7 @@ func Load(workingDir, dataDir string, debug bool) (*Config, error) {
 		return cfg, nil
 	}
 
-	if err := cfg.configureSelectedModels(providers); err != nil {
+	if err := cfg.configureSelectedModels(cfg.knownProviders); err != nil {
 		return nil, fmt.Errorf("failed to configure selected models: %w", err)
 	}
 	cfg.SetupAgents()
@@ -339,6 +340,10 @@ func (c *Config) setDefaults(workingDir, dataDir string) {
 	c.Options.ContextPaths = append(defaultContextPaths, c.Options.ContextPaths...)
 	slices.Sort(c.Options.ContextPaths)
 	c.Options.ContextPaths = slices.Compact(c.Options.ContextPaths)
+
+	if str, ok := os.LookupEnv("CRUSH_DISABLE_CATWALK"); ok {
+		c.Options.DisableCatwalk, _ = strconv.ParseBool(str)
+	}
 }
 
 var defaultLSPFileTypes = map[string][]string{

--- a/internal/tui/components/chat/splash/splash.go
+++ b/internal/tui/components/chat/splash/splash.go
@@ -397,7 +397,8 @@ func (s *splashCmp) setPreferredModel(selectedItem models.ModelOption) tea.Cmd {
 }
 
 func (s *splashCmp) getProvider(providerID catwalk.InferenceProvider) (*catwalk.Provider, error) {
-	providers, err := config.Providers()
+	cfg := config.Get()
+	providers, err := config.Providers(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tui/components/dialogs/models/list.go
+++ b/internal/tui/components/dialogs/models/list.go
@@ -49,7 +49,8 @@ func NewModelListComponent(keyMap list.KeyMap, inputPlaceholder string, shouldRe
 func (m *ModelListComponent) Init() tea.Cmd {
 	var cmds []tea.Cmd
 	if len(m.providers) == 0 {
-		providers, err := config.Providers()
+		cfg := config.Get()
+		providers, err := config.Providers(cfg)
 		filteredProviders := []catwalk.Provider{}
 		for _, p := range providers {
 			hasAPIKeyEnv := strings.HasPrefix(p.APIKey, "$")
@@ -119,7 +120,7 @@ func (m *ModelListComponent) SetModelType(modelType int) tea.Cmd {
 
 	// First, add any configured providers that are not in the known providers list
 	// These should appear at the top of the list
-	knownProviders, err := config.Providers()
+	knownProviders, err := config.Providers(cfg)
 	if err != nil {
 		return util.ReportError(err)
 	}

--- a/internal/tui/components/dialogs/models/models.go
+++ b/internal/tui/components/dialogs/models/models.go
@@ -350,7 +350,8 @@ func (m *modelDialogCmp) isProviderConfigured(providerID string) bool {
 }
 
 func (m *modelDialogCmp) getProvider(providerID catwalk.InferenceProvider) (*catwalk.Provider, error) {
-	providers, err := config.Providers()
+	cfg := config.Get()
+	providers, err := config.Providers(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/schema.json
+++ b/schema.json
@@ -271,6 +271,11 @@
           "examples": [
             ".crush"
           ]
+        },
+        "disable_catwalk": {
+          "type": "boolean",
+          "description": "Skip HTTP request to update providers automatically",
+          "default": false
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
* Follow-up of https://github.com/charmbracelet/catwalk/pull/48
* Closes https://github.com/charmbracelet/crush/issues/453
* Closes https://github.com/charmbracelet/crush/pull/689

Some people reported that they can't access Catwalk due to corporate restrictions on internet access, etc.

This PR adds the ability to disable Catwalk. Once disabled, Crush will use the latest available providers from the library, which might be outdated, but should still work if the Crush version is enough up-to-date.

Disabling via ENV:

```bash
env CRUSH_DISABLE_CATWALK=1 crush
```

Disabling via config:

```jsonc
// ~/.config/crush/crush.json
{
  "options": {
    "disable_catwalk": false
  }
}
```