### PR TITLE
feat: add AWS bearer token authentication for Bedrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ That said, you can also set environment variables for preferred providers.
 | `AWS_ACCESS_KEY_ID`         | AWS Bedrock (Claude)                               |
 | `AWS_SECRET_ACCESS_KEY`     | AWS Bedrock (Claude)                               |
 | `AWS_REGION`                | AWS Bedrock (Claude)                               |
+| `AWS_BEARER_TOKEN_BEDROCK`  | AWS Bedrock (Claude) Bearer Token                  |
 | `AWS_PROFILE`               | Custom AWS Profile                                 |
 | `AWS_REGION`                | AWS Region                                         |
 | `AZURE_OPENAI_API_ENDPOINT` | Azure OpenAI models                                |
@@ -476,9 +477,17 @@ Custom Anthropic-compatible providers follow this format:
 
 Crush currently supports running Anthropic models through Bedrock, with caching disabled.
 
-- A Bedrock provider will appear once you have AWS configured, i.e. `aws configure`
-- Crush also expects the `AWS_REGION` or `AWS_DEFAULT_REGION` to be set
-- To use a specific AWS profile set `AWS_PROFILE` in your environment, i.e. `AWS_PROFILE=myprofile crush`
+You can authenticate with Bedrock in two ways:
+
+1. **Bearer Token (recommended for simpler auth)**:
+   - Set `AWS_BEARER_TOKEN_BEDROCK` with your Bedrock API key
+   - Set `AWS_REGION` or `AWS_DEFAULT_REGION`
+   - Example: `AWS_BEARER_TOKEN_BEDROCK=bedrock-api-key-... AWS_REGION=us-east-1 crush`
+
+2. **AWS Credentials**:
+   - A Bedrock provider will appear once you have AWS configured, i.e. `aws configure`
+   - Crush also expects the `AWS_REGION` or `AWS_DEFAULT_REGION` to be set
+   - To use a specific AWS profile set `AWS_PROFILE` in your environment, i.e. `AWS_PROFILE=myprofile crush`
 
 ### Vertex AI Platform
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -213,6 +213,13 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 				}
 				continue
 			}
+			bearerToken := env.Get("AWS_BEARER_TOKEN_BEDROCK")
+			if bearerToken != "" {
+				if !strings.HasPrefix(bearerToken, "Bearer ") {
+					bearerToken = "Bearer " + bearerToken
+				}
+				prepared.APIKey = bearerToken
+			}
 			prepared.ExtraParams["region"] = env.Get("AWS_REGION")
 			if prepared.ExtraParams["region"] == "" {
 				prepared.ExtraParams["region"] = env.Get("AWS_DEFAULT_REGION")
@@ -577,6 +584,10 @@ func hasVertexCredentials(env env.Env) bool {
 }
 
 func hasAWSCredentials(env env.Env) bool {
+	if env.Get("AWS_BEARER_TOKEN_BEDROCK") != "" {
+		return true
+	}
+
 	if env.Get("AWS_ACCESS_KEY_ID") != "" && env.Get("AWS_SECRET_ACCESS_KEY") != "" {
 		return true
 	}


### PR DESCRIPTION
Adds support for authenticating with AWS Bedrock using bearer tokens
via the AWS_BEARER_TOKEN_BEDROCK environment variable. This provides
a simpler authentication method compared to full AWS credentials,
particularly useful in corporate environments.

Implementation:
- Detects when AWS_BEARER_TOKEN_BEDROCK is set and passes it as API key
- Bypasses the anthropic SDK's SigV4 middleware for bearer tokens
- Sets Bedrock base URL directly and uses Authorization header
- Falls back to SigV4 auth when AWS credentials are provided instead
- Maintains full backwards compatibility with existing credential auth

Changes:
- Updated hasAWSCredentials() to check for AWS_BEARER_TOKEN_BEDROCK
- Modified Bedrock provider config to pass bearer token with "Bearer " prefix
- Enhanced anthropic client to skip bedrock middleware for bearer tokens
- Added test coverage for bearer token authentication
- Updated README with bearer token documentation and usage examples

Bearer tokens are particularly useful in corporate environments where
teams need access to Bedrock without managing AWS credentials, IAM
roles, or account-level permissions. This streamlines AI development
workflows by allowing API key-based access similar to other LLM providers.

Note: This is a temporary workaround until the anthropic SDK adds native
bearer token support. An upstream PR has been submitted to add this
functionality: https://github.com/anthropics/anthropic-sdk-go/pull/240

References:
- https://github.com/aws/aws-sdk-go-v2/pull/3159
- https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html
- https://aws.amazon.com/blogs/machine-learning/accelerate-ai-development-with-amazon-bedrock-api-keys/

💘 Generated with Crush

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
