### PR TITLE
fix(mcp): always call ListTools to discover available tools

### DIFF
--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -74,9 +74,9 @@ func RefreshTools(ctx context.Context, name string) {
 }
 
 func getTools(ctx context.Context, session *mcp.ClientSession) ([]*Tool, error) {
-	if session.InitializeResult().Capabilities.Tools == nil {
-		return nil, nil
-	}
+	// Always call ListTools to get the actual available tools.
+	// The InitializeResult Capabilities.Tools field may be an empty object {},
+	// which is valid per MCP spec, but we still need to call ListTools to discover tools.
 	result, err := session.ListTools(ctx, &mcp.ListToolsParams{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Remove the nil check on Capabilities.Tools that was preventing tool discovery. The Capabilities field indicates what the server supports, but ListTools must always be called to get the actual list of available tools.

This fixes MCP servers that correctly return an empty tools object {"tools":{}} during initialization but provide tools when ListTools is called, such as mcp-docs-service.

Fixes #1445
