### PR TITLE
[Draft] ACP mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,8 @@ require (
 	mvdan.cc/sh/v3 v3.12.1-0.20250902163504-3cf4fd5717a5
 )
 
+require github.com/coder/acp-go-sdk v0.4.9 // indirect
+
 require (
 	cloud.google.com/go v0.116.0 // indirect
 	cloud.google.com/go/auth v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8
 github.com/charmbracelet/x/termios v0.1.1/go.mod h1:rB7fnv1TgOPOyyKRJ9o+AsTU/vK5WHJ2ivHeut/Pcwo=
 github.com/charmbracelet/x/windows v0.2.2 h1:IofanmuvaxnKHuV04sC0eBy/smG6kIKrWG2/jYn2GuM=
 github.com/charmbracelet/x/windows v0.2.2/go.mod h1:/8XtdKZzedat74NQFn0NGlGL4soHB0YQZrETF96h75k=
+github.com/coder/acp-go-sdk v0.4.9 h1:F4sKT2up4sMqNYt6yt2L9g4MaE09VPgt3eRqDFnoY5k=
+github.com/coder/acp-go-sdk v0.4.9/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=

--- a/internal/acp/agent.go
+++ b/internal/acp/agent.go
@@ -1,0 +1,290 @@
+package acp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/charmbracelet/crush/internal/app"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/cwd"
+	"github.com/charmbracelet/crush/internal/db"
+	"github.com/charmbracelet/crush/internal/llm/agent"
+	"github.com/coder/acp-go-sdk"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+type Agent struct {
+	app     *app.App
+	conn    *acp.AgentSideConnection
+	client  acp.ClientCapabilities
+	debug   bool
+	yolo    bool
+	dataDir string
+}
+
+var (
+	_ acp.Agent             = (*Agent)(nil)
+	_ acp.AgentLoader       = (*Agent)(nil)
+	_ acp.AgentExperimental = (*Agent)(nil)
+)
+
+func NewAgent(debug bool, yolo bool, dataDir string) (*Agent, error) {
+	return &Agent{
+		debug:   debug,
+		yolo:    yolo,
+		dataDir: dataDir,
+	}, nil
+}
+
+func (a *Agent) SetSessionMode(ctx context.Context, params acp.SetSessionModeRequest) (acp.SetSessionModeResponse, error) {
+	slog.Info("SetSessionMode")
+	return acp.SetSessionModeResponse{}, nil
+}
+
+func (a *Agent) SetSessionModel(ctx context.Context, params acp.SetSessionModelRequest) (acp.SetSessionModelResponse, error) {
+	slog.Info("SetSessionModel")
+	return acp.SetSessionModelResponse{}, nil
+}
+
+func (a *Agent) SetAgentConnection(conn *acp.AgentSideConnection) { a.conn = conn }
+
+func (a *Agent) Initialize(ctx context.Context, params acp.InitializeRequest) (acp.InitializeResponse, error) {
+	slog.Info("Initialize")
+	a.client = params.ClientCapabilities
+	return acp.InitializeResponse{
+		ProtocolVersion: acp.ProtocolVersionNumber,
+		AgentCapabilities: acp.AgentCapabilities{
+			LoadSession: false,
+			McpCapabilities: acp.McpCapabilities{
+				Http: false,
+				Sse:  false,
+			},
+			PromptCapabilities: acp.PromptCapabilities{
+				EmbeddedContext: true,
+				Audio:           false,
+				Image:           false,
+			},
+		},
+	}, nil
+}
+
+func (a *Agent) NewSession(ctx context.Context, params acp.NewSessionRequest) (acp.NewSessionResponse, error) {
+	slog.Info("New session requested...")
+	appInstance, err := a.setupApp(ctx, params)
+	if err != nil {
+		return acp.NewSessionResponse{}, err
+	}
+	a.app = appInstance
+
+	s, err := a.app.Sessions.Create(ctx, "New ACP Session")
+	if err != nil {
+		return acp.NewSessionResponse{}, err
+	}
+
+	// TODO: send models/modes
+	//models := a.app.Config().Models
+	resp := acp.NewSessionResponse{
+		Models:    nil,
+		Modes:     nil,
+		SessionId: acp.SessionId(s.ID),
+	}
+
+	go func() {
+		a.NotifySlashCommands(ctx, resp.SessionId)
+	}()
+	return resp, nil
+}
+
+func (a *Agent) NotifySlashCommands(ctx context.Context, sessionId acp.SessionId) {
+	notifyCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	if err := a.conn.SessionUpdate(notifyCtx, acp.SessionNotification{
+		SessionId: sessionId,
+		Update: acp.SessionUpdate{
+			AvailableCommandsUpdate: &acp.SessionUpdateAvailableCommandsUpdate{
+				AvailableCommands: a.availableCommands(),
+			},
+		},
+	}); err != nil {
+		slog.Error("failed to send available-commands update", "error", err)
+	}
+}
+
+func (a *Agent) availableCommands() []acp.AvailableCommand {
+	out := make([]acp.AvailableCommand, 0, len(slashRegistry))
+	for name := range slashRegistry {
+		out = append(out, acp.AvailableCommand{
+			Name: name,
+			Input: &acp.AvailableCommandInput{
+				&acp.UnstructuredCommandInput{
+					Hint: slashRegistry[name].Help(),
+				},
+			},
+		})
+	}
+
+	return out
+}
+
+func (a *Agent) Authenticate(ctx context.Context, _ acp.AuthenticateRequest) (acp.AuthenticateResponse, error) {
+	slog.Info("Authenticate")
+	return acp.AuthenticateResponse{}, nil
+}
+
+func (a *Agent) LoadSession(ctx context.Context, _ acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
+	slog.Info("LoadSession")
+	return acp.LoadSessionResponse{}, nil
+}
+
+func (a *Agent) Cancel(ctx context.Context, params acp.CancelNotification) error {
+	slog.Info("Cancel")
+	_, err := a.app.Sessions.Get(ctx, string(params.SessionId))
+	if err != nil {
+		return err
+	}
+
+	if a.app.CoderAgent != nil {
+		a.app.CoderAgent.Cancel(string(params.SessionId))
+	}
+
+	return nil
+}
+
+func (a *Agent) Prompt(ctx context.Context, params acp.PromptRequest) (acp.PromptResponse, error) {
+	slog.Info("Prompt")
+	var err error
+
+	if _, err = a.app.Sessions.Get(ctx, string(params.SessionId)); err != nil {
+		err = fmt.Errorf("session %s not found", params.SessionId)
+	} else {
+		// FIXME: Add support for different types of content (image, audio and etc)
+		cmd, txt := parseTextPrompt(params.Prompt)
+		if cmd != "" { // slash-command
+			err = a.handleSlash(ctx, cmd, txt, params)
+		} else { // normal LLM turn
+			err = a.streamAgentRun(ctx, params.SessionId, txt, false)
+		}
+	}
+
+	switch {
+	case err == nil:
+		return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+	case errors.Is(err, context.Canceled), errors.Is(err, agent.ErrRequestCancelled):
+		return acp.PromptResponse{StopReason: acp.StopReasonCancelled}, nil
+	default:
+		return acp.PromptResponse{}, err // real failure
+	}
+}
+
+func (a *Agent) handleSlash(ctx context.Context, name, text string, params acp.PromptRequest) error {
+	slog.Info("Handle slash command", "name", name)
+
+	cmd, ok := slashRegistry[name]
+	if !ok {
+		return fmt.Errorf("unknown command: %s", cmd)
+	}
+
+	return cmd.Exec(ctx, a, text, params)
+}
+
+func (a *Agent) setupApp(ctx context.Context, params acp.NewSessionRequest) (*app.App, error) {
+	cwDir, err := cwd.Resolve(params.Cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := config.Init(cwDir, a.dataDir, a.debug)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.Permissions == nil {
+		cfg.Permissions = &config.Permissions{}
+	}
+	cfg.Permissions.SkipRequests = a.yolo
+
+	if err := cwd.CreateDotCrushDir(cfg.Options.DataDirectory); err != nil {
+		return nil, err
+	}
+
+	// Connect to DB; this will also run migrations.
+	conn, err := db.Connect(ctx, cfg.Options.DataDirectory)
+	if err != nil {
+		return nil, err
+	}
+
+	appInstance, err := app.New(ctx, conn, cfg)
+	if err != nil {
+		slog.Error("Failed to create app instance", "error", err)
+		return nil, err
+	}
+
+	return appInstance, nil
+}
+
+// streamAgentRun streams whatever CoderAgent produces for the given prompt
+// and returns only when the run finishes (or context is cancelled).
+func (a *Agent) streamAgentRun(ctx context.Context, sessionId acp.SessionId, prompt string, modified bool) error {
+	slog.Debug("Stream agent's run.")
+	done, err := a.app.CoderAgent.Run(ctx, string(sessionId), prompt)
+	if err != nil {
+		return err
+	}
+
+	events := a.app.Messages.Subscribe(ctx)
+	if modified {
+		// in case if prompt was modified (e.g. slash command), we do not need to worry about duplicates
+		prompt = ""
+	}
+	updatesIter := newUpdatesIterator(prompt)
+
+	for {
+		select {
+		case result := <-done: // agent finished
+			// nil, context.Canceled, or agent.ErrRequestCancelled
+			return result.Error
+		case ev, ok := <-events:
+			if !ok {
+				// channel closed → agent finished cleanly
+				return nil
+			}
+
+			for update := range updatesIter.next(&ev.Payload) {
+				if err = a.conn.SessionUpdate(ctx, acp.SessionNotification{
+					SessionId: sessionId,
+					Update:    *update,
+				}); err != nil {
+					slog.Error("error sending update", err)
+					continue
+				}
+			}
+		}
+	}
+}
+
+// supposedly only one Text block from user?
+func parseTextPrompt(prompt []acp.ContentBlock) (cmd, rest string) {
+	for _, b := range prompt {
+		if b.Text == nil {
+			continue
+		}
+		txt := strings.TrimSpace(b.Text.Text)
+		if txt == "" || txt[0] != '/' {
+			return "", txt // normal message
+		}
+
+		// slash command
+		afterSlash := txt[1:]
+		i := strings.IndexByte(afterSlash, ' ')
+		if i == -1 {
+			return afterSlash, "" // "/cmd"
+		}
+
+		return afterSlash[:i], strings.TrimSpace(afterSlash[i:])
+	}
+
+	return "", ""
+}

--- a/internal/acp/server.go
+++ b/internal/acp/server.go
@@ -1,0 +1,79 @@
+package acp
+
+import (
+	"context"
+	"fmt"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/log"
+	"github.com/coder/acp-go-sdk"
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+)
+
+type Server struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	//TODO: Only stdio as transport is part of standard, http is still a draft, so only one agent until that
+	agent   *Agent
+	debug   bool
+	yolo    bool
+	dataDir string
+}
+
+func NewServer(ctx context.Context, debug bool, yolo bool, dataDir string) (*Server, error) {
+	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, os.Kill, syscall.SIGTERM)
+	log.Setup(
+		filepath.Join(LogsDir(), "logs", fmt.Sprintf("%s.log", config.AppName)),
+		debug,
+	)
+
+	return &Server{
+		ctx:     ctx,
+		cancel:  cancel,
+		debug:   debug,
+		yolo:    yolo,
+		dataDir: dataDir,
+	}, nil
+}
+
+func (s *Server) Run() error {
+	agent, err := NewAgent(s.debug, s.yolo, s.dataDir)
+	if err != nil {
+		return err
+	}
+	s.agent = agent
+	slog.Info("Running in ACP mode")
+
+	conn := acp.NewAgentSideConnection(agent, os.Stdout, os.Stdin)
+	agent.SetAgentConnection(conn)
+	conn.SetLogger(slog.Default())
+
+	select {
+	case <-conn.Done():
+		slog.Debug("peer disconnected, shutting down")
+	case <-s.ctx.Done():
+		slog.Debug("received termination signal, shutting down", "signal", s.ctx.Err())
+	}
+
+	return nil
+}
+
+func (s *Server) Shutdown() {
+	// Graceful shutdown
+	s.agent = nil
+}
+
+var LogsDir = sync.OnceValue(func() string {
+	tmp := filepath.Join(os.TempDir(), config.AppName)
+	if err := os.MkdirAll(tmp, 0755); err != nil {
+		slog.Error("could not create temp dir", "tmp", tmp)
+		os.Exit(-1)
+	}
+
+	return tmp
+})

--- a/internal/acp/sink.go
+++ b/internal/acp/sink.go
@@ -1,0 +1,71 @@
+package acp
+
+import (
+	"context"
+	"github.com/charmbracelet/crush/internal/app"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/permission"
+	"github.com/charmbracelet/crush/internal/pubsub"
+	"github.com/coder/acp-go-sdk"
+	"log/slog"
+)
+
+// implementing App's EventSink
+type agentEventSink struct {
+	ctx            context.Context
+	agent          *Agent
+	updatesIter    *updateIterator
+	lastUserPrompt string
+}
+
+var (
+	_ app.EventSink[any] = (*agentEventSink)(nil)
+)
+
+func newAgentSink(ctx context.Context, agent *Agent) *agentEventSink {
+	return &agentEventSink{
+		ctx:         ctx,
+		agent:       agent,
+		updatesIter: newUpdatesIterator(),
+	}
+}
+
+func (sink *agentEventSink) Send(msg any) {
+	switch ev := msg.(type) {
+	case pubsub.Event[message.Message]:
+		sink.handleMessage(ev.Payload)
+	case pubsub.Event[permission.PermissionRequest]:
+		sink.handlePermission(ev.Payload)
+	}
+}
+
+func (sink *agentEventSink) handleToolCall(t message.ToolCall) {
+	slog.Info("handleToolCall", "tool", t)
+}
+
+func (sink *agentEventSink) handleMessage(m message.Message) {
+	if m.Role == message.User && sink.lastUserPrompt == m.Content().String() {
+		return
+	}
+
+	for update := range sink.updatesIter.next(&m) {
+		if err := sink.agent.conn.SessionUpdate(sink.ctx, acp.SessionNotification{
+			SessionId: acp.SessionId(m.SessionID),
+			Update:    update,
+		}); err != nil {
+			slog.Error("session update failed", "error", err)
+		}
+	}
+}
+
+func (sink *agentEventSink) handlePermission(req permission.PermissionRequest) {
+	sink.agent.RequestPermission(sink.ctx, req)
+}
+
+func (sink *agentEventSink) LastUserPrompt(prompt string) {
+	sink.lastUserPrompt = prompt
+}
+
+func (sink *agentEventSink) Quit() {
+	//
+}

--- a/internal/acp/slash.go
+++ b/internal/acp/slash.go
@@ -1,0 +1,51 @@
+package acp
+
+import (
+	"context"
+	"fmt"
+	"github.com/charmbracelet/crush/internal/llm/prompt"
+	"github.com/coder/acp-go-sdk"
+)
+
+type slashCmd interface {
+	Help() string
+	Exec(ctx context.Context, agent *Agent, text string, params acp.PromptRequest) error
+}
+
+var slashRegistry = map[string]slashCmd{
+	"yolo": yoloCmd{},
+	"init": initCmd{},
+}
+
+type yoloCmd struct{}
+
+func (yoloCmd) Help() string { return "Toggle Yolo Mode" }
+func (yoloCmd) Exec(ctx context.Context, agent *Agent, text string, params acp.PromptRequest) error {
+	agent.app.Permissions.SetSkipRequests(!agent.app.Permissions.SkipRequests())
+	status := agent.app.Permissions.SkipRequests()
+
+	return agent.conn.SessionUpdate(ctx, acp.SessionNotification{
+		SessionId: params.SessionId,
+		Update: acp.SessionUpdate{
+			AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+				SessionUpdate: "agent_message_chunk", // TODO: double check this type for such cases - no LLM runs or tools
+				Content: acp.ContentBlock{
+					Text: &acp.ContentBlockText{
+						Text: fmt.Sprintf("YOLO mode is now **%s**.", map[bool]string{
+							true:  "ON",
+							false: "OFF",
+						}[status]),
+						Type: "text",
+					},
+				},
+			},
+		},
+	})
+}
+
+type initCmd struct{}
+
+func (initCmd) Help() string { return "Initialize Project" }
+func (initCmd) Exec(ctx context.Context, agent *Agent, text string, params acp.PromptRequest) error {
+	return agent.streamAgentRun(ctx, params.SessionId, prompt.Initialize(), true)
+}

--- a/internal/acp/slash.go
+++ b/internal/acp/slash.go
@@ -7,18 +7,36 @@ import (
 	"github.com/coder/acp-go-sdk"
 )
 
-type slashCmd interface {
+type SlashCommand interface {
+	Name() string
 	Help() string
 	Exec(ctx context.Context, agent *Agent, text string, params acp.PromptRequest) error
 }
 
-var slashRegistry = map[string]slashCmd{
-	"yolo": yoloCmd{},
-	"init": initCmd{},
+// AvailableCommands generates a slice of acp.AvailableCommand from a slice of SlashCommand
+func AvailableCommands(commands []SlashCommand) []acp.AvailableCommand {
+	out := make([]acp.AvailableCommand, 0, len(commands))
+	for _, cmd := range commands {
+		out = append(out, acp.AvailableCommand{
+			Name: cmd.Name(),
+			Input: &acp.AvailableCommandInput{
+				&acp.UnstructuredCommandInput{
+					Hint: cmd.Help(),
+				},
+			},
+		})
+	}
+	return out
+}
+
+var defaultSlashCommands = []SlashCommand{
+	yoloCmd{},
+	initCmd{},
 }
 
 type yoloCmd struct{}
 
+func (yoloCmd) Name() string { return "yolo" }
 func (yoloCmd) Help() string { return "Toggle Yolo Mode" }
 func (yoloCmd) Exec(ctx context.Context, agent *Agent, text string, params acp.PromptRequest) error {
 	agent.app.Permissions.SetSkipRequests(!agent.app.Permissions.SkipRequests())
@@ -45,6 +63,7 @@ func (yoloCmd) Exec(ctx context.Context, agent *Agent, text string, params acp.P
 
 type initCmd struct{}
 
+func (initCmd) Name() string { return "init" }
 func (initCmd) Help() string { return "Initialize Project" }
 func (initCmd) Exec(ctx context.Context, agent *Agent, text string, params acp.PromptRequest) error {
 	return agent.streamAgentRun(ctx, params.SessionId, prompt.Initialize(), true)

--- a/internal/acp/terminal/options.go
+++ b/internal/acp/terminal/options.go
@@ -1,0 +1,27 @@
+package terminal
+
+type createOpts struct {
+	args    []string
+	env     map[string]string
+	cwd     string
+	byteLim *int
+}
+
+// CreateOption defines a single optional argument for Create.
+type CreateOption func(*createOpts)
+
+func WithArgs(a ...string) CreateOption {
+	return func(o *createOpts) { o.args = a }
+}
+
+func WithEnv(e map[string]string) CreateOption {
+	return func(o *createOpts) { o.env = e }
+}
+
+func WithCwd(dir string) CreateOption {
+	return func(o *createOpts) { o.cwd = dir }
+}
+
+func WithByteLimit(n int) CreateOption {
+	return func(o *createOpts) { o.byteLim = &n }
+}

--- a/internal/acp/terminal/service.go
+++ b/internal/acp/terminal/service.go
@@ -1,0 +1,104 @@
+package terminal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/coder/acp-go-sdk"
+)
+
+// Service owns 0…N running terminals for one session.
+type Service struct {
+	conn        *acp.AgentSideConnection
+	termAllowed bool
+	mu          sync.RWMutex
+	term        map[acp.SessionId]map[ID]*Terminal
+}
+
+func NewService(conn *acp.AgentSideConnection, termAllowed bool) *Service {
+	return &Service{
+		conn:        conn,
+		termAllowed: termAllowed,
+		term:        make(map[acp.SessionId]map[ID]*Terminal),
+	}
+}
+
+// Create launches a new terminal and keeps it in the registry.
+func (s *Service) Create(ctx context.Context, sessionID acp.SessionId, cmd string, opts ...CreateOption) (*Terminal, error) {
+	if !s.termAllowed {
+		return nil, errors.New("client does not support terminal capability")
+	}
+
+	// apply defaults
+	co := &createOpts{}
+	for _, fn := range opts {
+		fn(co)
+	}
+
+	// build env slice
+	env := make([]acp.EnvVariable, 0, len(co.env))
+	for k, v := range co.env {
+		env = append(env, acp.EnvVariable{Name: k, Value: v})
+	}
+
+	t := New(cmd, co.args, env, co.cwd, co.byteLim)
+	if err := t.Start(ctx, s.conn, sessionID); err != nil {
+		return nil, err
+	}
+
+	// register
+	s.mu.Lock()
+	if s.term[sessionID] == nil {
+		s.term[sessionID] = make(map[ID]*Terminal)
+	}
+	s.term[sessionID][t.ID] = t
+	s.mu.Unlock()
+	return t, nil
+}
+
+// Get returns an existing terminal or error.
+func (s *Service) Get(sessionID acp.SessionId, id ID) (*Terminal, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	set, ok := s.term[sessionID]
+	if !ok {
+		return nil, fmt.Errorf("session %q has no terminals", sessionID)
+	}
+	t, ok := set[id]
+	if !ok {
+		return nil, fmt.Errorf("terminal %q not found", id)
+	}
+	return t, nil
+}
+
+// Release removes **one** terminal and calls its Release method.
+func (s *Service) Release(ctx context.Context, sessionID acp.SessionId, id ID) error {
+	s.mu.Lock()
+	t, ok := s.term[sessionID][id]
+	if !ok {
+		s.mu.Unlock()
+		return fmt.Errorf("terminal %q not found", id)
+	}
+	delete(s.term[sessionID], id)
+	if len(s.term[sessionID]) == 0 {
+		delete(s.term, sessionID)
+	}
+	s.mu.Unlock()
+
+	return t.Release(ctx, s.conn)
+}
+
+// ReleaseAll kills every terminal that belongs to a session (handy on session close).
+func (s *Service) ReleaseAll(ctx context.Context, sessionID acp.SessionId) {
+	s.mu.Lock()
+	set := s.term[sessionID]
+	delete(s.term, sessionID)
+	s.mu.Unlock()
+
+	for _, t := range set {
+		_ = t.Release(ctx, s.conn)
+	}
+}

--- a/internal/acp/terminal/terminal.go
+++ b/internal/acp/terminal/terminal.go
@@ -1,0 +1,108 @@
+package terminal
+
+import (
+	"context"
+	"github.com/coder/acp-go-sdk"
+	"github.com/google/uuid"
+	"log/slog"
+)
+
+type ID string
+
+// Terminal wraps one ACP terminal plus local metadata.
+type Terminal struct {
+	ID        ID
+	SessionID acp.SessionId
+	Cmd       string
+	Args      []string
+	Env       []acp.EnvVariable
+	Cwd       string
+	ByteLim   *int
+}
+
+// New creates a Terminal value, but does NOT start it.
+func New(cmd string, args []string, env []acp.EnvVariable, cwd string, byteLim *int) *Terminal {
+	return &Terminal{
+		Cmd:     cmd,
+		Args:    args,
+		Env:     env,
+		Cwd:     cwd,
+		ByteLim: byteLim,
+	}
+}
+
+// Start starts a command in a new terminal
+func (t *Terminal) Start(ctx context.Context, conn *acp.AgentSideConnection, sessionID acp.SessionId) error {
+	req := acp.CreateTerminalRequest{
+		SessionId:       sessionID,
+		Command:         t.Cmd,
+		Args:            t.Args,
+		Env:             t.Env,
+		OutputByteLimit: t.ByteLim,
+	}
+	if t.Cwd != "" {
+		req.Cwd = &t.Cwd
+	}
+
+	resp, err := conn.CreateTerminal(ctx, req)
+	if err != nil {
+		return err
+	}
+	t.ID = ID(resp.TerminalId)
+	t.SessionID = sessionID
+	return nil
+}
+
+// Output retrieves the current terminal output without waiting for the command to complete
+func (t *Terminal) Output(ctx context.Context, conn *acp.AgentSideConnection) (acp.TerminalOutputResponse, error) {
+	return conn.TerminalOutput(ctx, acp.TerminalOutputRequest{
+		SessionId:  t.SessionID,
+		TerminalId: string(t.ID),
+	})
+}
+
+// WaitForExit returns once the command completes
+func (t *Terminal) WaitForExit(ctx context.Context, conn *acp.AgentSideConnection) (acp.WaitForTerminalExitResponse, error) {
+	return conn.WaitForTerminalExit(ctx, acp.WaitForTerminalExitRequest{
+		SessionId:  t.SessionID,
+		TerminalId: string(t.ID),
+	})
+}
+
+// Kill terminates a command without releasing the terminal
+func (t *Terminal) Kill(ctx context.Context, conn *acp.AgentSideConnection) (acp.KillTerminalCommandResponse, error) {
+	return conn.KillTerminalCommand(ctx, acp.KillTerminalCommandRequest{
+		SessionId:  t.SessionID,
+		TerminalId: string(t.ID),
+	})
+}
+
+// Release kills the command if still running and releases all resources
+func (t *Terminal) Release(ctx context.Context, conn *acp.AgentSideConnection) error {
+	_, err := conn.ReleaseTerminal(ctx, acp.ReleaseTerminalRequest{
+		SessionId:  t.SessionID,
+		TerminalId: string(t.ID),
+	})
+	if err != nil {
+		slog.Error("could not release terminal", "err", err)
+	}
+
+	return err
+}
+
+// EmbedInToolCalls produces the SessionUpdate that advertises the terminal via tool calls
+func (t *Terminal) EmbedInToolCalls(ctx context.Context, conn *acp.AgentSideConnection) error {
+	return conn.SessionUpdate(ctx, acp.SessionNotification{
+		SessionId: t.SessionID,
+		Update: acp.SessionUpdate{
+			ToolCall: &acp.SessionUpdateToolCall{
+				ToolCallId: acp.ToolCallId("terminal_call_" + uuid.New().String()),
+				Kind:       acp.ToolKindExecute,
+				Status:     acp.ToolCallStatusInProgress,
+				Content: []acp.ToolCallContent{{
+					Terminal: &acp.ToolCallContentTerminal{TerminalId: string(t.ID)},
+				}},
+			},
+		},
+	})
+}

--- a/internal/acp/terminal/terminal.go
+++ b/internal/acp/terminal/terminal.go
@@ -99,9 +99,9 @@ func (t *Terminal) EmbedInToolCalls(ctx context.Context, conn *acp.AgentSideConn
 				ToolCallId: acp.ToolCallId("terminal_call_" + uuid.New().String()),
 				Kind:       acp.ToolKindExecute,
 				Status:     acp.ToolCallStatusInProgress,
-				Content: []acp.ToolCallContent{{
-					Terminal: &acp.ToolCallContentTerminal{TerminalId: string(t.ID)},
-				}},
+				Content: []acp.ToolCallContent{
+					acp.ToolTerminalRef(string(t.ID)),
+				},
 			},
 		},
 	})

--- a/internal/acp/tools.go
+++ b/internal/acp/tools.go
@@ -1,0 +1,115 @@
+package acp
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/charmbracelet/crush/internal/llm/tools"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/coder/acp-go-sdk"
+	"log/slog"
+	"strings"
+)
+
+type ToolCall message.ToolCall
+
+func (t ToolCall) Kind() acp.ToolKind {
+	switch t.Name {
+	case tools.BashToolName, tools.BashNoOutput:
+		return acp.ToolKindExecute
+	case tools.DownloadToolName, tools.FetchToolName:
+		return acp.ToolKindFetch
+	case tools.GlobToolName, tools.LSToolName, tools.GrepToolName:
+		return acp.ToolKindSearch
+	case tools.EditToolName, tools.MultiEditToolName, tools.WriteToolName:
+		return acp.ToolKindEdit
+	case tools.ViewToolName:
+		return acp.ToolKindRead
+	}
+
+	return acp.ToolKindOther
+}
+
+func (t ToolCall) StartToolCall() *acp.SessionUpdateToolCall {
+	result := &acp.SessionUpdateToolCall{
+		ToolCallId: acp.ToolCallId(t.ID),
+		Kind:       t.Kind(),
+		Title:      t.Name,
+		Status:     acp.ToolCallStatusPending,
+	}
+
+	return result
+}
+
+func (t ToolCall) UpdateToolCall() *acp.SessionUpdateToolCallUpdate {
+	input := map[string]any{}
+	if err := json.Unmarshal([]byte(t.Input), &input); err != nil {
+		slog.Warn("Error decoding input data", "err", err)
+	}
+
+	result := &acp.SessionUpdateToolCallUpdate{
+		ToolCallId: acp.ToolCallId(t.ID),
+		Status:     acp.Ptr(acp.ToolCallStatusInProgress),
+	}
+
+	filePath, _ := input["file_path"].(string)
+	offset, _ := input["offset"].(int)
+	limit, _ := input["limit"].(int)
+	oldText, _ := input["old_string"].(string)
+	newText, _ := input["new_string"].(string)
+	content, _ := input["content"].(string)
+
+	var locations []acp.ToolCallLocation
+	if filePath != "" {
+		locations = append(locations, acp.ToolCallLocation{
+			Path: filePath,
+			Line: acp.Ptr(offset),
+		})
+	}
+
+	switch t.Name {
+	case tools.EditToolName:
+		{
+			var title strings.Builder
+			title.WriteString("Edit ")
+			title.WriteString(filePath)
+			result.Title = acp.Ptr(title.String())
+			result.Content = []acp.ToolCallContent{acp.ToolDiffContent(filePath, newText, oldText)}
+		}
+	case tools.WriteToolName:
+		{
+			var title strings.Builder
+			title.WriteString("Edit ")
+			title.WriteString(filePath)
+			result.Title = acp.Ptr(title.String())
+
+			if filePath != "" {
+				result.Content = []acp.ToolCallContent{acp.ToolDiffContent(filePath, newText, "")}
+			} else {
+				result.Content = []acp.ToolCallContent{
+					acp.ToolContent(acp.ContentBlock{
+						Text: acp.Ptr(acp.ContentBlockText{Text: content}),
+					}),
+				}
+			}
+		}
+	case tools.ViewToolName:
+		{
+			var title strings.Builder
+			title.WriteString("Read ")
+			title.WriteString(filePath)
+			switch {
+			case limit > 0:
+				fmt.Fprintf(&title, " (%d - %d)", offset, offset+limit)
+			case offset > 0:
+				fmt.Fprintf(&title, " (from line %d)", offset)
+			default:
+				title.WriteString(" File")
+			}
+
+			result.Title = acp.Ptr(title.String())
+			result.Locations = locations
+		}
+	}
+
+	return result
+}

--- a/internal/acp/updates.go
+++ b/internal/acp/updates.go
@@ -1,0 +1,118 @@
+package acp
+
+import (
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/coder/acp-go-sdk"
+	"iter"
+)
+
+type updateIterator struct {
+	lastT  map[message.MessageRole]int
+	lastR  int
+	prompt string
+}
+
+func newUpdatesIterator(prompt string) *updateIterator {
+	return &updateIterator{
+		lastT:  make(map[message.MessageRole]int),
+		prompt: prompt,
+	}
+}
+
+func (it *updateIterator) next(msg *message.Message) iter.Seq[*acp.SessionUpdate] {
+	return func(yield func(*acp.SessionUpdate) bool) {
+		for _, p := range msg.Parts {
+			if n, ok := it.getUpdate(msg.Role, p); ok && !yield(n) {
+				return
+			}
+		}
+	}
+}
+
+// FIXME: Add support for different types of content (image, audio and etc)
+func (it *updateIterator) getContentBlock(role message.MessageRole, part message.ContentPart) *acp.ContentBlock {
+	switch v := part.(type) {
+	case message.TextContent:
+		lastLen := it.lastT[role]
+		nextLen := len(v.Text)
+		if nextLen <= lastLen {
+			return nil
+		}
+		delta := v.Text[lastLen:]
+		it.lastT[role] = nextLen
+		if delta != "" {
+			return &acp.ContentBlock{
+				Text: &acp.ContentBlockText{
+					Type: "text",
+					Text: delta,
+				},
+			}
+		}
+
+	case message.ReasoningContent:
+		if len(v.Thinking) <= it.lastR {
+			return nil
+		}
+
+		delta := v.Thinking[it.lastR:]
+		it.lastR = len(v.Thinking)
+		if delta != "" {
+			return &acp.ContentBlock{
+				Text: &acp.ContentBlockText{
+					Type: "text",
+					Text: delta,
+				},
+			}
+		}
+
+	case message.BinaryContent:
+	case message.ImageURLContent:
+	case message.Finish:
+	}
+
+	return nil
+}
+
+func (it *updateIterator) getUpdate(role message.MessageRole, part message.ContentPart) (*acp.SessionUpdate, bool) {
+	content := it.getContentBlock(role, part)
+	if content == nil {
+		return nil, false
+	}
+
+	switch role {
+	case message.Assistant:
+		switch part.(type) {
+		case message.ReasoningContent:
+			return &acp.SessionUpdate{
+				AgentThoughtChunk: &acp.SessionUpdateAgentThoughtChunk{
+					SessionUpdate: "agent_thought_chunk",
+					Content:       *content,
+				},
+			}, true
+
+		case message.TextContent:
+			return &acp.SessionUpdate{
+				AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
+					SessionUpdate: "agent_message_chunk",
+					Content:       *content,
+				},
+			}, true
+		}
+	case message.User:
+		if content.Text == nil || content.Text.Text != it.prompt {
+			return &acp.SessionUpdate{
+				UserMessageChunk: &acp.SessionUpdateUserMessageChunk{
+					SessionUpdate: "user_message_chunk",
+					Content:       *content,
+				},
+			}, true
+		}
+
+	case message.Tool:
+		//kind = "tool_result_chunk"
+	case message.System:
+		//kind = "agent_message_chunk"
+	}
+
+	return nil, false
+}

--- a/internal/acp/updates.go
+++ b/internal/acp/updates.go
@@ -43,7 +43,6 @@ func (it *updateIterator) getContentBlock(role message.MessageRole, part message
 		if delta != "" {
 			return &acp.ContentBlock{
 				Text: &acp.ContentBlockText{
-					Type: "text",
 					Text: delta,
 				},
 			}
@@ -59,7 +58,6 @@ func (it *updateIterator) getContentBlock(role message.MessageRole, part message
 		if delta != "" {
 			return &acp.ContentBlock{
 				Text: &acp.ContentBlockText{
-					Type: "text",
 					Text: delta,
 				},
 			}
@@ -85,16 +83,14 @@ func (it *updateIterator) getUpdate(role message.MessageRole, part message.Conte
 		case message.ReasoningContent:
 			return &acp.SessionUpdate{
 				AgentThoughtChunk: &acp.SessionUpdateAgentThoughtChunk{
-					SessionUpdate: "agent_thought_chunk",
-					Content:       *content,
+					Content: *content,
 				},
 			}, true
 
 		case message.TextContent:
 			return &acp.SessionUpdate{
 				AgentMessageChunk: &acp.SessionUpdateAgentMessageChunk{
-					SessionUpdate: "agent_message_chunk",
-					Content:       *content,
+					Content: *content,
 				},
 			}, true
 		}
@@ -102,8 +98,7 @@ func (it *updateIterator) getUpdate(role message.MessageRole, part message.Conte
 		if content.Text == nil || content.Text.Text != it.prompt {
 			return &acp.SessionUpdate{
 				UserMessageChunk: &acp.SessionUpdateUserMessageChunk{
-					SessionUpdate: "user_message_chunk",
-					Content:       *content,
+					Content: *content,
 				},
 			}, true
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -24,8 +24,8 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-type EventConsumer[T any] interface {
-	Send(m T)
+type EventSink[T any] interface {
+	Send(e T)
 	Quit()
 }
 
@@ -290,11 +290,11 @@ func (app *App) InitCoderAgent() error {
 	return nil
 }
 
-// Subscribe sends events to the TUI as tea.Msgs.
-func Subscribe[M any](app *App, consumer EventConsumer[M]) {
+// Subscribe sends events to the EventSink as M
+func Subscribe[M any](app *App, target EventSink[M]) {
 	defer log.RecoverPanic("app.Subscribe", func() {
 		slog.Info("Consumer subscription panic: attempting graceful shutdown")
-		consumer.Quit()
+		target.Quit()
 	})
 
 	app.consumerWg.Add(1)
@@ -317,7 +317,7 @@ func Subscribe[M any](app *App, consumer EventConsumer[M]) {
 				slog.Debug("Consumer message channel closed")
 				return
 			}
-			consumer.Send(msg.(M))
+			target.Send(msg.(M))
 		}
 	}
 }

--- a/internal/cmd/acp.go
+++ b/internal/cmd/acp.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"github.com/charmbracelet/crush/internal/acp"
+	"github.com/charmbracelet/crush/internal/event"
+	"github.com/spf13/cobra"
+)
+
+var acpCmd = &cobra.Command{
+	Use:   "acp",
+	Short: "Start the crush in ACP mode",
+	Long:  `Allows crush to be connected with ACP compliant clients.`,
+
+	RunE: func(cmd *cobra.Command, args []string) error {
+		debug, _ := cmd.Flags().GetBool("debug")
+		yolo, _ := cmd.Flags().GetBool("yolo")
+		dataDir, _ := cmd.Flags().GetString("data-dir")
+
+		acpServer, err := acp.NewServer(cmd.Context(), debug, yolo, dataDir)
+		if err != nil {
+			return err
+		}
+		defer acpServer.Shutdown()
+
+		if shouldEnableMetrics(false) {
+			event.Init()
+		}
+
+		event.AppInitialized()
+		defer event.AppExited()
+
+		if err = acpServer.Run(); err != nil {
+			event.Error(err)
+			return err
+		}
+
+		return nil
+	},
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	appName              = "crush"
+	AppName              = "crush"
 	defaultDataDirectory = ".crush"
 )
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -60,7 +60,7 @@ func Load(workingDir, dataDir string, debug bool) (*Config, error) {
 
 	// Setup logs
 	log.Setup(
-		filepath.Join(cfg.Options.DataDirectory, "logs", fmt.Sprintf("%s.log", appName)),
+		filepath.Join(cfg.Options.DataDirectory, "logs", fmt.Sprintf("%s.log", AppName)),
 		cfg.Options.Debug,
 	)
 
@@ -536,7 +536,7 @@ func lookupConfigs(cwd string) []string {
 		GlobalConfigData(),
 	}
 
-	configNames := []string{appName + ".json", "." + appName + ".json"}
+	configNames := []string{AppName + ".json", "." + AppName + ".json"}
 
 	foundConfigs, err := fsext.Lookup(cwd, configNames...)
 	if err != nil {
@@ -621,7 +621,7 @@ func hasAWSCredentials(env env.Env) bool {
 func GlobalConfig() string {
 	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
 	if xdgConfigHome != "" {
-		return filepath.Join(xdgConfigHome, appName, fmt.Sprintf("%s.json", appName))
+		return filepath.Join(xdgConfigHome, AppName, fmt.Sprintf("%s.json", AppName))
 	}
 
 	// return the path to the main config directory
@@ -632,10 +632,10 @@ func GlobalConfig() string {
 		if localAppData == "" {
 			localAppData = filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Local")
 		}
-		return filepath.Join(localAppData, appName, fmt.Sprintf("%s.json", appName))
+		return filepath.Join(localAppData, AppName, fmt.Sprintf("%s.json", AppName))
 	}
 
-	return filepath.Join(home.Dir(), ".config", appName, fmt.Sprintf("%s.json", appName))
+	return filepath.Join(home.Dir(), ".config", AppName, fmt.Sprintf("%s.json", AppName))
 }
 
 // GlobalConfigData returns the path to the main data directory for the application.
@@ -643,7 +643,7 @@ func GlobalConfig() string {
 func GlobalConfigData() string {
 	xdgDataHome := os.Getenv("XDG_DATA_HOME")
 	if xdgDataHome != "" {
-		return filepath.Join(xdgDataHome, appName, fmt.Sprintf("%s.json", appName))
+		return filepath.Join(xdgDataHome, AppName, fmt.Sprintf("%s.json", AppName))
 	}
 
 	// return the path to the main data directory
@@ -654,10 +654,10 @@ func GlobalConfigData() string {
 		if localAppData == "" {
 			localAppData = filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Local")
 		}
-		return filepath.Join(localAppData, appName, fmt.Sprintf("%s.json", appName))
+		return filepath.Join(localAppData, AppName, fmt.Sprintf("%s.json", AppName))
 	}
 
-	return filepath.Join(home.Dir(), ".local", "share", appName, fmt.Sprintf("%s.json", appName))
+	return filepath.Join(home.Dir(), ".local", "share", AppName, fmt.Sprintf("%s.json", AppName))
 }
 
 func assignIfNil[T any](ptr **T, val T) {

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -31,7 +31,7 @@ var (
 func providerCacheFileData() string {
 	xdgDataHome := os.Getenv("XDG_DATA_HOME")
 	if xdgDataHome != "" {
-		return filepath.Join(xdgDataHome, appName, "providers.json")
+		return filepath.Join(xdgDataHome, AppName, "providers.json")
 	}
 
 	// return the path to the main data directory
@@ -42,10 +42,10 @@ func providerCacheFileData() string {
 		if localAppData == "" {
 			localAppData = filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Local")
 		}
-		return filepath.Join(localAppData, appName, "providers.json")
+		return filepath.Join(localAppData, AppName, "providers.json")
 	}
 
-	return filepath.Join(home.Dir(), ".local", "share", appName, "providers.json")
+	return filepath.Join(home.Dir(), ".local", "share", AppName, "providers.json")
 }
 
 func saveProvidersInCache(path string, providers []catwalk.Provider) error {

--- a/internal/cwd/cwd.go
+++ b/internal/cwd/cwd.go
@@ -1,0 +1,37 @@
+package cwd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func Resolve(cwd string) (string, error) {
+	if cwd != "" {
+		err := os.Chdir(cwd)
+		if err != nil {
+			return "", fmt.Errorf("failed to change directory: %v", err)
+		}
+		return cwd, nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current working directory: %v", err)
+	}
+	return cwd, nil
+}
+
+func CreateDotCrushDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("failed to create data directory: %q %w", dir, err)
+	}
+
+	gitIgnorePath := filepath.Join(dir, ".gitignore")
+	if _, err := os.Stat(gitIgnorePath); os.IsNotExist(err) {
+		if err := os.WriteFile(gitIgnorePath, []byte("*\n"), 0o644); err != nil {
+			return fmt.Errorf("failed to create .gitignore file: %q %w", gitIgnorePath, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).


P.S.: IDE/Editor should start crush in acp mode, e.g. for Zed, its like this 

```
  "agent_servers": {
    "crush": {
      "command": "crush",
      "args": ["acp"],
      "env": {}
    }
  },
```

TODO: 
- [x] Initialization
- [ ] Session Setup
      - ~~Creating a Session~~
      - Loading Sessions
- [ ] Prompt Turn
      - ~~User Message~~
      - ~~Agent Processing~~
      - Agent Reports Output (agent plan and etc)
      - Tool Invocation and Status Reporting 
      - ~~Stop Reasons~~
      - ~~Cancellation~~
- [ ] Content
      - ~~Text Content~~
      - ~~Reasoning Content~~
      - Image Content
      - Audio Content
      - Embedded Resource 
      - Resource Link
- [ ] Tool Calls
      - Creating
      - Updating
      - ~~Requesting Permission~~
      - Status
      - Diffs
      - Following the Agent
- [x] File System
      - ~~Reading Files~~
      - ~~Writing Files~~
- [x] Terminals
      - ~~Executing Commands~~
      - ~~Embedding in Tool Calls~~
      - ~~Getting Output~~
      - ~~Waiting for Exit~~
      - ~~Killing Commands~~
      - ~~Releasing Terminals~~
- [ ] Agent Plan
      - Creating Plans
      - Updating Plans
      - Dynamic Planning
- [ ] Session Modes
      - Initial state
      - Setting the current mode
- [ ] Slash commands
      - ~~Advertising commands~~
      - ~~Running commands~~
      - Dynamic updates
- [ ] Transports
      - ~~stdio~~
      - http 
