### PR TITLE
feat: add seed prompt support for interactive mode

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -60,6 +60,10 @@ type App struct {
 	// global context and cleanup functions
 	globalCtx    context.Context
 	cleanupFuncs []func() error
+
+	// initialPrompt stores the seeded prompt for interactive mode.
+	// When set, the TUI will automatically send this prompt upon initialization.
+	initialPrompt string
 }
 
 // New initializes a new application instance.
@@ -120,6 +124,27 @@ func New(ctx context.Context, conn *sql.DB, cfg *config.Config) (*App, error) {
 // Config returns the application configuration.
 func (app *App) Config() *config.Config {
 	return app.config
+}
+
+// SetInitialPrompt sets the initial prompt for the interactive session.
+// When set, the TUI will automatically send this prompt upon initialization.
+func (app *App) SetInitialPrompt(prompt string) {
+	app.initialPrompt = prompt
+}
+
+// InitialPrompt returns the initial prompt for the interactive session.
+func (app *App) InitialPrompt() string {
+	return app.initialPrompt
+}
+
+// HasInitialPrompt returns true if an initial prompt has been set.
+func (app *App) HasInitialPrompt() bool {
+	return app.initialPrompt != ""
+}
+
+// ClearInitialPrompt clears the initial prompt after it has been used.
+func (app *App) ClearInitialPrompt() {
+	app.initialPrompt = ""
 }
 
 // RunNonInteractive runs the application in non-interactive mode with the


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
         related link:  https://github.com/charmbracelet/crush/issues/1791 

Assisted by: Claude Opus 4.5 via Crush
 
 ### Changes

- internal/cmd/root.go: Added -p/--prompt and -P/--prompt-file flags. Updated the Use string to accept positional arguments (crush "message"). Implemented collectInitialPrompt() to gather input with the following priority: -P > -p > Positional Arguments > Stdin.

- internal/app/app.go: Added initialPrompt field along with its getter and setter methods.

- internal/tui/tui.go: Defined a new InitialPromptMsg type. Added logic in Init() and Update() to automatically send the initial prompt to the chat page upon TUI startup.

### Notes on TUI Changes The modifications to the TUI are minimal and strictly limited to Init() and Update() methods for message passing. I have avoided touching any UI rendering logic to ensure this PR does not conflict with the ongoing UI refactoring.

### Verification

Environment: Tested and verified on Windows.

Functional: -p, -P, positional arguments, and piped stdin are all working as expected.

Unverified: I haven't tested shell redirection operators (< and <<<) as I don't have access to a macOS/Linux environment. Since this relies on the existing MaybePrependStdin() function, they should theoretically work, but I would appreciate a quick verification from the maintainers on those platforms.