### PR TITLE
refactor(ui): dialog: cleanup render logic and use RenderContext

### DIFF
--- a/internal/ui/dialog/filepicker.go
+++ b/internal/ui/dialog/filepicker.go
@@ -234,6 +234,7 @@ func (f *FilePicker) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	t := f.com.Styles
 	rc := NewRenderContext(t, width)
+	rc.Gap = 1
 	rc.Title = "Add Image"
 	rc.Help = f.help.View(f)
 

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -10,13 +10,11 @@ import (
 	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/uiutil"
 	uv "github.com/charmbracelet/ultraviolet"
-	"github.com/charmbracelet/x/ansi"
 )
 
 // ModelType represents the type of model to select.
@@ -253,19 +251,16 @@ func (m *Models) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	m.list.SetSize(innerWidth, height-heightOffset)
 	m.help.SetWidth(innerWidth)
 
-	titleStyle := t.Dialog.Title
-	dialogStyle := t.Dialog.View
+	rc := NewRenderContext(t, width)
+	rc.Title = "Switch Model"
+	rc.TitleInfo = m.modelTypeRadioView()
+	inputView := t.Dialog.InputPrompt.Render(m.input.View())
+	rc.AddPart(inputView)
+	listView := t.Dialog.List.Height(m.list.Height()).Render(m.list.Render())
+	rc.AddPart(listView)
+	rc.Help = m.help.View(m)
 
-	radios := m.modelTypeRadioView()
-
-	headerOffset := lipgloss.Width(radios) + titleStyle.GetHorizontalFrameSize() +
-		dialogStyle.GetHorizontalFrameSize()
-
-	header := common.DialogTitle(t, "Switch Model", width-headerOffset) + radios
-
-	helpView := ansi.Truncate(m.help.View(m), innerWidth, "")
-	view := HeaderInputListHelpView(t, width, m.list.Height(), header,
-		m.input.View(), m.list.Render(), helpView)
+	view := rc.Render()
 
 	cur := m.Cursor()
 	DrawCenterCursor(scr, area, view, cur)

--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -10,7 +10,6 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/list"
 	uv "github.com/charmbracelet/ultraviolet"
-	"github.com/charmbracelet/x/ansi"
 )
 
 // SessionsID is the identifier for the session selector dialog.
@@ -154,15 +153,15 @@ func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	s.list.SetSize(innerWidth, height-heightOffset)
 	s.help.SetWidth(innerWidth)
 
-	titleStyle := s.com.Styles.Dialog.Title
-	dialogStyle := s.com.Styles.Dialog.View.Width(width)
-	header := common.DialogTitle(s.com.Styles, "Switch Session",
-		max(0, width-dialogStyle.GetHorizontalFrameSize()-
-			titleStyle.GetHorizontalFrameSize()))
+	rc := NewRenderContext(t, width)
+	rc.Title = "Switch Session"
+	inputView := t.Dialog.InputPrompt.Render(s.input.View())
+	rc.AddPart(inputView)
+	listView := t.Dialog.List.Height(s.list.Height()).Render(s.list.Render())
+	rc.AddPart(listView)
+	rc.Help = s.help.View(s)
 
-	helpView := ansi.Truncate(s.help.View(s), innerWidth, "")
-	view := HeaderInputListHelpView(s.com.Styles, width, s.list.Height(), header,
-		s.input.View(), s.list.Render(), helpView)
+	view := rc.Render()
 
 	cur := s.Cursor()
 	DrawCenterCursor(scr, area, view, cur)


### PR DESCRIPTION
This change unifies the rendering logic for dialog models by introducing a RenderContext struct. This struct encapsulates common rendering parameters and methods, reducing code duplication and improving maintainability across dialog components.
