### PR TITLE
feat(tui): show / hint when editor is empty

### DIFF
--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -42,6 +42,7 @@ type Editor interface {
 	SetSession(session session.Session) tea.Cmd
 	IsCompletionsOpen() bool
 	HasAttachments() bool
+	IsEmpty() bool
 	Cursor() *tea.Cursor
 }
 
@@ -265,7 +266,7 @@ func (m *editorCmp) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 		curIdx := m.textarea.Width()*cur.Y + cur.X
 		switch {
 		// Open command palette when "/" is pressed on empty prompt
-		case msg.String() == "/" && len(strings.TrimSpace(m.textarea.Value())) == 0:
+		case msg.String() == "/" && m.IsEmpty():
 			return m, util.CmdHandler(dialogs.OpenDialogMsg{
 				Model: commands.NewCommandDialog(m.session.ID),
 			})
@@ -544,6 +545,10 @@ func (c *editorCmp) IsCompletionsOpen() bool {
 
 func (c *editorCmp) HasAttachments() bool {
 	return len(c.attachments) > 0
+}
+
+func (c *editorCmp) IsEmpty() bool {
+	return strings.TrimSpace(c.textarea.Value()) == ""
 }
 
 func normalPromptFunc(info textarea.PromptInfo) string {

--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -942,6 +942,9 @@ func (p *chatPage) Help() help.KeyMap {
 			key.WithKeys("ctrl+p"),
 			key.WithHelp("ctrl+p", "commands"),
 		)
+		if p.focusedPane == PanelTypeEditor && p.editor.IsEmpty() {
+			commandsBinding.SetHelp("/ or ctrl+p", "commands")
+		}
 		modelsBinding := key.NewBinding(
 			key.WithKeys("ctrl+m", "ctrl+l"),
 			key.WithHelp("ctrl+l", "models"),


### PR DESCRIPTION
![Peek 2025-11-25 15-03](https://github.com/user-attachments/assets/4d3a1654-9e7b-44d6-8523-98312bf12f3d)

Assisted-by: Claude Opus 4.5 via Crush

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
