### PR TITLE
fix(ui): fix wrong color on selected item info on dialogs

### DIFF
--- a/internal/ui/dialog/commands_item.go
+++ b/internal/ui/dialog/commands_item.go
@@ -70,7 +70,7 @@ func (c *CommandItem) Render(width int) string {
 		ItemBlurred:     c.t.Dialog.NormalItem,
 		ItemFocused:     c.t.Dialog.SelectedItem,
 		InfoTextBlurred: c.t.Base,
-		InfoTextFocused: c.t.Subtle,
+		InfoTextFocused: c.t.Base,
 	}
 	return renderItem(styles, c.title, c.shortcut, c.focused, width, c.cache, &c.m)
 }

--- a/internal/ui/dialog/models_item.go
+++ b/internal/ui/dialog/models_item.go
@@ -110,7 +110,7 @@ func (m *ModelItem) Render(width int) string {
 		ItemBlurred:     m.t.Dialog.NormalItem,
 		ItemFocused:     m.t.Dialog.SelectedItem,
 		InfoTextBlurred: m.t.Base,
-		InfoTextFocused: m.t.Subtle,
+		InfoTextFocused: m.t.Base,
 	}
 	return renderItem(styles, m.model.Name, providerInfo, m.focused, width, m.cache, &m.m)
 }

--- a/internal/ui/dialog/reasoning.go
+++ b/internal/ui/dialog/reasoning.go
@@ -297,7 +297,7 @@ func (r *ReasoningItem) Render(width int) string {
 		ItemBlurred:     r.t.Dialog.NormalItem,
 		ItemFocused:     r.t.Dialog.SelectedItem,
 		InfoTextBlurred: r.t.Base,
-		InfoTextFocused: r.t.Subtle,
+		InfoTextFocused: r.t.Base,
 	}
 	return renderItem(styles, r.title, info, r.focused, width, r.cache, &r.m)
 }


### PR DESCRIPTION
<details><summary>Before</summary>
<p>

<img width="651" height="643" alt="Screenshot 2026-01-28 at 18 15 31" src="https://github.com/user-attachments/assets/cb2a353c-9cd7-4f04-9858-8cc3be4b7670" />

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="650" height="642" alt="Screenshot 2026-01-28 at 18 15 55" src="https://github.com/user-attachments/assets/909bed20-a1fe-4892-b9cf-cab57e0e6189" />

</p>
</details> 
