### PR TITLE
fix: address panic due to possible `nil` map

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -654,6 +654,9 @@ func (c *coordinator) isAnthropicThinking(model config.SelectedModel) bool {
 
 func (c *coordinator) buildProvider(providerCfg config.ProviderConfig, model config.SelectedModel) (fantasy.Provider, error) {
 	headers := maps.Clone(providerCfg.ExtraHeaders)
+	if headers == nil {
+		headers = make(map[string]string)
+	}
 
 	// handle special headers for anthropic
 	if providerCfg.Type == anthropic.Name && c.isAnthropicThinking(model) {


### PR DESCRIPTION
Reported by `@lfsin` on our [community Discord](https://discord.com/channels/1032368467246075914/1404900884550516866/1433621590767304704).

    panic: assignment to entry in nil map

    goroutine 1 [running]:
    github.com/charmbracelet/crush/internal/agent.(*coordinator).buildProvider(0x14000426420, {{0x14000011738, 0x7}, {0x14000011738, 0x7}, {0x140001dbe60, 0x20}, {0x14000011760, 0x9}, {0x14000438600, ...}, ...}, ...)
            github.com/charmbracelet/crush/internal/agent/coordinator.go:663 +0x188
    github.com/charmbracelet/crush/internal/agent.(*coordinator).buildAgentModels(_, {_, _})
            github.com/charmbracelet/crush/internal/agent/coordinator.go:404 +0x220
    github.com/charmbracelet/crush/internal/agent.(*coordinator).buildAgent(0x14000426420, {0x106b5c7b8, 0x1400048c700}, 0x140001fa910, {{0x105e5c73d, 0x5}, {0x105e5c742, 0x5}, {0x105ebd034, 0x30}, ...})
            github.com/charmbracelet/crush/internal/agent/coordinator.go:288 +0x6c
    github.com/charmbracelet/crush/internal/agent.NewCoordinator({0x106b5c7b8, 0x1400048c700}, 0x140000fc0a0, {0x106b76800, 0x140002b95d8}, {0x106b6e470, 0x140002b95f0}, {0x106b73700, 0x140001ded10}, {0x106b73040, ...}, ...)
            github.com/charmbracelet/crush/internal/agent/coordinator.go:101 +0x1f8
    github.com/charmbracelet/crush/internal/app.(*App).InitCoderAgent(0x140001df290, {0x106b5c7b8, 0x1400048c700})
            github.com/charmbracelet/crush/internal/app/app.go:271 +0x94
    github.com/charmbracelet/crush/internal/app.New({0x106b5c7b8, 0x1400048c700}, 0x14000383040, 0x140000fc0a0)
            github.com/charmbracelet/crush/internal/app/app.go:93 +0x564
    github.com/charmbracelet/crush/internal/cmd.setupApp(0x107c8c260)
            github.com/charmbracelet/crush/internal/cmd/root.go:186 +0x1a0
    github.com/charmbracelet/crush/internal/cmd.init.func5(0x107c8c260, {0x105e6123e?, 0x7?, 0x105e5a13e?})
            github.com/charmbracelet/crush/internal/cmd/root.go:77 +0x34
    github.com/spf13/cobra.(*Command).execute(0x107c8c260, {0x140001ae030, 0x0, 0x0})
            github.com/spf13/cobra@v1.10.1/command.go:1015 +0x7d4
    github.com/spf13/cobra.(*Command).ExecuteC(0x107c8c260)
            github.com/spf13/cobra@v1.10.1/command.go:1148 +0x350
    github.com/spf13/cobra.(*Command).Execute(...)
            github.com/spf13/cobra@v1.10.1/command.go:1071
    github.com/spf13/cobra.(*Command).ExecuteContext(...)
            github.com/spf13/cobra@v1.10.1/command.go:1064
    github.com/charmbracelet/fang.Execute({0x106b5beb0, 0x107cfe900}, 0x107c8c260, {0x14000559f00, 0x2, 0x105ed3d5f?})
            github.com/charmbracelet/fang@v0.4.3/fang.go:173 +0x2e8
    github.com/charmbracelet/crush/internal/cmd.Execute()
            github.com/charmbracelet/crush/internal/cmd/root.go:143 +0x304
    main.main()
            github.com/charmbracelet/crush/main.go:23 +0x3c

