### PR TITLE
feat(init): elicit control/data flow, arch descs

### DIFF
--- a/internal/agent/templates/initialize.md.tpl
+++ b/internal/agent/templates/initialize.md.tpl
@@ -2,7 +2,7 @@ Analyze this codebase and create/update **{{.Config.Options.InitializeAs}}** to 
 
 **First**: Check if directory is empty or contains only config files. If so, stop and say "Directory appears empty or only contains config. Add source code first, then run this command to generate {{.Config.Options.InitializeAs}}."
 
-**Goal**: Document what an agent needs to know to work in this codebase - commands, patterns, conventions, gotchas.
+**Goal**: Document what an agent needs to know to work in this codebase - commands, patterns, conventions, gotchas, overall architecture, how components fit together
 
 **Discovery process**:
 
@@ -10,13 +10,13 @@ Analyze this codebase and create/update **{{.Config.Options.InitializeAs}}** to 
 2. Look for existing rule files (`.cursor/rules/*.md`, `.cursorrules`, `.github/copilot-instructions.md`, `claude.md`, `agents.md`) - only read if they exist
 3. Identify project type from config files and directory structure
 4. Find build/test/lint commands from config files, scripts, Makefiles, or CI configs
-5. Read representative source files to understand code patterns
+5. Read representative source files to understand code patterns, architecture, control/data flow
 6. If {{.Config.Options.InitializeAs}} exists, read and improve it
 
 **Content to include**:
 
 - Essential commands (build, test, run, deploy, etc.) - whatever is relevant for this project
-- Code organization and structure
+- Code organization and structure, application architecture and control/data flow
 - Naming conventions and style patterns
 - Testing approach and patterns
 - Important gotchas or non-obvious patterns


### PR DESCRIPTION
I find the current init prompt results in AGENTS.md files that are a little light on these particular details. I've been using this with all the repos I've used Crush in that didn't already have an AGENTS.md (very many) since August and quite like it.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
