### PR TITLE
fix(sqlite): increase busy timeout

### DIFF
--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -10,6 +10,16 @@ import (
 	"github.com/pressly/goose/v3"
 )
 
+var pragmas = map[string]string{
+	"foreign_keys":  "ON",
+	"journal_mode":  "WAL",
+	"page_size":     "4096",
+	"cache_size":    "-8000",
+	"synchronous":   "NORMAL",
+	"secure_delete": "ON",
+	"busy_timeout":  "30000",
+}
+
 // Connect opens a SQLite database connection and runs migrations.
 func Connect(ctx context.Context, dataDir string) (*sql.DB, error) {
 	if dataDir == "" {

--- a/internal/db/connect_modernc.go
+++ b/internal/db/connect_modernc.go
@@ -14,18 +14,15 @@ func openDB(dbPath string) (*sql.DB, error) {
 	// Set pragmas for better performance via _pragma query params.
 	// Format: _pragma=name(value)
 	params := url.Values{}
-	params.Add("_pragma", "foreign_keys(on)")
-	params.Add("_pragma", "journal_mode(WAL)")
-	params.Add("_pragma", "page_size(4096)")
-	params.Add("_pragma", "cache_size(-8000)")
-	params.Add("_pragma", "synchronous(NORMAL)")
-	params.Add("_pragma", "secure_delete(on)")
-	params.Add("_pragma", "busy_timeout(5000)")
+	for name, value := range pragmas {
+		params.Add("_pragma", fmt.Sprintf("%s(%s)", name, value))
+	}
 
 	dsn := fmt.Sprintf("file:%s?%s", dbPath, params.Encode())
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
+
 	return db, nil
 }


### PR DESCRIPTION
Also refactor so we have the same pragmas on both drivers.

I couldn't reproduce OP's issue, but they're likely trying to use many Crush instances at the same time, which may cause this.

The timeout was 5s only, so it was kind of easy to hit under load, I presume. Upping it to 30s should improve that. AFAIK there's no much else we can do.

See https://www.sqlite.org/rescode.html#busy

Closes #2129
