### PR TITLE
feat(tui): git-aware working directory display in sidebar

### DIFF
--- a/internal/gitinfo/gitinfo.go
+++ b/internal/gitinfo/gitinfo.go
@@ -1,0 +1,103 @@
+// Package gitinfo provides utilities for extracting git repository information.
+package gitinfo
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Info contains git repository information.
+type Info struct {
+	IsRepo     bool   // Whether the path is inside a git repo
+	RepoRoot   string // Absolute path to repo root
+	RepoName   string // Name of the repo (directory name)
+	PathInRepo string // Path relative to repo root
+	Branch     string // Current branch name
+	IsDirty    bool   // Whether there are uncommitted changes
+}
+
+var (
+	cache     *Info
+	cachePath string
+	cacheMu   sync.RWMutex
+	cacheTime time.Time
+	cacheTTL  = 2 * time.Second
+)
+
+// Get returns git info for the given path, with caching.
+func Get(path string) Info {
+	cacheMu.RLock()
+	if cache != nil && cachePath == path && time.Since(cacheTime) < cacheTTL {
+		info := *cache
+		cacheMu.RUnlock()
+		return info
+	}
+	cacheMu.RUnlock()
+
+	info := fetch(path)
+
+	cacheMu.Lock()
+	cache = &info
+	cachePath = path
+	cacheTime = time.Now()
+	cacheMu.Unlock()
+
+	return info
+}
+
+// Invalidate clears the cache, forcing a refresh on next Get.
+func Invalidate() {
+	cacheMu.Lock()
+	cache = nil
+	cacheMu.Unlock()
+}
+
+func fetch(path string) Info {
+	info := Info{}
+
+	// Get repo root.
+	cmd := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel")
+	out, err := cmd.Output()
+	if err != nil {
+		return info
+	}
+
+	info.IsRepo = true
+	info.RepoRoot = strings.TrimSpace(string(out))
+	info.RepoName = filepath.Base(info.RepoRoot)
+
+	// Calculate path inside repo.
+	if path != info.RepoRoot {
+		relPath, err := filepath.Rel(info.RepoRoot, path)
+		if err == nil && relPath != "." {
+			info.PathInRepo = relPath
+		}
+	}
+
+	// Get current branch.
+	cmd = exec.Command("git", "-C", path, "branch", "--show-current")
+	out, err = cmd.Output()
+	if err == nil {
+		info.Branch = strings.TrimSpace(string(out))
+	}
+	// Fallback for detached HEAD.
+	if info.Branch == "" {
+		cmd = exec.Command("git", "-C", path, "rev-parse", "--short", "HEAD")
+		out, err = cmd.Output()
+		if err == nil {
+			info.Branch = strings.TrimSpace(string(out))
+		}
+	}
+
+	// Check if dirty (uncommitted changes).
+	cmd = exec.Command("git", "-C", path, "status", "--porcelain")
+	out, err = cmd.Output()
+	if err == nil {
+		info.IsDirty = len(strings.TrimSpace(string(out))) > 0
+	}
+
+	return info
+}

--- a/internal/gitinfo/gitinfo_test.go
+++ b/internal/gitinfo/gitinfo_test.go
@@ -1,0 +1,72 @@
+package gitinfo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGet_InGitRepo(t *testing.T) {
+	t.Parallel()
+
+	// Use the crush repo itself for testing.
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	// Navigate up to find repo root.
+	repoRoot := wd
+	for {
+		if _, err := os.Stat(filepath.Join(repoRoot, ".git")); err == nil {
+			break
+		}
+		parent := filepath.Dir(repoRoot)
+		if parent == repoRoot {
+			t.Skip("Not running inside a git repository")
+		}
+		repoRoot = parent
+	}
+
+	Invalidate() // Clear cache.
+	info := Get(repoRoot)
+
+	require.True(t, info.IsRepo)
+	require.Equal(t, "crush", info.RepoName)
+	require.NotEmpty(t, info.Branch)
+	require.Empty(t, info.PathInRepo) // At root.
+
+	// Test subdirectory.
+	Invalidate()
+	subdir := filepath.Join(repoRoot, "internal", "gitinfo")
+	info = Get(subdir)
+
+	require.True(t, info.IsRepo)
+	require.Equal(t, "crush", info.RepoName)
+	require.Equal(t, filepath.Join("internal", "gitinfo"), info.PathInRepo)
+}
+
+func TestGet_NotGitRepo(t *testing.T) {
+	t.Parallel()
+
+	Invalidate()
+	info := Get(t.TempDir())
+
+	require.False(t, info.IsRepo)
+	require.Empty(t, info.Branch)
+	require.Empty(t, info.RepoName)
+}
+
+func TestGet_Caching(t *testing.T) {
+	t.Parallel()
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	Invalidate()
+	info1 := Get(wd)
+	info2 := Get(wd) // Should be cached.
+
+	require.Equal(t, info1.Branch, info2.Branch)
+	require.Equal(t, info1.RepoName, info2.RepoName)
+}


### PR DESCRIPTION
## Summary

Shows git repository info in the sidebar working directory display:
- **Repo name** (bold/accent): e.g., `crush`
- **Path inside repo** (muted): e.g., `/internal/tui`
- **Branch** (green if clean, yellow if dirty): e.g., `main` or `ela`
- **Dirty indicator**: yellow `•` when uncommitted changes exist

Non-git directories display the path in muted style as before.

Adds new `internal/gitinfo` package with 2-second caching.

## Test plan

- [x] Tests pass (`go test ./internal/gitinfo/...`)
- [x] Manual verification in git repos (clean/dirty states)
- [x] Manual verification in non-git directories


💘 Generated with Crush


Assisted-by: Claude Opus 4.5 via Crush <crush@charm.land>