### PR TITLE
fix: make hyper and copilot link styled on ui

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -38,6 +38,7 @@ import (
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/stringext"
+	"github.com/charmbracelet/x/exp/charmtone"
 )
 
 const defaultSessionName = "Untitled Session"
@@ -466,18 +467,19 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 		var fantasyErr *fantasy.Error
 		var providerErr *fantasy.ProviderError
 		const defaultTitle = "Provider Error"
+		linkStyle := lipgloss.NewStyle().Foreground(charmtone.Guac).Underline(true)
 		if isCancelErr {
 			currentAssistant.AddFinish(message.FinishReasonCanceled, "User canceled request", "")
 		} else if isPermissionErr {
 			currentAssistant.AddFinish(message.FinishReasonPermissionDenied, "User denied permission", "")
 		} else if errors.Is(err, hyper.ErrNoCredits) {
 			url := hyper.BaseURL()
-			link := lipgloss.NewStyle().Hyperlink(url, "id=hyper").Render(url)
+			link := linkStyle.Hyperlink(url, "id=hyper").Render(url)
 			currentAssistant.AddFinish(message.FinishReasonError, "No credits", "You're out of credits. Add more at "+link)
 		} else if errors.As(err, &providerErr) {
 			if providerErr.Message == "The requested model is not supported." {
 				url := "https://github.com/settings/copilot/features"
-				link := lipgloss.NewStyle().Hyperlink(url, "id=hyper").Render(url)
+				link := linkStyle.Hyperlink(url, "id=copilot").Render(url)
 				currentAssistant.AddFinish(
 					message.FinishReasonError,
 					"Copilot model not enabled",


### PR DESCRIPTION
To visually instruct the user that the link is clickable.

This will need to be ported to the new `ui` branch.

### Before

<img width="1087" height="178" alt="Screenshot 2026-01-14 at 16 22 48" src="https://github.com/user-attachments/assets/2b18c238-e9ad-4293-963e-87df4e894d5f" />

### After

<img width="1087" height="168" alt="Screenshot 2026-01-14 at 16 25 15" src="https://github.com/user-attachments/assets/fb5c6337-9ec6-47be-8d37-9186ebfdb279" />
