### PR TITLE
fix: always fetch providers live and not in background

### DIFF
--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -57,7 +57,7 @@ func TestProvider_loadProvidersWithIssues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to write old providers to file: %v", err)
 	}
-	providers, err := loadProviders(false, client, tmpPath)
+	providers, err := loadProviders(true, client, tmpPath)
 	require.NoError(t, err)
 	require.NotNil(t, providers)
 	require.Len(t, providers, 1)


### PR DESCRIPTION
We have this behavior that, if the cache is newer than 24 hours, we skip updating it live and do it in background instead. This is done to supposedly make boot a little bit quickier.

Problem is that potential changes weren't being reflected until Crush is restarted.

This PR essentially make updates always happen live so provider updates are seen immediately.

Keep in mind that we're still saving a cache on `providers.json` that is useful on future
runs if Crush is ran with `CRUSH_DISABLE_PROVIDER_AUTO_UPDATE=1`.