### PR TITLE
Avoid nil errors for tool parameters

### DIFF
--- a/CRUSH.md
+++ b/CRUSH.md
@@ -54,7 +54,7 @@ func TestYourFunction(t *testing.T) {
 ## Formatting
 
 - ALWAYS format any Go code you write.
-  - First, try `goftumpt -w .`.
+  - First, try `gofumpt -w .`.
   - If `gofumpt` is not available, use `goimports`.
   - If `goimports` is not available, use `gofmt`.
   - You can also use `task fmt` to run `gofumpt -w .` on the entire project,

--- a/internal/llm/agent/mcp-tools.go
+++ b/internal/llm/agent/mcp-tools.go
@@ -99,8 +99,8 @@ func (b *McpTool) Name() string {
 }
 
 func (b *McpTool) Info() tools.ToolInfo {
-	var parameters map[string]any
-	var required []string
+	parameters := make(map[string]any)
+	required := make([]string, 0)
 
 	if input, ok := b.tool.InputSchema.(map[string]any); ok {
 		if props, ok := input["properties"].(map[string]any); ok {


### PR DESCRIPTION
After #1208, when sending a request with a stdio tool (eg, goreleaser), I receive the following error:

POST "https://api.openai.com/v1/chat/completions": 400 Bad Request 
```json
{
   "message":"Invalid schema for function 'mcp_goreleaser_build': None is not of type 'object'.",
   "type":"invalid_request_error",
   "param":"tools[11].function.parameters",
   "code":"invalid_function_parameters"
}
```

This can occur when the tool parameter is not initialized.

This small fix prevents this from happening.


- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [X] I have created a discussion that was approved by a maintainer (for new features).
