### PR TITLE
fix: completion menu flickering with multi-byte character input

### DIFF
--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -31,6 +31,7 @@ import (
 	"github.com/charmbracelet/crush/internal/tui/styles"
 	"github.com/charmbracelet/crush/internal/tui/util"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/rivo/uniseg"
 )
 
 type Editor interface {
@@ -66,9 +67,10 @@ type editorCmp struct {
 	keyMap EditorKeyMap
 
 	// File path completions
-	currentQuery          string
-	completionsStartIndex int
-	isCompletionsOpen     bool
+	currentQuery              string
+	completionsStartIndex     int // Display width for curIdx comparison
+	completionsStartByteIndex int // Byte index for string slicing
+	isCompletionsOpen         bool
 }
 
 var DeleteKeyMaps = DeleteAttachmentKeyMaps{
@@ -191,9 +193,9 @@ func (m *editorCmp) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 			word := m.textarea.Word()
 			// If the selected item is a file, insert its path into the textarea
 			value := m.textarea.Value()
-			value = value[:m.completionsStartIndex] + // Remove the current query
+			value = value[:m.completionsStartByteIndex] + // Remove the current query
 				item.Path + // Insert the file path
-				value[m.completionsStartIndex+len(word):] // Append the rest of the value
+				value[m.completionsStartByteIndex+len(word):] // Append the rest of the value
 			// XXX: This will always move the cursor to the end of the textarea.
 			m.textarea.SetValue(value)
 			m.textarea.MoveToEnd()
@@ -201,6 +203,7 @@ func (m *editorCmp) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 				m.isCompletionsOpen = false
 				m.currentQuery = ""
 				m.completionsStartIndex = 0
+				m.completionsStartByteIndex = 0
 			}
 			content, err := os.ReadFile(item.Path)
 			if err != nil {
@@ -270,6 +273,7 @@ func (m *editorCmp) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 			m.isCompletionsOpen = true
 			m.currentQuery = ""
 			m.completionsStartIndex = curIdx
+			m.completionsStartByteIndex = curIdx // Initially same when no multi-byte chars before
 			cmds = append(cmds, m.startCompletions)
 		case m.isCompletionsOpen && curIdx <= m.completionsStartIndex:
 			cmds = append(cmds, util.CmdHandler(completions.CloseCompletionsMsg{}))
@@ -338,7 +342,17 @@ func (m *editorCmp) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 				word := m.textarea.Word()
 				if strings.HasPrefix(word, "@") {
 					// XXX: wont' work if editing in the middle of the field.
-					m.completionsStartIndex = strings.LastIndex(m.textarea.Value(), word)
+					// Calculate the index of the word by computing the display width
+					// of the text before the word.
+					fullText := m.textarea.Value()
+					wordByteIdx := strings.LastIndex(fullText, word)
+					// Use display width instead of byte index to handle multi-byte
+					// characters like Chinese correctly.
+					m.completionsStartIndex = uniseg.StringWidth(fullText[:wordByteIdx])
+					// Store byte index for string slicing operations.
+					m.completionsStartByteIndex = wordByteIdx
+					// Calculate display width for curIdx comparison to handle
+					// multi-byte characters like Chinese correctly.
 					m.currentQuery = word[1:]
 					x, y := m.completionsPosition()
 					x -= len(m.currentQuery)


### PR DESCRIPTION
Problem: When input box contains Chinese characters, typing '@' to trigger completion menu causes periodic flickering where menu appears and disappears repeatedly as user types.

Root cause: Mixed use of byte indices (strings.LastIndex) and display width calculations (curIdx) for cursor position comparisons. Chinese characters are multi-byte in UTF-8, causing byte index ≠ display width, leading to incorrect cursor boundary detection.

Solution: Separate concerns by maintaining both byte index and display width:
- completionsStartIndex: display width for curIdx comparison
- completionsStartByteIndex: byte index for string slicing operations

This ensures proper handling of multi-byte characters while maintaining correct string replacement functionality during completion selection.

Fixes completion menu behavior for input like: 啊啊啊啊啊 @m

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

---

## Steps to Reproduce the Completion Menu Flickering Bug

### Bug Description
When the input box contains multi-byte characters (such as Chinese characters), typing '@' to trigger the file completion menu causes periodic flickering where the menu repeatedly appears and disappears as the user continues typing.

### Reproduction Steps

1. **Launch the Crush Application**
   ```bash
   ./crush
   ```

2. **Input Multi-byte Characters**
   - Type some Chinese characters or other multi-byte Unicode text in the input box
   - For example: `啊啊啊啊啊 ` (multiple Chinese characters)
   - Ensure the cursor is positioned after the Chinese text

3. **Trigger File Completion Menu**
   - Press the '@' key to trigger file completion functionality
   - For example, type: `啊啊啊啊啊 @m`

4. **Observe the Bug**
   - **Expected Behavior**: The completion menu should display stably
   - **Bug Behavior**: The completion menu flickers, repeatedly opening and closing
   - **Triggers**: The longer the multi-byte text, the more pronounced the flickering becomes

### Specific Test Case

**Input Sequence Test**:
```
Type: 啊啊啊啊啊 @
Then try typing: m
```

**Expected Results**:
- ✅ **After Fix**: Completion menu displays stably, typing 'm' normally filters the file list
- ❌ **Bug Behavior**: Menu flickers continuously, opening and closing frequently

### Technical Details

**Root Cause**:
- The code mixed byte indices with display width calculations
- For multi-byte characters: byte count ≠ display width
- This leads to incorrect cursor boundary detection, causing the completion menu to frequently trigger opening/closing logic

**Affected Scenarios**:
- All inputs containing multi-byte characters
- Chinese, Japanese, Korean, and other Unicode characters
- The longer the character sequence, the more obvious the impact

### Environment Requirements
- System needs to have multi-byte character support
- Test directory should contain some files to demonstrate the completion functionality

This bug particularly affects Chinese users since this issue is very common in Chinese input scenarios.
