### PR TITLE
fix: strip path from `$SHELL`

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"reflect"
 	"runtime"
 
@@ -24,7 +25,7 @@ var (
 			Set("GOOS", runtime.GOOS).
 			Set("GOARCH", runtime.GOARCH).
 			Set("TERM", os.Getenv("TERM")).
-			Set("SHELL", os.Getenv("SHELL")).
+			Set("SHELL", filepath.Base(os.Getenv("SHELL"))).
 			Set("Version", version.Version).
 			Set("GoVersion", runtime.Version())
 )


### PR DESCRIPTION
This ensure we'll collect `zsh` instead of `/bin/zsh` or `/opt/homebrew/bin/zsh`, for example.