### PR TITLE
fix(tui): show thinking toggle for Vertex AI and Google providers

### DIFF
--- a/internal/tui/components/dialogs/commands/commands.go
+++ b/internal/tui/components/dialogs/commands/commands.go
@@ -363,8 +363,11 @@ func (c *commandDialogCmp) defaultCommands() []Command {
 		if providerCfg != nil && model != nil && model.CanReason {
 			selectedModel := cfg.Models[agentCfg.Model]
 
-			// Anthropic models: thinking toggle
-			if providerCfg.Type == catwalk.TypeAnthropic || providerCfg.Type == catwalk.Type(hyper.Name) {
+			// Thinking toggle for providers that support it
+			if providerCfg.Type == catwalk.TypeAnthropic ||
+				providerCfg.Type == catwalk.Type(hyper.Name) ||
+				providerCfg.Type == catwalk.TypeVertexAI ||
+				providerCfg.Type == catwalk.TypeGoogle {
 				status := "Enable"
 				if selectedModel.Think {
 					status = "Disable"


### PR DESCRIPTION

## Summary

- Extend thinking mode toggle in command palette to support Vertex AI and Google providers
- Previously only shown for Anthropic/Hyper, now also shows for models accessed via Google Vertex AI

## Test plan

- [ ] Use a Claude or Gemini model through Vertex AI provider
- [ ] Open command palette (Ctrl+K)
- [ ] Verify "Enable/Disable Thinking Mode" option appears


💘 Generated with Crush