### PR TITLE
fix(tui): yes/no init selection

### DIFF
--- a/internal/tui/components/chat/splash/splash.go
+++ b/internal/tui/components/chat/splash/splash.go
@@ -253,6 +253,7 @@ func (s *splashCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return s, cmd
 			}
 			if s.needsProjectInit {
+				s.selectedNo = false
 				return s, s.initializeProject()
 			}
 		case key.Matches(msg, s.keyMap.No):


### PR DESCRIPTION
This commit ensures that the "Yes" and "No" options in the init screen get properly selected when navigating with the keyboard.

Related: https://github.com/charmbracelet/crush/issues/1048
