### PR TITLE
fix: handle Ctrl+C in hypercrush auth

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -75,8 +75,7 @@ func loginHyper() error {
 	if !hyperp.Enabled() {
 		return fmt.Errorf("hyper not enabled")
 	}
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
-	defer cancel()
+	ctx := getLoginContext()
 
 	resp, err := hyper.InitiateDeviceAuth(ctx)
 	if err != nil {


### PR DESCRIPTION
Special thanks to @andreynering for the fix.

💘 Generated with Crush

Assisted-by: Kimi K2 Thinking via Crush <crush@charm.land>