### PR TITLE
ci: remove vx.y.z from the release notes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -303,6 +303,7 @@ changelog:
       - "^docs: update$"
       - "^test:"
       - "^test\\("
+      - "^v\\d.*"
       - "merge conflict"
       - "merge conflict"
       - Merge branch


### PR DESCRIPTION
`task release` creates a release commit, which we should probably ignore in the release notes.
