### PR TITLE
fix(write): handle array content from GLM and Qwen models

### DIFF
--- a/internal/agent/tools/write.go
+++ b/internal/agent/tools/write.go
@@ -33,7 +33,6 @@ type WriteParams struct {
 // UnmarshalJSON custom unmarshaler to handle both string and array of strings
 // This fixes compatibility with GLM 4.6 and Qwen 3 Coder 480B models that send content as arrays
 func (w *WriteParams) UnmarshalJSON(data []byte) error {
-	type Alias WriteParams
 	aux := &struct {
 		FilePath string      `json:"file_path"`
 		Content  interface{} `json:"content"`

--- a/internal/agent/tools/write.go
+++ b/internal/agent/tools/write.go
@@ -50,9 +50,11 @@ func (w *WriteParams) UnmarshalJSON(data []byte) error {
 	case []interface{}:
 		// Handle array of strings - join with newlines
 		var lines []string
-		for _, item := range v {
+		for i, item := range v {
 			if str, ok := item.(string); ok {
 				lines = append(lines, str)
+			} else {
+				return fmt.Errorf("array element at index %d is not a string: got %T", i, item)
 			}
 		}
 		w.Content = strings.Join(lines, "\n")

--- a/internal/agent/tools/write.go
+++ b/internal/agent/tools/write.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -27,6 +28,40 @@ var writeDescription []byte
 type WriteParams struct {
 	FilePath string `json:"file_path" description:"The path to the file to write"`
 	Content  string `json:"content" description:"The content to write to the file"`
+}
+
+// UnmarshalJSON custom unmarshaler to handle both string and array of strings
+// This fixes compatibility with GLM 4.6 and Qwen 3 Coder 480B models that send content as arrays
+func (w *WriteParams) UnmarshalJSON(data []byte) error {
+	type Alias WriteParams
+	aux := &struct {
+		FilePath string      `json:"file_path"`
+		Content  interface{} `json:"content"`
+	}{}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	w.FilePath = aux.FilePath
+
+	switch v := aux.Content.(type) {
+	case string:
+		w.Content = v
+	case []interface{}:
+		// Handle array of strings - join with newlines
+		var lines []string
+		for _, item := range v {
+			if str, ok := item.(string); ok {
+				lines = append(lines, str)
+			}
+		}
+		w.Content = strings.Join(lines, "\n")
+	default:
+		return fmt.Errorf("invalid type for content field: %T", v)
+	}
+
+	return nil
 }
 
 type WritePermissionsParams struct {


### PR DESCRIPTION
## Problem

Some models (GLM 4.6, Qwen 3 Coder 480B) send the write tool's `content` parameter as an array of strings instead of a single string, causing validation errors:

```
The write tool was called with invalid arguments:
"Invalid input: expected string, received array"
```

## Solution

This PR adds a custom `UnmarshalJSON` method to `WriteParams` that:
- ✅ Accepts string content (existing behavior, fully backward compatible)
- ✅ Accepts array of strings (joins with newlines)
- ✅ Provides clear error messages for invalid types

The fix is transparent to models that send strings and enables compatibility with models that send arrays.

## Affected Models

- GLM 4.6
- Qwen 3 Coder 480B  
- Any other models that send array content

## Testing

Tested with Venice.ai models via [VeniceCode](https://github.com/georgeglarson/venicecode) (Venice.ai-optimized fork of Crush).

## Code Changes

Adds 35 lines to `internal/agent/tools/write.go`:
- Custom `UnmarshalJSON` method for `WriteParams`
- Handles both string and array formats
- Zero breaking changes

## Related

- User report: Community feedback on GLM/Qwen compatibility
- VeniceCode: https://github.com/georgeglarson/venicecode