### PR TITLE
fix(ui): completions popup gets too narrow on single item

### DIFF
--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -128,16 +128,7 @@ func (c *Completions) SetFiles(files []string) {
 	c.list.SelectFirst()
 	c.list.ScrollToSelected()
 
-	// recalculate width by using just the visible items
-	start, end := c.list.VisibleItemIndices()
-	width := 0
-	if end != 0 {
-		for _, file := range files[start : end+1] {
-			width = max(width, ansi.StringWidth(file))
-		}
-	}
-	c.width = ordered.Clamp(width+2, int(minWidth), int(maxWidth))
-	c.list.SetSize(c.width, c.height)
+	c.updateSize()
 }
 
 // Close closes the completions popup.
@@ -158,14 +149,17 @@ func (c *Completions) Filter(query string) {
 	c.query = query
 	c.list.SetFilter(query)
 
-	// recalculate width by using just the visible items
+	c.updateSize()
+}
+
+func (c *Completions) updateSize() {
 	items := c.list.FilteredItems()
 	start, end := c.list.VisibleItemIndices()
 	width := 0
-	if end != 0 {
-		for _, item := range items[start : end+1] {
-			width = max(width, ansi.StringWidth(item.(interface{ Text() string }).Text()))
-		}
+	for i := start; i <= end; i++ {
+		item := c.list.ItemAt(i)
+		s := item.(interface{ Text() string }).Text()
+		width = max(width, ansi.StringWidth(s))
 	}
 	c.width = ordered.Clamp(width+2, int(minWidth), int(maxWidth))
 	c.height = ordered.Clamp(len(items), int(minHeight), int(maxHeight))


### PR DESCRIPTION
when there is a single item visible in the completions, it was rendering with the minWidth.

**before**:
<img width="578" height="338" alt="CleanShot 2026-02-04 at 16 56 40@2x" src="https://github.com/user-attachments/assets/0a2dcd2e-c522-4f69-b635-646ae892c5d2" />


**now**:

<img width="844" height="388" alt="CleanShot 2026-02-04 at 16 56 26@2x" src="https://github.com/user-attachments/assets/d9ee0def-2ed1-4785-9c72-a6d5b183b268" />
