### PR TITLE
feat: add OpenAI Codex OAuth provider

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -239,12 +239,17 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 
 	var currentAssistant *message.Message
 	var shouldSummarize bool
+	maxOutputTokens := &call.MaxOutputTokens
+	if largeModel.ModelCfg.Provider == config.OpenAICodexProviderID {
+		maxOutputTokens = nil
+	}
+
 	result, err := agent.Stream(genCtx, fantasy.AgentStreamCall{
 		Prompt:           message.PromptWithTextAttachments(call.Prompt, call.Attachments),
 		Files:            files,
 		Messages:         history,
 		ProviderOptions:  call.ProviderOptions,
-		MaxOutputTokens:  &call.MaxOutputTokens,
+		MaxOutputTokens:  maxOutputTokens,
 		TopP:             call.TopP,
 		Temperature:      call.Temperature,
 		PresencePenalty:  call.PresencePenalty,

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -642,6 +642,8 @@ func (c *coordinator) buildOpenaiCompatProvider(baseURL, apiKey string, headers 
 	if providerID == string(catwalk.InferenceProviderCopilot) {
 		opts = append(opts, openaicompat.WithUseResponsesAPI())
 		httpClient = copilot.NewClient(isSubAgent, c.cfg.Options.Debug)
+	} else if providerID == config.OpenAICodexProviderID {
+		opts = append(opts, openaicompat.WithUseResponsesAPI())
 	} else if c.cfg.Options.Debug {
 		httpClient = log.NewHTTPClient()
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupOpenAICodex(t *testing.T) {
+	t.Parallel()
+	pc := &ProviderConfig{}
+	pc.SetupOpenAICodex("test-account-id")
+
+	require.NotNil(t, pc.ExtraHeaders)
+	require.Equal(t, "test-account-id", pc.ExtraHeaders["chatgpt-account-id"])
+	require.Equal(t, "responses=experimental", pc.ExtraHeaders["OpenAI-Beta"])
+	require.Equal(t, "codex_cli_rs", pc.ExtraHeaders["originator"])
+
+	require.NotNil(t, pc.ExtraBody)
+	require.Equal(t, false, pc.ExtraBody["store"])
+	require.Equal(t, "You are a helpful coding assistant.", pc.ExtraBody["instructions"])
+	require.Contains(t, pc.ExtraBody["include"], "reasoning.encrypted_content")
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -23,6 +23,7 @@ import (
 	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/home"
 	"github.com/charmbracelet/crush/internal/log"
+	openaioauth "github.com/charmbracelet/crush/internal/oauth/openai"
 	powernapConfig "github.com/charmbracelet/x/powernap/pkg/config"
 	"github.com/qjebbs/go-jsons"
 )
@@ -209,6 +210,17 @@ func (c *Config) configureProviders(env env.Env, resolver VariableResolver, know
 			continue
 		case p.ID == catwalk.InferenceProviderCopilot && config.OAuthToken != nil:
 			prepared.SetupGitHubCopilot()
+		case string(p.ID) == OpenAICodexProviderID:
+			accountID := ""
+			if config.OAuthToken != nil {
+				parsed, err := openaioauth.ExtractAccountID(config.OAuthToken.AccessToken)
+				if err != nil {
+					slog.Warn("Failed to parse ChatGPT account id", "error", err)
+				} else {
+					accountID = parsed
+				}
+			}
+			prepared.SetupOpenAICodex(accountID)
 		}
 
 		switch p.ID {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1331,7 +1331,7 @@ func TestConfig_configureProvidersOpenAICodex(t *testing.T) {
 	require.NotContains(t, provider.ExtraHeaders, "chatgpt-account-id")
 	require.Equal(t, "responses=experimental", provider.ExtraHeaders["OpenAI-Beta"])
 	require.Equal(t, "codex_cli_rs", provider.ExtraHeaders["originator"])
-	require.False(t, provider.ExtraBody["store"])
+	require.Equal(t, false, provider.ExtraBody["store"])
 	require.Equal(t, "You are a helpful coding assistant.", provider.ExtraBody["instructions"])
 }
 

--- a/internal/config/openaicodex.go
+++ b/internal/config/openaicodex.go
@@ -1,0 +1,50 @@
+package config
+
+import "charm.land/catwalk/pkg/catwalk"
+
+const (
+	OpenAICodexProviderID   = "openai-codex"
+	openAICodexBaseURL      = "https://chatgpt.com/backend-api/codex"
+	openAICodexAPIKeyEnv    = "$OPENAI_CODEX_ACCESS_TOKEN"
+	openAICodexInstructions = "You are a helpful coding assistant."
+)
+
+// OpenAICodexProvider returns the catwalk provider for the OpenAI Codex service.
+func OpenAICodexProvider() catwalk.Provider {
+	models := []catwalk.Model{
+		openAICodexModel("gpt-5.2", "GPT-5.2", []string{"none", "low", "medium", "high", "xhigh"}, "medium"),
+		openAICodexModel("gpt-5.2-codex", "GPT-5.2 Codex", []string{"low", "medium", "high", "xhigh"}, "medium"),
+		openAICodexModel("gpt-5.1-codex-max", "GPT-5.1 Codex Max", []string{"low", "medium", "high", "xhigh"}, "medium"),
+		openAICodexModel("gpt-5.1-codex", "GPT-5.1 Codex", []string{"low", "medium", "high"}, "medium"),
+		openAICodexModel("gpt-5.1-codex-mini", "GPT-5.1 Codex Mini", []string{"medium", "high"}, "medium"),
+		openAICodexModel("gpt-5.1", "GPT-5.1", []string{"none", "low", "medium", "high"}, "medium"),
+	}
+
+	return catwalk.Provider{
+		ID:                  catwalk.InferenceProvider(OpenAICodexProviderID),
+		Name:                "OpenAI Codex (ChatGPT OAuth)",
+		APIEndpoint:         openAICodexBaseURL,
+		APIKey:              openAICodexAPIKeyEnv,
+		Type:                catwalk.TypeOpenAICompat,
+		Models:              models,
+		DefaultLargeModelID: "gpt-5.2-codex",
+		DefaultSmallModelID: "gpt-5.1-codex-mini",
+	}
+}
+
+func IsOpenAICodexProvider(providerID string) bool {
+	return providerID == OpenAICodexProviderID
+}
+
+func openAICodexModel(id, name string, reasoningLevels []string, defaultEffort string) catwalk.Model {
+	return catwalk.Model{
+		ID:                     id,
+		Name:                   name,
+		ContextWindow:          272000,
+		DefaultMaxTokens:       128000,
+		CanReason:              len(reasoningLevels) > 0,
+		ReasoningLevels:        reasoningLevels,
+		DefaultReasoningEffort: defaultEffort,
+		SupportsImages:         true,
+	}
+}

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -182,6 +182,11 @@ func Providers(cfg *Config) ([]catwalk.Provider, error) {
 		wg.Wait()
 
 		providerList = slices.Collect(providers.Seq())
+		if !slices.ContainsFunc(providerList, func(p catwalk.Provider) bool {
+			return p.ID == catwalk.InferenceProvider(OpenAICodexProviderID)
+		}) {
+			providerList = append(providerList, OpenAICodexProvider())
+		}
 		providerErr = errors.Join(errs...)
 	})
 	return providerList, providerErr

--- a/internal/oauth/openai/oauth.go
+++ b/internal/oauth/openai/oauth.go
@@ -1,0 +1,225 @@
+package openai
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/oauth"
+)
+
+const (
+	oauthClientID   = "app_EMoamEEZ73f0CkXaXp7hrann"
+	authorizeURL    = "https://auth.openai.com/oauth/authorize"
+	defaultTokenURL = "https://auth.openai.com/oauth/token"
+)
+
+var tokenURL = defaultTokenURL
+
+const (
+	Scope       = "openid profile email offline_access"
+	RedirectURL = "http://localhost:1455/auth/callback"
+)
+
+const (
+	HeaderAccountID     = "chatgpt-account-id"
+	HeaderOpenAIBeta    = "OpenAI-Beta"
+	HeaderOriginator    = "originator"
+	HeaderOpenAIBetaVal = "responses=experimental"
+	HeaderOriginatorVal = "codex_cli_rs"
+)
+
+const jwtClaimPath = "https://api.openai.com/auth"
+
+// AuthFlow holds the state for the OAuth2 authorization flow.
+type AuthFlow struct {
+	URL      string
+	State    string
+	Verifier string
+}
+
+// CreateAuthorizationFlow creates a new OAuth2 authorization flow.
+func CreateAuthorizationFlow() (AuthFlow, error) {
+	verifier, err := newCodeVerifier()
+	if err != nil {
+		return AuthFlow{}, err
+	}
+
+	state, err := newState()
+	if err != nil {
+		return AuthFlow{}, err
+	}
+
+	challenge := codeChallenge(verifier)
+	u, err := url.Parse(authorizeURL)
+	if err != nil {
+		return AuthFlow{}, fmt.Errorf("failed to parse authorize URL: %w", err)
+	}
+
+	q := u.Query()
+	q.Set("response_type", "code")
+	q.Set("client_id", oauthClientID)
+	q.Set("redirect_uri", RedirectURL)
+	q.Set("scope", Scope)
+	q.Set("code_challenge", challenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("state", state)
+	q.Set("id_token_add_organizations", "true")
+	q.Set("codex_cli_simplified_flow", "true")
+	q.Set("originator", HeaderOriginatorVal)
+	ud := *u
+	ud.RawQuery = q.Encode()
+
+	return AuthFlow{
+		URL:      ud.String(),
+		State:    state,
+		Verifier: verifier,
+	}, nil
+}
+
+func ParseAuthorizationInput(input string) (code, state string) {
+	value := strings.TrimSpace(input)
+	if value == "" {
+		return "", ""
+	}
+
+	if parsed, err := url.Parse(value); err == nil {
+		return parsed.Query().Get("code"), parsed.Query().Get("state")
+	}
+
+	if strings.Contains(value, "#") {
+		parts := strings.SplitN(value, "#", 2)
+		if len(parts) == 2 {
+			return parts[0], parts[1]
+		}
+	}
+
+	if strings.Contains(value, "code=") {
+		params, err := url.ParseQuery(value)
+		if err == nil {
+			return params.Get("code"), params.Get("state")
+		}
+	}
+
+	return value, ""
+}
+
+func ExchangeAuthorizationCode(ctx context.Context, code, verifier string) (*oauth.Token, error) {
+	if code == "" {
+		return nil, errors.New("authorization code is required")
+	}
+	values := url.Values{}
+	values.Set("grant_type", "authorization_code")
+	values.Set("client_id", oauthClientID)
+	values.Set("code", code)
+	values.Set("code_verifier", verifier)
+	values.Set("redirect_uri", RedirectURL)
+	return requestToken(ctx, values)
+}
+
+func RefreshToken(ctx context.Context, refreshToken string) (*oauth.Token, error) {
+	if refreshToken == "" {
+		return nil, errors.New("refresh token is required")
+	}
+	values := url.Values{}
+	values.Set("grant_type", "refresh_token")
+	values.Set("refresh_token", refreshToken)
+	values.Set("client_id", oauthClientID)
+	return requestToken(ctx, values)
+}
+
+func ExtractAccountID(accessToken string) (string, error) {
+	parts := strings.Split(accessToken, ".")
+	if len(parts) != 3 {
+		return "", errors.New("invalid JWT format")
+	}
+
+	decoded, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("failed to decode JWT payload: %w", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		return "", fmt.Errorf("failed to parse JWT payload: %w", err)
+	}
+
+	claim, ok := payload[jwtClaimPath].(map[string]any)
+	if !ok {
+		return "", errors.New("JWT claim missing chatgpt account data")
+	}
+	accountID, _ := claim["chatgpt_account_id"].(string)
+	if accountID == "" {
+		return "", errors.New("chatgpt account id missing in JWT")
+	}
+	return accountID, nil
+}
+
+func requestToken(ctx context.Context, values url.Values) (*oauth.Token, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, strings.NewReader(values.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to request token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token request failed: %s", resp.Status)
+	}
+
+	var payload struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	}
+	if payload.AccessToken == "" || payload.RefreshToken == "" || payload.ExpiresIn == 0 {
+		return nil, errors.New("token response missing required fields")
+	}
+
+	token := &oauth.Token{
+		AccessToken:  payload.AccessToken,
+		RefreshToken: payload.RefreshToken,
+		ExpiresIn:    payload.ExpiresIn,
+	}
+	token.SetExpiresAt()
+	return token, nil
+}
+
+func newCodeVerifier() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate verifier: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func codeChallenge(verifier string) string {
+	hash := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+func newState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate state: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/oauth/openai/oauth_test.go
+++ b/internal/oauth/openai/oauth_test.go
@@ -1,0 +1,119 @@
+package openai
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateAuthorizationFlow(t *testing.T) {
+	t.Parallel()
+	flow, err := CreateAuthorizationFlow()
+	require.NoError(t, err)
+	require.NotEmpty(t, flow.URL)
+	require.NotEmpty(t, flow.State)
+	require.NotEmpty(t, flow.Verifier)
+	require.Contains(t, flow.URL, "https://auth.openai.com/oauth/authorize")
+	require.Contains(t, flow.URL, "response_type=code")
+	require.Contains(t, flow.URL, "client_id="+oauthClientID)
+	require.Contains(t, flow.URL, "redirect_uri="+RedirectURL)
+	require.Contains(t, flow.URL, "scope="+Scope)
+	require.Contains(t, flow.URL, "code_challenge=")
+	require.Contains(t, flow.URL, "code_challenge_method=S256")
+	require.Contains(t, flow.URL, "state="+flow.State)
+}
+
+func TestExchangeAuthorizationCode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		err := r.ParseForm()
+		require.NoError(t, err)
+		require.Equal(t, "authorization_code", r.Form.Get("grant_type"))
+		require.Equal(t, oauthClientID, r.Form.Get("client_id"))
+		require.Equal(t, "test-code", r.Form.Get("code"))
+		require.Equal(t, "test-verifier", r.Form.Get("code_verifier"))
+		require.Equal(t, RedirectURL, r.Form.Get("redirect_uri"))
+
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token":  "test-access-token",
+			"refresh_token": "test-refresh-token",
+			"expires_in":    3600,
+		})
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	originalTokenURL := tokenURL
+	defer func() { tokenURL = originalTokenURL }()
+	tokenURL = server.URL
+
+	token, err := ExchangeAuthorizationCode(context.Background(), "test-code", "test-verifier")
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	require.Equal(t, "test-access-token", token.AccessToken)
+	require.Equal(t, "test-refresh-token", token.RefreshToken)
+	require.Equal(t, 3600, token.ExpiresIn)
+}
+
+func TestRefreshToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		err := r.ParseForm()
+		require.NoError(t, err)
+		require.Equal(t, "refresh_token", r.Form.Get("grant_type"))
+		require.Equal(t, oauthClientID, r.Form.Get("client_id"))
+		require.Equal(t, "test-refresh-token", r.Form.Get("refresh_token"))
+
+		w.Header().Set("Content-Type", "application/json")
+		err = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token":  "new-access-token",
+			"refresh_token": "new-refresh-token",
+			"expires_in":    3600,
+		})
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	originalTokenURL := tokenURL
+	defer func() { tokenURL = originalTokenURL }()
+	tokenURL = server.URL
+
+	token, err := RefreshToken(context.Background(), "test-refresh-token")
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	require.Equal(t, "new-access-token", token.AccessToken)
+	require.Equal(t, "new-refresh-token", token.RefreshToken)
+}
+
+func TestExtractAccountID(t *testing.T) {
+	t.Parallel()
+	// This is a simplified, decoded JWT payload for testing purposes.
+	// In a real scenario, this would be part of a full JWT.
+	payload := `{"https://api.openai.com/auth": {"chatgpt_account_id": "test-account-id"}}`
+	encodedPayload := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9." + base64.RawURLEncoding.EncodeToString([]byte(payload)) + ".SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
+	accountID, err := ExtractAccountID(encodedPayload)
+	require.NoError(t, err)
+	require.Equal(t, "test-account-id", accountID)
+
+	_, err = ExtractAccountID("invalid-jwt")
+	require.Error(t, err)
+}
+
+func TestSetExpiresAt(t *testing.T) {
+	t.Parallel()
+	token := &oauth.Token{
+		ExpiresIn: 3600,
+	}
+	token.SetExpiresAt()
+	require.WithinDuration(t, time.Now().Add(time.Hour), token.ExpiresAt, time.Second)
+}

--- a/internal/oauth/openai/server.go
+++ b/internal/oauth/openai/server.go
@@ -1,0 +1,99 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	callbackAddress = "127.0.0.1:1455"
+	callbackPath    = "/auth/callback"
+)
+
+type LocalServer struct {
+	server    *http.Server
+	listener  net.Listener
+	codeCh    chan string
+	closeOnce sync.Once
+}
+
+func StartLocalServer(state string) (*LocalServer, error) {
+	listener, err := net.Listen("tcp", callbackAddress)
+	if err != nil {
+		return nil, fmt.Errorf("failed to bind %s: %w", callbackAddress, err)
+	}
+
+	codeCh := make(chan string, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc(callbackPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("state") != state {
+			http.Error(w, "State mismatch", http.StatusBadRequest)
+			return
+		}
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			http.Error(w, "Missing authorization code", http.StatusBadRequest)
+			return
+		}
+		select {
+		case codeCh <- code:
+		default:
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte("<html><body><p>Authorization complete. You can close this window.</p></body></html>"))
+	})
+
+	server := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	local := &LocalServer{
+		server:   server,
+		listener: listener,
+		codeCh:   codeCh,
+	}
+
+	go func() {
+		_ = server.Serve(listener)
+	}()
+
+	return local, nil
+}
+
+func (s *LocalServer) WaitForCode(ctx context.Context) (string, error) {
+	select {
+	case code := <-s.codeCh:
+		return code, nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func (s *LocalServer) Close() error {
+	var err error
+	s.closeOnce.Do(func() {
+		if s.server == nil {
+			err = nil
+			return
+		}
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if shutdownErr := s.server.Shutdown(shutdownCtx); shutdownErr != nil {
+			err = shutdownErr
+			return
+		}
+		if s.listener == nil {
+			return
+		}
+		if closeErr := s.listener.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
+			err = closeErr
+		}
+	})
+	return err
+}

--- a/internal/tui/components/dialogs/models/keys.go
+++ b/internal/tui/components/dialogs/models/keys.go
@@ -18,6 +18,7 @@ type KeyMap struct {
 	isHyperDeviceFlow    bool
 	isCopilotDeviceFlow  bool
 	isCopilotUnavailable bool
+	isOpenAICodexFlow    bool
 }
 
 func DefaultKeyMap() KeyMap {
@@ -82,6 +83,19 @@ func (k KeyMap) ShortHelp() []key.Binding {
 			key.NewBinding(
 				key.WithKeys("enter"),
 				key.WithHelp("enter", "copy & open"),
+			),
+			k.Close,
+		}
+	}
+	if k.isOpenAICodexFlow {
+		return []key.Binding{
+			key.NewBinding(
+				key.WithKeys("c"),
+				key.WithHelp("c", "copy url"),
+			),
+			key.NewBinding(
+				key.WithKeys("enter"),
+				key.WithHelp("enter", "open browser"),
 			),
 			k.Close,
 		}

--- a/internal/tui/components/dialogs/models/list.go
+++ b/internal/tui/components/dialogs/models/list.go
@@ -64,7 +64,8 @@ func (m *ModelListComponent) Init() tea.Cmd {
 			hasAPIKeyEnv := strings.HasPrefix(p.APIKey, "$")
 			isHyper := p.ID == "hyper"
 			isCopilot := p.ID == catwalk.InferenceProviderCopilot
-			if (hasAPIKeyEnv && p.ID != catwalk.InferenceProviderAzure) || isHyper || isCopilot {
+			isOpenAICodex := string(p.ID) == config.OpenAICodexProviderID
+			if (hasAPIKeyEnv && p.ID != catwalk.InferenceProviderAzure) || isHyper || isCopilot || isOpenAICodex {
 				filteredProviders = append(filteredProviders, p)
 			}
 		}

--- a/internal/tui/components/dialogs/openai/device_flow.go
+++ b/internal/tui/components/dialogs/openai/device_flow.go
@@ -1,0 +1,233 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/oauth"
+	openaioauth "github.com/charmbracelet/crush/internal/oauth/openai"
+	"github.com/charmbracelet/crush/internal/tui/styles"
+	"github.com/charmbracelet/crush/internal/tui/util"
+	"github.com/pkg/browser"
+)
+
+// AuthFlowState represents the current state of the OAuth flow.
+type AuthFlowState int
+
+const (
+	AuthFlowStateDisplay AuthFlowState = iota
+	AuthFlowStateSuccess
+	AuthFlowStateError
+)
+
+// AuthInitiatedMsg is sent when the OAuth flow is initialized.
+type AuthInitiatedMsg struct {
+	Flow   openaioauth.AuthFlow
+	Server *openaioauth.LocalServer
+}
+
+// AuthCompletedMsg is sent when OAuth completes successfully.
+type AuthCompletedMsg struct {
+	Token *oauth.Token
+}
+
+// AuthErrorMsg is sent when OAuth encounters an error.
+type AuthErrorMsg struct {
+	Error error
+}
+
+// AuthFlow handles the OpenAI Codex OAuth authentication.
+type AuthFlow struct {
+	State      AuthFlowState
+	width      int
+	flow       openaioauth.AuthFlow
+	server     *openaioauth.LocalServer
+	token      *oauth.Token
+	lastError  error
+	cancelFunc context.CancelFunc
+	spinner    spinner.Model
+}
+
+// NewAuthFlow creates a new OAuth flow component.
+func NewAuthFlow() *AuthFlow {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(styles.CurrentTheme().GreenLight)
+	return &AuthFlow{
+		State:   AuthFlowStateDisplay,
+		spinner: s,
+	}
+}
+
+// Init initializes the OAuth flow.
+func (d *AuthFlow) Init() tea.Cmd {
+	return tea.Batch(d.spinner.Tick, d.initiateAuth)
+}
+
+// Update handles messages and state transitions.
+func (d *AuthFlow) Update(msg tea.Msg) (util.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	d.spinner, cmd = d.spinner.Update(msg)
+
+	switch msg := msg.(type) {
+	case AuthInitiatedMsg:
+		d.flow = msg.Flow
+		d.server = msg.Server
+		return d, tea.Batch(cmd, d.OpenURL(), d.startPolling())
+	case AuthCompletedMsg:
+		d.State = AuthFlowStateSuccess
+		d.token = msg.Token
+		d.stopPolling()
+		return d, nil
+	case AuthErrorMsg:
+		d.State = AuthFlowStateError
+		d.lastError = msg.Error
+		d.stopPolling()
+		return d, nil
+	}
+
+	return d, cmd
+}
+
+// View renders the OAuth dialog.
+func (d *AuthFlow) View() string {
+	t := styles.CurrentTheme()
+
+	primary := lipgloss.NewStyle().Foreground(t.Primary)
+	white := lipgloss.NewStyle().Foreground(t.White)
+	muted := lipgloss.NewStyle().Foreground(t.FgMuted)
+	green := lipgloss.NewStyle().Foreground(t.GreenLight)
+	errorStyle := lipgloss.NewStyle().Foreground(t.Error)
+
+	switch d.State {
+	case AuthFlowStateDisplay:
+		if d.flow.URL == "" {
+			return lipgloss.NewStyle().
+				Margin(0, 1).
+				Render(green.Render(d.spinner.View()) + muted.Render("Initializing..."))
+		}
+		instructions := lipgloss.NewStyle().
+			Margin(1, 1, 0, 1).
+			Width(d.width - 2).
+			Render(
+				white.Render("Press ") +
+					primary.Render("enter") +
+					white.Render(" to open the browser and log in."),
+			)
+
+		url := muted.
+			Margin(0, 1).
+			Width(d.width - 2).
+			Render("Browser not opening? Refer to\n" + lipgloss.NewStyle().Hyperlink(d.flow.URL, "id=openai-codex-auth").Render(d.flow.URL))
+
+		waiting := green.
+			Width(d.width-2).
+			Margin(1, 1, 0, 1).
+			Render(d.spinner.View() + "Waiting for authorization...")
+
+		return lipgloss.JoinVertical(
+			lipgloss.Left,
+			instructions,
+			url,
+			waiting,
+		)
+
+	case AuthFlowStateSuccess:
+		return green.Margin(0, 1).Render("Authentication successful!")
+
+	case AuthFlowStateError:
+		message := "Authentication failed. Try \"crush login openai-codex\"."
+		if d.lastError != nil {
+			message = fmt.Sprintf("Authentication failed: %v", d.lastError)
+		}
+		return errorStyle.Margin(0, 1).Render(message)
+	default:
+		return ""
+	}
+}
+
+// SetWidth sets the width of the dialog.
+func (d *AuthFlow) SetWidth(w int) {
+	d.width = w
+}
+
+// Cursor hides the cursor.
+func (d *AuthFlow) Cursor() *tea.Cursor { return nil }
+
+// CopyURL copies the auth URL to the clipboard.
+func (d *AuthFlow) CopyURL() tea.Cmd {
+	if d.flow.URL == "" {
+		return nil
+	}
+	return tea.Sequence(
+		tea.SetClipboard(d.flow.URL),
+		util.ReportInfo("URL copied to clipboard"),
+	)
+}
+
+// OpenURL opens the auth URL in the browser.
+func (d *AuthFlow) OpenURL() tea.Cmd {
+	if d.flow.URL == "" {
+		return nil
+	}
+	return tea.Sequence(
+		func() tea.Msg {
+			if err := browser.OpenURL(d.flow.URL); err != nil {
+				return AuthErrorMsg{Error: fmt.Errorf("failed to open browser: %w", err)}
+			}
+			return nil
+		},
+	)
+}
+
+// Cancel stops the OAuth flow.
+func (d *AuthFlow) Cancel() {
+	d.stopPolling()
+}
+
+func (d *AuthFlow) initiateAuth() tea.Msg {
+	flow, err := openaioauth.CreateAuthorizationFlow()
+	if err != nil {
+		return AuthErrorMsg{Error: err}
+	}
+	server, err := openaioauth.StartLocalServer(flow.State)
+	if err != nil {
+		return AuthErrorMsg{Error: err}
+	}
+	return AuthInitiatedMsg{Flow: flow, Server: server}
+}
+
+func (d *AuthFlow) startPolling() tea.Cmd {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	d.cancelFunc = cancel
+	return func() tea.Msg {
+		if d.server == nil {
+			return AuthErrorMsg{Error: fmt.Errorf("OAuth callback server not available")}
+		}
+		defer d.server.Close()
+		code, err := d.server.WaitForCode(ctx)
+		if err != nil {
+			return AuthErrorMsg{Error: err}
+		}
+		token, err := openaioauth.ExchangeAuthorizationCode(ctx, code, d.flow.Verifier)
+		if err != nil {
+			return AuthErrorMsg{Error: err}
+		}
+		return AuthCompletedMsg{Token: token}
+	}
+}
+
+func (d *AuthFlow) stopPolling() {
+	if d.cancelFunc != nil {
+		d.cancelFunc()
+		d.cancelFunc = nil
+	}
+	if d.server != nil {
+		_ = d.server.Close()
+		d.server = nil
+	}
+}

--- a/internal/tui/page/chat/chat.go
+++ b/internal/tui/page/chat/chat.go
@@ -1039,7 +1039,7 @@ func (p *chatPage) Help() help.KeyMap {
 	switch {
 	case p.isOnboarding:
 		switch {
-		case p.splash.IsShowingHyperOAuth2() || p.splash.IsShowingCopilotOAuth2():
+		case p.splash.IsShowingHyperOAuth2() || p.splash.IsShowingCopilotOAuth2() || p.splash.IsShowingOpenAICodexOAuth2():
 			shortList = append(shortList,
 				key.NewBinding(
 					key.WithKeys("enter"),

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -516,10 +516,11 @@ func getFilteredProviders(cfg *config.Config) ([]catwalk.Provider, error) {
 			isAzure         = p.ID == catwalk.InferenceProviderAzure
 			isCopilot       = p.ID == catwalk.InferenceProviderCopilot
 			isHyper         = string(p.ID) == "hyper"
+			isOpenAICodex   = string(p.ID) == config.OpenAICodexProviderID
 			hasAPIKeyEnv    = strings.HasPrefix(p.APIKey, "$")
 			_, isConfigured = cfg.Providers.Get(string(p.ID))
 		)
-		if isAzure || isCopilot || isHyper || hasAPIKeyEnv || isConfigured {
+		if isAzure || isCopilot || isHyper || isOpenAICodex || hasAPIKeyEnv || isConfigured {
 			filteredProviders = append(filteredProviders, p)
 		}
 	}

--- a/internal/ui/dialog/oauth_openai.go
+++ b/internal/ui/dialog/oauth_openai.go
@@ -1,0 +1,352 @@
+package dialog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/oauth"
+	openaioauth "github.com/charmbracelet/crush/internal/oauth/openai"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/uiutil"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/pkg/browser"
+)
+
+type openAICodexAuthInitMsg struct {
+	flow   openaioauth.AuthFlow
+	server *openaioauth.LocalServer
+	err    error
+}
+
+type openAICodexAuthTokenMsg struct {
+	token *oauth.Token
+}
+
+type openAICodexAuthErrorMsg struct {
+	err error
+}
+
+// OAuthOpenAI handles the OpenAI Codex OAuth flow authentication.
+type OAuthOpenAI struct {
+	com          *common.Common
+	isOnboarding bool
+
+	provider  catwalk.Provider
+	model     config.SelectedModel
+	modelType config.SelectedModelType
+
+	State OAuthState
+
+	spinner spinner.Model
+	help    help.Model
+	keyMap  struct {
+		Copy   key.Binding
+		Submit key.Binding
+		Close  key.Binding
+	}
+
+	width int
+
+	flow      openaioauth.AuthFlow
+	server    *openaioauth.LocalServer
+	token     *oauth.Token
+	lastError error
+	cancel    context.CancelFunc
+}
+
+var _ Dialog = (*OAuthOpenAI)(nil)
+
+// NewOAuthOpenAI creates a new OpenAI OAuth dialog.
+func NewOAuthOpenAI(
+	com *common.Common,
+	isOnboarding bool,
+	provider catwalk.Provider,
+	model config.SelectedModel,
+	modelType config.SelectedModelType,
+) (*OAuthOpenAI, tea.Cmd) {
+	t := com.Styles
+
+	m := OAuthOpenAI{}
+	m.com = com
+	m.isOnboarding = isOnboarding
+	m.provider = provider
+	m.model = model
+	m.modelType = modelType
+	m.width = 60
+	m.State = OAuthStateInitializing
+
+	m.spinner = spinner.New(
+		spinner.WithSpinner(spinner.Dot),
+		spinner.WithStyle(t.Base.Foreground(t.GreenLight)),
+	)
+
+	m.help = help.New()
+	m.help.Styles = t.DialogHelpStyles()
+
+	m.keyMap.Copy = key.NewBinding(
+		key.WithKeys("c"),
+		key.WithHelp("c", "copy url"),
+	)
+	m.keyMap.Submit = key.NewBinding(
+		key.WithKeys("enter", "ctrl+y"),
+		key.WithHelp("enter", "open browser"),
+	)
+	m.keyMap.Close = CloseKey
+
+	return &m, tea.Batch(m.spinner.Tick, m.initiateAuth)
+}
+
+// ID implements Dialog.
+func (m *OAuthOpenAI) ID() string {
+	return OAuthID
+}
+
+// HandleMsg handles messages and state transitions.
+func (m *OAuthOpenAI) HandleMsg(msg tea.Msg) Action {
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		switch m.State {
+		case OAuthStateInitializing, OAuthStateDisplay:
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			if cmd != nil {
+				return ActionCmd{cmd}
+			}
+		}
+
+	case openAICodexAuthInitMsg:
+		if msg.err != nil {
+			m.State = OAuthStateError
+			m.lastError = msg.err
+			return nil
+		}
+		m.flow = msg.flow
+		m.server = msg.server
+		m.State = OAuthStateDisplay
+		return ActionCmd{tea.Batch(m.openURL(), m.startPolling())}
+
+	case openAICodexAuthTokenMsg:
+		m.State = OAuthStateSuccess
+		m.token = msg.token
+		m.stopPolling()
+		return nil
+
+	case openAICodexAuthErrorMsg:
+		m.State = OAuthStateError
+		m.lastError = msg.err
+		m.stopPolling()
+		return ActionCmd{uiutil.ReportError(msg.err)}
+
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, m.keyMap.Copy):
+			cmd := m.copyURL()
+			return ActionCmd{cmd}
+		case key.Matches(msg, m.keyMap.Submit):
+			switch m.State {
+			case OAuthStateSuccess:
+				return m.saveKeyAndContinue()
+			default:
+				return ActionCmd{m.openURL()}
+			}
+		case key.Matches(msg, m.keyMap.Close):
+			switch m.State {
+			case OAuthStateSuccess:
+				return m.saveKeyAndContinue()
+			default:
+				m.stopPolling()
+				return ActionClose{}
+			}
+		}
+	}
+	return nil
+}
+
+// Draw implements Dialog.
+func (m *OAuthOpenAI) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	var (
+		t           = m.com.Styles
+		dialogStyle = t.Dialog.View.Width(m.width)
+	)
+	if m.isOnboarding {
+		view := m.dialogContent()
+		DrawOnboarding(scr, area, view)
+	} else {
+		view := dialogStyle.Render(m.dialogContent())
+		DrawCenter(scr, area, view)
+	}
+	return nil
+}
+
+func (m *OAuthOpenAI) dialogContent() string {
+	var (
+		t         = m.com.Styles
+		helpStyle = t.Dialog.HelpView
+	)
+
+	switch m.State {
+	case OAuthStateInitializing:
+		return m.innerDialogContent()
+	default:
+		elements := []string{
+			m.headerContent(),
+			m.innerDialogContent(),
+			helpStyle.Render(m.help.View(m)),
+		}
+		return strings.Join(elements, "\n")
+	}
+}
+
+func (m *OAuthOpenAI) headerContent() string {
+	var (
+		t            = m.com.Styles
+		titleStyle   = t.Dialog.Title
+		textStyle    = t.Dialog.PrimaryText
+		dialogStyle  = t.Dialog.View.Width(m.width)
+		headerOffset = titleStyle.GetHorizontalFrameSize() + dialogStyle.GetHorizontalFrameSize()
+	)
+	if m.isOnboarding {
+		return textStyle.Render(m.dialogTitle())
+	}
+	return common.DialogTitle(t, titleStyle.Render(m.dialogTitle()), m.width-headerOffset, m.com.Styles.Primary, m.com.Styles.Secondary)
+}
+
+func (m *OAuthOpenAI) innerDialogContent() string {
+	var (
+		t         = m.com.Styles
+		textStyle = t.Dialog.PrimaryText
+		muted     = t.Dialog.SecondaryText
+	)
+
+	switch m.State {
+	case OAuthStateInitializing:
+		return muted.Render(m.spinner.View() + "Starting OpenAI Codex authentication...")
+	case OAuthStateDisplay:
+		link := t.Dialog.SecondaryText.Hyperlink(m.flow.URL, "id=openai-codex-auth").Render(m.flow.URL)
+		return strings.Join([]string{
+			textStyle.Render("Press enter to open the browser and complete authentication."),
+			"",
+			muted.Render("Browser not opening? Open this URL manually:"),
+			link,
+			"",
+			muted.Render(m.spinner.View() + "Waiting for authorization..."),
+		}, "\n")
+	case OAuthStateSuccess:
+		return textStyle.Render("Authentication successful! Press enter to continue.")
+	case OAuthStateError:
+		errMsg := "Authentication failed. Try \"crush login openai-codex\" from the CLI."
+		if m.lastError != nil {
+			errMsg = fmt.Sprintf("Authentication failed: %v", m.lastError)
+		}
+		return t.Dialog.TitleError.Render(errMsg)
+	default:
+		return ""
+	}
+}
+
+func (m *OAuthOpenAI) dialogTitle() string {
+	var (
+		t           = m.com.Styles
+		textStyle   = t.Dialog.TitleText
+		accentStyle = t.Dialog.TitleAccent
+	)
+	return textStyle.Render("Authenticate with ") + accentStyle.Render("OpenAI Codex") + textStyle.Render(".")
+}
+
+// FullHelp returns the full help view.
+func (m *OAuthOpenAI) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{m.keyMap.Copy, m.keyMap.Submit, m.keyMap.Close}}
+}
+
+// ShortHelp returns the full help view.
+func (m *OAuthOpenAI) ShortHelp() []key.Binding {
+	return []key.Binding{m.keyMap.Copy, m.keyMap.Submit, m.keyMap.Close}
+}
+
+func (m *OAuthOpenAI) initiateAuth() tea.Msg {
+	flow, err := openaioauth.CreateAuthorizationFlow()
+	if err != nil {
+		return openAICodexAuthInitMsg{err: err}
+	}
+	server, err := openaioauth.StartLocalServer(flow.State)
+	if err != nil {
+		return openAICodexAuthInitMsg{flow: flow, err: err}
+	}
+	return openAICodexAuthInitMsg{flow: flow, server: server}
+}
+
+func (m *OAuthOpenAI) startPolling() tea.Cmd {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	m.cancel = cancel
+	return func() tea.Msg {
+		if m.server == nil {
+			return openAICodexAuthErrorMsg{err: fmt.Errorf("OAuth callback server not available")}
+		}
+		defer m.server.Close()
+		code, err := m.server.WaitForCode(ctx)
+		if err != nil {
+			return openAICodexAuthErrorMsg{err: err}
+		}
+		token, err := openaioauth.ExchangeAuthorizationCode(ctx, code, m.flow.Verifier)
+		if err != nil {
+			return openAICodexAuthErrorMsg{err: err}
+		}
+		return openAICodexAuthTokenMsg{token: token}
+	}
+}
+
+func (m *OAuthOpenAI) stopPolling() {
+	if m.cancel != nil {
+		m.cancel()
+		m.cancel = nil
+	}
+	if m.server != nil {
+		_ = m.server.Close()
+		m.server = nil
+	}
+}
+
+func (m *OAuthOpenAI) openURL() tea.Cmd {
+	return func() tea.Msg {
+		if m.flow.URL == "" {
+			return nil
+		}
+		if err := browser.OpenURL(m.flow.URL); err != nil {
+			return uiutil.ReportError(fmt.Errorf("failed to open browser: %w", err))()
+		}
+		return nil
+	}
+}
+
+func (m *OAuthOpenAI) copyURL() tea.Cmd {
+	if m.flow.URL == "" {
+		return nil
+	}
+	return tea.Sequence(
+		tea.SetClipboard(m.flow.URL),
+		uiutil.ReportInfo("URL copied to clipboard"),
+	)
+}
+
+func (m *OAuthOpenAI) saveKeyAndContinue() Action {
+	cfg := m.com.Config()
+
+	err := cfg.SetProviderAPIKey(string(m.provider.ID), m.token)
+	if err != nil {
+		return ActionCmd{uiutil.ReportError(fmt.Errorf("failed to save API key: %w", err))}
+	}
+
+	return ActionSelectModel{
+		Provider:  m.provider,
+		Model:     m.model,
+		ModelType: m.modelType,
+	}
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1383,6 +1383,8 @@ func (m *UI) openAuthenticationDialog(provider catwalk.Provider, model config.Se
 		dlg, cmd = dialog.NewOAuthHyper(m.com, isOnboarding, provider, model, modelType)
 	case catwalk.InferenceProviderCopilot:
 		dlg, cmd = dialog.NewOAuthCopilot(m.com, isOnboarding, provider, model, modelType)
+	case catwalk.InferenceProvider(config.OpenAICodexProviderID):
+		dlg, cmd = dialog.NewOAuthOpenAI(m.com, isOnboarding, provider, model, modelType)
 	default:
 		dlg, cmd = dialog.NewAPIKeyInput(m.com, isOnboarding, provider, model, modelType)
 	}


### PR DESCRIPTION
## Summary
- add OpenAI Codex (ChatGPT OAuth) provider with PKCE login, token refresh, and required request defaults
- integrate provider into config, CLI login, and UI/TUI auth flows
- adjust agent request shaping for Codex responses and add core OAuth/config tests

## Testing
- go test ./internal/oauth/openai/...
- go test ./internal/config/...
- go build .

OpenAI Codex (ChatGPT OAuth) uses the chatgpt.com backend (not the OpenAI API). Requires a ChatGPT account and is subject to OpenAI Terms/Usage Policies.

**NOTE:**
This adds an opt-in provider that uses ChatGPT OAuth + the chatgpt.com Codex backend (not the OpenAI API). Users should review OpenAI Terms/Usage Policies for compliance. **Users are responsible for compliance.**

Relates to #732 (closed) and #2023