### PR TITLE
chore: add task release

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -89,7 +89,7 @@ tasks:
     desc: Create and push a new tag following semver
     vars:
       NEXT:
-        sh: go run github.com/caarlos0/svu@latest next
+        sh: go run github.com/caarlos0/svu/v3@latest next
     prompt: "This will release {{.NEXT}}. Continue?"
     preconditions:
       - sh: '[ $(git symbolic-ref --short HEAD) = "main" ]'

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -89,7 +89,7 @@ tasks:
     desc: Create and push a new tag following semver
     vars:
       NEXT:
-        sh: go run github.com/caarlos0/svu/v3@latest next
+        sh: go run github.com/caarlos0/svu/v3@latest next --always
     prompt: "This will release {{.NEXT}}. Continue?"
     preconditions:
       - sh: '[ $(git symbolic-ref --short HEAD) = "main" ]'

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -84,3 +84,20 @@ tasks:
       - echo "Generated schema.json"
     generates:
       - schema.json
+
+  release:
+    desc: Create and push a new tag following semver
+    vars:
+      NEXT:
+        sh: go run github.com/caarlos0/svu@latest next
+    prompt: "This will release {{.NEXT}}. Continue?"
+    preconditions:
+      - sh: '[ $(git symbolic-ref --short HEAD) = "main" ]'
+        msg: Not on main branch
+      - sh: "[ $(git status --porcelain=2 | wc -l) = 0 ]"
+        msg: "Git is dirty"
+    cmds:
+      - git tag -d nightly
+      - git tag --sign {{.NEXT}} {{.CLI_ARGS}}
+      - echo "pushing {{.NEXT}}..."
+      - git push origin --tags


### PR DESCRIPTION
you can use it as:

```sh
task release -- -m 'some short description'
```

and it'll:

- figure out the next tag using svu
- check if you're on main
- check branch is clean
- drop the nightly tag (it's recreated, so if you have an old one, `git push --tags` will complain about it)
- `git tag --sign <next version>` + any args you pass to release
- `git push --tags`
