### PR TITLE
fix:ignore mouse clicks when isProjectInit is active 

### DIFF
--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -181,7 +181,7 @@ func (p *chatPage) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 		}
 		return p, nil
 	case tea.MouseClickMsg:
-		if p.isOnboarding {
+		if p.isOnboarding || p.isProjectInit {
 			return p, nil
 		}
 		if p.compact {
@@ -210,7 +210,7 @@ func (p *chatPage) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 		}
 		return p, nil
 	case tea.MouseReleaseMsg:
-		if p.isOnboarding {
+		if p.isOnboarding || p.isProjectInit {
 			return p, nil
 		}
 		if p.compact {


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
        fix:https://github.com/charmbracelet/crush/issues/1526
Here's why the bug happens:

   1. Start Up: When crush asks to initialize a project, it shows the Splash screen and focuses it.
   2. The Trigger: If you click the mouse anywhere in the terminal (which people often do to focus the window), crush detects it.
   3. The Bug: The code in chat.go sees the click and immediately moves focus to the hidden Chat or Editor behind the scenes. It remembers to block this during
      "Onboarding" but forgot to block it during "Project Init".
   4. The Result: You're looking at the Splash screen, but your keyboard is talking to the hidden Editor. It looks frozen, but it's just focused on the wrong
      thing.