### PR TITLE
fix(mcp): allow disabling standalone SSE stream

### DIFF
--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -422,8 +422,9 @@ func createTransport(ctx context.Context, m config.MCPConfig, resolver config.Va
 			},
 		}
 		return &mcp.StreamableClientTransport{
-			Endpoint:   m.URL,
-			HTTPClient: client,
+			Endpoint:             m.URL,
+			HTTPClient:           client,
+			DisableStandaloneSSE: m.DisableStandaloneSSE,
 		}, nil
 	case config.MCPSSE:
 		if strings.TrimSpace(m.URL) == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -183,6 +183,8 @@ type MCPConfig struct {
 
 	// TODO: maybe make it possible to get the value from the env
 	Headers map[string]string `json:"headers,omitempty" jsonschema:"description=HTTP headers for HTTP/SSE MCP servers"`
+
+	DisableStandaloneSSE bool `json:"disable_standalone_sse" jsonschema:"description=(HTTP only) Whether the client establishes a standalone SSE stream for receiving server-initiated messages,default=false"`
 }
 
 type LSPConfig struct {


### PR DESCRIPTION
This adds an option to set [DisableStandaloneSSE](https://pkg.go.dev/github.com/modelcontextprotocol/go-sdk@v1.3.0/mcp#StreamableClientTransport.DisableStandaloneSSE) (released in [modelcontextprotocol/go-sdk@`v1.3.0`](https://github.com/modelcontextprotocol/go-sdk/releases/tag/v1.3.0)) for `http` MCP servers. 

The feature is optional and servers that do not support will appear to hang, producing `context canceled` errors.

Sample config to reproduce the problem:

```json
{
  "$schema": "https://charm.land/crush.json",
  "mcp": {
    "tavily": {
      "type": "http",
      "url": "https://mcp.tavily.com/mcp/",
      "headers": {
        "Authorization": "Bearer $TAVILY_API_KEY"
      }
    }
  }
}
```

More context in modelcontextprotocol/go-sdk#729


- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
