### PR TITLE
feat: add allowed_commands configuration with CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,74 @@ completely hidden from the agent.
 
 To disable tools from MCP servers, see the [MCP config section](#mcps).
 
+### Configuring Individual Tools
+
+Some built-in tools can be configured with specific options. These configurations go in the `tools` section of your crush.json file.
+
+#### Bash Tool Configuration
+
+The bash tool can be configured to allow specific commands that would otherwise be blocked. This is useful when you need to use certain system commands for development or administration tasks.
+
+##### Configuration File
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "tools": {
+    "bash": {
+      "allowed_commands": ["curl", "wget", "apt", "npm", "go", "pnpm", "yarn"]
+    }
+  }
+}
+```
+
+##### Command Line Option
+
+You can also specify allowed commands directly via command line using the `-a` or `--allowed` flag, which has the highest priority (overrides both config file and hardcoded restrictions):
+
+```bash
+# Allow specific commands for interactive mode
+crush -a curl,wget,apt,npm
+
+# Allow commands with spaces
+crush -a "curl wget apt npm"
+
+# For non-interactive mode
+crush run -a curl,wget,apt "Install dependencies"
+```
+
+##### Priority Order
+
+Allowed commands are resolved in this priority order (highest to lowest):
+1. **Command line** (`-a/--allowed` flag) - highest priority
+2. **Configuration file** (`tools.bash.allowed_commands` in crush.json)
+3. **Hardcoded restrictions** - default if nothing else is specified
+
+##### How It Works
+
+The `allowed_commands` array removes specified commands from the banned commands list, allowing them to be used with any arguments. For example, if `"apt"` is in the allowed commands list:
+- `apt install python3` will be allowed
+- But `dnf install git` will still be blocked
+
+#### LS Tool Configuration
+
+The ls tool can be configured with limits to control output size:
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "tools": {
+    "ls": {
+      "max_depth": 0,
+      "max_items": 1000
+    }
+  }
+}
+```
+
+- `max_depth`: Maximum directory depth to traverse (0 = current directory only)
+- `max_items`: Maximum number of items to return
+
 ### Agent Skills
 
 Crush supports the [Agent Skills](https://agentskills.io) open standard for

--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -198,7 +198,7 @@ func coderAgent(r *vcr.Recorder, env fakeEnv, large, small fantasy.LanguageModel
 	}
 
 	allTools := []fantasy.AgentTool{
-		tools.NewBashTool(env.permissions, env.workingDir, cfg.Options.Attribution, modelName),
+		tools.NewBashTool(env.permissions, env.workingDir, cfg.Options.Attribution, modelName, cfg.Tools.Bash),
 		tools.NewDownloadTool(env.permissions, env.workingDir, r.GetDefaultClient()),
 		tools.NewEditTool(env.lspClients, env.permissions, env.history, env.workingDir),
 		tools.NewMultiEditTool(env.lspClients, env.permissions, env.history, env.workingDir),

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -389,7 +389,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent) ([]fan
 	}
 
 	allTools = append(allTools,
-		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Options.Attribution, modelName),
+		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Options.Attribution, modelName, c.cfg.Tools.Bash),
 		tools.NewJobOutputTool(),
 		tools.NewJobKillTool(),
 		tools.NewDownloadTool(c.permissions, c.cfg.WorkingDir(), nil),

--- a/internal/agent/tools/bash.tpl
+++ b/internal/agent/tools/bash.tpl
@@ -8,7 +8,8 @@ Common shell builtins and core utils available on Windows.
 
 <execution_steps>
 1. Directory Verification: If creating directories/files, use LS tool to verify parent exists
-2. Security Check: Banned commands ({{ .BannedCommands }}) return error - explain to user. Safe read-only commands execute without prompts
+2. Security Check: Banned commands ({{ .BannedCommands }}) return error - explain to user. Safe read-only commands execute without prompts{{ if .AllowedCommands }}
+   Allowed commands (removed from banned list via config): {{ .AllowedCommands }}{{ end }}
 3. Command Execution: Execute with proper quoting, capture output
 4. Auto-Background: Commands exceeding 1 minute automatically move to background and return shell ID
 5. Output Processing: Truncate if exceeds {{ .MaxOutputLength }} characters

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -29,6 +29,12 @@ crush run "What is this code doing?" <<< prrr.go
 
 # Run in quiet mode (hide the spinner)
 crush run --quiet "Generate a README for this project"
+
+# Allow specific commands for this run
+crush run -a curl,wget,apt "Install dependencies"
+
+# Allow multiple commands with spaces
+crush run -a "curl wget apt npm" "Setup project"
   `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		quiet, _ := cmd.Flags().GetBool("quiet")

--- a/internal/config/allowed_commands_test.go
+++ b/internal/config/allowed_commands_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllowedCommandsPriority(t *testing.T) {
+	tests := []struct {
+		name           string
+		configCommands []string
+		cliCommands    []string
+		expected       []string
+	}{
+		{
+			name:           "CLI overrides config",
+			configCommands: []string{"curl", "wget"},
+			cliCommands:    []string{"apt", "npm"},
+			expected:       []string{"apt", "npm"},
+		},
+		{
+			name:           "CLI empty uses config",
+			configCommands: []string{"curl", "wget"},
+			cliCommands:    []string{},
+			expected:       []string{"curl", "wget"},
+		},
+		{
+			name:           "Both empty returns empty",
+			configCommands: []string{},
+			cliCommands:    []string{},
+			expected:       []string{},
+		},
+		{
+			name:           "CLI with duplicates",
+			configCommands: []string{"curl", "wget"},
+			cliCommands:    []string{"apt", "npm", "apt"}, // duplicate apt
+			expected:       []string{"apt", "npm", "apt"}, // duplicates preserved
+		},
+		{
+			name:           "CLI preserves order",
+			configCommands: []string{"z", "y", "x"},
+			cliCommands:    []string{"a", "b", "c"},
+			expected:       []string{"a", "b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create config with allowed commands
+			cfg := &Config{
+				Tools: Tools{
+					Bash: ToolBash{
+						AllowedCommands: tt.configCommands,
+					},
+				},
+			}
+
+			// Simulate CLI override
+			result := cfg.Tools.Bash.AllowedCommands
+			if len(tt.cliCommands) > 0 {
+				result = tt.cliCommands
+			}
+
+			require.Equal(t, len(tt.expected), len(result))
+			assert.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToolBashDefaults(t *testing.T) {
+	t.Run("empty by default", func(t *testing.T) {
+		cfg := &Config{}
+		cfg.setDefaults("/tmp", "")
+
+		assert.Empty(t, cfg.Tools.Bash.AllowedCommands)
+	})
+
+	t.Run("preserves config values", func(t *testing.T) {
+		cfg := &Config{
+			Tools: Tools{
+				Bash: ToolBash{
+					AllowedCommands: []string{"curl", "wget"},
+				},
+			},
+		}
+		cfg.setDefaults("/tmp", "")
+
+		assert.Equal(t, []string{"curl", "wget"}, cfg.Tools.Bash.AllowedCommands)
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -347,7 +347,8 @@ type Agent struct {
 }
 
 type Tools struct {
-	Ls ToolLs `json:"ls,omitempty"`
+	Ls   ToolLs   `json:"ls,omitzero"`
+	Bash ToolBash `json:"bash,omitzero"`
 }
 
 type ToolLs struct {
@@ -357,6 +358,10 @@ type ToolLs struct {
 
 func (t ToolLs) Limits() (depth, items int) {
 	return ptrValOr(t.MaxDepth, 0), ptrValOr(t.MaxItems, 0)
+}
+
+type ToolBash struct {
+	AllowedCommands []string `json:"allowed_commands,omitempty" jsonschema:"description=List of commands to remove from the banned commands list,example=curl,example=wget"`
 }
 
 // Config holds the configuration for crush.

--- a/schema.json
+++ b/schema.json
@@ -689,10 +689,32 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "ToolBash": {
+      "properties": {
+        "allowed_commands": {
+          "items": {
+            "type": "string",
+            "examples": [
+              "curl",
+              "wget",
+              "apt",
+              "npm"
+            ]
+          },
+          "type": "array",
+          "description": "List of commands to remove from the banned commands list"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "Tools": {
       "properties": {
         "ls": {
           "$ref": "#/$defs/ToolLs"
+        },
+        "bash": {
+          "$ref": "#/$defs/ToolBash"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary:

- Adds  allowed_commands  configuration for bash tool to allow specific commands that would otherwise be blocked
- Fixes  allowed_commands  to also affect  ArgumentsBlocker  for package managers
- Adds  -a/--allowed  flag for command line allowed commands with highest priority
- Adds comprehensive documentation for the feature in README

## Changes:

1. Configuration: Add  tools.bash.allowed_commands  array in crush.json to specify commands to remove from banned list
2. CLI Support: Add  -a/--allowed  flag that overrides both config file and hardcoded restrictions
3. Priority Order: Command line > Configuration file > Hardcoded restrictions
4. Package Manager Support: When a command is allowed, its package manager subcommands (like  apt install ) are also
allowed
5. Documentation: Added detailed README section with examples and configuration options

## Example Usage:

```
# Configuration file
{
  "tools": {
    "bash": {
      "allowed_commands": ["curl", "wget", "apt", "npm"]
    }
  }
}

# Command line (highest priority)
crush -a curl,wget,apt,npm
crush run -a curl,wget,apt "Install dependencies"
```