### PR TITLE
feat: delete messages below, fork conversation

### DIFF
--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -28,6 +28,7 @@ type Service interface {
 	List(ctx context.Context, sessionID string) ([]Message, error)
 	ListUserMessages(ctx context.Context, sessionID string) ([]Message, error)
 	ListAllUserMessages(ctx context.Context) ([]Message, error)
+	Copy(ctx context.Context, sessionID string, message Message) (Message, error)
 	Delete(ctx context.Context, id string) error
 	DeleteSessionMessages(ctx context.Context, sessionID string) error
 }
@@ -93,6 +94,17 @@ func (s *service) Create(ctx context.Context, sessionID string, params CreateMes
 	// concurrent modifications to the Parts slice.
 	s.Publish(pubsub.CreatedEvent, message.Clone())
 	return message, nil
+}
+
+func (s *service) Copy(ctx context.Context, sessionID string, message Message) (Message, error) {
+	params := CreateMessageParams{
+		Role:             message.Role,
+		Parts:            message.Parts,
+		Model:            message.Model,
+		Provider:         message.Provider,
+		IsSummaryMessage: message.IsSummaryMessage,
+	}
+	return s.Create(ctx, sessionID, params)
 }
 
 func (s *service) DeleteSessionMessages(ctx context.Context, sessionID string) error {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/charmbracelet/crush/internal/db"
 	"github.com/charmbracelet/crush/internal/event"
+	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/google/uuid"
 )
@@ -42,6 +43,11 @@ type Session struct {
 	UpdatedAt        int64
 }
 
+type ForkMessageService interface {
+	List(ctx context.Context, sessionID string) ([]message.Message, error)
+	Copy(ctx context.Context, sessionID string, message message.Message) (message.Message, error)
+}
+
 type Service interface {
 	pubsub.Subscriber[Session]
 	Create(ctx context.Context, title string) (Session, error)
@@ -52,6 +58,7 @@ type Service interface {
 	Save(ctx context.Context, session Session) (Session, error)
 	UpdateTitleAndUsage(ctx context.Context, sessionID, title string, promptTokens, completionTokens int64, cost float64) error
 	Delete(ctx context.Context, id string) error
+	Fork(ctx context.Context, sourceSessionID, upToMessageID string, messageSvc ForkMessageService) (Session, error)
 
 	// Agent tool session management
 	CreateAgentToolSessionID(messageID, toolCallID string) string
@@ -137,6 +144,44 @@ func (s *service) Delete(ctx context.Context, id string) error {
 	s.Publish(pubsub.DeletedEvent, session)
 	event.SessionDeleted()
 	return nil
+}
+
+func (s *service) Fork(ctx context.Context, sourceSessionID, upToMessageID string, messageSvc ForkMessageService) (Session, error) {
+	messages, err := messageSvc.List(ctx, sourceSessionID)
+	if err != nil {
+		return Session{}, fmt.Errorf("listing messages: %w", err)
+	}
+
+	targetIndex := -1
+	for i, msg := range messages {
+		if msg.ID == upToMessageID {
+			targetIndex = i
+			break
+		}
+	}
+	if targetIndex == -1 {
+		return Session{}, fmt.Errorf("message not found: %s", upToMessageID)
+	}
+
+	sourceSession, err := s.Get(ctx, sourceSessionID)
+	if err != nil {
+		return Session{}, fmt.Errorf("getting source session: %w", err)
+	}
+
+	newSession, err := s.Create(ctx, "Forked: "+sourceSession.Title)
+	if err != nil {
+		return Session{}, fmt.Errorf("creating session: %w", err)
+	}
+
+	for i := 0; i <= targetIndex; i++ {
+		_, err = messageSvc.Copy(ctx, newSession.ID, messages[i])
+		if err != nil {
+			_ = s.Delete(ctx, newSession.ID)
+			return Session{}, fmt.Errorf("copying message: %w", err)
+		}
+	}
+
+	return newSession, nil
 }
 
 func (s *service) Get(ctx context.Context, id string) (Session, error) {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -173,7 +173,7 @@ func (s *service) Fork(ctx context.Context, sourceSessionID, upToMessageID strin
 		return Session{}, fmt.Errorf("creating session: %w", err)
 	}
 
-	for i := 0; i <= targetIndex; i++ {
+	for i := 0; i < targetIndex; i++ {
 		_, err = messageSvc.Copy(ctx, newSession.ID, messages[i])
 		if err != nil {
 			_ = s.Delete(ctx, newSession.ID)

--- a/internal/session/session_fork_test.go
+++ b/internal/session/session_fork_test.go
@@ -25,7 +25,7 @@ func TestFork(t *testing.T) {
 	sourceSession, err := svc.Create(ctx, "Source Session")
 	require.NoError(t, err)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		_, err = msgSvc.Create(ctx, sourceSession.ID, message.CreateMessageParams{
 			Role: message.User,
 			Parts: []message.ContentPart{

--- a/internal/session/session_fork_test.go
+++ b/internal/session/session_fork_test.go
@@ -53,7 +53,7 @@ func TestFork(t *testing.T) {
 	require.Contains(t, newSession.Title, sourceSession.Title)
 
 	forkedMessages := getMessages(newSession.ID)
-	require.Len(t, forkedMessages, 3)
+	require.Len(t, forkedMessages, 2)
 
 	for i, msg := range forkedMessages {
 		require.Equal(t, sourceMessages[i].Role, msg.Role)

--- a/internal/session/session_fork_test.go
+++ b/internal/session/session_fork_test.go
@@ -1,0 +1,83 @@
+package session
+
+import (
+	"context"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/db"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFork(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	conn, err := db.Connect(t.Context(), t.TempDir())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	q := db.New(conn)
+	svc := NewService(q, conn)
+	msgSvc := message.NewService(q)
+
+	sourceSession, err := svc.Create(ctx, "Source Session")
+	require.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		_, err = msgSvc.Create(ctx, sourceSession.ID, message.CreateMessageParams{
+			Role: message.User,
+			Parts: []message.ContentPart{
+				message.TextContent{Text: "Test message"},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	getMessages := func(sessionID string) []message.Message {
+		msgs, err := msgSvc.List(ctx, sessionID)
+		require.NoError(t, err)
+		return msgs
+	}
+
+	sourceMessages := getMessages(sourceSession.ID)
+	require.Len(t, sourceMessages, 5)
+
+	targetMessageID := sourceMessages[2].ID
+	newSession, err := svc.Fork(ctx, sourceSession.ID, targetMessageID, msgSvc)
+	require.NoError(t, err)
+	require.NotEmpty(t, newSession.ID)
+	require.NotEqual(t, sourceSession.ID, newSession.ID)
+	require.Contains(t, newSession.Title, "Forked:")
+	require.Contains(t, newSession.Title, sourceSession.Title)
+
+	forkedMessages := getMessages(newSession.ID)
+	require.Len(t, forkedMessages, 3)
+
+	for i, msg := range forkedMessages {
+		require.Equal(t, sourceMessages[i].Role, msg.Role)
+		require.Equal(t, sourceMessages[i].Parts[0], msg.Parts[0])
+	}
+}
+
+func TestForkInvalidMessageID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	conn, err := db.Connect(t.Context(), t.TempDir())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	q := db.New(conn)
+	svc := NewService(q, conn)
+	msgSvc := message.NewService(q)
+
+	sourceSession, err := svc.Create(ctx, "Source Session")
+	require.NoError(t, err)
+
+	_, err = svc.Fork(ctx, sourceSession.ID, "invalid-id", msgSvc)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "message not found")
+}

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -45,6 +45,7 @@ type ActionSelectModel struct {
 type (
 	ActionNewSession        struct{}
 	ActionForkConversation  struct{}
+	ActionDeleteMessages    struct{}
 	ActionToggleHelp        struct{}
 	ActionToggleCompactMode struct{}
 	ActionToggleThinking    struct{}

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -44,6 +44,7 @@ type ActionSelectModel struct {
 // Messages for commands
 type (
 	ActionNewSession        struct{}
+	ActionForkConversation  struct{}
 	ActionToggleHelp        struct{}
 	ActionToggleCompactMode struct{}
 	ActionToggleThinking    struct{}

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -393,7 +393,7 @@ func (c *Commands) defaultCommands() []*CommandItem {
 	if c.isUserMessageSelected {
 		commands = append(commands,
 			NewCommandItem(c.com.Styles, "fork_conversation", "Fork Conversation", "", ActionForkConversation{}),
-			NewCommandItem(c.com.Styles, "delete_messages", "Delete Messages (including this)", "", ActionDeleteMessages{}),
+			NewCommandItem(c.com.Styles, "delete_messages", "Delete Bellow", "", ActionDeleteMessages{}),
 		)
 	}
 

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -66,12 +66,13 @@ type Commands struct {
 	customCommands []commands.CustomCommand
 	mcpPrompts     []commands.MCPPrompt
 	canFork        bool // whether a user message is selected for forking
+	canDelete      bool // whether a user message is selected for deletion
 }
 
 var _ Dialog = (*Commands)(nil)
 
 // NewCommands creates a new commands dialog.
-func NewCommands(com *common.Common, sessionID string, customCommands []commands.CustomCommand, mcpPrompts []commands.MCPPrompt, canFork bool) (*Commands, error) {
+func NewCommands(com *common.Common, sessionID string, customCommands []commands.CustomCommand, mcpPrompts []commands.MCPPrompt, canFork, canDelete bool) (*Commands, error) {
 	c := &Commands{
 		com:            com,
 		selected:       SystemCommands,
@@ -79,6 +80,7 @@ func NewCommands(com *common.Common, sessionID string, customCommands []commands
 		customCommands: customCommands,
 		mcpPrompts:     mcpPrompts,
 		canFork:        canFork,
+		canDelete:      canDelete,
 	}
 
 	help := help.New()
@@ -393,6 +395,12 @@ func (c *Commands) defaultCommands() []*CommandItem {
 	if c.canFork {
 		commands = append(commands,
 			NewCommandItem(c.com.Styles, "fork_conversation", "Fork Conversation", "", ActionForkConversation{}),
+		)
+	}
+
+	if c.canDelete {
+		commands = append(commands,
+			NewCommandItem(c.com.Styles, "delete_messages", "Delete Messages (including this)", "", ActionDeleteMessages{}),
 		)
 	}
 

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -63,24 +63,22 @@ type Commands struct {
 
 	windowWidth int
 
-	customCommands []commands.CustomCommand
-	mcpPrompts     []commands.MCPPrompt
-	canFork        bool // whether a user message is selected for forking
-	canDelete      bool // whether a user message is selected for deletion
+	customCommands        []commands.CustomCommand
+	mcpPrompts            []commands.MCPPrompt
+	isUserMessageSelected bool // whether a user message is selected in chat
 }
 
 var _ Dialog = (*Commands)(nil)
 
 // NewCommands creates a new commands dialog.
-func NewCommands(com *common.Common, sessionID string, customCommands []commands.CustomCommand, mcpPrompts []commands.MCPPrompt, canFork, canDelete bool) (*Commands, error) {
+func NewCommands(com *common.Common, sessionID string, customCommands []commands.CustomCommand, mcpPrompts []commands.MCPPrompt, isUserMessageSelected bool) (*Commands, error) {
 	c := &Commands{
-		com:            com,
-		selected:       SystemCommands,
-		sessionID:      sessionID,
-		customCommands: customCommands,
-		mcpPrompts:     mcpPrompts,
-		canFork:        canFork,
-		canDelete:      canDelete,
+		com:                   com,
+		selected:              SystemCommands,
+		sessionID:             sessionID,
+		customCommands:        customCommands,
+		mcpPrompts:            mcpPrompts,
+		isUserMessageSelected: isUserMessageSelected,
 	}
 
 	help := help.New()
@@ -392,14 +390,9 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		NewCommandItem(c.com.Styles, "new_session", "New Session", "ctrl+n", ActionNewSession{}),
 	}
 
-	if c.canFork {
+	if c.isUserMessageSelected {
 		commands = append(commands,
 			NewCommandItem(c.com.Styles, "fork_conversation", "Fork Conversation", "", ActionForkConversation{}),
-		)
-	}
-
-	if c.canDelete {
-		commands = append(commands,
 			NewCommandItem(c.com.Styles, "delete_messages", "Delete Messages (including this)", "", ActionDeleteMessages{}),
 		)
 	}

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -65,18 +65,20 @@ type Commands struct {
 
 	customCommands []commands.CustomCommand
 	mcpPrompts     []commands.MCPPrompt
+	canFork        bool // whether a user message is selected for forking
 }
 
 var _ Dialog = (*Commands)(nil)
 
 // NewCommands creates a new commands dialog.
-func NewCommands(com *common.Common, sessionID string, customCommands []commands.CustomCommand, mcpPrompts []commands.MCPPrompt) (*Commands, error) {
+func NewCommands(com *common.Common, sessionID string, customCommands []commands.CustomCommand, mcpPrompts []commands.MCPPrompt, canFork bool) (*Commands, error) {
 	c := &Commands{
 		com:            com,
 		selected:       SystemCommands,
 		sessionID:      sessionID,
 		customCommands: customCommands,
 		mcpPrompts:     mcpPrompts,
+		canFork:        canFork,
 	}
 
 	help := help.New()
@@ -386,9 +388,18 @@ func (c *Commands) setCommandItems(commandType CommandType) {
 func (c *Commands) defaultCommands() []*CommandItem {
 	commands := []*CommandItem{
 		NewCommandItem(c.com.Styles, "new_session", "New Session", "ctrl+n", ActionNewSession{}),
+	}
+
+	if c.canFork {
+		commands = append(commands,
+			NewCommandItem(c.com.Styles, "fork_conversation", "Fork Conversation", "", ActionForkConversation{}),
+		)
+	}
+
+	commands = append(commands,
 		NewCommandItem(c.com.Styles, "switch_session", "Sessions", "ctrl+s", ActionOpenDialog{SessionsID}),
 		NewCommandItem(c.com.Styles, "switch_model", "Switch Model", "ctrl+l", ActionOpenDialog{ModelsID}),
-	}
+	)
 
 	// Only show compact command if there's an active session
 	if c.sessionID != "" {

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -246,6 +246,11 @@ func (m *Chat) SelectedItemInView() bool {
 	return m.list.SelectedItemInView()
 }
 
+// SelectedItem returns the currently selected item in the chat list.
+func (m *Chat) SelectedItem() list.Item {
+	return m.list.SelectedItem()
+}
+
 func (m *Chat) isSelectable(index int) bool {
 	item := m.list.ItemAt(index)
 	if item == nil {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -329,6 +329,56 @@ func (m *UI) focusEditor() tea.Cmd {
 	return m.textarea.Focus()
 }
 
+func (m *UI) fork() tea.Msg {
+	if m.isAgentBusy() {
+		return uiutil.ReportWarn("Agent is busy, please wait...")()
+	}
+	if m.session == nil {
+		return uiutil.ReportWarn("No session to fork...")()
+	}
+	selectedItem := m.chat.SelectedItem()
+	if selectedItem == nil {
+		return uiutil.ReportWarn("No message selected...")()
+	}
+	messageID, ok := m.getMessageIDFromItem(selectedItem)
+	if !ok {
+		return uiutil.ReportWarn("Cannot fork from selected item...")()
+	}
+	newSession, err := m.com.App.Sessions.Fork(context.Background(), m.session.ID, messageID, m.com.App.Messages)
+	if err != nil {
+		return uiutil.ReportError(err)()
+	}
+	return loadSessionMsg{
+		session: &newSession,
+		files:   []SessionFile{},
+	}
+}
+
+func (m *UI) delete() tea.Msg {
+	if m.isAgentBusy() {
+		return uiutil.ReportWarn("Agent is busy, please wait...")()
+	}
+	if m.session == nil {
+		return uiutil.ReportWarn("No session to delete from...")()
+	}
+	selectedItem := m.chat.SelectedItem()
+	if selectedItem == nil {
+		return uiutil.ReportWarn("No message selected...")()
+	}
+	if _, ok := selectedItem.(*chat.UserMessageItem); !ok {
+		return uiutil.ReportWarn("Can only delete from user messages...")()
+	}
+	messageID, ok := m.getMessageIDFromItem(selectedItem)
+	if !ok {
+		return uiutil.ReportWarn("Cannot get message ID from selected item...")()
+	}
+	err := m.com.App.Messages.DeleteMessagesFrom(context.Background(), m.session.ID, messageID)
+	if err != nil {
+		return uiutil.ReportError(err)()
+	}
+	return m.loadSession(m.session.ID)()
+}
+
 // loadCustomCommands loads the custom commands asynchronously.
 func (m *UI) loadCustomCommands() tea.Cmd {
 	return func() tea.Msg {
@@ -1165,76 +1215,12 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		}
 		cmds = append(cmds, m.initializeProject())
 		m.dialog.CloseDialog(dialog.CommandsID)
-
 	case dialog.ActionForkConversation:
-		if m.isAgentBusy() {
-			cmds = append(cmds, uiutil.ReportWarn("Agent is busy, please wait..."))
-			break
-		}
-		if m.session == nil {
-			cmds = append(cmds, uiutil.ReportWarn("No session to fork..."))
-			break
-		}
-		selectedItem := m.chat.SelectedItem()
-		if selectedItem == nil {
-			cmds = append(cmds, uiutil.ReportWarn("No message selected..."))
-			break
-		}
-		if _, ok := selectedItem.(*chat.UserMessageItem); !ok {
-			cmds = append(cmds, uiutil.ReportWarn("Can only fork from user messages..."))
-			break
-		}
-		messageID, ok := m.getMessageIDFromItem(selectedItem)
-		if !ok {
-			cmds = append(cmds, uiutil.ReportWarn("Cannot fork from selected item..."))
-			break
-		}
-		cmds = append(cmds, func() tea.Msg {
-			newSession, err := m.com.App.Sessions.Fork(context.Background(), m.session.ID, messageID, m.com.App.Messages)
-			if err != nil {
-				return uiutil.ReportError(err)()
-			}
-			return loadSessionMsg{
-				session: &newSession,
-				files:   []SessionFile{},
-			}
-		})
 		m.dialog.CloseDialog(dialog.CommandsID)
-		cmds = append(cmds, m.focusEditor())
-
+		cmds = append(cmds, m.fork, m.focusEditor())
 	case dialog.ActionDeleteMessages:
-		if m.isAgentBusy() {
-			cmds = append(cmds, uiutil.ReportWarn("Agent is busy, please wait..."))
-			break
-		}
-		if m.session == nil {
-			cmds = append(cmds, uiutil.ReportWarn("No session to delete from..."))
-			break
-		}
-		selectedItem := m.chat.SelectedItem()
-		if selectedItem == nil {
-			cmds = append(cmds, uiutil.ReportWarn("No message selected..."))
-			break
-		}
-		if _, ok := selectedItem.(*chat.UserMessageItem); !ok {
-			cmds = append(cmds, uiutil.ReportWarn("Can only delete from user messages..."))
-			break
-		}
-		messageID, ok := m.getMessageIDFromItem(selectedItem)
-		if !ok {
-			cmds = append(cmds, uiutil.ReportWarn("Cannot get message ID from selected item..."))
-			break
-		}
-		cmds = append(cmds, func() tea.Msg {
-			err := m.com.App.Messages.DeleteMessagesFrom(context.Background(), m.session.ID, messageID)
-			if err != nil {
-				return uiutil.ReportError(err)()
-			}
-			return m.loadSession(m.session.ID)()
-		})
 		m.dialog.CloseDialog(dialog.CommandsID)
-		cmds = append(cmds, m.focusEditor())
-
+		cmds = append(cmds, m.delete, m.focusEditor())
 	case dialog.ActionSelectModel:
 		if m.isAgentBusy() {
 			cmds = append(cmds, uiutil.ReportWarn("Agent is busy, please wait..."))

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2794,10 +2794,8 @@ func (m *UI) openModelsDialog() tea.Cmd {
 func (m *UI) openCommandsDialog() tea.Cmd {
 	isUserMessageSelected := false
 	selectedItem := m.chat.SelectedItem()
-	if selectedItem != nil {
-		if _, ok := selectedItem.(*chat.UserMessageItem); ok {
-			isUserMessageSelected = true
-		}
+	if _, ok := selectedItem.(*chat.UserMessageItem); ok {
+		isUserMessageSelected = true
 	}
 
 	if m.dialog.ContainsDialog(dialog.CommandsID) {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2559,8 +2559,8 @@ func (m *UI) getMessageIDFromItem(item list.Item) (string, bool) {
 	}
 	if msgItem, ok := item.(chat.MessageItem); ok {
 		itemID := msgItem.ID()
-		if strings.HasSuffix(itemID, ":assistant-info") {
-			baseID := strings.TrimSuffix(itemID, ":assistant-info")
+		if before, ok := strings.CutSuffix(itemID, ":assistant-info"); ok {
+			baseID := before
 			return baseID, true
 		}
 		return itemID, true


### PR DESCRIPTION
- this allows the user to select a previous user message, and then delete that message below (including the message itself), or fork into a new conversation
- tool calls previously made are not "forked", it merely creates a new conversation with the messages up to the one selected 


this is still wip.