### PR TITLE
feat: allow configurable bash commands via permissions.allowed_commands

### DIFF
--- a/crush.json
+++ b/crush.json
@@ -2,5 +2,8 @@
   "$schema": "https://charm.land/crush.json",
   "lsp": {
     "gopls": {}
+  },
+  "permissions": {
+    "allowed_commands": ["curl"]
   }
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,8 +147,9 @@ func (c Completions) Limits() (depth, items int) {
 }
 
 type Permissions struct {
-	AllowedTools []string `json:"allowed_tools,omitempty" jsonschema:"description=List of tools that don't require permission prompts,example=bash,example=view"` // Tools that don't require permission prompts
-	SkipRequests bool     `json:"-"`                                                                                                                              // Automatically accept all permissions (YOLO mode)
+	AllowedTools    []string `json:"allowed_tools,omitempty" jsonschema:"description=List of tools that don't require permission prompts,example=bash,example=view"` // Tools that don't require permission prompts
+	AllowedCommands []string `json:"allowed_commands,omitempty" jsonschema:"description=List of commands that are allowed in bash tool,example=curl,example=wget"`     // Commands that are allowed in bash tool
+	SkipRequests    bool     `json:"-"`                                                                                                                              // Automatically accept all permissions (YOLO mode)
 }
 
 type Attribution struct {

--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -183,9 +183,13 @@ func NewAgent(
 
 		// Base tools available to all agents
 		cwd := cfg.WorkingDir()
+		allowedCommands := []string{}
+		if cfg.Permissions != nil {
+			allowedCommands = cfg.Permissions.AllowedCommands
+		}
 		result := make(map[string]tools.BaseTool)
 		for _, tool := range []tools.BaseTool{
-			tools.NewBashTool(permissions, cwd, cfg.Options.Attribution),
+			tools.NewBashTool(permissions, cwd, cfg.Options.Attribution, allowedCommands),
 			tools.NewDownloadTool(permissions, cwd),
 			tools.NewEditTool(lspClients, permissions, history, cwd),
 			tools.NewMultiEditTool(lspClients, permissions, history, cwd),

--- a/schema.json
+++ b/schema.json
@@ -374,6 +374,17 @@
           },
           "type": "array",
           "description": "List of tools that don't require permission prompts"
+        },
+        "allowed_commands": {
+          "items": {
+            "type": "string",
+            "examples": [
+              "curl",
+              "wget"
+            ]
+          },
+          "type": "array",
+          "description": "List of commands that are allowed in bash tool"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Add support for configuring which bash commands are allowed through the crush.json permissions section. This allows users to enable specific commands like curl that are otherwise blocked for security reasons.

## Changes

- Add `allowed_commands` field to Permissions config
- Modify bash tool to respect allowed commands configuration  
- Update schema.json to include the new configuration option
- Update crush.json example to show curl as allowed

## Usage

Users can now add allowed commands in their crush.json:

```json
{
  "permissions": {
    "allowed_commands": ["curl", "wget", "ping"]
  }
}
```

This maintains security by default while giving users control over specific commands they need.