### PR TITLE
Hooks pr

### DIFF
--- a/internal/hooks/manager.go
+++ b/internal/hooks/manager.go
@@ -1,0 +1,348 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/csync"
+)
+
+type manager struct {
+	workingDir string
+	dataDir    string
+	config     *Config
+	executor   *Executor
+	hooks      *csync.Map[HookType, []string]
+}
+
+// NewManager creates a new hook manager.
+func NewManager(workingDir, dataDir string, cfg *Config) *manager {
+	if cfg == nil {
+		cfg = &Config{
+			TimeoutSeconds: 30,
+			Directories:    []string{filepath.Join(dataDir, "hooks")},
+		}
+	}
+
+	defaultHooksDir := filepath.Join(dataDir, "hooks")
+
+	// Ensure default directory if not specified.
+	if len(cfg.Directories) == 0 {
+		cfg.Directories = []string{defaultHooksDir}
+	} else {
+		// Always include default hooks directory even when user overrides config.
+		if !slices.Contains(cfg.Directories, defaultHooksDir) {
+			cfg.Directories = append([]string{defaultHooksDir}, cfg.Directories...)
+		}
+	}
+
+	return &manager{
+		workingDir: workingDir,
+		dataDir:    dataDir,
+		config:     cfg,
+		executor:   NewExecutor(workingDir),
+		hooks:      csync.NewMap[HookType, []string](),
+	}
+}
+
+// isExecutable checks if a file is executable.
+// On Unix: checks execute permission bits for .sh files.
+// On Windows: only recognizes .sh extension (as we use POSIX shell emulator).
+func isExecutable(info os.FileInfo) bool {
+	name := strings.ToLower(info.Name())
+	if !strings.HasSuffix(name, ".sh") {
+		return false
+	}
+
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode()&0o111 != 0
+}
+
+// executeHooks is the internal method that executes hooks for a given type.
+func (m *manager) executeHooks(ctx context.Context, hookType HookType, hookContext HookContext) (HookResult, error) {
+	if m.config.Disabled {
+		return HookResult{Continue: true}, nil
+	}
+
+	hookContext.HookType = hookType
+	hookContext.Environment = m.config.Environment
+
+	hooks := m.discoverHooks(hookType)
+	if len(hooks) == 0 {
+		return HookResult{Continue: true}, nil
+	}
+
+	slog.Debug("Executing hooks", "type", hookType, "count", len(hooks))
+
+	accumulated := HookResult{Continue: true}
+	for _, hookPath := range hooks {
+		if m.isDisabled(hookPath) {
+			slog.Debug("Skipping disabled hook", "path", hookPath)
+			continue
+		}
+
+		hookCtx, cancel := context.WithTimeout(ctx, time.Duration(m.config.TimeoutSeconds)*time.Second)
+
+		result, err := m.executor.Execute(hookCtx, hookPath, hookContext)
+		cancel()
+
+		if err != nil {
+			slog.Error("Hook execution failed", "path", hookPath, "error", err)
+			if hookType == HookPreToolUse {
+				accumulated.Continue = false
+				accumulated.Permission = "deny"
+				accumulated.Message = fmt.Sprintf("Hook failed: %v", err)
+				return accumulated, nil
+			}
+			continue
+		}
+
+		if result.Message != "" {
+			slog.Info("Hook message", "path", hookPath, "message", result.Message)
+		}
+
+		m.mergeResults(&accumulated, result)
+
+		if !result.Continue {
+			slog.Info("Hook stopped execution", "path", hookPath)
+			break
+		}
+	}
+
+	return accumulated, nil
+}
+
+// discoverHooks finds all executable hooks for the given type.
+func (m *manager) discoverHooks(hookType HookType) []string {
+	if cached, ok := m.hooks.Get(hookType); ok {
+		return cached
+	}
+
+	var hooks []string
+
+	for _, dir := range m.config.Directories {
+		if _, err := os.Stat(dir); err == nil {
+			entries, err := os.ReadDir(dir)
+			if err == nil {
+				for _, entry := range entries {
+					if entry.IsDir() {
+						continue
+					}
+
+					hookPath := filepath.Join(dir, entry.Name())
+
+					info, err := entry.Info()
+					if err != nil {
+						continue
+					}
+
+					if !isExecutable(info) {
+						continue
+					}
+
+					hooks = append(hooks, hookPath)
+					slog.Debug("Discovered catch-all hook", "path", hookPath, "type", hookType)
+				}
+			}
+		}
+
+		hookDir := filepath.Join(dir, string(hookType))
+		if _, err := os.Stat(hookDir); os.IsNotExist(err) {
+			continue
+		}
+
+		entries, err := os.ReadDir(hookDir)
+		if err != nil {
+			slog.Error("Failed to read hooks directory", "dir", hookDir, "error", err)
+			continue
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+
+			hookPath := filepath.Join(hookDir, entry.Name())
+
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+
+			if !isExecutable(info) {
+				slog.Debug("Skipping non-executable hook", "path", hookPath)
+				continue
+			}
+
+			hooks = append(hooks, hookPath)
+		}
+	}
+
+	if inlineHooks, ok := m.config.Inline[string(hookType)]; ok {
+		for _, inline := range inlineHooks {
+			hookPath, err := m.writeInlineHook(hookType, inline)
+			if err != nil {
+				slog.Error("Failed to write inline hook", "name", inline.Name, "error", err)
+				continue
+			}
+			hooks = append(hooks, hookPath)
+		}
+	}
+
+	sort.Strings(hooks)
+	m.hooks.Set(hookType, hooks)
+	return hooks
+}
+
+// writeInlineHook writes an inline hook script to a temp file.
+func (m *manager) writeInlineHook(hookType HookType, inline InlineHook) (string, error) {
+	tempDir := filepath.Join(m.dataDir, "hooks", ".inline", string(hookType))
+	if err := os.MkdirAll(tempDir, 0o755); err != nil {
+		return "", err
+	}
+
+	hookPath := filepath.Join(tempDir, inline.Name)
+	if err := os.WriteFile(hookPath, []byte(inline.Script), 0o755); err != nil {
+		return "", err
+	}
+
+	return hookPath, nil
+}
+
+// isDisabled checks if a hook is in the disabled list.
+func (m *manager) isDisabled(hookPath string) bool {
+	for _, dir := range m.config.Directories {
+		if rel, err := filepath.Rel(dir, hookPath); err == nil {
+			// Normalize to forward slashes for cross-platform comparison
+			rel = filepath.ToSlash(rel)
+			if slices.Contains(m.config.DisableHooks, rel) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// mergeResults merges a new result into the accumulated result.
+func (m *manager) mergeResults(accumulated *HookResult, new *HookResult) {
+	accumulated.Continue = accumulated.Continue && new.Continue
+
+	if new.Permission != "" {
+		if new.Permission == "deny" {
+			accumulated.Permission = "deny"
+		} else if new.Permission == "approve" && accumulated.Permission == "" {
+			accumulated.Permission = "approve"
+		}
+	}
+
+	if new.ModifiedPrompt != nil {
+		accumulated.ModifiedPrompt = new.ModifiedPrompt
+	}
+
+	if len(new.ModifiedInput) > 0 {
+		if accumulated.ModifiedInput == nil {
+			accumulated.ModifiedInput = make(map[string]any)
+		}
+		maps.Copy(accumulated.ModifiedInput, new.ModifiedInput)
+	}
+
+	if len(new.ModifiedOutput) > 0 {
+		if accumulated.ModifiedOutput == nil {
+			accumulated.ModifiedOutput = make(map[string]any)
+		}
+		maps.Copy(accumulated.ModifiedOutput, new.ModifiedOutput)
+	}
+
+	if new.ContextContent != "" {
+		if accumulated.ContextContent == "" {
+			accumulated.ContextContent = new.ContextContent
+		} else {
+			accumulated.ContextContent += "\n\n" + new.ContextContent
+		}
+	}
+
+	accumulated.ContextFiles = append(accumulated.ContextFiles, new.ContextFiles...)
+
+	if new.Message != "" {
+		if accumulated.Message == "" {
+			accumulated.Message = new.Message
+		} else {
+			accumulated.Message += "; " + new.Message
+		}
+	}
+}
+
+// ListHooks implements Manager.
+func (m *manager) ListHooks(hookType HookType) []string {
+	return m.discoverHooks(hookType)
+}
+
+// ExecuteUserPromptSubmit executes user-prompt-submit hooks.
+func (m *manager) ExecuteUserPromptSubmit(ctx context.Context, sessionID, workingDir string, data UserPromptSubmitData) (HookResult, error) {
+	hookCtx := HookContext{
+		SessionID:  sessionID,
+		WorkingDir: workingDir,
+		Data:       data,
+	}
+
+	return m.executeHooks(ctx, HookUserPromptSubmit, hookCtx)
+}
+
+// ExecutePreToolUse executes pre-tool-use hooks.
+func (m *manager) ExecutePreToolUse(ctx context.Context, sessionID, workingDir string, data PreToolUseData) (HookResult, error) {
+	hookCtx := HookContext{
+		SessionID:  sessionID,
+		WorkingDir: workingDir,
+		ToolName:   data.ToolName,
+		ToolCallID: data.ToolCallID,
+		Data:       data,
+	}
+
+	return m.executeHooks(ctx, HookPreToolUse, hookCtx)
+}
+
+// ExecutePostToolUse executes post-tool-use hooks.
+func (m *manager) ExecutePostToolUse(ctx context.Context, sessionID, workingDir string, data PostToolUseData) (HookResult, error) {
+	hookCtx := HookContext{
+		SessionID:  sessionID,
+		WorkingDir: workingDir,
+		ToolName:   data.ToolName,
+		ToolCallID: data.ToolCallID,
+		Data:       data,
+	}
+
+	return m.executeHooks(ctx, HookPostToolUse, hookCtx)
+}
+
+// ExecuteStop executes stop hooks.
+func (m *manager) ExecuteStop(ctx context.Context, sessionID, workingDir string, data StopData) (HookResult, error) {
+	hookCtx := HookContext{
+		SessionID:  sessionID,
+		WorkingDir: workingDir,
+		Data:       data,
+	}
+
+	return m.executeHooks(ctx, HookStop, hookCtx)
+}
+
+// ExecuteSessionStart executes session-start hooks.
+func (m *manager) ExecuteSessionStart(ctx context.Context, sessionID, workingDir string, data SessionStartData) (HookResult, error) {
+	hookCtx := HookContext{
+		SessionID:  sessionID,
+		WorkingDir: workingDir,
+		Data:       data,
+	}
+
+	return m.executeHooks(ctx, HookSessionStart, hookCtx)
+}

--- a/internal/hooks/manager_test.go
+++ b/internal/hooks/manager_test.go
@@ -1,0 +1,526 @@
+package hooks
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManager(t *testing.T) {
+	t.Run("discovers hooks in order", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "pre-tool-use")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Create hooks with numeric prefixes.
+		hooks := []string{"02-second.sh", "01-first.sh", "03-third.sh"}
+		for _, name := range hooks {
+			path := filepath.Join(hooksDir, name)
+			err := os.WriteFile(path, []byte("#!/bin/bash\necho test"), 0o755)
+			require.NoError(t, err)
+		}
+
+		mgr := NewManager(tempDir, dataDir, nil)
+		discovered := mgr.ListHooks(HookPreToolUse)
+
+		assert.Len(t, discovered, 3)
+		// Should be sorted alphabetically.
+		assert.Contains(t, discovered[0], "01-first.sh")
+		assert.Contains(t, discovered[1], "02-second.sh")
+		assert.Contains(t, discovered[2], "03-third.sh")
+	})
+
+	t.Run("skips non-executable files", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "pre-tool-use")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Create non-executable file.
+		path := filepath.Join(hooksDir, "non-executable.sh")
+		err := os.WriteFile(path, []byte("#!/bin/bash\necho test"), 0o644)
+		require.NoError(t, err)
+
+		mgr := NewManager(tempDir, dataDir, nil)
+		discovered := mgr.ListHooks(HookPreToolUse)
+
+		// On Windows, .sh files are always considered executable
+		// On Unix, non-executable files (0o644) should be skipped
+		if runtime.GOOS == "windows" {
+			assert.Len(t, discovered, 1, "On Windows, .sh files are executable regardless of permissions")
+		} else {
+			assert.Len(t, discovered, 0, "On Unix, non-executable files should be skipped")
+		}
+	})
+
+	t.Run("discovers hooks by extension on all platforms", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "pre-tool-use")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Only .sh files are recognized as hooks.
+		// On Unix, they need execute permission. On Windows, extension is enough.
+		validHook := filepath.Join(hooksDir, "valid-hook.sh")
+		err := os.WriteFile(validHook, []byte("#!/bin/bash\necho test"), 0o755)
+		require.NoError(t, err)
+
+		// These should NOT be discovered (wrong extensions).
+		invalidFiles := []string{"hook.bat", "hook.cmd", "hook.ps1", "hook.txt"}
+		for _, name := range invalidFiles {
+			path := filepath.Join(hooksDir, name)
+			err := os.WriteFile(path, []byte("echo test"), 0o755)
+			require.NoError(t, err)
+		}
+
+		mgr := NewManager(tempDir, dataDir, nil)
+		discovered := mgr.ListHooks(HookPreToolUse)
+
+		// Only the .sh file should be discovered.
+		assert.Len(t, discovered, 1)
+		assert.Contains(t, discovered[0], "valid-hook.sh")
+	})
+
+	t.Run("executes multiple hooks and merges results", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "user-prompt-submit")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Hook 1: Adds context.
+		hook1 := filepath.Join(hooksDir, "01-add-context.sh")
+		err := os.WriteFile(hook1, []byte(`#!/bin/bash
+crush_add_context "Context from hook 1"
+`), 0o755)
+		require.NoError(t, err)
+
+		// Hook 2: Adds more context.
+		hook2 := filepath.Join(hooksDir, "02-add-more.sh")
+		err = os.WriteFile(hook2, []byte(`#!/bin/bash
+crush_add_context "Context from hook 2"
+`), 0o755)
+		require.NoError(t, err)
+
+		mgr := NewManager(tempDir, dataDir, nil)
+		ctx := context.Background()
+		result, err := mgr.ExecuteUserPromptSubmit(ctx, "test", tempDir, UserPromptSubmitData{
+			Prompt: "test prompt",
+		})
+
+		require.NoError(t, err)
+		assert.True(t, result.Continue)
+		// Contexts should be merged with \n\n separator.
+		assert.Equal(t, "Context from hook 1\n\nContext from hook 2", result.ContextContent)
+	})
+
+	t.Run("stops on first hook that sets continue=false", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "pre-tool-use")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Hook 1: Denies.
+		hook1 := filepath.Join(hooksDir, "01-deny.sh")
+		err := os.WriteFile(hook1, []byte(`#!/bin/bash
+crush_deny "blocked"
+`), 0o755)
+		require.NoError(t, err)
+
+		// Hook 2: Should not execute.
+		hook2 := filepath.Join(hooksDir, "02-never-runs.sh")
+		err = os.WriteFile(hook2, []byte(`#!/bin/bash
+export CRUSH_MESSAGE="should not see this"
+`), 0o755)
+		require.NoError(t, err)
+
+		mgr := NewManager(tempDir, dataDir, nil)
+		ctx := context.Background()
+		result, err := mgr.ExecutePreToolUse(ctx, "test", tempDir, PreToolUseData{})
+
+		require.NoError(t, err)
+		assert.False(t, result.Continue)
+		assert.Equal(t, "deny", result.Permission)
+		assert.Equal(t, "blocked", result.Message)
+		assert.NotContains(t, result.Message, "should not see this")
+	})
+
+	t.Run("merges permissions with deny winning", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "pre-tool-use")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Hook 1: Approves.
+		hook1 := filepath.Join(hooksDir, "01-approve.sh")
+		err := os.WriteFile(hook1, []byte(`#!/bin/bash
+export CRUSH_PERMISSION=approve
+`), 0o755)
+		require.NoError(t, err)
+
+		// Hook 2: Denies (should win).
+		hook2 := filepath.Join(hooksDir, "02-deny.sh")
+		err = os.WriteFile(hook2, []byte(`#!/bin/bash
+export CRUSH_PERMISSION=deny
+`), 0o755)
+		require.NoError(t, err)
+
+		mgr := NewManager(tempDir, dataDir, nil)
+		ctx := context.Background()
+		result, err := mgr.ExecutePreToolUse(ctx, "test", tempDir, PreToolUseData{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "deny", result.Permission)
+	})
+
+	t.Run("disabled hooks are skipped", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "pre-tool-use")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Hook 1: Should run.
+		hook1 := filepath.Join(hooksDir, "01-enabled.sh")
+		err := os.WriteFile(hook1, []byte(`#!/bin/bash
+export CRUSH_MESSAGE="enabled"
+`), 0o755)
+		require.NoError(t, err)
+
+		// Hook 2: Disabled.
+		hook2 := filepath.Join(hooksDir, "02-disabled.sh")
+		err = os.WriteFile(hook2, []byte(`#!/bin/bash
+export CRUSH_MESSAGE="disabled"
+`), 0o755)
+		require.NoError(t, err)
+
+		cfg := &Config{
+			TimeoutSeconds: 30,
+			Directories:    []string{filepath.Join(dataDir, "hooks")},
+			DisableHooks:   []string{"pre-tool-use/02-disabled.sh"},
+		}
+
+		mgr := NewManager(tempDir, dataDir, cfg)
+		ctx := context.Background()
+		result, err := mgr.ExecutePreToolUse(ctx, "test", tempDir, PreToolUseData{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "enabled", result.Message)
+	})
+
+	t.Run("inline hooks are executed", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+
+		cfg := &Config{
+			TimeoutSeconds: 30,
+			Directories:    []string{filepath.Join(dataDir, "hooks")},
+			Inline: map[string][]InlineHook{
+				"user-prompt-submit": {
+					{
+						Name: "inline-test.sh",
+						Script: `#!/bin/bash
+export CRUSH_MESSAGE="inline hook executed"
+`,
+					},
+				},
+			},
+		}
+
+		mgr := NewManager(tempDir, dataDir, cfg)
+		ctx := context.Background()
+		result, err := mgr.ExecuteUserPromptSubmit(ctx, "test", tempDir, UserPromptSubmitData{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "inline hook executed", result.Message)
+	})
+
+	t.Run("returns empty result when hooks disabled", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+
+		cfg := &Config{}
+
+		mgr := NewManager(tempDir, dataDir, cfg)
+		ctx := context.Background()
+		result, err := mgr.ExecutePreToolUse(ctx, "test", tempDir, PreToolUseData{})
+
+		require.NoError(t, err)
+		assert.True(t, result.Continue)
+		assert.Empty(t, result.Message)
+	})
+
+	t.Run("returns empty result when no hooks found", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+
+		mgr := NewManager(tempDir, dataDir, nil)
+		ctx := context.Background()
+		result, err := mgr.ExecutePreToolUse(ctx, "test", tempDir, PreToolUseData{})
+
+		require.NoError(t, err)
+		assert.True(t, result.Continue)
+	})
+
+	t.Run("handles hook failure on PreToolUse by denying", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "pre-tool-use")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Hook that fails with exit 1.
+		hook := filepath.Join(hooksDir, "01-fail.sh")
+		err := os.WriteFile(hook, []byte(`#!/bin/bash
+exit 1
+`), 0o755)
+		require.NoError(t, err)
+
+		mgr := NewManager(tempDir, dataDir, nil)
+		ctx := context.Background()
+		result, err := mgr.ExecutePreToolUse(ctx, "test", tempDir, PreToolUseData{})
+
+		require.NoError(t, err)
+		assert.False(t, result.Continue)
+		assert.Equal(t, "deny", result.Permission)
+		assert.Contains(t, result.Message, "Hook failed")
+	})
+
+	t.Run("caches discovered hooks", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "pre-tool-use")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		hook := filepath.Join(hooksDir, "01-test.sh")
+		err := os.WriteFile(hook, []byte("#!/bin/bash\necho test"), 0o755)
+		require.NoError(t, err)
+
+		mgr := NewManager(tempDir, dataDir, nil)
+
+		// First call - discovers.
+		hooks1 := mgr.ListHooks(HookPreToolUse)
+		assert.Len(t, hooks1, 1)
+
+		// Second call - should use cache.
+		hooks2 := mgr.ListHooks(HookPreToolUse)
+		assert.Equal(t, hooks1, hooks2)
+	})
+
+	t.Run("catch-all hooks at root execute for all types", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Create catch-all hook at root level.
+		catchAllHook := filepath.Join(hooksDir, "00-catch-all.sh")
+		err := os.WriteFile(catchAllHook, []byte(`#!/bin/bash
+export CRUSH_MESSAGE="catch-all: $CRUSH_HOOK_TYPE"
+`), 0o755)
+		require.NoError(t, err)
+
+		// Create specific hook for pre-tool-use.
+		specificDir := filepath.Join(hooksDir, "pre-tool-use")
+		require.NoError(t, os.MkdirAll(specificDir, 0o755))
+		specificHook := filepath.Join(specificDir, "01-specific.sh")
+		err = os.WriteFile(specificHook, []byte(`#!/bin/bash
+export CRUSH_MESSAGE="$CRUSH_MESSAGE; specific hook"
+`), 0o755)
+		require.NoError(t, err)
+
+		mgr := NewManager(tempDir, dataDir, nil)
+
+		// Test PreToolUse - should execute both catch-all and specific.
+		ctx := context.Background()
+		result, err := mgr.ExecutePreToolUse(ctx, "test", tempDir, PreToolUseData{})
+
+		require.NoError(t, err)
+		assert.Contains(t, result.Message, "catch-all: pre-tool-use")
+		assert.Contains(t, result.Message, "specific hook")
+
+		// Test UserPromptSubmit - should only execute catch-all.
+		result2, err := mgr.ExecuteUserPromptSubmit(ctx, "test", tempDir, UserPromptSubmitData{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "catch-all: user-prompt-submit", result2.Message)
+		assert.NotContains(t, result2.Message, "specific hook")
+	})
+
+	t.Run("passes environment variables from config to hooks", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "pre-tool-use")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Hook that checks for custom environment variables.
+		hook := filepath.Join(hooksDir, "01-check-env.sh")
+		err := os.WriteFile(hook, []byte(`#!/bin/bash
+if [ "$CUSTOM_API_KEY" = "test-key-123" ] && [ "$CUSTOM_ENV" = "production" ]; then
+  export CRUSH_MESSAGE="config environment variables received"
+else
+  export CRUSH_MESSAGE="environment variables missing"
+fi
+`), 0o755)
+		require.NoError(t, err)
+
+		cfg := &Config{
+			TimeoutSeconds: 30,
+			Directories:    []string{filepath.Join(dataDir, "hooks")},
+			Environment: map[string]string{
+				"CUSTOM_API_KEY": "test-key-123",
+				"CUSTOM_ENV":     "production",
+			},
+		}
+
+		mgr := NewManager(tempDir, dataDir, cfg)
+		ctx := context.Background()
+		result, err := mgr.ExecutePreToolUse(ctx, "test", tempDir, PreToolUseData{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "config environment variables received", result.Message)
+	})
+
+	t.Run("handles inline hook write failure gracefully", func(t *testing.T) {
+		tempDir := t.TempDir()
+		// Use a read-only directory as dataDir to force write failure.
+		readOnlyDir := filepath.Join(tempDir, "readonly")
+		require.NoError(t, os.MkdirAll(readOnlyDir, 0o555)) // Read-only
+
+		cfg := &Config{
+			TimeoutSeconds: 30,
+			Directories:    []string{filepath.Join(readOnlyDir, "hooks")},
+			Inline: map[string][]InlineHook{
+				"pre-tool-use": {
+					{
+						Name:   "inline-fail.sh",
+						Script: "#!/bin/bash\necho test",
+					},
+				},
+			},
+		}
+
+		mgr := NewManager(tempDir, readOnlyDir, cfg)
+		ctx := context.Background()
+
+		// Should not error even though inline hook write fails.
+		// The hook will be skipped and logged.
+		result, err := mgr.ExecutePreToolUse(ctx, "test", tempDir, PreToolUseData{})
+
+		require.NoError(t, err)
+		assert.True(t, result.Continue) // Should continue despite write failure
+	})
+
+	t.Run("handles hooks directory read failure gracefully", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "pre-tool-use")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Create a hook file.
+		hook := filepath.Join(hooksDir, "01-test.sh")
+		require.NoError(t, os.WriteFile(hook, []byte("#!/bin/bash\necho test"), 0o755))
+
+		mgr := NewManager(tempDir, dataDir, nil)
+
+		// Make directory unreadable after discovery to test error path.
+		// Note: This is tricky to test reliably cross-platform.
+		// On some systems, we can't make a directory unreadable if we own it.
+		// We'll test that hooks are cached and re-discovery works.
+		hooks1 := mgr.ListHooks(HookPreToolUse)
+		assert.Len(t, hooks1, 1)
+
+		// Add another hook.
+		hook2 := filepath.Join(hooksDir, "02-test.sh")
+		require.NoError(t, os.WriteFile(hook2, []byte("#!/bin/bash\necho test2"), 0o755))
+
+		// Should still return cached hooks (won't see new one).
+		hooks2 := mgr.ListHooks(HookPreToolUse)
+		assert.Len(t, hooks2, 1, "hooks are cached, new hook not seen")
+	})
+
+	t.Run("approve permission is set when accumulated is empty", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "pre-tool-use")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Single hook that approves.
+		hook := filepath.Join(hooksDir, "01-approve.sh")
+		require.NoError(t, os.WriteFile(hook, []byte(`#!/bin/bash
+export CRUSH_PERMISSION=approve
+export CRUSH_MESSAGE="auto-approved"
+`), 0o755))
+
+		mgr := NewManager(tempDir, dataDir, nil)
+		ctx := context.Background()
+		result, err := mgr.ExecutePreToolUse(ctx, "test", tempDir, PreToolUseData{})
+
+		require.NoError(t, err)
+		assert.Equal(t, "approve", result.Permission)
+		assert.Equal(t, "auto-approved", result.Message)
+	})
+
+	t.Run("executes session-start hooks", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "session-start")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Hook: Adds session context.
+		hook := filepath.Join(hooksDir, "01-session-context.sh")
+		err := os.WriteFile(hook, []byte(`#!/bin/bash
+crush_add_context "Session started: ${CRUSH_SESSION_ID}"
+`), 0o755)
+		require.NoError(t, err)
+
+		mgr := NewManager(tempDir, dataDir, nil)
+		ctx := context.Background()
+		result, err := mgr.ExecuteSessionStart(ctx, "session-123", tempDir, SessionStartData{
+			SessionID:   "session-123",
+			SessionName: "Test Session",
+			WorkingDir:  tempDir,
+			Model:       "grok-4-1-fast",
+			Provider:    "xai",
+			IsResume:    false,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, result.Continue)
+		// Note: Environment variable substitution happens in shell, verify context is set
+		assert.NotEmpty(t, result.ContextContent)
+	})
+
+	t.Run("session-start hook can deny session", func(t *testing.T) {
+		tempDir := t.TempDir()
+		dataDir := filepath.Join(tempDir, ".crush")
+		hooksDir := filepath.Join(dataDir, "hooks", "session-start")
+		require.NoError(t, os.MkdirAll(hooksDir, 0o755))
+
+		// Hook: Denies session initialization.
+		hook := filepath.Join(hooksDir, "01-block-session.sh")
+		err := os.WriteFile(hook, []byte(`#!/bin/bash
+export CRUSH_CONTINUE=false
+export CRUSH_MESSAGE="Session denied by security policy"
+`), 0o755)
+		require.NoError(t, err)
+
+		mgr := NewManager(tempDir, dataDir, nil)
+		ctx := context.Background()
+		result, err := mgr.ExecuteSessionStart(ctx, "session-456", tempDir, SessionStartData{
+			SessionID:   "session-456",
+			SessionName: "Test Session",
+			WorkingDir:  tempDir,
+			Model:       "grok-4-1-fast",
+			Provider:    "xai",
+			IsResume:    false,
+		})
+
+		require.NoError(t, err)
+		assert.False(t, result.Continue)
+		assert.Equal(t, "Session denied by security policy", result.Message)
+	})
+}

--- a/internal/hooks/types.go
+++ b/internal/hooks/types.go
@@ -1,0 +1,151 @@
+// Package hooks provides a Git-like hooks system for Crush.
+//
+// Hooks are executable scripts that run at specific points in the application
+// lifecycle. They can modify behavior, add context, control permissions, and
+// audit activity.
+package hooks
+
+import "context"
+
+// HookType represents the type of hook.
+type HookType string
+
+const (
+	// HookUserPromptSubmit executes after user submits prompt, before sending to LLM.
+	HookUserPromptSubmit HookType = "user-prompt-submit"
+
+	// HookPreToolUse executes after LLM requests tool use, before permission check & execution.
+	HookPreToolUse HookType = "pre-tool-use"
+
+	// HookPostToolUse executes after tool executes, before result sent to LLM.
+	HookPostToolUse HookType = "post-tool-use"
+
+	// HookStop executes when agent conversation loop stops or is cancelled.
+	HookStop HookType = "stop"
+
+	// HookSessionStart executes when a new session is created or resumed.
+	HookSessionStart HookType = "session-start"
+)
+
+// HookContext contains the data passed to hooks.
+type HookContext struct {
+	// HookType is the type of hook being executed.
+	HookType HookType
+
+	// SessionID is the current session ID.
+	SessionID string
+
+	// WorkingDir is the working directory.
+	WorkingDir string
+
+	// Data is hook-specific data marshaled to JSON and passed via stdin.
+	// For UserPromptSubmit: prompt, attachments, model, is_first_message
+	// For PreToolUse: tool_name, tool_call_id, tool_input
+	// For PostToolUse: tool_name, tool_call_id, tool_input, tool_output, execution_time_ms
+	// For Stop: reason
+	Data any
+
+	// ToolName is the tool name (for tool hooks only).
+	ToolName string
+
+	// ToolCallID is the tool call ID (for tool hooks only).
+	ToolCallID string
+
+	// Environment contains additional environment variables to pass to the hook.
+	Environment map[string]string
+}
+
+// HookResult contains the result of hook execution.
+type HookResult struct {
+	// HookType the hook type
+	HookType HookType `json:"hook_type"`
+	// Name the name of the hook (usually the file name)
+	Name string `json:"name"`
+	// Path hook path
+	Path string `json:"path"`
+	// AllResults stores all results for this event
+	AllResults []HookResult `json:"all_results,omitempty"`
+	// Continue indicates whether to continue execution.
+	// If false, execution stops.
+	Continue bool `json:"continue"`
+
+	// Permission decision (for PreToolUse hooks only).
+	// Values: "ask" (default), "approve", "deny"
+	Permission string `json:"permission"`
+
+	// ModifiedPrompt is the modified user prompt (for UserPromptSubmit).
+	ModifiedPrompt *string `json:"modified_prompt"`
+
+	// ModifiedInput is the modified tool input parameters (for PreToolUse).
+	// This is a map that can be merged with the original tool input.
+	ModifiedInput map[string]any `json:"modified_input"`
+
+	// ModifiedOutput is the modified tool output (for PostToolUse).
+	ModifiedOutput map[string]any `json:"modified_output"`
+
+	// ContextContent is raw text content to add to LLM context.
+	ContextContent string `json:"context_content"`
+
+	// ContextFiles is a list of file paths to load and add to LLM context.
+	ContextFiles []string `json:"context_files"`
+
+	// Message is a user-facing message (logged and potentially displayed).
+	Message string `json:"message"`
+}
+
+// Manager coordinates hook discovery and execution.
+type Manager interface {
+	// ListHooks returns all discovered hooks for a given type.
+	ListHooks(hookType HookType) []string
+
+	// ExecuteUserPromptSubmit executes the UserPromptSubmit event
+	ExecuteUserPromptSubmit(ctx context.Context, sessionID, workingDir string, data UserPromptSubmitData) (HookResult, error)
+
+	// ExecutePreToolUse executes the PreToolUse event
+	ExecutePreToolUse(ctx context.Context, sessionID, workingDir string, data PreToolUseData) (HookResult, error)
+
+	// ExecutePostToolUse executes the PostToolUse event
+	ExecutePostToolUse(ctx context.Context, sessionID, workingDir string, data PostToolUseData) (HookResult, error)
+
+	// ExecuteStop executes the Stop event
+	ExecuteStop(ctx context.Context, sessionID, workingDir string, data StopData) (HookResult, error)
+
+	// ExecuteSessionStart executes the SessionStart event
+	ExecuteSessionStart(ctx context.Context, sessionID, workingDir string, data SessionStartData) (HookResult, error)
+}
+
+type UserPromptSubmitData struct {
+	Prompt         string   `json:"prompt"`
+	Attachments    []string `json:"attachments"`
+	Model          string   `json:"model"`
+	Provider       string   `json:"provider"`
+	IsFirstMessage bool     `json:"is_first_message"`
+}
+
+type PreToolUseData struct {
+	ToolName   string         `json:"tool_name"`
+	ToolCallID string         `json:"tool_call_id"`
+	ToolInput  map[string]any `json:"tool_input"`
+}
+
+type PostToolUseData struct {
+	ToolName        string         `json:"tool_name"`
+	ToolCallID      string         `json:"tool_call_id"`
+	ToolInput       map[string]any `json:"tool_input"`
+	ToolOutput      map[string]any `json:"tool_output"`
+	ExecutionTimeMs int64          `json:"execution_time_ms"`
+}
+
+type StopData struct {
+	Reason string `json:"reason"`
+}
+
+// SessionStartData contains data for the session-start hook.
+type SessionStartData struct {
+	SessionID   string `json:"session_id"`
+	SessionName string `json:"session_name"`
+	WorkingDir  string `json:"working_dir"`
+	Model       string `json:"model"`
+	Provider    string `json:"provider"`
+	IsResume    bool   `json:"is_resume"` // true if resuming existing session
+}


### PR DESCRIPTION
## Summary

  Implements the missing `HookSessionStart` event from PR #1487, enabling external hooks to run at session initialization.

  ## Changes

  - Added `HookSessionStart` constant and `SessionStartData` struct
  - Implemented `ExecuteSessionStart` method in Manager interface
  - Added hook execution in both TUI and non-interactive modes
  - Included comprehensive tests for SessionStart hook functionality

  ## Testing

  - Added 2 tests to `internal/hooks/manager_test.go`
  - All existing tests pass
  - Tests verify: hook execution, context addition, and session denial capability

  ## Use Case

  External hooks can now run at session start for:
  - Loading PAI context and skill systems
  - Environment setup and initialization
  - Session state preparation

  Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [N/A - This is from PR #1487, not a new feature ] I have created a discussion that was approved by a maintainer (for new features).
