### PR TITLE
feat: add MaxSteps option to limit agent iterations

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -98,6 +98,7 @@ type sessionAgent struct {
 	messages             message.Service
 	disableAutoSummarize bool
 	isYolo               bool
+	maxSteps             int
 
 	messageQueue   *csync.Map[string, []SessionAgentCall]
 	activeRequests *csync.Map[string, context.CancelFunc]
@@ -114,6 +115,8 @@ type SessionAgentOptions struct {
 	Sessions             session.Service
 	Messages             message.Service
 	Tools                []fantasy.AgentTool
+	// MaxSteps limits the number of agent steps (LLM calls). 0 means no limit.
+	MaxSteps int
 }
 
 func NewSessionAgent(
@@ -130,6 +133,7 @@ func NewSessionAgent(
 		disableAutoSummarize: opts.DisableAutoSummarize,
 		tools:                csync.NewSliceFrom(opts.Tools),
 		isYolo:               opts.IsYolo,
+		maxSteps:             opts.MaxSteps,
 		messageQueue:         csync.NewMap[string, []SessionAgentCall](),
 		activeRequests:       csync.NewMap[string, context.CancelFunc](),
 	}
@@ -378,7 +382,11 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 			return a.messages.Update(genCtx, *currentAssistant)
 		},
 		StopWhen: []fantasy.StopCondition{
-			func(_ []fantasy.StepResult) bool {
+			func(steps []fantasy.StepResult) bool {
+				// Stop if max steps reached.
+				if a.maxSteps > 0 && len(steps) >= a.maxSteps {
+					return true
+				}
 				cw := int64(largeModel.CatwalkCfg.ContextWindow)
 				tokens := currentSession.CompletionTokens + currentSession.PromptTokens
 				remaining := cw - tokens

--- a/internal/agent/agentic_fetch_tool.go
+++ b/internal/agent/agentic_fetch_tool.go
@@ -181,6 +181,7 @@ func (c *coordinator) agenticFetchTool(_ context.Context, client *http.Client) (
 				Sessions:             c.sessions,
 				Messages:             c.messages,
 				Tools:                fetchTools,
+				MaxSteps:             15, // Limit fetch agent iterations
 			})
 
 			agentToolSessionID := c.sessions.CreateAgentToolSessionID(validationResult.AgentMessageID, call.ID)

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -334,6 +334,7 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		c.sessions,
 		c.messages,
 		nil,
+		0, // MaxSteps: no limit for main agent
 	})
 
 	c.readyWg.Go(func() error {


### PR DESCRIPTION

## Summary

- Add `MaxSteps` field to `SessionAgentOptions` to limit the number of agent steps (LLM calls)
- Set agentic_fetch to 15 steps max to prevent runaway execution
- 0 means no limit (default for main agent)

This fixes an issue where agentic_fetch could run indefinitely when the model kept calling tools.

## Test plan

- [x] Code compiles
- [ ] Manual testing with agentic_fetch to verify it terminates


💘 Generated with Crush

---
Partially addresses #1851