### PR TITLE
fix: 1039: fix lsp watcher error - too many files

### DIFF
--- a/internal/lsp/watcher/global_watcher.go
+++ b/internal/lsp/watcher/global_watcher.go
@@ -3,6 +3,7 @@ package watcher
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"sync"
@@ -114,7 +115,7 @@ func Start() error {
 	err := fsext.WalkDirectories(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			slog.Debug("lsp watcher: Skipping directory due to error", "path", path, "error", err)
-			return nil // Skip directories we can't access
+			return fs.SkipDir
 		}
 		watchedDirs = append(watchedDirs, path)
 		return nil


### PR DESCRIPTION
Trying to get this out so it can be tested by anyone willing (it works on my machine).

I will update this description with some before and after file system stats.

The main issue is that the filtering is used on the event handling side, and not on the notify setup side.

This patch builds a list of non ignored directories and sets up a watcher on those instead.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
