### PR TITLE
Fix: Copy ProviderOptions when merging provider configurations

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -190,6 +190,7 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 			SystemPromptPrefix: config.SystemPromptPrefix,
 			ExtraHeaders:       headers,
 			ExtraBody:          config.ExtraBody,
+			ProviderOptions:    config.ProviderOptions,
 			ExtraParams:        make(map[string]string),
 			Models:             p.Models,
 		}


### PR DESCRIPTION
Fixes #1472

## Summary

This PR fixes a critical bug where provider-specific options configured via `provider_options` in `crush.json` were being silently ignored for all providers.

## Problem

The `configureProviders` function in `internal/config/load.go` creates provider configurations by copying fields from Catwalk providers and user config, but it was missing the `ProviderOptions` field. This caused all provider-specific configuration to be lost during the merge process.

### Impact

- **All providers affected**: OpenRouter, OpenAI, custom providers, etc.
- **Silent failure**: No error or warning shown to users
- **Configuration ignored**: Features like reasoning parameters, usage tracking options, and custom provider settings were completely ignored

### Example Configuration That Didn't Work

```json
{
  "providers": {
    "openrouter": {
      "provider_options": {
        "reasoning": {
          "max_tokens": 2000
        },
        "include_usage": false
      }
    }
  }
}
```

These options would be loaded from the config file but never applied to requests.

## Solution

Added one line at `internal/config/load.go:193` to copy the `ProviderOptions` field:

```go
ProviderOptions:    config.ProviderOptions,
```

This ensures that provider-specific options from user configuration are properly merged into the final provider config.

## Testing

**Before fix**:
- Provider options present in loaded config
- Options missing after `configureProviders`
- Requests sent without provider-specific configuration

**After fix**:
- Provider options preserved through configuration merge
- Options correctly applied to provider requests
- Tested with OpenRouter + Gemini 3 Pro Preview with reasoning parameters

## Files Changed

- `internal/config/load.go`: Added `ProviderOptions` field copy (1 line)

## Scope

This is a **minimal, surgical fix** that:
- Affects only the configuration merging logic
- Does not change any behavior for users not using `provider_options`
- Fixes the issue for all current and future providers
- Is backwards compatible

