### PR TITLE
fix: kimi coding api key validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -635,6 +635,10 @@ func (c *ProviderConfig) TestConnection(resolver VariableResolver) error {
 			baseURL = "https://api.anthropic.com/v1"
 		}
 		testURL = baseURL + "/models"
+		// TODO: replace with const when catwalk is released
+		if c.ID == "kimi-coding" {
+			testURL = baseURL + "/v1/models"
+		}
 		headers["x-api-key"] = apiKey
 		headers["anthropic-version"] = "2023-06-01"
 	case catwalk.TypeGoogle:


### PR DESCRIPTION
I will replace the string with the const when we release catwalk.