### PR TITLE
fix(mcp): client being killed

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -362,7 +362,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent) ([]fan
 		}
 		if len(agent.AllowedMCP) == 0 {
 			// No MCPs allowed
-			slog.Warn("MCPs not allowed")
+			slog.Debug("no MCPs allowed", "tool", tool.Name(), "agent", agent.Name)
 			break
 		}
 
@@ -374,6 +374,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent) ([]fan
 				filteredTools = append(filteredTools, tool)
 			}
 		}
+		slog.Debug("MCP not allowed", "tool", tool.Name(), "agent", agent.Name)
 	}
 	slices.SortFunc(filteredTools, func(a, b fantasy.AgentTool) int {
 		return strings.Compare(a.Info().Name, b.Info().Name)


### PR DESCRIPTION
Couple of problems fixed:

1. we were double timeouting the session init
1. some irrelevant logs were as warns
1. when a mcp client ping failed, we were deleting its tools and never checking them again

So, now:

- timeout is handle only in one place, and its not the context
- on session renew, it'll not delete tools. It's assumed the tools are the same as before, if not, the server should send events about them
- added an extra debug log, and moved the existing log to debug

closes #1394
closes #1406
