### PR TITLE
feat: abortable tools and search space protection

### DIFF
--- a/internal/agent/tools/glob.go
+++ b/internal/agent/tools/glob.go
@@ -46,7 +46,7 @@ func NewGlobTool(workingDir string) fantasy.AgentTool {
 
 			files, truncated, err := globFiles(ctx, params.Pattern, searchPath, 100)
 			if err != nil {
-				return fantasy.ToolResponse{}, fmt.Errorf("error finding files: %w", err)
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("error finding files: %v", err)), nil
 			}
 
 			var output string
@@ -81,7 +81,7 @@ func globFiles(ctx context.Context, pattern, searchPath string, limit int) ([]st
 		slog.Warn("Ripgrep execution failed, falling back to doublestar", "error", err)
 	}
 
-	return fsext.GlobWithDoubleStar(pattern, searchPath, limit)
+	return fsext.GlobWithDoubleStar(ctx, pattern, searchPath, limit)
 }
 
 func runRipgrep(cmd *exec.Cmd, searchRoot string, limit int) ([]string, error) {

--- a/internal/agent/tools/grep_test.go
+++ b/internal/agent/tools/grep_test.go
@@ -85,7 +85,9 @@ func TestGrepWithIgnoreFiles(t *testing.T) {
 
 	// Test both implementations
 	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
-		"regex": searchFilesWithRegex,
+		"regex": func(pattern, path, include string) ([]grepMatch, error) {
+			return searchFilesWithRegex(t.Context(), pattern, path, include)
+		},
 		"rg": func(pattern, path, include string) ([]grepMatch, error) {
 			return searchWithRipgrep(t.Context(), pattern, path, include)
 		},
@@ -145,7 +147,9 @@ func TestSearchImplementations(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".crushignore"), []byte("file5.txt\n"), 0o644))
 
 	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
-		"regex": searchFilesWithRegex,
+		"regex": func(pattern, path, include string) ([]grepMatch, error) {
+			return searchFilesWithRegex(t.Context(), pattern, path, include)
+		},
 		"rg": func(pattern, path, include string) ([]grepMatch, error) {
 			return searchWithRipgrep(t.Context(), pattern, path, include)
 		},
@@ -396,7 +400,9 @@ func TestColumnMatch(t *testing.T) {
 
 	// Test both implementations
 	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
-		"regex": searchFilesWithRegex,
+		"regex": func(pattern, path, include string) ([]grepMatch, error) {
+			return searchFilesWithRegex(t.Context(), pattern, path, include)
+		},
 		"rg": func(pattern, path, include string) ([]grepMatch, error) {
 			return searchWithRipgrep(t.Context(), pattern, path, include)
 		},

--- a/internal/agent/tools/ls.go
+++ b/internal/agent/tools/ls.go
@@ -105,7 +105,7 @@ func NewLsTool(permissions permission.Service, workingDir string, lsConfig confi
 				}
 			}
 
-			output, metadata, err := ListDirectoryTree(searchPath, params, lsConfig)
+			output, metadata, err := ListDirectoryTree(ctx, searchPath, params, lsConfig)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
@@ -117,7 +117,7 @@ func NewLsTool(permissions permission.Service, workingDir string, lsConfig confi
 		})
 }
 
-func ListDirectoryTree(searchPath string, params LSParams, lsConfig config.ToolLs) (string, LSResponseMetadata, error) {
+func ListDirectoryTree(ctx context.Context, searchPath string, params LSParams, lsConfig config.ToolLs) (string, LSResponseMetadata, error) {
 	if _, err := os.Stat(searchPath); os.IsNotExist(err) {
 		return "", LSResponseMetadata{}, fmt.Errorf("path does not exist: %s", searchPath)
 	}
@@ -125,6 +125,7 @@ func ListDirectoryTree(searchPath string, params LSParams, lsConfig config.ToolL
 	depth, limit := lsConfig.Limits()
 	maxFiles := cmp.Or(limit, maxLSFiles)
 	files, truncated, err := fsext.ListDirectory(
+		ctx,
 		searchPath,
 		params.Ignore,
 		cmp.Or(params.Depth, depth),

--- a/internal/app/lsp.go
+++ b/internal/app/lsp.go
@@ -26,7 +26,7 @@ func (app *App) createAndStartLSPClient(ctx context.Context, name string, config
 	slog.Debug("Creating LSP client", "name", name, "command", config.Command, "fileTypes", config.FileTypes, "args", config.Args)
 
 	// Check if any root markers exist in the working directory (config now has defaults)
-	if !lsp.HasRootMarkers(app.config.WorkingDir(), config.RootMarkers) {
+	if !lsp.HasRootMarkers(ctx, app.config.WorkingDir(), config.RootMarkers) {
 		slog.Debug("Skipping LSP client: no root markers found", "name", name, "rootMarkers", config.RootMarkers)
 		updateLSPState(name, lsp.StateDisabled, nil, nil, 0)
 		return

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -103,7 +104,7 @@ func contextPathsExist(dir string) (bool, error) {
 
 // dirHasNoVisibleFiles returns true if the directory has no files/dirs after applying ignore rules
 func dirHasNoVisibleFiles(dir string) (bool, error) {
-	files, _, err := fsext.ListDirectory(dir, nil, 1, 1)
+	files, _, err := fsext.ListDirectory(context.Background(), dir, nil, 1, 1)
 	if err != nil {
 		return false, err
 	}

--- a/internal/fsext/fileutil_test.go
+++ b/internal/fsext/fileutil_test.go
@@ -24,7 +24,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test content"), 0o644))
 		}
 
-		matches, truncated, err := GlobWithDoubleStar("**/main.go", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "**/main.go", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -47,7 +47,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package main"), 0o644))
 		require.NoError(t, os.WriteFile(pkgFile, []byte("test"), 0o644))
 
-		matches, truncated, err := GlobWithDoubleStar("pkg", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "pkg", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -66,7 +66,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.MkdirAll(dir, 0o755))
 		}
 
-		matches, truncated, err := GlobWithDoubleStar("**/pkg", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "**/pkg", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -95,7 +95,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("package main"), 0o644))
 		}
 
-		matches, truncated, err := GlobWithDoubleStar("pkg/**", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "pkg/**", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -124,7 +124,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 		}
 
-		matches, truncated, err := GlobWithDoubleStar("**/*.txt", testDir, 5)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "**/*.txt", testDir, 5)
 		require.NoError(t, err)
 		require.True(t, truncated, "Expected truncation with limit")
 		require.Len(t, matches, 5, "Expected exactly 5 matches with limit")
@@ -143,7 +143,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 		}
 
-		matches, truncated, err := GlobWithDoubleStar("a/b/c/file1.txt", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "a/b/c/file1.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -171,7 +171,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.NoError(t, os.Chtimes(file2, m2, m2))
 		require.NoError(t, os.Chtimes(file3, m3, m3))
 
-		matches, truncated, err := GlobWithDoubleStar("*.txt", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "*.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -181,7 +181,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 	t.Run("handles empty directory", func(t *testing.T) {
 		testDir := t.TempDir()
 
-		matches, truncated, err := GlobWithDoubleStar("**", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "**", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		// Even empty directories should return the directory itself
@@ -191,7 +191,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 	t.Run("handles non-existent search path", func(t *testing.T) {
 		nonExistentDir := filepath.Join(t.TempDir(), "does", "not", "exist")
 
-		matches, truncated, err := GlobWithDoubleStar("**", nonExistentDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "**", nonExistentDir, 0)
 		require.Error(t, err, "Should return error for non-existent search path")
 		require.False(t, truncated)
 		require.Empty(t, matches)
@@ -219,17 +219,17 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		ignoredFileInDir := filepath.Join(testDir, "backup", "old.txt")
 		require.NoError(t, os.WriteFile(ignoredFileInDir, []byte("old content"), 0o644))
 
-		matches, truncated, err := GlobWithDoubleStar("*.tmp", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "*.tmp", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Empty(t, matches, "Expected no matches for '*.tmp' pattern (should be ignored)")
 
-		matches, truncated, err = GlobWithDoubleStar("backup", testDir, 0)
+		matches, truncated, err = GlobWithDoubleStar(t.Context(), "backup", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Empty(t, matches, "Expected no matches for 'backup' pattern (should be ignored)")
 
-		matches, truncated, err = GlobWithDoubleStar("*.txt", testDir, 0)
+		matches, truncated, err = GlobWithDoubleStar(t.Context(), "*.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Equal(t, []string{goodFile}, matches)
@@ -257,7 +257,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.NoError(t, os.Chtimes(middleDir, tMiddle, tMiddle))
 		require.NoError(t, os.Chtimes(oldestFile, tNewest, tNewest))
 
-		matches, truncated, err := GlobWithDoubleStar("*.rs", testDir, 0)
+		matches, truncated, err := GlobWithDoubleStar(t.Context(), "*.rs", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Len(t, matches, 3)

--- a/internal/fsext/ls_test.go
+++ b/internal/fsext/ls_test.go
@@ -28,7 +28,7 @@ func TestListDirectory(t *testing.T) {
 	}
 
 	t.Run("no limit", func(t *testing.T) {
-		files, truncated, err := ListDirectory(tmp, nil, -1, -1)
+		files, truncated, err := ListDirectory(t.Context(), tmp, nil, -1, -1)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Len(t, files, 4)
@@ -40,7 +40,7 @@ func TestListDirectory(t *testing.T) {
 		}, relPaths(t, files, tmp))
 	})
 	t.Run("limit", func(t *testing.T) {
-		files, truncated, err := ListDirectory(tmp, nil, -1, 2)
+		files, truncated, err := ListDirectory(t.Context(), tmp, nil, -1, 2)
 		require.NoError(t, err)
 		require.True(t, truncated)
 		require.Len(t, files, 2)

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -501,13 +501,13 @@ func (c *Client) FindReferences(ctx context.Context, filepath string, line, char
 
 // HasRootMarkers checks if any of the specified root marker patterns exist in the given directory.
 // Uses glob patterns to match files, allowing for more flexible matching.
-func HasRootMarkers(dir string, rootMarkers []string) bool {
+func HasRootMarkers(ctx context.Context, dir string, rootMarkers []string) bool {
 	if len(rootMarkers) == 0 {
 		return true
 	}
 	for _, pattern := range rootMarkers {
 		// Use fsext.GlobWithDoubleStar to find matches
-		matches, _, err := fsext.GlobWithDoubleStar(pattern, dir, 1)
+		matches, _, err := fsext.GlobWithDoubleStar(ctx, pattern, dir, 1)
 		if err == nil && len(matches) > 0 {
 			return true
 		}

--- a/internal/lsp/rootmarkers_test.go
+++ b/internal/lsp/rootmarkers_test.go
@@ -15,10 +15,10 @@ func TestHasRootMarkers(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Test with empty root markers (should return true)
-	require.True(t, HasRootMarkers(tmpDir, []string{}))
+	require.True(t, HasRootMarkers(t.Context(), tmpDir, []string{}))
 
 	// Test with non-existent markers
-	require.False(t, HasRootMarkers(tmpDir, []string{"go.mod", "package.json"}))
+	require.False(t, HasRootMarkers(t.Context(), tmpDir, []string{"go.mod", "package.json"}))
 
 	// Create a go.mod file
 	goModPath := filepath.Join(tmpDir, "go.mod")
@@ -26,12 +26,12 @@ func TestHasRootMarkers(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test with existing marker
-	require.True(t, HasRootMarkers(tmpDir, []string{"go.mod", "package.json"}))
+	require.True(t, HasRootMarkers(t.Context(), tmpDir, []string{"go.mod", "package.json"}))
 
 	// Test with only non-existent markers
-	require.False(t, HasRootMarkers(tmpDir, []string{"package.json", "Cargo.toml"}))
+	require.False(t, HasRootMarkers(t.Context(), tmpDir, []string{"package.json", "Cargo.toml"}))
 
 	// Test with glob patterns
-	require.True(t, HasRootMarkers(tmpDir, []string{"*.mod"}))
-	require.False(t, HasRootMarkers(tmpDir, []string{"*.json"}))
+	require.True(t, HasRootMarkers(t.Context(), tmpDir, []string{"*.mod"}))
+	require.False(t, HasRootMarkers(t.Context(), tmpDir, []string{"*.json"}))
 }

--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -1,6 +1,7 @@
 package editor
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -609,7 +610,7 @@ func (m *editorCmp) SetPosition(x, y int) tea.Cmd {
 func (m *editorCmp) startCompletions() tea.Msg {
 	ls := m.app.Config().Options.TUI.Completions
 	depth, limit := ls.Limits()
-	files, _, _ := fsext.ListDirectory(".", nil, depth, limit)
+	files, _, _ := fsext.ListDirectory(context.Background(), ".", nil, depth, limit)
 	slices.Sort(files)
 	completionItems := make([]completions.Completion, 0, len(files))
 	for _, file := range files {


### PR DESCRIPTION
## Summary

This PR fixes the issue where tools like Grep can hang indefinitely with "Working..." status when context is cancelled.

### Problem
When a user sends a new message while a tool is running, the tool should abort. However, tools continue running in the background indefinitely, leaving the UI stuck showing "Working..." animation even though the agent has moved on.

### Solution
- **Context-aware tool execution**: Glob, Grep, and LS tools now check for context cancellation during file walking and abort early
- **Search space protection**: Limits file scanning to 10,000 files to prevent runaway operations on large directories
- **Atomic counters**: Uses `sync/atomic` for thread-safe file counting in parallel fastwalk operations

### Changes
- `internal/fsext/fileutil.go`: Add context cancellation and file limit to GlobWithDoubleStar
- `internal/fsext/ls.go`: Add context cancellation and file limit to ListDirectory
- `internal/agent/tools/glob.go`, `grep.go`, `ls.go`: Pass context to fsext functions

## Test plan

- [x] Unit tests pass
- [x] Verified early termination on context cancel
- [x] Verified 10k file limit triggers error message

💘 Generated with Crush

---
Fixes #1855