### PR TITLE
[mcp] add type assertion guards

### DIFF
--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -98,9 +98,26 @@ func (b *McpTool) Name() string {
 }
 
 func (b *McpTool) Info() tools.ToolInfo {
-	input := b.tool.InputSchema.(map[string]any)
-	required, _ := input["required"].([]string)
-	parameters, _ := input["properties"].(map[string]any)
+	var parameters map[string]any
+	var required []string
+
+	if input, ok := b.tool.InputSchema.(map[string]any); ok {
+		if props, ok := input["properties"].(map[string]any); ok {
+			parameters = props
+		}
+		if req, ok := input["required"].([]any); ok {
+			// Convert []any -> []string when elements are strings
+			for _, v := range req {
+				if s, ok := v.(string); ok {
+					required = append(required, s)
+				}
+			}
+		} else if reqStr, ok := input["required"].([]string); ok {
+			// Handle case where it's already []string
+			required = reqStr
+		}
+	}
+
 	return tools.ToolInfo{
 		Name:        fmt.Sprintf("mcp_%s_%s", b.mcpName, b.tool.Name),
 		Description: b.tool.Description,


### PR DESCRIPTION
In McpTool.Info(), the code assumes specific shapes for tool.InputSchema during casting.  We add guards to prevent panics.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

I was reviewing the latest releases and saw that there was an upgrade from `mcp-go` to the `modelcontextprotocol/go-sdk`.  As I've used the latter `go-mcp`, I was familiar with updating from breaking change from a type-assertive API to its later "safe" API.   I saw the new one uses naked type assertions.   I thought that was a bad idea, and spent time looking at flow to see that maybe it was safe.   But component-level it's not clear.

I used crush to do this along with ChatGPT-5 with some hand-edits.   The AI noticed another concern of deeper type-casting of `[]any` to `[]string`.   I asked it if it was sure -- it does make sense in a general case, I think.    Anyway, here's the conversation.

Thanks for `crush`!  All that was human, the following is my crush session.

----

`EW: look at the code in mcp-tools.go   i am concerned that there needs to be type assertions`

Thanks — I reviewed internal/llm/agent/mcp-tools.go with a focus on places where dynamic types are used and where type assertions could fail or be unsafe.

Key findings and fixes needed:

- In McpTool.Info(), the code assumes specific shapes for tool.InputSchema:
  - input := b.tool.InputSchema.(map[string]any)
  - required, _ := input["required"].([]string)
  - properties, _ := input["properties"].(map[string]any)
- The MCP Tool input schema is JSON Schema-like, and after JSON unmarshalling, arrays typically come through as []any, not []string. This makes required, _ := input["required"].([]string) always fail, silently yielding an empty required slice. Also, input itself may not always be a map[string]any, and properties might be absent or of a different type.
- In runTool(), the iteration over result.Content is guarded properly with a type assertion to *mcp.TextContent and a safe fallback, which is fine.

What I will change:

- Make Info() robust by:
  - Safely asserting b.tool.InputSchema to map[string]any, falling back to empty fields if not.
  - Converting required from []any to []string if present and properly typed.
  - Passing through properties only if it’s a map[string]any; otherwise default to nil or empty map.

Plan:

- Update Info() to handle type assertions defensively with conversions.
- Run diagnostics to ensure no type errors.

Now I will implement the changes to McpTool.Info() accordingly and then run diagnostics.

----

I updated McpTool.Info() to perform safe type assertions and conversions for the MCP tool’s InputSchema:

• Guarded the map[string]any assertion on InputSchema.
• Properly handle required when it is []any (most common after JSON unmarshal) by converting elements to []string;
also accept []string directly.
• Only set Parameters when properties is a map[string]any; otherwise leave nil.

Project diagnostics show no new issues.

----

`EW: can you double-check the thinking about needing to check both []any and []string`

Short answer: yes, we should check both. Here’s why:

• The MCP Tool input schema ultimately comes from JSON. Go’s encoding/json unmarshals JSON arrays into []any by
default when the target type is interface{}.
• In practice, b.tool.InputSchema is interface{}, and tool schemas flow through JSON unmarshalling. Therefore,
required is most commonly []any with string elements.
• However, depending on upstream types (e.g., if the SDK or another layer already typed the field as []string, or
if a custom unmarshal occurs), required may already be []string.
• To be robust across both cases, we need to:
• Prefer handling []any and convert elements to []string.
• Also accept []string directly in case the type is already specific.


This dual check prevents silently dropping required keys (which was happening before with only []string) and
avoids panics or incorrect assumptions across different providers/SDK versions.
