### PR TITLE
fix: improve group filtering

### DIFF
--- a/internal/tui/exp/list/filterable_group.go
+++ b/internal/tui/exp/list/filterable_group.go
@@ -217,11 +217,11 @@ func (f *filterableGroupList[T]) filterItemsInGroup(group Group[T], query string
 		return items
 	}
 
-	gname := f.getGroupName(group)
+	name := f.getGroupName(group) + " "
 
 	names := make([]string, len(group.Items))
 	for i, item := range group.Items {
-		names[i] = strings.ToLower(gname + " " + item.FilterValue())
+		names[i] = strings.ToLower(name + item.FilterValue())
 	}
 
 	matches := fuzzy.Find(query, names)
@@ -236,10 +236,10 @@ func (f *filterableGroupList[T]) filterItemsInGroup(group Group[T], query string
 			var idxs []int
 			for _, idx := range match.MatchedIndexes {
 				// adjusts removing group name highlights
-				if idx < len(gname)+1 {
+				if idx < len(name) {
 					continue
 				}
-				idxs = append(idxs, idx-len(gname)-1)
+				idxs = append(idxs, idx-len(name))
 			}
 			f.setMatchIndexes(item, idxs)
 			matchedItems = append(matchedItems, item)


### PR DESCRIPTION
- handle group+model search without spaces
- better matches
- simpler implementation

alt implementation of #1001

<img width="1170" height="714" alt="image" src="https://github.com/user-attachments/assets/70feac27-04da-4c9d-afd3-871eb9c93092" />

<img width="1206" height="1030" alt="image" src="https://github.com/user-attachments/assets/69337e4e-8d0d-4a1d-82f7-259fc168f2a6" />

<img width="1150" height="1014" alt="CleanShot 2025-09-12 at 09 03 02@2x" src="https://github.com/user-attachments/assets/190335c2-164e-4ecd-b628-dc668c476355" />

<img width="1102" height="1064" alt="CleanShot 2025-09-12 at 09 04 32@2x" src="https://github.com/user-attachments/assets/ce56ad39-b69f-4881-8543-ec0b51eec87d" />
