### PR TITLE
fix: paste large file paths as text instead of showing error

### DIFF
--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -662,6 +662,13 @@ func filepathToFile(name string) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return nil, "", err
+	}
+	if fileInfo.Size() > int64(maxAttachmentSize) {
+		return nil, "", errNotAFile
+	}
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
- [*] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).


Fixes #1798

**Problem:**
`filepathToFile()` treats any pasted text that resolves to a valid file path as a file attachment, even when the user just wants to paste the path as text. For files larger than 5MB, this results in an error instead of gracefully falling back to pasting the path as text.

**Fix:**
Added a file size check using `os.Stat()` before reading the file content. If the file exceeds `maxAttachmentSize` (5MB), return `errNotAFile` so the path is pasted as plain text instead of showing an error.

**Steps to reproduce (before fix):**
1. Copy a file path like `/path/to/file.xyz` (where file is >5MB)
2. Paste into crush prompt with ctrl+shift+v
3. Get error "Warning File is too big (>5mb)"

**After fix:**
Path is pasted as text.
