### PR TITLE
chore(taskfile): change `release` task to add a commit for the tag

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -97,7 +97,8 @@ tasks:
       - sh: "[ $(git status --porcelain=2 | wc -l) = 0 ]"
         msg: "Git is dirty"
     cmds:
+      - git commit --allow-empty -m "{{.NEXT}}"
       - git tag -d nightly
       - git tag --sign {{.NEXT}} {{.CLI_ARGS}}
-      - echo "pushing {{.NEXT}}..."
+      - echo "Pushing {{.NEXT}}..."
       - git push origin --tags


### PR DESCRIPTION
This means we'll have a commit for the tag, just like https://github.com/charmbracelet/crush/commit/8593f958e0d5218c946d47205af4f682040dc3be, for example.