### PR TITLE
feat: add protective layer for context window size

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -358,7 +358,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 				// add a protective layer for the context window size
 				if cw <= 0 {
 					// use default value or skit Summarize check
-					cw = 128000 // Set the default to 128k?
+					cw = 131072 // Set the default to 128k?
 				}
 				tokens := currentSession.CompletionTokens + currentSession.PromptTokens
 				remaining := cw - tokens

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -355,6 +355,11 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 		StopWhen: []fantasy.StopCondition{
 			func(_ []fantasy.StepResult) bool {
 				cw := int64(a.largeModel.CatwalkCfg.ContextWindow)
+				// add a protective layer for the context window size
+				if cw <= 0 {
+					// use default value or skit Summarize check
+					cw = 128000 // Set the default to 128k?
+				}
 				tokens := currentSession.CompletionTokens + currentSession.PromptTokens
 				remaining := cw - tokens
 				var threshold int64


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
    
This feat adds defensive logic for context window size, inspired by #1521.