### PR TITLE
fix(ui): ensure `%d Queued` text is visible

### DIFF
--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -66,7 +66,8 @@ func queuePill(queue int, focused, panelFocused bool, t *styles.Styles) string {
 		triangles = triangles[:queue]
 	}
 
-	content := fmt.Sprintf("%s %d Queued", strings.Join(triangles, ""), queue)
+	text := t.Base.Render(fmt.Sprintf("%d Queued", queue))
+	content := fmt.Sprintf("%s %s", strings.Join(triangles, ""), text)
 	return pillStyle(focused, panelFocused, t).Render(content)
 }
 


### PR DESCRIPTION
Due to how the text was being rendered, `%d Queued` was being print with the default style, making it invisible if the terminal was in light mode (dark text by default).

### Before

<img width="328" height="213" alt="Screenshot 2026-02-02 at 17 35 17" src="https://github.com/user-attachments/assets/96f8c752-7bbc-4771-82aa-eae16ca973f6" />

### After

<img width="405" height="210" alt="Screenshot 2026-02-02 at 17 35 13" src="https://github.com/user-attachments/assets/38af5f43-6c95-4aa0-ae1e-34cc9eab99b2" />

