### PR TITLE
Parity for calling OpenAI/Azure, fixes for using Azure, introduce "verbosity" as parameter similar to "reasoning_effort", TUI controls and alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ That said, you can also set environment variables for preferred providers.
 | `AWS_ACCESS_KEY_ID`        | AWS Bedrock (Claude)                               |
 | `AWS_SECRET_ACCESS_KEY`    | AWS Bedrock (Claude)                               |
 | `AWS_REGION`               | AWS Bedrock (Claude)                               |
-| `AZURE_OPENAI_ENDPOINT`    | Azure OpenAI models                                |
+| `AZURE_OPENAI_API_ENDPOINT`    | Azure OpenAI models                                |
 | `AZURE_OPENAI_API_KEY`     | Azure OpenAI models (optional when using Entra ID) |
 | `AZURE_OPENAI_API_VERSION` | Azure OpenAI models                                |
 

--- a/internal/llm/prompt/coder.go
+++ b/internal/llm/prompt/coder.go
@@ -22,6 +22,9 @@ func CoderPrompt(p string, contextFiles ...string) string {
 	case string(catwalk.InferenceProviderOpenAI):
 		// seems to behave better
 		basePrompt = string(coderV2Prompt)
+	case string(catwalk.InferenceProviderAzure):
+		// align Azure with OpenAI prompt behavior
+		basePrompt = string(coderV2Prompt)
 	case string(catwalk.InferenceProviderGemini):
 		basePrompt = string(geminiCoderPrompt)
 	}

--- a/internal/llm/provider/openai.go
+++ b/internal/llm/provider/openai.go
@@ -58,6 +58,10 @@ func createOpenAIClient(opts providerClientOptions) openai.Client {
 	}
 
 	for extraKey, extraValue := range opts.extraBody {
+		// ignore verbosity from extra_body to avoid split-brain configuration
+		if strings.EqualFold(extraKey, "verbosity") {
+			continue
+		}
 		openaiClientOptions = append(openaiClientOptions, option.WithJSONSet(extraKey, extraValue))
 	}
 
@@ -225,6 +229,9 @@ func (o *openaiClient) preparedParams(messages []openai.ChatCompletionMessagePar
 	}
 
 	reasoningEffort := modelConfig.ReasoningEffort
+	if reasoningEffort == "" && model.CanReason {
+		reasoningEffort = model.DefaultReasoningEffort
+	}
 
 	params := openai.ChatCompletionNewParams{
 		Model:    openai.ChatModel(model.ID),
@@ -243,17 +250,19 @@ func (o *openaiClient) preparedParams(messages []openai.ChatCompletionMessagePar
 	}
 	if model.CanReason {
 		params.MaxCompletionTokens = openai.Int(maxTokens)
-		switch reasoningEffort {
-		case "low":
-			params.ReasoningEffort = shared.ReasoningEffortLow
-		case "medium":
-			params.ReasoningEffort = shared.ReasoningEffortMedium
-		case "high":
-			params.ReasoningEffort = shared.ReasoningEffortHigh
-		case "minimal":
-			params.ReasoningEffort = shared.ReasoningEffort("minimal")
-		default:
-			params.ReasoningEffort = shared.ReasoningEffort(reasoningEffort)
+		if reasoningEffort != "" {
+			switch reasoningEffort {
+			case "low":
+				params.ReasoningEffort = shared.ReasoningEffortLow
+			case "medium":
+				params.ReasoningEffort = shared.ReasoningEffortMedium
+			case "high":
+				params.ReasoningEffort = shared.ReasoningEffortHigh
+			case "minimal":
+				params.ReasoningEffort = shared.ReasoningEffort("minimal")
+			default:
+				params.ReasoningEffort = shared.ReasoningEffort(reasoningEffort)
+			}
 		}
 	} else {
 		params.MaxTokens = openai.Int(maxTokens)
@@ -267,9 +276,30 @@ func (o *openaiClient) send(ctx context.Context, messages []message.Message, too
 	attempts := 0
 	for {
 		attempts++
+		// Optional per-call request options (e.g., verbosity)
+		cfg := config.Get()
+		modelConfig := cfg.Models[config.SelectedModelTypeLarge]
+		if o.providerOptions.modelType == config.SelectedModelTypeSmall {
+			modelConfig = cfg.Models[config.SelectedModelTypeSmall]
+		}
+		var reqOpts []option.RequestOption
+		// Bind verbosity to can_reason and apply default fallback from provider model_overrides
+		if m := o.Model(); m.CanReason {
+			v := modelConfig.Verbosity
+			if v == "" {
+				if dv, ok := o.providerOptions.config.DefaultVerbosityByModel[m.ID]; ok {
+					v = dv
+				}
+			}
+			if v != "" {
+				reqOpts = append(reqOpts, option.WithJSONSet("verbosity", v))
+			}
+		}
+
 		openaiResponse, err := o.client.Chat.Completions.New(
 			ctx,
 			params,
+			reqOpts...,
 		)
 		// If there is an error we are going to see if we can retry the call
 		if err != nil {
@@ -330,9 +360,30 @@ func (o *openaiClient) stream(ctx context.Context, messages []message.Message, t
 			if len(params.Tools) == 0 {
 				params.Tools = nil
 			}
+			// Optional per-call request options (e.g., verbosity)
+			cfg := config.Get()
+			modelConfig := cfg.Models[config.SelectedModelTypeLarge]
+			if o.providerOptions.modelType == config.SelectedModelTypeSmall {
+				modelConfig = cfg.Models[config.SelectedModelTypeSmall]
+			}
+			var reqOpts []option.RequestOption
+			// Bind verbosity to can_reason and apply default fallback from provider model_overrides
+			if m := o.Model(); m.CanReason {
+				v := modelConfig.Verbosity
+				if v == "" {
+					if dv, ok := o.providerOptions.config.DefaultVerbosityByModel[m.ID]; ok {
+						v = dv
+					}
+				}
+				if v != "" {
+					reqOpts = append(reqOpts, option.WithJSONSet("verbosity", v))
+				}
+			}
+
 			openaiStream := o.client.Chat.Completions.NewStreaming(
 				ctx,
 				params,
+				reqOpts...,
 			)
 
 			acc := openai.ChatCompletionAccumulator{}

--- a/internal/tui/components/chat/sidebar/sidebar.go
+++ b/internal/tui/components/chat/sidebar/sidebar.go
@@ -563,7 +563,7 @@ func (s *sidebarCmp) currentModelBlock() string {
 	if model.CanReason {
 		reasoningInfoStyle := t.S().Subtle.PaddingLeft(2)
 		switch modelProvider.Type {
-		case catwalk.TypeOpenAI:
+		case catwalk.TypeOpenAI, catwalk.TypeAzure:
 			reasoningEffort := model.DefaultReasoningEffort
 			if selectedModel.ReasoningEffort != "" {
 				reasoningEffort = selectedModel.ReasoningEffort
@@ -577,6 +577,20 @@ func (s *sidebarCmp) currentModelBlock() string {
 			} else {
 				parts = append(parts, reasoningInfoStyle.Render(formatter.String("Thinking off")))
 			}
+		}
+	}
+	// Show Verbosity only for reasoning-capable models; use SelectedModel override or provider model default
+	if model.CanReason {
+		v := selectedModel.Verbosity
+		if v == "" && modelProvider != nil {
+			if dv, ok := modelProvider.DefaultVerbosityByModel[model.ID]; ok {
+				v = dv
+			}
+		}
+		if v != "" {
+			infoStyle := t.S().Subtle.PaddingLeft(2)
+			formatter := cases.Title(language.English, cases.NoLower)
+			parts = append(parts, infoStyle.Render(formatter.String(fmt.Sprintf("Verbosity %s", v))))
 		}
 	}
 	if s.session.ID != "" {

--- a/schema.json
+++ b/schema.json
@@ -212,6 +212,14 @@
         "default_reasoning_effort": {
           "type": "string"
         },
+        "default_verbosity": {
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
+        },
         "supports_attachments": {
           "type": "boolean"
         }
@@ -391,6 +399,15 @@
             "high"
           ],
           "description": "Reasoning effort level for OpenAI models that support it"
+        },
+        "verbosity": {
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ],
+          "description": "Verbosity level for models that support it"
         },
         "max_tokens": {
           "type": "integer",


### PR DESCRIPTION
### Describe your changes
This PR fixes issues when using the new GPT-5-style-models and aligns the usage of both affected providers OpenAI and Azure to parity. Further the new "verbosity" parameter is introduced and behaves identically to "reasoning_effort".

Details:
- Verbosity applies only when can_reason = true
- Precedence: SelectedModel override > per-model defaults > none
- Sidebar follows the same effective value than the requests
- Per-model defaults: default_verbosity read from providers.<id>.models[] 
- Azure now matches OpenAI behavior in prompt/headers/body/per-call options
- TUI commands: set Reasoning Effort (minimal/low/medium/high) and Verbosity (low/medium/high). 
- Persistence of selected effort and verbosity is identically to Anthropic thinking on/off.
- A model switch resets the slot to defaults

Examples of fixed issues:
- Reasoning Effort default missing in requests while UI showed a default:
  - Before: UI displayed “Reasoning High” (from model default), but request did not include reasoning_effort when SelectedModel.ReasoningEffort was empty.
  - After: If Selected is empty and can_reason = true, the request includes the model default (ReasoningEffort). UI and request are now aligned.
- Azure parity, prompt, and request customization:
  - Before: Azure did not apply provider extras (headers/body) and per-call options symmetrically to OpenAI. Features depending on request customization (e.g., verbosity via per-call options) were ineffective. In addition, reasoning_effort suffered from the same default-missing behavior as OpenAI. 
  - After: Azure now mirrors OpenAI for extras and per-call options; and reasoning_effort default is applied in requests when Selected is empty and can_reason = true. 
- Calls to Azure with GPT-5 showed extremely short answers with degraded quality.  
  - Before: Azure used anthropic.md to generate the coder prompt.
  - After: Azure uses v2.md as coder prompt like OpenAI
- Verbosity was neither injected nor visible:
  - Before: No request injection and no Sidebar badge.
  - After: Injected per call (only when can_reason), with precedence Selected > default_verbosity; Sidebar shows the same effective value.
- Selected vs. Catalog inconsistencies on model switch:
  - Before: Stale overrides caused mismatches with model defaults.
  - After: Forced reset to defaults (Effort/MaxTokens/Think; Verbosity via default_verbosity fallback) yields deterministic behavior.
- BONUS: In the Readme.md the environment variable for the Azure Endpoint was not correctly mentioned. I incorporated a fix for this as well.

Persistence of GPT-5-Style-Parameters:
- Identical to Anthropic “Think”: SelectedModel fields are persisted via config.UpdatePreferredModel(...) to ~/.local/share/crush/crush.json. No separate persistence layer.

### Related issue: https://github.com/charmbracelet/crush/issues/943

### Checklist before requesting a review

- [ X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)  I read the CLA - fine for me. 
- [ X] I have performed a self-review of my code. Yes I did - and I polished and tested it !

### This is a bugfix with some shiny polish.

- [ X] I have created a (tiny) discussion 
- [X ] A project maintainer has approved this feature request. Link to comment:  No. I started a discussion about the issue and asked if I shall do a PR. Received a "Yes". This PR contains the fix and some shiny polish. 
