### PR TITLE
feat: add bedrock thinking/reasoning support

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -292,6 +292,17 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 		if err == nil {
 			options[google.Name] = parsed
 		}
+	case bedrock.Name:
+		_, hasThink := mergedOptions["thinking"]
+		if !hasThink && model.ModelCfg.Think {
+			mergedOptions["thinking"] = map[string]any{
+				"reasoning_effort": "medium",
+			}
+		}
+		parsed, err := bedrock.ParseOptions(mergedOptions)
+		if err == nil {
+			options[bedrock.Name] = parsed
+		}
 	case openaicompat.Name:
 		_, hasReasoningEffort := mergedOptions["reasoning_effort"]
 		if !hasReasoningEffort && model.ModelCfg.ReasoningEffort != "" {

--- a/internal/tui/components/dialogs/commands/commands.go
+++ b/internal/tui/components/dialogs/commands/commands.go
@@ -363,8 +363,8 @@ func (c *commandDialogCmp) defaultCommands() []Command {
 		if providerCfg != nil && model != nil && model.CanReason {
 			selectedModel := cfg.Models[agentCfg.Model]
 
-			// Anthropic models: thinking toggle
-			if providerCfg.Type == catwalk.TypeAnthropic || providerCfg.Type == catwalk.Type(hyper.Name) {
+			// Anthropic/Bedrock models: thinking toggle
+			if providerCfg.Type == catwalk.TypeAnthropic || providerCfg.Type == catwalk.Type(hyper.Name) || providerCfg.Type == catwalk.TypeBedrock {
 				status := "Enable"
 				if selectedModel.Think {
 					status = "Disable"


### PR DESCRIPTION
- Add thinking toggle visibility for Bedrock models in commands dialog
- Update coordinator to use reasoning_effort (medium) for Bedrock thinking
- Enables /think command for Bedrock models that support reasoning

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
