### PR TITLE
fix(provider): do not retry auth errors, lower max tries

### DIFF
--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -507,7 +507,7 @@ func (a *anthropicClient) shouldRetry(attempts int, err error) (bool, int64, err
 	}
 
 	isOverloaded := strings.Contains(apiErr.Error(), "overloaded") || strings.Contains(apiErr.Error(), "rate limit exceeded")
-	if apiErr.StatusCode != 429 && apiErr.StatusCode != 529 && !isOverloaded {
+	if apiErr.StatusCode != http.StatusTooManyRequests && apiErr.StatusCode != 529 && !isOverloaded {
 		return false, 0, err
 	}
 

--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -507,6 +507,7 @@ func (a *anthropicClient) shouldRetry(attempts int, err error) (bool, int64, err
 	}
 
 	isOverloaded := strings.Contains(apiErr.Error(), "overloaded") || strings.Contains(apiErr.Error(), "rate limit exceeded")
+	// 529 (unofficial): The service is overloaded
 	if apiErr.StatusCode != http.StatusTooManyRequests && apiErr.StatusCode != 529 && !isOverloaded {
 		return false, 0, err
 	}

--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -493,12 +493,7 @@ func (a *anthropicClient) shouldRetry(attempts int, err error) (bool, int64, err
 	}
 
 	if apiErr.StatusCode == 401 {
-		a.providerOptions.apiKey, err = config.Get().Resolve(a.providerOptions.config.APIKey)
-		if err != nil {
-			return false, 0, fmt.Errorf("failed to resolve API key: %w", err)
-		}
-		a.client = createAnthropicClient(a.providerOptions, a.tp)
-		return true, 0, nil
+		return false, 0, err
 	}
 
 	// Handle context limit exceeded error (400 Bad Request)

--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -492,12 +493,12 @@ func (a *anthropicClient) shouldRetry(attempts int, err error) (bool, int64, err
 		return false, 0, fmt.Errorf("maximum retry attempts reached for rate limit: %d retries", maxRetries)
 	}
 
-	if apiErr.StatusCode == 401 {
+	if apiErr.StatusCode == http.StatusUnauthorized {
 		return false, 0, err
 	}
 
 	// Handle context limit exceeded error (400 Bad Request)
-	if apiErr.StatusCode == 400 {
+	if apiErr.StatusCode == http.StatusBadRequest {
 		if adjusted, ok := a.handleContextLimitError(apiErr); ok {
 			a.adjustedMaxTokens = adjusted
 			slog.Debug("Adjusted max_tokens due to context limit", "new_max_tokens", adjusted)

--- a/internal/llm/provider/anthropic.go
+++ b/internal/llm/provider/anthropic.go
@@ -509,7 +509,18 @@ func (a *anthropicClient) shouldRetry(attempts int, err error) (bool, int64, err
 	isOverloaded := strings.Contains(apiErr.Error(), "overloaded") || strings.Contains(apiErr.Error(), "rate limit exceeded")
 	// 529 (unofficial): The service is overloaded
 	if apiErr.StatusCode != http.StatusTooManyRequests && apiErr.StatusCode != 529 && !isOverloaded {
-		return false, 0, err
+		prev := a.providerOptions.apiKey
+		// in case the key comes from a script, we try to re-evaluate it.
+		a.providerOptions.apiKey, err = config.Get().Resolve(a.providerOptions.config.APIKey)
+		if err != nil {
+			return false, 0, fmt.Errorf("failed to resolve API key: %w", err)
+		}
+		// if it didn't change, do not retry.
+		if prev == a.providerOptions.apiKey {
+			return false, 0, err
+		}
+		a.client = createAnthropicClient(a.providerOptions, a.tp)
+		return true, 0, nil
 	}
 
 	retryMs := 0

--- a/internal/llm/provider/gemini.go
+++ b/internal/llm/provider/gemini.go
@@ -436,15 +436,7 @@ func (g *geminiClient) shouldRetry(attempts int, err error) (bool, int64, error)
 
 	// Check for token expiration (401 Unauthorized)
 	if contains(errMsg, "unauthorized", "invalid api key", "api key expired") {
-		g.providerOptions.apiKey, err = config.Get().Resolve(g.providerOptions.config.APIKey)
-		if err != nil {
-			return false, 0, fmt.Errorf("failed to resolve API key: %w", err)
-		}
-		g.client, err = createGeminiClient(g.providerOptions)
-		if err != nil {
-			return false, 0, fmt.Errorf("failed to create Gemini client after API key refresh: %w", err)
-		}
-		return true, 0, nil
+		return false, 0, err
 	}
 
 	// Check for common rate limit error messages

--- a/internal/llm/provider/openai.go
+++ b/internal/llm/provider/openai.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"strings"
 	"time"
 
@@ -513,11 +514,11 @@ func (o *openaiClient) shouldRetry(attempts int, err error) (bool, int64, error)
 	retryAfterValues := []string{}
 	if errors.As(err, &apiErr) {
 		// Check for token expiration (401 Unauthorized)
-		if apiErr.StatusCode == 401 {
+		if apiErr.StatusCode == http.StatusUnauthorized {
 			return false, 0, err
 		}
 
-		if apiErr.StatusCode != 429 && apiErr.StatusCode != 500 {
+		if apiErr.StatusCode != http.StatusTooManyRequests && apiErr.StatusCode != http.StatusInternalServerError {
 			return false, 0, err
 		}
 

--- a/internal/llm/provider/openai.go
+++ b/internal/llm/provider/openai.go
@@ -514,12 +514,7 @@ func (o *openaiClient) shouldRetry(attempts int, err error) (bool, int64, error)
 	if errors.As(err, &apiErr) {
 		// Check for token expiration (401 Unauthorized)
 		if apiErr.StatusCode == 401 {
-			o.providerOptions.apiKey, err = config.Get().Resolve(o.providerOptions.config.APIKey)
-			if err != nil {
-				return false, 0, fmt.Errorf("failed to resolve API key: %w", err)
-			}
-			o.client = createOpenAIClient(o.providerOptions)
-			return true, 0, nil
+			return false, 0, err
 		}
 
 		if apiErr.StatusCode != 429 && apiErr.StatusCode != 500 {

--- a/internal/llm/provider/provider.go
+++ b/internal/llm/provider/provider.go
@@ -13,7 +13,7 @@ import (
 
 type EventType string
 
-const maxRetries = 8
+const maxRetries = 3
 
 const (
 	EventContentStart   EventType = "content_start"


### PR DESCRIPTION
If auth failed... its unlikely it'll work next time

Also lowered retries from 8 to 3 - IMHO 8 is too many? It takes a long time and if it didn't work the first couple of times... it's unlikely it'll work in the 8th, IMHO.

closes #741

