### PR TITLE
fix: fix `c` key not working in model filter

### DIFF
--- a/internal/tui/components/dialogs/models/models.go
+++ b/internal/tui/components/dialogs/models/models.go
@@ -143,17 +143,15 @@ func (m *modelDialogCmp) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 		return m, util.CmdHandler(dialogs.CloseDialogMsg{})
 	case tea.KeyPressMsg:
 		switch {
-		case key.Matches(msg, key.NewBinding(key.WithKeys("c", "C"))):
-			if m.showClaudeOAuth2 && m.claudeOAuth2.State == claude.OAuthStateURL {
-				return m, tea.Sequence(
-					tea.SetClipboard(m.claudeOAuth2.URL),
-					func() tea.Msg {
-						_ = clipboard.WriteAll(m.claudeOAuth2.URL)
-						return nil
-					},
-					util.ReportInfo("URL copied to clipboard"),
-				)
-			}
+		case key.Matches(msg, key.NewBinding(key.WithKeys("c", "C"))) && m.showClaudeOAuth2 && m.claudeOAuth2.State == claude.OAuthStateURL:
+			return m, tea.Sequence(
+				tea.SetClipboard(m.claudeOAuth2.URL),
+				func() tea.Msg {
+					_ = clipboard.WriteAll(m.claudeOAuth2.URL)
+					return nil
+				},
+				util.ReportInfo("URL copied to clipboard"),
+			)
 		case key.Matches(msg, m.keyMap.Choose) && m.showClaudeAuthMethodChooser:
 			m.claudeAuthMethodChooser.ToggleChoice()
 			return m, nil


### PR DESCRIPTION
fixes #1530 
follow-up on #1514 

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).

---

The bug:

In the model chooser, keypress `c` doesn't work. The same issue is found in the Anthropic API key input.

---

The cause:

Keypress `c` is only handled for copying url Anthropic OAuth URL: [        case key.Matches(msg, key.NewBinding(key.WithKeys("c", "C"))):](https://github.com/charmbracelet/crush/blob/f508c6b39a06b7865bb52f592d9b66daf48b40e9/internal/tui/components/dialogs/models/models.go#L146)

---

The fix:

Also handle keypress `c` for regular inputs by letting it fall through to default case.