### PR TITLE
fix(config): respect disable_default_providers option

### DIFF
--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -140,6 +140,9 @@ var (
 // 3. try to get the fresh list of providers, and return either this new list,
 // the cached list, or the embedded list if all others fail.
 func Providers(cfg *Config) ([]catwalk.Provider, error) {
+	if cfg.Options.DisableDefaultProviders {
+		return nil, nil
+	}
 	providerOnce.Do(func() {
 		var wg sync.WaitGroup
 		var errs []error


### PR DESCRIPTION
## Summary

Fixes #1852

- Fixed the `disable_default_providers` option to actually disable default providers
- Added early return in `Providers()` function when the option is enabled

## Problem

The `disable_default_providers` configuration option was not being respected. Even when set to `true`, Crush would still load and use default providers from Catwalk.

## Solution

Added a check at the beginning of the `Providers()` function in `internal/config/provider.go` to return early when `cfg.Options.DisableDefaultProviders` is `true`, preventing any default provider loading.

## Changes

```go
func Providers(cfg *Config) ([]catwalk.Provider, error) {
+	if cfg.Options.DisableDefaultProviders {
+		return nil, nil
+	}
	providerOnce.Do(func() {
		// ... existing code
```

## Test Plan

- [ ] Set `disable_default_providers: true` in crush.json
- [ ] Verify that no default providers are loaded
- [ ] Verify that custom providers still work correctly
- [ ] Test with `disable_default_providers: false` to ensure normal behavior is unchanged

💘 Generated with Crush