### PR TITLE
chore: update session styling and style definitions

### DIFF
--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -261,11 +261,11 @@ func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		rc.ViewStyle = t.Dialog.Sessions.DeletingView
 		rc.AddPart(t.Dialog.Sessions.DeletingMessage.Render("Delete this session?"))
 	case sessionsModeUpdating:
-		rc.TitleStyle = t.Dialog.Sessions.UpdatingTitle
-		rc.TitleGradientFromColor = t.Dialog.Sessions.UpdatingTitleGradientFromColor
-		rc.TitleGradientToColor = t.Dialog.Sessions.UpdatingTitleGradientToColor
-		rc.ViewStyle = t.Dialog.Sessions.UpdatingView
-		message := t.Dialog.Sessions.UpdatingMessage.Render("Rename this session?")
+		rc.TitleStyle = t.Dialog.Sessions.RenamingingTitle
+		rc.TitleGradientFromColor = t.Dialog.Sessions.RenamingTitleGradientFromColor
+		rc.TitleGradientToColor = t.Dialog.Sessions.RenamingTitleGradientToColor
+		rc.ViewStyle = t.Dialog.Sessions.RenamingView
+		message := t.Dialog.Sessions.RenamingingMessage.Render("Rename this session?")
 		rc.AddPart(message)
 		item := s.selectedSessionItem()
 		if item == nil {
@@ -279,8 +279,8 @@ func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		start, end := s.list.VisibleItemIndices()
 		selectedIndex := s.list.Selected()
 
-		titleStyle := t.Dialog.Sessions.UpdatingTitle
-		dialogStyle := t.Dialog.Sessions.UpdatingView
+		titleStyle := t.Dialog.Sessions.RenamingingTitle
+		dialogStyle := t.Dialog.Sessions.RenamingView
 		inputStyle := t.Dialog.InputPrompt
 
 		// Adjust cursor position to account for dialog layout + message

--- a/internal/ui/dialog/sessions_item.go
+++ b/internal/ui/dialog/sessions_item.go
@@ -88,8 +88,8 @@ func (s *SessionItem) Render(width int) string {
 		styles.ItemBlurred = s.t.Dialog.Sessions.DeletingItemBlurred
 		styles.ItemFocused = s.t.Dialog.Sessions.DeletingItemFocused
 	case sessionsModeUpdating:
-		styles.ItemBlurred = s.t.Dialog.Sessions.UpdatingItemBlurred
-		styles.ItemFocused = s.t.Dialog.Sessions.UpdatingItemFocused
+		styles.ItemBlurred = s.t.Dialog.Sessions.RenamingItemBlurred
+		styles.ItemFocused = s.t.Dialog.Sessions.RenamingingItemFocused
 		if s.focused {
 			inputWidth := width - styles.InfoTextFocused.GetHorizontalFrameSize()
 			s.updateTitleInput.SetWidth(inputWidth)
@@ -193,7 +193,7 @@ func sessionItems(t *styles.Styles, mode sessionsMode, sessions ...session.Sessi
 			item.updateTitleInput.SetVirtualCursor(false)
 			item.updateTitleInput.Prompt = ""
 			inputStyle := t.TextInput
-			inputStyle.Focused.Placeholder = t.Dialog.Sessions.UpdatingPlaceholder
+			inputStyle.Focused.Placeholder = t.Dialog.Sessions.RenamingPlaceholder
 			item.updateTitleInput.SetStyles(inputStyle)
 			item.updateTitleInput.Focus()
 		}

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -380,14 +380,14 @@ type Styles struct {
 			DeletingTitleGradientToColor   color.Color
 
 			// styles for when we are in update mode
-			UpdatingView                   lipgloss.Style
-			UpdatingItemFocused            lipgloss.Style
-			UpdatingItemBlurred            lipgloss.Style
-			UpdatingTitle                  lipgloss.Style
-			UpdatingMessage                lipgloss.Style
-			UpdatingTitleGradientFromColor color.Color
-			UpdatingTitleGradientToColor   color.Color
-			UpdatingPlaceholder            lipgloss.Style
+			RenamingView                   lipgloss.Style
+			RenamingingItemFocused         lipgloss.Style
+			RenamingItemBlurred            lipgloss.Style
+			RenamingingTitle               lipgloss.Style
+			RenamingingMessage             lipgloss.Style
+			RenamingTitleGradientFromColor color.Color
+			RenamingTitleGradientToColor   color.Color
+			RenamingPlaceholder            lipgloss.Style
 		}
 	}
 
@@ -1299,14 +1299,14 @@ func DefaultStyles() Styles {
 	s.Dialog.Sessions.DeletingItemBlurred = s.Dialog.NormalItem.Foreground(fgSubtle)
 	s.Dialog.Sessions.DeletingItemFocused = s.Dialog.SelectedItem.Background(red).Foreground(charmtone.Butter)
 
-	s.Dialog.Sessions.UpdatingTitle = s.Dialog.Title.Foreground(charmtone.Zest)
-	s.Dialog.Sessions.UpdatingView = s.Dialog.View.BorderForeground(charmtone.Zest)
-	s.Dialog.Sessions.UpdatingMessage = s.Base.Padding(1)
-	s.Dialog.Sessions.UpdatingTitleGradientFromColor = charmtone.Zest
-	s.Dialog.Sessions.UpdatingTitleGradientToColor = charmtone.Bok
-	s.Dialog.Sessions.UpdatingItemBlurred = s.Dialog.NormalItem.Foreground(fgSubtle)
-	s.Dialog.Sessions.UpdatingItemFocused = s.Dialog.SelectedItem.UnsetBackground().UnsetForeground()
-	s.Dialog.Sessions.UpdatingPlaceholder = base.Foreground(charmtone.Squid)
+	s.Dialog.Sessions.RenamingingTitle = s.Dialog.Title.Foreground(charmtone.Zest)
+	s.Dialog.Sessions.RenamingView = s.Dialog.View.BorderForeground(charmtone.Zest)
+	s.Dialog.Sessions.RenamingingMessage = s.Base.Padding(1)
+	s.Dialog.Sessions.RenamingTitleGradientFromColor = charmtone.Zest
+	s.Dialog.Sessions.RenamingTitleGradientToColor = charmtone.Bok
+	s.Dialog.Sessions.RenamingItemBlurred = s.Dialog.NormalItem.Foreground(fgSubtle)
+	s.Dialog.Sessions.RenamingingItemFocused = s.Dialog.SelectedItem.UnsetBackground().UnsetForeground()
+	s.Dialog.Sessions.RenamingPlaceholder = base.Foreground(charmtone.Squid)
 
 	s.Status.Help = lipgloss.NewStyle().Padding(0, 1)
 	s.Status.SuccessIndicator = base.Foreground(bgSubtle).Background(green).Padding(0, 1).Bold(true).SetString("OKAY!")


### PR DESCRIPTION
These revisions make some small updates to the styling of items during session deletion and renaming. It also changes style names around renaming from `update` to `rename` for clarity.