### PR TITLE
fix: make the commands dialog less taller

### DIFF
--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -29,8 +29,9 @@ type CommandType uint
 func (c CommandType) String() string { return []string{"System", "User", "MCP"}[c] }
 
 const (
-	sidebarCompactModeBreakpoint  = 120
-	defaultCommandsDialogMaxWidth = 70
+	sidebarCompactModeBreakpoint   = 120
+	defaultCommandsDialogMaxHeight = 20
+	defaultCommandsDialogMaxWidth  = 70
 )
 
 const (
@@ -242,7 +243,7 @@ func commandsRadioView(sty *styles.Styles, selected CommandType, hasUserCmds boo
 func (c *Commands) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	t := c.com.Styles
 	width := max(0, min(defaultCommandsDialogMaxWidth, area.Dx()))
-	height := max(0, min(defaultDialogHeight, area.Dy()))
+	height := max(0, min(defaultCommandsDialogMaxHeight, area.Dy()))
 	if area.Dx() != c.windowWidth && c.selected == SystemCommands {
 		c.windowWidth = area.Dx()
 		// since some items in the list depend on width (e.g. toggle sidebar command),


### PR DESCRIPTION
<details><summary>Before</summary>
<p>

<img width="647" height="636" alt="Screenshot 2026-01-28 at 14 17 52" src="https://github.com/user-attachments/assets/d0c1013e-92a3-46ff-a024-f1f12db7de78" />

</p>
</details>


<details><summary>After</summary>
<p>

<img width="646" height="437" alt="Screenshot 2026-01-28 at 14 18 15" src="https://github.com/user-attachments/assets/7bdf69ad-4a3f-45f2-82ed-1ba65dd5c432" />

</p>
</details>