### PR TITLE
no need to check cancelled ctx

### DIFF
--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -343,7 +343,7 @@ func (a *agent) Run(ctx context.Context, sessionID string, content string, attac
 	if !a.Model().SupportsImages && attachments != nil {
 		attachments = nil
 	}
-	events := make(chan AgentEvent)
+	events := make(chan AgentEvent, 1)
 	if a.IsSessionBusy(sessionID) {
 		existing, ok := a.promptQueue.Get(sessionID)
 		if !ok {


### PR DESCRIPTION
- [+] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [-] I have created a discussion that was approved by a maintainer (for new features).

There is no need to check the cancellation of a cancelled context. Such a check may lead to undefined behavior: if a `result` is available, it may or may not be delivered to the `events` channel, depending on the random selection outcome of the `select` statement.