### PR TITLE
fix(mcp): improve cache hits when using MCPs

### DIFF
--- a/internal/llm/agent/agent.go
+++ b/internal/llm/agent/agent.go
@@ -535,6 +535,10 @@ func (a *agent) getAllTools() ([]tools.BaseTool, error) {
 		}
 		allTools = append(allTools, agentTool)
 	}
+
+	slices.SortFunc(allTools, func(a, b tools.BaseTool) int {
+		return strings.Compare(a.Name(), b.Name())
+	})
 	return allTools, nil
 }
 


### PR DESCRIPTION
This ensures that tools always have the same order, so caching works better.

In practice this means faster responses to subsequent messages in a conversation.

Closes https://github.com/charmbracelet/crush/issues/1249
