### PR TITLE
feat: CRUSH_DATA_DIRECTORY

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -350,6 +350,8 @@ func (c *Config) setDefaults(workingDir, dataDir string) {
 	}
 	if dataDir != "" {
 		c.Options.DataDirectory = dataDir
+	} else if envDir, ok := os.LookupEnv("CRUSH_DATA_DIRECTORY"); ok && envDir != "" {
+		c.Options.DataDirectory = envDir
 	} else if c.Options.DataDirectory == "" {
 		if path, ok := fsext.LookupClosest(workingDir, defaultDataDirectory); ok {
 			c.Options.DataDirectory = path

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -56,6 +56,24 @@ func TestConfig_setDefaults(t *testing.T) {
 	require.Equal(t, "/tmp", cfg.workingDir)
 }
 
+func TestConfig_setDefaults_dataDirEnvVar(t *testing.T) {
+	t.Setenv("CRUSH_DATA_DIRECTORY", "/custom/data")
+
+	cfg := &Config{}
+	cfg.setDefaults("/tmp", "")
+
+	require.Equal(t, "/custom/data", cfg.Options.DataDirectory)
+}
+
+func TestConfig_setDefaults_dataDirFlagOverridesEnv(t *testing.T) {
+	t.Setenv("CRUSH_DATA_DIRECTORY", "/from/env")
+
+	cfg := &Config{}
+	cfg.setDefaults("/tmp", "/from/flag")
+
+	require.Equal(t, "/from/flag", cfg.Options.DataDirectory)
+}
+
 func TestConfig_configureProviders(t *testing.T) {
 	knownProviders := []catwalk.Provider{
 		{


### PR DESCRIPTION
this allows to change crush data directory using environment variables.

this is especially useful when using work trees, e.g.:

```sh
git clone --bare foo/bar
cd bar.git
echo "CRUSH_DATA_DIRECTORY=$PWD/data" >.env
```

then

```sh
git worktree add feat-1
cd feat-1
crush
```

and


```sh
git worktree add feat-2
cd feat-2
crush
```

and the data dir for both will be the same (assuming you have something like `direnv` installed), so you can share session data, commands, etc.