### PR TITLE
feat: paste/close bindings in user cmd dialog

### DIFF
--- a/internal/tui/components/dialogs/commands/arguments.go
+++ b/internal/tui/components/dialogs/commands/arguments.go
@@ -130,6 +130,8 @@ func (c *commandArgumentsDialogCmp) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			c.inputs[c.focusIndex].Focus()
 		case key.Matches(msg, c.keys.Paste):
 			return c, textinput.Paste
+		case key.Matches(msg, c.keys.Close):
+			return c, util.CmdHandler(dialogs.CloseDialogMsg{})
 		default:
 			var cmd tea.Cmd
 			c.inputs[c.focusIndex], cmd = c.inputs[c.focusIndex].Update(msg)

--- a/internal/tui/components/dialogs/commands/keys.go
+++ b/internal/tui/components/dialogs/commands/keys.go
@@ -77,6 +77,7 @@ type ArgumentsDialogKeyMap struct {
 	Next     key.Binding
 	Previous key.Binding
 	Paste    key.Binding
+	Close    key.Binding
 }
 
 func DefaultArgumentsDialogKeyMap() ArgumentsDialogKeyMap {
@@ -98,6 +99,10 @@ func DefaultArgumentsDialogKeyMap() ArgumentsDialogKeyMap {
 			key.WithKeys("ctrl+v"),
 			key.WithHelp("ctrl+v", "paste"),
 		),
+		Close: key.NewBinding(
+			key.WithKeys("esc", "alt+esc"),
+			key.WithHelp("esc", "cancel"),
+		),
 	}
 }
 
@@ -108,6 +113,7 @@ func (k ArgumentsDialogKeyMap) KeyBindings() []key.Binding {
 		k.Next,
 		k.Previous,
 		k.Paste,
+		k.Close,
 	}
 }
 
@@ -129,5 +135,6 @@ func (k ArgumentsDialogKeyMap) ShortHelp() []key.Binding {
 		k.Next,
 		k.Previous,
 		k.Paste,
+		k.Close,
 	}
 }


### PR DESCRIPTION
When executing user commands (feature whose documentation in the [command-docs](https://github.com/charmbracelet/crush/tree/command-docs) branch hasn't been merged into main yet) with variables, the variable dialog doesn't allow for pasting into the variable fields or closing the dialog (that I saw). The only way to dismiss the dialog if you didn't mean to invoke that command is to quit Crush entirely.

To test from the UI, have a command in `~/.config/crush/commands/something.md` with a `$VARIABLE`. Open the commands dialog, invoke the `user:something` command, then try to paste into the VARIABLE field or close the dialog.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
