### PR TITLE
ci(goreleaser): fix aur_sorces build to properly set the version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -116,7 +116,7 @@ aur_sources:
       export CGO_CXXFLAGS="${CXXFLAGS}"
       export CGO_LDFLAGS="${LDFLAGS}"
       export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
-      go build -ldflags="-w -s -buildid='' -linkmode=external -X main.version=v${pkgver}" .
+      go build -ldflags="-w -s -buildid='' -linkmode=external -X github.com/charmbracelet/crush/internal/version.Version=v${pkgver}" .
       ./crush completion bash >./completions/crush.bash
       ./crush completion zsh >./completions/crush.zsh
       ./crush completion fish >./completions/crush.fish


### PR DESCRIPTION
it seems that the variable provided to -ldflags, at some point changed from `main.version` to `github.com/charmbracelet/crush/internal/version.Version`, so reflect that to the build script for the [AUR package](https://aur.archlinux.org/packages/crush).

Otherwise, a package built from AUR reports the version as "`crush version devel`" and also complains with:
```
HEY!  This is a development version of Crush. The latest version is v0.35.0. 
```
on each start.

expected change in the PKGBUILD is:
```
diff --git a/PKGBUILD b/PKGBUILD
index e9afb74..58779bf 100644
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -23,7 +23,7 @@ build() {
   export CGO_CXXFLAGS="${CXXFLAGS}"
   export CGO_LDFLAGS="${LDFLAGS}"
   export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
-  go build -ldflags="-w -s -buildid='' -linkmode=external -X main.version=v${pkgver}" .
+  go build -ldflags="-w -s -buildid='' -linkmode=external -X github.com/charmbracelet/crush/internal/version.Version=v${pkgver}" .
   ./crush completion bash >./completions/crush.bash
   ./crush completion zsh >./completions/crush.zsh
   ./crush completion fish >./completions/crush.fish
```

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
