### PR TITLE
fix(gemini): use full MIME type for binary content in message convers…

### DIFF
--- a/internal/llm/provider/gemini.go
+++ b/internal/llm/provider/gemini.go
@@ -70,9 +70,8 @@ func (g *geminiClient) convertMessages(messages []message.Message) []*genai.Cont
 			var parts []*genai.Part
 			parts = append(parts, &genai.Part{Text: msg.Content().String()})
 			for _, binaryContent := range msg.BinaryContent() {
-				imageFormat := strings.Split(binaryContent.MIMEType, "/")
 				parts = append(parts, &genai.Part{InlineData: &genai.Blob{
-					MIMEType: imageFormat[1],
+					MIMEType: binaryContent.MIMEType,
 					Data:     binaryContent.Data,
 				}})
 			}


### PR DESCRIPTION
(fixes charmbracelet/crush#995)

The fix involved removing the string splitting logic and directly using the complete MIMEType from the binaryContent. The corrected code now properly passes the full MIME type (e.g., "image/jpeg" or "image/png") to the Gemini API, which  resolved the error charmbracelet/crush#995 were encountering.

tested by:
<img width="1107" height="606" alt="image" src="https://github.com/user-attachments/assets/90fbabe7-ef1f-4701-89e7-f8f76c332499" />

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
