### PR TITLE
feat(tui): set window title to working directory

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/event"
+	"github.com/charmbracelet/crush/internal/home"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/stringext"
@@ -592,6 +593,7 @@ func (a *appModel) View() tea.View {
 	view.AltScreen = true
 	view.MouseMode = tea.MouseModeCellMotion
 	view.BackgroundColor = t.BgBase
+	view.WindowTitle = "crush " + home.Short(config.Get().WorkingDir())
 	if a.wWidth < 25 || a.wHeight < 15 {
 		view.Content = t.S().Base.Width(a.wWidth).Height(a.wHeight).
 			Align(lipgloss.Center, lipgloss.Center).


### PR DESCRIPTION
- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

**One-line change** in `internal/tui/tui.go`

 ## Summary
  - Sets the terminal window title to `crush ~/path/to/cwd` format
  - Uses the existing `home.Short()` helper to display shortened paths

Small quality of life addition. Tested manually on: ghostty, kitty and terminal.app. 

Checked ui branch to see if there were any related changes. 

Future improvement: could update the window title to include the session title from the sidebar (e.g., crush ~/proj - Fix login bug) once a conversation is started.


<img width="377" height="364" alt="Screenshot 2026-01-15 at 10 04 33 AM" src="https://github.com/user-attachments/assets/b8b3fb71-a488-4ba8-9ec9-dae871f78ed5" />
