### PR TITLE
chore: remove dead (duplicate) code

### DIFF
--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -188,15 +188,6 @@ func (s *permissionService) Request(ctx context.Context, opts CreatePermissionRe
 	}
 	s.sessionPermissionsMu.RUnlock()
 
-	s.sessionPermissionsMu.RLock()
-	for _, p := range s.sessionPermissions {
-		if p.ToolName == permission.ToolName && p.Action == permission.Action && p.SessionID == permission.SessionID && p.Path == permission.Path {
-			s.sessionPermissionsMu.RUnlock()
-			return true, nil
-		}
-	}
-	s.sessionPermissionsMu.RUnlock()
-
 	s.activeRequestMu.Lock()
 	s.activeRequest = &permission
 	s.activeRequestMu.Unlock()


### PR DESCRIPTION
This removes a duplicated code block. The duplicated code is directly above. This code either never executes, or executes the exact same check that already happened.