### PR TITLE
fix(ui): completions offset for attachments row

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1889,7 +1889,7 @@ func (m *UI) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 			x = screenW - w
 		}
 		x = max(0, x)
-		y = max(0, y)
+		y = max(0, y+1) // Offset for attachments row
 
 		completionsView := uv.NewStyledString(m.completions.Render())
 		completionsView.Draw(scr, image.Rectangle{


### PR DESCRIPTION
refs #2129

<img width="1120" height="606" alt="CleanShot 2026-02-12 at 11 05 27@2x" src="https://github.com/user-attachments/assets/94906bd5-e42e-4b83-98a9-3358b257e8ce" />
