### PR TITLE
fix: quitting leaves the screen neater, by clearing the quit dialog, and moving the cursor so the terminal doesn’t reset the lower half. Add sassy goodbye quips.

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -36,6 +36,7 @@ import (
 	"github.com/charmbracelet/crush/internal/tui/page/chat"
 	"github.com/charmbracelet/crush/internal/tui/styles"
 	"github.com/charmbracelet/crush/internal/tui/util"
+	"github.com/charmbracelet/x/ansi"
 	"golang.org/x/mod/semver"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -267,6 +268,11 @@ func (a *appModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return a, util.CmdHandler(dialogs.OpenDialogMsg{
 			Model: quit.NewQuitDialog(),
 		})
+	case quit.QuitMsg:
+		return a, tea.Sequence(
+			tea.Raw(ansi.CursorPosition(1, msg.Height)),
+			tea.Quit,
+		)
 	case commands.ToggleYoloModeMsg:
 		a.app.Permissions.SetSkipRequests(!a.app.Permissions.SkipRequests())
 	case commands.ToggleHelpMsg:


### PR DESCRIPTION
When quitting via the quit dialog (Ctrl-C → Yes), the cursor is now moved to the bottom of the screen before exiting. This prevents the terminal from clearing content below the dialog position when returning to normal terminal mode.

## Problem

Previously, when exiting Crush through the quit dialog, the cursor remained at the dialog's position (middle of screen). When the altscreen was disabled and the terminal returned to normal mode, content below that cursor position would be cleared. This could cause loss of valuable information that Crush had just displayed (e.g., final commands to run).

## Solution

Use `tea.Sequence()` to move the cursor to the bottom of the screen via `ansi.CursorPosition()` before executing `tea.Quit`. This ensures the cursor is positioned such that no prior content is lost when the terminal is restored.

💘 Generated with Crush