### PR TITLE
fix: set hyper api key as well

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -555,6 +555,8 @@ func (c *Config) RefreshOAuthToken(ctx context.Context, providerID string) error
 	case string(catwalk.InferenceProviderCopilot):
 		providerConfig.APIKey = newToken.AccessToken
 		providerConfig.SetupGitHubCopilot()
+	case hyperp.Name:
+		providerConfig.APIKey = newToken.AccessToken
 	}
 
 	c.Providers.Set(providerID, providerConfig)


### PR DESCRIPTION
this should fix refreshing the token when needed.