### PR TITLE
feat(copilot): add GitHub Copilot as LLM provider

### DIFF
--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -166,7 +166,7 @@ func coderAgent(r *vcr.Recorder, env fakeEnv, large, small fantasy.LanguageModel
 	if err != nil {
 		return nil, err
 	}
-	cfg, err := config.Init(env.workingDir, "", false)
+	cfg, err := config.Init(env.workingDir, "")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -51,7 +51,7 @@ var logsCmd = &cobra.Command{
 			log.SetColorProfile(colorprofile.NoTTY)
 		}
 
-		cfg, err := config.Load(cwd, dataDir, false)
+		cfg, err := config.Load(cwd, dataDir)
 		if err != nil {
 			return fmt.Errorf("failed to load configuration: %v", err)
 		}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -174,7 +174,11 @@ func setupApp(cmd *cobra.Command) (*app.App, error) {
 		return nil, err
 	}
 
-	cfg, err := config.Init(cwd, dataDir, debug)
+	opts := []config.LoadOption{config.WithCopilot()}
+	if debug {
+		opts = append(opts, config.WithDebug())
+	}
+	cfg, err := config.Init(cwd, dataDir, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,12 +13,13 @@ import (
 	"time"
 
 	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"github.com/invopop/jsonschema"
+	"github.com/tidwall/sjson"
+
 	"github.com/charmbracelet/crush/internal/csync"
 	"github.com/charmbracelet/crush/internal/env"
 	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/charmbracelet/crush/internal/oauth/claude"
-	"github.com/invopop/jsonschema"
-	"github.com/tidwall/sjson"
 )
 
 const (
@@ -84,6 +85,9 @@ type SelectedModel struct {
 	ProviderOptions map[string]any `json:"provider_options,omitempty" jsonschema:"description=Additional provider-specific options for the model"`
 }
 
+// CopilotProviderID is the provider ID for GitHub Copilot.
+const CopilotProviderID = "copilot"
+
 type ProviderConfig struct {
 	// The provider's id.
 	ID string `json:"id,omitempty" jsonschema:"description=Unique identifier for the provider,example=openai"`
@@ -97,6 +101,9 @@ type ProviderConfig struct {
 	APIKey string `json:"api_key,omitempty" jsonschema:"description=API key for authentication with the provider,example=$OPENAI_API_KEY"`
 	// OAuthToken for providers that use OAuth2 authentication.
 	OAuthToken *oauth.Token `json:"oauth,omitempty" jsonschema:"description=OAuth2 token for authentication with the provider"`
+	// CopilotGitHubToken is the GitHub OAuth token for Copilot authentication.
+	// This is read from the IDE's apps.json file and used to obtain Copilot API tokens.
+	CopilotGitHubToken string `json:"-"`
 	// Marks the provider as disabled.
 	Disable bool `json:"disable,omitempty" jsonschema:"description=Whether this provider is disabled,default=false"`
 

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -22,8 +22,8 @@ type ProjectInitFlag struct {
 // TODO: we need to remove the global config instance keeping it now just until everything is migrated
 var instance atomic.Pointer[Config]
 
-func Init(workingDir, dataDir string, debug bool) (*Config, error) {
-	cfg, err := Load(workingDir, dataDir, debug)
+func Init(workingDir, dataDir string, opts ...LoadOption) (*Config, error) {
+	cfg, err := Load(workingDir, dataDir, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/oauth/copilot/keeper.go
+++ b/internal/oauth/copilot/keeper.go
@@ -1,0 +1,89 @@
+package copilot
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// minRefreshInterval is the minimum time between token refresh attempts.
+const minRefreshInterval = 5 * time.Minute
+
+// TokenKeeper manages Copilot token lifecycle with rate-limited refresh.
+type TokenKeeper struct {
+	mu           sync.RWMutex
+	githubToken  string
+	copilotToken *CopilotToken
+	lastRefresh  time.Time
+}
+
+// NewTokenKeeper creates a new TokenKeeper with the given GitHub OAuth token.
+func NewTokenKeeper(githubToken string) *TokenKeeper {
+	return &TokenKeeper{
+		githubToken: githubToken,
+	}
+}
+
+// GetToken returns a valid Copilot token, refreshing if necessary.
+// Refresh is rate-limited to at most once per 5 minutes.
+func (k *TokenKeeper) GetToken(ctx context.Context) (string, error) {
+	// Fast path: check if we have a valid cached token.
+	k.mu.RLock()
+	if k.copilotToken != nil && !k.copilotToken.IsExpired() {
+		token := k.copilotToken.Token
+		k.mu.RUnlock()
+		return token, nil
+	}
+	k.mu.RUnlock()
+
+	// Slow path: need to refresh.
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if k.copilotToken != nil && !k.copilotToken.IsExpired() {
+		return k.copilotToken.Token, nil
+	}
+
+	// Check rate limit.
+	if time.Since(k.lastRefresh) < minRefreshInterval && k.copilotToken != nil {
+		slog.Debug("copilot: token refresh rate-limited, using potentially expired token")
+		return k.copilotToken.Token, nil
+	}
+
+	// Refresh the token.
+	slog.Debug("copilot: refreshing token")
+	token, err := GetCopilotToken(ctx, k.githubToken)
+	if err != nil {
+		// If we have an old token, return it with a warning.
+		if k.copilotToken != nil {
+			slog.Warn("copilot: failed to refresh token, using cached token", "error", err)
+			return k.copilotToken.Token, nil
+		}
+		return "", fmt.Errorf("failed to get copilot token: %w", err)
+	}
+
+	k.copilotToken = token
+	k.lastRefresh = time.Now()
+	slog.Debug("copilot: token refreshed", "expires_at", token.ExpiresAt)
+
+	return token.Token, nil
+}
+
+// GetHeaders returns Copilot API headers with a fresh token.
+func (k *TokenKeeper) GetHeaders(ctx context.Context) (map[string]string, error) {
+	token, err := k.GetToken(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return CopilotHeaders(token), nil
+}
+
+// HasValidToken checks if the keeper has a non-expired token without refreshing.
+func (k *TokenKeeper) HasValidToken() bool {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	return k.copilotToken != nil && !k.copilotToken.IsExpired()
+}

--- a/internal/oauth/copilot/oauth.go
+++ b/internal/oauth/copilot/oauth.go
@@ -1,0 +1,285 @@
+// Package copilot provides token management for GitHub Copilot integration.
+// It reads OAuth tokens from existing IDE installations (VSCode/JetBrains)
+// and exchanges them for short-lived Copilot API tokens.
+package copilot
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// VSCode's OAuth client ID - used as the key in apps.json.
+const vscodeClientID = "Iv1.b507a08c87ecfe98"
+
+// GitHub API endpoints.
+const (
+	githubAPIBaseURL = "https://api.github.com"
+)
+
+// Copilot API configuration.
+const (
+	copilotVersion       = "0.26.7"
+	editorPluginVersion  = "copilot-chat/" + copilotVersion
+	userAgent            = "GitHubCopilotChat/" + copilotVersion
+	apiVersion           = "2025-04-01"
+	defaultVSCodeVersion = "1.100.0"
+)
+
+// AppsEntry represents a single entry in the apps.json file.
+type AppsEntry struct {
+	User        string `json:"user"`
+	OAuthToken  string `json:"oauth_token"`
+	GitHubAppID string `json:"githubAppId"`
+}
+
+// CopilotToken represents a GitHub Copilot API token.
+type CopilotToken struct {
+	Token     string `json:"token"`
+	ExpiresAt int64  `json:"expires_at"`
+	RefreshIn int64  `json:"refresh_in"`
+}
+
+// IsExpired checks if the Copilot token is expired or about to expire.
+func (t *CopilotToken) IsExpired() bool {
+	// Add 60 second buffer before expiration.
+	return time.Now().Unix() >= (t.ExpiresAt - 60)
+}
+
+// AppsJSONPath returns the path to the GitHub Copilot apps.json file.
+func AppsJSONPath() string {
+	var configDir string
+	switch runtime.GOOS {
+	case "windows":
+		configDir = filepath.Join(os.Getenv("LOCALAPPDATA"), "github-copilot")
+	default:
+		home, _ := os.UserHomeDir()
+		configDir = filepath.Join(home, ".config", "github-copilot")
+	}
+	return filepath.Join(configDir, "apps.json")
+}
+
+// ReadGitHubToken reads the GitHub OAuth token from the IDE's apps.json file.
+// It looks for the VSCode client ID entry.
+func ReadGitHubToken() (string, error) {
+	path := AppsJSONPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read apps.json: %w", err)
+	}
+
+	var apps map[string]AppsEntry
+	if err := json.Unmarshal(data, &apps); err != nil {
+		return "", fmt.Errorf("failed to parse apps.json: %w", err)
+	}
+
+	// Look for VSCode's client ID entry.
+	key := "github.com:" + vscodeClientID
+	entry, ok := apps[key]
+	if !ok {
+		return "", fmt.Errorf("no VSCode Copilot token found in apps.json")
+	}
+
+	if entry.OAuthToken == "" {
+		return "", fmt.Errorf("empty OAuth token in apps.json")
+	}
+
+	return entry.OAuthToken, nil
+}
+
+// HasGitHubToken checks if a valid GitHub token exists without reading it.
+func HasGitHubToken() bool {
+	path := AppsJSONPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+
+	var apps map[string]AppsEntry
+	if err := json.Unmarshal(data, &apps); err != nil {
+		return false
+	}
+
+	key := "github.com:" + vscodeClientID
+	entry, ok := apps[key]
+	return ok && entry.OAuthToken != ""
+}
+
+// GetCopilotToken exchanges a GitHub OAuth token for a Copilot API token.
+func GetCopilotToken(ctx context.Context, githubToken string) (*CopilotToken, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", githubAPIBaseURL+"/copilot_internal/v2/token", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	setGitHubHeaders(req, githubToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get copilot token: status %d body %q", resp.StatusCode, string(data))
+	}
+
+	var result CopilotToken
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// CopilotBaseURL returns the Copilot API base URL.
+// Currently only supports individual accounts.
+func CopilotBaseURL() string {
+	return "https://api.githubcopilot.com"
+}
+
+// CopilotHeaders returns the headers required for Copilot API requests.
+func CopilotHeaders(copilotToken string) map[string]string {
+	return map[string]string{
+		"Authorization":           "Bearer " + copilotToken,
+		"Content-Type":            "application/json",
+		"copilot-integration-id":  "vscode-chat",
+		"editor-version":          "vscode/" + defaultVSCodeVersion,
+		"editor-plugin-version":   editorPluginVersion,
+		"User-Agent":              userAgent,
+		"openai-intent":           "conversation-panel",
+		"x-github-api-version":    apiVersion,
+		"x-request-id":            uuid.New().String(),
+		"x-vscode-user-agent-lib": "electron-fetch",
+	}
+}
+
+func setGitHubHeaders(req *http.Request, token string) {
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("editor-version", "vscode/"+defaultVSCodeVersion)
+	req.Header.Set("editor-plugin-version", editorPluginVersion)
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("x-github-api-version", apiVersion)
+}
+
+// Model represents a Copilot model from the /models endpoint.
+type Model struct {
+	ID                 string           `json:"id"`
+	Name               string           `json:"name"`
+	Version            string           `json:"version"`
+	Vendor             string           `json:"vendor"`
+	Preview            bool             `json:"preview"`
+	ModelPickerEnabled bool             `json:"model_picker_enabled"`
+	Capabilities       ModelCapability  `json:"capabilities"`
+	Policy             *ModelPolicy     `json:"policy,omitempty"`
+}
+
+// ModelCapability describes the model's capabilities and limits.
+type ModelCapability struct {
+	Family   string       `json:"family"`
+	Type     string       `json:"type"`
+	Tokenizer string      `json:"tokenizer"`
+	Limits   ModelLimits  `json:"limits"`
+	Supports ModelSupports `json:"supports"`
+}
+
+// ModelLimits defines token limits for the model.
+type ModelLimits struct {
+	MaxContextWindowTokens int `json:"max_context_window_tokens,omitempty"`
+	MaxOutputTokens        int `json:"max_output_tokens,omitempty"`
+	MaxPromptTokens        int `json:"max_prompt_tokens,omitempty"`
+}
+
+// ModelSupports describes what features the model supports.
+type ModelSupports struct {
+	ToolCalls         bool `json:"tool_calls,omitempty"`
+	ParallelToolCalls bool `json:"parallel_tool_calls,omitempty"`
+}
+
+// ModelPolicy contains policy information for the model.
+type ModelPolicy struct {
+	State string `json:"state"`
+	Terms string `json:"terms"`
+}
+
+// ModelsResponse is the response from the /models endpoint.
+type ModelsResponse struct {
+	Data   []Model `json:"data"`
+	Object string  `json:"object"`
+}
+
+// GetModels fetches the list of available models from the Copilot API.
+func GetModels(ctx context.Context, copilotToken string) ([]Model, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", CopilotBaseURL()+"/models", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	headers := CopilotHeaders(copilotToken)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get models: status %d body %q", resp.StatusCode, string(data))
+	}
+
+	var result ModelsResponse
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, err
+	}
+
+	return result.Data, nil
+}
+
+func request(ctx context.Context, method, url string, body any, headers map[string]string) (*http.Response, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	return http.DefaultClient.Do(req)
+}

--- a/internal/tui/components/dialogs/models/list_recent_test.go
+++ b/internal/tui/components/dialogs/models/list_recent_test.go
@@ -89,7 +89,7 @@ func TestModelList_RecentlyUsedSectionAndPrunesInvalid(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dataConfDir, "providers.json"), emptyProviders, 0o644))
 
 	// Initialize global config instance (no network due to auto-update disabled)
-	_, err = config.Init(cfgDir, dataDir, false)
+	_, err = config.Init(cfgDir, dataDir)
 	require.NoError(t, err)
 
 	// Build a small provider set for the list component
@@ -198,7 +198,7 @@ func TestModelList_PrunesInvalidModelWithinValidProvider(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dataConfDir, "providers.json"), emptyProviders, 0o644))
 
 	// Initialize global config instance
-	_, err = config.Init(cfgDir, dataDir, false)
+	_, err = config.Init(cfgDir, dataDir)
 	require.NoError(t, err)
 
 	// Build provider set that only includes m1, not "missing"
@@ -313,7 +313,7 @@ func TestModelList_AllRecentsInvalid(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dataConfDir, "providers.json"), emptyProviders, 0o644))
 
 	// Initialize global config instance with isolated dataDir
-	_, err = config.Init(cfgDir, dataDir, false)
+	_, err = config.Init(cfgDir, dataDir)
 	require.NoError(t, err)
 
 	// Build provider set (doesn't include unknown1 or unknown2)


### PR DESCRIPTION
## Summary

Adds support for using GitHub Copilot as an LLM provider by reusing OAuth tokens from existing IDE installations (VSCode/JetBrains).

- Add `internal/oauth/copilot` package for token management
- TokenKeeper handles token lifecycle with rate-limited refresh
- Dynamic model discovery via Copilot `/models` endpoint
- Functional options pattern for `config.Load()` and `config.Init()`
- `WithCopilot()` option enables auto-detection (CLI only)
- `WithDebug()` option replaces debug parameter

### Token source rationale

GitHub does not provide an official way to register OAuth apps for Copilot API access. Existing implementations either impersonate VSCode's OAuth client ID (`Iv1.b507a08c87ecfe98`) to perform the device flow, or read tokens from `~/.config/github-copilot/apps.json`:

**Impersonate VSCode client ID:**
- [sst/opencode](https://github.com/sst/opencode-github-copilot/blob/main/auth.ts)
- [ericc-ch/copilot-api](https://github.com/ericc-ch/copilot-api/blob/master/src/lib/api-config.ts)
- [B00TK1D/copilot-api](https://github.com/B00TK1D/copilot-api/blob/main/api.py)

**Read from apps.json:**
- [Aider-AI/aider](https://aider.chat/docs/llms/github.html)

Impersonating an IDE's OAuth credentials seemed inappropriate, so this implementation reads from `~/.config/github-copilot/apps.json` which requires an existing Copilot-enabled IDE installation.

### Comparison with #1546

| Aspect | #1546 | This PR |
|--------|-------|---------|
| **Auth method** | Device code flow (impersonates VSCode OAuth client ID) | Reads from existing IDE `apps.json` |
| **Login command** | Required (`crush login copilot`) | Not required (auto-detects) |
| **Requires IDE** | No | Yes (VSCode/JetBrains with Copilot) |
| **Model discovery** | None — user must manually configure models in config | Dynamic via `/models` endpoint |
| **Token management** | Basic refresh | TokenKeeper with rate-limited refresh |

The key advantage of this implementation is **automatic model discovery**. GitHub Copilot's available models change over time, and this PR fetches them dynamically from the API. In contrast, #1546 requires users to manually maintain a list of model IDs in their configuration file.

## Test plan

- [x] Verify Copilot provider appears when `apps.json` exists with valid token
- [x] Verify Copilot provider is not registered when `apps.json` is missing
- [x] Verify models are dynamically fetched from Copilot API
- [ ] Verify token refresh works correctly
- [x] Run existing tests to ensure no regressions

Closes #1178