### PR TITLE
fix: Fix a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ That said, you can also set environment variables for preferred providers.
 | `AWS_ACCESS_KEY_ID`        | AWS Bedrock (Claude)                               |
 | `AWS_SECRET_ACCESS_KEY`    | AWS Bedrock (Claude)                               |
 | `AWS_REGION`               | AWS Bedrock (Claude)                               |
-| `AZURE_OPENAI_ENDPOINT`    | Azure OpenAI models                                |
+| `AZURE_OPENAI_API_ENDPOINT`| Azure OpenAI models                                |
 | `AZURE_OPENAI_API_KEY`     | Azure OpenAI models (optional when using Entra ID) |
 | `AZURE_OPENAI_API_VERSION` | Azure OpenAI models                                |
 


### PR DESCRIPTION
The environment variable indicated to configure the Azure AI endpoint did not match the value in [Catwalk][].

[Catwalk]: https://github.com/charmbracelet/catwalk/blob/9d9a86e3a4aec20b8874175c115a3533d5083b54/internal/providers/configs/azure.json#L6

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
