### PR TITLE
test: fix local test suite, ignore machine environ

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"testing"
 
 	"github.com/charmbracelet/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/csync"
@@ -672,7 +673,7 @@ func hasAWSCredentials(env env.Env) bool {
 		return true
 	}
 
-	if _, err := os.Stat(filepath.Join(home.Dir(), ".aws/credentials")); err == nil {
+	if _, err := os.Stat(filepath.Join(home.Dir(), ".aws/credentials")); err == nil && !testing.Testing() {
 		return true
 	}
 

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -1,6 +1,9 @@
 package env
 
-import "os"
+import (
+	"os"
+	"testing"
+)
 
 type Env interface {
 	Get(key string) string
@@ -23,6 +26,9 @@ func (o *osEnv) Env() []string {
 }
 
 func New() Env {
+	if testing.Testing() {
+		return NewFromMap(nil)
+	}
 	return &osEnv{}
 }
 

--- a/internal/env/env_test.go
+++ b/internal/env/env_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestOsEnv_Get(t *testing.T) {
-	env := New()
+	env := &osEnv{}
 
 	// Test getting an existing environment variable
 	t.Setenv("TEST_VAR", "test_value")
@@ -22,7 +22,7 @@ func TestOsEnv_Get(t *testing.T) {
 }
 
 func TestOsEnv_Env(t *testing.T) {
-	env := New()
+	env := &osEnv{}
 
 	envVars := env.Env()
 


### PR DESCRIPTION
Certain providers (Bedrock and others) look for local ENV or files to authenticate. We should ignore those on the test suite, or some tests will fail the these set.