### PR TITLE
sec: show persistent shell path in permission dialog

### DIFF
--- a/internal/llm/tools/bash.go
+++ b/internal/llm/tools/bash.go
@@ -370,10 +370,11 @@ func (b *bashTool) Run(ctx context.Context, call ToolCall) (ToolResponse, error)
 		return ToolResponse{}, fmt.Errorf("session ID and message ID are required for executing shell command")
 	}
 	if !isSafeReadOnly {
+		shell := shell.GetPersistentShell(b.workingDir)
 		p := b.permissions.Request(
 			permission.CreatePermissionRequest{
 				SessionID:   sessionID,
-				Path:        b.workingDir,
+				Path:        shell.GetWorkingDir(),
 				ToolCallID:  call.ID,
 				ToolName:    BashToolName,
 				Action:      "execute",


### PR DESCRIPTION
Currently it will always show the path of when it was started.

This can be confusing, as the user might use a prompt like 

> run `cd /etc`

and then:

> run `cat ./shadow` 

and the permission dialog would not show that the path is `/etc`.

This fixes it.