### PR TITLE
fix: cap posthog shutdown timeout

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -39,8 +39,9 @@ func SetNonInteractive(nonInteractive bool) {
 
 func Init() {
 	c, err := posthog.NewWithConfig(key, posthog.Config{
-		Endpoint: endpoint,
-		Logger:   logger{},
+		Endpoint:        endpoint,
+		Logger:          logger{},
+		ShutdownTimeout: 500 * time.Millisecond,
 	})
 	if err != nil {
 		slog.Error("Failed to initialize PostHog client", "error", err)


### PR DESCRIPTION
This caps the time Posthog waits to send events as we shutdown. We may lose an exit event, but I believe the user experience gain here is worth it.

Thanks to @taigrr for flagging this.