### PR TITLE
fix: improve lsp_references

### DIFF
--- a/internal/agent/tools/references.go
+++ b/internal/agent/tools/references.go
@@ -25,10 +25,6 @@ type ReferencesParams struct {
 	Path   string `json:"path,omitempty" description:"The directory to search in. Use a directory/file to narrow down the symbol search. Defaults to the current working directory."`
 }
 
-type referencesTool struct {
-	lspClients *csync.Map[string, *lsp.Client]
-}
-
 const ReferencesToolName = "lsp_references"
 
 //go:embed references.md
@@ -85,10 +81,6 @@ func NewReferencesTool(lspClients *csync.Map[string, *lsp.Client]) fantasy.Agent
 			}
 			return fantasy.NewTextResponse(fmt.Sprintf("No references found for symbol '%s'", params.Symbol)), nil
 		})
-}
-
-func (r *referencesTool) Name() string {
-	return ReferencesToolName
 }
 
 func find(ctx context.Context, lspClients *csync.Map[string, *lsp.Client], symbol string, match grepMatch) ([]protocol.Location, error) {

--- a/internal/agent/tools/references.md
+++ b/internal/agent/tools/references.md
@@ -1,5 +1,12 @@
 Find all references to/usage of a symbol by name using the Language Server Protocol (LSP).
 
+<critical_rules>
+- NEVER use grep for searching code! Always use lsp_references instead!
+- A symbol can be a variable, function, method, package, constant, or any other name.
+- This applies to ALL symbols: project-defined, stdlib (e.g., `strings.Cut`), and external packages.
+- Only fall back to grep for non-symbol text searches (log messages, config keys, comments, string literals).
+</critical_rules>
+
 <usage>
 - Provide symbol name (e.g., "MyFunction", "myVariable", "MyType").
 - Optional path to narrow search to a directory or file (defaults to current directory).
@@ -11,6 +18,7 @@ Find all references to/usage of a symbol by name using the Language Server Proto
 - Returns references grouped by file with line and column numbers.
 - Supports multiple programming languages via LSP.
 - Finds only real references (not comments or unrelated strings).
+- Works for both project-defined symbols AND external/stdlib symbols (e.g., `strings.Cut`, `fmt.Println`).
 </features>
 
 <limitations>
@@ -19,8 +27,6 @@ Find all references to/usage of a symbol by name using the Language Server Proto
 </limitations>
 
 <tips>
-- Use this first when searching for where a symbol is used.
-- Do not use grep/glob for symbol searches.
 - Narrow scope with the path parameter for faster, more relevant results.
-- Use qualified names (e.g., pkg.Func, Class.method) for higher precision.
+- Use qualified names (e.g., pkg.Func, Class.method, strings.Cut, fmt.Errorf) for higher precision.
 </tips>


### PR DESCRIPTION
I've noticed that most times the LLM uses grep instead of this.

This seems to improve it a bit. Now if I ask about names that look like functions or something like that, it uses find references first.
