### PR TITLE
fix(grep): prevent tool from hanging when context is cancelled

### DIFF
--- a/internal/agent/tools/grep_test.go
+++ b/internal/agent/tools/grep_test.go
@@ -85,7 +85,9 @@ func TestGrepWithIgnoreFiles(t *testing.T) {
 
 	// Test both implementations
 	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
-		"regex": searchFilesWithRegex,
+		"regex": func(pattern, path, include string) ([]grepMatch, error) {
+			return searchFilesWithRegex(t.Context(), pattern, path, include)
+		},
 		"rg": func(pattern, path, include string) ([]grepMatch, error) {
 			return searchWithRipgrep(t.Context(), pattern, path, include)
 		},
@@ -145,7 +147,9 @@ func TestSearchImplementations(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".crushignore"), []byte("file5.txt\n"), 0o644))
 
 	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
-		"regex": searchFilesWithRegex,
+		"regex": func(pattern, path, include string) ([]grepMatch, error) {
+			return searchFilesWithRegex(t.Context(), pattern, path, include)
+		},
 		"rg": func(pattern, path, include string) ([]grepMatch, error) {
 			return searchWithRipgrep(t.Context(), pattern, path, include)
 		},
@@ -396,7 +400,9 @@ func TestColumnMatch(t *testing.T) {
 
 	// Test both implementations
 	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
-		"regex": searchFilesWithRegex,
+		"regex": func(pattern, path, include string) ([]grepMatch, error) {
+			return searchFilesWithRegex(t.Context(), pattern, path, include)
+		},
 		"rg": func(pattern, path, include string) ([]grepMatch, error) {
 			return searchWithRipgrep(t.Context(), pattern, path, include)
 		},


### PR DESCRIPTION
## Summary

• Fixed grep tool hanging with "Working..." status indefinitely when context is cancelled
• Added proper context cancellation support to `searchFilesWithRegex()` function
• Tool now properly cleans up when user cancels or context is cancelled

## Problem

When Grep tool uses its regex fallback implementation (when ripgrep is unavailable), it can hang indefinitely with UI showing "Working..." status. This happens because:

1. `searchFilesWithRegex()` did not accept a `context.Context` parameter
2. The `filepath.Walk()` callback never checked if context was cancelled
3. The function can take minutes to complete on large codebases (reads 512 bytes from every file to detect if it's text)
4. When context is cancelled, function never returns, leaving's `activeRequests` map with a cancel function
5. `IsBusy()` returns `true` as long as `activeRequests` contains a cancel function, so UI shows "Working..." forever

## Root Cause

The UI displays "Working..." when `AgentCoordinator.IsBusy()` returns true. This happens when `activeRequests` map contains a cancel function for a session. The cancel function is added when a tool starts and removed via `defer` when it completes. Since `searchFilesWithRegex()` never completes when context is cancelled, defer never runs, and `activeRequests` never gets cleaned up.

## Solution

Modified `searchFilesWithRegex()` function to:

1. **Accept a context.Context parameter** - Allows cancellation to propagate through the function
2. **Check context cancellation in filepath.Walk callback** - Aborts walk immediately when context is cancelled
3. **Check context after Walk completes** - Catches cancellations that happened late in the process
4. **Pass context through call chain** - `searchFiles()` → `searchFilesWithRegex(ctx, ...)`

Bonus fix: Improved error handling using `errors.Is()` instead of direct comparison for EOF checks.

## Testing

- ✅ All existing grep tests pass
- ✅ All tools tests pass (5.573s)
- ✅ Project builds successfully

## Files Changed

- `internal/agent/tools/grep.go` - Added context support and cancellation checks
- `internal/agent/tools/grep_test.go` - Updated tests to pass context