### PR TITLE
fix: ensure the commands and models dialogs render with borders

### DIFF
--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -240,8 +240,8 @@ func commandsRadioView(sty *styles.Styles, selected CommandType, hasUserCmds boo
 // Draw implements [Dialog].
 func (c *Commands) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	t := c.com.Styles
-	width := max(0, min(defaultCommandsDialogMaxWidth, area.Dx()))
-	height := max(0, min(defaultCommandsDialogMaxHeight, area.Dy()))
+	width := max(0, min(defaultCommandsDialogMaxWidth, area.Dx()-t.Dialog.View.GetHorizontalBorderSize()))
+	height := max(0, min(defaultCommandsDialogMaxHeight, area.Dy()-t.Dialog.View.GetVerticalBorderSize()))
 	if area.Dx() != c.windowWidth && c.selected == SystemCommands {
 		c.windowWidth = area.Dx()
 		// since some items in the list depend on width (e.g. toggle sidebar command),

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -251,8 +251,8 @@ func (m *Models) modelTypeRadioView() string {
 // Draw implements [Dialog].
 func (m *Models) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	t := m.com.Styles
-	width := max(0, min(defaultModelsDialogMaxWidth, area.Dx()))
-	height := max(0, min(defaultDialogHeight, area.Dy()))
+	width := max(0, min(defaultModelsDialogMaxWidth, area.Dx()-t.Dialog.View.GetHorizontalBorderSize()))
+	height := max(0, min(defaultDialogHeight, area.Dy()-t.Dialog.View.GetVerticalBorderSize()))
 	innerWidth := width - t.Dialog.View.GetHorizontalFrameSize()
 	heightOffset := t.Dialog.Title.GetVerticalFrameSize() + titleContentHeight +
 		t.Dialog.InputPrompt.GetVerticalFrameSize() + inputContentHeight +


### PR DESCRIPTION
We need to consider the frame size on the calc.

<details><summary>Before</summary>
<p>

<img width="468" height="386" alt="Screenshot 2026-01-30 at 16 43 49" src="https://github.com/user-attachments/assets/4ba7f67a-8938-4f22-94cd-f45e46b5d7e7" />

</p>
</details>

<details><summary>After</summary>
<p>

<img width="469" height="385" alt="Screenshot 2026-01-30 at 16 44 57" src="https://github.com/user-attachments/assets/ca439ff2-8a29-4e01-9d91-f919055ebb7d" />

<img width="490" height="468" alt="Screenshot 2026-01-30 at 16 48 48" src="https://github.com/user-attachments/assets/1ea0506e-5338-4266-a6d7-064fccaa3d3c" />

</p>
</details> 
