### PR TITLE
fix: prevent goroutine orphaning in mcp.Close() and shell.KillAll()

### DIFF
--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -124,26 +124,29 @@ func GetState(name string) (ClientInfo, bool) {
 
 // Close closes all MCP clients. This should be called during application shutdown.
 func Close() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
 	var wg sync.WaitGroup
-	done := make(chan struct{}, 1)
-	go func() {
-		for name, session := range sessions.Seq2() {
-			wg.Go(func() {
-				if err := session.Close(); err != nil &&
+	for name, session := range sessions.Seq2() {
+		wg.Go(func() {
+			done := make(chan error, 1)
+			go func() {
+				done <- session.Close()
+			}()
+			select {
+			case err := <-done:
+				if err != nil &&
 					!errors.Is(err, io.EOF) &&
 					!errors.Is(err, context.Canceled) &&
 					err.Error() != "signal: killed" {
 					slog.Warn("Failed to shutdown MCP client", "name", name, "error", err)
 				}
-			})
-		}
-		wg.Wait()
-		done <- struct{}{}
-	}()
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
+			case <-ctx.Done():
+			}
+		})
 	}
+	wg.Wait()
 	broker.Shutdown()
 	return nil
 }


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

mcp.Close() and BackgroundShellManager.KillAll() both use the same pattern: spawn a goroutine to do cleanup, then `select` on a 5-second `time.After`. If the timeout fires first, the function returns but the cleanup goroutine keeps running indefinitely, holding references to MCP sessions or background shells and their resources.                                                                                                                                                                               
                                                                                                                                                                                                          
## Steps to reproduce
1. Have an MCP server or background shell that is slow to shut down (>5s);
2. Trigger application shutdown (e.g. quit the TUI);
3. The cleanup goroutine is orphaned and leaks until the process exits.

## Fix
Replace the outer goroutine + time.After pattern with context.WithTimeout, matching the established pattern used in 16+ other places in the codebase (e.g. LSPManager.StopAll). Each per-session/per-shell goroutine now races its cleanup against ctx.Done(), so when the deadline fires all goroutines unblock and wg.Wait() returns promptly.
