### PR TITLE
fix: make sure to unlock in goroutine

### DIFF
--- a/internal/csync/maps.go
+++ b/internal/csync/maps.go
@@ -33,8 +33,8 @@ func NewLazyMap[K comparable, V any](load func() map[K]V) *Map[K, V] {
 	m := &Map[K, V]{}
 	m.mu.Lock()
 	go func() {
+		defer m.mu.Unlock()
 		m.inner = load()
-		m.mu.Unlock()
 	}()
 	return m
 }


### PR DESCRIPTION
if `load()` panics, the mutex is never unlocked. Not much of a problem I think, but its a small fix anyway.