### PR TITLE
fix(sec): do not output resolved command

### DIFF
--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -227,7 +227,7 @@ func (s *Shell) blockHandler() func(next interp.ExecHandlerFunc) interp.ExecHand
 
 			for _, blockFunc := range s.blockFuncs {
 				if blockFunc(args) {
-					return fmt.Errorf("command is not allowed for security reasons: %s", args[0])
+					return fmt.Errorf("command is not allowed for security reasons: %q", args[0])
 				}
 			}
 


### PR DESCRIPTION
Sometimes the LLM will ignore instructions to not use curl and use it anyway, especially for API calls.

It will then be blocked, and the error will contain the resolved command, including replacing environment variables with their actual values.

This should prevent that.
