### PR TITLE
fix: splash padding y

### DIFF
--- a/internal/tui/components/chat/splash/splash.go
+++ b/internal/tui/components/chat/splash/splash.go
@@ -656,7 +656,7 @@ func (s *splashCmp) View() string {
 
 	switch {
 	case s.showClaudeAuthMethodChooser:
-		remainingHeight := s.height - lipgloss.Height(s.logoRendered) - (SplashScreenPaddingY * 2)
+		remainingHeight := s.height - lipgloss.Height(s.logoRendered) - SplashScreenPaddingY
 		chooserView := s.claudeAuthMethodChooser.View()
 		authMethodSelector := t.S().Base.AlignVertical(lipgloss.Bottom).Height(remainingHeight).Render(
 			lipgloss.JoinVertical(
@@ -672,7 +672,7 @@ func (s *splashCmp) View() string {
 			authMethodSelector,
 		)
 	case s.showClaudeOAuth2:
-		remainingHeight := s.height - lipgloss.Height(s.logoRendered) - (SplashScreenPaddingY * 2)
+		remainingHeight := s.height - lipgloss.Height(s.logoRendered) - SplashScreenPaddingY
 		oauth2View := s.claudeOAuth2.View()
 		oauthSelector := t.S().Base.AlignVertical(lipgloss.Bottom).Height(remainingHeight).Render(
 			lipgloss.JoinVertical(
@@ -688,7 +688,7 @@ func (s *splashCmp) View() string {
 			oauthSelector,
 		)
 	case s.showHyperDeviceFlow:
-		remainingHeight := s.height - lipgloss.Height(s.logoRendered) - (SplashScreenPaddingY * 2)
+		remainingHeight := s.height - lipgloss.Height(s.logoRendered) - SplashScreenPaddingY
 		hyperView := s.hyperDeviceFlow.View()
 		hyperSelector := t.S().Base.AlignVertical(lipgloss.Bottom).Height(remainingHeight).Render(
 			lipgloss.JoinVertical(
@@ -703,7 +703,7 @@ func (s *splashCmp) View() string {
 			hyperSelector,
 		)
 	case s.showCopilotDeviceFlow:
-		remainingHeight := s.height - lipgloss.Height(s.logoRendered) - (SplashScreenPaddingY * 2)
+		remainingHeight := s.height - lipgloss.Height(s.logoRendered) - SplashScreenPaddingY
 		copilotView := s.copilotDeviceFlow.View()
 		copilotSelector := t.S().Base.AlignVertical(lipgloss.Bottom).Height(remainingHeight).Render(
 			lipgloss.JoinVertical(
@@ -718,7 +718,7 @@ func (s *splashCmp) View() string {
 			copilotSelector,
 		)
 	case s.needsAPIKey:
-		remainingHeight := s.height - lipgloss.Height(s.logoRendered) - (SplashScreenPaddingY * 2)
+		remainingHeight := s.height - lipgloss.Height(s.logoRendered) - SplashScreenPaddingY
 		apiKeyView := t.S().Base.PaddingLeft(1).Render(s.apiKeyInput.View())
 		apiKeySelector := t.S().Base.AlignVertical(lipgloss.Bottom).Height(remainingHeight).Render(
 			lipgloss.JoinVertical(
@@ -733,7 +733,7 @@ func (s *splashCmp) View() string {
 		)
 	case s.isOnboarding:
 		modelListView := s.modelList.View()
-		remainingHeight := s.height - lipgloss.Height(s.logoRendered) - (SplashScreenPaddingY * 2)
+		remainingHeight := s.height - lipgloss.Height(s.logoRendered) - SplashScreenPaddingY
 		modelSelector := t.S().Base.AlignVertical(lipgloss.Bottom).Height(remainingHeight).Render(
 			lipgloss.JoinVertical(
 				lipgloss.Left,


### PR DESCRIPTION
<img width="2064" height="2046" alt="CleanShot 2025-12-19 at 09 33 26@2x" src="https://github.com/user-attachments/assets/b72ca00e-a16a-4ebf-be37-2106c203472f" />
<img width="1162" height="696" alt="CleanShot 2025-12-19 at 09 33 05@2x" src="https://github.com/user-attachments/assets/9bd7c8fc-cf01-492b-8934-76f1a0b35e39" />
<img width="926" height="442" alt="CleanShot 2025-12-19 at 09 32 49@2x" src="https://github.com/user-attachments/assets/f83e8fad-2c32-4540-a316-6af7a62b8243" />
<img width="1102" height="734" alt="CleanShot 2025-12-19 at 09 32 43@2x" src="https://github.com/user-attachments/assets/26d2b3f5-a895-483d-b9af-1fb8b34a8cdc" />


per @meowgorithm request, and also made it consistent.