### PR TITLE
fix(mcp): ensure command environment is set only if non-empty

### DIFF
--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -398,7 +398,9 @@ func createMCPTransport(ctx context.Context, m config.MCPConfig, resolver config
 			return nil, fmt.Errorf("mcp stdio config requires a non-empty 'command' field")
 		}
 		cmd := exec.CommandContext(ctx, home.Long(command), m.Args...)
-		cmd.Env = m.ResolvedEnv()
+		if env := m.ResolvedEnv(); len(env) > 0 {
+			cmd.Env = env
+		}
 		return &mcp.CommandTransport{
 			Command: cmd,
 		}, nil


### PR DESCRIPTION
# Fix MCP Loading Issue with Environment Variables

## 🐛 Problem

When MCP configurations don't specify any environment variables, the `ResolvedEnv()` method returns an empty slice `[]string{}`. Setting `exec.Cmd.Env` to an empty slice causes the child process to run with **no environment variables at all**, which can cause MCP processes to fail during startup as they may depend on system environment variables like `PATH`, `HOME`, etc.

## ✅ Solution

Only set `cmd.Env` when there are actually environment variables to configure. When `ResolvedEnv()` returns an empty slice, leave `cmd.Env` as `nil` so the child process inherits the parent's environment variables.

## 🔧 Changes

**File:** `internal/llm/agent/mcp-tools.go`

```diff
- cmd.Env = m.ResolvedEnv()
+ if env := m.ResolvedEnv(); len(env) > 0 {
+     cmd.Env = env
+ }
```

### What this change does:
- Added a nil check in `createMCPTransport()` to only set `cmd.Env` when `m.ResolvedEnv()` returns a non-empty slice
- This ensures MCP processes have access to necessary system environment variables when no custom environment is specified

## 🧪 Testing

- [x] MCP clients should now start successfully even when no custom environment variables are configured
- [x] Existing functionality with custom environment variables remains unchanged
- [x] No breaking changes to the existing API

## 📝 Background

In Go's `os/exec` package:
- When `Cmd.Env` is `nil`: child process inherits parent's environment
- When `Cmd.Env` is `[]string{}`: child process gets **no** environment variables
- When `Cmd.Env` is `[]string{"KEY=value"}`: child process gets only specified variables

This fix resolves MCP loading failures that occurred when configurations didn't specify custom environment variables.

## 🎯 Impact

- **Before**: MCP processes could fail to start when no custom env vars were configured
- **After**: MCP processes inherit system environment and start reliably
- **Risk**: Low - only affects the environment variable handling logic