### PR TITLE
fix(ui): rework cursor can appear out of place on multi-line

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1455,6 +1455,9 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			case key.Matches(msg, m.keyMap.Editor.Newline):
 				m.textarea.InsertRune('\n')
 				m.closeCompletions()
+				ta, cmd := m.textarea.Update(msg)
+				m.textarea = ta
+				cmds = append(cmds, cmd)
 			default:
 				if handleGlobalKeys(msg) {
 					// Handle global keys first before passing to textarea.


### PR DESCRIPTION
Ensure we update the textarea after inserting a newline to keep the cursor position accurate.

