### PR TITLE
fix: clean up active requests and cancel context on panic in agent ru…

### DIFF
--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -370,6 +370,8 @@ func (a *agent) Run(ctx context.Context, sessionID string, content string, attac
 	go func() {
 		slog.Debug("Request started", "sessionID", sessionID)
 		defer log.RecoverPanic("agent.Run", func() {
+			a.activeRequests.Del(sessionID)
+			cancel()
 			events <- a.err(fmt.Errorf("panic while running the agent"))
 		})
 		var attachmentParts []message.ContentPart


### PR DESCRIPTION
…n (#1093)
the issue was, the code missing cleanup logic in its panic handler, resulting UI components not able to update the correct status
by remove paniced request from active list, the UI now correctly refreshed its state and no longer stale in "Working..." message.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
