### PR TITLE
fix: schema incorrectly marks optional fields as required

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -187,7 +187,7 @@ type MCPConfig struct {
 
 type LSPConfig struct {
 	Disabled    bool              `json:"disabled,omitempty" jsonschema:"description=Whether this LSP server is disabled,default=false"`
-	Command     string            `json:"command,omitempty" jsonschema:"required,description=Command to execute for the LSP server,example=gopls"`
+	Command     string            `json:"command,omitempty" jsonschema:"description=Command to execute for the LSP server,example=gopls"`
 	Args        []string          `json:"args,omitempty" jsonschema:"description=Arguments to pass to the LSP server command"`
 	Env         map[string]string `json:"env,omitempty" jsonschema:"description=Environment variables to set to the LSP server command"`
 	FileTypes   []string          `json:"filetypes,omitempty" jsonschema:"description=File types this LSP server handles,example=go,example=mod,example=rs,example=c,example=js,example=ts"`
@@ -346,7 +346,7 @@ type Agent struct {
 }
 
 type Tools struct {
-	Ls ToolLs `json:"ls,omitzero"`
+	Ls ToolLs `json:"ls,omitempty"`
 }
 
 type ToolLs struct {
@@ -379,7 +379,7 @@ type Config struct {
 
 	Permissions *Permissions `json:"permissions,omitempty" jsonschema:"description=Permission settings for tool usage"`
 
-	Tools Tools `json:"tools,omitzero" jsonschema:"description=Tool configurations"`
+	Tools Tools `json:"tools,omitempty" jsonschema:"description=Tool configurations"`
 
 	Agents map[string]Agent `json:"-"`
 

--- a/schema.json
+++ b/schema.json
@@ -92,10 +92,7 @@
         }
       },
       "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "tools"
-      ]
+      "type": "object"
     },
     "LSPConfig": {
       "properties": {
@@ -162,10 +159,7 @@
         }
       },
       "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "command"
-      ]
+      "type": "object"
     },
     "LSPs": {
       "additionalProperties": {
@@ -698,10 +692,7 @@
         }
       },
       "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "ls"
-      ]
+      "type": "object"
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes two schema validation issues that forced users to specify unnecessary fields in their configuration files.

1. **`tools.ls` incorrectly marked as required**
   - Changed `Tools.Ls` and `Config.Tools` from `omitzero` to `omitempty`
   - The `invopop/jsonschema` library doesn't recognize Go 1.25's `omitzero` tag

2. **`lsp.command` incorrectly marked as required**
   - Removed `jsonschema:"required"` tag from `LSPConfig.Command`
   - The project's own `crush.json` doesn't include command field for gopls

After this fix, users can use minimal configurations without being forced to specify `tools.ls` or `lsp.command` fields.

## Test plan

- [x] Verified schema generation with `task schema`
- [x] Checked that `tools` and `tools.ls` are now optional in generated schema
- [x] Confirmed `lsp.command` is no longer marked as required

Closes #1848