### PR TITLE
fix: address potential panic on initialization

### DIFF
--- a/internal/app/lsp.go
+++ b/internal/app/lsp.go
@@ -76,8 +76,10 @@ func (app *App) initLSPClients(ctx context.Context) {
 	}
 	wg.Wait()
 
-	if err := app.AgentCoordinator.UpdateModels(ctx); err != nil {
-		slog.Error("Failed to refresh tools after LSP startup", "error", err)
+	if app.AgentCoordinator != nil {
+		if err := app.AgentCoordinator.UpdateModels(ctx); err != nil {
+			slog.Error("Failed to refresh tools after LSP startup", "error", err)
+		}
 	}
 }
 


### PR DESCRIPTION
Easily reproducible for a new setup (onboarding):

```bash
env CRUSH_GLOBAL_DATA=tmp/data CRUSH_GLOBAL_CONFIG=tmp/config crush
```