### PR TITLE
feat(log): add retry mechanism to HTTP client for better provider reliability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/rivo/uniseg v0.4.7
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/sahilm/fuzzy v0.1.1
+	github.com/sethvargo/go-retry v0.3.0
 	github.com/spf13/cobra v1.10.2
 	github.com/srwiley/oksvg v0.0.0-20221011165216-be6e8873101c
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
@@ -150,7 +151,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
-	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/sourcegraph/jsonrpc2 v0.2.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/tetratelabs/wazero v1.11.0 // indirect

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -543,10 +543,8 @@ func (c *coordinator) buildAnthropicProvider(baseURL, apiKey string, headers map
 		opts = append(opts, anthropic.WithBaseURL(baseURL))
 	}
 
-	if c.cfg.Options.Debug {
-		httpClient := log.NewHTTPClient()
-		opts = append(opts, anthropic.WithHTTPClient(httpClient))
-	}
+	httpClient := log.NewHTTPClientWithRetry(c.cfg.Options.Debug)
+	opts = append(opts, anthropic.WithHTTPClient(httpClient))
 	return anthropic.New(opts...)
 }
 
@@ -555,10 +553,8 @@ func (c *coordinator) buildOpenaiProvider(baseURL, apiKey string, headers map[st
 		openai.WithAPIKey(apiKey),
 		openai.WithUseResponsesAPI(),
 	}
-	if c.cfg.Options.Debug {
-		httpClient := log.NewHTTPClient()
-		opts = append(opts, openai.WithHTTPClient(httpClient))
-	}
+	httpClient := log.NewHTTPClientWithRetry(c.cfg.Options.Debug)
+	opts = append(opts, openai.WithHTTPClient(httpClient))
 	if len(headers) > 0 {
 		opts = append(opts, openai.WithHeaders(headers))
 	}
@@ -572,10 +568,8 @@ func (c *coordinator) buildOpenrouterProvider(_, apiKey string, headers map[stri
 	opts := []openrouter.Option{
 		openrouter.WithAPIKey(apiKey),
 	}
-	if c.cfg.Options.Debug {
-		httpClient := log.NewHTTPClient()
-		opts = append(opts, openrouter.WithHTTPClient(httpClient))
-	}
+	httpClient := log.NewHTTPClientWithRetry(c.cfg.Options.Debug)
+	opts = append(opts, openrouter.WithHTTPClient(httpClient))
 	if len(headers) > 0 {
 		opts = append(opts, openrouter.WithHeaders(headers))
 	}
@@ -588,17 +582,15 @@ func (c *coordinator) buildOpenaiCompatProvider(baseURL, apiKey string, headers 
 		openaicompat.WithAPIKey(apiKey),
 	}
 
-	// Set HTTP client based on provider and debug mode.
+	// Set HTTP client based on provider.
 	var httpClient *http.Client
 	if providerID == string(catwalk.InferenceProviderCopilot) {
 		opts = append(opts, openaicompat.WithUseResponsesAPI())
 		httpClient = copilot.NewClient(isSubAgent, c.cfg.Options.Debug)
-	} else if c.cfg.Options.Debug {
-		httpClient = log.NewHTTPClient()
+	} else {
+		httpClient = log.NewHTTPClientWithRetry(c.cfg.Options.Debug)
 	}
-	if httpClient != nil {
-		opts = append(opts, openaicompat.WithHTTPClient(httpClient))
-	}
+	opts = append(opts, openaicompat.WithHTTPClient(httpClient))
 
 	if len(headers) > 0 {
 		opts = append(opts, openaicompat.WithHeaders(headers))
@@ -617,10 +609,8 @@ func (c *coordinator) buildAzureProvider(baseURL, apiKey string, headers map[str
 		azure.WithAPIKey(apiKey),
 		azure.WithUseResponsesAPI(),
 	}
-	if c.cfg.Options.Debug {
-		httpClient := log.NewHTTPClient()
-		opts = append(opts, azure.WithHTTPClient(httpClient))
-	}
+	httpClient := log.NewHTTPClientWithRetry(c.cfg.Options.Debug)
+	opts = append(opts, azure.WithHTTPClient(httpClient))
 	if options == nil {
 		options = make(map[string]string)
 	}
@@ -636,10 +626,8 @@ func (c *coordinator) buildAzureProvider(baseURL, apiKey string, headers map[str
 
 func (c *coordinator) buildBedrockProvider(headers map[string]string) (fantasy.Provider, error) {
 	var opts []bedrock.Option
-	if c.cfg.Options.Debug {
-		httpClient := log.NewHTTPClient()
-		opts = append(opts, bedrock.WithHTTPClient(httpClient))
-	}
+	httpClient := log.NewHTTPClientWithRetry(c.cfg.Options.Debug)
+	opts = append(opts, bedrock.WithHTTPClient(httpClient))
 	if len(headers) > 0 {
 		opts = append(opts, bedrock.WithHeaders(headers))
 	}
@@ -655,10 +643,8 @@ func (c *coordinator) buildGoogleProvider(baseURL, apiKey string, headers map[st
 		google.WithBaseURL(baseURL),
 		google.WithGeminiAPIKey(apiKey),
 	}
-	if c.cfg.Options.Debug {
-		httpClient := log.NewHTTPClient()
-		opts = append(opts, google.WithHTTPClient(httpClient))
-	}
+	httpClient := log.NewHTTPClientWithRetry(c.cfg.Options.Debug)
+	opts = append(opts, google.WithHTTPClient(httpClient))
 	if len(headers) > 0 {
 		opts = append(opts, google.WithHeaders(headers))
 	}
@@ -688,10 +674,8 @@ func (c *coordinator) buildHyperProvider(baseURL, apiKey string) (fantasy.Provid
 		hyper.WithBaseURL(baseURL),
 		hyper.WithAPIKey(apiKey),
 	}
-	if c.cfg.Options.Debug {
-		httpClient := log.NewHTTPClient()
-		opts = append(opts, hyper.WithHTTPClient(httpClient))
-	}
+	httpClient := log.NewHTTPClientWithRetry(c.cfg.Options.Debug)
+	opts = append(opts, hyper.WithHTTPClient(httpClient))
 	return hyper.New(opts...)
 }
 

--- a/internal/log/retry.go
+++ b/internal/log/retry.go
@@ -1,0 +1,221 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/sethvargo/go-retry"
+)
+
+// DefaultRetryConfig provides sensible defaults for retrying HTTP requests.
+var DefaultRetryConfig = RetryConfig{
+	MaxRetries:  3,
+	BaseBackoff: 500 * time.Millisecond,
+	MaxBackoff:  30 * time.Second,
+	Jitter:      250 * time.Millisecond,
+}
+
+// RetryConfig configures retry behavior for HTTP requests.
+type RetryConfig struct {
+	// MaxRetries is the maximum number of retry attempts (not including the
+	// initial request).
+	MaxRetries uint64
+	// BaseBackoff is the initial backoff duration before exponential increase.
+	BaseBackoff time.Duration
+	// MaxBackoff caps the maximum backoff duration between retries.
+	MaxBackoff time.Duration
+	// Jitter adds randomness to backoff to prevent thundering herd.
+	Jitter time.Duration
+}
+
+// RetryTransport is an http.RoundTripper that retries transient failures with
+// exponential backoff.
+type RetryTransport struct {
+	Transport http.RoundTripper
+	Config    RetryConfig
+}
+
+// NewRetryTransport creates a new RetryTransport with the given config.
+func NewRetryTransport(transport http.RoundTripper, cfg RetryConfig) *RetryTransport {
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	return &RetryTransport{
+		Transport: transport,
+		Config:    cfg,
+	}
+}
+
+// RoundTrip implements http.RoundTripper with retry logic.
+func (rt *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Build backoff strategy: exponential with jitter, capped, and limited retries.
+	backoff := retry.NewExponential(rt.Config.BaseBackoff)
+	backoff = retry.WithCappedDuration(rt.Config.MaxBackoff, backoff)
+	backoff = retry.WithJitter(rt.Config.Jitter, backoff)
+	backoff = retry.WithMaxRetries(rt.Config.MaxRetries, backoff)
+
+	// Buffer the request body so we can retry.
+	var bodyBytes []byte
+	if req.Body != nil && req.Body != http.NoBody {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body.Close()
+	}
+
+	var resp *http.Response
+	var lastResp *http.Response
+	var attempt int
+
+	err := retry.Do(req.Context(), backoff, func(ctx context.Context) error {
+		attempt++
+
+		// Reset body for each attempt.
+		if bodyBytes != nil {
+			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		}
+
+		var err error
+		resp, err = rt.Transport.RoundTrip(req)
+		if err != nil {
+			if rt.isRetryableError(err) {
+				slog.Warn("HTTP request failed, retrying",
+					"method", req.Method,
+					"url", req.URL.String(),
+					"attempt", attempt,
+					"error", err,
+				)
+				return retry.RetryableError(err)
+			}
+			// Non-retryable error.
+			return err
+		}
+
+		// Check for retryable HTTP status codes.
+		if rt.isRetryableStatus(resp.StatusCode) {
+			// Keep the last response in case retries are exhausted.
+			lastResp = resp
+
+			delay := rt.getRetryAfter(resp)
+			slog.Warn("HTTP request returned retryable status, retrying",
+				"method", req.Method,
+				"url", req.URL.String(),
+				"status", resp.StatusCode,
+				"attempt", attempt,
+				"retry_after", delay,
+			)
+			return retry.RetryableError(errors.New(resp.Status))
+		}
+
+		return nil
+	})
+	// If retries exhausted but we have a response, return it (caller can check
+	// status code).
+	if err != nil {
+		if lastResp != nil {
+			return lastResp, nil
+		}
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// isRetryableError checks if the error is a transient network error that
+// should be retried.
+func (rt *RetryTransport) isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check for network errors (timeout, connection refused, etc.)
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return netErr.Timeout() || netErr.Temporary() //nolint:staticcheck // Temporary() is deprecated but still useful
+	}
+
+	// Check for connection reset, EOF, and similar I/O errors.
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	// Check for specific error strings that indicate transient failures.
+	errStr := err.Error()
+	transientPatterns := []string{
+		"connection reset",
+		"connection refused",
+		"no such host",
+		"network is unreachable",
+		"i/o timeout",
+		"TLS handshake timeout",
+		"context deadline exceeded",
+	}
+	for _, pattern := range transientPatterns {
+		if bytes.Contains([]byte(errStr), []byte(pattern)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isRetryableStatus checks if the HTTP status code indicates a retryable
+// condition.
+func (rt *RetryTransport) isRetryableStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests, // 429
+		http.StatusBadGateway,         // 502
+		http.StatusServiceUnavailable, // 503
+		http.StatusGatewayTimeout:     // 504
+		return true
+	default:
+		return false
+	}
+}
+
+// getRetryAfter parses the Retry-After header if present.
+func (rt *RetryTransport) getRetryAfter(resp *http.Response) time.Duration {
+	header := resp.Header.Get("Retry-After")
+	if header == "" {
+		return 0
+	}
+
+	// Try parsing as seconds.
+	if seconds, err := strconv.Atoi(header); err == nil && seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+
+	// Try parsing as HTTP date.
+	if t, err := http.ParseTime(header); err == nil {
+		return time.Until(t)
+	}
+
+	return 0
+}
+
+// NewHTTPClientWithRetry creates an HTTP client with retry and optional debug
+// logging.
+func NewHTTPClientWithRetry(debug bool) *http.Client {
+	var transport http.RoundTripper = http.DefaultTransport
+
+	// Add retry layer.
+	transport = NewRetryTransport(transport, DefaultRetryConfig)
+
+	// Add logging layer on top if debug is enabled.
+	if debug {
+		transport = &HTTPRoundTripLogger{Transport: transport}
+	}
+
+	return &http.Client{
+		Transport: transport,
+	}
+}

--- a/internal/log/retry_test.go
+++ b/internal/log/retry_test.go
@@ -1,0 +1,349 @@
+package log
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryTransport_SuccessOnFirstAttempt(t *testing.T) {
+	t.Parallel()
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+	}))
+	defer server.Close()
+
+	client := &http.Client{
+		Transport: NewRetryTransport(nil, DefaultRetryConfig),
+	}
+
+	resp, err := client.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int32(1), atomic.LoadInt32(&attempts))
+}
+
+func TestRetryTransport_RetryOn503(t *testing.T) {
+	t.Parallel()
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+	}))
+	defer server.Close()
+
+	cfg := RetryConfig{
+		MaxRetries:  5,
+		BaseBackoff: 10 * time.Millisecond,
+		MaxBackoff:  100 * time.Millisecond,
+		Jitter:      5 * time.Millisecond,
+	}
+
+	client := &http.Client{
+		Transport: NewRetryTransport(nil, cfg),
+	}
+
+	resp, err := client.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+}
+
+func TestRetryTransport_RetryOn429(t *testing.T) {
+	t.Parallel()
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count < 2 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := RetryConfig{
+		MaxRetries:  3,
+		BaseBackoff: 10 * time.Millisecond,
+		MaxBackoff:  100 * time.Millisecond,
+		Jitter:      5 * time.Millisecond,
+	}
+
+	client := &http.Client{
+		Transport: NewRetryTransport(nil, cfg),
+	}
+
+	resp, err := client.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, int32(2), atomic.LoadInt32(&attempts))
+}
+
+func TestRetryTransport_NoRetryOn4xx(t *testing.T) {
+	t.Parallel()
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	cfg := RetryConfig{
+		MaxRetries:  3,
+		BaseBackoff: 10 * time.Millisecond,
+		MaxBackoff:  100 * time.Millisecond,
+		Jitter:      5 * time.Millisecond,
+	}
+
+	client := &http.Client{
+		Transport: NewRetryTransport(nil, cfg),
+	}
+
+	resp, err := client.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Equal(t, int32(1), atomic.LoadInt32(&attempts))
+}
+
+func TestRetryTransport_MaxRetriesExhausted(t *testing.T) {
+	t.Parallel()
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	cfg := RetryConfig{
+		MaxRetries:  2,
+		BaseBackoff: 10 * time.Millisecond,
+		MaxBackoff:  50 * time.Millisecond,
+		Jitter:      5 * time.Millisecond,
+	}
+
+	client := &http.Client{
+		Transport: NewRetryTransport(nil, cfg),
+	}
+
+	resp, err := client.Get(server.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Should have tried 1 initial + 2 retries = 3 attempts.
+	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	require.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+}
+
+func TestRetryTransport_PreservesRequestBody(t *testing.T) {
+	t.Parallel()
+
+	var attempts int32
+	var lastBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		body, _ := io.ReadAll(r.Body)
+		lastBody = string(body)
+		if count < 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := RetryConfig{
+		MaxRetries:  3,
+		BaseBackoff: 10 * time.Millisecond,
+		MaxBackoff:  100 * time.Millisecond,
+		Jitter:      5 * time.Millisecond,
+	}
+
+	client := &http.Client{
+		Transport: NewRetryTransport(nil, cfg),
+	}
+
+	req, err := http.NewRequest("POST", server.URL, strings.NewReader("test body"))
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "test body", lastBody)
+	require.Equal(t, int32(2), atomic.LoadInt32(&attempts))
+}
+
+func TestRetryTransport_RespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		// Add delay to ensure context cancels during backoff, not during request.
+		time.Sleep(10 * time.Millisecond)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	cfg := RetryConfig{
+		MaxRetries:  10,
+		BaseBackoff: 200 * time.Millisecond, // Long backoff so context cancels during wait.
+		MaxBackoff:  1 * time.Second,
+		Jitter:      10 * time.Millisecond,
+	}
+
+	client := &http.Client{
+		Transport: NewRetryTransport(nil, cfg),
+	}
+
+	// Short timeout to cancel during backoff between retries.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", server.URL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+
+	// Either we get an error (context canceled) or a 503 response.
+	if err != nil {
+		require.True(t, strings.Contains(err.Error(), "context"))
+	} else {
+		// Got a response before context was canceled, that's also acceptable.
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	}
+
+	// Should have at least tried once.
+	require.GreaterOrEqual(t, atomic.LoadInt32(&attempts), int32(1))
+}
+
+func TestRetryTransport_IsRetryableError(t *testing.T) {
+	t.Parallel()
+
+	rt := &RetryTransport{}
+
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"nil error", nil, false},
+		{"io.EOF", io.EOF, true},
+		{"io.ErrUnexpectedEOF", io.ErrUnexpectedEOF, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := rt.isRetryableError(tc.err)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestRetryTransport_IsRetryableStatus(t *testing.T) {
+	t.Parallel()
+
+	rt := &RetryTransport{}
+
+	testCases := []struct {
+		status   int
+		expected bool
+	}{
+		{http.StatusOK, false},
+		{http.StatusBadRequest, false},
+		{http.StatusUnauthorized, false},
+		{http.StatusNotFound, false},
+		{http.StatusTooManyRequests, true},
+		{http.StatusInternalServerError, false},
+		{http.StatusBadGateway, true},
+		{http.StatusServiceUnavailable, true},
+		{http.StatusGatewayTimeout, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			result := rt.isRetryableStatus(tc.status)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestRetryTransport_GetRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	rt := &RetryTransport{}
+
+	t.Run("no header", func(t *testing.T) {
+		resp := &http.Response{Header: http.Header{}}
+		require.Equal(t, time.Duration(0), rt.getRetryAfter(resp))
+	})
+
+	t.Run("seconds", func(t *testing.T) {
+		resp := &http.Response{Header: http.Header{}}
+		resp.Header.Set("Retry-After", "5")
+		require.Equal(t, 5*time.Second, rt.getRetryAfter(resp))
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		resp := &http.Response{Header: http.Header{}}
+		resp.Header.Set("Retry-After", "invalid")
+		require.Equal(t, time.Duration(0), rt.getRetryAfter(resp))
+	})
+}
+
+func TestNewHTTPClientWithRetry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("without debug", func(t *testing.T) {
+		client := NewHTTPClientWithRetry(false)
+		require.NotNil(t, client)
+		require.NotNil(t, client.Transport)
+
+		// Should be a RetryTransport.
+		_, ok := client.Transport.(*RetryTransport)
+		require.True(t, ok)
+	})
+
+	t.Run("with debug", func(t *testing.T) {
+		client := NewHTTPClientWithRetry(true)
+		require.NotNil(t, client)
+		require.NotNil(t, client.Transport)
+
+		// Should be a HTTPRoundTripLogger wrapping RetryTransport.
+		logger, ok := client.Transport.(*HTTPRoundTripLogger)
+		require.True(t, ok)
+		_, ok = logger.Transport.(*RetryTransport)
+		require.True(t, ok)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds retry mechanism with exponential backoff to HTTP client for transient failures (5xx, 429, connection errors)
- Applies retry-enabled HTTP client to all provider builders for improved reliability

## Test plan

- [x] Unit tests for retry logic (`internal/log/retry_test.go`)
- [ ] Manual testing with providers


🐾 Generated with Crush