### PR TITLE
fix: hide mailto: prefix in rendered email links

### DIFF
--- a/internal/tui/styles/markdown.go
+++ b/internal/tui/styles/markdown.go
@@ -160,6 +160,7 @@ func PlainMarkdownStyle() ansi.StyleConfig {
 			Bold:            boolPtr(true),
 			Color:           fgColor,
 			BackgroundColor: bgColor,
+			Format:          "{{.text}}", // Only show link text, hide URL to prevent "mailto:" prefix from showing
 		},
 		Image: ansi.StylePrimitive{
 			Underline:       boolPtr(true),

--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -305,8 +305,9 @@ func (t *Theme) buildStyles() *Styles {
 				Underline: boolPtr(true),
 			},
 			LinkText: ansi.StylePrimitive{
-				Color: stringPtr(charmtone.Guac.Hex()),
-				Bold:  boolPtr(true),
+				Color:  stringPtr(charmtone.Guac.Hex()),
+				Bold:   boolPtr(true),
+				Format: "{{.text}}", // Only show link text, hide URL to prevent "mailto:" prefix from showing
 			},
 			Image: ansi.StylePrimitive{
 				Color:     stringPtr(charmtone.Cheeky.Hex()),


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
     fix: https://github.com/charmbracelet/crush/issues/1638

Issue Description:
  Issue #1638 states that email addresses displayed in conversations are rendered with the mailto: link alongside them, for example, appearing as user@example.com (mailto:user@example.com), which negatively impacts readability.

  Code Changes:
  You have modified the internal/tui/styles/markdown.go and internal/tui/styles/theme.go files as follows:

   1 LinkText: ansi.StylePrimitive{
   2     // ... existing configuration
   3     Format: "{{.text}}", // Only show link text, hide URL to prevent "mailto:" prefix from showing
   4 },

  Reasoning:
  This project utilizes the glamour library for Markdown rendering. glamour's default link styling often includes the URL (e.g., {{.text}} ({{.url}})). Byexplicitly setting the Format property of LinkText to {{.text}}, the renderer is instructed to display only the text content of the link (which is the emailaddress itself), thereby suppressing the underlying mailto: URL.

  Conclusion:
  The modifications in these two files precisely target the Markdown rendering style configuration, forcing the hiding of the link URL. This is exactly the action required to fix this issue.
