### PR TITLE
fix:prevent crash when pressing ctrl+f on model selector

### DIFF
--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -379,8 +379,17 @@ func (p *chatPage) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 			}
 			return p, p.newSession()
 		case key.Matches(msg, p.keyMap.AddAttachment):
+			// Skip attachment handling during onboarding/splash screen
+			if p.focusedPane == PanelTypeSplash || p.isOnboarding {
+				u, cmd := p.splash.Update(msg)
+				p.splash = u.(splash.Splash)
+				return p, cmd
+			}
 			agentCfg := config.Get().Agents[config.AgentCoder]
 			model := config.Get().GetModelByType(agentCfg.Model)
+			if model == nil {
+				return p, util.ReportWarn("No model configured yet")
+			}
 			if model.SupportsImages {
 				return p, util.CmdHandler(commands.OpenFilePickerMsg{})
 			} else {


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
fix: https://github.com/charmbracelet/crush/issues/1426
     This fixes a nil pointer dereference panic that occurred when pressing'ctrl+f' (Add Attachment) on the initial model selector screen.
    Changes:
    - Added a check to bypass attachment logic if on the splash/onboarding screen.
    - Added a nil check for the model configuration before accessing its properties.