### PR TITLE
fix: remove restriction for text content to be utf8

### DIFF
--- a/internal/agent/tools/view.go
+++ b/internal/agent/tools/view.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"unicode/utf8"
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/csync"
@@ -164,12 +163,12 @@ func NewViewTool(lspClients *csync.Map[string, *lsp.Client], permissions permiss
 				return fantasy.NewImageResponse([]byte(encoded), mimeType), nil
 			}
 
-			// Read the file content
-			content, lineCount, err := readTextFile(filePath, params.Offset, params.Limit)
-			isValidUt8 := utf8.ValidString(content)
-			if !isValidUt8 {
-				return fantasy.NewTextErrorResponse("File content is not valid UTF-8"), nil
+			// Check if it's a text file before reading.
+			if !isTextFile(filePath) {
+				return fantasy.NewTextErrorResponse("File appears to not be a text file"), nil
 			}
+
+			content, lineCount, err := readTextFile(filePath, params.Offset, params.Limit)
 			if err != nil {
 				return fantasy.ToolResponse{}, fmt.Errorf("error reading file: %w", err)
 			}


### PR DESCRIPTION
Fixes https://github.com/charmbracelet/crush/issues/1671

Before:
<img width="1199" height="178" alt="Screenshot 2025-12-19 at 11 22 09" src="https://github.com/user-attachments/assets/a59f593b-e72c-40db-a074-8f4868e340a4" />

After:
<img width="1058" height="437" alt="Screenshot 2025-12-19 at 11 21 15" src="https://github.com/user-attachments/assets/9181b18f-8755-4c5e-9aaa-381b09c35856" />
