### PR TITLE
fix(ui): cursor mispositioned when pasting large blocks of text in textarea

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -684,8 +684,13 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 		}
 	case openEditorMsg:
+		var cmd tea.Cmd
 		m.textarea.SetValue(msg.Text)
 		m.textarea.MoveToEnd()
+		m.textarea, cmd = m.textarea.Update(msg)
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case uiutil.InfoMsg:
 		m.status.SetInfoMsg(msg)
 		ttl := msg.TTL


### PR DESCRIPTION
This fixes an issue where the cursor gets misplaced after opening the editor and type a multi-line prompt

Fixes: https://github.com/charmbracelet/crush/issues/2110