### PR TITLE
fix: race condition where title might not be generated

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -183,6 +183,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 			a.generateTitle(titleCtx, call.SessionID, call.Prompt)
 		})
 	}
+	defer wg.Wait()
 
 	// Add the user message to the session.
 	_, err = a.createUserMessage(ctx, call)
@@ -491,7 +492,6 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 		}
 		return nil, err
 	}
-	wg.Wait()
 
 	if shouldSummarize {
 		a.activeRequests.Del(call.SessionID)


### PR DESCRIPTION
This fixes a race condition where the the session title could not be generated, resulting in "Untitled Session".