### PR TITLE
fix(sqlite): busy timeout

### DIFF
--- a/internal/db/connect_modernc.go
+++ b/internal/db/connect_modernc.go
@@ -20,6 +20,7 @@ func openDB(dbPath string) (*sql.DB, error) {
 	params.Add("_pragma", "cache_size(-8000)")
 	params.Add("_pragma", "synchronous(NORMAL)")
 	params.Add("_pragma", "secure_delete(on)")
+	params.Add("_pragma", "busy_timeout(5000)")
 
 	dsn := fmt.Sprintf("file:%s?%s", dbPath, params.Encode())
 	db, err := sql.Open("sqlite", dsn)

--- a/internal/db/connect_ncruces.go
+++ b/internal/db/connect_ncruces.go
@@ -20,6 +20,7 @@ func openDB(dbPath string) (*sql.DB, error) {
 		"PRAGMA cache_size = -8000;",
 		"PRAGMA synchronous = NORMAL;",
 		"PRAGMA secure_delete = ON;",
+		"PRAGMA busy_timeout = 5000;",
 	}
 
 	db, err := driver.Open(dbPath, func(c *sqlite3.Conn) error {


### PR DESCRIPTION
right now, if 2 writes happen concurrently it'll just fail.

this adds a 5s timeout in which sqlite should retry 

i guess the modernc driver somehow emerged this bug in some test runs (it doesn't always happens), so it probably happens in prod as well.

see: https://sqlite.org/c3ref/busy_timeout.html
see: https://github.com/charmbracelet/crush/actions/runs/20860362075/job/59938146149