### PR TITLE
BUGFIX: middle click paste support

### DIFF
--- a/internal/tui/components/chat/editor/editor.go
+++ b/internal/tui/components/chat/editor/editor.go
@@ -301,6 +301,15 @@ func (m *editorCmp) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 	case commands.ToggleYoloModeMsg:
 		m.setEditorPrompt()
 		return m, nil
+	case tea.MouseClickMsg:
+		// Handle middle-click paste from X11 PRIMARY selection.
+		if msg.Button == tea.MouseMiddle {
+			if text := readPrimarySelection(); text != "" {
+				// Re-use paste handling by converting to a PasteMsg.
+				return m.Update(tea.PasteMsg{Content: text})
+			}
+		}
+		return m, nil
 	case tea.KeyPressMsg:
 		cur := m.textarea.Cursor()
 		curIdx := m.textarea.Width()*cur.Y + cur.X

--- a/internal/tui/components/chat/editor/primary_selection.go
+++ b/internal/tui/components/chat/editor/primary_selection.go
@@ -1,0 +1,47 @@
+package editor
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// readPrimarySelection reads text from the X11 PRIMARY selection (used for
+// middle-click paste on Linux). Returns empty string if not available.
+func readPrimarySelection() string {
+	if runtime.GOOS != "linux" {
+		return ""
+	}
+
+	// Try wl-paste for Wayland first.
+	if os.Getenv("WAYLAND_DISPLAY") != "" {
+		if path, err := exec.LookPath("wl-paste"); err == nil {
+			cmd := exec.Command(path, "--no-newline", "--primary")
+			out, err := cmd.Output()
+			if err == nil {
+				return string(out)
+			}
+		}
+	}
+
+	// Try xclip for X11.
+	if path, err := exec.LookPath("xclip"); err == nil {
+		cmd := exec.Command(path, "-selection", "primary", "-o")
+		out, err := cmd.Output()
+		if err == nil {
+			return strings.TrimSuffix(string(out), "\n")
+		}
+	}
+
+	// Fall back to xsel.
+	if path, err := exec.LookPath("xsel"); err == nil {
+		cmd := exec.Command(path, "--primary", "--output")
+		out, err := cmd.Output()
+		if err == nil {
+			return strings.TrimSuffix(string(out), "\n")
+		}
+	}
+
+	return ""
+}

--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -220,10 +220,22 @@ func (p *chatPage) Update(msg tea.Msg) (util.Model, tea.Cmd) {
 			p.focusedPane = PanelTypeChat
 			p.chat.Focus()
 			p.editor.Blur()
+			// Route middle-click to editor for PRIMARY selection paste.
+			if msg.Button == tea.MouseMiddle {
+				u, cmd := p.editor.Update(msg)
+				p.editor = u.(editor.Editor)
+				return p, cmd
+			}
 		} else {
 			p.focusedPane = PanelTypeEditor
 			p.editor.Focus()
 			p.chat.Blur()
+			// Route middle-click to editor for PRIMARY selection paste.
+			if msg.Button == tea.MouseMiddle {
+				u, cmd := p.editor.Update(msg)
+				p.editor = u.(editor.Editor)
+				return p, cmd
+			}
 		}
 		u, cmd := p.chat.Update(msg)
 		p.chat = u.(chat.MessageListCmp)

--- a/internal/ui/model/primary_selection.go
+++ b/internal/ui/model/primary_selection.go
@@ -1,0 +1,47 @@
+package model
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// readPrimarySelection reads text from the X11 PRIMARY selection (used for
+// middle-click paste on Linux). Returns empty string if not available.
+func readPrimarySelection() string {
+	if runtime.GOOS != "linux" {
+		return ""
+	}
+
+	// Try wl-paste for Wayland first.
+	if os.Getenv("WAYLAND_DISPLAY") != "" {
+		if path, err := exec.LookPath("wl-paste"); err == nil {
+			cmd := exec.Command(path, "--no-newline", "--primary")
+			out, err := cmd.Output()
+			if err == nil {
+				return string(out)
+			}
+		}
+	}
+
+	// Try xclip for X11.
+	if path, err := exec.LookPath("xclip"); err == nil {
+		cmd := exec.Command(path, "-selection", "primary", "-o")
+		out, err := cmd.Output()
+		if err == nil {
+			return strings.TrimSuffix(string(out), "\n")
+		}
+	}
+
+	// Fall back to xsel.
+	if path, err := exec.LookPath("xsel"); err == nil {
+		cmd := exec.Command(path, "--primary", "--output")
+		out, err := cmd.Output()
+		if err == nil {
+			return strings.TrimSuffix(string(out), "\n")
+		}
+	}
+
+	return ""
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -524,6 +524,16 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case copyChatHighlightMsg:
 		cmds = append(cmds, m.copyChatHighlight())
 	case tea.MouseClickMsg:
+		// Handle middle-click paste from X11 PRIMARY selection.
+		if msg.Button == tea.MouseMiddle {
+			if text := readPrimarySelection(); text != "" {
+				// Re-use paste handling by converting to a PasteMsg.
+				if cmd := m.handlePasteMsg(tea.PasteMsg{Content: text}); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
+				return m, tea.Batch(cmds...)
+			}
+		}
 		// Pass mouse events to dialogs first if any are open.
 		if m.dialog.HasDialogs() {
 			m.dialog.Update(msg)


### PR DESCRIPTION
Crush currently does not function as a proper terminal app in linux environments, ignoring middle click paste. This PR addresses that via xclip/xsel/wl-clipboard

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).

