### PR TITLE
refactor: rename visible items to filtered items

### DIFF
--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -83,7 +83,7 @@ func (c *Completions) Query() string {
 
 // Size returns the visible size of the popup.
 func (c *Completions) Size() (width, height int) {
-	visible := len(c.list.VisibleItems())
+	visible := len(c.list.FilteredItems())
 	return c.width, min(visible, c.height)
 }
 
@@ -159,7 +159,7 @@ func (c *Completions) Filter(query string) {
 	c.list.SetFilter(query)
 
 	// recalculate width by using just the visible items
-	items := c.list.VisibleItems()
+	items := c.list.FilteredItems()
 	start, end := c.list.VisibleItemIndices()
 	width := 0
 	if end != 0 {
@@ -176,7 +176,7 @@ func (c *Completions) Filter(query string) {
 
 // HasItems returns whether there are visible items.
 func (c *Completions) HasItems() bool {
-	return len(c.list.VisibleItems()) > 0
+	return len(c.list.FilteredItems()) > 0
 }
 
 // Update handles key events for the completions.
@@ -215,7 +215,7 @@ func (c *Completions) Update(msg tea.KeyPressMsg) (tea.Msg, bool) {
 
 // selectPrev selects the previous item with circular navigation.
 func (c *Completions) selectPrev() {
-	items := c.list.VisibleItems()
+	items := c.list.FilteredItems()
 	if len(items) == 0 {
 		return
 	}
@@ -227,7 +227,7 @@ func (c *Completions) selectPrev() {
 
 // selectNext selects the next item with circular navigation.
 func (c *Completions) selectNext() {
-	items := c.list.VisibleItems()
+	items := c.list.FilteredItems()
 	if len(items) == 0 {
 		return
 	}
@@ -239,7 +239,7 @@ func (c *Completions) selectNext() {
 
 // selectCurrent returns a command with the currently selected item.
 func (c *Completions) selectCurrent(insert bool) tea.Msg {
-	items := c.list.VisibleItems()
+	items := c.list.FilteredItems()
 	if len(items) == 0 {
 		return nil
 	}
@@ -270,7 +270,7 @@ func (c *Completions) Render() string {
 		return ""
 	}
 
-	items := c.list.VisibleItems()
+	items := c.list.FilteredItems()
 	if len(items) == 0 {
 		return ""
 	}

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -188,7 +188,7 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 			}
 		default:
 			var cmd tea.Cmd
-			for _, item := range c.list.VisibleItems() {
+			for _, item := range c.list.FilteredItems() {
 				if item, ok := item.(*CommandItem); ok && item != nil {
 					if msg.String() == item.Shortcut() {
 						return item.Action()

--- a/internal/ui/dialog/reasoning.go
+++ b/internal/ui/dialog/reasoning.go
@@ -176,7 +176,7 @@ func (r *Reasoning) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	inputView := t.Dialog.InputPrompt.Render(r.input.View())
 	rc.AddPart(inputView)
 
-	visibleCount := len(r.list.VisibleItems())
+	visibleCount := len(r.list.FilteredItems())
 	if r.list.Height() >= visibleCount {
 		r.list.ScrollToTop()
 	} else {

--- a/internal/ui/list/filterable.go
+++ b/internal/ui/list/filterable.go
@@ -69,7 +69,7 @@ func (f *FilterableList) PrependItems(items ...FilterableItem) {
 // SetFilter sets the filter query and updates the list items.
 func (f *FilterableList) SetFilter(q string) {
 	f.query = q
-	f.List.SetItems(f.VisibleItems()...)
+	f.List.SetItems(f.FilteredItems()...)
 	f.ScrollToTop()
 }
 
@@ -87,8 +87,8 @@ func (f FilterableItemsSource) String(i int) string {
 	return f[i].Filter()
 }
 
-// VisibleItems returns the visible items after filtering.
-func (f *FilterableList) VisibleItems() []Item {
+// FilteredItems returns the visible items after filtering.
+func (f *FilterableList) FilteredItems() []Item {
 	if f.query == "" {
 		items := make([]Item, len(f.items))
 		for i, item := range f.items {
@@ -120,6 +120,6 @@ func (f *FilterableList) VisibleItems() []Item {
 
 // Render renders the filterable list.
 func (f *FilterableList) Render() string {
-	f.List.SetItems(f.VisibleItems()...)
+	f.List.SetItems(f.FilteredItems()...)
 	return f.List.Render()
 }


### PR DESCRIPTION
the name VisibleItems is misleading because it does not take into account the height of the list and returns all items that match the filter.
