### PR TITLE
feat: add use_bearer_auth flag for OAuth-style authentication

### DIFF
--- a/internal/agent/bearer_auth_test.go
+++ b/internal/agent/bearer_auth_test.go
@@ -1,0 +1,185 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildAnthropicProvider_UseBearerAuth(t *testing.T) {
+	t.Run("uses Bearer auth when use_bearer_auth is true", func(t *testing.T) {
+		// Create a test HTTP server
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"models": []}`))
+		}))
+		defer server.Close()
+
+		cfg := &config.Config{
+			Providers: csync.NewMap[string, config.ProviderConfig](),
+			Models: map[config.SelectedModelType]config.SelectedModel{
+				config.SelectedModelTypeLarge: {
+					Model:    "claude-sonnet-4-5-20250929",
+					Provider: "anthropic",
+				},
+			},
+			Options: &config.Options{},
+		}
+
+		providerCfg := config.ProviderConfig{
+			ID:            "anthropic",
+			Name:          "Anthropic",
+			Type:          catwalk.TypeAnthropic,
+			BaseURL:       server.URL,
+			APIKey:        "test-api-key",
+			UseBearerAuth: true,
+			ExtraHeaders:  make(map[string]string),
+		}
+		cfg.Providers.Set("anthropic", providerCfg)
+
+		c := &coordinator{
+			cfg: cfg,
+		}
+
+		modelCfg := config.SelectedModel{
+			Model:    "claude-sonnet-4-5-20250929",
+			Provider: "anthropic",
+		}
+
+		_, err := c.buildProvider(providerCfg, modelCfg)
+		require.NoError(t, err)
+
+		// Note: We can't directly verify the headers without making an actual API call,
+		// but we can verify the configuration was set up correctly
+		require.True(t, providerCfg.UseBearerAuth, "UseBearerAuth should be true")
+		require.Nil(t, providerCfg.OAuthToken, "OAuthToken should be nil when using bearer auth flag")
+	})
+
+	t.Run("includes oauth beta header when use_bearer_auth is true", func(t *testing.T) {
+		cfg := &config.Config{
+			Providers: csync.NewMap[string, config.ProviderConfig](),
+			Options:   &config.Options{},
+		}
+
+		providerCfg := config.ProviderConfig{
+			ID:            "anthropic",
+			Name:          "Anthropic",
+			Type:          catwalk.TypeAnthropic,
+			APIKey:        "test-api-key",
+			UseBearerAuth: true,
+			ExtraHeaders:  make(map[string]string),
+		}
+
+		c := &coordinator{
+			cfg: cfg,
+		}
+
+		modelCfg := config.SelectedModel{
+			Model:    "claude-sonnet-4-5-20250929",
+			Provider: "anthropic",
+		}
+
+		// The buildProvider method should add the oauth beta header when UseBearerAuth is true
+		_, err := c.buildProvider(providerCfg, modelCfg)
+		require.NoError(t, err)
+	})
+
+	t.Run("does not use Bearer auth when use_bearer_auth is false", func(t *testing.T) {
+		cfg := &config.Config{
+			Providers: csync.NewMap[string, config.ProviderConfig](),
+			Options:   &config.Options{},
+		}
+
+		providerCfg := config.ProviderConfig{
+			ID:            "anthropic",
+			Name:          "Anthropic",
+			Type:          catwalk.TypeAnthropic,
+			APIKey:        "test-api-key",
+			UseBearerAuth: false,
+			ExtraHeaders:  make(map[string]string),
+		}
+
+		c := &coordinator{
+			cfg: cfg,
+		}
+
+		modelCfg := config.SelectedModel{
+			Model:    "claude-sonnet-4-5-20250929",
+			Provider: "anthropic",
+		}
+
+		_, err := c.buildProvider(providerCfg, modelCfg)
+		require.NoError(t, err)
+
+		require.False(t, providerCfg.UseBearerAuth, "UseBearerAuth should be false")
+	})
+}
+
+func TestBuildProvider_OAuthBetaHeader(t *testing.T) {
+	t.Run("adds oauth beta header when use_bearer_auth is true", func(t *testing.T) {
+		cfg := &config.Config{
+			Providers: csync.NewMap[string, config.ProviderConfig](),
+			Options:   &config.Options{},
+		}
+
+		providerCfg := config.ProviderConfig{
+			ID:            "anthropic",
+			Name:          "Anthropic",
+			Type:          catwalk.TypeAnthropic,
+			APIKey:        "test-api-key",
+			UseBearerAuth: true,
+			ExtraHeaders:  make(map[string]string),
+		}
+
+		c := &coordinator{
+			cfg: cfg,
+		}
+
+		modelCfg := config.SelectedModel{
+			Model:    "claude-sonnet-4-5-20250929",
+			Provider: "anthropic",
+		}
+
+		ctx := context.Background()
+		_ = ctx
+
+		// Build the provider - this should set up headers internally
+		_, err := c.buildProvider(providerCfg, modelCfg)
+		require.NoError(t, err)
+	})
+
+	t.Run("merges oauth beta header with thinking header when both are needed", func(t *testing.T) {
+		cfg := &config.Config{
+			Providers: csync.NewMap[string, config.ProviderConfig](),
+			Options:   &config.Options{},
+		}
+
+		providerCfg := config.ProviderConfig{
+			ID:            "anthropic",
+			Name:          "Anthropic",
+			Type:          catwalk.TypeAnthropic,
+			APIKey:        "test-api-key",
+			UseBearerAuth: true,
+			ExtraHeaders:  make(map[string]string),
+		}
+
+		c := &coordinator{
+			cfg: cfg,
+		}
+
+		modelCfg := config.SelectedModel{
+			Model:    "claude-sonnet-4-5-20250929",
+			Provider: "anthropic",
+			Think:    true, // Enable thinking mode
+		}
+
+		_, err := c.buildProvider(providerCfg, modelCfg)
+		require.NoError(t, err)
+	})
+}

--- a/internal/config/bearer_auth_test.go
+++ b/internal/config/bearer_auth_test.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/catwalk/pkg/catwalk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderConfig_UseBearerAuth(t *testing.T) {
+	t.Run("bearer auth flag is false by default", func(t *testing.T) {
+		cfg := ProviderConfig{}
+		require.False(t, cfg.UseBearerAuth)
+	})
+
+	t.Run("bearer auth flag can be set to true", func(t *testing.T) {
+		cfg := ProviderConfig{
+			UseBearerAuth: true,
+		}
+		require.True(t, cfg.UseBearerAuth)
+	})
+}
+
+func TestProviderConfig_TestConnection_BearerAuth(t *testing.T) {
+	t.Run("uses X-Api-Key header when bearer auth is disabled", func(t *testing.T) {
+		// This test verifies the header logic by checking what headers would be set
+		// We can't easily test the actual HTTP call without mocking, but we can verify
+		// the configuration is correct
+		cfg := ProviderConfig{
+			ID:            "anthropic",
+			Type:          catwalk.TypeAnthropic,
+			APIKey:        "test-key",
+			UseBearerAuth: false,
+			ExtraHeaders:  make(map[string]string),
+		}
+		require.False(t, cfg.UseBearerAuth)
+		require.Nil(t, cfg.OAuthToken)
+	})
+
+	t.Run("uses Bearer token when bearer auth is enabled", func(t *testing.T) {
+		cfg := ProviderConfig{
+			ID:            "anthropic",
+			Type:          catwalk.TypeAnthropic,
+			APIKey:        "test-key",
+			UseBearerAuth: true,
+			ExtraHeaders:  make(map[string]string),
+		}
+		require.True(t, cfg.UseBearerAuth)
+		require.Nil(t, cfg.OAuthToken)
+	})
+}

--- a/schema.json
+++ b/schema.json
@@ -499,6 +499,11 @@
           "$ref": "#/$defs/Token",
           "description": "OAuth2 token for authentication with the provider"
         },
+        "use_bearer_auth": {
+          "type": "boolean",
+          "description": "Use Bearer token authentication with Authorization header instead of provider-specific authentication headers",
+          "default": false
+        },
         "disable": {
           "type": "boolean",
           "description": "Whether this provider is disabled",


### PR DESCRIPTION
## Summary
This PR adds a new `use_bearer_auth` configuration flag that enables OAuth-style Bearer token authentication for normal API keys.

## Changes
- Added `UseBearerAuth` boolean field to `ProviderConfig` struct
- Updated JSON schema with the new field
- Modified provider building logic to use Bearer authentication when flag is enabled
- Updated `TestConnection` to respect the flag
- Automatically adds the `anthropic-beta: oauth-2025-04-20` header when using Bearer auth with Anthropic

## Usage
When enabled for Anthropic providers, the API key will be sent using the `Authorization: Bearer` header instead of the `X-Api-Key` header, along with the required OAuth beta header.

```json
{
  "providers": {
    "anthropic": {
      "api_key": "$ANTHROPIC_API_KEY",
      "use_bearer_auth": true
    }
  }
}
```

This is useful for API keys that require OAuth-style authentication without going through the full OAuth flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)