### PR TITLE
fix: ensure it's possible to quit (`ctrl+c`) even when a dialog is open

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -406,6 +406,16 @@ func (a *appModel) handleWindowResize(width, height int) tea.Cmd {
 
 // handleKeyPressMsg processes keyboard input and routes to appropriate handlers.
 func (a *appModel) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
+	// Check this first as the user should be able to quit no matter what.
+	if key.Matches(msg, a.keyMap.Quit) {
+		if a.dialog.ActiveDialogID() == quit.QuitDialogID {
+			return tea.Quit
+		}
+		return util.CmdHandler(dialogs.OpenDialogMsg{
+			Model: quit.NewQuitDialog(),
+		})
+	}
+
 	if a.completions.Open() {
 		// completions
 		keyMap := a.completions.KeyMap()
@@ -430,14 +440,6 @@ func (a *appModel) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		a.showingFullHelp = !a.showingFullHelp
 		return a.handleWindowResize(a.wWidth, a.wHeight)
 	// dialogs
-	case key.Matches(msg, a.keyMap.Quit):
-		if a.dialog.ActiveDialogID() == quit.QuitDialogID {
-			return tea.Quit
-		}
-		return util.CmdHandler(dialogs.OpenDialogMsg{
-			Model: quit.NewQuitDialog(),
-		})
-
 	case key.Matches(msg, a.keyMap.Commands):
 		// if the app is not configured show no commands
 		if !a.isConfigured {


### PR DESCRIPTION
This used to work in the beginning, another another fix introduced this bug.

`ctrl+c` should have priority over other events and checks.

<img width="704" height="472" alt="Screenshot 2025-09-10 at 10 13 37" src="https://github.com/user-attachments/assets/824af8e7-0de0-4bcf-832c-353e5a1a86eb" />
