### PR TITLE
:llama: `ollama` > Only models that support tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ Local models can also be configured via OpenAI-compatible API. Here are two comm
 
 #### Ollama
 
+You can use local AI with `ollama` but take good care that the model you use supports tools.
+
 ```json
 {
   "providers": {


### PR DESCRIPTION
# :grey_question: About

Hi guys, I'm staring to give  atry to crush around local ai on ollama... for gpu poor.

Maybe could be added that LLM should suppport tool calling.

```
ERROR  API Error

POST "http://localhost:11434/v1/chat/completions": 400 Bad Request
{"message":"registry.ollama.ai/library/gemma3:270m does not support
tools","type":"api_error","param":null,"code":null}
```

<img width="1001" height="502" alt="image" src="https://github.com/user-attachments/assets/ea4ac0a9-b517-48dd-ba82-d961d4ac736c" />


I'm now giving a try to `llama3.1:8b`... but it makes me think about building a set of confs to setup ollama on validated models.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
