### PR TITLE
Don't notify update available when running local build

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -54,7 +54,7 @@ func Check(ctx context.Context, current string, client Client) (Info, error) {
 		Latest:  current,
 	}
 
-	if info.Current == "devel" || info.Current == "unknown" {
+	if info.Current == "devel" || info.Current == "unknown" || strings.Contains(info.Current, "dirty") {
 		return info, nil
 	}
 
@@ -64,6 +64,7 @@ func Check(ctx context.Context, current string, client Client) (Info, error) {
 	}
 
 	info.Latest = strings.TrimPrefix(release.TagName, "v")
+	info.Current = strings.TrimPrefix(info.Current, "v")
 	info.URL = release.HTMLURL
 	return info, nil
 }


### PR DESCRIPTION
After #361 when running local builds with uncommitted changes (dirty), we receive the update notification.

Also, the notification has a double `v` in the version.


<img width="809" height="369" alt="image" src="https://github.com/user-attachments/assets/1c790f73-d5a0-4054-bb68-4f49c199aa00" />

<img width="614" height="69" alt="image" src="https://github.com/user-attachments/assets/d9b85122-eeb4-4a99-9888-c8c7ddb0f861" />



- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
