### PR TITLE
fix(sqlite): remove WAL pragma

### DIFF
--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -23,7 +23,7 @@ func Connect(ctx context.Context, dataDir string) (*sql.DB, error) {
 	// Set pragmas for better performance
 	pragmas := []string{
 		"PRAGMA foreign_keys = ON;",
-		"PRAGMA journal_mode = WAL;",
+		"PRAGMA journal_mode = DELETE;",
 		"PRAGMA page_size = 4096;",
 		"PRAGMA cache_size = -8000;",
 		"PRAGMA synchronous = NORMAL;",


### PR DESCRIPTION
Honestly I don't think we really need it.

We basically only append to the messages tables, the default journaling seems enough to me.

Using the default will also allow to use SMB shares, and reduce IO.

Closes #473
See https://blog.sqlite.ai/journal-modes-in-sqlite 
See https://sqlite.org/pragma.html
