### PR TITLE
refactor(lsp): use same handle file in client and manager

### DIFF
--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -329,26 +329,7 @@ func (c *Client) HandlesFile(path string) bool {
 		slog.Debug("File outside workspace", "name", c.name, "file", path, "workDir", c.workDir)
 		return false
 	}
-
-	// If no file types are specified, handle all files (backward compatibility).
-	if len(c.fileTypes) == 0 {
-		return true
-	}
-
-	kind := powernap.DetectLanguage(path)
-	name := strings.ToLower(filepath.Base(path))
-	for _, filetype := range c.fileTypes {
-		suffix := strings.ToLower(filetype)
-		if !strings.HasPrefix(suffix, ".") {
-			suffix = "." + suffix
-		}
-		if strings.HasSuffix(name, suffix) || filetype == string(kind) {
-			slog.Debug("Handles file", "name", c.name, "file", name, "filetype", filetype, "kind", kind)
-			return true
-		}
-	}
-	slog.Debug("Doesn't handle file", "name", c.name, "file", name)
-	return false
+	return handlesFiletype(c.name, c.fileTypes, path)
 }
 
 // OpenFile opens a file in the LSP server.


### PR DESCRIPTION
this should work better when the lsp config has no filetypes (e.g. user set-up).