### PR TITLE
feat: prefer gh CLI over web scraping for GitHub URLs

### DIFF
--- a/internal/agent/templates/agentic_fetch.md
+++ b/internal/agent/templates/agentic_fetch.md
@@ -52,6 +52,7 @@ DO NOT use this tool when:
 - For complex pages, ask the agent to focus on specific sections
 - The agent has access to web_search, web_fetch, grep, and view tools
 - If you just need raw content, use the fetch tool instead to save tokens
+- For GitHub content (PRs, issues, repos, commits), prefer using gh CLI via the bash tool instead of web_fetch for better data quality. This tool should be used as a fallback for GitHub URLs when gh CLI is unavailable or fails.
 </tips>
 
 <examples>

--- a/internal/agent/tools/bash.tpl
+++ b/internal/agent/tools/bash.tpl
@@ -42,6 +42,17 @@ Common shell builtins and core utils available on Windows.
   * Short-lived scripts
 </background_execution>
 
+<github_integration>
+**Note**: The gh CLI is available for all GitHub-related operations. When fetching GitHub content (PRs, issues, repos, commits), prefer gh CLI over web scraping:
+
+- `gh pr view <number> --repo <owner>/<repo> --json <fields>` - Fetch PR details
+- `gh issue view <number> --repo <owner>/<repo> --json <fields>` - Fetch issue details
+- `gh repo view <owner>/<repo> --json <fields>` - Fetch repository details
+- `gh api repos/<owner>/<repo>/commits/<sha>` - Fetch commit details
+
+This provides structured JSON data with better quality than HTML parsing. See the agentic_fetch sub-agent prompt for detailed field lists and usage examples.
+</github_integration>
+
 <git_commits>
 When user asks to create git commit:
 

--- a/internal/agent/tools/web_fetch.md
+++ b/internal/agent/tools/web_fetch.md
@@ -25,4 +25,5 @@ Fetches content from a web URL (for use by sub-agents).
 - For large pages saved to files, use grep to find relevant sections first
 - Don't fetch unnecessary pages - only when needed to answer the question
 - Focus on extracting specific information from the fetched content
+- For GitHub content (PRs, issues, repos, commits), prefer using gh CLI via the bash tool instead of web_fetch for better data quality. This tool should be used as a fallback for GitHub URLs when gh CLI is unavailable or fails.
 </tips>


### PR DESCRIPTION
## Summary

Add prompt instructions to guide agents to use `gh` CLI instead of `web_fetch` when fetching GitHub content (PRs, issues, repos, commits). This provides structured JSON data with better quality and reliability than HTML parsing.

## Changes

- **bash.tpl**: Add `<github_integration>` section with gh CLI command examples for PRs, issues, repos, and commits
- **agentic_fetch.md**: Add tip in `<tips>` section to prefer gh CLI for GitHub URLs
- **web_fetch.md**: Add tip to use gh CLI as primary method for GitHub content

## Benefits

- ✅ Better data quality with structured JSON vs fragile HTML parsing
- ✅ Access to rich metadata (reviews, check runs, reactions, timeline events)
- ✅ More reliable API contract vs HTML structure changes
- ✅ Faster direct API access vs web scraping overhead
- ✅ Graceful fallback to web_fetch if gh CLI fails

## Implementation Approach

This is a **prompt-driven solution** with no code changes required:
- Main agent sees GitHub URL → considers bash tool (with gh CLI guidance) instead of agentic_fetch
- If gh CLI fails → gracefully falls back to web_fetch
- Easy to rollback by reverting prompt files

## Test Plan

- [x] Test with PR URL: Verified agent uses gh CLI to fetch PR data
- [x] Test with issue URL: Verified agent uses gh CLI to fetch issue data
<img width="1902" height="553" alt="image" src="https://github.com/user-attachments/assets/ff8197d8-f53c-47d2-9bbd-e0a5cc58bcbb" />
- [x] Verified fallback: Confirmed web_fetch is used when gh CLI unavailable
<img width="1888" height="699" alt="image" src="https://github.com/user-attachments/assets/0dc1faf5-ebe9-458f-ae13-d48cabde4607" />


## Note on Test Failures

The test failures in `TestCoderAgent` are expected because the bash tool prompt was modified (added `<github_integration>` section), which changes the system prompt sent to the API. The VCR cassettes need to be re-recorded with the new prompt.

To fix: Delete or re-record the cassette files in `internal/agent/testdata/TestCoderAgent/*/` and run tests with valid API keys.

Closes #2215