### PR TITLE
chore: print a bug reporting notice when crush crashes

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -94,7 +94,7 @@ crush -y
 		if _, err := program.Run(); err != nil {
 			event.Error(err)
 			slog.Error("TUI run error", "error", err)
-			return errors.New("Crush crashed. If metrics are enabled, we were notified about it. If you'd like to report it, please copy the stacktrace above and open an issue at https://github.com/charmbracelet/crush/issues/new?template=bug.yml")
+			return errors.New("Crush crashed. If metrics are enabled, we were notified about it. If you'd like to report it, please copy the stacktrace above and open an issue at https://github.com/charmbracelet/crush/issues/new?template=bug.yml") //nolint:staticcheck
 		}
 		return nil
 	},


### PR DESCRIPTION
This revision vastly improves the message after a crash, and provides instructions to the user on how to best improve report the associated bug.

<p><img width="1203" height="353" alt="Screenshot 2025-10-01 at 1 44 03 PM" src="https://github.com/user-attachments/assets/ee0a0229-2eb2-4c79-bb9e-a9036bdecb11" /></p>

All the credit in this revision goes to @andreynering.