### PR TITLE
perf: use strings.Builder for string concatenation in loops

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,6 +12,7 @@ import (
 	"charm.land/x/vcr"
 	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -616,6 +618,40 @@ func TestCoderAgent(t *testing.T) {
 				require.True(t, foundGlobResult, "Expected to find glob tool result")
 				require.True(t, foundLSResult, "Expected to find ls tool result")
 			})
+		})
+	}
+}
+
+func makeTestTodos(n int) []session.Todo {
+	todos := make([]session.Todo, n)
+	for i := range n {
+		todos[i] = session.Todo{
+			Status:  session.TodoStatusPending,
+			Content: fmt.Sprintf("Task %d: Implement feature with some description that makes it realistic", i),
+		}
+	}
+	return todos
+}
+
+func BenchmarkBuildSummaryPrompt(b *testing.B) {
+	cases := []struct {
+		name     string
+		numTodos int
+	}{
+		{"0todos", 0},
+		{"5todos", 5},
+		{"10todos", 10},
+		{"50todos", 50},
+	}
+
+	for _, tc := range cases {
+		todos := makeTestTodos(tc.numTodos)
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				_ = buildSummaryPrompt(todos)
+			}
 		})
 	}
 }

--- a/internal/message/content.go
+++ b/internal/message/content.go
@@ -437,23 +437,27 @@ func (m *Message) AddBinary(mimeType string, data []byte) {
 }
 
 func PromptWithTextAttachments(prompt string, attachments []Attachment) string {
+	var sb strings.Builder
+	sb.WriteString(prompt)
 	addedAttachments := false
 	for _, content := range attachments {
 		if !content.IsText() {
 			continue
 		}
 		if !addedAttachments {
-			prompt += "\n<system_info>The files below have been attached by the user, consider them in your response</system_info>\n"
+			sb.WriteString("\n<system_info>The files below have been attached by the user, consider them in your response</system_info>\n")
 			addedAttachments = true
 		}
-		tag := `<file>\n`
 		if content.FilePath != "" {
-			tag = fmt.Sprintf("<file path='%s'>\n", content.FilePath)
+			fmt.Fprintf(&sb, "<file path='%s'>\n", content.FilePath)
+		} else {
+			sb.WriteString("<file>\n")
 		}
-		prompt += tag
-		prompt += "\n" + string(content.Content) + "\n</file>\n"
+		sb.WriteString("\n")
+		sb.Write(content.Content)
+		sb.WriteString("\n</file>\n")
 	}
-	return prompt
+	return sb.String()
 }
 
 func (m *Message) ToAIMessage() []fantasy.Message {

--- a/internal/message/content_test.go
+++ b/internal/message/content_test.go
@@ -1,0 +1,45 @@
+package message
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func makeTestAttachments(n int, contentSize int) []Attachment {
+	attachments := make([]Attachment, n)
+	content := []byte(strings.Repeat("x", contentSize))
+	for i := range n {
+		attachments[i] = Attachment{
+			FilePath: fmt.Sprintf("/path/to/file%d.txt", i),
+			MimeType: "text/plain",
+			Content:  content,
+		}
+	}
+	return attachments
+}
+
+func BenchmarkPromptWithTextAttachments(b *testing.B) {
+	cases := []struct {
+		name        string
+		numFiles    int
+		contentSize int
+	}{
+		{"1file_100bytes", 1, 100},
+		{"5files_1KB", 5, 1024},
+		{"10files_10KB", 10, 10 * 1024},
+		{"20files_50KB", 20, 50 * 1024},
+	}
+
+	for _, tc := range cases {
+		attachments := makeTestAttachments(tc.numFiles, tc.contentSize)
+		prompt := "Process these files"
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				_ = PromptWithTextAttachments(prompt, attachments)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Replace += string concatenation with strings.Builder in:
- buildSummaryPrompt (extracted from Summarize)
- PromptWithTextAttachments

Benchmark results:

PromptWithTextAttachments (20 files × 50KB):
  Old: 1.37ms, 20.6MB, 90 allocs New: 281µs, 5.2MB, 37 allocs (4.9× faster, 4× less memory)

buildSummaryPrompt (50 todos):
  Old: 16µs, 136KB, 203 allocs New: 5.7µs, 19KB, 111 allocs (2.8× faster, 7× less memory)
