### PR TITLE
fix(openrouter): fix api key validation for openrouter

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -460,7 +460,11 @@ func (c *ProviderConfig) TestConnection(resolver VariableResolver) error {
 		if baseURL == "" {
 			baseURL = "https://api.openai.com/v1"
 		}
-		testURL = baseURL + "/models"
+		if c.Name == "OpenRouter" {
+			testURL = baseURL + "/credits"
+		} else {
+			testURL = baseURL + "/models"
+		}
 		headers["Authorization"] = "Bearer " + apiKey
 	case catwalk.TypeAnthropic:
 		baseURL, _ := resolver.ResolveValue(c.BaseURL)


### PR DESCRIPTION
`/models` is accessible for everyone on OpenRouter, without the need for any authorization. The `Authorization: Bearer *` was basically always ignore by their API.

Using a different private API to validate the key for OpenRouter.
