### PR TITLE
feat: add boring theme (grayscale-based colorscheme)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,6 +129,7 @@ type TUIOptions struct {
 	CompactMode bool   `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
 	DiffMode    string `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
 	// Here we can add themes later or any TUI related options
+	Theme string `json:"theme,omitempty" jsonschema:"description=Theme to use for the TUI interface,enum=charmtone,enum=boring,default=charmtone"`
 }
 
 type Permissions struct {

--- a/internal/tui/styles/boring.go
+++ b/internal/tui/styles/boring.go
@@ -1,0 +1,100 @@
+package styles
+
+import "github.com/charmbracelet/lipgloss/v2"
+
+func NewBoringTheme() *Theme {
+	// Grayscale Palette
+	var (
+		night       = lipgloss.Color("#1c1c1c")
+		raisinBlack = lipgloss.Color("#222222")
+		charleston  = lipgloss.Color("#2b2b2b")
+		jet         = lipgloss.Color("#333333")
+		onyx        = lipgloss.Color("#3d3d3d")
+		gunmetal    = lipgloss.Color("#4e4e4e")
+		granite     = lipgloss.Color("#5f5f5f")
+		stone       = lipgloss.Color("#7a7a7a")
+		lightSilver = lipgloss.Color("#c5c5c5")
+		white       = lipgloss.Color("#ffffff")
+	)
+
+	// Accent Palette
+	var (
+		fern       = lipgloss.Color("#6a8e5f")
+		forest     = lipgloss.Color("#4a703c")
+		olivine    = lipgloss.Color("#b5c8b0")
+		terracotta = lipgloss.Color("#c95e52")
+		redwood    = lipgloss.Color("#a14f46")
+		salmon     = lipgloss.Color("#e48981")
+		rose       = lipgloss.Color("#d17d8a")
+		sand       = lipgloss.Color("#d7c08d")
+		teal       = lipgloss.Color("#5e9a9b")
+		sky        = lipgloss.Color("#669cd6")
+	)
+
+	t := &Theme{
+		Name:   "boring",
+		IsDark: true,
+
+		Primary:   granite,
+		Secondary: gunmetal,
+		Tertiary:  onyx,
+		Accent:    stone,
+
+		// Backgrounds
+		BgBase:        night,
+		BgBaseLighter: charleston,
+		BgSubtle:      raisinBlack,
+		BgOverlay:     jet,
+
+		// Foregrounds
+		FgBase:      lightSilver,
+		FgMuted:     stone,
+		FgHalfMuted: granite,
+		FgSubtle:    gunmetal,
+		FgSelected:  white,
+
+		// Borders
+		Border:      raisinBlack,
+		BorderFocus: granite,
+
+		// Status
+		Success: fern,
+		Error:   terracotta,
+		Warning: sand,
+		Info:    teal,
+
+		// Colors
+		White: lightSilver,
+
+		BlueLight: sky,
+		Blue:      teal,
+
+		Yellow: sand,
+		Citron: olivine,
+
+		Green:      fern,
+		GreenDark:  forest,
+		GreenLight: olivine,
+
+		Red:      terracotta,
+		RedDark:  redwood,
+		RedLight: salmon,
+		Cherry:   rose,
+	}
+
+	// Text selection.
+	t.TextSelection = lipgloss.NewStyle().Foreground(white).Background(granite)
+
+	// LSP and MCP status.
+	t.ItemOfflineIcon = lipgloss.NewStyle().Foreground(stone).SetString("●")
+	t.ItemBusyIcon = t.ItemOfflineIcon.Foreground(sand)
+	t.ItemErrorIcon = t.ItemOfflineIcon.Foreground(terracotta)
+	t.ItemOnlineIcon = t.ItemOfflineIcon.Foreground(fern)
+
+	t.YoloIconFocused = lipgloss.NewStyle().Foreground(night).Background(sand).Bold(true).SetString(" ! ")
+	t.YoloIconBlurred = t.YoloIconFocused.Foreground(lightSilver).Background(gunmetal)
+	t.YoloDotsFocused = lipgloss.NewStyle().Foreground(sand).SetString(":::")
+	t.YoloDotsBlurred = t.YoloDotsFocused.Foreground(stone)
+
+	return t
+}

--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -520,8 +520,9 @@ func NewManager() *Manager {
 
 	t := NewCharmtoneTheme() // default theme
 	m.Register(t)
-	m.current = m.themes[t.Name]
+	m.Register(NewBoringTheme())
 
+	m.current = m.themes[t.Name]
 	return m
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -600,6 +600,14 @@ func (a *appModel) View() tea.View {
 
 // New creates and initializes a new TUI application model.
 func New(app *app.App) tea.Model {
+	cfg := config.Get()
+	if cfg.Options.TUI.Theme != "" {
+		stylesManager := styles.NewManager()
+		stylesManager.SetTheme(cfg.Options.TUI.Theme)
+
+		styles.SetDefaultManager(stylesManager)
+	}
+
 	chatPage := chat.New(app)
 	keyMap := DefaultKeyMap()
 	keyMap.pageBindings = chatPage.Bindings()

--- a/schema.json
+++ b/schema.json
@@ -427,6 +427,15 @@
             "split"
           ],
           "description": "Diff mode for the TUI interface"
+        },
+        "theme": {
+          "type": "string",
+          "enum": [
+            "charmtone",
+            "boring"
+          ],
+          "description": "Theme to use for the TUI interface",
+          "default": "charmtone"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
### Describe your changes

Hi! This PR tries to save kwayza's eyes by adding a grayscale-based colorscheme 

<img width="709" height="170" alt="1756485744" src="https://github.com/user-attachments/assets/2e519680-4f20-4a06-be8e-e32e8af8a2aa" />

[link](https://www.youtube.com/watch?v=YcTuy9e2roM&lc=UgyiIeRiQCxstVEQPUd4AaABAg)

Users can now select the Boring theme by setting `"theme": "boring"` in their Crush config file under the `tui` section.

Let me know if this goes in the wrong direction or if any changes are needed. Thanks!


### Checklist before requesting a review

- [ x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x ] I have performed a self-review of my code


