### PR TITLE
chore: switch from bar cursor to blocky cursor

### DIFF
--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -179,7 +179,7 @@ func (t *Theme) buildStyles() *Styles {
 			},
 			Cursor: textinput.CursorStyle{
 				Color: t.Secondary,
-				Shape: tea.CursorBar,
+				Shape: tea.CursorBlock,
 				Blink: true,
 			},
 		},
@@ -204,7 +204,7 @@ func (t *Theme) buildStyles() *Styles {
 			},
 			Cursor: textarea.CursorStyle{
 				Color: t.Secondary,
-				Shape: tea.CursorBar,
+				Shape: tea.CursorBlock,
 				Blink: true,
 			},
 		},


### PR DESCRIPTION
The blocky cursor is way easier to see and is just graphically more striking.

Later on, we can use the bar cursor selectively for modal input modes (i.e. a vim-style insert mode). In the meantime, this is a lot stronger.

<img width="582" src="https://github.com/user-attachments/assets/2f189ae4-f5e7-4999-a339-6117ff8a7da0" />

<img width="582" src="https://github.com/user-attachments/assets/ad90af53-c0ec-45b8-8176-c7d623eb6be1" />
