### PR TITLE
fix(config): allow directories as root markers

### DIFF
--- a/internal/fsext/fileutil.go
+++ b/internal/fsext/fileutil.go
@@ -92,7 +92,6 @@ func GlobWithDoubleStar(pattern, searchPath string, limit int) ([]string, bool, 
 			if walker.ShouldSkip(path) {
 				return filepath.SkipDir
 			}
-			return nil
 		}
 
 		if walker.ShouldSkip(path) {

--- a/internal/fsext/fileutil.go
+++ b/internal/fsext/fileutil.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"time"
@@ -78,9 +77,7 @@ func (w *FastGlobWalker) ShouldSkip(path string) bool {
 func GlobWithDoubleStar(pattern, searchPath string, limit int) ([]string, bool, error) {
 	// Normalize pattern to forward slashes on Windows so their config can use
 	// backslashes
-	if runtime.GOOS == "windows" {
-		pattern = filepath.ToSlash(pattern)
-	}
+	pattern = filepath.ToSlash(pattern)
 
 	walker := NewFastGlobWalker(searchPath)
 	var matches []FileInfo

--- a/internal/fsext/fileutil_test.go
+++ b/internal/fsext/fileutil_test.go
@@ -21,10 +21,8 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		readmeMd := filepath.Join(testDir, "README.md")
 
 		for _, file := range []string{mainGo, utilsGo, helperGo, readmeMd} {
-			err := os.MkdirAll(filepath.Dir(file), 0o755)
-			require.NoError(t, err)
-			err = os.WriteFile(file, []byte("test content"), 0o644)
-			require.NoError(t, err)
+			require.NoError(t, os.MkdirAll(filepath.Dir(file), 0o755))
+			require.NoError(t, os.WriteFile(file, []byte("test content"), 0o644))
 		}
 
 		// Test finding a specific .go file pattern
@@ -53,15 +51,12 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		pkgFile := filepath.Join(testDir, "pkg.txt")
 
 		for _, dir := range []string{srcDir, pkgDir, internalDir, cmdDir} {
-			err := os.MkdirAll(dir, 0o755)
-			require.NoError(t, err)
+			require.NoError(t, os.MkdirAll(dir, 0o755))
 		}
 
 		// Create files in directories and a similarly named file
-		err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package main"), 0o644)
-		require.NoError(t, err)
-		err = os.WriteFile(pkgFile, []byte("test"), 0o644)
-		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package main"), 0o644))
+		require.NoError(t, os.WriteFile(pkgFile, []byte("test"), 0o644))
 
 		// Test finding a specific directory pattern (this tests the fix for the bug)
 		// Look specifically for "pkg" directory, not others and not similar files
@@ -92,8 +87,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		otherDir := filepath.Join(testDir, "other")
 
 		for _, dir := range []string{srcPkgDir, libPkgDir, mainPkgDir, otherDir} {
-			err := os.MkdirAll(dir, 0o755)
-			require.NoError(t, err)
+			require.NoError(t, os.MkdirAll(dir, 0o755))
 		}
 
 		// Test **/pkg pattern - should find all pkg directories at any level
@@ -128,12 +122,10 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		pkgSubdir := filepath.Join(pkgDir, "internal")
 		pkgSubfile := filepath.Join(pkgSubdir, "helper.go")
 
-		err := os.MkdirAll(pkgSubdir, 0o755)
-		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(pkgSubdir, 0o755))
 
 		for _, file := range []string{pkgFile1, pkgFile2, pkgSubfile} {
-			err = os.WriteFile(file, []byte("package main"), 0o644)
-			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(file, []byte("package main"), 0o644))
 		}
 
 		// Test pkg/** pattern - should find directory and all its contents
@@ -163,10 +155,8 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		// Create many test files
 		for i := range 10 {
 			file := filepath.Join(testDir, "file", fmt.Sprintf("test%d.txt", i))
-			err := os.MkdirAll(filepath.Dir(file), 0o755)
-			require.NoError(t, err)
-			err = os.WriteFile(file, []byte("test"), 0o644)
-			require.NoError(t, err)
+			require.NoError(t, os.MkdirAll(filepath.Dir(file), 0o755))
+			require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 		}
 
 		// Test with limit
@@ -186,10 +176,8 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		file4 := filepath.Join(testDir, "file4.txt")
 
 		for _, file := range []string{file1, file2, file3, file4} {
-			err := os.MkdirAll(filepath.Dir(file), 0o755)
-			require.NoError(t, err)
-			err = os.WriteFile(file, []byte("test"), 0o644)
-			require.NoError(t, err)
+			require.NoError(t, os.MkdirAll(filepath.Dir(file), 0o755))
+			require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 		}
 
 		// Test specific nested pattern - look for file1.txt specifically
@@ -216,19 +204,16 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		file3 := filepath.Join(testDir, "file3.txt")
 
 		// Create files with delays to ensure different modification times
-		err := os.WriteFile(file1, []byte("first"), 0o644)
-		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(file1, []byte("first"), 0o644))
 
 		// Small delay to ensure different modification times
 		time.Sleep(10 * time.Millisecond)
 
-		err = os.WriteFile(file2, []byte("second"), 0o644)
-		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(file2, []byte("second"), 0o644))
 
 		time.Sleep(10 * time.Millisecond)
 
-		err = os.WriteFile(file3, []byte("third"), 0o644)
-		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(file3, []byte("third"), 0o644))
 
 		matches, truncated, err := GlobWithDoubleStar("*.txt", testDir, 0)
 		require.NoError(t, err)
@@ -269,8 +254,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		rootIgnore := filepath.Join(testDir, ".crushignore")
 
 		// Root .crushignore ignores *.tmp files and backup directories
-		err := os.WriteFile(rootIgnore, []byte("*.tmp\nbackup/\n"), 0o644)
-		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(rootIgnore, []byte("*.tmp\nbackup/\n"), 0o644))
 
 		// Create test files and directories
 		goodFile := filepath.Join(testDir, "good.txt")
@@ -280,16 +264,11 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		ignoredFileInDir := filepath.Join(testDir, "backup", "old.txt")
 
 		// Create all files and directories
-		err = os.WriteFile(goodFile, []byte("content"), 0o644)
-		require.NoError(t, err)
-		err = os.WriteFile(badFile, []byte("temp content"), 0o644)
-		require.NoError(t, err)
-		err = os.MkdirAll(goodDir, 0o755)
-		require.NoError(t, err)
-		err = os.MkdirAll(ignoredDir, 0o755)
-		require.NoError(t, err)
-		err = os.WriteFile(ignoredFileInDir, []byte("old content"), 0o644)
-		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(goodFile, []byte("content"), 0o644))
+		require.NoError(t, os.WriteFile(badFile, []byte("temp content"), 0o644))
+		require.NoError(t, os.MkdirAll(goodDir, 0o755))
+		require.NoError(t, os.MkdirAll(ignoredDir, 0o755))
+		require.NoError(t, os.WriteFile(ignoredFileInDir, []byte("old content"), 0o644))
 
 		// Test that ignore patterns work for files
 		matches, truncated, err := GlobWithDoubleStar("*.tmp", testDir, 0)
@@ -327,20 +306,17 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		midFile := filepath.Join(testDir, "mid.test")
 
 		// Create old file first
-		err := os.WriteFile(oldFile, []byte("old"), 0o644)
-		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(oldFile, []byte("old"), 0o644))
 
 		time.Sleep(1 * time.Millisecond)
 
 		// Create directory
-		err = os.MkdirAll(newDir, 0o755)
-		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(newDir, 0o755))
 
 		time.Sleep(1 * time.Millisecond)
 
 		// Create newer file
-		err = os.WriteFile(midFile, []byte("mid"), 0o644)
-		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(midFile, []byte("mid"), 0o644))
 
 		// Test pattern that matches both files and directories
 		matches, truncated, err := GlobWithDoubleStar("*.test", testDir, 0)

--- a/internal/fsext/fileutil_test.go
+++ b/internal/fsext/fileutil_test.go
@@ -15,7 +15,6 @@ func TestGlobWithDoubleStar(t *testing.T) {
 	t.Run("finds files matching pattern", func(t *testing.T) {
 		testDir := t.TempDir()
 
-		// Create test files
 		mainGo := filepath.Join(testDir, "src", "main.go")
 		utilsGo := filepath.Join(testDir, "src", "utils.go")
 		helperGo := filepath.Join(testDir, "pkg", "helper.go")
@@ -26,19 +25,16 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test content"), 0o644))
 		}
 
-		// Test finding a specific .go file pattern
 		matches, truncated, err := GlobWithDoubleStar("**/main.go", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
-		// Should find exactly main.go file
 		require.Equal(t, matches, []string{mainGo})
 	})
 
 	t.Run("finds directories matching pattern", func(t *testing.T) {
 		testDir := t.TempDir()
 
-		// Create test directories and files
 		srcDir := filepath.Join(testDir, "src")
 		pkgDir := filepath.Join(testDir, "pkg")
 		internalDir := filepath.Join(testDir, "internal")
@@ -49,24 +45,19 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.MkdirAll(dir, 0o755))
 		}
 
-		// Create files in directories and a similarly named file
 		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package main"), 0o644))
 		require.NoError(t, os.WriteFile(pkgFile, []byte("test"), 0o644))
 
-		// Test finding a specific directory pattern (this tests the fix for the bug)
-		// Look specifically for "pkg" directory, not others and not similar files
 		matches, truncated, err := GlobWithDoubleStar("pkg", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
-		// Should find exactly the pkg directory
 		require.Equal(t, matches, []string{pkgDir})
 	})
 
 	t.Run("finds nested directories with wildcard patterns", func(t *testing.T) {
 		testDir := t.TempDir()
 
-		// Create nested directory structure
 		srcPkgDir := filepath.Join(testDir, "src", "pkg")
 		libPkgDir := filepath.Join(testDir, "lib", "pkg")
 		mainPkgDir := filepath.Join(testDir, "pkg")
@@ -76,12 +67,10 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.MkdirAll(dir, 0o755))
 		}
 
-		// Test **/pkg pattern - should find all pkg directories at any level
 		matches, truncated, err := GlobWithDoubleStar("**/pkg", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
-		// Convert to relative paths for easier comparison
 		var relativeMatches []string
 		for _, match := range matches {
 			rel, err := filepath.Rel(testDir, match)
@@ -89,14 +78,12 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			relativeMatches = append(relativeMatches, filepath.ToSlash(rel))
 		}
 
-		// Should find all three pkg directories
 		require.ElementsMatch(t, relativeMatches, []string{"pkg", "src/pkg", "lib/pkg"})
 	})
 
 	t.Run("finds directory contents with recursive patterns", func(t *testing.T) {
 		testDir := t.TempDir()
 
-		// Create directory with contents
 		pkgDir := filepath.Join(testDir, "pkg")
 		pkgFile1 := filepath.Join(pkgDir, "main.go")
 		pkgFile2 := filepath.Join(pkgDir, "utils.go")
@@ -109,7 +96,6 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("package main"), 0o644))
 		}
 
-		// Test pkg/** pattern - should find directory and all its contents
 		matches, truncated, err := GlobWithDoubleStar("pkg/**", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
@@ -121,7 +107,6 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			relativeMatches = append(relativeMatches, filepath.ToSlash(rel))
 		}
 
-		// Should find the directory itself and all contents
 		require.ElementsMatch(t, relativeMatches, []string{
 			"pkg",
 			"pkg/main.go",
@@ -134,14 +119,12 @@ func TestGlobWithDoubleStar(t *testing.T) {
 	t.Run("respects limit parameter", func(t *testing.T) {
 		testDir := t.TempDir()
 
-		// Create many test files
 		for i := range 10 {
 			file := filepath.Join(testDir, "file", fmt.Sprintf("test%d.txt", i))
 			require.NoError(t, os.MkdirAll(filepath.Dir(file), 0o755))
 			require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 		}
 
-		// Test with limit
 		matches, truncated, err := GlobWithDoubleStar("**/*.txt", testDir, 5)
 		require.NoError(t, err)
 		require.True(t, truncated, "Expected truncation with limit")
@@ -151,7 +134,6 @@ func TestGlobWithDoubleStar(t *testing.T) {
 	t.Run("handles nested directory patterns", func(t *testing.T) {
 		testDir := t.TempDir()
 
-		// Create nested structure
 		file1 := filepath.Join(testDir, "a", "b", "c", "file1.txt")
 		file2 := filepath.Join(testDir, "a", "b", "file2.txt")
 		file3 := filepath.Join(testDir, "a", "file3.txt")
@@ -162,12 +144,10 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 		}
 
-		// Test specific nested pattern - look for file1.txt specifically
 		matches, truncated, err := GlobWithDoubleStar("a/b/c/file1.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
-		// Should find exactly file1.txt
 		require.Equal(t, matches, []string{file1})
 	})
 
@@ -175,22 +155,20 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			testDir := t.TempDir()
 
-			// Create files
 			file1 := filepath.Join(testDir, "file1.txt")
-			file2 := filepath.Join(testDir, "file2.txt")
-			file3 := filepath.Join(testDir, "file3.txt")
-
 			require.NoError(t, os.WriteFile(file1, []byte("first"), 0o644))
+
+			file2 := filepath.Join(testDir, "file2.txt")
 			require.NoError(t, os.WriteFile(file2, []byte("second"), 0o644))
+
+			file3 := filepath.Join(testDir, "file3.txt")
 			require.NoError(t, os.WriteFile(file3, []byte("third"), 0o644))
 
-			// Set deterministic mtimes using the fake clock
 			base := time.Now()
 			m1 := base
 			m2 := base.Add(1 * time.Millisecond)
 			m3 := base.Add(2 * time.Millisecond)
 
-			// Set atime and mtime; only mtime matters for your sort
 			require.NoError(t, os.Chtimes(file1, m1, m1))
 			require.NoError(t, os.Chtimes(file2, m2, m2))
 			require.NoError(t, os.Chtimes(file3, m3, m3))
@@ -198,8 +176,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			matches, truncated, err := GlobWithDoubleStar("*.txt", testDir, 0)
 			require.NoError(t, err)
 			require.False(t, truncated)
-			// Files should be sorted by modification time (newest first)
-			// So file3 should be first, file2 second, file1 last
+
 			require.Equal(t, matches, []string{file3, file2, file1})
 		})
 	})
@@ -226,48 +203,38 @@ func TestGlobWithDoubleStar(t *testing.T) {
 	t.Run("respects basic ignore patterns", func(t *testing.T) {
 		testDir := t.TempDir()
 
-		// Create basic ignore structure
 		rootIgnore := filepath.Join(testDir, ".crushignore")
 
-		// Root .crushignore ignores *.tmp files and backup directories
 		require.NoError(t, os.WriteFile(rootIgnore, []byte("*.tmp\nbackup/\n"), 0o644))
 
-		// Create test files and directories
 		goodFile := filepath.Join(testDir, "good.txt")
-		badFile := filepath.Join(testDir, "bad.tmp")
-		goodDir := filepath.Join(testDir, "src")
-		ignoredDir := filepath.Join(testDir, "backup")
-		ignoredFileInDir := filepath.Join(testDir, "backup", "old.txt")
-
-		// Create all files and directories
 		require.NoError(t, os.WriteFile(goodFile, []byte("content"), 0o644))
+
+		badFile := filepath.Join(testDir, "bad.tmp")
 		require.NoError(t, os.WriteFile(badFile, []byte("temp content"), 0o644))
+
+		goodDir := filepath.Join(testDir, "src")
 		require.NoError(t, os.MkdirAll(goodDir, 0o755))
+
+		ignoredDir := filepath.Join(testDir, "backup")
 		require.NoError(t, os.MkdirAll(ignoredDir, 0o755))
+
+		ignoredFileInDir := filepath.Join(testDir, "backup", "old.txt")
 		require.NoError(t, os.WriteFile(ignoredFileInDir, []byte("old content"), 0o644))
 
-		// Test that ignore patterns work for files
 		matches, truncated, err := GlobWithDoubleStar("*.tmp", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
-
-		// Should find no .tmp files (ignored by .crushignore)
 		require.Empty(t, matches, "Expected no matches for '*.tmp' pattern (should be ignored)")
 
-		// Test that ignore patterns work for directories
 		matches, truncated, err = GlobWithDoubleStar("backup", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
-
-		// Should find no backup directory (ignored by .crushignore)
 		require.Empty(t, matches, "Expected no matches for 'backup' pattern (should be ignored)")
 
-		// Test that non-ignored files are found
 		matches, truncated, err = GlobWithDoubleStar("*.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
-
-		// Should find only the good file, not the one in ignored directory
 		require.Equal(t, matches, []string{goodFile})
 	})
 
@@ -275,30 +242,32 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		synctest.Test(t, func(t *testing.T) {
 			testDir := t.TempDir()
 
-			oldFile := filepath.Join(testDir, "old.test")
-			newDir := filepath.Join(testDir, "new.test")
-			midFile := filepath.Join(testDir, "mid.test")
+			oldestFile := filepath.Join(testDir, "old.test")
+			require.NoError(t, os.WriteFile(oldestFile, []byte("old"), 0o644))
 
-			require.NoError(t, os.WriteFile(oldFile, []byte("old"), 0o644))
-			require.NoError(t, os.MkdirAll(newDir, 0o755))
-			require.NoError(t, os.WriteFile(midFile, []byte("mid"), 0o644))
+			middleDir := filepath.Join(testDir, "mid.test")
+			require.NoError(t, os.MkdirAll(middleDir, 0o755))
 
-			// Deterministic ordering via fake time
+			newestFile := filepath.Join(testDir, "new.test")
+			require.NoError(t, os.WriteFile(newestFile, []byte("new"), 0o644))
+
 			base := time.Now()
-			tOld := base
-			tDir := base.Add(1 * time.Millisecond)
-			tMid := base.Add(2 * time.Millisecond)
+			tOldest := base
+			tMiddle := base.Add(1 * time.Millisecond)
+			tNewest := base.Add(2 * time.Millisecond)
 
-			require.NoError(t, os.Chtimes(oldFile, tOld, tOld))
-			require.NoError(t, os.Chtimes(newDir, tDir, tDir))
-			require.NoError(t, os.Chtimes(midFile, tMid, tMid))
+			// Reverse the expected order
+			require.NoError(t, os.Chtimes(newestFile, tOldest, tOldest))
+			require.NoError(t, os.Chtimes(middleDir, tMiddle, tMiddle))
+			require.NoError(t, os.Chtimes(oldestFile, tNewest, tNewest))
 
-			// Test pattern that matches both files and directories
 			matches, truncated, err := GlobWithDoubleStar("*.test", testDir, 0)
 			require.NoError(t, err)
 			require.False(t, truncated)
-			// Results should be sorted by modification time (newest first)
-			require.Equal(t, matches, []string{midFile, newDir, oldFile})
+
+			// Results should be sorted by mod time, but we set the oldestFile
+			// to have the most recent mod time
+			require.Equal(t, matches, []string{oldestFile, middleDir, newestFile})
 		})
 	})
 }

--- a/internal/fsext/fileutil_test.go
+++ b/internal/fsext/fileutil_test.go
@@ -31,13 +31,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.False(t, truncated)
 
 		// Should find exactly main.go file
-		require.Len(t, matches, 1, "Expected exactly 1 match for '**/main.go' pattern")
-		require.Equal(t, mainGo, matches[0], "Expected to find main.go specifically")
-
-		// Verify other files don't match this pattern
-		require.NotContains(t, matches, utilsGo, "utils.go should not match '**/main.go' pattern")
-		require.NotContains(t, matches, helperGo, "helper.go should not match '**/main.go' pattern")
-		require.NotContains(t, matches, readmeMd, "README.md should not match '**/main.go' pattern")
+		require.Equal(t, matches, []string{mainGo})
 	})
 
 	t.Run("finds directories matching pattern", func(t *testing.T) {
@@ -65,16 +59,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.False(t, truncated)
 
 		// Should find exactly the pkg directory
-		require.Len(t, matches, 1, "Expected exactly 1 match for 'pkg' pattern")
-		require.Equal(t, pkgDir, matches[0], "Expected to find pkg directory specifically")
-
-		// Verify other directories don't match this pattern
-		require.NotContains(t, matches, srcDir, "src directory should not match 'pkg' pattern")
-		require.NotContains(t, matches, internalDir, "internal directory should not match 'pkg' pattern")
-		require.NotContains(t, matches, cmdDir, "cmd directory should not match 'pkg' pattern")
-
-		// Verify similar files don't match directory pattern
-		require.NotContains(t, matches, pkgFile, "pkg.txt file should not match 'pkg' pattern")
+		require.Equal(t, matches, []string{pkgDir})
 	})
 
 	t.Run("finds nested directories with wildcard patterns", func(t *testing.T) {
@@ -186,13 +171,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.False(t, truncated)
 
 		// Should find exactly file1.txt
-		require.Len(t, matches, 1, "Expected exactly 1 match for 'a/b/c/file1.txt' pattern")
-		require.Equal(t, filepath.ToSlash(file1), filepath.ToSlash(matches[0]), "Expected to find file1.txt specifically")
-
-		// Verify other files don't match this specific pattern
-		require.NotContains(t, matches, file2, "file2.txt should not match 'a/b/c/file1.txt' pattern")
-		require.NotContains(t, matches, file3, "file3.txt should not match 'a/b/c/file1.txt' pattern")
-		require.NotContains(t, matches, file4, "file4.txt should not match 'a/b/c/file1.txt' pattern")
+		require.Equal(t, filepath.ToSlash(file1), filepath.ToSlash(matches[0]))
 	})
 
 	t.Run("returns results sorted by modification time (newest first)", func(t *testing.T) {


### PR DESCRIPTION
The removed line was preventing users from setting directories as root markers, which should be allowed according to the [`Config.LSPConfig.RootMarkers`](https://github.com/charmbracelet/crush/blob/main/internal/config/config.go#L125C87-L125C138) JSON description.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
