### PR TITLE
feat(ui): move attachments below the editor

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1928,8 +1928,8 @@ func (m *UI) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 		if m.textarea.Focused() {
 			cur := m.textarea.Cursor()
-			cur.X++                            // Adjust for app margins
-			cur.Y += m.layout.editor.Min.Y + 1 // Offset for attachments row
+			cur.X++ // Adjust for app margins
+			cur.Y += m.layout.editor.Min.Y
 			return cur
 		}
 	}
@@ -2682,8 +2682,8 @@ func (m *UI) renderEditorView(width int) string {
 		attachmentsView = m.attachments.Render(width)
 	}
 	return strings.Join([]string{
-		attachmentsView,
 		m.textarea.View(),
+		attachmentsView,
 		"", // margin at bottom of editor
 	}, "\n")
 }


### PR DESCRIPTION
Experimenting with this.

Looks like this: 

<img width="1172" height="390" alt="CleanShot 2026-02-12 at 10 15 17@2x" src="https://github.com/user-attachments/assets/b77f4883-8f26-4522-afa5-d6baf1c3b0fc" />


What do you think?