### PR TITLE
feat: auto-continue on context truncation and incomplete todos

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1142,13 +1142,15 @@ func buildSummaryPrompt(todos []session.Todo) string {
 	return sb.String()
 }
 
-// isTruncationError checks if the error is due to output truncation (e.g., XML
-// parsing failures from truncated tool calls).
-func isTruncationError(err error) bool {
+// isRecoverableError checks if the error is due to output truncation, server
+// issues, or other transient failures that can be recovered by summarizing and
+// re-queuing.
+func isRecoverableError(err error) bool {
 	if err == nil {
 		return false
 	}
 	errStr := err.Error()
+
 	// XML parsing errors from truncated tool calls.
 	if strings.Contains(errStr, "XML syntax error") {
 		return true
@@ -1169,7 +1171,55 @@ func isTruncationError(err error) bool {
 	if strings.Contains(errStr, "unexpected EOF") {
 		return true
 	}
+
+	// Server/infrastructure errors that may be transient.
+	if strings.Contains(errStr, "connection reset") {
+		return true
+	}
+	if strings.Contains(errStr, "connection refused") {
+		return true
+	}
+	if strings.Contains(errStr, "context deadline exceeded") {
+		return true
+	}
+	if strings.Contains(errStr, "timeout") {
+		return true
+	}
+	if strings.Contains(errStr, "server error") {
+		return true
+	}
+	if strings.Contains(errStr, "internal server error") {
+		return true
+	}
+	if strings.Contains(errStr, "bad gateway") {
+		return true
+	}
+	if strings.Contains(errStr, "service unavailable") {
+		return true
+	}
+	if strings.Contains(errStr, "gateway timeout") {
+		return true
+	}
+	// Ollama-specific errors.
+	if strings.Contains(errStr, "model is loading") {
+		return true
+	}
+	if strings.Contains(errStr, "out of memory") {
+		return true
+	}
+	if strings.Contains(errStr, "CUDA") {
+		return true
+	}
+	if strings.Contains(errStr, "GPU") {
+		return true
+	}
+
 	return false
+}
+
+// isTruncationError is an alias for backwards compatibility.
+func isTruncationError(err error) bool {
+	return isRecoverableError(err)
 }
 
 // hasIncompleteTodos checks if the session has any todos that are not completed.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -664,11 +664,13 @@ func TestIsTruncationError(t *testing.T) {
 		err      error
 		expected bool
 	}{
+		// Nil error.
 		{
 			name:     "nil error",
 			err:      nil,
 			expected: false,
 		},
+		// Truncation errors.
 		{
 			name:     "XML syntax error",
 			err:      fmt.Errorf("failed to parse: XML syntax error on line 1: element <tool_call> closed by </arg_value>"),
@@ -685,19 +687,9 @@ func TestIsTruncationError(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "regular error",
-			err:      fmt.Errorf("connection refused"),
-			expected: false,
-		},
-		{
 			name:     "wrapped XML error",
 			err:      fmt.Errorf("tool parsing failed: %w", fmt.Errorf("XML syntax error on line 5")),
 			expected: true,
-		},
-		{
-			name:     "rate limit error",
-			err:      fmt.Errorf("rate limit exceeded"),
-			expected: false,
 		},
 		{
 			name:     "failed to parse XML wrapper",
@@ -708,6 +700,74 @@ func TestIsTruncationError(t *testing.T) {
 			name:     "tool call parsing failed",
 			err:      fmt.Errorf("glm-4.6 tool call parsing failed: some error"),
 			expected: true,
+		},
+		// Server/infrastructure errors (now recoverable).
+		{
+			name:     "connection refused",
+			err:      fmt.Errorf("dial tcp: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "connection reset",
+			err:      fmt.Errorf("read: connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "context deadline exceeded",
+			err:      fmt.Errorf("context deadline exceeded"),
+			expected: true,
+		},
+		{
+			name:     "timeout error",
+			err:      fmt.Errorf("request timeout after 30s"),
+			expected: true,
+		},
+		{
+			name:     "internal server error",
+			err:      fmt.Errorf("internal server error"),
+			expected: true,
+		},
+		{
+			name:     "bad gateway",
+			err:      fmt.Errorf("502 bad gateway"),
+			expected: true,
+		},
+		{
+			name:     "service unavailable",
+			err:      fmt.Errorf("503 service unavailable"),
+			expected: true,
+		},
+		{
+			name:     "gateway timeout",
+			err:      fmt.Errorf("504 gateway timeout"),
+			expected: true,
+		},
+		// Ollama-specific errors.
+		{
+			name:     "model is loading",
+			err:      fmt.Errorf("model is loading, please wait"),
+			expected: true,
+		},
+		{
+			name:     "out of memory",
+			err:      fmt.Errorf("CUDA out of memory"),
+			expected: true,
+		},
+		{
+			name:     "GPU error",
+			err:      fmt.Errorf("GPU memory exhausted"),
+			expected: true,
+		},
+		// Non-recoverable errors.
+		{
+			name:     "rate limit error",
+			err:      fmt.Errorf("rate limit exceeded"),
+			expected: false,
+		},
+		{
+			name:     "authentication error",
+			err:      fmt.Errorf("invalid API key"),
+			expected: false,
 		},
 	}
 


### PR DESCRIPTION
My problem: testing different local LLMs, the context window is usually very small (32k up to 50k) and every once in a while, the tool calling stops because the XML gets truncated. Then Crush just stops even though there are still tasks to be made. This Pull Request aims to implement an "auto-resume" routine.

- Detect truncation errors (XML/JSON parsing failures from truncated tool calls) and automatically summarize + re-queue to continue
- Extend re-queue condition after auto-summarize to also check for incomplete todos, not just pending tool calls
- Add unit tests for isTruncationError and hasIncompleteTodos helpers

💘 Generated with Crush

Assisted-by: Anthropic: Claude Opus 4.5 via Crush <crush@charm.land>

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
