### PR TITLE
fix: fix pasting files on some terminal emulators

### DIFF
--- a/internal/fsext/paste_test.go
+++ b/internal/fsext/paste_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPasteStringToPaths(t *testing.T) {
-	t.Run("Windows", func(t *testing.T) {
+func TestParsePastedFiles(t *testing.T) {
+	t.Run("WindowsTerminal", func(t *testing.T) {
 		tests := []struct {
 			name     string
 			input    string
@@ -24,7 +24,7 @@ func TestPasteStringToPaths(t *testing.T) {
 				expected: []string{`C:\path\my-screenshot-one.png`, `C:\path\my-screenshot-two.png`, `C:\path\my-screenshot-three.png`},
 			},
 			{
-				name:     "sigle with spaces",
+				name:     "single with spaces",
 				input:    `"C:\path\my screenshot one.png"`,
 				expected: []string{`C:\path\my screenshot one.png`},
 			},
@@ -46,7 +46,7 @@ func TestPasteStringToPaths(t *testing.T) {
 			{
 				name:     "text outside quotes",
 				input:    `"C:\path\file.png" some random text "C:\path\file2.png"`,
-				expected: []string{`C:\path\file.png`, `C:\path\file2.png`},
+				expected: nil,
 			},
 			{
 				name:     "multiple spaces between paths",
@@ -66,7 +66,7 @@ func TestPasteStringToPaths(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				result := windowsPasteStringToPaths(tt.input)
+				result := windowsTerminalParsePastedFiles(tt.input)
 				require.Equal(t, tt.expected, result)
 			})
 		}
@@ -141,7 +141,7 @@ func TestPasteStringToPaths(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				result := unixPasteStringToPaths(tt.input)
+				result := unixParsePastedFiles(tt.input)
 				require.Equal(t, tt.expected, result)
 			})
 		}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2915,7 +2915,7 @@ func (m *UI) handlePasteMsg(msg tea.PasteMsg) tea.Cmd {
 	// Attempt to parse pasted content as file paths. If possible to parse,
 	// all files exist and are valid, add as attachments.
 	// Otherwise, paste as text.
-	paths := fsext.PasteStringToPaths(msg.Content)
+	paths := fsext.ParsePastedFiles(msg.Content)
 	allExistsAndValid := func() bool {
 		for _, path := range paths {
 			if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -2955,6 +2955,9 @@ func (m *UI) handleFilePathPaste(path string) tea.Cmd {
 		fileInfo, err := os.Stat(path)
 		if err != nil {
 			return uiutil.ReportError(err)
+		}
+		if fileInfo.IsDir() {
+			return uiutil.ReportWarn("Cannot attach a directory")
 		}
 		if fileInfo.Size() > common.MaxAttachmentSize {
 			return uiutil.ReportWarn("File is too big (>5mb)")


### PR DESCRIPTION
* Check `WT_SESSION` instead of `GOOS` for Windows Terminal.
* Be more strict on Windows Terminal: do not allow chars outside quotes (prevents false positives).
* Some terminals just paste the literal paths (Rio as separate events, Kitty separated by a line break). If it contains valid path(s) for existing file(s), just use that.
* Workaround Rio on Windows that adds NULL chars to the string.