### PR TITLE
fix(prompt): reduce initial token usage by not sending file tree

### DIFF
--- a/internal/llm/prompt/coder.go
+++ b/internal/llm/prompt/coder.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/charmbracelet/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/config"
-	"github.com/charmbracelet/crush/internal/llm/tools"
 )
 
 func CoderPrompt(p string, contextFiles ...string) string {
@@ -53,7 +52,6 @@ func getEnvironmentInfo() string {
 	isGit := isGitRepo(cwd)
 	platform := runtime.GOOS
 	date := time.Now().Format("1/2/2006")
-	output, _, _ := tools.ListDirectoryTree(cwd, tools.LSParams{})
 	return fmt.Sprintf(`Here is useful information about the environment you are running in:
 <env>
 Working directory: %s
@@ -61,10 +59,7 @@ Is directory a git repo: %s
 Platform: %s
 Today's date: %s
 </env>
-<project>
-%s
-</project>
-		`, cwd, boolToYesNo(isGit), platform, date, output)
+		`, cwd, boolToYesNo(isGit), platform, date)
 }
 
 func isGitRepo(dir string) bool {


### PR DESCRIPTION
It can get quite big - the LLM can use the `ls` tool at any time to build the tree, so I think this is probably a good trade of, as it would save a lot of prompt usage, especially on big projects.

It would also potentially save a bunch of money for people.

## Stats

Sending a prompt (`hi`) in Crush's root dir, no MCPs/LSPs, qwen coder 3:

### Before 
17.9k tokens

### Now
11.7k tokens
