### PR TITLE
fix: handle providers that do not send the right index

### DIFF
--- a/internal/llm/provider/openai.go
+++ b/internal/llm/provider/openai.go
@@ -398,7 +398,6 @@ func (o *openaiClient) stream(ctx context.Context, messages []message.Message, t
 								},
 							}
 							toolMap[toolCall.ID] = msgToolCalls[toolCall.Index]
-
 						}
 						toolCalls := []openai.ChatCompletionMessageToolCall{}
 						for _, tc := range toolMap {


### PR DESCRIPTION
This PR fixes xAI issues. Basically, xAI wasn't sending the correct index for tool calls.