### PR TITLE
refactor: add assistant info item

### DIFF
--- a/internal/ui/AGENTS.md
+++ b/internal/ui/AGENTS.md
@@ -4,6 +4,8 @@
 - Never use commands to send messages when you can directly mutate children or state.
 - Keep things simple; do not overcomplicate.
 - Create files if needed to separate logic; do not nest models.
+- Always do IO in commands
+- Never change the model state inside of a command use messages and than update the state in the main loop
 
 ## Architecture
 

--- a/internal/ui/common/elements.go
+++ b/internal/ui/common/elements.go
@@ -26,15 +26,35 @@ type ModelContextInfo struct {
 	Cost         float64
 }
 
-// ModelInfo renders model information including name, reasoning settings, and
-// optional context usage/cost.
-func ModelInfo(t *styles.Styles, modelName string, reasoningInfo string, context *ModelContextInfo, width int) string {
+// ModelInfo renders model information including name, provider, reasoning
+// settings, and optional context usage/cost.
+func ModelInfo(t *styles.Styles, modelName, providerName, reasoningInfo string, context *ModelContextInfo, width int) string {
 	modelIcon := t.Subtle.Render(styles.ModelIcon)
 	modelName = t.Base.Render(modelName)
-	modelInfo := fmt.Sprintf("%s %s", modelIcon, modelName)
 
-	parts := []string{
-		modelInfo,
+	// Build first line with model name and optionally provider on the same line
+	var firstLine string
+	if providerName != "" {
+		providerInfo := t.Muted.Render(fmt.Sprintf("via %s", providerName))
+		modelWithProvider := fmt.Sprintf("%s %s %s", modelIcon, modelName, providerInfo)
+
+		// Check if it fits on one line
+		if lipgloss.Width(modelWithProvider) <= width {
+			firstLine = modelWithProvider
+		} else {
+			// If it doesn't fit, put provider on next line
+			firstLine = fmt.Sprintf("%s %s", modelIcon, modelName)
+		}
+	} else {
+		firstLine = fmt.Sprintf("%s %s", modelIcon, modelName)
+	}
+
+	parts := []string{firstLine}
+
+	// If provider didn't fit on first line, add it as second line
+	if providerName != "" && !strings.Contains(firstLine, "via") {
+		providerInfo := fmt.Sprintf("via %s", providerName)
+		parts = append(parts, t.Muted.PaddingLeft(2).Render(providerInfo))
 	}
 
 	if reasoningInfo != "" {

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -18,23 +18,32 @@ import (
 func (m *UI) modelInfo(width int) string {
 	model := m.selectedLargeModel()
 	reasoningInfo := ""
-	if model != nil && model.CatwalkCfg.CanReason {
+	providerName := ""
+
+	if model != nil {
+		// Get provider name first
 		providerConfig, ok := m.com.Config().Providers.Get(model.ModelCfg.Provider)
 		if ok {
-			switch providerConfig.Type {
-			case catwalk.TypeAnthropic:
-				if model.ModelCfg.Think {
-					reasoningInfo = "Thinking On"
-				} else {
-					reasoningInfo = "Thinking Off"
+			providerName = providerConfig.Name
+
+			// Only check reasoning if model can reason
+			if model.CatwalkCfg.CanReason {
+				switch providerConfig.Type {
+				case catwalk.TypeAnthropic:
+					if model.ModelCfg.Think {
+						reasoningInfo = "Thinking On"
+					} else {
+						reasoningInfo = "Thinking Off"
+					}
+				default:
+					formatter := cases.Title(language.English, cases.NoLower)
+					reasoningEffort := cmp.Or(model.ModelCfg.ReasoningEffort, model.CatwalkCfg.DefaultReasoningEffort)
+					reasoningInfo = formatter.String(fmt.Sprintf("Reasoning %s", reasoningEffort))
 				}
-			default:
-				formatter := cases.Title(language.English, cases.NoLower)
-				reasoningEffort := cmp.Or(model.ModelCfg.ReasoningEffort, model.CatwalkCfg.DefaultReasoningEffort)
-				reasoningInfo = formatter.String(fmt.Sprintf("Reasoning %s", reasoningEffort))
 			}
 		}
 	}
+
 	var modelContext *common.ModelContextInfo
 	if m.session != nil {
 		modelContext = &common.ModelContextInfo{
@@ -43,7 +52,7 @@ func (m *UI) modelInfo(width int) string {
 			ModelContext: model.CatwalkCfg.ContextWindow,
 		}
 	}
-	return common.ModelInfo(m.com.Styles, model.CatwalkCfg.Name, reasoningInfo, modelContext, width)
+	return common.ModelInfo(m.com.Styles, model.CatwalkCfg.Name, providerName, reasoningInfo, modelContext, width)
 }
 
 // getDynamicHeightLimits will give us the num of items to show in each section based on the hight

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -115,6 +115,8 @@ type UI struct {
 	session      *session.Session
 	sessionFiles []SessionFile
 
+	lastUserMessageTime int64
+
 	// The width and height of the terminal in cells.
 	width  int
 	height int
@@ -579,11 +581,26 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 		msgPtrs[i] = &msgs[i]
 	}
 	toolResultMap := chat.BuildToolResultMap(msgPtrs)
+	if len(msgPtrs) > 0 {
+		m.lastUserMessageTime = msgPtrs[0].CreatedAt
+	}
 
 	// Add messages to chat with linked tool results
 	items := make([]chat.MessageItem, 0, len(msgs)*2)
 	for _, msg := range msgPtrs {
-		items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap)...)
+		switch msg.Role {
+		case message.User:
+			m.lastUserMessageTime = msg.CreatedAt
+			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap)...)
+		case message.Assistant:
+			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap)...)
+			if msg.FinishPart() != nil && msg.FinishPart().Reason == message.FinishReasonEndTurn {
+				infoItem := chat.NewAssistantInfoItem(m.com.Styles, msg, time.Unix(m.lastUserMessageTime, 0))
+				items = append(items, infoItem)
+			}
+		default:
+			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap)...)
+		}
 	}
 
 	// Load nested tool calls for agent/agentic_fetch tools.
@@ -675,7 +692,8 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 		return nil
 	}
 	switch msg.Role {
-	case message.User, message.Assistant:
+	case message.User:
+		m.lastUserMessageTime = msg.CreatedAt
 		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil)
 		for _, item := range items {
 			if animatable, ok := item.(chat.Animatable); ok {
@@ -687,6 +705,26 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 		m.chat.AppendMessages(items...)
 		if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
 			cmds = append(cmds, cmd)
+		}
+	case message.Assistant:
+		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil)
+		for _, item := range items {
+			if animatable, ok := item.(chat.Animatable); ok {
+				if cmd := animatable.StartAnimation(); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
+			}
+		}
+		m.chat.AppendMessages(items...)
+		if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		if msg.FinishPart() != nil && msg.FinishPart().Reason == message.FinishReasonEndTurn {
+			infoItem := chat.NewAssistantInfoItem(m.com.Styles, &msg, time.Unix(m.lastUserMessageTime, 0))
+			m.chat.AppendMessages(infoItem)
+			if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
 		}
 	case message.Tool:
 		for _, tr := range msg.ToolResults() {
@@ -716,9 +754,23 @@ func (m *UI) updateSessionMessage(msg message.Message) tea.Cmd {
 		}
 	}
 
+	shouldRenderAssistant := chat.ShouldRenderAssistantMessage(&msg)
 	// if the message of the assistant does not have any  response just tool calls we need to remove it
-	if !chat.ShouldRenderAssistantMessage(&msg) && len(msg.ToolCalls()) > 0 && existingItem != nil {
+	if !shouldRenderAssistant && len(msg.ToolCalls()) > 0 && existingItem != nil {
 		m.chat.RemoveMessage(msg.ID)
+		if infoItem := m.chat.MessageItem(chat.AssistantInfoID(msg.ID)); infoItem != nil {
+			m.chat.RemoveMessage(chat.AssistantInfoID(msg.ID))
+		}
+	}
+
+	if shouldRenderAssistant && msg.FinishPart() != nil && msg.FinishPart().Reason == message.FinishReasonEndTurn {
+		if infoItem := m.chat.MessageItem(chat.AssistantInfoID(msg.ID)); infoItem == nil {
+			newInfoItem := chat.NewAssistantInfoItem(m.com.Styles, &msg, time.Unix(m.lastUserMessageTime, 0))
+			m.chat.AppendMessages(newInfoItem)
+			if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
 	}
 
 	var items []chat.MessageItem

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -236,6 +236,10 @@ type Styles struct {
 			ThinkingTruncationHint lipgloss.Style // "… (N lines hidden)" hint
 			ThinkingFooterTitle    lipgloss.Style // "Thought for" text
 			ThinkingFooterDuration lipgloss.Style // Duration value
+			AssistantInfoIcon      lipgloss.Style
+			AssistantInfoModel     lipgloss.Style
+			AssistantInfoProvider  lipgloss.Style
+			AssistantInfoDuration  lipgloss.Style
 		}
 	}
 
@@ -1185,6 +1189,10 @@ func DefaultStyles() Styles {
 	// No padding or border for compact tool calls within messages
 	s.Chat.Message.ToolCallCompact = s.Muted
 	s.Chat.Message.SectionHeader = s.Base.PaddingLeft(2)
+	s.Chat.Message.AssistantInfoIcon = s.Subtle
+	s.Chat.Message.AssistantInfoModel = s.Muted
+	s.Chat.Message.AssistantInfoProvider = s.Subtle
+	s.Chat.Message.AssistantInfoDuration = s.Subtle
 
 	// Thinking section styles
 	s.Chat.Message.ThinkingBox = s.Subtle.Background(bgBaseLighter)


### PR DESCRIPTION
This adds the assistant info item to the chat and also updates the model info to include the provider

<img width="403" height="271" alt="Screenshot 2026-01-15 at 13 45 49" src="https://github.com/user-attachments/assets/4214c95b-0c12-4bcd-82cb-733a28a2f8eb" />
<img width="258" height="200" alt="Screenshot 2026-01-15 at 13 45 40" src="https://github.com/user-attachments/assets/52231584-be92-496a-ac43-d22a19cbd53e" />
<img width="2266" height="250" alt="Screenshot 2026-01-15 at 13 45 14" src="https://github.com/user-attachments/assets/0e9b1d06-8a92-4a25-ab94-302975e20a62" />
