### PR TITLE
Fix: Chinese text not copied correctly to clipboard (#2155)

### DIFF
--- a/internal/ui/list/highlight.go
+++ b/internal/ui/list/highlight.go
@@ -126,7 +126,7 @@ func HighlightBuffer(content string, area image.Rectangle, startLine, startCol, 
 			}
 			cell := line.At(x)
 			if cell != nil {
-				line.Set(x, highlighter(x, y, cell))
+				highlighter(x, y, cell)
 			}
 		}
 	}


### PR DESCRIPTION
# Fix: Chinese text not copied correctly to clipboard

## Problem

When selecting and copying text containing Chinese (or other wide) characters, only the English content was copied. The Chinese characters were replaced with spaces.

**Example:**
- Original text: `"你好！我是Crush"`
- Copied text: `"   !    Crush"` (with unwanted spaces)

## Root Cause

Wide characters (like Chinese) occupy 2 terminal columns:
- Position 0: Stores "你" with `Width = 2`
- Position 1: Placeholder cell with `Width = 0` (empty content)

The `line.Set()` function in ultraviolet has a side-effect, when called on a wide character, it first empties all associated cells including placeholders before writing the new value. This converted placeholder cells into space characters.

## Solution I found

In `HighlightBuffer`, replaced `line.Set()` with a direct highlighter call:

```go
// Before (broken):
line.Set(x, highlighter(x, y, cell))

// After (fixed):
highlighter(x, y, cell)
```

Since highlighting only modifies the cell's **style** (not content/width), and the highlighter receives a pointer, calling it directly modifies the cell in place without triggering the corruption side-effect.

## Testing

- [x] `task build` passes
- [x] `task test` passes
- [x] Manual verification: Chinese text can be selected and copied correctly :))


- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
