### PR TITLE
fix: thinking sidebar

### DIFF
--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -27,7 +27,7 @@ func (m *UI) modelInfo(width int) string {
 
 			// Only check reasoning if model can reason
 			if model.CatwalkCfg.CanReason {
-				if model.ModelCfg.ReasoningEffort == "" {
+				if len(model.CatwalkCfg.ReasoningLevels) == 0 {
 					if model.ModelCfg.Think {
 						reasoningInfo = "Thinking On"
 					} else {


### PR DESCRIPTION
sometimes it defaults to reasoning medium even though there's no reasoning levels.

this check the absence of levels instead.