### PR TITLE
docs: Update license link to point to LICENSE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ We’d love to hear your thoughts on this project. Need help? We gotchu. You can
 
 ## License
 
-[FSL-1.1-MIT](https://github.com/charmbracelet/crush/raw/main/LICENSE)
+[FSL-1.1-MIT](https://github.com/charmbracelet/crush/raw/main/LICENSE.md)
 
 ---
 


### PR DESCRIPTION
The LICENSE file was renamed to LICENSE.md which broke the link in the README.md

### Describe your changes

change `https://github.com/charmbracelet/crush/raw/main/LICENSE` to `https://github.com/charmbracelet/crush/raw/main/LICENSE.md`

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code
