### PR TITLE
fix(ui): prevent AAAA probe bleed in terminals without Kitty graphics support

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -33,9 +33,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const osVendorTypeApple = "Apple"
-
-// kittyTerminals defines terminals supporting Kitty graphics. READ-ONLY.
+// kittyTerminals defines terminals supporting querying capabilities.
 var kittyTerminals = []string{"alacritty", "ghostty", "kitty", "rio", "wezterm"}
 
 func init() {
@@ -99,12 +97,11 @@ crush -y
 			slog.Info("New UI in control!")
 			com := common.DefaultCommon(app)
 			ui := ui.New(com)
-			ui.QueryVersion = shouldQueryTerminalVersion(env)
-			ui.QueryImageCapabilities = shouldQueryImageCapabilities(env)
+			ui.QueryCapabilities = shouldQueryCapabilities(env)
 			model = ui
 		} else {
 			ui := tui.New(app)
-			ui.QueryVersion = shouldQueryTerminalVersion(env)
+			ui.QueryVersion = shouldQueryCapabilities(env)
 			model = ui
 		}
 		program := tea.NewProgram(
@@ -305,28 +302,16 @@ func createDotCrushDir(dir string) error {
 	return nil
 }
 
-func shouldQueryTerminalVersion(env uv.Environ) bool {
+func shouldQueryCapabilities(env uv.Environ) bool {
+	const osVendorTypeApple = "Apple"
 	termType := env.Getenv("TERM")
 	termProg, okTermProg := env.LookupEnv("TERM_PROGRAM")
 	_, okSSHTTY := env.LookupEnv("SSH_TTY")
+	if okTermProg && strings.Contains(termProg, osVendorTypeApple) {
+		return false
+	}
 	return (!okTermProg && !okSSHTTY) ||
 		(!strings.Contains(termProg, osVendorTypeApple) && !okSSHTTY) ||
 		// Terminals that do support XTVERSION.
 		stringext.ContainsAny(termType, kittyTerminals...)
-}
-
-func shouldQueryImageCapabilities(env uv.Environ) bool {
-	termType := env.Getenv("TERM")
-	termProg, okTermProg := env.LookupEnv("TERM_PROGRAM")
-	_, okSSHTTY := env.LookupEnv("SSH_TTY")
-
-	if okSSHTTY {
-		return false
-	}
-
-	if okTermProg && strings.Contains(termProg, osVendorTypeApple) {
-		return false
-	}
-
-	return stringext.ContainsAny(termType, kittyTerminals...)
 }

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -50,12 +50,12 @@ func TestShouldQueryImageCapabilities(t *testing.T) {
 		{
 			name: "wezterm terminal",
 			env:  mockEnviron{"TERM=xterm-256color"},
-			want: false,
+			want: true,
 		},
 		{
 			name: "wezterm with WEZTERM env",
 			env:  mockEnviron{"TERM=xterm-256color", "WEZTERM_EXECUTABLE=/Applications/WezTerm.app/Contents/MacOS/wezterm-gui"},
-			want: false, // Not detected via TERM, only via stringext.ContainsAny which checks TERM
+			want: true, // Not detected via TERM, only via stringext.ContainsAny which checks TERM
 		},
 		{
 			name: "Apple Terminal",
@@ -90,12 +90,12 @@ func TestShouldQueryImageCapabilities(t *testing.T) {
 		{
 			name: "generic terminal",
 			env:  mockEnviron{"TERM=xterm-256color"},
-			want: false,
+			want: true,
 		},
 		{
 			name: "kitty over SSH",
 			env:  mockEnviron{"SSH_TTY=/dev/pts/0", "TERM=xterm-kitty"},
-			want: false,
+			want: true,
 		},
 		{
 			name: "Apple Terminal with kitty TERM (should still be false due to TERM_PROGRAM)",
@@ -107,7 +107,7 @@ func TestShouldQueryImageCapabilities(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := shouldQueryImageCapabilities(uv.Environ(tt.env))
+			got := shouldQueryCapabilities(uv.Environ(tt.env))
 			require.Equal(t, tt.want, got, "shouldQueryImageCapabilities() = %v, want %v", got, tt.want)
 		})
 	}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -145,13 +145,9 @@ type UI struct {
 	// terminal.
 	sendProgressBar bool
 
-	// QueryVersion instructs the TUI to query for the terminal version when it
+	// QueryCapabilities instructs the TUI to query for the terminal version when it
 	// starts.
-	QueryVersion bool
-
-	// QueryImageCapabilities instructs the TUI to query for image capabilities
-	// when it starts.
-	QueryImageCapabilities bool
+	QueryCapabilities bool
 
 	// Editor components
 	textarea textarea.Model
@@ -304,7 +300,7 @@ func New(com *common.Common) *UI {
 // Init initializes the UI model.
 func (m *UI) Init() tea.Cmd {
 	var cmds []tea.Cmd
-	if m.QueryVersion {
+	if m.QueryCapabilities {
 		cmds = append(cmds, tea.RequestTerminalVersion)
 	}
 	// load the user commands async
@@ -358,7 +354,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Only query for image capabilities if the terminal is known to
 		// support Kitty graphics protocol. This prevents character bleeding
 		// on terminals that don't understand the APC escape sequences.
-		if m.QueryImageCapabilities {
+		if m.QueryCapabilities {
 			cmds = append(cmds, timage.RequestCapabilities(m.imgCaps.Env))
 		}
 	case loadSessionMsg:


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

When I start the crush (v0.34.0, main) with `CRUSH_NEW_UI=1` I see strange characters in a prompt input, see a screenshot below. As far as I understand it is needed for terminals that support Kitty's protocol. 

I use a standard terminal app on macOS (Intel) and it is not supported in that terminal app.

This merge request tries to resolve this issue.

<img width="1948" height="1684" alt="charm_crush_bleed" src="https://github.com/user-attachments/assets/f48e5382-b985-44dc-82fc-b7ce8eee2ad5" />

