### PR TITLE
feat: add command substitution support to extra_headers

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"maps"
 	"net/http"
 	"os"
 	"slices"
@@ -706,9 +705,10 @@ func (c *coordinator) isAnthropicThinking(model config.SelectedModel) bool {
 }
 
 func (c *coordinator) buildProvider(providerCfg config.ProviderConfig, model config.SelectedModel) (fantasy.Provider, error) {
-	headers := maps.Clone(providerCfg.ExtraHeaders)
-	if headers == nil {
-		headers = make(map[string]string)
+	headers := make(map[string]string)
+	for k, v := range providerCfg.ExtraHeaders {
+		resolvedValue, _ := c.cfg.Resolve(v)
+		headers[k] = resolvedValue
 	}
 
 	// handle special headers for anthropic

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -807,7 +807,8 @@ func (c *ProviderConfig) TestConnection(resolver VariableResolver) error {
 		req.Header.Set(k, v)
 	}
 	for k, v := range c.ExtraHeaders {
-		req.Header.Set(k, v)
+		resolvedValue, _ := resolver.ResolveValue(v)
+		req.Header.Set(k, resolvedValue)
 	}
 	b, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Resolves #1747 by adding $(command) resolution to provider extra_headers:
- coordinator.go: resolve extra_headers values through c.cfg.Resolve()
- config.go: resolve extra_headers in TestConnection method

This enables dynamic token generation for LiteLLM proxy and OAuth2/JWT scenarios.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
