### PR TITLE
fix(tui): show thinking status for VertexAI models in sidebar

### DIFF
--- a/internal/tui/components/chat/sidebar/sidebar.go
+++ b/internal/tui/components/chat/sidebar/sidebar.go
@@ -563,7 +563,7 @@ func (s *sidebarCmp) currentModelBlock() string {
 	if model.CanReason {
 		reasoningInfoStyle := t.S().Subtle.PaddingLeft(2)
 		switch modelProvider.Type {
-		case catwalk.TypeAnthropic:
+		case catwalk.TypeAnthropic, catwalk.TypeVertexAI:
 			formatter := cases.Title(language.English, cases.NoLower)
 			if selectedModel.Think {
 				parts = append(parts, reasoningInfoStyle.Render(formatter.String("Thinking on")))


### PR DESCRIPTION
## Summary

- Extends thinking toggle visibility to Vertex AI provider (in addition to Google and Anthropic)
- Both Vertex AI and Google use Gemini models that support extended thinking

## Test plan

- [x] Verified thinking toggle shows for Vertex AI provider

💘 Generated with Crush