### PR TITLE
fix(lint): don't shadow 'env' variable

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -33,7 +33,7 @@ func getModels(t *testing.T, r *recorder.Recorder, pair modelPair) (fantasy.Lang
 	return large, small
 }
 
-func setupAgent(t *testing.T, pair modelPair) (SessionAgent, env) {
+func setupAgent(t *testing.T, pair modelPair) (SessionAgent, fakeEnv) {
 	r := newRecorder(t)
 	large, small := getModels(t, r, pair)
 	env := testEnv(t)

--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -30,7 +30,8 @@ import (
 	_ "github.com/joho/godotenv/autoload"
 )
 
-type env struct {
+// fakeEnv is an environment for testing.
+type fakeEnv struct {
 	workingDir  string
 	sessions    session.Service
 	messages    message.Service
@@ -100,7 +101,7 @@ func zAIBuilder(model string) builderFunc {
 	}
 }
 
-func testEnv(t *testing.T) env {
+func testEnv(t *testing.T) fakeEnv {
 	workingDir := filepath.Join("/tmp/crush-test/", t.Name())
 	os.RemoveAll(workingDir)
 
@@ -123,7 +124,7 @@ func testEnv(t *testing.T) env {
 		os.RemoveAll(workingDir)
 	})
 
-	return env{
+	return fakeEnv{
 		workingDir,
 		sessions,
 		messages,
@@ -133,7 +134,7 @@ func testEnv(t *testing.T) env {
 	}
 }
 
-func testSessionAgent(env env, large, small fantasy.LanguageModel, systemPrompt string, tools ...fantasy.AgentTool) SessionAgent {
+func testSessionAgent(env fakeEnv, large, small fantasy.LanguageModel, systemPrompt string, tools ...fantasy.AgentTool) SessionAgent {
 	largeModel := Model{
 		Model: large,
 		CatwalkCfg: catwalk.Model{
@@ -152,7 +153,7 @@ func testSessionAgent(env env, large, small fantasy.LanguageModel, systemPrompt 
 	return agent
 }
 
-func coderAgent(r *recorder.Recorder, env env, large, small fantasy.LanguageModel) (SessionAgent, error) {
+func coderAgent(r *recorder.Recorder, env fakeEnv, large, small fantasy.LanguageModel) (SessionAgent, error) {
 	fixedTime := func() time.Time {
 		t, _ := time.Parse("1/2/2006", "1/1/2025")
 		return t


### PR DESCRIPTION
Elsewhere in the package, many things are called `env`. This change renames the `env` type used in testing to fix shadow warnings.