### PR TITLE
fix: rethink global config path on windows: use `$HOME/.config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ or globally, with the following priority:
 
 1. `.crush.json`
 2. `crush.json`
-3. `$HOME/.config/crush/crush.json` (Windows: `%USERPROFILE%\AppData\Local\crush\crush.json`)
+3. `$HOME/.config/crush/crush.json`
 
 Configuration itself is stored as a JSON object:
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -662,17 +662,6 @@ func GlobalConfig() string {
 		return filepath.Join(xdgConfigHome, appName, fmt.Sprintf("%s.json", appName))
 	}
 
-	// return the path to the main config directory
-	// for windows, it should be in `%LOCALAPPDATA%/crush/`
-	// for linux and macOS, it should be in `$HOME/.config/crush/`
-	if runtime.GOOS == "windows" {
-		localAppData := os.Getenv("LOCALAPPDATA")
-		if localAppData == "" {
-			localAppData = filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Local")
-		}
-		return filepath.Join(localAppData, appName, fmt.Sprintf("%s.json", appName))
-	}
-
 	return filepath.Join(home.Dir(), ".config", appName, fmt.Sprintf("%s.json", appName))
 }
 


### PR DESCRIPTION
* Fixes #1347

We made a mistake when it comes to the global config path on Windows. On macOS and Linux we use two different paths for data and config: `XDG_DATA_HOME` and `XDG_CONFIG_HOME`. On Windows though, we were using the same path for both data and config: `LOCALAPPDATA`. This caused confusion and means the user has no separate dir to store config separate of data.

In theory we could consider something as `APPDATA`, but honestly, I propose that we just use `$HOME/.config`. It's easier to find and consistent with how other tools work. Git and other terminal tools also use `$HOME/.config`, so users are used to it.

This is not a breaking change because the old path will still load, so existing setting will load as expected.