### PR TITLE
fix(lsp): enable lsp tools based if lsp client is active

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -409,7 +409,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent) ([]fan
 		tools.NewWriteTool(c.lspClients, c.permissions, c.history, c.filetracker, c.cfg.WorkingDir()),
 	)
 
-	if len(c.cfg.LSP) > 0 {
+	if c.lspClients.Len() > 0 {
 		allTools = append(allTools, tools.NewDiagnosticsTool(c.lspClients), tools.NewReferencesTool(c.lspClients), tools.NewLSPRestartTool(c.lspClients))
 	}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -62,6 +62,9 @@ type App struct {
 
 	config *config.Config
 
+	lspToolsMu    sync.Mutex
+	lspToolsReady bool
+
 	serviceEventsWG *sync.WaitGroup
 	eventsCtx       context.Context
 	events          chan tea.Msg
@@ -477,6 +480,7 @@ func (app *App) InitCoderAgent(ctx context.Context) error {
 		slog.Error("Failed to create coder agent", "err", err)
 		return err
 	}
+	app.refreshLSPTools(ctx)
 	return nil
 }
 


### PR DESCRIPTION
Currently, lsp tools are only active if crush config contains lsp settings.
LSPs started by auto-discovery mechanism is not taken into account for adding lsp tools to the agent tool list.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
