### PR TITLE
fix: tool calls break the conversation if interrupted

### DIFF
--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -151,6 +151,9 @@ func (a *anthropicClient) convertMessages(messages []message.Message) (anthropic
 			}
 
 			for _, toolCall := range msg.ToolCalls() {
+				if !toolCall.Finished {
+					continue
+				}
 				var inputMap map[string]any
 				err := json.Unmarshal([]byte(toolCall.Input), &inputMap)
 				if err != nil {

--- a/internal/llm/provider/gemini.go
+++ b/internal/llm/provider/gemini.go
@@ -81,6 +81,9 @@ func (g *geminiClient) convertMessages(messages []message.Message) []*genai.Cont
 
 			if len(msg.ToolCalls()) > 0 {
 				for _, call := range msg.ToolCalls() {
+					if !call.Finished {
+						continue
+					}
 					args, _ := parseJSONToMap(call.Input)
 					assistantParts = append(assistantParts, &genai.Part{
 						FunctionCall: &genai.FunctionCall{


### PR DESCRIPTION
### Describe your changes

Fix invalid assistant messages after an interrupted tool call.

- OpenAI path:
    - Only serialize finished tool calls (`ToolCall.Finished == true`) in assistant messages.
    - Skip appending empty assistant messages (no `content` and no finished `tool_calls`)
- Anthropic path:
    - Only emit tool_use blocks for finished calls. 
- Gemini/Vertex path:
    - Only emit function calls for finished calls. 


How to test:

- Start a tool call (e.g., ask the agent to grep), interrupt with Ctrl+C
mid-run, then send a new prompt.
- Before: OpenAI-style providers returned a 400 for invalid assistant
message.
- After: Request proceeds without error; conversation continues
normally.

### Related issue/discussion:

Fixes #920 

### Checklist before requesting a review

- [X] I have read CONTRIBUTING.md (https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to
comment:
