### PR TITLE
feat: allow session switching while agent is active

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -72,6 +72,7 @@ type SessionAgent interface {
 	CancelAll()
 	IsSessionBusy(sessionID string) bool
 	IsBusy() bool
+	BusySessionIDs() []string
 	QueuedPrompts(sessionID string) int
 	QueuedPromptsList(sessionID string) []string
 	ClearQueue(sessionID string)
@@ -941,6 +942,16 @@ func (a *sessionAgent) IsBusy() bool {
 func (a *sessionAgent) IsSessionBusy(sessionID string) bool {
 	_, busy := a.activeRequests.Get(sessionID)
 	return busy
+}
+
+func (a *sessionAgent) BusySessionIDs() []string {
+	var ids []string
+	for sessionID, cancelFunc := range a.activeRequests.Seq2() {
+		if cancelFunc != nil {
+			ids = append(ids, sessionID)
+		}
+	}
+	return ids
 }
 
 func (a *sessionAgent) QueuedPrompts(sessionID string) int {

--- a/internal/agent/busy_sessions_test.go
+++ b/internal/agent/busy_sessions_test.go
@@ -1,0 +1,175 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBusySessionIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty slice when no sessions are active", func(t *testing.T) {
+		t.Parallel()
+		agent := &sessionAgent{
+			activeRequests: csync.NewMap[string, context.CancelFunc](),
+			messageQueue:   csync.NewMap[string, []SessionAgentCall](),
+		}
+
+		ids := agent.BusySessionIDs()
+		assert.Empty(t, ids)
+	})
+
+	t.Run("returns session IDs with active requests", func(t *testing.T) {
+		t.Parallel()
+		agent := &sessionAgent{
+			activeRequests: csync.NewMap[string, context.CancelFunc](),
+			messageQueue:   csync.NewMap[string, []SessionAgentCall](),
+		}
+
+		// Simulate active sessions
+		_, cancel1 := context.WithCancel(context.Background())
+		_, cancel2 := context.WithCancel(context.Background())
+		agent.activeRequests.Set("session-1", cancel1)
+		agent.activeRequests.Set("session-2", cancel2)
+
+		ids := agent.BusySessionIDs()
+		assert.Len(t, ids, 2)
+		assert.Contains(t, ids, "session-1")
+		assert.Contains(t, ids, "session-2")
+
+		// Cleanup
+		cancel1()
+		cancel2()
+	})
+
+	t.Run("does not include sessions with nil cancel func", func(t *testing.T) {
+		t.Parallel()
+		agent := &sessionAgent{
+			activeRequests: csync.NewMap[string, context.CancelFunc](),
+			messageQueue:   csync.NewMap[string, []SessionAgentCall](),
+		}
+
+		// Add one active and one with nil cancel
+		_, cancel1 := context.WithCancel(context.Background())
+		agent.activeRequests.Set("session-active", cancel1)
+		agent.activeRequests.Set("session-nil", nil)
+
+		ids := agent.BusySessionIDs()
+		assert.Len(t, ids, 1)
+		assert.Contains(t, ids, "session-active")
+		assert.NotContains(t, ids, "session-nil")
+
+		cancel1()
+	})
+}
+
+func TestIsSessionBusy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns false for non-existent session", func(t *testing.T) {
+		t.Parallel()
+		agent := &sessionAgent{
+			activeRequests: csync.NewMap[string, context.CancelFunc](),
+			messageQueue:   csync.NewMap[string, []SessionAgentCall](),
+		}
+
+		assert.False(t, agent.IsSessionBusy("non-existent"))
+	})
+
+	t.Run("returns true for active session", func(t *testing.T) {
+		t.Parallel()
+		agent := &sessionAgent{
+			activeRequests: csync.NewMap[string, context.CancelFunc](),
+			messageQueue:   csync.NewMap[string, []SessionAgentCall](),
+		}
+
+		_, cancel := context.WithCancel(context.Background())
+		agent.activeRequests.Set("session-1", cancel)
+
+		assert.True(t, agent.IsSessionBusy("session-1"))
+		assert.False(t, agent.IsSessionBusy("session-2"))
+
+		cancel()
+	})
+}
+
+func TestIsBusy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns false when no active requests", func(t *testing.T) {
+		t.Parallel()
+		agent := &sessionAgent{
+			activeRequests: csync.NewMap[string, context.CancelFunc](),
+			messageQueue:   csync.NewMap[string, []SessionAgentCall](),
+		}
+
+		assert.False(t, agent.IsBusy())
+	})
+
+	t.Run("returns true when any session is active", func(t *testing.T) {
+		t.Parallel()
+		agent := &sessionAgent{
+			activeRequests: csync.NewMap[string, context.CancelFunc](),
+			messageQueue:   csync.NewMap[string, []SessionAgentCall](),
+		}
+
+		_, cancel := context.WithCancel(context.Background())
+		agent.activeRequests.Set("session-1", cancel)
+
+		assert.True(t, agent.IsBusy())
+
+		cancel()
+	})
+}
+
+func TestConcurrentBusySessionAccess(t *testing.T) {
+	t.Parallel()
+
+	agent := &sessionAgent{
+		activeRequests: csync.NewMap[string, context.CancelFunc](),
+		messageQueue:   csync.NewMap[string, []SessionAgentCall](),
+	}
+
+	var wg sync.WaitGroup
+	const numGoroutines = 10
+
+	// Concurrently add sessions
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			_, cancel := context.WithCancel(context.Background())
+			agent.activeRequests.Set(string(rune('a'+id)), cancel)
+		}(i)
+	}
+
+	// Concurrently read busy sessions
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = agent.BusySessionIDs()
+			_ = agent.IsBusy()
+		}()
+	}
+
+	// Wait with timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "test timed out - potential deadlock")
+	}
+}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -50,6 +50,7 @@ type Coordinator interface {
 	CancelAll()
 	IsSessionBusy(sessionID string) bool
 	IsBusy() bool
+	BusySessionIDs() []string
 	QueuedPrompts(sessionID string) int
 	QueuedPromptsList(sessionID string) []string
 	ClearQueue(sessionID string)
@@ -786,6 +787,10 @@ func (c *coordinator) IsBusy() bool {
 
 func (c *coordinator) IsSessionBusy(sessionID string) bool {
 	return c.currentAgent.IsSessionBusy(sessionID)
+}
+
+func (c *coordinator) BusySessionIDs() []string {
+	return c.currentAgent.BusySessionIDs()
 }
 
 func (c *coordinator) Model() Model {

--- a/internal/tui/components/dialogs/sessions/sessions_test.go
+++ b/internal/tui/components/dialogs/sessions/sessions_test.go
@@ -1,0 +1,80 @@
+package sessions
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSessionDialogCmp(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates dialog with sessions", func(t *testing.T) {
+		t.Parallel()
+		sessions := []session.Session{
+			{ID: "session-1", Title: "First Session"},
+			{ID: "session-2", Title: "Second Session"},
+		}
+
+		dialog := NewSessionDialogCmp(sessions, "", nil)
+		assert.NotNil(t, dialog)
+		assert.Equal(t, SessionsDialogID, dialog.ID())
+	})
+
+	t.Run("creates dialog with empty sessions", func(t *testing.T) {
+		t.Parallel()
+		dialog := NewSessionDialogCmp([]session.Session{}, "", nil)
+		assert.NotNil(t, dialog)
+	})
+
+	t.Run("marks busy sessions with indicator", func(t *testing.T) {
+		t.Parallel()
+		sessions := []session.Session{
+			{ID: "session-1", Title: "Active Session"},
+			{ID: "session-2", Title: "Idle Session"},
+			{ID: "session-3", Title: "Another Active"},
+		}
+		busyIDs := []string{"session-1", "session-3"}
+
+		dialog := NewSessionDialogCmp(sessions, "", busyIDs)
+		assert.NotNil(t, dialog)
+
+		// Verify dialog was created - the busy indicator logic is internal
+		// but we can verify the dialog handles the busy IDs without panicking
+		cmp, ok := dialog.(*sessionDialogCmp)
+		assert.True(t, ok)
+		assert.Equal(t, busyIDs, cmp.busySessionIDs)
+	})
+
+	t.Run("handles nil busy session IDs", func(t *testing.T) {
+		t.Parallel()
+		sessions := []session.Session{
+			{ID: "session-1", Title: "Test Session"},
+		}
+
+		// Should not panic with nil busySessionIDs
+		dialog := NewSessionDialogCmp(sessions, "", nil)
+		assert.NotNil(t, dialog)
+	})
+
+	t.Run("tracks selected session ID", func(t *testing.T) {
+		t.Parallel()
+		sessions := []session.Session{
+			{ID: "session-1", Title: "First"},
+			{ID: "session-2", Title: "Second"},
+		}
+
+		dialog := NewSessionDialogCmp(sessions, "session-2", nil)
+		cmp, ok := dialog.(*sessionDialogCmp)
+		assert.True(t, ok)
+		assert.Equal(t, "session-2", cmp.selectedSessionID)
+	})
+}
+
+func TestBusyIndicator(t *testing.T) {
+	t.Parallel()
+
+	// Verify the busy indicator constant is set correctly
+	assert.Equal(t, "●", busyIndicator)
+}

--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -397,10 +397,6 @@ func (p *chatPage) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 		return p, tea.Batch(cmds...)
 
 	case commands.CommandRunCustomMsg:
-		if p.app.AgentCoordinator.IsBusy() {
-			return p, util.ReportWarn("Agent is busy, please wait before executing a command...")
-		}
-
 		cmd := p.sendMessage(msg.Content, nil)
 		if cmd != nil {
 			return p, cmd
@@ -421,9 +417,6 @@ func (p *chatPage) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 		p.focusedPane = PanelTypeEditor
 		return p, p.SetSize(p.width, p.height)
 	case commands.NewSessionsMsg:
-		if p.app.AgentCoordinator.IsBusy() {
-			return p, util.ReportWarn("Agent is busy, please wait before starting a new session...")
-		}
 		return p, p.newSession()
 	case tea.KeyPressMsg:
 		switch {
@@ -431,9 +424,6 @@ func (p *chatPage) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 			// if we have no agent do nothing
 			if p.app.AgentCoordinator == nil {
 				return p, nil
-			}
-			if p.app.AgentCoordinator.IsBusy() {
-				return p, util.ReportWarn("Agent is busy, please wait before starting a new session...")
 			}
 			return p, p.newSession()
 		case key.Matches(msg, p.keyMap.AddAttachment):


### PR DESCRIPTION

## Summary

- Enable switching sessions while an agent is running in the background
- Add visual indicator (●) in session list for sessions with active agents
- Allow creating new sessions without waiting for current agent to complete

## Test plan

- [x] Build passes
- [x] Unit tests for BusySessionIDs() and session dialog
- [ ] Manual test: start agent, switch to another session, verify agent continues running
- [ ] Manual test: verify busy indicator appears for sessions with active agents


💘 Generated with Crush