### PR TITLE
fix: only notify UI of permission request if not auto-approved

### DIFF
--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -135,9 +135,6 @@ func (s *permissionService) Request(ctx context.Context, opts CreatePermissionRe
 	}
 
 	// tell the UI that a permission was requested
-	s.notificationBroker.Publish(pubsub.CreatedEvent, PermissionNotification{
-		ToolCallID: opts.ToolCallID,
-	})
 	s.requestMu.Lock()
 	defer s.requestMu.Unlock()
 
@@ -204,6 +201,11 @@ func (s *permissionService) Request(ctx context.Context, opts CreatePermissionRe
 	respCh := make(chan bool, 1)
 	s.pendingRequests.Set(permission.ID, respCh)
 	defer s.pendingRequests.Del(permission.ID)
+
+	// Notify the UI that permission is being requested for this tool call.
+	s.notificationBroker.Publish(pubsub.CreatedEvent, PermissionNotification{
+		ToolCallID: opts.ToolCallID,
+	})
 
 	// Publish the request
 	s.Publish(pubsub.CreatedEvent, permission)


### PR DESCRIPTION
## Summary

This PR fixes an issue where the UI would show a "Requesting permission..." message even if the tool was already in the allowlist or the session was auto-approved.

The `permissionService.Request` method was publishing a `PermissionNotification` before performing any of its internal bypass checks. I've moved the notification after the allowlist and auto-approval checks so it only triggers when an actual user intervention is required.

## Test plan

1. Run a tool that is in the allowlist.
2. Verify "Requesting permission..." does not appear.
3. Run a tool that requires permission.
4. Verify "Requesting permission..." appears as expected.


💘 Generated with Crush