### PR TITLE
fix: should also copy on `y` (additionally to `c`)

### DIFF
--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -258,7 +258,7 @@ func (a *AssistantMessageItem) HandleMouseClick(btn ansi.MouseButton, x, y int) 
 
 // HandleKeyEvent implements KeyEventHandler.
 func (a *AssistantMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
-	if key.String() == "c" {
+	if k := key.String(); k == "c" || k == "y" {
 		text := a.message.Content().Text
 		return true, common.CopyToClipboard(text, "Message copied to clipboard")
 	}

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -420,7 +420,7 @@ func (t *baseToolMessageItem) HandleMouseClick(btn ansi.MouseButton, x, y int) b
 
 // HandleKeyEvent implements KeyEventHandler.
 func (t *baseToolMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
-	if key.String() == "c" {
+	if k := key.String(); k == "c" || k == "y" {
 		text := t.formatToolForCopy()
 		return true, common.CopyToClipboard(text, "Tool content copied to clipboard")
 	}

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -96,7 +96,7 @@ func (m *UserMessageItem) renderAttachments(width int) string {
 
 // HandleKeyEvent implements KeyEventHandler.
 func (m *UserMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
-	if key.String() == "c" {
+	if k := key.String(); k == "c" || k == "y" {
 		text := m.message.Content().Text
 		return true, common.CopyToClipboard(text, "Message copied to clipboard")
 	}


### PR DESCRIPTION
* Follow-up of #1947

<img width="1530" height="639" alt="Screenshot 2026-01-26 at 11 01 02" src="https://github.com/user-attachments/assets/19200509-63b8-4e1f-9ce8-6cb58a726579" />
