### PR TITLE
fix: append ImageURLContent part in unmarshallParts

### DIFF
--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -256,6 +256,7 @@ func unmarshallParts(data []byte) ([]ContentPart, error) {
 			if err := json.Unmarshal(wrapper.Data, &part); err != nil {
 				return nil, err
 			}
+			parts = append(parts, part)
 		case binaryType:
 			part := BinaryContent{}
 			if err := json.Unmarshal(wrapper.Data, &part); err != nil {


### PR DESCRIPTION
The imageURLType case was unmarshaling the part but not adding it
   to the returned parts slice, causing ImageURLContent parts to be
   lost when reading messages from the database.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
