### PR TITLE
fix: improve ux for presenting errors from providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	charm.land/bubbles/v2 v2.0.0-beta.1.0.20251104200223-da0b892d1759
 	charm.land/bubbletea/v2 v2.0.0-rc.1.0.20251106195925-579e174cd7fa
-	charm.land/fantasy v0.1.6
+	charm.land/fantasy v0.2.0
 	charm.land/lipgloss/v2 v2.0.0-beta.3.0.20251106193318-19329a3e8410
 	github.com/JohannesKaufmann/html-to-markdown v1.6.0
 	github.com/MakeNowJust/heredoc v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ charm.land/bubbles/v2 v2.0.0-beta.1.0.20251104200223-da0b892d1759 h1:P1MxkVl8ZeI
 charm.land/bubbles/v2 v2.0.0-beta.1.0.20251104200223-da0b892d1759/go.mod h1:G7JWaj3kDT0BDB+h5BLDUhhBLpDoRLKrpOp5QrA2SQs=
 charm.land/bubbletea/v2 v2.0.0-rc.1.0.20251106195925-579e174cd7fa h1:J30WneaxF2CV3f2ofamxlr+RwyF6LKSJ3UesrtHfU9I=
 charm.land/bubbletea/v2 v2.0.0-rc.1.0.20251106195925-579e174cd7fa/go.mod h1:lUNldRH4wRBZ9SGFqlss1Pep7QXzgV/Fp+V9BsAhOPc=
-charm.land/fantasy v0.1.6 h1:laomMUqUaniQoLx7UOb+MLUpIGJPoNwsXvw1PbzgnB8=
-charm.land/fantasy v0.1.6/go.mod h1:JpFcJ5zs/1CjmYYGAZ7GaFmeBv0mPaTzEPRG6Eic5pc=
+charm.land/fantasy v0.2.0 h1:BO1eMugePqrXe46zlNQZI6ajzqt/kft0IMiIAYBqsAo=
+charm.land/fantasy v0.2.0/go.mod h1:JpFcJ5zs/1CjmYYGAZ7GaFmeBv0mPaTzEPRG6Eic5pc=
 charm.land/lipgloss/v2 v2.0.0-beta.3.0.20251106193318-19329a3e8410 h1:D9PbaszZYpB4nj+d6HTWr1onlmlyuGVNfL9gAi8iB3k=
 charm.land/lipgloss/v2 v2.0.0-beta.3.0.20251106193318-19329a3e8410/go.mod h1:1qZyvvVCenJO2M1ac2mX0yyiIZJoZmDM4DG4s0udJkU=
 cloud.google.com/go v0.116.0 h1:B3fRrSDkLRt5qSHWe40ERJvhvnQwdZiHu0bJOpldweE=

--- a/internal/stringext/string.go
+++ b/internal/stringext/string.go
@@ -1,0 +1,10 @@
+package stringext
+
+import (
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+func Capitalize(text string) string {
+	return cases.Title(language.English, cases.Compact).String(text)
+}


### PR DESCRIPTION
* Fantasy PR: https://github.com/charmbracelet/fantasy/pull/61

> [!NOTE]
> This currently depends on the PR using `replace` locally. We need to remove this before merging.

Today, most errors are shown in a non-ideal way. We want to make it easier for the users to understand what gone wrong.

- [x] Show error titles from Fantasy

Future TODO:

- [ ] Figure it out the proper UI to show status code, response body, etc.
- [ ] Show response body, if JSON, with proper indentation and syntax highlight.