### PR TITLE
fix: add up/down arrow key navigation to permissions dialog

### DIFF
--- a/internal/tui/components/dialogs/permissions/keys.go
+++ b/internal/tui/components/dialogs/permissions/keys.go
@@ -7,6 +7,8 @@ import (
 type KeyMap struct {
 	Left,
 	Right,
+	Up,
+	Down,
 	Tab,
 	Select,
 	Allow,
@@ -28,6 +30,14 @@ func DefaultKeyMap() KeyMap {
 		Right: key.NewBinding(
 			key.WithKeys("right", "l"),
 			key.WithHelp("→", "next"),
+		),
+		Up: key.NewBinding(
+			key.WithKeys("up", "k"),
+			key.WithHelp("↑", "previous"),
+		),
+		Down: key.NewBinding(
+			key.WithKeys("down", "j"),
+			key.WithHelp("↓", "next"),
 		),
 		Tab: key.NewBinding(
 			key.WithKeys("tab"),
@@ -77,6 +87,8 @@ func (k KeyMap) KeyBindings() []key.Binding {
 	return []key.Binding{
 		k.Left,
 		k.Right,
+		k.Up,
+		k.Down,
 		k.Tab,
 		k.Select,
 		k.Allow,

--- a/internal/tui/components/dialogs/permissions/permissions.go
+++ b/internal/tui/components/dialogs/permissions/permissions.go
@@ -107,10 +107,10 @@ func (p *permissionDialogCmp) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 		cmds = append(cmds, cmd)
 	case tea.KeyPressMsg:
 		switch {
-		case key.Matches(msg, p.keyMap.Right) || key.Matches(msg, p.keyMap.Tab):
+		case key.Matches(msg, p.keyMap.Right) || key.Matches(msg, p.keyMap.Tab) || key.Matches(msg, p.keyMap.Down):
 			p.selectedOption = (p.selectedOption + 1) % 3
 			return p, nil
-		case key.Matches(msg, p.keyMap.Left):
+		case key.Matches(msg, p.keyMap.Left) || key.Matches(msg, p.keyMap.Up):
 			p.selectedOption = (p.selectedOption + 2) % 3
 		case key.Matches(msg, p.keyMap.Select):
 			return p, p.selectCurrentOption()


### PR DESCRIPTION
Add support for up and down arrow keys (and j/k) to navigate between permission dialog buttons, matching the left/right (and h/l) navigation that already exists.

Fixes #1416
