### PR TITLE
Revert "fix: prevent filename insertion when dragging attachments"

### DIFF
--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -247,6 +247,7 @@ func (m *editorCmp) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 		if !attachment.IsText() && !attachment.IsImage() {
 			return m, util.ReportWarn("Invalid file content type: " + mimeType)
 		}
+		m.textarea.InsertString(attachment.FileName)
 		return m, util.CmdHandler(filepicker.FilePickedMsg{
 			Attachment: attachment,
 		})


### PR DESCRIPTION
Reverts charmbracelet/crush#1683.

Per @BrunoKrugel’s acute note in #1772, we're reverting this so that LLM has the full paths it needs for context.