### PR TITLE
[UI] Add copy disambiguation for attachments in user messages (#2169)

### DIFF
--- a/internal/ui/attachments/attachments_test.go
+++ b/internal/ui/attachments/attachments_test.go
@@ -1,0 +1,211 @@
+package attachments
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestRenderer creates a renderer with test styles.
+func createTestRenderer() *Renderer {
+	baseStyle := lipgloss.NewStyle()
+	normalStyle := baseStyle.Padding(0, 1).MarginRight(1).Background(lipgloss.Color("#555")).Foreground(lipgloss.Color("#fff"))
+	deletingStyle := baseStyle.Padding(0, 1).Bold(true).Background(lipgloss.Color("#f00")).Foreground(lipgloss.Color("#fff"))
+	copySelectingStyle := baseStyle.Padding(0, 1).Bold(true).Background(lipgloss.Color("#00f")).Foreground(lipgloss.Color("#fff"))
+	imageStyle := baseStyle.Foreground(lipgloss.Color("#0f0")).Background(lipgloss.Color("#555")).Padding(0, 1)
+	textStyle := baseStyle.Foreground(lipgloss.Color("#ff0")).Background(lipgloss.Color("#555")).Padding(0, 1)
+
+	return NewRenderer(normalStyle, deletingStyle, copySelectingStyle, imageStyle, textStyle)
+}
+
+// createTestAttachments creates test attachments.
+func createTestAttachments(n int) []message.Attachment {
+	attachments := make([]message.Attachment, n)
+	for i := range n {
+		mimeType := "text/plain"
+		if i%2 == 1 {
+			mimeType = "image/png"
+		}
+		attachments[i] = message.Attachment{
+			FilePath: "/path/to/file",
+			FileName: "file" + string(rune('0'+i)) + ".txt",
+			MimeType: mimeType,
+			Content:  []byte("content"),
+		}
+	}
+	return attachments
+}
+
+func TestRenderer_Render_NormalMode(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestRenderer()
+	atts := createTestAttachments(3)
+
+	result := renderer.Render(atts, false, 100)
+
+	require.NotEmpty(t, result)
+	// Should not contain indices in normal mode
+	require.NotContains(t, result, "[0]")
+	require.NotContains(t, result, "[1]")
+	require.NotContains(t, result, "[2]")
+}
+
+func TestRenderer_Render_DeleteMode(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestRenderer()
+	atts := createTestAttachments(3)
+
+	result := renderer.Render(atts, true, 100)
+
+	require.NotEmpty(t, result)
+	// In delete mode, indices should be visible
+	require.Contains(t, result, "0")
+	require.Contains(t, result, "1")
+	require.Contains(t, result, "2")
+}
+
+func TestRenderer_RenderWithMode_CopySelecting(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestRenderer()
+	atts := createTestAttachments(3)
+
+	result := renderer.RenderWithMode(atts, false, true, 100)
+
+	require.NotEmpty(t, result)
+	// In copy selecting mode, indices should be visible
+	require.Contains(t, result, "0")
+	require.Contains(t, result, "1")
+	require.Contains(t, result, "2")
+}
+
+func TestRenderer_RenderWithMode_Normal(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestRenderer()
+	atts := createTestAttachments(3)
+
+	result := renderer.RenderWithMode(atts, false, false, 100)
+
+	require.NotEmpty(t, result)
+	// Should not contain indices in normal mode
+	// (checking that the index numbers aren't there as standalone tokens)
+	lines := strings.Split(result, "\n")
+	for _, line := range lines {
+		// The result should not have bare numbers that look like indices
+		// This is a heuristic check
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "0" || trimmed == "1" || trimmed == "2" {
+			t.Errorf("Normal mode should not show indices, found: %s", trimmed)
+		}
+	}
+}
+
+func TestRenderer_RenderWithMode_DeleteAndCopy(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestRenderer()
+	atts := createTestAttachments(2)
+
+	// When both deleting and copySelecting are true, deleting takes precedence
+	result := renderer.RenderWithMode(atts, true, true, 100)
+
+	require.NotEmpty(t, result)
+	// Should still render with indices
+	require.Contains(t, result, "0")
+	require.Contains(t, result, "1")
+}
+
+func TestRenderer_Render_EmptyAttachments(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestRenderer()
+	var atts []message.Attachment
+
+	result := renderer.Render(atts, false, 100)
+
+	require.Empty(t, result)
+}
+
+func TestRenderer_RenderWithMode_EmptyAttachments(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestRenderer()
+	var atts []message.Attachment
+
+	result := renderer.RenderWithMode(atts, false, true, 100)
+
+	require.Empty(t, result)
+}
+
+func TestRenderer_Render_LongFilenameTruncation(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestRenderer()
+	atts := []message.Attachment{
+		{
+			FilePath: "/path/to/very-long-filename-that-should-be-truncated.txt",
+			FileName: "very-long-filename-that-should-be-truncated.txt",
+			MimeType: "text/plain",
+		},
+	}
+
+	result := renderer.Render(atts, false, 100)
+
+	require.NotEmpty(t, result)
+	// The result should not contain the full long filename
+	require.NotContains(t, result, "very-long-filename-that-should-be-truncated.txt")
+}
+
+func TestRenderer_Icon_TextAttachment(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestRenderer()
+	textAtt := message.Attachment{
+		FilePath: "/path/to/file.txt",
+		FileName: "file.txt",
+		MimeType: "text/plain",
+	}
+
+	icon := renderer.icon(textAtt)
+
+	// Should return text style (not image style)
+	// We can't directly compare styles, but we can verify it's not nil
+	require.NotNil(t, icon)
+}
+
+func TestRenderer_Icon_ImageAttachment(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestRenderer()
+	imageAtt := message.Attachment{
+		FilePath: "/path/to/image.png",
+		FileName: "image.png",
+		MimeType: "image/png",
+	}
+
+	icon := renderer.icon(imageAtt)
+
+	// Should return image style
+	require.NotNil(t, icon)
+}
+
+func TestRenderer_Render_MoreAttachmentsIndicator(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestRenderer()
+	// Create many attachments to trigger the "more..." indicator
+	atts := createTestAttachments(10)
+
+	// Render with a narrow width to force the "more..." indicator
+	result := renderer.Render(atts, false, 50)
+
+	require.NotEmpty(t, result)
+	// Should contain "more" indicator
+	require.Contains(t, strings.ToLower(result), "more")
+}

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -263,6 +263,7 @@ func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults m
 		r := attachments.NewRenderer(
 			sty.Attachments.Normal,
 			sty.Attachments.Deleting,
+			sty.Attachments.CopySelecting,
 			sty.Attachments.Image,
 			sty.Attachments.Text,
 		)

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -9,7 +10,18 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/util"
 )
+
+// copyModeState represents the state of copy selection mode.
+type copyModeState int
+
+const (
+	copyModeInactive copyModeState = iota
+	copyModeSelecting
+)
+
+const copyModeTimeout = 5 * time.Second
 
 // UserMessageItem represents a user message in the chat UI.
 type UserMessageItem struct {
@@ -17,20 +29,23 @@ type UserMessageItem struct {
 	*cachedMessageItem
 	*focusableMessageItem
 
-	attachments *attachments.Renderer
-	message     *message.Message
-	sty         *styles.Styles
+	attachments   *attachments.Renderer
+	message       *message.Message
+	sty           *styles.Styles
+	copyMode      copyModeState
+	copyModeTimer time.Time
 }
 
 // NewUserMessageItem creates a new UserMessageItem.
-func NewUserMessageItem(sty *styles.Styles, message *message.Message, attachments *attachments.Renderer) MessageItem {
+func NewUserMessageItem(sty *styles.Styles, message *message.Message, attachmentsRenderer *attachments.Renderer) MessageItem {
 	return &UserMessageItem{
 		highlightableMessageItem: defaultHighlighter(sty),
 		cachedMessageItem:        &cachedMessageItem{},
 		focusableMessageItem:     &focusableMessageItem{},
-		attachments:              attachments,
+		attachments:              attachmentsRenderer,
 		message:                  message,
 		sty:                      sty,
+		copyMode:                 copyModeInactive,
 	}
 }
 
@@ -84,21 +99,119 @@ func (m *UserMessageItem) ID() string {
 
 // renderAttachments renders attachments.
 func (m *UserMessageItem) renderAttachments(width int) string {
-	var attachments []message.Attachment
+	var atts []message.Attachment
 	for _, at := range m.message.BinaryContent() {
-		attachments = append(attachments, message.Attachment{
+		atts = append(atts, message.Attachment{
 			FileName: at.Path,
 			MimeType: at.MIMEType,
 		})
 	}
-	return m.attachments.Render(attachments, false, width)
+	return m.attachments.RenderWithMode(atts, false, m.copyMode == copyModeSelecting, width)
 }
 
 // HandleKeyEvent implements KeyEventHandler.
-func (m *UserMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
-	if k := key.String(); k == "c" || k == "y" {
-		text := m.message.Content().Text
-		return true, common.CopyToClipboard(text, "Message copied to clipboard")
+func (m *UserMessageItem) HandleKeyEvent(keyMsg tea.KeyMsg) (bool, tea.Cmd) {
+	k := keyMsg.String()
+
+	// Check if copy mode has timed out
+	if m.copyMode == copyModeSelecting && time.Since(m.copyModeTimer) > copyModeTimeout {
+		m.copyMode = copyModeInactive
+		m.clearCache()
 	}
+
+	// Handle copy mode selection
+	if m.copyMode == copyModeSelecting {
+		switch k {
+		case "esc":
+			m.copyMode = copyModeInactive
+			m.clearCache()
+			return true, nil
+		case "enter", "c", "y":
+			// Copy message text (default behavior)
+			m.copyMode = copyModeInactive
+			m.clearCache()
+			text := m.message.Content().Text
+			return true, common.CopyToClipboard(text, "Message text copied to clipboard")
+		case "a":
+			// Copy all text attachment contents
+			m.copyMode = copyModeInactive
+			m.clearCache()
+			return m.copyAllTextAttachments()
+		default:
+			// Check for digit keys (0-9)
+			if len(k) == 1 && k[0] >= '0' && k[0] <= '9' {
+				idx := int(k[0] - '0')
+				binaryContent := m.message.BinaryContent()
+				if idx < len(binaryContent) {
+					m.copyMode = copyModeInactive
+					m.clearCache()
+					return m.copyAttachmentAtIndex(idx)
+				}
+			}
+			// Invalid key, stay in copy mode but refresh timer
+			m.copyModeTimer = time.Now()
+			return true, util.ReportInfo("Press 0-9 for attachment, Enter for message text, Esc to cancel")
+		}
+	}
+
+	// Initiate copy mode
+	if k == "c" || k == "y" {
+		binaryContent := m.message.BinaryContent()
+
+		// If no attachments, copy message text directly
+		if len(binaryContent) == 0 {
+			text := m.message.Content().Text
+			return true, common.CopyToClipboard(text, "Message copied to clipboard")
+		}
+
+		// If only one text attachment, copy it directly (shortcut)
+		if len(binaryContent) == 1 && strings.HasPrefix(binaryContent[0].MIMEType, "text/") {
+			return m.copyAttachmentAtIndex(0)
+		}
+
+		// Enter copy selection mode
+		m.copyMode = copyModeSelecting
+		m.copyModeTimer = time.Now()
+		m.clearCache() // Clear cache to show attachment indices
+		return true, util.ReportInfo("Press 0-9 to copy attachment, Enter for message text, A for all text, Esc to cancel")
+	}
+
 	return false, nil
+}
+
+// copyAttachmentAtIndex copies the attachment at the given index.
+func (m *UserMessageItem) copyAttachmentAtIndex(idx int) (bool, tea.Cmd) {
+	binaryContent := m.message.BinaryContent()
+	if idx >= len(binaryContent) {
+		return false, nil
+	}
+
+	att := binaryContent[idx]
+	if strings.HasPrefix(att.MIMEType, "text/") && len(att.Data) > 0 {
+		return true, common.CopyToClipboard(string(att.Data), "Attachment content copied to clipboard")
+	}
+	// For binary attachments, copy the path
+	return true, common.CopyToClipboard(att.Path, "Attachment path copied to clipboard")
+}
+
+// copyAllTextAttachments copies all text attachment contents.
+func (m *UserMessageItem) copyAllTextAttachments() (bool, tea.Cmd) {
+	binaryContent := m.message.BinaryContent()
+	var textContents []string
+
+	for _, bc := range binaryContent {
+		if strings.HasPrefix(bc.MIMEType, "text/") && len(bc.Data) > 0 {
+			textContents = append(textContents, string(bc.Data))
+		}
+	}
+
+	if len(textContents) > 0 {
+		return true, common.CopyToClipboard(strings.Join(textContents, "\n\n"), "All attachment contents copied to clipboard")
+	}
+	// No text attachments found, copy all paths
+	var paths []string
+	for _, bc := range binaryContent {
+		paths = append(paths, bc.Path)
+	}
+	return true, common.CopyToClipboard(strings.Join(paths, "\n"), "Attachment paths copied to clipboard")
 }

--- a/internal/ui/chat/user_test.go
+++ b/internal/ui/chat/user_test.go
@@ -1,0 +1,358 @@
+package chat
+
+import (
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/stretchr/testify/require"
+)
+
+// makeKeyMsg creates a tea.KeyPressMsg for testing.
+func makeKeyMsg(code rune, text string) tea.KeyPressMsg {
+	return tea.KeyPressMsg(tea.Key{
+		Code: code,
+		Text: text,
+	})
+}
+
+// makeSpecialKeyMsg creates a tea.KeyPressMsg for special keys (enter, esc, etc).
+func makeSpecialKeyMsg(code rune) tea.KeyPressMsg {
+	return tea.KeyPressMsg(tea.Key{
+		Code: code,
+		Text: "",
+	})
+}
+
+// createTestStyles creates a styles object for testing.
+func createTestStyles() *styles.Styles {
+	s := styles.DefaultStyles()
+	return &s
+}
+
+// createTestAttachmentRenderer creates an attachment renderer for testing.
+func createTestAttachmentRenderer() *attachments.Renderer {
+	sty := createTestStyles()
+	return attachments.NewRenderer(
+		sty.Attachments.Normal,
+		sty.Attachments.Deleting,
+		sty.Attachments.CopySelecting,
+		sty.Attachments.Image,
+		sty.Attachments.Text,
+	)
+}
+
+// createTestMessage creates a test message with optional binary content.
+func createTestMessage(id, text string, binaryContent ...message.BinaryContent) *message.Message {
+	msg := &message.Message{
+		ID: id,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: text},
+		},
+	}
+	for _, bc := range binaryContent {
+		msg.Parts = append(msg.Parts, bc)
+	}
+	return msg
+}
+
+// createTextAttachment creates a text attachment for testing.
+func createTextAttachment(path string, data []byte) message.BinaryContent {
+	return message.BinaryContent{
+		Path:     path,
+		MIMEType: "text/plain",
+		Data:     data,
+	}
+}
+
+// createImageAttachment creates an image attachment for testing.
+func createImageAttachment(path string) message.BinaryContent {
+	return message.BinaryContent{
+		Path:     path,
+		MIMEType: "image/png",
+		Data:     []byte("fake-image-data"),
+	}
+}
+
+func TestUserMessageItem_HandleKeyEvent_NoAttachments(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestAttachmentRenderer()
+	msg := createTestMessage("msg-1", "Hello, world!")
+	item := NewUserMessageItem(createTestStyles(), msg, renderer).(*UserMessageItem)
+
+	// Press 'c' - should copy message text directly
+	keyMsg := makeKeyMsg('c', "c")
+	handled, cmd := item.HandleKeyEvent(keyMsg)
+
+	require.True(t, handled, "Expected key event to be handled")
+	require.NotNil(t, cmd, "Expected a command to be returned")
+	require.Equal(t, copyModeInactive, item.copyMode, "Copy mode should remain inactive")
+}
+
+func TestUserMessageItem_HandleKeyEvent_SingleTextAttachment(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestAttachmentRenderer()
+	attachmentContent := []byte("Attachment content here")
+	msg := createTestMessage(
+		"msg-1",
+		"Message text",
+		createTextAttachment("file.txt", attachmentContent),
+	)
+	item := NewUserMessageItem(createTestStyles(), msg, renderer).(*UserMessageItem)
+
+	// Press 'c' - should copy attachment content directly (shortcut for single text attachment)
+	keyMsg := makeKeyMsg('c', "c")
+	handled, cmd := item.HandleKeyEvent(keyMsg)
+
+	require.True(t, handled, "Expected key event to be handled")
+	require.NotNil(t, cmd, "Expected a command to be returned")
+	// Copy mode should remain inactive since we copied directly
+	require.Equal(t, copyModeInactive, item.copyMode, "Copy mode should remain inactive for single text attachment shortcut")
+}
+
+func TestUserMessageItem_HandleKeyEvent_MultipleAttachments_EntersCopyMode(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestAttachmentRenderer()
+	msg := createTestMessage(
+		"msg-1",
+		"Message text",
+		createTextAttachment("file1.txt", []byte("Content 1")),
+		createTextAttachment("file2.txt", []byte("Content 2")),
+	)
+	item := NewUserMessageItem(createTestStyles(), msg, renderer).(*UserMessageItem)
+
+	// Press 'c' - should enter copy selection mode
+	keyMsg := makeKeyMsg('c', "c")
+	handled, cmd := item.HandleKeyEvent(keyMsg)
+
+	require.True(t, handled, "Expected key event to be handled")
+	require.NotNil(t, cmd, "Expected a command to be returned")
+	require.Equal(t, copyModeSelecting, item.copyMode, "Should enter copy selection mode")
+	require.False(t, item.copyModeTimer.IsZero(), "Copy mode timer should be set")
+}
+
+func TestUserMessageItem_HandleKeyEvent_CopyMode_CopyAttachmentByIndex(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestAttachmentRenderer()
+	msg := createTestMessage(
+		"msg-1",
+		"Message text",
+		createTextAttachment("file1.txt", []byte("Content 1")),
+		createTextAttachment("file2.txt", []byte("Content 2")),
+	)
+	item := NewUserMessageItem(createTestStyles(), msg, renderer).(*UserMessageItem)
+
+	// Enter copy mode
+	item.copyMode = copyModeSelecting
+	item.copyModeTimer = time.Now()
+
+	// Press '1' - should copy attachment at index 1
+	keyMsg := makeKeyMsg('1', "1")
+	handled, cmd := item.HandleKeyEvent(keyMsg)
+
+	require.True(t, handled, "Expected key event to be handled")
+	require.NotNil(t, cmd, "Expected a command to be returned")
+	require.Equal(t, copyModeInactive, item.copyMode, "Copy mode should be deactivated after copying")
+}
+
+func TestUserMessageItem_HandleKeyEvent_CopyMode_CopyMessageText(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestAttachmentRenderer()
+	msg := createTestMessage(
+		"msg-1",
+		"Message text",
+		createTextAttachment("file1.txt", []byte("Content 1")),
+	)
+	item := NewUserMessageItem(createTestStyles(), msg, renderer).(*UserMessageItem)
+
+	// Enter copy mode
+	item.copyMode = copyModeSelecting
+	item.copyModeTimer = time.Now()
+
+	// Press 'enter' - should copy message text
+	keyMsg := makeSpecialKeyMsg(tea.KeyEnter)
+	handled, cmd := item.HandleKeyEvent(keyMsg)
+
+	require.True(t, handled, "Expected key event to be handled")
+	require.NotNil(t, cmd, "Expected a command to be returned")
+	require.Equal(t, copyModeInactive, item.copyMode, "Copy mode should be deactivated after copying")
+}
+
+func TestUserMessageItem_HandleKeyEvent_CopyMode_CopyAllTextAttachments(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestAttachmentRenderer()
+	msg := createTestMessage(
+		"msg-1",
+		"Message text",
+		createTextAttachment("file1.txt", []byte("Content 1")),
+		createTextAttachment("file2.txt", []byte("Content 2")),
+	)
+	item := NewUserMessageItem(createTestStyles(), msg, renderer).(*UserMessageItem)
+
+	// Enter copy mode
+	item.copyMode = copyModeSelecting
+	item.copyModeTimer = time.Now()
+
+	// Press 'a' - should copy all text attachment contents
+	keyMsg := makeKeyMsg('a', "a")
+	handled, cmd := item.HandleKeyEvent(keyMsg)
+
+	require.True(t, handled, "Expected key event to be handled")
+	require.NotNil(t, cmd, "Expected a command to be returned")
+	require.Equal(t, copyModeInactive, item.copyMode, "Copy mode should be deactivated after copying")
+}
+
+func TestUserMessageItem_HandleKeyEvent_CopyMode_Cancel(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestAttachmentRenderer()
+	msg := createTestMessage(
+		"msg-1",
+		"Message text",
+		createTextAttachment("file1.txt", []byte("Content 1")),
+	)
+	item := NewUserMessageItem(createTestStyles(), msg, renderer).(*UserMessageItem)
+
+	// Enter copy mode
+	item.copyMode = copyModeSelecting
+	item.copyModeTimer = time.Now()
+
+	// Press 'esc' - should cancel copy mode
+	keyMsg := makeSpecialKeyMsg(tea.KeyEscape)
+	handled, cmd := item.HandleKeyEvent(keyMsg)
+
+	require.True(t, handled, "Expected key event to be handled")
+	require.Nil(t, cmd, "Expected no command for cancel")
+	require.Equal(t, copyModeInactive, item.copyMode, "Copy mode should be deactivated")
+}
+
+func TestUserMessageItem_HandleKeyEvent_CopyMode_InvalidKey(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestAttachmentRenderer()
+	msg := createTestMessage(
+		"msg-1",
+		"Message text",
+		createTextAttachment("file1.txt", []byte("Content 1")),
+	)
+	item := NewUserMessageItem(createTestStyles(), msg, renderer).(*UserMessageItem)
+
+	// Enter copy mode
+	item.copyMode = copyModeSelecting
+	originalTime := time.Now()
+	item.copyModeTimer = originalTime
+
+	// Press 'z' (invalid key) - should stay in copy mode and refresh timer
+	time.Sleep(10 * time.Millisecond) // Ensure time passes
+	keyMsg := makeKeyMsg('z', "z")
+	handled, cmd := item.HandleKeyEvent(keyMsg)
+
+	require.True(t, handled, "Expected key event to be handled")
+	require.NotNil(t, cmd, "Expected info command for invalid key")
+	require.Equal(t, copyModeSelecting, item.copyMode, "Should remain in copy selection mode")
+	require.True(t, item.copyModeTimer.After(originalTime), "Copy mode timer should be refreshed")
+}
+
+func TestUserMessageItem_HandleKeyEvent_CopyMode_Timeout(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestAttachmentRenderer()
+	// Need multiple attachments to ensure copy mode is re-entered after timeout
+	msg := createTestMessage(
+		"msg-1",
+		"Message text",
+		createTextAttachment("file1.txt", []byte("Content 1")),
+		createTextAttachment("file2.txt", []byte("Content 2")),
+	)
+	item := NewUserMessageItem(createTestStyles(), msg, renderer).(*UserMessageItem)
+
+	// Enter copy mode with an expired timer
+	item.copyMode = copyModeSelecting
+	item.copyModeTimer = time.Now().Add(-10 * time.Second) // Expired 10 seconds ago
+
+	// Press 'c' - should be treated as new copy initiation since mode timed out
+	keyMsg := makeKeyMsg('c', "c")
+	handled, _ := item.HandleKeyEvent(keyMsg)
+
+	require.True(t, handled, "Expected key event to be handled")
+	// After timeout, copy mode should be re-entered (due to multiple attachments)
+	require.Equal(t, copyModeSelecting, item.copyMode, "Should re-enter copy selection mode")
+}
+
+func TestUserMessageItem_HandleKeyEvent_BinaryAttachment_CopiesPath(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestAttachmentRenderer()
+	msg := createTestMessage(
+		"msg-1",
+		"Message text",
+		createImageAttachment("image.png"),
+	)
+	item := NewUserMessageItem(createTestStyles(), msg, renderer).(*UserMessageItem)
+
+	// Enter copy mode
+	item.copyMode = copyModeSelecting
+	item.copyModeTimer = time.Now()
+
+	// Press '0' - should copy attachment path (since it's binary)
+	keyMsg := makeKeyMsg('0', "0")
+	handled, cmd := item.HandleKeyEvent(keyMsg)
+
+	require.True(t, handled, "Expected key event to be handled")
+	require.NotNil(t, cmd, "Expected a command to be returned")
+	require.Equal(t, copyModeInactive, item.copyMode, "Copy mode should be deactivated")
+}
+
+func TestUserMessageItem_HandleKeyEvent_IndexOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestAttachmentRenderer()
+	msg := createTestMessage(
+		"msg-1",
+		"Message text",
+		createTextAttachment("file1.txt", []byte("Content 1")),
+	)
+	item := NewUserMessageItem(createTestStyles(), msg, renderer).(*UserMessageItem)
+
+	// Enter copy mode
+	item.copyMode = copyModeSelecting
+	item.copyModeTimer = time.Now()
+
+	// Press '5' - index out of range, should stay in copy mode
+	keyMsg := makeKeyMsg('5', "5")
+	handled, cmd := item.HandleKeyEvent(keyMsg)
+
+	require.True(t, handled, "Expected key event to be handled")
+	require.NotNil(t, cmd, "Expected info command for invalid index")
+	require.Equal(t, copyModeSelecting, item.copyMode, "Should remain in copy selection mode")
+}
+
+func TestUserMessageItem_CopyMode_UsesYKey(t *testing.T) {
+	t.Parallel()
+
+	renderer := createTestAttachmentRenderer()
+	msg := createTestMessage(
+		"msg-1",
+		"Message text",
+		createTextAttachment("file1.txt", []byte("Content 1")),
+		createTextAttachment("file2.txt", []byte("Content 2")),
+	)
+	item := NewUserMessageItem(createTestStyles(), msg, renderer).(*UserMessageItem)
+
+	// Press 'y' - should also enter copy selection mode
+	keyMsg := makeKeyMsg('y', "y")
+	handled, cmd := item.HandleKeyEvent(keyMsg)
+
+	require.True(t, handled, "Expected key event to be handled")
+	require.NotNil(t, cmd, "Expected a command to be returned")
+	require.Equal(t, copyModeSelecting, item.copyMode, "Should enter copy selection mode with 'y' key")
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -262,6 +262,7 @@ func New(com *common.Common) *UI {
 		attachments.NewRenderer(
 			com.Styles.Attachments.Normal,
 			com.Styles.Attachments.Deleting,
+			com.Styles.Attachments.CopySelecting,
 			com.Styles.Attachments.Image,
 			com.Styles.Attachments.Text,
 		),

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -422,10 +422,11 @@ type Styles struct {
 
 	// Attachments styles
 	Attachments struct {
-		Normal   lipgloss.Style
-		Image    lipgloss.Style
-		Text     lipgloss.Style
-		Deleting lipgloss.Style
+		Normal        lipgloss.Style
+		Image         lipgloss.Style
+		Text          lipgloss.Style
+		Deleting      lipgloss.Style
+		CopySelecting lipgloss.Style
 	}
 
 	// Pills styles for todo/queue pills
@@ -1340,6 +1341,7 @@ func DefaultStyles() Styles {
 	s.Attachments.Text = attachmentIconStyle.SetString(TextIcon)
 	s.Attachments.Normal = base.Padding(0, 1).MarginRight(1).Background(fgMuted).Foreground(fgBase)
 	s.Attachments.Deleting = base.Padding(0, 1).Bold(true).Background(red).Foreground(fgBase)
+	s.Attachments.CopySelecting = base.Padding(0, 1).Bold(true).Background(primary).Foreground(fgBase)
 
 	// Pills styles
 	s.Pills.Base = base.Padding(0, 1)


### PR DESCRIPTION
Description:
When a user message contains both text content and attachments (particularly pasted text files), pressing 'c' or 'y' to copy created ambiguity about whether to copy the message text or attachment content.

This CL implements a two-phase copy selection mode:
1. First 'c'/'y' press enters "copy selection mode" when multiple attachments exist, showing numbered indices on attachments
2. Second input selects what to copy:
   - 0-9: Copy attachment at index (content for text, path for binary)
   - Enter/c/y: Copy message text (preserves original behavior)
   - a: Copy ALL text attachment contents
   - Esc: Cancel selection mode
   - Timeout: Auto-cancel after 5 seconds of inactivity

[Screencast From 2026-02-08 09-43-51.webm](https://github.com/user-attachments/assets/2de6d75d-4959-436f-8cc2-f3bbbb0d7e84)


For single text attachments, the content is copied directly (shortcut). For messages without attachments, behavior remains unchanged.

Changes:
- Added copyModeState to UserMessageItem for tracking selection state
- Added CopySelecting style to attachments renderer
- Added RenderWithMode() to attachments.Renderer for index display
- Modified HandleKeyEvent() to implement two-phase selection
- Added copyAttachmentAtIndex() and copyAllTextAttachments() helpers
- Added cache clearing when copy mode changes for visual updates

Files modified:
- internal/ui/styles/styles.go: Added CopySelecting style
- internal/ui/attachments/attachments.go: Added RenderWithMode()
- internal/ui/chat/user.go: Implemented copy selection logic
- internal/ui/chat/messages.go: Updated NewRenderer call
- internal/ui/model/ui.go: Updated NewRenderer call

Tested:
- Unit tests added for copy mode functionality (12 tests)
- Unit tests added for attachment rendering with indices (11 tests)
- All existing tests pass
- Manual testing scenarios:
  * Message without attachments → copies message text
  * Single text attachment → copies attachment content directly
  * Multiple text attachments → enters selection mode
  * Mixed attachments → copies appropriate content by index
  * Binary attachment → copies file path
  * Timeout behavior verified

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

# Discussion
#2169 
