### PR TITLE
fix(completions): use mcp resource URI as completion value

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2556,12 +2556,7 @@ func (m *UI) insertFileCompletion(path string) tea.Cmd {
 // insertMCPResourceCompletion inserts the selected resource into the textarea,
 // replacing the @query, and adds the resource as an attachment.
 func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValue) tea.Cmd {
-	displayText := item.Title
-	if displayText == "" {
-		displayText = item.URI
-	}
-
-	if !m.insertCompletionText(displayText) {
+	if !m.insertCompletionText(item.URI) {
 		return nil
 	}
 
@@ -2601,7 +2596,7 @@ func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValu
 
 		return message.Attachment{
 			FilePath: item.URI,
-			FileName: displayText,
+			FileName: item.URI,
 			MimeType: mimeType,
 			Content:  data,
 		}


### PR DESCRIPTION
The title might confuse the LLM, using the URI directly seems better.

<img width="568" height="210" alt="CleanShot 2026-02-12 at 10 31 14@2x" src="https://github.com/user-attachments/assets/d388c9f0-e096-4e3c-9aca-5f05ffbf956d" />

before it would add `completions.md` to the editor instead.