### PR TITLE
fix: include error details in agent tool responses

### DIFF
--- a/internal/agent/agent_tool.go
+++ b/internal/agent/agent_tool.go
@@ -83,7 +83,7 @@ func (c *coordinator) agentTool(ctx context.Context) (fantasy.AgentTool, error) 
 				PresencePenalty:  model.ModelCfg.PresencePenalty,
 			})
 			if err != nil {
-				return fantasy.NewTextErrorResponse("error generating response"), nil
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("error generating response: %s", err)), nil
 			}
 			updatedSession, err := c.sessions.Get(ctx, session.ID)
 			if err != nil {

--- a/internal/agent/agentic_fetch_tool.go
+++ b/internal/agent/agentic_fetch_tool.go
@@ -193,7 +193,7 @@ func (c *coordinator) agenticFetchTool(_ context.Context, client *http.Client) (
 				PresencePenalty:  small.ModelCfg.PresencePenalty,
 			})
 			if err != nil {
-				return fantasy.NewTextErrorResponse("error generating response"), nil
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("error generating response: %s", err)), nil
 			}
 
 			updatedSession, err := c.sessions.Get(ctx, session.ID)


### PR DESCRIPTION
Previously, when agent.Run() failed in both the agent tool and agentic fetch tool, users would only see "error generating response" without any context about what went wrong. This made debugging configuration issues (like misconfigured small_agent_model or unreachable local servers) difficult if a small model is configured but incorrectly.

Now the actual error is included in the response, making it immediately clear what the problem is. For example, users will now see messages like:
- "error generating response: 403 invalid API key"
- "error generating response: Post \"http://...\": dial tcp ...: host is down"

This improves the debugging experience without changing the error handling flow.

💘 Generated with Crush

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
