### PR TITLE
feat(ui): add ctrl+h to hide permission dialog

### DIFF
--- a/internal/ui/dialog/dialog.go
+++ b/internal/ui/dialog/dialog.go
@@ -64,6 +64,16 @@ func (d *Overlay) HasDialogs() bool {
 	return len(d.dialogs) > 0
 }
 
+// HasDialogsExcept checks if there are dialogs other than the specified ID.
+func (d *Overlay) HasDialogsExcept(dialogID string) bool {
+	for _, dialog := range d.dialogs {
+		if dialog.ID() != dialogID {
+			return true
+		}
+	}
+	return len(d.dialogs) > 1
+}
+
 // ContainsDialog checks if a dialog with the specified ID exists.
 func (d *Overlay) ContainsDialog(dialogID string) bool {
 	for _, dialog := range d.dialogs {
@@ -113,6 +123,14 @@ func (d *Overlay) DialogLast() Dialog {
 		return nil
 	}
 	return d.dialogs[len(d.dialogs)-1]
+}
+
+// FrontDialogID returns the ID of the topmost dialog.
+func (d *Overlay) FrontDialogID() string {
+	if len(d.dialogs) == 0 {
+		return ""
+	}
+	return d.dialogs[len(d.dialogs)-1].ID()
 }
 
 // BringToFront brings the dialog with the specified ID to the front.
@@ -199,6 +217,18 @@ func DrawOnboardingCursor(scr uv.Screen, area uv.Rectangle, view string, cur *te
 func (d *Overlay) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	var cur *tea.Cursor
 	for _, dialog := range d.dialogs {
+		cur = dialog.Draw(scr, area)
+	}
+	return cur
+}
+
+// DrawExcept renders the overlay and its dialogs, skipping the specified dialog.
+func (d *Overlay) DrawExcept(dialogID string, scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	var cur *tea.Cursor
+	for _, dialog := range d.dialogs {
+		if dialog.ID() == dialogID {
+			continue
+		}
 		cur = dialog.Draw(scr, area)
 	}
 	return cur

--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -95,6 +95,7 @@ type permissionsKeyMap struct {
 	ScrollRight      key.Binding
 	Choose           key.Binding
 	Scroll           key.Binding
+	Hide             key.Binding
 }
 
 func defaultPermissionsKeyMap() permissionsKeyMap {
@@ -159,6 +160,10 @@ func defaultPermissionsKeyMap() permissionsKeyMap {
 		Scroll: key.NewBinding(
 			key.WithKeys("shift+left", "shift+down", "shift+up", "shift+right"),
 			key.WithHelp("shift+←↓↑→", "scroll"),
+		),
+		Hide: key.NewBinding(
+			key.WithKeys("ctrl+h"),
+			key.WithHelp("ctrl+h", "hide dialog"),
 		),
 	}
 }
@@ -768,6 +773,7 @@ func (p *Permissions) ShortHelp() []key.Binding {
 		p.keyMap.Choose,
 		p.keyMap.Select,
 		p.keyMap.Close,
+		p.keyMap.Hide,
 	}
 
 	if p.canScroll() {

--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -57,13 +57,14 @@ type KeyMap struct {
 	}
 
 	// Global key maps
-	Quit     key.Binding
-	Help     key.Binding
-	Commands key.Binding
-	Models   key.Binding
-	Suspend  key.Binding
-	Sessions key.Binding
-	Tab      key.Binding
+	Quit                 key.Binding
+	Help                 key.Binding
+	Commands             key.Binding
+	Models               key.Binding
+	Suspend              key.Binding
+	Sessions             key.Binding
+	Tab                  key.Binding
+	HidePermissionDialog key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
@@ -95,6 +96,10 @@ func DefaultKeyMap() KeyMap {
 		Tab: key.NewBinding(
 			key.WithKeys("tab"),
 			key.WithHelp("tab", "change focus"),
+		),
+		HidePermissionDialog: key.NewBinding(
+			key.WithKeys("ctrl+h"),
+			key.WithHelp("ctrl+h", "hide permission dialog"),
 		),
 	}
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -147,6 +147,9 @@ type UI struct {
 	dialog *dialog.Overlay
 	status *Status
 
+	permissionDialogHidden    bool
+	permissionDialogPrevFocus uiFocusState
+
 	// isCanceling tracks whether the user has pressed escape once to cancel.
 	isCanceling bool
 
@@ -168,6 +171,7 @@ type UI struct {
 
 	readyPlaceholder   string
 	workingPlaceholder string
+	editorPlaceholder  string
 
 	// Completions state
 	completions              *completions.Completions
@@ -649,8 +653,10 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.MouseWheelMsg:
 		// Pass mouse events to dialogs first if any are open.
 		if m.dialog.HasDialogs() {
-			m.dialog.Update(msg)
-			return m, tea.Batch(cmds...)
+			if !m.isPermissionDialogFrontHidden() {
+				m.dialog.Update(msg)
+				return m, tea.Batch(cmds...)
+			}
 		}
 
 		// Otherwise handle mouse wheel for chat.
@@ -1335,6 +1341,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		m.dialog.CloseDialog(dialog.ReasoningID)
 	case dialog.ActionPermissionResponse:
 		m.dialog.CloseDialog(dialog.PermissionsID)
+		m.permissionDialogHidden = false
 		switch msg.Action {
 		case dialog.PermissionAllow:
 			m.com.App.Permissions.Grant(msg.Permission)
@@ -1501,9 +1508,45 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		return tea.Batch(cmds...)
 	}
 
+	// Handle Ctrl+H to toggle permission dialog visibility
+	if key.Matches(msg, m.keyMap.HidePermissionDialog) {
+		if m.dialog.FrontDialogID() == dialog.PermissionsID {
+			m.permissionDialogHidden = !m.permissionDialogHidden
+			if m.permissionDialogHidden {
+				// Store focus and placeholder, switch to main (chat)
+				m.permissionDialogPrevFocus = m.focus
+				m.editorPlaceholder = m.textarea.Placeholder
+				m.focus = uiFocusMain
+				m.textarea.Blur()
+				m.chat.Focus()
+			} else {
+				// Restore previous focus and placeholder
+				m.focus = m.permissionDialogPrevFocus
+				if m.editorPlaceholder != "" {
+					m.textarea.Placeholder = m.editorPlaceholder
+					m.editorPlaceholder = ""
+				}
+				if m.focus == uiFocusEditor {
+					cmds = append(cmds, m.textarea.Focus())
+				}
+			}
+			return tea.Batch(cmds...)
+		}
+	}
+
 	// Route all messages to dialog if one is open.
-	if m.dialog.HasDialogs() {
+	if m.dialog.HasDialogs() && !m.isPermissionDialogFrontHidden() {
 		return m.handleDialogMsg(msg)
+	}
+
+	// When permission dialog is hidden, suppress focus switching keys
+	if m.isPermissionDialogFrontHidden() {
+		switch {
+		case key.Matches(msg, m.keyMap.Tab):
+			return nil
+		case key.Matches(msg, m.keyMap.Chat.Cancel):
+			return nil
+		}
 	}
 
 	// Handle cancel key when agent is busy.
@@ -1900,8 +1943,17 @@ func (m *UI) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	// This needs to come last to overlay on top of everything. We always pass
 	// the full screen bounds because the dialogs will position themselves
 	// accordingly.
-	if m.dialog.HasDialogs() {
+	hasDialogs := m.dialog.HasDialogs()
+	if m.permissionDialogHidden {
+		hasDialogs = m.dialog.HasDialogsExcept(dialog.PermissionsID)
+	}
+	if hasDialogs {
+		if m.permissionDialogHidden {
+			return m.dialog.DrawExcept(dialog.PermissionsID, scr, scr.Bounds())
+		}
 		return m.dialog.Draw(scr, scr.Bounds())
+	} else if m.dialog.HasDialogs() {
+		m.dialog.DrawExcept(dialog.PermissionsID, scr, scr.Bounds())
 	}
 
 	switch m.focus {
@@ -1967,6 +2019,7 @@ func (m *UI) ShortHelp() []key.Binding {
 	k := &m.keyMap
 	tab := k.Tab
 	commands := k.Commands
+	permissionDialogHidden := m.isPermissionDialogFrontHidden()
 	if m.focus == uiFocusEditor && m.textarea.Value() == "" {
 		commands.SetHelp("/ or ctrl+p", "commands")
 	}
@@ -1976,7 +2029,7 @@ func (m *UI) ShortHelp() []key.Binding {
 		binds = append(binds, k.Quit)
 	case uiChat:
 		// Show cancel binding if agent is busy.
-		if m.isAgentBusy() {
+		if m.isAgentBusy() && !permissionDialogHidden {
 			cancelBinding := k.Chat.Cancel
 			if m.isCanceling {
 				cancelBinding.SetHelp("esc", "press again to cancel")
@@ -1992,8 +2045,10 @@ func (m *UI) ShortHelp() []key.Binding {
 			tab.SetHelp("tab", "focus editor")
 		}
 
+		if !permissionDialogHidden {
+			binds = append(binds, tab)
+		}
 		binds = append(binds,
-			tab,
 			commands,
 			k.Models,
 		)
@@ -2043,6 +2098,7 @@ func (m *UI) FullHelp() [][]key.Binding {
 	hasAttachments := len(m.attachments.List()) > 0
 	hasSession := m.hasSession()
 	commands := k.Commands
+	permissionDialogHidden := m.isPermissionDialogFrontHidden()
 	if m.focus == uiFocusEditor && m.textarea.Value() == "" {
 		commands.SetHelp("/ or ctrl+p", "commands")
 	}
@@ -2055,7 +2111,7 @@ func (m *UI) FullHelp() [][]key.Binding {
 			})
 	case uiChat:
 		// Show cancel binding if agent is busy.
-		if m.isAgentBusy() {
+		if m.isAgentBusy() && !permissionDialogHidden {
 			cancelBinding := k.Chat.Cancel
 			if m.isCanceling {
 				cancelBinding.SetHelp("esc", "press again to cancel")
@@ -2073,8 +2129,10 @@ func (m *UI) FullHelp() [][]key.Binding {
 			tab.SetHelp("tab", "focus editor")
 		}
 
+		if !permissionDialogHidden {
+			mainBinds = append(mainBinds, tab)
+		}
 		mainBinds = append(mainBinds,
-			tab,
 			commands,
 			k.Models,
 			k.Sessions,
@@ -2644,6 +2702,10 @@ func (m *UI) hasSession() bool {
 	return m.session != nil && m.session.ID != ""
 }
 
+func (m *UI) isPermissionDialogFrontHidden() bool {
+	return m.permissionDialogHidden && m.dialog.FrontDialogID() == dialog.PermissionsID
+}
+
 // mimeOf detects the MIME type of the given content.
 func mimeOf(content []byte) string {
 	mimeBufferSize := min(512, len(content))
@@ -2675,6 +2737,10 @@ func (m *UI) randomizePlaceholders() {
 
 // renderEditorView renders the editor view with attachments if any.
 func (m *UI) renderEditorView(width int) string {
+	if m.permissionDialogHidden {
+		m.textarea.Placeholder = "Prompt input disabled while permissions pending (ctrl+h to show)"
+	}
+
 	if len(m.attachments.List()) == 0 {
 		return m.textarea.View()
 	}


### PR DESCRIPTION
**Problem**
Permissions dialog modal visually blocks the underlying chat messages, often making it hard or impossible to read the model's reasoning for requiring some permissions.

**Solution**
Add a new binding `ctrl+h` (open to change) to hide/toggle the permission dialog.

When the permission dialog is hidden
- focus is put on the chat
- `tab` binding disabled and hidden, disallowing focusing on the editor (text input) -- placeholder in the editor to signify permissions pending state
- `esc` binding disabled and hidden -- maybe `esc` could be declining the permission or reopening the permission dialog


<img width="1425" height="675" alt="image" src="https://github.com/user-attachments/assets/f9ee45c5-4163-4c0c-b293-ff747d8a8bd4" />
<img width="1423" height="674" alt="image" src="https://github.com/user-attachments/assets/6aba03af-a557-412c-b288-6fad69af28c2" />

This feature is only implemented for the new UI implementation. Must use `CRUSH_NEW_UI=1`.
Didn't feel I was worth it to implement across the 2 UIs.


- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

closes https://github.com/charmbracelet/crush/issues/1405

