### PR TITLE
fix(list): cap rendered filterable list while keeping full search set

### DIFF
--- a/internal/tui/exp/list/filterable.go
+++ b/internal/tui/exp/list/filterable.go
@@ -245,7 +245,7 @@ func (f *filterableList[T]) Filter(query string) tea.Cmd {
 
 	f.selectedItemIdx = -1
 	if query == "" || len(f.items) == 0 {
-		return f.list.SetItems(f.items)
+		return f.list.SetItems(f.visibleItems(f.items))
 	}
 
 	matches := fuzzy.FindFrom(query, f)
@@ -274,7 +274,7 @@ func (f *filterableList[T]) Filter(query string) tea.Cmd {
 
 func (f *filterableList[T]) SetItems(items []T) tea.Cmd {
 	f.items = items
-	return f.list.SetItems(items)
+	return f.list.SetItems(f.visibleItems(items))
 }
 
 func (f *filterableList[T]) Cursor() *tea.Cursor {
@@ -316,4 +316,14 @@ func (f *filterableList[T]) String(i int) string {
 
 func (f *filterableList[T]) Len() int {
 	return len(f.items)
+}
+
+// visibleItems returns the subset of items that should be rendered based on
+// the configured resultsSize limit. The underlying source (f.items) remains
+// intact so filtering still searches the full set.
+func (f *filterableList[T]) visibleItems(items []T) []T {
+	if f.resultsSize > 0 && len(items) > f.resultsSize {
+		return items[:f.resultsSize]
+	}
+	return items
 }


### PR DESCRIPTION
**Problem**
In https://github.com/charmbracelet/crush/pull/1193 I added a 25-item render cap, but the full file list has always been passed to the list pre-filter. The old two-pass async renderer hid that cost; after switching to a synchronous render in https://github.com/charmbracelet/crush/pull/1325, handing thousands of items to the renderer surfaced as lag and effectively bypassed the intended cap.

This issue is very noticeable upon entering `@` in large/huge projects (eg linux kernel).
I bisected the issue down to #1325 so pinging @kujtimiihoxha 

**Solution**
Keep the full dataset for filtering, but cap the items handed to the renderer (including empty queries) so only the first N (25) draw while searches still span all files.


- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
