### PR TITLE
fix(ui): ensure we anchor the chat view to the bottom when toggling

### DIFF
--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -79,7 +79,7 @@ func (l *List) Gap() int {
 func (l *List) AtBottom() bool {
 	const margin = 2
 
-	if len(l.items) == 0 {
+	if len(l.items) == 0 || l.offsetIdx >= len(l.items)-1 {
 		return true
 	}
 

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -439,6 +439,9 @@ func (m *Chat) ToggleExpandedSelectedItem() {
 	if expandable, ok := m.list.SelectedItem().(chat.Expandable); ok {
 		expandable.ToggleExpanded()
 		m.list.ScrollToIndex(m.list.Selected())
+		if m.list.AtBottom() {
+			m.list.ScrollToBottom()
+		}
 	}
 }
 
@@ -547,6 +550,9 @@ func (m *Chat) HandleDelayedClick(msg DelayedClickMsg) bool {
 			expandable.ToggleExpanded()
 		}
 		m.list.ScrollToIndex(m.list.Selected())
+		if m.list.AtBottom() {
+			m.list.ScrollToBottom()
+		}
 		return handled
 	}
 


### PR DESCRIPTION
an item at the bottom of the chat

When toggling an item in the chat, if that item is at the bottom of the chat, we want to ensure that we stay anchored to the bottom. This prevents a gap from appearing at the bottom of the chat when toggling an item that is currently selected and at the bottom.
