### PR TITLE
docs(readme): mention contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,10 @@ We’re committed to building sustainable, trusted integrations with model
 providers. If you’re a provider interested in working with us,
 [reach out](mailto:vt100@charm.sh).
 
+## Contributing
+
+See the [contributing guide](https://github.com/charmbracelet/crush?tab=contributing-ov-file).
+
 ## Whatcha think?
 
 We’d love to hear your thoughts on this project. Need help? We gotchu. You can find us on:


### PR DESCRIPTION
* Closes #1064

Asking a review mostly to get opinions on what to link. Our projects usually link [`/contribute`](https://github.com/charmbracelet/crush/contribute), but it doesn't show the content directly, which is a bit odd. We could link the [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md) file directly, but for now I linked [the Contribute tab on the repo homepage](https://github.com/charmbracelet/crush?tab=contributing-ov-file).