### PR TITLE
Fix #1169 malformed JSON handling

### DIFF
--- a/internal/llm/provider/openai.go
+++ b/internal/llm/provider/openai.go
@@ -573,6 +573,11 @@ func (o *openaiClient) toolCalls(completion openai.ChatCompletion) []message.Too
 			if call.Function.Name == "" {
 				continue
 			}
+			var temp map[string]interface{}
+			if err := json.Unmarshal([]byte(call.Function.Arguments), &temp); err != nil {
+				slog.Warn("Skipping tool call with invalid JSON arguments", "error", err, "arguments", call.Function.Arguments)
+				continue
+			}
 			toolCall := message.ToolCall{
 				ID:       call.ID,
 				Name:     call.Function.Name,

--- a/internal/tui/components/chat/messages/renderer.go
+++ b/internal/tui/components/chat/messages/renderer.go
@@ -122,7 +122,7 @@ func (br baseRenderer) makeNestedHeader(v *toolCallCmp, tool string, width int, 
 		} else {
 			icon = t.S().Base.Foreground(t.Green).Render(styles.ToolSuccess)
 		}
-	} else if v.cancelled {
+	} else if v.cancelled || v.retryMode {
 		icon = t.S().Muted.Render(styles.ToolPending)
 	}
 	tool = t.S().Base.Foreground(t.FgHalfMuted).Render(tool)
@@ -143,7 +143,7 @@ func (br baseRenderer) makeHeader(v *toolCallCmp, tool string, width int, params
 		} else {
 			icon = t.S().Base.Foreground(t.Green).Render(styles.ToolSuccess)
 		}
-	} else if v.cancelled {
+	} else if v.cancelled || v.retryMode {
 		icon = t.S().Muted.Render(styles.ToolPending)
 	}
 	tool = t.S().Base.Foreground(t.Blue).Render(tool)


### PR DESCRIPTION
**the PR address this issue: #1169 **
when model generated a tool call with invalid JSON,
the application saved this malformed tool call into the conversation history.
on EVERY subsequent request, the API server will likely reject the request, responding with 400 Bad requests.
though this is an edge case, however, it happens quite often, espeically on those less capable models or in complex prompt
critically, when this happen,  the agent will stuck, render the session not usable anymore

**how it is solved**
detect the  malformed JSON responses senario , implemented retry mechanism , nesssary error handling, and UI updating.

**Changes:**
- **OpenAI Provider (`internal/llm/provider/openai.go`):**
  - Added JSON validation for tool call arguments to prevent malformed responses
  - Implemented malformed JSON response simulation for testing
  - Enhanced error handling for tool call processing

- **Gemini Provider (`internal/llm/provider/gemini.go`):**
  - Added malformed JSON detection and retry logic for tool calls
  - Improved error handling and response validation
  - Enhanced tool call processing reliability

- **UI Components:**
  - Added retry mode for tool calls in chat interface (`internal/tui/components/chat/messages/tool.go`)
  - Updated rendering logic to reflect retry state in the UI (`internal/tui/components/chat/messages/renderer.go`)
  - Implemented timer-based retry mode exit for better UX

- **Testing:**
  - Deliberately reproduce this error for testing malformed JSON scenarios
  - Removed testing malformed JSON logic from LLM providers (cleanup)

**Files Changed:**
- `internal/llm/provider/gemini.go` (105 additions, 37 deletions)
- `internal/llm/provider/openai.go` (61 additions, 9 deletions)  
- `internal/tui/components/chat/messages/renderer.go` (4 changes)
- `internal/tui/components/chat/messages/tool.go` (28 additions, 1 deletion)

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
