### PR TITLE
fix(tui): guard model selection when list is empty

### DIFF
--- a/internal/tui/components/dialogs/models/models.go
+++ b/internal/tui/components/dialogs/models/models.go
@@ -199,6 +199,9 @@ func (m *modelDialogCmp) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 				return m, m.copilotDeviceFlow.CopyCodeAndOpenURL()
 			}
 			selectedItem := m.modelList.SelectedModel()
+			if selectedItem == nil {
+				return m, nil
+			}
 
 			modelType := config.SelectedModelTypeLarge
 			if m.modelList.GetModelType() == SmallModelType {


### PR DESCRIPTION
**Problem**
Crush panics when hitting `enter` with an empty models list in the "Switch Model" dialog.

eg:
<img width="558" height="202" alt="image" src="https://github.com/user-attachments/assets/c0a80b21-1ef4-4c09-abda-b3cd666a908d" />

<details>
<summary>panic stack trace</summary>

```
Caught panic:

runtime error: invalid memory address or nil pointer dereference

Restoring terminal...

goroutine 1 [running]:
runtime/debug.Stack()
	/home/jt/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.linux-amd64/src/runtime/debug/stack.go:26 +0x5e
charm.land/bubbletea/v2.(*Program).recoverFromPanic(0xc0012401e0, {0x1d2ac60, 0x3b2b090})
	/home/jt/go/pkg/mod/charm.land/bubbletea/v2@v2.0.0-rc.2.0.20251216153312-819e2e89c62e/tea.go:1235 +0x152
charm.land/bubbletea/v2.(*Program).Run.func2()
	/home/jt/go/pkg/mod/charm.land/bubbletea/v2@v2.0.0-rc.2.0.20251216153312-819e2e89c62e/tea.go:996 +0xe6
panic({0x1d2ac60?, 0x3b2b090?})
	/home/jt/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.25.5.linux-amd64/src/runtime/panic.go:783 +0x132
github.com/charmbracelet/crush/internal/tui/components/dialogs/models.(*modelDialogCmp).Update(0xc000829508, {0x2019100?, 0xc001118d80?})
	/home/jt/projects/crush/internal/tui/components/dialogs/models/models.go:283 +0x14c3
github.com/charmbracelet/crush/internal/tui/components/dialogs.dialogCmp.Update({0x17b, 0x42, {0xc000041f30, 0x1, 0x1}, 0xc001219170, {{{0xc0003d96a0, 0x2, 0x2}, {{...}, ...}, ...}}}, ...)
	/home/jt/projects/crush/internal/tui/components/dialogs/dialogs.go:94 +0x267
github.com/charmbracelet/crush/internal/tui.(*appModel).handleKeyPressMsg(0xc001266a08, {{0x0, 0x0}, 0x0, 0xd, 0x0, 0x0, 0x0})
	/home/jt/projects/crush/internal/tui/tui.go:488 +0x812
github.com/charmbracelet/crush/internal/tui.(*appModel).Update(0xc001266a08, {0x2019100, 0xc001118cf0})
	/home/jt/projects/crush/internal/tui/tui.go:348 +0x6dd
charm.land/bubbletea/v2.(*Program).eventLoop(0xc0012401e0, {0x2898b28?, 0xc001266a08?}, 0xc001228d20)
	/home/jt/go/pkg/mod/charm.land/bubbletea/v2@v2.0.0-rc.2.0.20251216153312-819e2e89c62e/tea.go:845 +0x13f1
charm.land/bubbletea/v2.(*Program).Run(0xc0012401e0)
	/home/jt/go/pkg/mod/charm.land/bubbletea/v2@v2.0.0-rc.2.0.20251216153312-819e2e89c62e/tea.go:1100 +0xb10
github.com/charmbracelet/crush/internal/cmd.init.func7(0x3b58360, {0x2120f44?, 0x7?, 0x2119912?})
	/home/jt/projects/crush/internal/cmd/root.go:101 +0x227
github.com/spf13/cobra.(*Command).execute(0x3b58360, {0xc000134030, 0x0, 0x0})
	/home/jt/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015 +0xb02
github.com/spf13/cobra.(*Command).ExecuteC(0x3b58360)
	/home/jt/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148 +0x465
github.com/spf13/cobra.(*Command).Execute(...)
	/home/jt/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/home/jt/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1064
github.com/charmbracelet/fang.Execute({0x28a3390, 0x3bc4d80}, 0x3b58360, {0xc0005d9f08, 0x2, 0x219bc8d?})
	/home/jt/go/pkg/mod/github.com/charmbracelet/fang@v0.4.4/fang.go:173 +0x392
github.com/charmbracelet/crush/internal/cmd.Execute()
	/home/jt/projects/crush/internal/cmd/root.go:146 +0x3c5
main.main()
	/home/jt/projects/crush/main.go:23 +0x36


   ERROR

  Crush crashed. If metrics are enabled, we were notified about it. If you'd like to report it, please copy the
  stacktrace above and open an issue at https://github.com/charmbracelet/crush/issues/new?template=bug.yml.

exit status 1

```

</details>

**Solution**
Guard against `nil` selection. No-op I think is reasonable behavior.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
