### PR TITLE
ci: use goreleaser nightly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
     with:
       go_version: "1.25"
       macos_sign_entitlements: "./.github/entitlements.plist"
+      # XXX: remove it after goreleaser 2.14.
       goreleaser_version: nightly
     secrets:
       docker_username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
reason: https://github.com/goreleaser/goreleaser/commit/20d273bf4a96d2cebd0d99dcd9b10dc17cf71d61

should fix https://github.com/charmbracelet/nur/issues/42
needs: https://github.com/charmbracelet/meta/pull/271