### PR TITLE
fix: clear regex cache on new session to prevent unbounded growth

### DIFF
--- a/internal/agent/tools/grep.go
+++ b/internal/agent/tools/grep.go
@@ -64,6 +64,17 @@ func (rc *regexCache) get(pattern string) (*regexp.Regexp, error) {
 	return regex, nil
 }
 
+// ResetCache clears compiled regex caches to prevent unbounded growth across sessions.
+func ResetCache() {
+	searchRegexCache.mu.Lock()
+	clear(searchRegexCache.cache)
+	searchRegexCache.mu.Unlock()
+
+	globRegexCache.mu.Lock()
+	clear(globRegexCache.cache)
+	globRegexCache.mu.Unlock()
+}
+
 // Global regex cache instances
 var (
 	searchRegexCache = newRegexCache()

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -24,6 +24,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/lipgloss/v2"
+	agenttools "github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/commands"
@@ -2973,6 +2974,7 @@ func (m *UI) newSession() tea.Cmd {
 	m.promptQueue = 0
 	m.pillsView = ""
 	m.historyReset()
+	agenttools.ResetCache()
 	return tea.Batch(
 		func() tea.Msg {
 			m.com.App.LSPManager.StopAll(context.Background())


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

Two global regex caches (searchRegexCache, globRegexCache) in internal/agent/tools/grep.go are backed by plain maps with no eviction. Every unique search pattern and glob pattern compiled during agent tool use is cached permanently. In long-running sessions with varied search patterns, memory grows linearly with unique patterns. Compiled *regexp.Regexp objects can be large depending on complexity.

## Fix
Clear both caches on new session start.