### PR TITLE
feat: add detailed version info with git shortref and dirty status

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -37,7 +37,7 @@ tasks:
   build:
     desc: Run build
     vars:
-      LDFLAGS: '{{if .VERSION}}-ldflags="-X github.com/charmbracelet/crush/internal/version.Version={{.VERSION}}"{{end}}'
+      LDFLAGS: "{{if .VERSION}}-ldflags=\"-X 'github.com/charmbracelet/crush/internal/version.Version={{.VERSION}}'\"{{end}}"
     cmds:
       - "go build {{if .RACE}}-race{{end}} {{.LDFLAGS}} ."
     generates:
@@ -76,7 +76,7 @@ tasks:
   install:
     desc: Install the application
     vars:
-      LDFLAGS: '{{if .VERSION}}-ldflags="-X github.com/charmbracelet/crush/internal/version.Version={{.VERSION}}"{{end}}'
+      LDFLAGS: "{{if .VERSION}}-ldflags=\"-X 'github.com/charmbracelet/crush/internal/version.Version={{.VERSION}}'\"{{end}}"
     cmds:
       - task: fetch-tags
       - go install {{.LDFLAGS}} -v .


### PR DESCRIPTION
## Summary

This PR improves the version information provided by `crush --version` by:
- Including the git shortref and dirty status when running a development build.
- Adding a fallback to the `git` command for version detection when build info is not available.
- Updating `Taskfile.yaml` to correctly pass version information via `ldflags`.


💘 Generated with Crush