### PR TITLE
Improve quit dialog user experience with clearer keyboard shortcuts and better layout.

### DIFF
--- a/internal/tui/components/dialogs/quit/quit.go
+++ b/internal/tui/components/dialogs/quit/quit.go
@@ -80,16 +80,26 @@ func (q *quitDialogCmp) View() string {
 	}
 
 	const horizontalPadding = 3
-	yesButton := yesStyle.PaddingLeft(horizontalPadding).Underline(true).Render("Y") +
-		yesStyle.PaddingRight(horizontalPadding).Render("ep!")
-	noButton := noStyle.PaddingLeft(horizontalPadding).Underline(true).Render("N") +
-		noStyle.PaddingRight(horizontalPadding).Render("ope")
+	// Render complete button text with brackets in one go
+	yesButton := yesStyle.PaddingLeft(horizontalPadding).Render("[Y]es, quit Crush") +
+		yesStyle.PaddingRight(horizontalPadding).Render("")
+	noButton := noStyle.PaddingLeft(horizontalPadding).Render("[N]o, continue") +
+		noStyle.PaddingRight(horizontalPadding).Render("")
 
-	buttons := baseStyle.Width(lipgloss.Width(question)).Align(lipgloss.Right).Render(
-		lipgloss.JoinHorizontal(lipgloss.Center, yesButton, "  ", noButton),
+	// Calculate the total width needed for centered layout
+	yesButtonWidth := lipgloss.Width(yesButton)
+	noButtonWidth := lipgloss.Width(noButton)
+	totalButtonsWidth := yesButtonWidth + noButtonWidth + 6 // 6 for spacing
+
+	// Create a centered container for the buttons
+	buttons := baseStyle.Width(totalButtonsWidth).Align(lipgloss.Center).Render(
+		lipgloss.JoinHorizontal(lipgloss.Center, yesButton, "   ", noButton),
 	)
 
-	content := baseStyle.Render(
+	// Calculate the maximum width for proper centering
+	maxWidth := max(lipgloss.Width(question), totalButtonsWidth)
+
+	content := baseStyle.Width(maxWidth).Align(lipgloss.Center).Render(
 		lipgloss.JoinVertical(
 			lipgloss.Center,
 			question,
@@ -110,7 +120,15 @@ func (q *quitDialogCmp) Position() (int, int) {
 	row := q.wHeight / 2
 	row -= 7 / 2
 	col := q.wWidth / 2
-	col -= (lipgloss.Width(question) + 4) / 2
+
+	// Calculate dialog width more accurately
+	const horizontalPadding = 3
+	yesButtonWidth := lipgloss.Width("[Y]es, quit Crush") + horizontalPadding
+	noButtonWidth := lipgloss.Width("[N]o, continue") + horizontalPadding
+	totalButtonsWidth := yesButtonWidth + noButtonWidth + 6
+	dialogWidth := max(lipgloss.Width(question), totalButtonsWidth) + 4 // +4 for padding
+
+	col -= dialogWidth / 2
 
 	return row, col
 }


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).


## 🎯 Summary
Improve quit dialog user experience by making keyboard shortcuts more visible and button text more descriptive.

## 🔧 Changes
- **Keyboard shortcuts**: Replace underlines with brackets `[Y]` `[N]` for better visibility
- **Button text**: Change from "Yep!/Nope" to "Yes, quit Crush/No, continue" for clarity
- **Layout**: Improve centering and symmetry of button alignment
- **Safety**: Maintain default selection of "No" to prevent accidental exits

## 🎨 Visual Changes
**Before:**

<img width="469" height="167" alt="Screenshot 2025-09-28 at 20 50 27" src="https://github.com/user-attachments/assets/e37f6efc-b12f-4bb3-b273-10187397f972" />

**After:**

<img width="743" height="198" alt="Screenshot 2025-09-28 at 20 57 57" src="https://github.com/user-attachments/assets/6d6e534b-8891-443f-93cb-fc4b1d63c2dd" />

## 🧪 Testing
- [x] Y key still exits the application
- [x] N key still cancels the dialog
- [x] Enter key defaults to "No" selection
- [x] Left/Right arrows still switch selection
- [x] Layout displays correctly at different terminal sizes
- [x] All existing keyboard shortcuts work as expected

## 📱 Compatibility
- ✅ No breaking changes to existing functionality
- ✅ All keyboard shortcuts remain the same
- ✅ Works with all terminal themes
- ✅ Maintains accessibility

## 💡 Rationale
This improvement addresses a common UX issue where new users couldn't easily identify keyboard shortcuts due to subtle underlines. The bracket notation `[Y]` `[N]` is more prominent and follows common CLI application conventions.

The more descriptive button text ("Yes, quit Crush" vs "Yep!") helps users understand exactly what each option does, reducing confusion and potential mistakes.
