### PR TITLE
refactor: simplify `home.Dir()`

### DIFF
--- a/internal/home/home.go
+++ b/internal/home/home.go
@@ -6,38 +6,33 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 )
 
-// Dir returns the users home directory, or if it fails, tries to create a new
-// temporary directory and use that instead.
-var Dir = sync.OnceValue(func() string {
-	home, err := os.UserHomeDir()
-	if err == nil {
-		slog.Debug("user home directory", "home", home)
-		return home
+var homedir, homedirErr = os.UserHomeDir()
+
+func init() {
+	if homedirErr != nil {
+		slog.Error("failed to get user home directory", "error", homedirErr)
 	}
-	tmp, err := os.MkdirTemp("crush", "")
-	if err != nil {
-		slog.Error("could not find the user home directory")
-		return ""
-	}
-	slog.Warn("could not find the user home directory, using a temporary one", "home", tmp)
-	return tmp
-})
+}
+
+// Dir returns the user home directory.
+func Dir() string {
+	return homedir
+}
 
 // Short replaces the actual home path from [Dir] with `~`.
 func Short(p string) string {
-	if !strings.HasPrefix(p, Dir()) || Dir() == "" {
+	if homedir == "" || !strings.HasPrefix(p, homedir) {
 		return p
 	}
-	return filepath.Join("~", strings.TrimPrefix(p, Dir()))
+	return filepath.Join("~", strings.TrimPrefix(p, homedir))
 }
 
 // Long replaces the `~` with actual home path from [Dir].
 func Long(p string) string {
-	if !strings.HasPrefix(p, "~") || Dir() == "" {
+	if homedir == "" || !strings.HasPrefix(p, "~") {
 		return p
 	}
-	return strings.Replace(p, "~", Dir(), 1)
+	return strings.Replace(p, "~", homedir, 1)
 }


### PR DESCRIPTION
* Realistically, this should almost never fail.
* If it does, returning `""` probably makes more sense than a temp dir. Empty means Go will assume the working directory.
* Getting rid of `sync.Once` is good as it locks and this can be called on every render cycle. (Used to compute `~` on the sidebar, etc).