### PR TITLE
fix(agent): resolve title generation prompt conflict

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -762,8 +762,8 @@ func (a *sessionAgent) getSessionMessages(ctx context.Context, session session.S
 }
 
 // generateTitle generates a session titled based on the initial prompt.
-func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, userPrompt string) {
-	if userPrompt == "" {
+func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, initialUserPrompt string) {
+	if initialUserPrompt == "" {
 		return
 	}
 
@@ -771,20 +771,33 @@ func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, user
 	largeModel := a.largeModel.Get()
 	systemPromptPrefix := a.systemPromptPrefix.Get()
 
-	var maxOutputTokens int64 = 40
-	if smallModel.CatwalkCfg.CanReason {
-		maxOutputTokens = smallModel.CatwalkCfg.DefaultMaxTokens
+	// buildConfig constructs the system prompt, user prompt, and max tokens
+	// based on the model's reasoning capability.
+	buildConfig := func(m Model) (systemPrompt string, userPrompt string, maxTokens int64) {
+		if m.CatwalkCfg.CanReason {
+			// Reasoning models: allow reasoning, provide think tags.
+			return string(titlePrompt),
+				fmt.Sprintf("Generate a concise title for the following content:\n\n%s\n<think>\n\n</think>", initialUserPrompt),
+				m.CatwalkCfg.DefaultMaxTokens
+		}
+		// Non-reasoning models: direct output, add /no_think directive.
+		return string(titlePrompt) + "\n/no_think",
+			fmt.Sprintf("Generate a concise title for the following content:\n\n%s", initialUserPrompt),
+			40
 	}
 
-	newAgent := func(m fantasy.LanguageModel, p []byte, tok int64) fantasy.Agent {
+	// Build configuration for the small model.
+	systemPrompt, userPrompt, maxOutputTokens := buildConfig(smallModel)
+
+	newAgent := func(m fantasy.LanguageModel, sysPrompt string, tok int64) fantasy.Agent {
 		return fantasy.NewAgent(m,
-			fantasy.WithSystemPrompt(string(p)+"\n /no_think"),
+			fantasy.WithSystemPrompt(sysPrompt),
 			fantasy.WithMaxOutputTokens(tok),
 		)
 	}
 
 	streamCall := fantasy.AgentStreamCall{
-		Prompt: fmt.Sprintf("Generate a concise title for the following content:\n\n%s\n <think>\n\n</think>", userPrompt),
+		Prompt: userPrompt,
 		PrepareStep: func(callCtx context.Context, opts fantasy.PrepareStepFunctionOptions) (_ context.Context, prepared fantasy.PrepareStepResult, err error) {
 			prepared.Messages = opts.Messages
 			if systemPromptPrefix != "" {
@@ -798,7 +811,7 @@ func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, user
 
 	// Use the small model to generate the title.
 	model := smallModel
-	agent := newAgent(model.Model, titlePrompt, maxOutputTokens)
+	agent := newAgent(model.Model, systemPrompt, maxOutputTokens)
 	resp, err := agent.Stream(ctx, streamCall)
 	if err == nil {
 		// We successfully generated a title with the small model.
@@ -807,7 +820,11 @@ func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, user
 		// It didn't work. Let's try with the big model.
 		slog.Error("error generating title with small model; trying big model", "err", err)
 		model = largeModel
-		agent = newAgent(model.Model, titlePrompt, maxOutputTokens)
+
+		// Rebuild configuration for the large model.
+		systemPrompt, streamCall.Prompt, maxOutputTokens = buildConfig(largeModel)
+
+		agent = newAgent(model.Model, systemPrompt, maxOutputTokens)
 		resp, err = agent.Stream(ctx, streamCall)
 		if err == nil {
 			slog.Info("generated title with large model")


### PR DESCRIPTION
## Summary

This PR resolves a prompt conflict in the `generateTitle` function where `/no_think` and `<think>` tags were being used simultaneously, causing fragmented output especially with smaller models like Ministral 8B.

### Changes Made

- Added `buildConfig` helper function to dynamically construct prompts based on model's `CanReason` capability
- **Reasoning models** (o1, DeepSeek-R1, GLM-4.7): Now properly utilize their reasoning capability by removing `/no_think` directive and keeping `<think>` tags
- **Non-reasoning models** (GPT-4, Claude, Ministral): Get clear, conflict-free instructions with `/no_think` and without `<think>` tags
- Updated both small model and large model fallback logic to use dynamic configuration

### Technical Details

**Before**:
```go
// Always used /no_think in system prompt
systemPrompt: titlePrompt + "\n /no_think"
// Always included <think> tags in user prompt
userPrompt: "Generate a concise title...\n <think>\n\n</think>"
// ❌ Conflict: contradictory instructions
```

**After**:
```go
if model.CatwalkCfg.CanReason {
    // Reasoning models: allow reasoning
    systemPrompt: titlePrompt  // no /no_think
    userPrompt: "Generate...\n<think>\n\n</think>"
} else {
    // Non-reasoning models: direct output
    systemPrompt: titlePrompt + "\n/no_think"
    userPrompt: "Generate..."  // no <think> tags
}
```

### VCR Cassette Tests
**VCR cassette tests will fail** because the prompt format has changed.

The recorded cassettes contain the old prompt format:
```yaml
# Old format in cassettes
messages: [{"content": "Generate a concise title...\n <think>\n\n</think>"}]
system: "...\n /no_think"
```

New requests use a different format based on model capability:
```yaml
# New format for non-reasoning models
messages: [{"content": "Generate a concise title..."}]  # no <think>
system: "...\n/no_think"  # no space
```

Fixes #1980