### PR TITLE
fix(ui): fix permissions dialog rendering on small windows

### DIFF
--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -48,7 +48,7 @@ const (
 	// layoutSpacingLines is the number of empty lines used for layout spacing.
 	layoutSpacingLines = 4
 	// minWindowWidth is the minimum window width before forcing fullscreen.
-	minWindowWidth = 60
+	minWindowWidth = 77
 	// minWindowHeight is the minimum window height before forcing fullscreen.
 	minWindowHeight = 20
 )
@@ -392,6 +392,7 @@ func (p *Permissions) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		} else {
 			availableHeight = maxHeight - fixedHeight
 		}
+		availableHeight = max(availableHeight, 3)
 	} else {
 		availableHeight = maxHeight - headerHeight - buttonsHeight - helpHeight - frameHeight
 	}


### PR DESCRIPTION
* Follow-up of #2068

---


* Ensure the viewport content is at least 3 cells tall, to always be able to render at least 1 line of content + 1 top and 1 bottom margin.
* Render in fullscreen as soon as we don't have enough space to render buttons without wrapping.

<details><summary>Before</summary>
<p>

<img width="808" height="637" alt="Screenshot 2026-02-02 at 14 34 04" src="https://github.com/user-attachments/assets/6b0a5a39-0c06-4fbb-9689-573c4114ffae" />

<img width="567" height="637" alt="Screenshot 2026-02-02 at 14 35 30" src="https://github.com/user-attachments/assets/fa70dc78-6c99-4772-95fe-e28d81f2c8fd" />

</p>
</details> 

<details><summary>After</summary>
<p>

https://github.com/user-attachments/assets/f75d39c0-0387-4ae7-8695-282fa974fe2c

</p>
</details> 