### PR TITLE
feat: limit filepath walk, automatically non git repositories

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,6 +129,14 @@ type TUIOptions struct {
 	CompactMode bool   `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
 	DiffMode    string `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
 	// Here we can add themes later or any TUI related options
+	//
+
+	Completions Completions `json:"completions,omitzero" jsonschema:"description=Completions UI options"`
+}
+
+// Completions defines options for the completions UI.
+type Completions struct {
+	MaxDepth int `json:"max_depth,omitempty" jsonschema:"description=Maximum depth for the ls tool,default=0,example=10"`
 }
 
 type Permissions struct {
@@ -237,6 +245,15 @@ type Agent struct {
 	ContextPaths []string `json:"context_paths,omitempty"`
 }
 
+type Tools struct {
+	Ls ToolLs `json:"ls,omitzero"`
+}
+
+type ToolLs struct {
+	MaxDepth int `json:"max_depth,omitempty" jsonschema:"description=Maximum depth for the ls tool,default=0,example=10"`
+	MaxItems int `json:"max_items,omitempty" jsonschema:"description=Maximum number of items to return for the ls tool,default=1000,example=100"`
+}
+
 // Config holds the configuration for crush.
 type Config struct {
 	Schema string `json:"$schema,omitempty"`
@@ -254,6 +271,8 @@ type Config struct {
 	Options *Options `json:"options,omitempty" jsonschema:"description=General application options"`
 
 	Permissions *Permissions `json:"permissions,omitempty" jsonschema:"description=Permission settings for tool usage"`
+
+	Tools Tools `json:"tools,omitzero" jsonschema:"description=Tool configurations"`
 
 	// Internal
 	workingDir string `json:"-"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -136,7 +136,12 @@ type TUIOptions struct {
 
 // Completions defines options for the completions UI.
 type Completions struct {
-	MaxDepth int `json:"max_depth,omitempty" jsonschema:"description=Maximum depth for the ls tool,default=0,example=10"`
+	MaxDepth *int `json:"max_depth,omitempty" jsonschema:"description=Maximum depth for the ls tool,default=0,example=10"`
+	MaxItems *int `json:"max_items,omitempty" jsonschema:"description=Maximum number of items to return for the ls tool,default=1000,example=100"`
+}
+
+func (c Completions) Limits() (depth, items int) {
+	return ptrValOr(c.MaxDepth, -1), ptrValOr(c.MaxItems, -1)
 }
 
 type Permissions struct {
@@ -250,8 +255,12 @@ type Tools struct {
 }
 
 type ToolLs struct {
-	MaxDepth int `json:"max_depth,omitempty" jsonschema:"description=Maximum depth for the ls tool,default=0,example=10"`
-	MaxItems int `json:"max_items,omitempty" jsonschema:"description=Maximum number of items to return for the ls tool,default=1000,example=100"`
+	MaxDepth *int `json:"max_depth,omitempty" jsonschema:"description=Maximum depth for the ls tool,default=0,example=10"`
+	MaxItems *int `json:"max_items,omitempty" jsonschema:"description=Maximum number of items to return for the ls tool,default=1000,example=100"`
+}
+
+func (t ToolLs) Limits() (depth, items int) {
+	return ptrValOr(t.MaxDepth, -1), ptrValOr(t.MaxItems, -1)
 }
 
 // Config holds the configuration for crush.
@@ -580,4 +589,11 @@ func resolveEnvs(envs map[string]string) []string {
 		res = append(res, fmt.Sprintf("%s=%s", k, v))
 	}
 	return res
+}
+
+func ptrValOr[T any](t *T, el T) T {
+	if t == nil {
+		return el
+	}
+	return *t
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,12 +1,14 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"maps"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -65,6 +67,16 @@ func Load(workingDir, dataDir string, debug bool) (*Config, error) {
 		filepath.Join(cfg.Options.DataDirectory, "logs", fmt.Sprintf("%s.log", appName)),
 		cfg.Options.Debug,
 	)
+
+	if bts, err := exec.CommandContext(context.Background(), "git", "rev-parse", "--is-inside-work-tree").CombinedOutput(); err != nil || strings.TrimSpace(string(bts)) != "true" {
+		const depth = 2
+		const items = 64
+		slog.Warn("No git repository detected in working directory, will limit file walk operations", "depth", depth, "items", items)
+		assignIfNil(&cfg.Tools.Ls.MaxDepth, depth)
+		assignIfNil(&cfg.Tools.Ls.MaxItems, items)
+		assignIfNil(&cfg.Options.TUI.Completions.MaxDepth, depth)
+		assignIfNil(&cfg.Options.TUI.Completions.MaxItems, items)
+	}
 
 	// Load known providers, this loads the config from catwalk
 	providers, err := Providers(cfg)
@@ -613,4 +625,10 @@ func GlobalConfigData() string {
 	}
 
 	return filepath.Join(home.Dir(), ".local", "share", appName, fmt.Sprintf("%s.json", appName))
+}
+
+func assignIfNil[T any](ptr **T, val T) {
+	if *ptr == nil {
+		*ptr = &val
+	}
 }

--- a/internal/fsext/ls.go
+++ b/internal/fsext/ls.go
@@ -1,6 +1,8 @@
 package fsext
 
 import (
+	"errors"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -70,6 +72,14 @@ var commonIgnorePatterns = sync.OnceValue(func() ignore.IgnoreParser {
 
 		// Crush
 		".crush",
+
+		"OrbStack",
+		".local",
+		".share",
+		"Library",
+		"Applications",
+		"Movies",
+		"Pictures",
 	)
 })
 
@@ -199,16 +209,17 @@ func (dl *directoryLister) getIgnore(path string) ignore.IgnoreParser {
 }
 
 // ListDirectory lists files and directories in the specified path,
-func ListDirectory(initialPath string, ignorePatterns []string, limit int) ([]string, bool, error) {
+func ListDirectory(initialPath string, ignorePatterns []string, depth, limit int) ([]string, bool, error) {
 	var results []string
-	truncated := false
 	dl := NewDirectoryLister(initialPath)
 
+	slog.Warn("listing directory", "path", initialPath, "depth", depth, "limit", limit, "ignorePatterns", ignorePatterns)
+
 	conf := fastwalk.Config{
-		Follow: true,
-		// Use forward slashes when running a Windows binary under WSL or MSYS
-		ToSlash: fastwalk.DefaultToSlash(),
-		Sort:    fastwalk.SortDirsFirst,
+		Follow:   true,
+		ToSlash:  fastwalk.DefaultToSlash(),
+		Sort:     fastwalk.SortDirsFirst,
+		MaxDepth: depth,
 	}
 
 	err := fastwalk.Walk(&conf, initialPath, func(path string, d os.DirEntry, err error) error {
@@ -218,7 +229,7 @@ func ListDirectory(initialPath string, ignorePatterns []string, limit int) ([]st
 
 		if dl.shouldIgnore(path, ignorePatterns) {
 			if d.IsDir() {
-				return filepath.SkipDir
+				return fs.SkipDir
 			}
 			return nil
 		}
@@ -230,16 +241,18 @@ func ListDirectory(initialPath string, ignorePatterns []string, limit int) ([]st
 			results = append(results, path)
 		}
 
-		if limit > 0 && len(results) >= limit {
-			truncated = true
-			return filepath.SkipAll
+		if limit > -1 && len(results) >= limit {
+			return fs.SkipAll
 		}
 
 		return nil
 	})
-	if err != nil && len(results) == 0 {
-		return nil, truncated, err
+	if err != nil && !errors.Is(err, fs.SkipAll) {
+		return nil, false, err
 	}
 
-	return results, truncated, nil
+	if limit > -1 && len(results) >= limit {
+		return results[:limit], true, nil
+	}
+	return results, false, nil
 }

--- a/internal/fsext/ls_test.go
+++ b/internal/fsext/ls_test.go
@@ -45,7 +45,7 @@ func TestListDirectory(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	files, truncated, err := ListDirectory(".", nil, 0)
+	files, truncated, err := ListDirectory(".", nil, -1, -1)
 	require.NoError(t, err)
 	assert.False(t, truncated)
 	assert.Equal(t, len(files), 4)

--- a/internal/llm/tools/ls.go
+++ b/internal/llm/tools/ls.go
@@ -175,11 +175,12 @@ func (l *lsTool) Run(ctx context.Context, call ToolCall) (ToolResponse, error) {
 
 	// Get file count for metadata
 	ls := config.Get().Tools.Ls
+	depth, limit := ls.Limits()
 	files, truncated, err := fsext.ListDirectory(
 		searchPath,
 		params.Ignore,
-		ls.MaxDepth,
-		min(ls.MaxItems, maxLSFiles),
+		depth,
+		min(limit, maxLSFiles),
 	)
 	if err != nil {
 		return ToolResponse{}, fmt.Errorf("error listing directory for metadata: %w", err)
@@ -200,11 +201,12 @@ func ListDirectoryTree(searchPath string, ignore []string) (string, error) {
 	}
 
 	ls := config.Get().Tools.Ls
-	maxFiles := min(maxLSFiles, ls.MaxItems)
+	depth, limit := ls.Limits()
+	maxFiles := min(maxLSFiles, limit)
 	files, truncated, err := fsext.ListDirectory(
 		searchPath,
 		ignore,
-		ls.MaxDepth,
+		depth,
 		maxFiles,
 	)
 	if err != nil {

--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -480,7 +480,8 @@ func (m *editorCmp) SetPosition(x, y int) tea.Cmd {
 }
 
 func (m *editorCmp) startCompletions() tea.Msg {
-	files, _, _ := fsext.ListDirectory(".", nil, 0)
+	ls := m.app.Config().Options.TUI.Completions
+	files, _, _ := fsext.ListDirectory(".", nil, int(ls.MaxDepth), -1)
 	slices.Sort(files)
 	completionItems := make([]completions.Completion, 0, len(files))
 	for _, file := range files {

--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -481,7 +481,8 @@ func (m *editorCmp) SetPosition(x, y int) tea.Cmd {
 
 func (m *editorCmp) startCompletions() tea.Msg {
 	ls := m.app.Config().Options.TUI.Completions
-	files, _, _ := fsext.ListDirectory(".", nil, int(ls.MaxDepth), -1)
+	depth, limit := ls.Limits()
+	files, _, _ := fsext.ListDirectory(".", nil, depth, limit)
 	slices.Sort(files)
 	completionItems := make([]completions.Completion, 0, len(files))
 	for _, file := range files {

--- a/schema.json
+++ b/schema.json
@@ -12,6 +12,14 @@
           "examples": [
             10
           ]
+        },
+        "max_items": {
+          "type": "integer",
+          "description": "Maximum number of items to return for the ls tool",
+          "default": 1000,
+          "examples": [
+            100
+          ]
         }
       },
       "additionalProperties": false,

--- a/schema.json
+++ b/schema.json
@@ -3,6 +3,20 @@
   "$id": "https://github.com/charmbracelet/crush/internal/config/config",
   "$ref": "#/$defs/Config",
   "$defs": {
+    "Completions": {
+      "properties": {
+        "max_depth": {
+          "type": "integer",
+          "description": "Maximum depth for the ls tool",
+          "default": 0,
+          "examples": [
+            10
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "Config": {
       "properties": {
         "$schema": {
@@ -37,10 +51,17 @@
         "permissions": {
           "$ref": "#/$defs/Permissions",
           "description": "Permission settings for tool usage"
+        },
+        "tools": {
+          "$ref": "#/$defs/Tools",
+          "description": "Tool configurations"
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "required": [
+        "tools"
+      ]
     },
     "LSPConfig": {
       "properties": {
@@ -442,10 +463,51 @@
             "split"
           ],
           "description": "Diff mode for the TUI interface"
+        },
+        "completions": {
+          "$ref": "#/$defs/Completions",
+          "description": "Completions UI options"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "completions"
+      ]
+    },
+    "ToolLs": {
+      "properties": {
+        "max_depth": {
+          "type": "integer",
+          "description": "Maximum depth for the ls tool",
+          "default": 0,
+          "examples": [
+            10
+          ]
+        },
+        "max_items": {
+          "type": "integer",
+          "description": "Maximum number of items to return for the ls tool",
+          "default": 1000,
+          "examples": [
+            100
+          ]
         }
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "Tools": {
+      "properties": {
+        "ls": {
+          "$ref": "#/$defs/ToolLs"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ls"
+      ]
     }
   }
 }


### PR DESCRIPTION
This PR has 2 features that relate to each other:

### 1. Limit file path walk depth/max items if the CWD is not a git repository

When it starts, it'll check if the CWD is a git directory, if it isn't, it'll limit the depth of `fsext` walks to `2` and max items to `64`.

If you run `crush` in your `$HOME`, for example, it'll likely never finish walking the tree. 
FZF has the same issue, but it "hides" it by doing things in background. This would require a bunch of extra work in Crush for it work properly, and will be made on another PR.

This is to "stop the bleed".

### 2. Allow the user to configure depth and max items

Allows the user to limit the FS walking stuff for both the `list` tool and for the `/` file completion:

```json
{
  "$schema": "https://charm.land/crush.json",
  "tools": {
    "ls": {
      "max_depth": 3,
      "max_items": 100
    }
  },
  "options": {
    "tui": {
      "completions": {
        "max_depth": 5,
        "max_items": 1000
      }
    }
  }
}
```

This is the same configuration that is set in **item 1**, and will be respected over the git repository check.