### PR TITLE
fix:Edit tool error on new file creation due to logical fallthrough

### DIFF
--- a/internal/agent/tools/edit.go
+++ b/internal/agent/tools/edit.go
@@ -71,19 +71,12 @@ func NewEditTool(lspClients *csync.Map[string, *lsp.Client], permissions permiss
 
 			if params.OldString == "" {
 				response, err = createNewFile(editCtx, params.FilePath, params.NewString, call)
-				if err != nil {
-					return response, err
-				}
-			}
-
-			if params.NewString == "" {
+			} else if params.NewString == "" {
 				response, err = deleteContent(editCtx, params.FilePath, params.OldString, params.ReplaceAll, call)
-				if err != nil {
-					return response, err
-				}
+			} else {
+				response, err = replaceContent(editCtx, params.FilePath, params.OldString, params.NewString, params.ReplaceAll, call)
 			}
 
-			response, err = replaceContent(editCtx, params.FilePath, params.OldString, params.NewString, params.ReplaceAll, call)
 			if err != nil {
 				return response, err
 			}


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
fix: https://github.com/charmbracelet/crush/issues/1484
   
In internal/agent/tools/edit.go, the NewEditTool function used sequential if statements without else blocks:  

  When creating a file (OldString is empty), the code would execute createNewFile, but then immediately proceed to execute replaceContent. This caused the valid "File created" response to be
  overwritten by the result of replaceContent, which would often fail or produce malformed output since it was operating on the same file with invalid parameters for a replacement operation.

  The Fix:
  I have refactored the logic in NewEditTool to use an if - else if - else structure. This ensures that the Create, Delete, and Replace operations are mutually exclusive.

```go
   1 if params.OldString == "" {
   2     response, err = createNewFile(...)
   3 } else if params.NewString == "" {
   4     response, err = deleteContent(...)
   5 } else {
   6     response, err = replaceContent(...)
   7 }
```

  This change ensures that once a file is created, the tool returns the success response immediately  without attempting redundant operations.