### PR TITLE
fix: update MultiEdit permission desc to reflect actual applied edits

### DIFF
--- a/internal/agent/tools/multiedit.go
+++ b/internal/agent/tools/multiedit.go
@@ -165,13 +165,20 @@ func processMultiEditWithCreation(edit editContext, params MultiEditParams, call
 	// Check permissions
 	_, additions, removals := diff.GenerateDiff("", currentContent, strings.TrimPrefix(params.FilePath, edit.workingDir))
 
+	editsApplied := len(params.Edits) - len(failedEdits)
+	var description string
+	if len(failedEdits) > 0 {
+		description = fmt.Sprintf("Create file %s with %d of %d edits (%d failed)", params.FilePath, editsApplied, len(params.Edits), len(failedEdits))
+	} else {
+		description = fmt.Sprintf("Create file %s with %d edits", params.FilePath, editsApplied)
+	}
 	p := edit.permissions.Request(permission.CreatePermissionRequest{
 		SessionID:   sessionID,
 		Path:        fsext.PathOrPrefix(params.FilePath, edit.workingDir),
 		ToolCallID:  call.ID,
 		ToolName:    MultiEditToolName,
 		Action:      "write",
-		Description: fmt.Sprintf("Create file %s with %d edits", params.FilePath, len(params.Edits)),
+		Description: description,
 		Params: MultiEditPermissionsParams{
 			FilePath:   params.FilePath,
 			OldContent: "",
@@ -202,7 +209,6 @@ func processMultiEditWithCreation(edit editContext, params MultiEditParams, call
 	recordFileWrite(params.FilePath)
 	recordFileRead(params.FilePath)
 
-	editsApplied := len(params.Edits) - len(failedEdits)
 	var message string
 	if len(failedEdits) > 0 {
 		message = fmt.Sprintf("File created with %d of %d edits: %s (%d edit(s) failed)", editsApplied, len(params.Edits), params.FilePath, len(failedEdits))
@@ -299,13 +305,21 @@ func processMultiEditExistingFile(edit editContext, params MultiEditParams, call
 
 	// Generate diff and check permissions
 	_, additions, removals := diff.GenerateDiff(oldContent, currentContent, strings.TrimPrefix(params.FilePath, edit.workingDir))
+
+	editsApplied := len(params.Edits) - len(failedEdits)
+	var description string
+	if len(failedEdits) > 0 {
+		description = fmt.Sprintf("Apply %d of %d edits to file %s (%d failed)", editsApplied, len(params.Edits), params.FilePath, len(failedEdits))
+	} else {
+		description = fmt.Sprintf("Apply %d edits to file %s", editsApplied, params.FilePath)
+	}
 	p := edit.permissions.Request(permission.CreatePermissionRequest{
 		SessionID:   sessionID,
 		Path:        fsext.PathOrPrefix(params.FilePath, edit.workingDir),
 		ToolCallID:  call.ID,
 		ToolName:    MultiEditToolName,
 		Action:      "write",
-		Description: fmt.Sprintf("Apply %d edits to file %s", len(params.Edits), params.FilePath),
+		Description: description,
 		Params: MultiEditPermissionsParams{
 			FilePath:   params.FilePath,
 			OldContent: oldContent,
@@ -351,7 +365,6 @@ func processMultiEditExistingFile(edit editContext, params MultiEditParams, call
 	recordFileWrite(params.FilePath)
 	recordFileRead(params.FilePath)
 
-	editsApplied := len(params.Edits) - len(failedEdits)
 	var message string
 	if len(failedEdits) > 0 {
 		message = fmt.Sprintf("Applied %d of %d edits to file: %s (%d edit(s) failed)", editsApplied, len(params.Edits), params.FilePath, len(failedEdits))


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
    
     fix:https://github.com/charmbracelet/crush/issues/1470
     
     Hey! 👋 I noticed that when the MultiEdit tool runs, if one of the edits fails (e.g., text not found), the permission dialog still claims it's applying all edits. This confuses users because the diff
  only shows the successful ones (e.g., text says "Apply 2 edits" but diff only shows 1 change).

  The Fix:
  I updated multiedit.go to calculate the number of successful vs. failed edits before asking for permission.
  Now, if an edit fails, the dialog will honestly say something like:
  > "Apply 1 of 2 edits to file ... (1 failed)"

  This matches the generated diff perfectly and clears up the confusion. 🐛🔨