### PR TITLE
feat(lsp): lazy-start server on filetype view

### DIFF
--- a/internal/ui/model/lsp.go
+++ b/internal/ui/model/lsp.go
@@ -89,6 +89,9 @@ func lspList(t *styles.Styles, lsps []LSPInfo, width, maxItems int) string {
 		var description string
 		var diagnostics string
 		switch l.State {
+		case lsp.StateStandby:
+			icon = t.ItemOfflineIcon.String()
+			description = t.Subtle.Render("standby")
 		case lsp.StateStarting:
 			icon = t.ItemBusyIcon.String()
 			description = t.Subtle.Render("starting...")


### PR DESCRIPTION
PoC for lazy loading LSPs.

some issues:
- paths given on the very first prompt (and sometimes other prompts) don't trigger "view" tool when using `@` to provide file paths and so LSP doesn't attach
  <img width="1393" height="668" alt="image" src="https://github.com/user-attachments/assets/e46fad35-c780-428a-8fb1-93acbe438f48" />
- new session keeps prior LSPs alive



- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
