### PR TITLE
feat: add multi-credential support for providers

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -715,7 +715,6 @@ func (c *coordinator) buildProvider(providerCfg config.ProviderConfig, model con
 		headers = make(map[string]string)
 	}
 
-	// handle special headers for anthropic
 	if providerCfg.Type == anthropic.Name && c.isAnthropicThinking(model) {
 		if v, ok := headers["anthropic-beta"]; ok {
 			headers["anthropic-beta"] = v + ",interleaved-thinking-2025-05-14"
@@ -724,7 +723,10 @@ func (c *coordinator) buildProvider(providerCfg config.ProviderConfig, model con
 		}
 	}
 
-	apiKey, _ := c.cfg.Resolve(providerCfg.APIKey)
+	apiKey, oauthToken, _ := providerCfg.ResolveCredential(model.Credential, c.cfg.Resolver())
+	if oauthToken != nil {
+		apiKey = oauthToken.AccessToken
+	}
 	baseURL, _ := c.cfg.Resolve(providerCfg.BaseURL)
 
 	switch providerCfg.Type {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -192,6 +192,7 @@ func (pc *ProviderConfig) ResolveCredential(credentialName string, resolver Vari
 					return "", cred.OAuthToken, nil
 				}
 				resolved, _ := resolver.ResolveValue(cred.APIKey)
+				pc.APIKeyTemplate = cred.APIKey // Store template for re-resolution on 401
 				return resolved, nil, nil
 			}
 		}
@@ -204,11 +205,13 @@ func (pc *ProviderConfig) ResolveCredential(credentialName string, resolver Vari
 				return "", cred.OAuthToken, nil
 			}
 			resolved, _ := resolver.ResolveValue(cred.APIKey)
+			pc.APIKeyTemplate = cred.APIKey // Store template for re-resolution on 401
 			return resolved, nil, nil
 		}
 	}
 
 	resolved, _ := resolver.ResolveValue(pc.APIKey)
+	pc.APIKeyTemplate = pc.APIKey // Store template for re-resolution on 401
 	return resolved, pc.OAuthToken, nil
 }
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -261,6 +261,7 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 				continue
 			}
 		}
+		prepared.MigrateCredentials()
 		c.Providers.Set(string(p.ID), prepared)
 	}
 
@@ -314,6 +315,7 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 			continue
 		}
 
+		providerConfig.MigrateCredentials()
 		c.Providers.Set(id, providerConfig)
 	}
 	return nil

--- a/internal/tui/components/dialogs/models/credential.go
+++ b/internal/tui/components/dialogs/models/credential.go
@@ -1,0 +1,135 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/tui/styles"
+	"github.com/charmbracelet/crush/internal/tui/util"
+)
+
+type CredentialSelectedMsg struct {
+	Credential string
+}
+
+type CredentialOption struct {
+	Name        string
+	IsDefault   bool
+	DisplayName string
+}
+
+type CredentialSelector struct {
+	width             int
+	height            int
+	credentials       []CredentialOption
+	selectedIndex     int
+	providerID        string
+	providerName      string
+	selectedModel     *ModelOption
+	selectedModelType config.SelectedModelType
+}
+
+func NewCredentialSelector(providerID, providerName string, credentials []config.ProviderCredential, selectedModel *ModelOption, modelType config.SelectedModelType) *CredentialSelector {
+	opts := make([]CredentialOption, len(credentials))
+	for i, cred := range credentials {
+		displayName := cred.Name
+		if cred.Default {
+			displayName += " (default)"
+		}
+		opts[i] = CredentialOption{
+			Name:        cred.Name,
+			IsDefault:   cred.Default,
+			DisplayName: displayName,
+		}
+	}
+
+	return &CredentialSelector{
+		credentials:       opts,
+		selectedIndex:     0,
+		providerID:        providerID,
+		providerName:      providerName,
+		selectedModel:     selectedModel,
+		selectedModelType: modelType,
+	}
+}
+
+func (c *CredentialSelector) Init() tea.Cmd {
+	return nil
+}
+
+func (c *CredentialSelector) Update(msg tea.Msg) (util.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter", " ", "k":
+			if c.selectedIndex >= 0 && c.selectedIndex < len(c.credentials) {
+				return c, util.CmdHandler(CredentialSelectedMsg{
+					Credential: c.credentials[c.selectedIndex].Name,
+				})
+			}
+		case "up", "ctrl+p":
+			if c.selectedIndex > 0 {
+				c.selectedIndex--
+			}
+		case "down", "ctrl+n":
+			if c.selectedIndex < len(c.credentials)-1 {
+				c.selectedIndex++
+			}
+		case "esc", "q":
+			return c, util.CmdHandler(CloseModelDialogMsg{})
+		}
+	}
+	return c, nil
+}
+
+func (c *CredentialSelector) SetSize(width, height int) tea.Cmd {
+	c.width = width
+	c.height = height
+	return nil
+}
+
+func (c *CredentialSelector) View() string {
+	if c.width == 0 {
+		c.width = 50
+	}
+	if c.height == 0 {
+		c.height = 20
+	}
+
+	t := styles.CurrentTheme()
+	titleStyle := t.S().Title.PaddingLeft(1).Width(c.width - 2)
+	headerStyle := t.S().Base.MarginLeft(1).Width(c.width - 4)
+	itemStyle := t.S().Base.PaddingLeft(1).Width(c.width - 4)
+	selectedStyle := t.S().TextSelected.PaddingLeft(1).Width(c.width - 4)
+
+	var content strings.Builder
+
+	content.WriteString(titleStyle.Render(fmt.Sprintf("Select Credential for %s", c.providerName)))
+	content.WriteString("\n\n")
+	content.WriteString(headerStyle.Render("Choose which credential to use:"))
+	content.WriteString("\n\n")
+
+	for i, cred := range c.credentials {
+		if i == c.selectedIndex {
+			content.WriteString(selectedStyle.Render(fmt.Sprintf("• %s", cred.DisplayName)))
+		} else {
+			content.WriteString(itemStyle.Render(fmt.Sprintf("  %s", cred.DisplayName)))
+		}
+		content.WriteString("\n")
+	}
+
+	helpStyle := t.S().Subtle.MarginTop(1).PaddingLeft(1)
+	content.WriteString("\n")
+	content.WriteString(helpStyle.Render("↑↓: Navigate • Enter: Select • Esc: Cancel"))
+
+	return t.S().Base.Render(content.String())
+}
+
+func (c *CredentialSelector) SelectedCredential() string {
+	if c.selectedIndex >= 0 && c.selectedIndex < len(c.credentials) {
+		return c.credentials[c.selectedIndex].Name
+	}
+	return ""
+}

--- a/schema.json
+++ b/schema.json
@@ -462,6 +462,39 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "ProviderCredential": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique identifier for this credential",
+          "examples": [
+            "work"
+          ]
+        },
+        "api_key": {
+          "type": "string",
+          "description": "API key for this credential",
+          "examples": [
+            "$OPENAI_API_KEY"
+          ]
+        },
+        "oauth": {
+          "$ref": "#/$defs/Token",
+          "description": "OAuth2 token for this credential"
+        },
+        "default": {
+          "type": "boolean",
+          "description": "Whether this is the default credential for the provider",
+          "default": false
+        },
+        "created_at": {
+          "type": "integer",
+          "description": "Unix timestamp when this credential was created"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "ProviderConfig": {
       "properties": {
         "id": {
@@ -498,6 +531,13 @@
           ],
           "description": "Provider type that determines the API format",
           "default": "openai"
+        },
+        "credentials": {
+          "items": {
+            "$ref": "#/$defs/ProviderCredential"
+          },
+          "type": "array",
+          "description": "Multiple credentials for this provider"
         },
         "api_key": {
           "type": "string",
@@ -559,6 +599,13 @@
           "description": "The model provider ID that matches a key in the providers config",
           "examples": [
             "openai"
+          ]
+        },
+        "credential": {
+          "type": "string",
+          "description": "Credential name to use for this provider",
+          "examples": [
+            "work"
           ]
         },
         "reasoning_effort": {


### PR DESCRIPTION
Users can now optionally name credentials during API key entry (e.g., "work", "personal"). Press Tab to switch between API key and credential name fields. The default name is "default" if left blank.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
