### PR TITLE
feat: add max_wait_time parameter to job_output tool

### DIFF
--- a/internal/agent/tools/job_output.md
+++ b/internal/agent/tools/job_output.md
@@ -4,16 +4,27 @@ Retrieves the current output from a background shell.
 - Provide the shell ID returned from a background bash execution
 - Returns the current stdout and stderr output
 - Indicates whether the shell has completed execution
+- Optionally wait for the job to complete with max_wait_time parameter
 </usage>
 
 <features>
 - View output from running background processes
 - Check if background process has completed
 - Get cumulative output from process start
+- Wait for job completion with timeout
+- Monitor long-running tasks without continuous polling
 </features>
+
+<parameters>
+- shell_id (required): The ID of the background shell to retrieve output from
+- max_wait_time (optional): Maximum time in seconds to wait for the job to complete. If not set or set to 0, will return immediately without waiting
+</parameters>
 
 <tips>
 - Use this to monitor long-running processes
 - Check the 'done' status to see if process completed
 - Can be called multiple times to view incremental output
+- Use max_wait_time to avoid polling for long-running tasks
+- If timeout is reached, the tool will indicate the task is still running and suggest trying again with a longer wait time
+- Set max_wait_time to 0 or omit it for immediate status check
 </tips>

--- a/internal/agent/tools/job_output_integration_test.go
+++ b/internal/agent/tools/job_output_integration_test.go
@@ -1,0 +1,58 @@
+package tools
+
+import (
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/shell"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobOutputWithWaitTime_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	t.Run("background shell wait functionality", func(t *testing.T) {
+		// This test manually verifies the wait logic we implemented in job_output.go
+		workingDir := t.TempDir()
+		bgManager := shell.GetBackgroundShellManager()
+
+		// Start a quick task
+		bgShell, err := bgManager.Start(t.Context(), workingDir, nil, "sleep 0.5 && echo 'done'", "")
+		require.NoError(t, err)
+		defer bgManager.Kill(bgShell.ID)
+
+		// Simulate the wait logic from our job_output tool
+		maxWaitTime := 2 // 2 seconds
+		done := false
+
+		// Get initial state
+		_, _, initialDone, err := bgShell.GetOutput()
+		require.NoError(t, err)
+		require.False(t, initialDone, "Task should not be done immediately")
+
+		// Wait for completion with timeout (simulating our job_output logic)
+		if !initialDone && maxWaitTime > 0 {
+			waitDone := make(chan bool, 1)
+
+			go func() {
+				bgShell.Wait()
+				waitDone <- true
+			}()
+
+			select {
+			case <-waitDone:
+				// Task completed
+				_, _, done, err = bgShell.GetOutput()
+				require.NoError(t, err)
+				require.True(t, done, "Task should be completed")
+			case <-time.After(time.Duration(maxWaitTime) * time.Second):
+				// Timeout
+				t.Fatal("Should not have timed out for a 0.5 second task with 2 second timeout")
+			}
+		}
+
+		require.True(t, done, "Task should have completed successfully")
+	})
+}

--- a/internal/tui/components/chat/messages/renderer.go
+++ b/internal/tui/components/chat/messages/renderer.go
@@ -330,7 +330,14 @@ func (bor bashOutputRenderer) Render(v *toolCallCmp) string {
 	if v.isNested {
 		width -= 4 // Adjust for nested tool call indentation
 	}
-	header := makeJobHeader(v, "Output", fmt.Sprintf("PID %s", params.ShellID), description, width)
+
+	// Build additional info for max_wait_time if present
+	pidInfo := fmt.Sprintf("PID %s", params.ShellID)
+	if params.MaxWaitTime != nil && *params.MaxWaitTime > 0 {
+		pidInfo += fmt.Sprintf(" (wait %ds)", *params.MaxWaitTime)
+	}
+
+	header := makeJobHeader(v, "Output", pidInfo, description, width)
 	if v.isNested {
 		return v.style().Render(header)
 	}


### PR DESCRIPTION
Allow job_output tool to wait for job completion with configurable timeout. The tool now supports a max_wait_time parameter that enables monitoring long-running tasks without continuous polling. When the timeout is reached, it provides helpful feedback suggesting a longer wait time.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

This should not be considered a feature, but rather a fix. It prevents the crush from repeatedly calling job_output within a short period to check if the task is completed.

In YOLO mode, the crush sent over 20 requests in one minute to check if the compilation task was finished, and the repeated tool calls quickly exceeded the model's context limit. This is a serious issue.

Adding a maximum wait time parameter can resolve this problem.
