### PR TITLE
perf(list): optimize filter performance and limit results

### DIFF
--- a/internal/tui/exp/list/filterable.go
+++ b/internal/tui/exp/list/filterable.go
@@ -3,8 +3,6 @@ package list
 import (
 	"regexp"
 	"slices"
-	"sort"
-	"strings"
 
 	"github.com/charmbracelet/bubbles/v2/key"
 	"github.com/charmbracelet/bubbles/v2/textinput"
@@ -18,6 +16,9 @@ import (
 // Pre-compiled regex for checking if a string is alphanumeric.
 var alphanumericRegex = regexp.MustCompile(`^[a-zA-Z0-9]*$`)
 
+// Maximum number of filter results to display.
+const maxFilterResults = 25
+
 type FilterableItem interface {
 	Item
 	FilterValue() string
@@ -29,6 +30,7 @@ type FilterableList[T FilterableItem] interface {
 	SetInputWidth(int)
 	SetInputPlaceholder(string)
 	Filter(q string) tea.Cmd
+	fuzzy.Source
 }
 
 type HasMatchIndexes interface {
@@ -246,22 +248,15 @@ func (f *filterableList[T]) Filter(query string) tea.Cmd {
 		return f.list.SetItems(f.items)
 	}
 
-	words := make([]string, len(f.items))
-	for i, item := range f.items {
-		words[i] = strings.ToLower(item.FilterValue())
-	}
-
-	matches := fuzzy.Find(query, words)
-
-	sort.SliceStable(matches, func(i, j int) bool {
-		return matches[i].Score > matches[j].Score
-	})
+	matches := fuzzy.FindFrom(query, f)
 
 	var matchedItems []T
-	for _, match := range matches {
+	matchCount := min(len(matches), maxFilterResults)
+	for i := range matchCount {
+		match := matches[i]
 		item := f.items[match.Index]
-		if i, ok := any(item).(HasMatchIndexes); ok {
-			i.MatchIndexes(match.MatchedIndexes)
+		if it, ok := any(item).(HasMatchIndexes); ok {
+			it.MatchIndexes(match.MatchedIndexes)
 		}
 		matchedItems = append(matchedItems, item)
 	}
@@ -306,4 +301,12 @@ func (f *filterableList[T]) SetInputWidth(w int) {
 
 func (f *filterableList[T]) SetInputPlaceholder(ph string) {
 	f.placeholder = ph
+}
+
+func (f *filterableList[T]) String(i int) string {
+	return f.items[i].FilterValue()
+}
+
+func (f *filterableList[T]) Len() int {
+	return len(f.items)
 }


### PR DESCRIPTION
This PR refactors the filterable list's Filter method to improve performance and user experience through three key changes:

## Changes

### 1. Switch from fuzzy.Find to fuzzy.FindFrom
- Eliminates redundant string allocations by avoiding intermediate list
- The fuzzy library already uses strings.EqualFold internally for case-insensitive matching, so the pre-lowercased copy was wasted allocation and processing
- Implements fuzzy.Source interface (String/Len methods) to provide direct access to items without intermediate allocations

### 2. Remove redundant sorting
- fuzzy.FindFrom already performs stable score-based sorting internally
- The additional sort.SliceStable was redundant and added unnecessary overhead
- Stable sorting behavior is preserved by the library

### 3. Cap displayed results at 25 items
- Prevents UI lag when filtering large lists (e.g., project-wide file searches with thousands of matches)
- Benchmarking against similar tools shows comparable limits:
  * Codex: 8 items
  * Opencode: 10 items  
  * Claude Code: 15 items
  * Gemini CLI: 24 items
  * Copilot CLI: 50 items
- 25 items represents a practical middle ground that keeps the UI responsive while providing enough context for users to find matches
- Extracted to a package constant (`maxFilterResults`) for easy tuning

## Additional improvements
- Remove unused imports (sort, strings)
- Improve variable naming (i -> it) to avoid shadowing in type assertion
- All existing tests pass

## Performance impact
- Reduces allocations per filter operation (no intermediate string slice)
- Eliminates O(n) lowercasing loop for n items
- Eliminates O(m log m) sort for m matches when m can be large
- Caps rendering cost regardless of match count