### PR TITLE
fix(claude): add authentication refresh on 401 errors

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"net/http"
 	"os"
 	"slices"
 	"strings"
@@ -108,6 +109,11 @@ func NewCoordinator(
 }
 
 // Run implements Coordinator.
+// It executes a prompt with the current agent. If the provider uses OAuth
+// authentication, it will automatically refresh expired tokens before making
+// the request. If the request fails with a 401 authentication error, it will
+// attempt to refresh the OAuth token or re-resolve shell substitution API keys
+// and retry once.
 func (c *coordinator) Run(ctx context.Context, sessionID string, prompt string, attachments ...message.Attachment) (*fantasy.AgentResult, error) {
 	if err := c.readyWg.Wait(); err != nil {
 		return nil, err
@@ -155,6 +161,75 @@ func (c *coordinator) Run(ctx context.Context, sessionID string, prompt string, 
 		FrequencyPenalty: freqPenalty,
 		PresencePenalty:  presPenalty,
 	})
+	// Check if we got a 401 authentication error (token expired mid-flight or rotated).
+	if err != nil {
+		var providerErr *fantasy.ProviderError
+		if errors.As(err, &providerErr) && providerErr.StatusCode == http.StatusUnauthorized {
+			// Try OAuth token refresh first.
+			if providerCfg.OAuthToken != nil {
+				slog.Info("Received 401 authentication error, attempting OAuth token refresh and retry", "provider", providerCfg.ID)
+				if refreshErr := c.cfg.RefreshOAuthToken(ctx, providerCfg.ID); refreshErr != nil {
+					slog.Error("Failed to refresh OAuth token after 401 error", "provider", providerCfg.ID, "error", refreshErr)
+					return nil, err // Return original error
+				}
+
+				// Rebuild models with refreshed token.
+				if updateErr := c.UpdateModels(ctx); updateErr != nil {
+					slog.Error("Failed to update models after token refresh", "error", updateErr)
+					return nil, err // Return original error
+				}
+
+				// Retry the request with refreshed token.
+				slog.Info("Retrying request with refreshed OAuth token", "provider", providerCfg.ID)
+				result, err = c.currentAgent.Run(ctx, SessionAgentCall{
+					SessionID:        sessionID,
+					Prompt:           prompt,
+					Attachments:      attachments,
+					MaxOutputTokens:  maxTokens,
+					ProviderOptions:  mergedOptions,
+					Temperature:      temp,
+					TopP:             topP,
+					TopK:             topK,
+					FrequencyPenalty: freqPenalty,
+					PresencePenalty:  presPenalty,
+				})
+			} else if strings.Contains(providerCfg.APIKeyTemplate, "$") {
+				// Try re-resolving shell substitution API key.
+				slog.Info("Received 401 authentication error, re-resolving shell substitution API key and retry", "provider", providerCfg.ID)
+				newAPIKey, resolveErr := c.cfg.Resolve(providerCfg.APIKeyTemplate)
+				if resolveErr != nil {
+					slog.Error("Failed to re-resolve API key after 401 error", "provider", providerCfg.ID, "error", resolveErr)
+					return nil, err // Return original error
+				}
+
+				// Update provider config with new API key.
+				providerCfg.APIKey = newAPIKey
+				c.cfg.Providers.Set(providerCfg.ID, providerCfg)
+
+				// Rebuild models with new API key.
+				if updateErr := c.UpdateModels(ctx); updateErr != nil {
+					slog.Error("Failed to update models after API key refresh", "error", updateErr)
+					return nil, err // Return original error
+				}
+
+				// Retry the request with new API key.
+				slog.Info("Retrying request with refreshed API key", "provider", providerCfg.ID)
+				result, err = c.currentAgent.Run(ctx, SessionAgentCall{
+					SessionID:        sessionID,
+					Prompt:           prompt,
+					Attachments:      attachments,
+					MaxOutputTokens:  maxTokens,
+					ProviderOptions:  mergedOptions,
+					Temperature:      temp,
+					TopP:             topP,
+					TopK:             topK,
+					FrequencyPenalty: freqPenalty,
+					PresencePenalty:  presPenalty,
+				})
+			}
+		}
+	}
+
 	return result, err
 }
 

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -131,13 +131,6 @@ func (c *coordinator) Run(ctx context.Context, sessionID string, prompt string, 
 
 	mergedOptions, temp, topP, topK, freqPenalty, presPenalty := mergeCallOptions(model, providerCfg)
 
-	if providerCfg.OAuthToken != nil && providerCfg.OAuthToken.IsExpired() {
-		slog.Info("Detected expired OAuth token. Attempting refresh.", "provider", providerCfg.ID)
-		if refreshErr := c.refreshOAuth2Token(ctx, providerCfg); refreshErr != nil {
-			slog.Error("Failed to refresh OAuth token", "provider", providerCfg.ID, "err", refreshErr)
-		}
-	}
-
 	run := func() (*fantasy.AgentResult, error) {
 		return c.currentAgent.Run(ctx, SessionAgentCall{
 			SessionID:        sessionID,

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -19,11 +18,9 @@ import (
 	"github.com/charmbracelet/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/csync"
 	"github.com/charmbracelet/crush/internal/env"
-	"github.com/charmbracelet/crush/internal/event"
 	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/home"
 	"github.com/charmbracelet/crush/internal/log"
-	"github.com/charmbracelet/crush/internal/oauth/claude"
 	powernapConfig "github.com/charmbracelet/x/powernap/pkg/config"
 )
 
@@ -201,25 +198,6 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 		}
 
 		if p.ID == catwalk.InferenceProviderAnthropic && config.OAuthToken != nil {
-			if config.OAuthToken.IsExpired() {
-				newToken, err := claude.RefreshToken(context.TODO(), config.OAuthToken.RefreshToken)
-				if err == nil {
-					slog.Info("Successfully refreshed Anthropic OAuth token")
-					config.OAuthToken = newToken
-					prepared.OAuthToken = newToken
-					if err := cmp.Or(
-						c.SetConfigField("providers.anthropic.api_key", newToken.AccessToken),
-						c.SetConfigField("providers.anthropic.oauth", newToken),
-					); err != nil {
-						return err
-					}
-				} else {
-					slog.Error("Failed to refresh Anthropic OAuth token", "error", err)
-					event.Error(err)
-				}
-			} else {
-				slog.Info("Using existing non-expired Anthropic OAuth token")
-			}
 			prepared.SetupClaudeCode()
 		}
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -189,6 +189,7 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 			Name:               p.Name,
 			BaseURL:            p.APIEndpoint,
 			APIKey:             p.APIKey,
+			APIKeyTemplate:     p.APIKey, // Store original template for re-resolution
 			OAuthToken:         config.OAuthToken,
 			Type:               p.Type,
 			Disable:            config.Disable,


### PR DESCRIPTION
## Summary

Adds automatic authentication refresh on 401 errors for both OAuth tokens and shell substitution API keys.

## Problem

When using scripts, authentication can expire mid-execution causing 401 errors that fail the entire script:
- OAuth tokens expire during long-running operations
- Credential files get rotated (e.g., agenix, vault)
- Short-lived tokens from secret management systems

## Solution

Catch 401 authentication errors and automatically retry once after:
1. **OAuth tokens (Anthropic)**: Refresh using the refresh token
2. **Shell substitution API keys**: Re-execute shell commands like `$(cat /run/agenix/crush)`

## Changes

- Add `APIKeyTemplate` field to track original API key templates for re-resolution
- Enhanced 401 error handler in coordinator to detect and refresh expired credentials
- Updated `RefreshOAuthToken()` to preserve config immutability

Assisted-by: Claude Sonnet 4.5 via Crush <crush@charm.land>

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).