### PR TITLE
Display first 4 chars of SessionId in session selector

### DIFF
--- a/internal/tui/components/dialogs/sessions/sessions.go
+++ b/internal/tui/components/dialogs/sessions/sessions.go
@@ -48,7 +48,7 @@ func NewSessionDialogCmp(sessions []session.Session, selectedID string) SessionD
 	items := make([]list.CompletionItem[session.Session], len(sessions))
 	if len(sessions) > 0 {
 		for i, session := range sessions {
-			items[i] = list.NewCompletionItem(session.Title, session, list.WithCompletionID(session.ID))
+			items[i] = list.NewCompletionItem("["+session.ID[:4]+"] "+session.Title, session, list.WithCompletionID(session.ID))
 		}
 	}
 


### PR DESCRIPTION
 - What: Adds the first 4 characters of the SessionId as a prefix to session names in the session selector dialog
 - Why: Makes it easier to identify sessions by their ID prefix
 - How: Modified the session list creation to prepend [ID] to session titles using string concatenation

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
