### PR TITLE
Fix disable in model picker

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -131,8 +131,8 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 		// if the user configured a known provider we need to allow it to override a couple of parameters
 		if configExists {
 			if config.Disable {
+				//Note: we must leave disabled providers in the config so that later calls for providers can properly filter out disabled providers.
 				slog.Debug("Skipping provider due to disable flag", "provider", p.ID)
-				c.Providers.Del(string(p.ID))
 				continue
 			}
 			if config.BaseURL != "" {

--- a/internal/tui/components/dialogs/models/list.go
+++ b/internal/tui/components/dialogs/models/list.go
@@ -120,18 +120,13 @@ func (m *ModelListComponent) SetModelType(modelType int) tea.Cmd {
 
 	// First, add any configured providers that are not in the known providers list
 	// These should appear at the top of the list
-	knownProviders, err := config.Providers(cfg)
-	if err != nil {
-		return util.ReportError(err)
-	}
 	for providerID, providerConfig := range cfg.Providers.Seq2() {
 		if providerConfig.Disable {
 			continue
 		}
 
 		// Check if this provider is not in the known providers list
-		if !slices.ContainsFunc(knownProviders, func(p catwalk.Provider) bool { return p.ID == catwalk.InferenceProvider(providerID) }) ||
-			!slices.ContainsFunc(m.providers, func(p catwalk.Provider) bool { return p.ID == catwalk.InferenceProvider(providerID) }) {
+		if !slices.ContainsFunc(m.providers, func(p catwalk.Provider) bool { return p.ID == catwalk.InferenceProvider(providerID) }) {
 			// Convert config provider to provider.Provider format
 			configProvider := catwalk.Provider{
 				Name:   providerConfig.Name,
@@ -196,7 +191,8 @@ func (m *ModelListComponent) SetModelType(modelType int) tea.Cmd {
 		}
 
 		// Check if this provider is configured and not disabled
-		if providerConfig, exists := cfg.Providers.Get(string(provider.ID)); exists && providerConfig.Disable {
+		providerConfig, exists := cfg.Providers.Get(string(provider.ID))
+		if exists && providerConfig.Disable {
 			continue
 		}
 
@@ -206,7 +202,7 @@ func (m *ModelListComponent) SetModelType(modelType int) tea.Cmd {
 		}
 
 		section := list.NewItemSection(name)
-		if _, ok := cfg.Providers.Get(string(provider.ID)); ok {
+		if exists {
 			section.SetInfo(configured)
 		}
 		group := list.Group[list.CompletionItem[ModelOption]]{


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Currently when setting a config like:
```json
{
  "$schema": "https://charm.land/crush.json",
  "providers": {
    "anthropic": {"disable": true},
  }
}
```

models from anthropic still show up in the model picker. this add a bunch of visual noise that users can't easily opt out of.
It appears that this was not the intent (since `disable` is checked in the model picker and the simple resolution is to maintain disabled providers in the config, purely so their disabled-ness can be checked after initialization!