### PR TITLE
fix(agent): support flat_rate cost handling

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -103,6 +103,7 @@ type Model struct {
 	Model      fantasy.LanguageModel
 	CatwalkCfg catwalk.Model
 	ModelCfg   config.SelectedModel
+	FlatRate   bool
 }
 
 type sessionAgent struct {
@@ -979,6 +980,11 @@ func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, user
 		cost = *openrouterCost
 	}
 
+	// Skip cost accumulation
+	if model.FlatRate {
+		cost = 0
+	}
+
 	promptTokens := resp.TotalUsage.InputTokens + resp.TotalUsage.CacheCreationTokens
 	completionTokens := resp.TotalUsage.OutputTokens
 
@@ -1013,12 +1019,17 @@ func (a *sessionAgent) updateSessionUsage(model Model, session *session.Session,
 
 	a.eventTokensUsed(session.ID, model, usage, cost)
 
+	// Use override cost if available (e.g., from OpenRouter).
 	if overrideCost != nil {
-		session.Cost += *overrideCost
-	} else {
-		session.Cost += cost
+		cost = *overrideCost
 	}
 
+	// Skip cost accumulation
+	if model.FlatRate {
+		cost = 0
+	}
+
+	session.Cost += cost
 	session.CompletionTokens = usage.OutputTokens
 	session.PromptTokens = usage.InputTokens + usage.CacheReadTokens
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -607,10 +607,12 @@ func (c *coordinator) buildAgentModels(ctx context.Context, isSubAgent bool) (Mo
 			Model:      largeModel,
 			CatwalkCfg: *largeCatwalkModel,
 			ModelCfg:   largeModelCfg,
+			FlatRate:   largeProviderCfg.FlatRate,
 		}, Model{
 			Model:      smallModel,
 			CatwalkCfg: *smallCatwalkModel,
 			ModelCfg:   smallModelCfg,
+			FlatRate:   smallProviderCfg.FlatRate,
 		}, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,6 +120,9 @@ type ProviderConfig struct {
 	// Used to pass extra parameters to the provider.
 	ExtraParams map[string]string `json:"-"`
 
+	// Skip cost accumulation for this provider when using subscription or flat rate billing.
+	FlatRate bool `json:"flat_rate,omitempty" jsonschema:"description=Flat-rate mode for this provider"`
+
 	// The provider models
 	Models []catwalk.Model `json:"models,omitempty" jsonschema:"description=List of models available from this provider"`
 }

--- a/schema.json
+++ b/schema.json
@@ -560,6 +560,10 @@
           "type": "object",
           "description": "Additional provider-specific options for this provider"
         },
+        "flat_rate": {
+          "type": "boolean",
+          "description": "Flat-rate mode for this provider"
+        },
         "models": {
           "items": {
             "$ref": "#/$defs/Model"


### PR DESCRIPTION
## Description

This PR updates the fix for incorrect cost calculations on subscription/flat-rate providers.

Instead of mutating model prices during provider configuration, we now handle this at usage accumulation time with an explicit provider-level `flat_rate` flag.

Fixes #1096

## Changes

- Added provider-level `flat_rate` config support in `ProviderConfig`
- Propagated `flat_rate` into runtime `agent.Model` as `FlatRate`
- Updated session usage cost accumulation logic:
  - apply override/provider cost first when present
  - then enforce flat-rate behavior (cost stays `0`)
- Updated title generation usage-cost path to honor `FlatRate` as well
- Regenerated `schema.json` to include the new `flat_rate` field

## Why this approach

- Avoids mutating provider model pricing metadata
- Keeps billing behavior in the usage accounting path (`updateSessionUsage` and title usage update)
- Works as a generic mechanism for any subscription-based provider
- Supports explicit user configuration when subscription vs usage-based billing cannot be auto-detected

## Testing

- `go test ./internal/agent/...`
