### PR TITLE
ci: use OIDC for npm login

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
       fury_token: ${{ secrets.FURY_TOKEN }}
       nfpm_gpg_key: ${{ secrets.NFPM_GPG_KEY }}
       nfpm_passphrase: ${{ secrets.NFPM_PASSPHRASE }}
-      npm_token: ${{ secrets.NPM_TOKEN }}
       snapcraft_token: ${{ secrets.SNAPCRAFT_TOKEN }}
       aur_key: ${{ secrets.AUR_KEY }}
       macos_sign_p12: ${{ secrets.MACOS_SIGN_P12 }}


### PR DESCRIPTION
needs https://github.com/charmbracelet/meta/pull/274

see https://www.npmjs.com/package/@charmland/crush/access 
see https://docs.npmjs.com/trusted-publishers
