### PR TITLE
feat: abortable tools and search space protection

### DIFF
--- a/VERTEX_THINKING_BUG.md
+++ b/VERTEX_THINKING_BUG.md
@@ -1,0 +1,59 @@
+# Vertex AI Thinking Toggle Bug
+
+## Summary
+
+Thinking mode toggle doesn't work for Claude models on Vertex AI. The UI command exists but has no effect.
+
+## Symptoms
+
+1. "Enable Thinking Mode" command appears in command palette (Ctrl+P)
+2. Running the command shows "Thinking mode enabled" toast
+3. Sidebar does NOT update to show "Thinking on"
+4. Thinking is NOT actually sent to the API
+
+## Root Cause
+
+Two places check provider type but don't include Vertex AI:
+
+### 1. Sidebar Display (`internal/tui/components/chat/sidebar/sidebar.go:567`)
+
+```go
+switch modelProvider.Type {
+case catwalk.TypeAnthropic:
+    // Shows "Thinking on/off"
+default:
+    // Shows "Reasoning {effort}" - WRONG for Vertex AI
+}
+```
+
+**Fix:** Add `catwalk.TypeVertexAI` case that displays thinking status like Anthropic.
+
+### 2. API Options (`internal/agent/coordinator.go:276-343`)
+
+```go
+switch providerCfg.Type {
+case anthropic.Name:
+    // Applies thinking options with budget_tokens
+case google.Name:
+    // Applies thinking_config for Google AI
+// MISSING: "google-vertex" case
+}
+```
+
+**Fix:** Add `"google-vertex"` case. Vertex AI uses the same API format as `google.Name` (uses `google.ParseOptions`), so it should apply `thinking_config` like the `google.Name` case.
+
+Note: Provider building at line 822 already handles `"google-vertex"` correctly - it's only the options merging that's missing.
+
+## Files to Modify
+
+| File | Line | Change |
+|------|------|--------|
+| `internal/tui/components/chat/sidebar/sidebar.go` | 567 | Add `case catwalk.TypeVertexAI:` with same logic as `TypeAnthropic` |
+| `internal/agent/coordinator.go` | 322 | Change `case google.Name:` to `case google.Name, "google-vertex":` |
+
+## Testing
+
+1. Configure Vertex AI provider with Claude Opus 4.5
+2. Open command palette, run "Enable Thinking Mode"
+3. Verify sidebar shows "Thinking On"
+4. Send a message and verify thinking blocks appear in response

--- a/VISUAL_BUG_ANALYSIS.md
+++ b/VISUAL_BUG_ANALYSIS.md
@@ -1,0 +1,345 @@
+# Visual Bug Analysis: Text Input Field Rendering Issue
+
+## Executive Summary
+
+**Problem**: Text input field is invisible after session restore, only cursor visible.
+
+**Most Likely Root Cause**: The bubbles viewport component returns an empty string when its effective content area (width or height after subtracting frame size) is 0. The cursor is still rendered because it's calculated independently.
+
+**Key Code Paths**:
+1. `viewport.View()` returns "" if `w == 0 || h == 0`
+2. `viewport.visibleLines()` returns nil if `maxHeight == 0 || maxWidth == 0`  
+3. Where `maxHeight = max(0, Height - Style.GetVerticalFrameSize())`
+
+**Status**: Root cause mechanism identified. Need to determine what triggers the zero dimension condition.
+
+---
+
+## Problem Description
+
+- Text input field (editor) rendering is completely gone after session restore
+- Only a pink cursor block is visible at the bottom
+- Cursor position appears 1-2 lines above where it should be in other instances
+- Problem persists across session restore after restart
+
+## Affected Session
+
+Database: `~/mobile/gabriela-bogk/mob-code-search/.crush/crush.db`
+Session ID: `e7f3b6fc-f3cf-41f0-95c9-beb31020213c`
+Title: "Technical difficulties interrupted our progress on documentation"
+Message count: 186
+
+---
+
+## Code Analysis
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `internal/tui/page/chat/chat.go` | Main chat page layout and sizing |
+| `internal/tui/components/chat/editor/editor.go` | Text input component |
+| `internal/tui/tui.go` | Main app model, window resize handling |
+| `charm.land/bubbles/v2/textarea` | Textarea component from bubbles |
+| `charm.land/bubbles/v2/viewport` | Viewport component (renders textarea content) |
+
+### Constants
+
+```go
+EditorHeight = 5          // Height of editor including padding
+HeaderHeight = 1          // Height of header (compact mode)
+pillHeightWithBorder = 3  // Height of pills area
+```
+
+### Editor Height Flow
+
+1. `WindowSizeMsg` arrives → `tui.handleWindowResize()`
+2. Height adjusted: `height -= 2` (or 5 for full help)
+3. `chat.SetSize(width, height)` called
+4. Editor gets: `editor.SetSize(width, EditorHeight)` → always 5
+5. Textarea gets: `textarea.SetHeight(height - 2)` → 3 lines
+6. Position set: `editor.SetPosition(0, height - EditorHeight)`
+
+### Cursor Position Calculation
+
+```go
+// editor.go:500-508
+func (m *editorCmp) Cursor() *tea.Cursor {
+    cursor := m.textarea.Cursor()
+    if cursor != nil {
+        c := *cursor
+        c.X = c.X + m.x + 1
+        c.Y = c.Y + m.y + 1  // m.y = position set by SetPosition
+        return &c
+    }
+    return nil
+}
+```
+
+---
+
+## Theories
+
+### Theory 1: Race Condition in Session Restore
+**Status**: Less likely
+
+When restoring a session, `setSession` calls `SetSize(p.width, p.height)`. The page dimensions are set from WindowSizeMsg which should arrive early.
+
+Analysis shows that WindowSizeMsg sets p.width and p.height before any session operations.
+
+### Theory 2: Pills Height Miscalculation
+**Status**: Possible but unlikely
+
+In compact mode (line 821):
+```go
+cmds = append(cmds, p.chat.SetSize(width, height-EditorHeight-HeaderHeight-pillsAreaHeight))
+```
+
+This affects the chat area, not the editor. Editor always gets `EditorHeight=5`.
+
+### Theory 3: Initialization Sequence Issue
+**Status**: Investigated - Not the primary cause
+
+- Editor created with default textarea dimensions 40x6
+- WindowSizeMsg should arrive before View is needed for user interaction
+- Textarea has protective minimum width/height clamping
+
+### Theory 4: Viewport Returns Empty String
+**Status**: KEY FINDING
+
+Found in `bubbles/v2/viewport/viewport.go:734-736`:
+```go
+if w == 0 || h == 0 {
+    return ""
+}
+```
+
+If the viewport has width=0 OR height=0, View() returns empty string.
+
+**Analysis of how this could happen**:
+- Viewport inside textarea is created with width=0, height=0
+- textarea.New() calls SetHeight(6) and SetWidth(40) which should fix this
+- editor.SetSize() calls textarea.SetWidth(width-2) and textarea.SetHeight(height-2)
+- These have minimum value protection in textarea code
+
+### Theory 5: Style Width/Height Override
+**Status**: Under investigation
+
+The viewport.View() checks if Style.GetWidth() or Style.GetHeight() return non-zero values, and uses min(dimensions, style) in that case. If a style sets width or height to 0, it wouldn't override the viewport dimensions (only non-zero values are used).
+
+### Theory 6: Compositor/Layer Issue
+**Status**: New theory
+
+The chatPage uses `lipgloss.NewCompositor` with layers. The editor is part of the base `chatView` layer. If something causes the chatView string to be malformed or the compositor to render incorrectly, the editor could be cut off.
+
+---
+
+## Investigation Log
+
+### 2026-01-16: Initial Analysis
+
+**Examined files**:
+- `internal/tui/page/chat/chat.go` - SetSize, View functions
+- `internal/tui/components/chat/editor/editor.go` - SetSize, View, Cursor functions
+- `internal/tui/tui.go` - handleWindowResize, WindowSizeMsg handling
+
+**Key findings**:
+1. EditorHeight is constant (5), should not change
+2. Editor constructor does NOT initialize width/height (defaults to 0)
+3. Recent commit `cd41a84e` fixed cursor drift by using struct copies in Cursor() methods
+4. Cursor Y = textarea.cursor.Y + m.y + 1, where m.y comes from SetPosition
+
+### 2026-01-16: Viewport Analysis
+
+**Examined bubbles library**:
+- `textarea/textarea.go` - New(), SetWidth(), SetHeight(), Cursor()
+- `viewport/viewport.go` - View(), SetWidth(), SetHeight()
+
+**Critical findings**:
+
+1. **Viewport returns "" when dimensions are zero** (viewport.go:734-736)
+   - If `w == 0 || h == 0`, `View()` returns empty string
+   - This is the smoking gun for invisible editor content
+
+2. **Textarea has minimum width protection** (textarea.go:1118-1119)
+   - `minWidth := reservedInner + reservedOuter + 1`
+   - `inputWidth := max(w, minWidth)`
+   - Even negative widths are clamped to minWidth
+
+3. **Textarea has minimum height protection** (textarea.go:1152-1158)
+   - `m.height = max(h, minHeight)`  // minHeight = 1
+   - Heights are clamped to at least 1
+
+4. **Textarea has default dimensions** (textarea.go:369-370)
+   - Default height: 6, default width: 40
+   - Set in `New()` function
+
+5. **Cursor is calculated independently of View**
+   - `Cursor()` method uses `m.LineInfo()` and `m.viewport.YOffset()`
+   - Does NOT depend on View() being non-empty
+   - Cursor can still be positioned even when content is invisible
+
+### 2026-01-16: Deep Dive into Dimension Propagation
+
+**Tracing the flow**:
+
+1. `viewport.New()` creates viewport with width=0, height=0
+2. `setInitialValues()` does NOT set width/height
+3. `textarea.New()` calls `SetHeight(6)` and `SetWidth(40)`
+4. `textarea.SetHeight(6)` → `viewport.SetHeight(6)` 
+5. `textarea.SetWidth(40)` → `viewport.SetWidth(inputWidth - reservedOuter)`
+
+The viewport SHOULD have positive dimensions after textarea.New() completes.
+
+**Question**: What could reset viewport dimensions to 0 after initialization?
+
+Possibilities:
+- Direct call to viewport.SetWidth(0) or SetHeight(0) - NOT found in codebase
+- Style override - checked, crush styles don't set width/height on textarea
+- Some bubbles internal operation - needs more investigation
+
+---
+
+## Current Status
+
+The investigation has identified that the viewport returning "" is the likely cause, but we haven't found what sets the viewport dimensions to 0.
+
+**Next steps**:
+1. Add debug logging to editor.SetSize to capture width/height values
+2. Add debug logging to textarea.View() to check viewport dimensions
+3. Look for any resize events that could trigger with bad dimensions
+4. Check if the issue is specific to session restore or window resize
+
+---
+
+## Test Results
+
+(To be updated with test results)
+
+---
+
+## Conclusions
+
+### Preliminary Conclusion
+
+The most likely cause is that the viewport component inside the textarea has width=0 or height=0, which causes its View() method to return an empty string. The cursor still appears because cursor positioning is calculated independently.
+
+### Root Cause - Potential Discovery
+
+**New Finding**: The viewport's `visibleLines()` also checks dimensions:
+```go
+// viewport.go:329-335
+func (m Model) visibleLines() (lines []string) {
+    maxHeight := m.maxHeight()
+    maxWidth := m.maxWidth()
+
+    if maxHeight == 0 || maxWidth == 0 {
+        return nil
+    }
+    ...
+}
+```
+
+Where:
+```go
+func (m Model) maxWidth() int {
+    return max(0, m.Width()-m.Style.GetHorizontalFrameSize()-gutterSize)
+}
+func (m Model) maxHeight() int {
+    return max(0, m.Height()-m.Style.GetVerticalFrameSize())
+}
+```
+
+**This means**: Even if viewport.Width() > 0 and viewport.Height() > 0, if the Style has frame sizes (borders, padding) that exceed the dimensions, the content area becomes 0.
+
+For example:
+- If viewport.Height() = 1 and Style has 1 line of border/padding, maxHeight = 0
+- If viewport.Width() = 10 and Style has 12px of frame, maxWidth = 0
+
+This could explain the issue if the textarea's Base style (from crush's theme) has padding/border that exceeds the available space.
+
+### Potential Investigation Approaches
+
+1. **Add instrumentation** - Log dimensions at key points
+2. **Binary search git history** - Find when the bug was introduced
+3. **Check bubbles version** - See if there were recent changes to textarea/viewport
+4. **Reproduce in isolation** - Create a minimal test case
+
+### Possible Fix (if we can't find root cause)
+
+Add defensive guards in editor.View():
+```go
+func (m *editorCmp) View() string {
+    t := styles.CurrentTheme()
+    
+    // Guard against zero dimensions
+    if m.width <= 0 || m.height <= 0 {
+        return "" // Or return a placeholder
+    }
+    
+    // ... rest of view logic
+}
+```
+
+Or in editor.SetSize():
+```go
+func (m *editorCmp) SetSize(width, height int) tea.Cmd {
+    if width <= 2 || height <= 2 {
+        return nil  // Skip invalid dimensions
+    }
+    m.width = width
+    m.height = height
+    m.textarea.SetWidth(width - 2)
+    m.textarea.SetHeight(height - 2)
+    return nil
+}
+```
+
+---
+
+## Debug Logging Added (2026-01-16)
+
+Debug logging has been added to track dimensions when the bug is triggered.
+
+### Files Modified
+
+1. **`internal/tui/components/chat/editor/editor.go`**
+   - `SetSize()`: Logs width, height, textarea dimensions
+   - `View()`: Warns if textarea.View() returns empty string
+   - `SetPosition()`: Logs x, y values
+
+2. **`internal/tui/page/chat/chat.go`**
+   - `SetSize()`: Logs incoming dimensions, session state, compact mode, and editor sizing
+
+### Log Messages to Watch For
+
+| Message | Level | Meaning |
+|---------|-------|---------|
+| `editor.SetSize` | DEBUG | Normal dimension setting |
+| `editor.SetSize: invalid dimensions` | WARN | Textarea dimensions are ≤0 |
+| `editor.View: textarea.View() returned empty string` | WARN | **BUG TRIGGERED** |
+| `chatPage.SetSize` | DEBUG | Page-level dimension setting |
+| `editor.SetPosition` | DEBUG | Editor position in the layout |
+
+### How to Use
+
+1. Run crush with debug logging enabled: `crush --debug` or with log level set to debug
+2. Use the application normally
+3. When the bug triggers, check logs for warning messages
+4. Look for `editor.View: textarea.View() returned empty string` - this confirms the issue
+
+### Expected Log Output (Normal)
+
+```
+DEBUG chatPage.SetSize width=120 height=40 session_id="" compact=false splash_fullscreen=false
+DEBUG chatPage.SetSize: no session, editor sizing editor_width=120 editor_height=5 editor_y=35
+DEBUG editor.SetSize width=120 height=5 textarea_width=118 textarea_height=3 actual_ta_width=118 actual_ta_height=3
+DEBUG editor.SetPosition x=0 y=35
+```
+
+### Expected Log Output (Bug Triggered)
+
+```
+WARN editor.SetSize: invalid dimensions textarea_width=-1 textarea_height=0
+WARN editor.View: textarea.View() returned empty string width=1 height=2 ...
+```

--- a/internal/agent/tools/glob.go
+++ b/internal/agent/tools/glob.go
@@ -46,7 +46,7 @@ func NewGlobTool(workingDir string) fantasy.AgentTool {
 
 			files, truncated, err := globFiles(ctx, params.Pattern, searchPath, 100)
 			if err != nil {
-				return fantasy.ToolResponse{}, fmt.Errorf("error finding files: %w", err)
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("error finding files: %v", err)), nil
 			}
 
 			var output string
@@ -81,7 +81,7 @@ func globFiles(ctx context.Context, pattern, searchPath string, limit int) ([]st
 		slog.Warn("Ripgrep execution failed, falling back to doublestar", "error", err)
 	}
 
-	return fsext.GlobWithDoubleStar(pattern, searchPath, limit)
+	return fsext.GlobWithDoubleStar(ctx, pattern, searchPath, limit)
 }
 
 func runRipgrep(cmd *exec.Cmd, searchRoot string, limit int) ([]string, error) {

--- a/internal/agent/tools/grep_test.go
+++ b/internal/agent/tools/grep_test.go
@@ -85,7 +85,9 @@ func TestGrepWithIgnoreFiles(t *testing.T) {
 
 	// Test both implementations
 	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
-		"regex": searchFilesWithRegex,
+		"regex": func(pattern, path, include string) ([]grepMatch, error) {
+			return searchFilesWithRegex(t.Context(), pattern, path, include)
+		},
 		"rg": func(pattern, path, include string) ([]grepMatch, error) {
 			return searchWithRipgrep(t.Context(), pattern, path, include)
 		},
@@ -145,7 +147,9 @@ func TestSearchImplementations(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".crushignore"), []byte("file5.txt\n"), 0o644))
 
 	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
-		"regex": searchFilesWithRegex,
+		"regex": func(pattern, path, include string) ([]grepMatch, error) {
+			return searchFilesWithRegex(t.Context(), pattern, path, include)
+		},
 		"rg": func(pattern, path, include string) ([]grepMatch, error) {
 			return searchWithRipgrep(t.Context(), pattern, path, include)
 		},
@@ -396,7 +400,9 @@ func TestColumnMatch(t *testing.T) {
 
 	// Test both implementations
 	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
-		"regex": searchFilesWithRegex,
+		"regex": func(pattern, path, include string) ([]grepMatch, error) {
+			return searchFilesWithRegex(t.Context(), pattern, path, include)
+		},
 		"rg": func(pattern, path, include string) ([]grepMatch, error) {
 			return searchWithRipgrep(t.Context(), pattern, path, include)
 		},

--- a/internal/agent/tools/ls.go
+++ b/internal/agent/tools/ls.go
@@ -105,7 +105,7 @@ func NewLsTool(permissions permission.Service, workingDir string, lsConfig confi
 				}
 			}
 
-			output, metadata, err := ListDirectoryTree(searchPath, params, lsConfig)
+			output, metadata, err := ListDirectoryTree(ctx, searchPath, params, lsConfig)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
@@ -117,7 +117,7 @@ func NewLsTool(permissions permission.Service, workingDir string, lsConfig confi
 		})
 }
 
-func ListDirectoryTree(searchPath string, params LSParams, lsConfig config.ToolLs) (string, LSResponseMetadata, error) {
+func ListDirectoryTree(ctx context.Context, searchPath string, params LSParams, lsConfig config.ToolLs) (string, LSResponseMetadata, error) {
 	if _, err := os.Stat(searchPath); os.IsNotExist(err) {
 		return "", LSResponseMetadata{}, fmt.Errorf("path does not exist: %s", searchPath)
 	}
@@ -125,6 +125,7 @@ func ListDirectoryTree(searchPath string, params LSParams, lsConfig config.ToolL
 	depth, limit := lsConfig.Limits()
 	maxFiles := cmp.Or(limit, maxLSFiles)
 	files, truncated, err := fsext.ListDirectory(
+		ctx,
 		searchPath,
 		params.Ignore,
 		cmp.Or(params.Depth, depth),

--- a/internal/app/lsp.go
+++ b/internal/app/lsp.go
@@ -26,7 +26,7 @@ func (app *App) createAndStartLSPClient(ctx context.Context, name string, config
 	slog.Debug("Creating LSP client", "name", name, "command", config.Command, "fileTypes", config.FileTypes, "args", config.Args)
 
 	// Check if any root markers exist in the working directory (config now has defaults)
-	if !lsp.HasRootMarkers(app.config.WorkingDir(), config.RootMarkers) {
+	if !lsp.HasRootMarkers(ctx, app.config.WorkingDir(), config.RootMarkers) {
 		slog.Debug("Skipping LSP client: no root markers found", "name", name, "rootMarkers", config.RootMarkers)
 		updateLSPState(name, lsp.StateDisabled, nil, nil, 0)
 		return

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -103,7 +104,7 @@ func contextPathsExist(dir string) (bool, error) {
 
 // dirHasNoVisibleFiles returns true if the directory has no files/dirs after applying ignore rules
 func dirHasNoVisibleFiles(dir string) (bool, error) {
-	files, _, err := fsext.ListDirectory(dir, nil, 1, 1)
+	files, _, err := fsext.ListDirectory(context.Background(), dir, nil, 1, 1)
 	if err != nil {
 		return false, err
 	}

--- a/internal/fsext/fileutil_test.go
+++ b/internal/fsext/fileutil_test.go
@@ -24,7 +24,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test content"), 0o644))
 		}
 
-		matches, truncated, err := GlobWithDoubleStar("**/main.go", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "**/main.go", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -47,7 +47,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package main"), 0o644))
 		require.NoError(t, os.WriteFile(pkgFile, []byte("test"), 0o644))
 
-		matches, truncated, err := GlobWithDoubleStar("pkg", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "pkg", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -66,7 +66,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.MkdirAll(dir, 0o755))
 		}
 
-		matches, truncated, err := GlobWithDoubleStar("**/pkg", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "**/pkg", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -95,7 +95,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("package main"), 0o644))
 		}
 
-		matches, truncated, err := GlobWithDoubleStar("pkg/**", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "pkg/**", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -124,7 +124,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 		}
 
-		matches, truncated, err := GlobWithDoubleStar("**/*.txt", testDir, 5)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "**/*.txt", testDir, 5)
 		require.NoError(t, err)
 		require.True(t, truncated, "Expected truncation with limit")
 		require.Len(t, matches, 5, "Expected exactly 5 matches with limit")
@@ -143,7 +143,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 		}
 
-		matches, truncated, err := GlobWithDoubleStar("a/b/c/file1.txt", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "a/b/c/file1.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -171,7 +171,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.NoError(t, os.Chtimes(file2, m2, m2))
 		require.NoError(t, os.Chtimes(file3, m3, m3))
 
-		matches, truncated, err := GlobWithDoubleStar("*.txt", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "*.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -181,7 +181,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 	t.Run("handles empty directory", func(t *testing.T) {
 		testDir := t.TempDir()
 
-		matches, truncated, err := GlobWithDoubleStar("**", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "**", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		// Even empty directories should return the directory itself
@@ -191,7 +191,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 	t.Run("handles non-existent search path", func(t *testing.T) {
 		nonExistentDir := filepath.Join(t.TempDir(), "does", "not", "exist")
 
-		matches, truncated, err := GlobWithDoubleStar("**", nonExistentDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "**", nonExistentDir, 0)
 		require.Error(t, err, "Should return error for non-existent search path")
 		require.False(t, truncated)
 		require.Empty(t, matches)
@@ -219,17 +219,17 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		ignoredFileInDir := filepath.Join(testDir, "backup", "old.txt")
 		require.NoError(t, os.WriteFile(ignoredFileInDir, []byte("old content"), 0o644))
 
-		matches, truncated, err := GlobWithDoubleStar("*.tmp", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "*.tmp", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Empty(t, matches, "Expected no matches for '*.tmp' pattern (should be ignored)")
 
-		matches, truncated, err = GlobWithDoubleStar("backup", testDir, 0)
+		matches, truncated, err = GlobWithDoubleStar(t.Context(), "backup", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Empty(t, matches, "Expected no matches for 'backup' pattern (should be ignored)")
 
-		matches, truncated, err = GlobWithDoubleStar("*.txt", testDir, 0)
+		matches, truncated, err = GlobWithDoubleStar(t.Context(), "*.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Equal(t, []string{goodFile}, matches)
@@ -257,7 +257,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.NoError(t, os.Chtimes(middleDir, tMiddle, tMiddle))
 		require.NoError(t, os.Chtimes(oldestFile, tNewest, tNewest))
 
-		matches, truncated, err := GlobWithDoubleStar("*.rs", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "*.rs", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Len(t, matches, 3)

--- a/internal/fsext/ls_test.go
+++ b/internal/fsext/ls_test.go
@@ -28,7 +28,7 @@ func TestListDirectory(t *testing.T) {
 	}
 
 	t.Run("no limit", func(t *testing.T) {
-		files, truncated, err := ListDirectory(tmp, nil, -1, -1)
+		files, truncated, err := ListDirectory(t.Context(), tmp, nil, -1, -1)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Len(t, files, 4)
@@ -40,7 +40,7 @@ func TestListDirectory(t *testing.T) {
 		}, relPaths(t, files, tmp))
 	})
 	t.Run("limit", func(t *testing.T) {
-		files, truncated, err := ListDirectory(tmp, nil, -1, 2)
+		files, truncated, err := ListDirectory(t.Context(), tmp, nil, -1, 2)
 		require.NoError(t, err)
 		require.True(t, truncated)
 		require.Len(t, files, 2)

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -501,13 +501,13 @@ func (c *Client) FindReferences(ctx context.Context, filepath string, line, char
 
 // HasRootMarkers checks if any of the specified root marker patterns exist in the given directory.
 // Uses glob patterns to match files, allowing for more flexible matching.
-func HasRootMarkers(dir string, rootMarkers []string) bool {
+func HasRootMarkers(ctx context.Context, dir string, rootMarkers []string) bool {
 	if len(rootMarkers) == 0 {
 		return true
 	}
 	for _, pattern := range rootMarkers {
 		// Use fsext.GlobWithDoubleStar to find matches
-		matches, _, err := fsext.GlobWithDoubleStar(pattern, dir, 1)
+		matches, _, err := fsext.GlobWithDoubleStar(ctx, pattern, dir, 1)
 		if err == nil && len(matches) > 0 {
 			return true
 		}

--- a/internal/lsp/rootmarkers_test.go
+++ b/internal/lsp/rootmarkers_test.go
@@ -15,10 +15,10 @@ func TestHasRootMarkers(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Test with empty root markers (should return true)
-	require.True(t, HasRootMarkers(tmpDir, []string{}))
+	require.True(t, HasRootMarkers(t.Context(), tmpDir, []string{}))
 
 	// Test with non-existent markers
-	require.False(t, HasRootMarkers(tmpDir, []string{"go.mod", "package.json"}))
+	require.False(t, HasRootMarkers(t.Context(), tmpDir, []string{"go.mod", "package.json"}))
 
 	// Create a go.mod file
 	goModPath := filepath.Join(tmpDir, "go.mod")
@@ -26,12 +26,12 @@ func TestHasRootMarkers(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test with existing marker
-	require.True(t, HasRootMarkers(tmpDir, []string{"go.mod", "package.json"}))
+	require.True(t, HasRootMarkers(t.Context(), tmpDir, []string{"go.mod", "package.json"}))
 
 	// Test with only non-existent markers
-	require.False(t, HasRootMarkers(tmpDir, []string{"package.json", "Cargo.toml"}))
+	require.False(t, HasRootMarkers(t.Context(), tmpDir, []string{"package.json", "Cargo.toml"}))
 
 	// Test with glob patterns
-	require.True(t, HasRootMarkers(tmpDir, []string{"*.mod"}))
-	require.False(t, HasRootMarkers(tmpDir, []string{"*.json"}))
+	require.True(t, HasRootMarkers(t.Context(), tmpDir, []string{"*.mod"}))
+	require.False(t, HasRootMarkers(t.Context(), tmpDir, []string{"*.json"}))
 }

--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -1,6 +1,7 @@
 package editor
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -609,7 +610,7 @@ func (m *editorCmp) SetPosition(x, y int) tea.Cmd {
 func (m *editorCmp) startCompletions() tea.Msg {
 	ls := m.app.Config().Options.TUI.Completions
 	depth, limit := ls.Limits()
-	files, _, _ := fsext.ListDirectory(".", nil, depth, limit)
+	files, _, _ := fsext.ListDirectory(context.Background(), ".", nil, depth, limit)
 	slices.Sort(files)
 	completionItems := make([]completions.Completion, 0, len(files))
 	for _, file := range files {


### PR DESCRIPTION
## Summary

This PR fixes the issue where tools like Grep can hang indefinitely with "Working..." status when context is cancelled.

### Problem
When a user sends a new message while a tool is running, the tool should abort. However, tools continue running in the background indefinitely, leaving the UI stuck showing "Working..." animation even though the agent has moved on.

### Solution
- **Context-aware tool execution**: Glob, Grep, and LS tools now check for context cancellation during file walking and abort early
- **Search space protection**: Limits file scanning to 10,000 files to prevent runaway operations on large directories
- **Atomic counters**: Uses `sync/atomic` for thread-safe file counting in parallel fastwalk operations

### Changes
- `internal/fsext/fileutil.go`: Add context cancellation and file limit to GlobWithDoubleStar
- `internal/fsext/ls.go`: Add context cancellation and file limit to ListDirectory
- `internal/agent/tools/glob.go`, `grep.go`, `ls.go`: Pass context to fsext functions

## Test plan

- [x] Unit tests pass
- [x] Verified early termination on context cancel
- [x] Verified 10k file limit triggers error message

💘 Generated with Crush

---
Fixes #1855