### PR TITLE
fix(ui): show auto-discovered LSPs

### DIFF
--- a/internal/ui/model/lsp.go
+++ b/internal/ui/model/lsp.go
@@ -2,6 +2,8 @@ package model
 
 import (
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -21,16 +23,14 @@ type LSPInfo struct {
 // lspInfo renders the LSP status section showing active LSP clients and their
 // diagnostic counts.
 func (m *UI) lspInfo(width, maxItems int, isSection bool) string {
-	var lsps []LSPInfo
 	t := m.com.Styles
-	lspConfigs := m.com.Config().LSP.Sorted()
 
-	for _, cfg := range lspConfigs {
-		state, ok := m.lspStates[cfg.Name]
-		if !ok {
-			continue
-		}
+	states := slices.SortedFunc(maps.Values(m.lspStates), func(a, b app.LSPClientInfo) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 
+	var lsps []LSPInfo
+	for _, state := range states {
 		client, ok := m.com.App.LSPClients.Get(state.Name)
 		if !ok {
 			continue


### PR DESCRIPTION
The fix changes iteration from configs-only to all cached states, displaying both configured and auto-discovered LSPs.

**Problem**
When using `CRUSH_NEW_UI=1`, auto-discovered LSPs (from https://github.com/charmbracelet/crush/pull/1834) are not shown in the UI.
<img width="1126" height="1353" alt="image" src="https://github.com/user-attachments/assets/90c5ad9f-23da-49fd-a362-c126e5c80945" />

It looks like this is due to how the lsp info rendering is based only on the lsps listed in the config. https://github.com/charmbracelet/crush/blob/133cb6f9b03d769e5328e5124506e1c6e321c075/internal/ui/model/lsp.go#L26

**Solution**
Operate over `UI.lspStates` so info for all registered LSPs can be displayed to the user.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
