### PR TITLE
Feat/auto continue on truncation

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -412,10 +412,6 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 	a.eventPromptResponded(call.SessionID, time.Since(startTime).Truncate(time.Second))
 
 	if err != nil {
-		slog.Debug("agent.Run error received",
-			"error", err.Error(),
-			"is_truncation", isTruncationError(err),
-			"session_id", call.SessionID)
 		isCancelErr := errors.Is(err, context.Canceled)
 		isPermissionErr := errors.Is(err, permission.ErrorPermissionDenied)
 		if currentAssistant == nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -222,6 +222,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 
 	var currentAssistant *message.Message
 	var shouldSummarize bool
+	var hitMaxTokens bool
 	result, err := agent.Stream(genCtx, fantasy.AgentStreamCall{
 		Prompt:           message.PromptWithTextAttachments(call.Prompt, call.Attachments),
 		Files:            files,
@@ -365,6 +366,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 			switch stepResult.FinishReason {
 			case fantasy.FinishReasonLength:
 				finishReason = message.FinishReasonMaxTokens
+				hitMaxTokens = true
+				slog.Info("model hit max output tokens, will attempt auto-recovery",
+					"session_id", call.SessionID)
 			case fantasy.FinishReasonStop:
 				finishReason = message.FinishReasonEndTurn
 			case fantasy.FinishReasonToolCalls:
@@ -408,6 +412,10 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 	a.eventPromptResponded(call.SessionID, time.Since(startTime).Truncate(time.Second))
 
 	if err != nil {
+		slog.Debug("agent.Run error received",
+			"error", err.Error(),
+			"is_truncation", isTruncationError(err),
+			"session_id", call.SessionID)
 		isCancelErr := errors.Is(err, context.Canceled)
 		isPermissionErr := errors.Is(err, permission.ErrorPermissionDenied)
 		if currentAssistant == nil {
@@ -506,7 +514,31 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 		if updateErr != nil {
 			return nil, updateErr
 		}
+
+		// Check if this is a truncation error (e.g., XML parsing failure from
+		// truncated tool calls). If so, attempt to auto-summarize and re-queue.
+		if isTruncationError(err) && !a.disableAutoSummarize {
+			slog.Info("detected truncation error, attempting auto-summarize and re-queue",
+				"error", err.Error(),
+				"session_id", call.SessionID)
+			a.activeRequests.Del(call.SessionID)
+			if summarizeErr := a.Summarize(ctx, call.SessionID, call.ProviderOptions); summarizeErr != nil {
+				slog.Warn("auto-summarize after truncation error failed", "error", summarizeErr)
+				return nil, err
+			}
+			// Re-queue the call to continue from where we left off.
+			call.Prompt = fmt.Sprintf("The previous session was interrupted due to output truncation. The initial user request was: `%s`. Please continue from where you left off.", call.Prompt)
+			a.messageQueue.Set(call.SessionID, []SessionAgentCall{call})
+			// Process the queued message.
+			return a.Run(ctx, call)
+		}
+
 		return nil, err
+	}
+
+	// Handle max tokens hit (output truncation) - trigger auto-summarize and re-queue.
+	if hitMaxTokens && !a.disableAutoSummarize {
+		shouldSummarize = true
 	}
 
 	if shouldSummarize {
@@ -514,8 +546,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 		if summarizeErr := a.Summarize(genCtx, call.SessionID, call.ProviderOptions); summarizeErr != nil {
 			return nil, summarizeErr
 		}
-		// If the agent wasn't done...
-		if len(currentAssistant.ToolCalls()) > 0 {
+		// If the agent wasn't done (has pending tool calls, incomplete todos, or hit max tokens)...
+		hasPendingWork := len(currentAssistant.ToolCalls()) > 0 || hasIncompleteTodos(currentSession.Todos) || hitMaxTokens
+		if hasPendingWork {
 			existing, ok := a.messageQueue.Get(call.SessionID)
 			if !ok {
 				existing = []SessionAgentCall{}
@@ -1134,4 +1167,44 @@ func buildSummaryPrompt(todos []session.Todo) string {
 		sb.WriteString("Instruct the resuming assistant to use the `todos` tool to continue tracking progress on these tasks.")
 	}
 	return sb.String()
+}
+
+// isTruncationError checks if the error is due to output truncation (e.g., XML
+// parsing failures from truncated tool calls).
+func isTruncationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	// XML parsing errors from truncated tool calls.
+	if strings.Contains(errStr, "XML syntax error") {
+		return true
+	}
+	// Failed to parse XML (wrapper message).
+	if strings.Contains(errStr, "failed to parse XML") {
+		return true
+	}
+	// Tool call parsing failed (from providers like GLM).
+	if strings.Contains(errStr, "tool call parsing failed") {
+		return true
+	}
+	// JSON parsing errors from truncated tool calls.
+	if strings.Contains(errStr, "unexpected end of JSON") {
+		return true
+	}
+	// Generic truncation indicators.
+	if strings.Contains(errStr, "unexpected EOF") {
+		return true
+	}
+	return false
+}
+
+// hasIncompleteTodos checks if the session has any todos that are not completed.
+func hasIncompleteTodos(todos []session.Todo) bool {
+	for _, todo := range todos {
+		if todo.Status != session.TodoStatusCompleted {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -660,11 +660,13 @@ func TestIsTruncationError(t *testing.T) {
 		err      error
 		expected bool
 	}{
+		// Nil error.
 		{
 			name:     "nil error",
 			err:      nil,
 			expected: false,
 		},
+		// Truncation errors.
 		{
 			name:     "XML syntax error",
 			err:      fmt.Errorf("failed to parse: XML syntax error on line 1: element <tool_call> closed by </arg_value>"),
@@ -681,19 +683,9 @@ func TestIsTruncationError(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "regular error",
-			err:      fmt.Errorf("connection refused"),
-			expected: false,
-		},
-		{
 			name:     "wrapped XML error",
 			err:      fmt.Errorf("tool parsing failed: %w", fmt.Errorf("XML syntax error on line 5")),
 			expected: true,
-		},
-		{
-			name:     "rate limit error",
-			err:      fmt.Errorf("rate limit exceeded"),
-			expected: false,
 		},
 		{
 			name:     "failed to parse XML wrapper",
@@ -704,6 +696,74 @@ func TestIsTruncationError(t *testing.T) {
 			name:     "tool call parsing failed",
 			err:      fmt.Errorf("glm-4.6 tool call parsing failed: some error"),
 			expected: true,
+		},
+		// Server/infrastructure errors (now recoverable).
+		{
+			name:     "connection refused",
+			err:      fmt.Errorf("dial tcp: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "connection reset",
+			err:      fmt.Errorf("read: connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "context deadline exceeded",
+			err:      fmt.Errorf("context deadline exceeded"),
+			expected: true,
+		},
+		{
+			name:     "timeout error",
+			err:      fmt.Errorf("request timeout after 30s"),
+			expected: true,
+		},
+		{
+			name:     "internal server error",
+			err:      fmt.Errorf("internal server error"),
+			expected: true,
+		},
+		{
+			name:     "bad gateway",
+			err:      fmt.Errorf("502 bad gateway"),
+			expected: true,
+		},
+		{
+			name:     "service unavailable",
+			err:      fmt.Errorf("503 service unavailable"),
+			expected: true,
+		},
+		{
+			name:     "gateway timeout",
+			err:      fmt.Errorf("504 gateway timeout"),
+			expected: true,
+		},
+		// Ollama-specific errors.
+		{
+			name:     "model is loading",
+			err:      fmt.Errorf("model is loading, please wait"),
+			expected: true,
+		},
+		{
+			name:     "out of memory",
+			err:      fmt.Errorf("CUDA out of memory"),
+			expected: true,
+		},
+		{
+			name:     "GPU error",
+			err:      fmt.Errorf("GPU memory exhausted"),
+			expected: true,
+		},
+		// Non-recoverable errors.
+		{
+			name:     "rate limit error",
+			err:      fmt.Errorf("rate limit exceeded"),
+			expected: false,
+		},
+		{
+			name:     "authentication error",
+			err:      fmt.Errorf("invalid API key"),
+			expected: false,
 		},
 	}
 


### PR DESCRIPTION
This is a reopened PR to fix my previous one.

The goal is to make Crush try to auto-continue even if processing stops because of XML truncation on tool calling or OOM restarts from Ollama. Particularly common when using local LLM with small context windows (eg. 32k). It becomes annoying very fast to manually ask to continue everytime the context window blows up. I couldn't find a deterministic algorithm but I think this heuristic should catch most cases.

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
