### PR TITLE
[POC] feat: add Fish-style tab completion for progressive path navigation

### DIFF
--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -27,6 +27,7 @@ const (
 type SelectionMsg[T any] struct {
 	Value    T
 	KeepOpen bool // If true, insert without closing.
+	Continue bool // If true, update query and continue completing (Tab behavior).
 }
 
 // ClosedMsg is sent when the completions are closed.
@@ -214,14 +215,17 @@ func (c *Completions) Update(msg tea.KeyPressMsg) (tea.Msg, bool) {
 
 	case key.Matches(msg, c.keyMap.UpInsert):
 		c.selectPrev()
-		return c.selectCurrent(true), true
+		return c.selectCurrent(true, false), true
 
 	case key.Matches(msg, c.keyMap.DownInsert):
 		c.selectNext()
-		return c.selectCurrent(true), true
+		return c.selectCurrent(true, false), true
 
 	case key.Matches(msg, c.keyMap.Select):
-		return c.selectCurrent(false), true
+		return c.selectCurrent(false, false), true
+
+	case key.Matches(msg, c.keyMap.Continue):
+		return c.selectCurrent(true, true), true
 
 	case key.Matches(msg, c.keyMap.Cancel):
 		c.Close()
@@ -256,7 +260,7 @@ func (c *Completions) selectNext() {
 }
 
 // selectCurrent returns a command with the currently selected item.
-func (c *Completions) selectCurrent(keepOpen bool) tea.Msg {
+func (c *Completions) selectCurrent(keepOpen, continueMode bool) tea.Msg {
 	items := c.list.FilteredItems()
 	if len(items) == 0 {
 		return nil
@@ -281,11 +285,13 @@ func (c *Completions) selectCurrent(keepOpen bool) tea.Msg {
 		return SelectionMsg[ResourceCompletionValue]{
 			Value:    item,
 			KeepOpen: keepOpen,
+			Continue: continueMode,
 		}
 	case FileCompletionValue:
 		return SelectionMsg[FileCompletionValue]{
 			Value:    item,
 			KeepOpen: keepOpen,
+			Continue: continueMode,
 		}
 	default:
 		return nil

--- a/internal/ui/completions/completions_test.go
+++ b/internal/ui/completions/completions_test.go
@@ -1,0 +1,106 @@
+package completions
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectCurrent(t *testing.T) {
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+
+	files := []FileCompletionValue{
+		{Path: "/tmp/test"},
+		{Path: "/tmp/other"},
+	}
+	c.SetItems(files, nil)
+
+	t.Run("select without continue", func(t *testing.T) {
+		c.open = true
+		msg := c.selectCurrent(false, false)
+
+		sel, ok := msg.(SelectionMsg[FileCompletionValue])
+		assert.True(t, ok)
+		assert.Equal(t, "/tmp/test", sel.Value.Path)
+		assert.False(t, sel.KeepOpen)
+		assert.False(t, sel.Continue)
+		assert.False(t, c.open, "completions should close")
+	})
+
+	t.Run("select with keepOpen", func(t *testing.T) {
+		c.open = true
+		msg := c.selectCurrent(true, false)
+
+		sel, ok := msg.(SelectionMsg[FileCompletionValue])
+		assert.True(t, ok)
+		assert.True(t, sel.KeepOpen)
+		assert.False(t, sel.Continue)
+		assert.True(t, c.open, "completions should stay open")
+	})
+
+	t.Run("select with continue mode", func(t *testing.T) {
+		c.open = true
+		msg := c.selectCurrent(true, true)
+
+		sel, ok := msg.(SelectionMsg[FileCompletionValue])
+		assert.True(t, ok)
+		assert.True(t, sel.KeepOpen)
+		assert.True(t, sel.Continue)
+		assert.True(t, c.open, "completions should stay open")
+	})
+}
+
+func TestKeyMapContinueBinding(t *testing.T) {
+	km := DefaultKeyMap()
+
+	// Test that Continue is bound to Tab
+	assert.True(t, key.Matches(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}), km.Continue))
+	assert.False(t, key.Matches(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}), km.Continue))
+
+	// Test that Select is NOT bound to Tab anymore
+	assert.False(t, key.Matches(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}), km.Select))
+	assert.True(t, key.Matches(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}), km.Select))
+}
+
+func TestUpdateWithTabKey(t *testing.T) {
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+
+	files := []FileCompletionValue{
+		{Path: "/tmp/test"},
+	}
+	c.SetItems(files, nil)
+
+	// Simulate Tab press
+	msg, handled := c.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyTab}))
+
+	assert.True(t, handled, "Tab should be handled")
+
+	sel, ok := msg.(SelectionMsg[FileCompletionValue])
+	assert.True(t, ok, "should return SelectionMsg")
+	assert.Equal(t, "/tmp/test", sel.Value.Path)
+	assert.True(t, sel.KeepOpen, "should keep open for Tab")
+	assert.True(t, sel.Continue, "should have Continue=true for Tab")
+}
+
+func TestUpdateWithEnterKey(t *testing.T) {
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+
+	files := []FileCompletionValue{
+		{Path: "/tmp/test"},
+	}
+	c.SetItems(files, nil)
+
+	// Simulate Enter press
+	msg, handled := c.Update(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+
+	assert.True(t, handled, "Enter should be handled")
+
+	sel, ok := msg.(SelectionMsg[FileCompletionValue])
+	assert.True(t, ok, "should return SelectionMsg")
+	assert.Equal(t, "/tmp/test", sel.Value.Path)
+	assert.False(t, sel.KeepOpen, "should close for Enter")
+	assert.False(t, sel.Continue, "should have Continue=false for Enter")
+}

--- a/internal/ui/completions/keys.go
+++ b/internal/ui/completions/keys.go
@@ -9,7 +9,8 @@ type KeyMap struct {
 	Down,
 	Up,
 	Select,
-	Cancel key.Binding
+	Cancel,
+	Continue key.Binding
 	DownInsert,
 	UpInsert key.Binding
 }
@@ -26,8 +27,12 @@ func DefaultKeyMap() KeyMap {
 			key.WithHelp("up", "move up"),
 		),
 		Select: key.NewBinding(
-			key.WithKeys("enter", "tab", "ctrl+y"),
+			key.WithKeys("enter", "ctrl+y"),
 			key.WithHelp("enter", "select"),
+		),
+		Continue: key.NewBinding(
+			key.WithKeys("tab"),
+			key.WithHelp("tab", "complete & continue"),
 		),
 		Cancel: key.NewBinding(
 			key.WithKeys("esc", "alt+esc"),
@@ -50,6 +55,7 @@ func (k KeyMap) KeyBindings() []key.Binding {
 		k.Down,
 		k.Up,
 		k.Select,
+		k.Continue,
 		k.Cancel,
 	}
 }

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1530,9 +1530,13 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				if msg, ok := m.completions.Update(msg); ok {
 					switch msg := msg.(type) {
 					case completions.SelectionMsg[completions.FileCompletionValue]:
-						cmds = append(cmds, m.insertFileCompletion(msg.Value.Path))
+						cmds = append(cmds, m.insertFileCompletion(msg.Value.Path, msg.Continue))
 						if !msg.KeepOpen {
 							m.closeCompletions()
+						} else if msg.Continue {
+							// Update query to continue completing from selected path.
+							m.completionsQuery = msg.Value.Path
+							m.completions.Filter(m.completionsQuery)
 						}
 					case completions.SelectionMsg[completions.ResourceCompletionValue]:
 						cmds = append(cmds, m.insertMCPResourceCompletion(msg.Value))
@@ -1683,12 +1687,14 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 						// Close on space.
 						m.closeCompletions()
 					} else {
-						// Extract current word and filter.
-						word := m.textareaWord()
-						if strings.HasPrefix(word, "@") {
-							m.completionsQuery = word[1:]
+						// Extract query from @ to cursor position.
+						value := m.textarea.Value()
+						cursorPos := len(value)
+						if cursorPos > m.completionsStartIndex {
+							query := value[m.completionsStartIndex+1 : cursorPos]
+							m.completionsQuery = query
 							m.completions.Filter(m.completionsQuery)
-						} else if m.completionsOpen {
+						} else {
 							m.closeCompletions()
 						}
 					}
@@ -2496,7 +2502,7 @@ func (m *UI) closeCompletions() {
 
 // insertCompletionText replaces the @query in the textarea with the given text.
 // Returns false if the replacement cannot be performed.
-func (m *UI) insertCompletionText(text string) bool {
+func (m *UI) insertCompletionText(text string, addSpace bool) bool {
 	value := m.textarea.Value()
 	if m.completionsStartIndex > len(value) {
 		return false
@@ -2507,14 +2513,22 @@ func (m *UI) insertCompletionText(text string) bool {
 	newValue := value[:m.completionsStartIndex] + text + value[endIdx:]
 	m.textarea.SetValue(newValue)
 	m.textarea.MoveToEnd()
-	m.textarea.InsertRune(' ')
+	if addSpace {
+		m.textarea.InsertRune(' ')
+	}
 	return true
 }
 
 // insertFileCompletion inserts the selected file path into the textarea,
 // replacing the @query, and adds the file as an attachment.
-func (m *UI) insertFileCompletion(path string) tea.Cmd {
-	if !m.insertCompletionText(path) {
+// If continueMode is true, no trailing space is added and the file is not attached.
+func (m *UI) insertFileCompletion(path string, continueMode bool) tea.Cmd {
+	if !m.insertCompletionText(path, !continueMode) {
+		return nil
+	}
+
+	// In continue mode, we don't add the file as an attachment yet.
+	if continueMode {
 		return nil
 	}
 
@@ -2559,7 +2573,7 @@ func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValu
 		displayText = item.URI
 	}
 
-	if !m.insertCompletionText(displayText) {
+	if !m.insertCompletionText(displayText, true) {
 		return nil
 	}
 


### PR DESCRIPTION
  This change implements Fish-shell style tab completion where Tab inserts
  the selected path and continues completion from that point, while Enter
  accepts and closes. This allows users to progressively navigate into
  directories (e.g., @/tmp -> Tab -> /tmp/test -> Tab -> /tmp/test/file).

  Key changes:
  - Add Continue key binding (Tab) separate from Select (Enter)
  - Add Continue field to SelectionMsg to indicate continue mode
  - Modify selectCurrent() to handle continue vs accept modes
  - Fix query extraction to handle paths with slashes correctly by using completionsStartIndex instead of textarea.Word()

  Files modified:
  - internal/ui/completions/keys.go
  - internal/ui/completions/completions.go
  - internal/ui/completions/completions_test.go
  - internal/ui/model/ui.go

  TEST=go test ./internal/ui/completions/... && go build .

closes #2166 2166

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
