### PR TITLE
fix: editor: exclude native clipboard support from linux/386 builds

### DIFF
--- a/internal/tui/components/chat/editor/clipboard.go
+++ b/internal/tui/components/chat/editor/clipboard.go
@@ -1,0 +1,8 @@
+package editor
+
+type clipboardFormat int
+
+const (
+	clipboardFormatText clipboardFormat = iota
+	clipboardFormatImage
+)

--- a/internal/tui/components/chat/editor/clipboard_linux_386.go
+++ b/internal/tui/components/chat/editor/clipboard_linux_386.go
@@ -1,0 +1,7 @@
+//go:build linux && 386
+
+package editor
+
+func readClipboard(clipboardFormat) ([]byte, error) {
+	return nil, errClipboardPlatformUnsupported
+}

--- a/internal/tui/components/chat/editor/clipboard_other.go
+++ b/internal/tui/components/chat/editor/clipboard_other.go
@@ -1,0 +1,15 @@
+//go:build !linux || !386
+
+package editor
+
+import "github.com/aymanbagabas/go-nativeclipboard"
+
+func readClipboard(f clipboardFormat) ([]byte, error) {
+	switch f {
+	case clipboardFormatText:
+		return nativeclipboard.Text.Read()
+	case clipboardFormatImage:
+		return nativeclipboard.Image.Read()
+	}
+	return nil, errClipboardUnknownFormat
+}

--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -16,7 +16,6 @@ import (
 	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	nativeclipboard "github.com/aymanbagabas/go-nativeclipboard"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/filetracker"
 	"github.com/charmbracelet/crush/internal/fsext"
@@ -33,6 +32,11 @@ import (
 	"github.com/charmbracelet/crush/internal/tui/util"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/editor"
+)
+
+var (
+	errClipboardPlatformUnsupported = fmt.Errorf("clipboard operations are not supported on this platform")
+	errClipboardUnknownFormat       = fmt.Errorf("unknown clipboard format")
 )
 
 type Editor interface {
@@ -341,12 +345,12 @@ func (m *editorCmp) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 		}
 		// Handle image paste from clipboard
 		if key.Matches(msg, m.keyMap.PasteImage) {
-			imageData, err := nativeclipboard.Image.Read()
+			imageData, err := readClipboard(clipboardFormatImage)
 
 			if err != nil || len(imageData) == 0 {
 				// If no image data found, try to get text data (could be file path)
 				var textData []byte
-				textData, err = nativeclipboard.Text.Read()
+				textData, err = readClipboard(clipboardFormatText)
 				if err != nil || len(textData) == 0 {
 					// If clipboard is empty, show a warning
 					return m, util.ReportWarn("No data found in clipboard. Note: Some terminals may not support reading image data from clipboard directly.")


### PR DESCRIPTION
This is a quick workaround to exclude native clipboard support from linux/386 builds, which currently fails due to an issue in the purego library.

Related: https://github.com/ebitengine/purego/issues/388
