### PR TITLE
fix: fix goroutine panic due to waiting for channel for too long

### DIFF
--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -374,7 +374,10 @@ func (a *agent) Run(ctx context.Context, sessionID string, content string, attac
 		a.activeRequests.Del(sessionID)
 		cancel()
 		a.Publish(pubsub.CreatedEvent, result)
-		events <- result
+		select {
+		case events <- result:
+		case <-genCtx.Done():
+		}
 		close(events)
 	}()
 	return events, nil


### PR DESCRIPTION
We need to give up if the context was canceled.

Fixes #100