### PR TITLE
chore: add vcr cassette files to `.gitignore`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.golden linguist-generated=true -text
 .github/crush-schema.json linguist-generated=true
+internal/agent/testdata/**/*.yaml -diff linguist-generated=true


### PR DESCRIPTION
This means that Git and GitHub won't show diff of these files by default, as they are very verbose.