### PR TITLE
fix(ui): clear image cache when FilePicker closes to prevent unbounded memory growth

### DIFF
--- a/internal/ui/image/image.go
+++ b/internal/ui/image/image.go
@@ -68,8 +68,8 @@ var (
 	cachedMutex  sync.RWMutex
 )
 
-// Reset clears the image cache, freeing all cached decoded images.
-func Reset() {
+// ResetCache clears the image cache, freeing all cached decoded images.
+func ResetCache() {
 	cachedMutex.Lock()
 	clear(cachedImages)
 	cachedMutex.Unlock()

--- a/internal/ui/image/image_test.go
+++ b/internal/ui/image/image_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReset(t *testing.T) {
+func TestResetCache(t *testing.T) {
 	t.Parallel()
 
 	cachedMutex.Lock()
@@ -23,7 +23,7 @@ func TestReset(t *testing.T) {
 	}
 	cachedMutex.Unlock()
 
-	Reset()
+	ResetCache()
 
 	cachedMutex.RLock()
 	length := len(cachedImages)
@@ -36,7 +36,7 @@ func TestResetIdempotent(t *testing.T) {
 	t.Parallel()
 
 	// Calling Reset on an empty cache should not panic.
-	Reset()
+	ResetCache()
 
 	cachedMutex.RLock()
 	length := len(cachedImages)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1139,7 +1139,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		}
 
 		if m.dialog.ContainsDialog(dialog.FilePickerID) {
-			defer fimage.Reset()
+			defer fimage.ResetCache()
 		}
 
 		m.dialog.CloseFrontDialog()
@@ -1357,7 +1357,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 				return nil
 			},
 			func() tea.Msg {
-				fimage.Reset()
+				fimage.ResetCache()
 				return nil
 			},
 		))


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

The global cachedImages map in internal/ui/image/image.go stores decoded image.Image objects keyed by {id, cols, rows}. It has no eviction, no size limit, and no TTL — it only grows. Every unique image file browsed in the FilePicker adds a permanent entry that persists for the entire process lifetime.

Each entry holds a fully decoded RGBA image, which can be several MB of pixel data depending on the source image dimensions.

## Reproduction
1. Open the FilePicker dialog
2. Browse through directories containing many image files (the preview triggers caching)
3. Close the FilePicker
4. Repeat — memory usage only increases, never decreases

## Expected behavior
Cached images should be freed when they are no longer needed. The cache is only used by the FilePicker dialog, so all entries become dead weight the moment the dialog closes.

## Impact
Long-running sessions that frequently use the FilePicker will accumulate unbounded memory from stale image data that will never be accessed again.