### PR TITLE
feat(provider): add per-provider disable_streaming with non-streaming fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,26 @@ Local models can also be configured via OpenAI-compatible API. Here are two comm
 }
 ```
 
+If a provider only offers non-streaming completions, set
+`"disable_streaming": true` to have Crush fall back to the non-streaming API
+while still emitting a single streamed response event:
+
+```json
+{
+  "providers": {
+    "nonstream": {
+      "type": "openai",
+      "base_url": "https://example.com/v1",
+      "api_key": "$NONSTREAM_API_KEY",
+      "disable_streaming": true,
+      "models": [
+        { "id": "example-large", "name": "Example Large" }
+      ]
+    }
+  }
+}
+```
+
 ### Custom Providers
 
 Crush supports custom provider configurations for both OpenAI-compatible and

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,10 @@ type ProviderConfig struct {
 	// Marks the provider as disabled.
 	Disable bool `json:"disable,omitempty" jsonschema:"description=Whether this provider is disabled,default=false"`
 
+	// Disable streaming for this provider; when disabled the system falls back to
+	// non-streaming responses while still emitting a single stream event.
+	DisableStreaming bool `json:"disable_streaming,omitempty" jsonschema:"description=Disable streaming for this provider,default=false"`
+
 	// Custom system prompt prefix.
 	SystemPromptPrefix string `json:"system_prompt_prefix,omitempty" jsonschema:"description=Custom prefix to add to system prompts for this provider"`
 

--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -576,6 +576,10 @@ loop:
 				}
 				return assistantMsg, nil, processErr
 			}
+
+			if event.Type == provider.EventComplete {
+				break loop
+			}
 		case <-ctx.Done():
 			a.finishMessage(context.Background(), &assistantMsg, message.FinishReasonCanceled, "Request cancelled", "")
 			return assistantMsg, nil, ctx.Err()

--- a/internal/llm/agent/agent_nostreaming_test.go
+++ b/internal/llm/agent/agent_nostreaming_test.go
@@ -1,0 +1,154 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/llm/provider"
+	"github.com/charmbracelet/crush/internal/llm/tools"
+	"github.com/charmbracelet/crush/internal/lsp"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/permission"
+	"github.com/charmbracelet/crush/internal/pubsub"
+	"github.com/charmbracelet/crush/internal/session"
+)
+
+// fakeProvider sends a single EventComplete and never closes the channel.
+type fakeProvider struct{}
+
+func (f *fakeProvider) SendMessages(ctx context.Context, messages []message.Message, tools []tools.BaseTool) (*provider.ProviderResponse, error) {
+	return &provider.ProviderResponse{Content: "hello", FinishReason: message.FinishReasonEndTurn}, nil
+}
+
+func (f *fakeProvider) StreamResponse(ctx context.Context, messages []message.Message, tools []tools.BaseTool) <-chan provider.ProviderEvent {
+	ch := make(chan provider.ProviderEvent, 2)
+	go func() {
+		ch <- provider.ProviderEvent{Type: provider.EventContentDelta, Content: "hello"}
+		ch <- provider.ProviderEvent{Type: provider.EventComplete, Response: &provider.ProviderResponse{Content: "hello", FinishReason: message.FinishReasonEndTurn}}
+		<-ctx.Done()
+	}()
+	return ch
+}
+
+func (f *fakeProvider) Model() catwalk.Model { return catwalk.Model{ID: "fake"} }
+
+// minimal in-memory message service used by the agent in tests
+type memMessageService struct {
+	pub *pubsub.Broker[message.Message]
+}
+
+func (m *memMessageService) Subscribe(ctx context.Context) <-chan pubsub.Event[message.Message] {
+	return m.pub.Subscribe(ctx)
+}
+
+func (m *memMessageService) Create(ctx context.Context, sessionID string, params message.CreateMessageParams) (message.Message, error) {
+	msg := message.Message{ID: "m1", SessionID: sessionID, Role: params.Role, Parts: params.Parts}
+	m.pub.Publish(pubsub.CreatedEvent, msg)
+	return msg, nil
+}
+
+func (m *memMessageService) Update(ctx context.Context, msg message.Message) error {
+	m.pub.Publish(pubsub.UpdatedEvent, msg)
+	return nil
+}
+
+func (m *memMessageService) Get(ctx context.Context, id string) (message.Message, error) {
+	return message.Message{}, nil
+}
+
+func (m *memMessageService) List(ctx context.Context, sessionID string) ([]message.Message, error) {
+	return nil, nil
+}
+
+func (m *memMessageService) Delete(ctx context.Context, id string) error { return nil }
+
+func (m *memMessageService) DeleteSessionMessages(ctx context.Context, sessionID string) error {
+	return nil
+}
+
+// minimal session service
+type memSessionService struct{}
+
+func (s *memSessionService) Subscribe(ctx context.Context) <-chan pubsub.Event[session.Session] {
+	ch := make(chan pubsub.Event[session.Session])
+	close(ch)
+	return ch
+}
+
+func (s *memSessionService) Create(ctx context.Context, title string) (session.Session, error) {
+	return session.Session{ID: "s1"}, nil
+}
+
+func (s *memSessionService) CreateTitleSession(ctx context.Context, parentSessionID string) (session.Session, error) {
+	return session.Session{ID: "title-" + parentSessionID}, nil
+}
+
+func (s *memSessionService) CreateTaskSession(ctx context.Context, toolCallID, parentSessionID, title string) (session.Session, error) {
+	return session.Session{ID: toolCallID}, nil
+}
+
+func (s *memSessionService) Get(ctx context.Context, id string) (session.Session, error) {
+	return session.Session{ID: id}, nil
+}
+
+func (s *memSessionService) List(ctx context.Context) ([]session.Session, error) { return nil, nil }
+
+func (s *memSessionService) Save(ctx context.Context, sess session.Session) (session.Session, error) {
+	return sess, nil
+}
+
+func (s *memSessionService) Delete(ctx context.Context, id string) error { return nil }
+
+func TestStreamAndHandleEvents_EventComplete_NoClose(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := config.Init(".", "", true)
+	if err != nil {
+		t.Fatalf("failed to init config: %v", err)
+	}
+	cfg.Providers = csync.NewMap[string, config.ProviderConfig]()
+	cfg.Providers.Set("test", config.ProviderConfig{
+		ID:     "test",
+		Models: []catwalk.Model{{ID: "m1"}},
+	})
+	cfg.Models = map[config.SelectedModelType]config.SelectedModel{
+		config.SelectedModelTypeLarge: {Provider: "test", Model: "m1"},
+	}
+	cfg.SetupAgents()
+
+	a := &agent{
+		Broker:         pubsub.NewBroker[AgentEvent](),
+		agentCfg:       config.Agent{Model: config.SelectedModelTypeLarge},
+		messages:       &memMessageService{pub: pubsub.NewBroker[message.Message]()},
+		sessions:       &memSessionService{},
+		permissions:    permission.NewPermissionService(".", true, nil),
+		provider:       &fakeProvider{},
+		providerID:     "fake",
+		baseTools:      csync.NewMap[string, tools.BaseTool](),
+		mcpTools:       csync.NewMap[string, tools.BaseTool](),
+		lspClients:     csync.NewMap[string, *lsp.Client](),
+		activeRequests: csync.NewMap[string, context.CancelFunc](),
+		promptQueue:    csync.NewMap[string, []string](),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	assistant, _, err := a.streamAndHandleEvents(ctx, "sess1", []message.Message{{
+		Role:  message.User,
+		Parts: []message.ContentPart{message.TextContent{Text: "hi"}},
+	}})
+	if err != nil {
+		t.Fatalf("streamAndHandleEvents error: %v", err)
+	}
+	if assistant.Content().Text != "hello" {
+		t.Fatalf("expected content 'hello', got %q", assistant.Content().Text)
+	}
+	if assistant.FinishReason() == "" {
+		t.Fatalf("expected finish reason to be set")
+	}
+}

--- a/internal/llm/provider/provider.go
+++ b/internal/llm/provider/provider.go
@@ -68,6 +68,7 @@ type providerClientOptions struct {
 	modelType          config.SelectedModelType
 	model              func(config.SelectedModelType) catwalk.Model
 	disableCache       bool
+	disableStreaming   bool
 	systemMessage      string
 	systemPromptPrefix string
 	maxTokens          int64
@@ -108,7 +109,28 @@ func (p *baseProvider[C]) SendMessages(ctx context.Context, messages []message.M
 
 func (p *baseProvider[C]) StreamResponse(ctx context.Context, messages []message.Message, tools []tools.BaseTool) <-chan ProviderEvent {
 	messages = p.cleanMessages(messages)
-	return p.client.stream(ctx, messages, tools)
+
+	if !p.options.disableStreaming {
+		return p.client.stream(ctx, messages, tools)
+	}
+
+	// Fallback to non-streaming call while still exposing a stream-like API.
+	// Emit a single ContentDelta (when content exists) followed by Complete.
+	eventChan := make(chan ProviderEvent, 2)
+	go func() {
+		defer close(eventChan)
+		resp, err := p.client.send(ctx, messages, tools)
+		if err != nil {
+			eventChan <- ProviderEvent{Type: EventError, Error: err}
+			return
+		}
+		if resp != nil && resp.Content != "" {
+			eventChan <- ProviderEvent{Type: EventContentDelta, Content: resp.Content}
+		}
+		eventChan <- ProviderEvent{Type: EventComplete, Response: resp}
+	}()
+
+	return eventChan
 }
 
 func (p *baseProvider[C]) Model() catwalk.Model {
@@ -165,6 +187,7 @@ func NewProvider(cfg config.ProviderConfig, opts ...ProviderClientOption) (Provi
 		extraBody:          cfg.ExtraBody,
 		extraParams:        cfg.ExtraParams,
 		systemPromptPrefix: cfg.SystemPromptPrefix,
+		disableStreaming:   cfg.DisableStreaming,
 		model: func(tp config.SelectedModelType) catwalk.Model {
 			return *config.Get().GetModelByType(tp)
 		},
@@ -205,4 +228,10 @@ func NewProvider(cfg config.ProviderConfig, opts ...ProviderClientOption) (Provi
 		}, nil
 	}
 	return nil, fmt.Errorf("provider not supported: %s", cfg.Type)
+}
+
+func WithDisableStreaming(disable bool) ProviderClientOption {
+	return func(options *providerClientOptions) {
+		options.disableStreaming = disable
+	}
 }

--- a/internal/llm/provider/provider_nostreaming_test.go
+++ b/internal/llm/provider/provider_nostreaming_test.go
@@ -1,0 +1,139 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/llm/tools"
+	"github.com/charmbracelet/crush/internal/message"
+)
+
+type fakeClient struct {
+	resp         *ProviderResponse
+	err          error
+	streamEvents []ProviderEvent
+	sendCalled   bool
+	streamCalled bool
+}
+
+func (f *fakeClient) send(ctx context.Context, messages []message.Message, tools []tools.BaseTool) (*ProviderResponse, error) {
+	f.sendCalled = true
+	return f.resp, f.err
+}
+
+func (f *fakeClient) stream(ctx context.Context, messages []message.Message, tools []tools.BaseTool) <-chan ProviderEvent {
+	f.streamCalled = true
+	ch := make(chan ProviderEvent, len(f.streamEvents))
+	for _, e := range f.streamEvents {
+		ch <- e
+	}
+	close(ch)
+	return ch
+}
+
+func (f *fakeClient) Model() catwalk.Model { return catwalk.Model{ID: "fake"} }
+
+// Test that when disableStreaming is true, StreamResponse emits a ContentDelta then Complete using send.
+func TestBaseProvider_StreamResponse_FallbackComplete(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{resp: &ProviderResponse{Content: "hello"}}
+	p := &baseProvider[*fakeClient]{
+		options: providerClientOptions{disableStreaming: true},
+		client:  fc,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	msgs := []message.Message{{Role: message.User, Parts: []message.ContentPart{message.TextContent{Text: "hi"}}}}
+	ch := p.StreamResponse(ctx, msgs, nil)
+
+	var events []ProviderEvent
+	for ev := range ch {
+		events = append(events, ev)
+	}
+
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[0].Type != EventContentDelta || events[0].Content != "hello" {
+		t.Fatalf("expected first ContentDelta 'hello', got %+v", events[0])
+	}
+	if events[1].Type != EventComplete {
+		t.Fatalf("expected second EventComplete, got %v", events[1].Type)
+	}
+	if events[1].Response == nil || events[1].Response.Content != "hello" {
+		t.Fatalf("unexpected response: %+v", events[1].Response)
+	}
+	if !fc.sendCalled || fc.streamCalled {
+		t.Fatalf("expected sendCalled=true and streamCalled=false, got send=%v stream=%v", fc.sendCalled, fc.streamCalled)
+	}
+}
+
+// Test that errors are surfaced as a single EventError when disableStreaming is true.
+func TestBaseProvider_StreamResponse_FallbackError(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{err: errors.New("boom")}
+	p := &baseProvider[*fakeClient]{
+		options: providerClientOptions{disableStreaming: true},
+		client:  fc,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	msgs := []message.Message{{Role: message.User, Parts: []message.ContentPart{message.TextContent{Text: "hi"}}}}
+	ch := p.StreamResponse(ctx, msgs, nil)
+
+	var events []ProviderEvent
+	for ev := range ch {
+		events = append(events, ev)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Type != EventError {
+		t.Fatalf("expected EventError, got %v", events[0].Type)
+	}
+	if events[0].Error == nil || events[0].Error.Error() != "boom" {
+		t.Fatalf("unexpected error: %v", events[0].Error)
+	}
+	if !fc.sendCalled || fc.streamCalled {
+		t.Fatalf("expected sendCalled=true and streamCalled=false, got send=%v stream=%v", fc.sendCalled, fc.streamCalled)
+	}
+}
+
+// Test that when disableStreaming is false, we pass through to the client's stream.
+func TestBaseProvider_StreamResponse_PassThrough(t *testing.T) {
+	t.Parallel()
+
+	fc := &fakeClient{streamEvents: []ProviderEvent{{Type: EventContentDelta, Content: "x"}}}
+	p := &baseProvider[*fakeClient]{
+		options: providerClientOptions{disableStreaming: false},
+		client:  fc,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	t.Cleanup(cancel)
+
+	msgs := []message.Message{{Role: message.User, Parts: []message.ContentPart{message.TextContent{Text: "hi"}}}}
+	ch := p.StreamResponse(ctx, msgs, nil)
+
+	var events []ProviderEvent
+	for ev := range ch {
+		events = append(events, ev)
+	}
+
+	if len(events) != 1 || events[0].Type != EventContentDelta || events[0].Content != "x" {
+		t.Fatalf("unexpected streamed events: %+v", events)
+	}
+	if !fc.streamCalled || fc.sendCalled {
+		t.Fatalf("expected streamCalled=true and sendCalled=false, got send=%v stream=%v", fc.sendCalled, fc.streamCalled)
+	}
+}

--- a/schema.json
+++ b/schema.json
@@ -427,6 +427,11 @@
           "description": "Whether this provider is disabled",
           "default": false
         },
+        "disable_streaming": {
+          "type": "boolean",
+          "description": "Disable streaming for this provider",
+          "default": false
+        },
         "system_prompt_prefix": {
           "type": "string",
           "description": "Custom prefix to add to system prompts for this provider"


### PR DESCRIPTION
This PR helps to avoid this error `Your organization must be verified to stream this model` if verifying is not possible

This PR adds a provider-level option to disable streaming while keeping the agent-facing streaming API intact.

## What

- Add disable_streaming (boolean) to ProviderConfig and schema.json.
- When enabled, baseProvider.StreamResponse performs a non‑streaming send(...) and emits exactly one EventContentDelta (full content, if any) followed by EventComplete (or a single
EventError on failure).
- Agent no longer special‑cases non‑streaming; removed the EventComplete content-append fallback. Usage tracking still runs via a.TrackUsage(...).
- Documentation in README and CRUSH.md updated with config example and clarified event behavior.
- Tests updated/added:
    - internal/llm/provider/provider_nostreaming_test.go: fallback delta+complete, fallback error, pass‑through when not disabled.
    - internal/llm/agent/agent_nostreaming_test.go: ensures we break on EventComplete even if the stream isn’t closed and content persisted via delta.

## Why

- Some providers/APIs or deployments do not support server‑sent streaming.
- Users may prefer a single final streamed result while retaining the same event-driven plumbing.
- Keeps agent/event handling consistent across modes without caller special cases.

## Details

- Default unchanged (disable_streaming: false).
- Fallback is confined to the provider layer; the agent still uses StreamResponse.

Files touched

- internal/config/config.go: add DisableStreaming to ProviderConfig.
- internal/config/load.go: propagate DisableStreaming.
- internal/llm/provider/provider.go: fallback emits delta→complete; WithDisableStreaming.
- internal/llm/agent/agent.go: remove EventComplete content fallback; always call TrackUsage.
- schema.json, README.md, CRUSH.md: docs and schema.