### PR TITLE
fix(tui): don't crash when there are MCP servers but no agents

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -255,6 +255,11 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt 
 }
 
 func (app *App) UpdateAgentModel(ctx context.Context) error {
+	// There are currently no agents configured.
+	if app.AgentCoordinator == nil {
+		return nil
+	}
+
 	return app.AgentCoordinator.UpdateModels(ctx)
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,31 @@
+package app
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	exitVal := m.Run()
+	os.Exit(exitVal)
+}
+
+// TestUpdateAgentModel_NilCoordinator verifies that UpdateAgentModel handles
+// a nil AgentCoordinator gracefully. This occurs when MCP servers are
+// configured but no AI agents are set up.
+func TestUpdateAgentModel_NilCoordinator(t *testing.T) {
+	app := &App{
+		AgentCoordinator: nil,
+		events:           make(chan tea.Msg, 100),
+	}
+
+	err := app.UpdateAgentModel(t.Context())
+	require.NoError(t, err)
+}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1,0 +1,80 @@
+package tui
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/app"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/ncruces/go-sqlite3"
+	"github.com/ncruces/go-sqlite3/driver"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	exitVal := m.Run()
+	os.Exit(exitVal)
+}
+
+// TestMCPEventWithUnconfiguredApp is an integration test verifying that we can
+// start up the TUI properly when there are MCP servers but no AI agents
+// configured.
+func TestMCPEventWithUnconfiguredApp(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// Avoid touching any real config or database
+	conn, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
+		return c.Exec("PRAGMA foreign_keys = ON;")
+	})
+	require.NoError(t, err)
+	defer conn.Close()
+
+	cfg, err := config.Init(t.TempDir(), t.TempDir(), false)
+	require.NoError(t, err)
+
+	cfg.MCP = map[string]config.MCPConfig{
+		"test-mcp": {
+			Type:     config.MCPStdio,
+			Command:  "echo",
+			Disabled: true,
+		},
+	}
+
+	require.False(t, cfg.IsConfigured())
+
+	mcpEvents := mcp.SubscribeEvents(ctx)
+
+	appInstance, err := app.New(ctx, conn, cfg)
+	require.NoError(t, err)
+	defer appInstance.Shutdown()
+
+	require.Nil(t, appInstance.AgentCoordinator)
+
+	ui := New(appInstance)
+	program := tea.NewProgram(ui, tea.WithContext(ctx), tea.WithoutRenderer())
+
+	go appInstance.Subscribe(program)
+
+	// Wait for MCP event, then quit
+	go func() {
+		for ev := range mcpEvents {
+			if ev.Payload.Type != mcp.EventStateChanged {
+				continue
+			}
+
+			program.Send(tea.Quit())
+			return
+		}
+	}()
+
+	_, err = program.Run()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
When there are MCP servers but no AI agents configured, the TUI currently crashes due to a nil pointer dereference. We receive an `mcp.EventStateChanged` event, when the MCP server is initialised. This causes us to attempt to access the agent coordinator, which is `nil` when there are no agents set up.

The fix is to add a `nil` guard before accessing the coordinator. With this fix, instead of crashing, the app proceeds to the UI, allowing credentials to be set up as normal.

Tests are included. Reverting the fix causes the tests to fail as expected.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
