### PR TITLE
Text selection in text input area

### DIFF
--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -60,6 +60,7 @@ type editorCmp struct {
 	deleteMode         bool
 	readyPlaceholder   string
 	workingPlaceholder string
+	allSelected        bool // Track if all text is selected
 
 	keyMap EditorKeyMap
 
@@ -305,22 +306,50 @@ func (m *editorCmp) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 			}
 			return m, m.openEditor(m.textarea.Value())
 		}
+		if key.Matches(msg, m.keyMap.SelectAll) {
+			// Select all text in the textarea
+			if m.textarea.Value() != "" {
+				m.allSelected = true
+			}
+			return m, nil
+		}
 		if key.Matches(msg, DeleteKeyMaps.Escape) {
 			m.deleteMode = false
+			m.allSelected = false // Deselect on escape
 			return m, nil
 		}
 		if key.Matches(msg, m.keyMap.Newline) {
 			m.textarea.InsertRune('\n')
+			m.allSelected = false // Deselect after typing
 			cmds = append(cmds, util.CmdHandler(completions.CloseCompletionsMsg{}))
+		}
+		// Handle text operations for selected text
+		if m.allSelected {
+			switch msg.String() {
+			case "backspace", "delete":
+				m.textarea.SetValue("")
+				m.allSelected = false
+				return m, nil
+			case "left", "right", "up", "down", "home", "end", "pgup", "pgdown":
+				// Cursor movement triggers deselection
+				m.allSelected = false
+			default:
+				// Any other key press (typing) triggers deselection
+				if msg.Code != 0 && unicode.IsPrint(msg.Code) {
+					m.textarea.SetValue("")
+					m.allSelected = false
+				}
+			}
 		}
 		// Handle Enter key
 		if m.textarea.Focused() && key.Matches(msg, m.keyMap.SendMessage) {
 			value := m.textarea.Value()
-			if strings.HasSuffix(value, "\\") {
+			if before, ok := strings.CutSuffix(value, "\\"); ok {
 				// If the last character is a backslash, remove it and add a newline.
-				m.textarea.SetValue(strings.TrimSuffix(value, "\\"))
+				m.textarea.SetValue(before)
 			} else {
 				// Otherwise, send the message
+				m.allSelected = false
 				return m, m.send()
 			}
 		}
@@ -508,43 +537,43 @@ func (m *editorCmp) startCompletions() tea.Msg {
 }
 
 // Blur implements Container.
-func (c *editorCmp) Blur() tea.Cmd {
-	c.textarea.Blur()
+func (m *editorCmp) Blur() tea.Cmd {
+	m.textarea.Blur()
 	return nil
 }
 
 // Focus implements Container.
-func (c *editorCmp) Focus() tea.Cmd {
-	return c.textarea.Focus()
+func (m *editorCmp) Focus() tea.Cmd {
+	return m.textarea.Focus()
 }
 
 // IsFocused implements Container.
-func (c *editorCmp) IsFocused() bool {
-	return c.textarea.Focused()
+func (m *editorCmp) IsFocused() bool {
+	return m.textarea.Focused()
 }
 
 // Bindings implements Container.
-func (c *editorCmp) Bindings() []key.Binding {
-	return c.keyMap.KeyBindings()
+func (m *editorCmp) Bindings() []key.Binding {
+	return m.keyMap.KeyBindings()
 }
 
 // TODO: most likely we do not need to have the session here
 // we need to move some functionality to the page level
-func (c *editorCmp) SetSession(session session.Session) tea.Cmd {
-	c.session = session
+func (m *editorCmp) SetSession(session session.Session) tea.Cmd {
+	m.session = session
 	return nil
 }
 
-func (c *editorCmp) IsCompletionsOpen() bool {
-	return c.isCompletionsOpen
+func (m *editorCmp) IsCompletionsOpen() bool {
+	return m.isCompletionsOpen
 }
 
-func (c *editorCmp) HasAttachments() bool {
-	return len(c.attachments) > 0
+func (m *editorCmp) HasAttachments() bool {
+	return len(m.attachments) > 0
 }
 
-func (c *editorCmp) IsEmpty() bool {
-	return strings.TrimSpace(c.textarea.Value()) == ""
+func (m *editorCmp) IsEmpty() bool {
+	return strings.TrimSpace(m.textarea.Value()) == ""
 }
 
 func normalPromptFunc(info textarea.PromptInfo) string {

--- a/internal/tui/components/chat/editor/keys.go
+++ b/internal/tui/components/chat/editor/keys.go
@@ -9,6 +9,7 @@ type EditorKeyMap struct {
 	SendMessage key.Binding
 	OpenEditor  key.Binding
 	Newline     key.Binding
+	SelectAll   key.Binding
 }
 
 func DefaultEditorKeyMap() EditorKeyMap {
@@ -32,6 +33,10 @@ func DefaultEditorKeyMap() EditorKeyMap {
 			// to reflect that.
 			key.WithHelp("ctrl+j", "newline"),
 		),
+		SelectAll: key.NewBinding(
+			key.WithKeys("ctrl+a"),
+			key.WithHelp("ctrl+a", "select all"),
+		),
 	}
 }
 
@@ -42,6 +47,7 @@ func (k EditorKeyMap) KeyBindings() []key.Binding {
 		k.SendMessage,
 		k.OpenEditor,
 		k.Newline,
+		k.SelectAll,
 		AttachmentsKeyMaps.AttachmentDeleteMode,
 		AttachmentsKeyMaps.DeleteAllAttachments,
 		AttachmentsKeyMaps.Escape,


### PR DESCRIPTION
It is really frustrating to paste the wrong text in the prompt area and be unable to delete the whole message.

This PR introduces support to "ctrl+a" text selection.

Also, fixed the `ST1016` warnings from the `editor.go`.

https://github.com/user-attachments/assets/d3eb6626-dc24-45a8-9f7b-a8efe11ccb92


---

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
