### PR TITLE
fix(tui): remove ctrl+d deny keybind

### DIFF
--- a/internal/tui/components/dialogs/permissions/keys.go
+++ b/internal/tui/components/dialogs/permissions/keys.go
@@ -42,7 +42,7 @@ func DefaultKeyMap() KeyMap {
 			key.WithHelp("s", "allow session"),
 		),
 		Deny: key.NewBinding(
-			key.WithKeys("d", "D", "ctrl+d", "esc"),
+			key.WithKeys("d", "D", "esc"),
 			key.WithHelp("d", "deny"),
 		),
 		Select: key.NewBinding(


### PR DESCRIPTION
it conflics with show/hide details

I wonder if we should remove ctrl+s and ctrl+a as well - ctrl+s conflicts with the session switcher.

closes #1268
