### PR TITLE
feat(config): add support for global user context files

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,15 @@ var defaultContextPaths = []string{
 	"Agents.md",
 }
 
+// defaultUserContextPaths contains paths to user-level context files loaded from the home directory.
+// These are loaded before project-level context, allowing user preferences to be set globally.
+// Paths starting with ~ are expanded to the user's home directory.
+var defaultUserContextPaths = []string{
+	"~/.config/crush/CRUSH.md",
+	"~/.config/crush/CRUSH.local.md",
+	"~/.config/AGENTS.md",
+}
+
 type SelectedModelType string
 
 const (

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -358,6 +358,10 @@ func (c *Config) setDefaults(workingDir, dataDir string) {
 	c.applyLSPDefaults()
 
 	// Add the default context paths if they are not already present
+	// First add user-level context paths from home directory (with ~ expansion)
+	userContextPaths := expandUserContextPaths()
+	c.Options.ContextPaths = append(userContextPaths, c.Options.ContextPaths...)
+	// Then add project-level default context paths
 	c.Options.ContextPaths = append(defaultContextPaths, c.Options.ContextPaths...)
 	slices.Sort(c.Options.ContextPaths)
 	c.Options.ContextPaths = slices.Compact(c.Options.ContextPaths)
@@ -735,4 +739,14 @@ func isInsideWorktree() bool {
 		"--is-inside-work-tree",
 	).CombinedOutput()
 	return err == nil && strings.TrimSpace(string(bts)) == "true"
+}
+
+// expandUserContextPaths returns expanded user-level context paths from home directory.
+// Paths starting with ~ are expanded to the user's actual home directory.
+func expandUserContextPaths() []string {
+	expanded := make([]string, 0, len(defaultUserContextPaths))
+	for _, p := range defaultUserContextPaths {
+		expanded = append(expanded, home.Long(p))
+	}
+	return expanded
 }


### PR DESCRIPTION
Issue:
previously global rules were not loaded and ignored

Improvement:
Load user-level context files from ~/.config/crush/CRUSH.md,
~/.config/crush/CRUSH.local.md, and ~/.config/AGENTS.md by default.

Result:
This allows users to define global preferences and instructions that
apply across all projects, similar to Claude Code's ~/.claude/CLAUDE.md.

Refs: #1643, #1050

- [ x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ?] I have created a discussion that was approved by a maintainer (for new features).
