### PR TITLE
fix: restore terminal cursor style on exit

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/charmbracelet/crush/internal/version"
 	"github.com/charmbracelet/fang"
 	"github.com/charmbracelet/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/exp/charmtone"
 	"github.com/charmbracelet/x/term"
 	"github.com/spf13/cobra"
@@ -77,6 +78,7 @@ crush -y
 			return err
 		}
 		defer app.Shutdown()
+		defer restoreCursor()
 
 		event.AppInitialized()
 
@@ -249,4 +251,13 @@ func createDotCrushDir(dir string) error {
 	}
 
 	return nil
+}
+
+func restoreCursor() {
+	if !term.IsTerminal(os.Stdout.Fd()) {
+		return
+	}
+
+	fmt.Print(ansi.SetCursorStyle(0))
+	fmt.Print(ansi.ShowCursor)
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -31,6 +31,7 @@ crush run -q "Generate a README for this project"
 			return err
 		}
 		defer app.Shutdown()
+		defer restoreCursor()
 
 		if !app.Config().IsConfigured() {
 			return fmt.Errorf("no providers configured - please run 'crush' to set up a provider interactively")


### PR DESCRIPTION
#1298 
Fixes an issue where the cursor style was not properly restored when
exiting crush, particularly affecting terminals like urxvt with tmux. 

Previously, when crush exited, the cursor would remain as a pink
vertical bar instead of returning to the user's configured cursor
style (typically a blinking block).

This fix adds a restoreCursor() function that:
- Resets the cursor style to default (blinking block) using ANSI
  escape sequences
- Ensures the cursor is visible
- Is called via defer in both interactive and non-interactive modes

The fix uses the charmbracelet/x/ansi package to send the proper
DECSCUSR escape sequence (CSI 0 SP q) to reset the cursor style
and show the cursor on program exit.

This is my first contribution to this repository. Please let me
know if I'm missing anything or if there are any additional changes
needed to align with project conventions.