### PR TITLE
fix(ui): Fix small UI typo

### DIFF
--- a/internal/ui/dialog/api_key_input.go
+++ b/internal/ui/dialog/api_key_input.go
@@ -76,7 +76,7 @@ func NewAPIKeyInput(
 
 	m.input = textinput.New()
 	m.input.SetVirtualCursor(false)
-	m.input.Placeholder = "Enter you API key..."
+	m.input.Placeholder = "Enter your API key..."
 	m.input.SetStyles(com.Styles.TextInput)
 	m.input.Focus()
 	m.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding


### PR DESCRIPTION
This PR is a 1-byte change that fixes a typo shown when first entering your API key in a project: "Enter you API key"  → "Enter your API key".

<img width="778" height="281" alt="api-key-typo" src="https://github.com/user-attachments/assets/0f73d43d-9fa1-4ea6-85a4-2c5c3131e89d" />

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
