### PR TITLE
fix(editor): fix opening `$EDITOR` w/ and w/o args

### DIFF
--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -6,7 +6,6 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -112,11 +111,8 @@ func (m *editorCmp) openEditor(value string) tea.Cmd {
 	if _, err := tmpfile.WriteString(value); err != nil {
 		return util.ReportError(err)
 	}
-	c := exec.CommandContext(context.TODO(), editor, tmpfile.Name())
-	c.Stdin = os.Stdin
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
-	return tea.ExecProcess(c, func(err error) tea.Msg {
+	cmdStr := editor + " " + tmpfile.Name()
+	return util.ExecShell(context.TODO(), cmdStr, func(err error) tea.Msg {
 		if err != nil {
 			return util.ReportError(err)
 		}

--- a/internal/tui/util/shell.go
+++ b/internal/tui/util/shell.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+
+	tea "charm.land/bubbletea/v2"
+	"mvdan.cc/sh/v3/shell"
+)
+
+// ExecShell parses a shell command string and executes it with exec.Command.
+// Uses shell.Fields for proper handling of shell syntax like quotes and
+// arguments while preserving TTY handling for terminal editors.
+func ExecShell(ctx context.Context, cmdStr string, callback tea.ExecCallback) tea.Cmd {
+	fields, err := shell.Fields(cmdStr, nil)
+	if err != nil {
+		return ReportError(err)
+	}
+	if len(fields) == 0 {
+		return ReportError(errors.New("empty command"))
+	}
+
+	cmd := exec.CommandContext(ctx, fields[0], fields[1:]...)
+	return tea.ExecProcess(cmd, callback)
+}


### PR DESCRIPTION
References: #1481
References: #1519

Afaict, `interp` was enough to kick off the GUI process for Zed, but not enough for the TUI process for `vim` and I didn't think to check with vim :facepalm: Instead of executing `EDITOR` as a line of shell with `interp` as in #1481, this parses the fields of the command and passes them to the same executor that already works.

https://github.com/user-attachments/assets/3b6492d3-fb61-4445-a3f1-900ad58fbc39

As far as I can tell, bubbletea is supposed to wire up stdin/out/err, so I left these out. Should they be added back?
```
	c.Stdin = os.Stdin
	c.Stdout = os.Stdout
	c.Stderr = os.Stderr
```

Assisted-by: Claude Sonnet 4.5 via Crush <crush@charm.land>

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
