### PR TITLE
fix(bedrock): detect credentials set by `aws configure`

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -605,6 +605,11 @@ func hasAWSCredentials(env env.Env) bool {
 		env.Get("AWS_CONTAINER_CREDENTIALS_FULL_URI") != "" {
 		return true
 	}
+
+	if _, err := os.Stat(filepath.Join(home.Dir(), ".aws/credentials")); err == nil {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
The current codes look for envs, but `aws configure` actually write credentials and config into files on the `$HOME/.aws` directory.
