### PR TITLE
fix: change binding to open/close todo list from `ctrl+space` to `ctrl+t`

### DIFF
--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -173,8 +173,8 @@ func DefaultKeyMap() KeyMap {
 		key.WithHelp("ctrl+d", "toggle details"),
 	)
 	km.Chat.TogglePills = key.NewBinding(
-		key.WithKeys("ctrl+space"),
-		key.WithHelp("ctrl+space", "toggle tasks"),
+		key.WithKeys("ctrl+t", "ctrl+space"),
+		key.WithHelp("ctrl+t", "toggle tasks"),
 	)
 	km.Chat.PillLeft = key.NewBinding(
 		key.WithKeys("left"),

--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -270,7 +270,7 @@ func (m *UI) renderPills() {
 	if m.pillsExpanded {
 		helpDesc = "close"
 	}
-	helpKey := t.Pills.HelpKey.Render("ctrl+space")
+	helpKey := t.Pills.HelpKey.Render("ctrl+t")
 	helpText := t.Pills.HelpText.Render(helpDesc)
 	helpHint := lipgloss.JoinHorizontal(lipgloss.Center, helpKey, " ", helpText)
 	pillsRow = lipgloss.JoinHorizontal(lipgloss.Center, pillsRow, " ", helpHint)


### PR DESCRIPTION
* Fixes #1618

<kbd>ctrl+space</kbd> is used by some terminal emulators and operating system, so some users were enable to use it. <kbd>ctrl+t</kbd> should work everywhere.

<details><summary>Before</summary>
<p>

<img width="735" height="229" alt="Screenshot 2026-02-11 at 17 30 32" src="https://github.com/user-attachments/assets/7f7b62dd-ec9a-426a-885a-213f355ab6da" />

</p>
</details> 

<details><summary>After</summary>
<p>

<img width="689" height="222" alt="Screenshot 2026-02-11 at 17 31 51" src="https://github.com/user-attachments/assets/73630137-8bb8-4106-9100-e45c1271eb7d" />

</p>
</details> 


