### PR TITLE
fix(stats): resizing breaks pie charts

### DIFF
--- a/internal/cmd/stats/index.css
+++ b/internal/cmd/stats/index.css
@@ -189,20 +189,15 @@ body {
 }
 
 .chart-row {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  display: flex;
+  flex-wrap: wrap;
   gap: 1.5rem;
   width: 100%;
 }
 
 .chart-row .chart-card {
-  width: 100%;
-}
-
-@media (max-width: 1024px) {
-  .chart-row {
-    grid-template-columns: 1fr;
-  }
+  flex: 1 1 300px;
+  max-width: calc((100% - 1.5rem) / 2);
 }
 
 .chart-card h2 {


### PR DESCRIPTION
resizing the browser would "break" the pie charts, cutting them off

