### PR TITLE
fix: use visual width instead of byte length for text truncation

### DIFF
--- a/internal/tui/components/chat/messages/renderer.go
+++ b/internal/tui/components/chat/messages/renderer.go
@@ -1025,7 +1025,7 @@ func renderPlainContent(v *toolCallCmp, content string) string {
 		}
 		ln = ansiext.Escape(ln)
 		ln = " " + ln
-		if len(ln) > width {
+		if lipgloss.Width(ln) > width {
 			ln = v.fit(ln, width)
 		}
 		out = append(out, t.S().Muted.

--- a/internal/tui/components/chat/messages/tool.go
+++ b/internal/tui/components/chat/messages/tool.go
@@ -790,6 +790,9 @@ func (m *toolCallCmp) textWidth() int {
 
 // fit truncates content to fit within the specified width with ellipsis
 func (m *toolCallCmp) fit(content string, width int) string {
+	if lipgloss.Width(content) <= width {
+		return content
+	}
 	t := styles.CurrentTheme()
 	lineStyle := t.S().Muted
 	dots := lineStyle.Render("…")


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
   fix:https://github.com/charmbracelet/crush/issues/1485
   
Why is this happening?
  The code was confusing bytes with screen width.
  It checked if a line was "too long" using len(string), which counts bytes. But Chinese characters (and emojis) use more bytes (usually 3) than they take up
  screen space (2 columns).
  So, a short Chinese string could have a high byte count, tricking the code into thinking it needed to be chopped off, causing missing characters.

  The Fix:
   1. Stop Guessing: In renderPlainContent, change the check from len(ln) (bytes) to lipgloss.Width(ln) (actual visual width).
   2. Safety Check: Update the fit() function to double-check lipgloss.Width before trying to truncate. If the text fits, just leave it alone.

  Why optimize?
  By adding the width check inside fit(), we protect every part of the app that uses this function, not just the plain text renderer. It's a safety net that
  prevents this bug from popping up elsewhere.