### PR TITLE
chore(task): fetch tags before installing

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -68,6 +68,7 @@ tasks:
     vars:
       LDFLAGS: '{{if .VERSION}}-ldflags="-X github.com/charmbracelet/crush/internal/version.Version={{.VERSION}}"{{end}}'
     cmds:
+      - task: fetch-tags
       - go install {{.LDFLAGS}} -v .
 
   profile:cpu:


### PR DESCRIPTION
Just to make sure the version number is up to date.