### PR TITLE
chore: group dependabot updates to reduce noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,16 +26,3 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "05:00"
-      timezone: "America/New_York"
-    labels:
-      - "area: dependencies"
-    commit-message:
-      prefix: "chore"
-      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      all:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -26,3 +30,7 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      all:
+        patterns:
+          - "*"


### PR DESCRIPTION
This is proposal. See main PR on `meta`:

* https://github.com/charmbracelet/meta/pull/235

Opened here because we disabled the Dependabot config sync for this repository.