### PR TITLE
internal/ui: fix panic in completions width calculation

### DIFF
--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -180,10 +180,14 @@ func (c *Completions) updateSize() {
 	items := c.list.FilteredItems()
 	start, end := c.list.VisibleItemIndices()
 	width := 0
-	for i := start; i <= end; i++ {
-		item := c.list.ItemAt(i)
-		s := item.(interface{ Text() string }).Text()
-		width = max(width, ansi.StringWidth(s))
+
+	// Calculate the maximum width of visible items.
+	if len(items) > 0 {
+		for i := start; i <= end; i++ {
+			item := c.list.ItemAt(i)
+			s := item.(interface{ Text() string }).Text()
+			width = max(width, ansi.StringWidth(s))
+		}
 	}
 	c.width = ordered.Clamp(width+2, int(minWidth), int(maxWidth))
 	c.height = ordered.Clamp(len(items), int(minHeight), int(maxHeight))

--- a/internal/ui/completions/completions_test.go
+++ b/internal/ui/completions/completions_test.go
@@ -1,0 +1,40 @@
+package completions
+
+import (
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateSize(t *testing.T) {
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+
+	// Test with 1 item
+	files := []FileCompletionValue{
+		{Path: "long_filename_that_should_determine_width"},
+	}
+	c.SetItems(files, nil)
+
+	// Expected width: length of string + 2 (padding/borders if any, strictly +2 in updateSize)
+	// "long_filename_that_should_determine_width" is 41 chars.
+	// width should be 43.
+	// But clamps apply: minWidth=10, maxWidth=100.
+	expectedWidth := 43
+	assert.Equal(t, expectedWidth, c.width, "Width should be calculated correctly for 1 item")
+
+	// Test with 0 items
+	c.SetItems(nil, nil)
+	// Width should be minWidth? Or whatever it was before?
+	// The loop doesn't run, width=0. Clamped to minWidth (10).
+	assert.Equal(t, minWidth, c.width, "Width should be minWidth for 0 items")
+
+	// Test with multiple items
+	files = []FileCompletionValue{
+		{Path: "short"},
+		{Path: "longer_path"},
+	}
+	c.SetItems(files, nil)
+	// "longer_path" is 11 chars. +2 = 13.
+	assert.Equal(t, 13, c.width, "Width should be calculated correctly for multiple items")
+}

--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -243,13 +243,14 @@ func (l *List) ScrollBy(lines int) {
 
 // VisibleItemIndices finds the range of items that are visible in the viewport.
 // This is used for checking if selected item is in view.
-func (l *List) VisibleItemIndices() (startIdx, endIdx int) {
+// It returns the start and end indices of the visible items (inclusive).
+func (l *List) VisibleItemIndices() (startIdxInclusive, endIdxInclusive int) {
 	if len(l.items) == 0 {
 		return 0, 0
 	}
 
-	startIdx = l.offsetIdx
-	currentIdx := startIdx
+	startIdxInclusive = l.offsetIdx
+	currentIdx := startIdxInclusive
 	visibleHeight := -l.offsetLine
 
 	for currentIdx < len(l.items) {
@@ -265,12 +266,12 @@ func (l *List) VisibleItemIndices() (startIdx, endIdx int) {
 		currentIdx++
 	}
 
-	endIdx = currentIdx
-	if endIdx >= len(l.items) {
-		endIdx = len(l.items) - 1
+	endIdxInclusive = currentIdx
+	if endIdxInclusive >= len(l.items) {
+		endIdxInclusive = len(l.items) - 1
 	}
 
-	return startIdx, endIdx
+	return startIdxInclusive, endIdxInclusive
 }
 
 // Render renders the list and returns the visible lines.


### PR DESCRIPTION
When the completions list is empty, `VisibleItemIndices` returns `(0, 0)`. The width calculation loop iterates from start to end inclusive, causing it to execute for index 0 even when no items exist.

This results in a panic because `ItemAt(0)` returns nil, which fails the type assertion: interface conversion: interface is `nil`, not `interface { Text() string }`

Fix this by guarding the width calculation loop with a check for len(items) > 0. This ensures we only attempt to access items when the list is non-empty.

- Added TestUpdateSize.

closes #2163 

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
