### PR TITLE
feat: add npm distribution with optionalDependencies pattern

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,119 @@
+# Publish npm packages with optionalDependencies pattern
+# This workflow runs after the main release workflow completes
+# It creates platform-specific npm packages with embedded binaries
+
+name: NPM Publish (optionalDependencies)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 0.43.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build-npm-packages:
+    name: Build npm packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Get version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Download release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          mkdir -p dist
+          
+          # Download all archive files
+          gh release download "v${VERSION}" \
+            --pattern "crush_${VERSION}_*.tar.gz" \
+            --pattern "crush_${VERSION}_*.zip" \
+            --dir dist \
+            --skip-existing || true
+          
+          ls -la dist/
+
+      - name: Build npm packages
+        run: |
+          chmod +x scripts/npm-optional-deps/build-npm-packages.sh
+          ./scripts/npm-optional-deps/build-npm-packages.sh "${{ steps.version.outputs.version }}" ./dist
+
+      - name: Upload npm packages as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-packages
+          path: dist/npm/*.tgz
+          retention-days: 7
+
+  publish-npm:
+    name: Publish to npm
+    needs: build-npm-packages
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - name: Download npm packages
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-packages
+          path: packages
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: List packages
+        run: ls -la packages/
+
+      - name: Publish platform packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd packages
+          
+          # Publish platform packages first
+          for pkg in charmland-crush-linux-*.tgz charmland-crush-darwin-*.tgz charmland-crush-win32-*.tgz; do
+            if [ -f "$pkg" ]; then
+              echo "Publishing $pkg..."
+              npm publish "$pkg" --access public || echo "Failed to publish $pkg (may already exist)"
+            fi
+          done
+
+      - name: Publish main package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cd packages
+          
+          # Find and publish main package (the one without platform suffix)
+          for pkg in charmland-crush-[0-9]*.tgz; do
+            if [ -f "$pkg" ]; then
+              echo "Publishing main package: $pkg"
+              npm publish "$pkg" --access public
+            fi
+          done

--- a/scripts/npm-optional-deps/README.md
+++ b/scripts/npm-optional-deps/README.md
@@ -1,0 +1,98 @@
+# npm Distribution with optionalDependencies
+
+This directory contains scripts for building npm packages using the **optionalDependencies pattern** - the same approach used by esbuild, SWC, Turbo, and OpenCode.
+
+## Why This Approach?
+
+The default goreleaser npm publisher uses a postinstall script that downloads binaries from GitHub releases. This fails in environments where:
+
+- `registry.npmjs.org` is allowed (standard for development)
+- `github.com` / `objects.githubusercontent.com` is blocked (common security policy)
+
+The optionalDependencies pattern embeds binaries directly in platform-specific npm packages, so everything downloads from `registry.npmjs.org` only.
+
+## How It Works
+
+Instead of one package that downloads at install time:
+
+```
+@charmland/crush (postinstall downloads from GitHub) ❌
+```
+
+We create multiple packages with embedded binaries:
+
+```
+@charmland/crush (thin wrapper, no downloads)
+  └── optionalDependencies:
+      ├── @charmland/crush-linux-x64   (18MB binary embedded)
+      ├── @charmland/crush-linux-arm64 (18MB binary embedded)
+      ├── @charmland/crush-darwin-x64  (18MB binary embedded)
+      ├── @charmland/crush-darwin-arm64(18MB binary embedded)
+      ├── @charmland/crush-win32-x64   (18MB binary embedded)
+      └── ...
+```
+
+npm automatically installs only the package matching the user's platform.
+
+## Usage
+
+### Building Packages
+
+After running goreleaser (which creates the archives):
+
+```bash
+./scripts/npm-optional-deps/build-npm-packages.sh 0.43.0 ./dist
+```
+
+This creates:
+- `dist/npm/charmland-crush-linux-x64-0.43.0.tgz`
+- `dist/npm/charmland-crush-darwin-arm64-0.43.0.tgz`
+- `dist/npm/charmland-crush-0.43.0.tgz` (main package)
+- etc.
+
+### Publishing
+
+```bash
+cd dist/npm
+
+# Publish platform packages first
+npm publish charmland-crush-linux-x64-0.43.0.tgz --access public
+npm publish charmland-crush-darwin-arm64-0.43.0.tgz --access public
+# ... etc
+
+# Then publish main package
+npm publish charmland-crush-0.43.0.tgz --access public
+```
+
+### GitHub Actions
+
+The `.github/workflows/npm-publish.yml` workflow automates this process. It:
+1. Triggers on new releases
+2. Downloads release archives
+3. Builds npm packages
+4. Publishes to npm registry
+
+## Files
+
+- `build-npm-packages.sh` - Main build script
+- `crush-wrapper.js` - JavaScript wrapper that finds and executes the platform binary
+
+## Supported Platforms
+
+| Platform | Package |
+|----------|---------|
+| Linux x64 | `@charmland/crush-linux-x64` |
+| Linux ARM64 | `@charmland/crush-linux-arm64` |
+| Linux x86 | `@charmland/crush-linux-ia32` |
+| Linux ARM | `@charmland/crush-linux-arm` |
+| macOS x64 | `@charmland/crush-darwin-x64` |
+| macOS ARM64 | `@charmland/crush-darwin-arm64` |
+| Windows x64 | `@charmland/crush-win32-x64` |
+| Windows ARM64 | `@charmland/crush-win32-arm64` |
+| Windows x86 | `@charmland/crush-win32-ia32` |
+
+## References
+
+- [esbuild npm distribution](https://github.com/evanw/esbuild/blob/main/npm/esbuild/package.json)
+- [OpenCode npm distribution](https://github.com/anomalyco/opencode)
+- [Issue #2230](https://github.com/charmbracelet/crush/issues/2230) - Original feature request

--- a/scripts/npm-optional-deps/build-npm-packages.sh
+++ b/scripts/npm-optional-deps/build-npm-packages.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+# build-npm-packages.sh
+# Builds npm packages using the optionalDependencies pattern (like esbuild/opencode)
+# This creates platform-specific packages with embedded binaries instead of postinstall downloads
+#
+# Usage: ./scripts/npm-optional-deps/build-npm-packages.sh <version> <dist-dir>
+# Example: ./scripts/npm-optional-deps/build-npm-packages.sh 0.43.0 ./dist
+
+set -euo pipefail
+
+VERSION="${1:-}"
+DIST_DIR="${2:-./dist}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NPM_DIR="${DIST_DIR}/npm"
+
+if [ -z "$VERSION" ]; then
+    echo "Usage: $0 <version> [dist-dir]"
+    echo "Example: $0 0.43.0 ./dist"
+    exit 1
+fi
+
+echo "Building npm packages for Crush v${VERSION}"
+echo "Distribution directory: ${DIST_DIR}"
+
+# Clean and create npm directory
+rm -rf "${NPM_DIR}"
+mkdir -p "${NPM_DIR}"
+
+# Platform mappings: goreleaser archive name -> npm platform-arch
+declare -A PLATFORMS=(
+    ["Linux_x86_64"]="linux-x64"
+    ["Linux_arm64"]="linux-arm64"
+    ["Linux_i386"]="linux-ia32"
+    ["Linux_armv7"]="linux-arm"
+    ["Darwin_x86_64"]="darwin-x64"
+    ["Darwin_arm64"]="darwin-arm64"
+    ["Windows_x86_64"]="win32-x64"
+    ["Windows_arm64"]="win32-arm64"
+    ["Windows_i386"]="win32-ia32"
+)
+
+# OS mappings for package.json
+declare -A OS_MAP=(
+    ["linux-x64"]="linux"
+    ["linux-arm64"]="linux"
+    ["linux-ia32"]="linux"
+    ["linux-arm"]="linux"
+    ["darwin-x64"]="darwin"
+    ["darwin-arm64"]="darwin"
+    ["win32-x64"]="win32"
+    ["win32-arm64"]="win32"
+    ["win32-ia32"]="win32"
+)
+
+# CPU mappings for package.json
+declare -A CPU_MAP=(
+    ["linux-x64"]="x64"
+    ["linux-arm64"]="arm64"
+    ["linux-ia32"]="ia32"
+    ["linux-arm"]="arm"
+    ["darwin-x64"]="x64"
+    ["darwin-arm64"]="arm64"
+    ["win32-x64"]="x64"
+    ["win32-arm64"]="arm64"
+    ["win32-ia32"]="ia32"
+)
+
+OPTIONAL_DEPS=""
+BUILT_PLATFORMS=""
+
+# Build platform-specific packages
+for archive_suffix in "${!PLATFORMS[@]}"; do
+    npm_platform="${PLATFORMS[$archive_suffix]}"
+    os="${OS_MAP[$npm_platform]}"
+    cpu="${CPU_MAP[$npm_platform]}"
+    
+    # Find the archive
+    if [ "$os" = "win32" ]; then
+        archive="${DIST_DIR}/crush_${VERSION}_${archive_suffix}.zip"
+        binary_name="crush.exe"
+    else
+        archive="${DIST_DIR}/crush_${VERSION}_${archive_suffix}.tar.gz"
+        binary_name="crush"
+    fi
+    
+    if [ ! -f "$archive" ]; then
+        echo "  Skipping ${npm_platform}: archive not found (${archive})"
+        continue
+    fi
+    
+    echo "  Building @charmland/crush-${npm_platform}..."
+    
+    pkg_dir="${NPM_DIR}/crush-${npm_platform}"
+    mkdir -p "${pkg_dir}/bin"
+    
+    # Extract binary
+    if [ "$os" = "win32" ]; then
+        unzip -q -j "$archive" "*/${binary_name}" -d "${pkg_dir}/bin/" 2>/dev/null || \
+        unzip -q -j "$archive" "${binary_name}" -d "${pkg_dir}/bin/" 2>/dev/null || \
+        unzip -q "$archive" -d "${pkg_dir}/temp" && mv "${pkg_dir}/temp"/*/"${binary_name}" "${pkg_dir}/bin/" && rm -rf "${pkg_dir}/temp"
+    else
+        tar -xzf "$archive" --strip-components=1 -C "${pkg_dir}/bin" --wildcards "*/${binary_name}" 2>/dev/null || \
+        tar -xzf "$archive" -C "${pkg_dir}/bin" "${binary_name}" 2>/dev/null || \
+        (tar -xzf "$archive" -C "${pkg_dir}" && mv "${pkg_dir}"/crush_*/"${binary_name}" "${pkg_dir}/bin/" && rm -rf "${pkg_dir}"/crush_*)
+    fi
+    
+    chmod +x "${pkg_dir}/bin/${binary_name}" 2>/dev/null || true
+    
+    # Create package.json
+    cat > "${pkg_dir}/package.json" << EOF
+{
+  "name": "@charmland/crush-${npm_platform}",
+  "version": "${VERSION}",
+  "description": "Crush binary for ${npm_platform}",
+  "license": "FSL-1.1-MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/charmbracelet/crush.git"
+  },
+  "homepage": "https://charm.sh/crush",
+  "bugs": {
+    "url": "https://github.com/charmbracelet/crush/issues"
+  },
+  "os": ["${os}"],
+  "cpu": ["${cpu}"],
+  "files": ["bin/"],
+  "preferUnplugged": true
+}
+EOF
+    
+    # Create README
+    cat > "${pkg_dir}/README.md" << EOF
+# @charmland/crush-${npm_platform}
+
+Platform-specific binary package for Crush on ${npm_platform}.
+
+This package is automatically installed as a dependency of \`@charmland/crush\`.
+You should not need to install this package directly.
+
+## About Crush
+
+Crush is a glamorous agentic coding assistant for your terminal.
+Learn more at https://charm.sh/crush
+EOF
+    
+    # Pack the package
+    (cd "${pkg_dir}" && npm pack --pack-destination "${NPM_DIR}")
+    
+    # Add to optional dependencies
+    if [ -n "$OPTIONAL_DEPS" ]; then
+        OPTIONAL_DEPS="${OPTIONAL_DEPS},"
+    fi
+    OPTIONAL_DEPS="${OPTIONAL_DEPS}
+    \"@charmland/crush-${npm_platform}\": \"${VERSION}\""
+    
+    BUILT_PLATFORMS="${BUILT_PLATFORMS} ${npm_platform}"
+done
+
+echo ""
+echo "Building main @charmland/crush package..."
+
+# Create main wrapper package
+main_pkg="${NPM_DIR}/crush"
+mkdir -p "${main_pkg}/bin"
+
+# Copy wrapper script
+cp "${SCRIPT_DIR}/crush-wrapper.js" "${main_pkg}/bin/crush.js"
+chmod +x "${main_pkg}/bin/crush.js"
+
+# Copy README and LICENSE from repo root
+cp "${DIST_DIR}/../README.md" "${main_pkg}/" 2>/dev/null || echo "# Crush" > "${main_pkg}/README.md"
+cp "${DIST_DIR}/../LICENSE.md" "${main_pkg}/" 2>/dev/null || true
+
+# Create package.json
+cat > "${main_pkg}/package.json" << EOF
+{
+  "name": "@charmland/crush",
+  "version": "${VERSION}",
+  "description": "Glamourous agentic coding for all - A powerful terminal-based AI assistant for developers",
+  "license": "FSL-1.1-MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/charmbracelet/crush.git"
+  },
+  "homepage": "https://charm.sh/crush",
+  "bugs": {
+    "url": "https://github.com/charmbracelet/crush/issues"
+  },
+  "keywords": [
+    "ai",
+    "cli",
+    "coding",
+    "assistant",
+    "terminal",
+    "llm",
+    "agent",
+    "charm"
+  ],
+  "bin": {
+    "crush": "./bin/crush.js"
+  },
+  "files": ["bin/", "README.md", "LICENSE.md"],
+  "engines": {
+    "node": ">=16"
+  },
+  "optionalDependencies": {${OPTIONAL_DEPS}
+  }
+}
+EOF
+
+# Pack main package
+(cd "${main_pkg}" && npm pack --pack-destination "${NPM_DIR}")
+
+echo ""
+echo "=========================================="
+echo "npm packages built successfully!"
+echo "=========================================="
+echo ""
+echo "Output directory: ${NPM_DIR}"
+echo "Platforms built:${BUILT_PLATFORMS}"
+echo ""
+echo "Packages created:"
+ls -la "${NPM_DIR}"/*.tgz
+echo ""
+echo "To publish:"
+echo "  cd ${NPM_DIR}"
+echo "  npm publish charmland-crush-*.tgz --access public"
+echo "  npm publish charmland-crush-${VERSION}.tgz --access public"

--- a/scripts/npm-optional-deps/crush-wrapper.js
+++ b/scripts/npm-optional-deps/crush-wrapper.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Crush CLI wrapper script
+ * 
+ * This script finds and executes the platform-specific Crush binary
+ * from the optionalDependencies packages.
+ * 
+ * Pattern based on esbuild, turbo, and opencode distribution.
+ */
+
+const { execFileSync, spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+const PACKAGE_NAME = '@charmland/crush';
+
+/**
+ * Get the platform-specific package name
+ */
+function getPlatformPackage() {
+  const platform = process.platform;
+  const arch = process.arch;
+  return `${PACKAGE_NAME}-${platform}-${arch}`;
+}
+
+/**
+ * Find the binary in various possible locations
+ */
+function findBinary() {
+  const platform = process.platform;
+  const arch = process.arch;
+  const platformPkg = getPlatformPackage();
+  const binaryName = platform === 'win32' ? 'crush.exe' : 'crush';
+  
+  // Possible locations to check
+  const locations = [
+    // Standard node_modules location (most common)
+    path.join(__dirname, '..', '..', platformPkg, 'bin', binaryName),
+    
+    // Hoisted to root node_modules
+    path.join(__dirname, '..', '..', '..', platformPkg, 'bin', binaryName),
+    
+    // pnpm/yarn PnP style
+    (() => {
+      try {
+        const resolved = require.resolve(`${platformPkg}/bin/${binaryName}`);
+        return resolved;
+      } catch {
+        return null;
+      }
+    })(),
+    
+    // Fallback: try to resolve the package and find bin inside
+    (() => {
+      try {
+        const pkgPath = require.resolve(`${platformPkg}/package.json`);
+        return path.join(path.dirname(pkgPath), 'bin', binaryName);
+      } catch {
+        return null;
+      }
+    })(),
+  ].filter(Boolean);
+  
+  for (const loc of locations) {
+    if (fs.existsSync(loc)) {
+      return loc;
+    }
+  }
+  
+  return null;
+}
+
+/**
+ * Print helpful error message when binary is not found
+ */
+function printNotFoundError() {
+  const platform = process.platform;
+  const arch = process.arch;
+  const platformPkg = getPlatformPackage();
+  
+  console.error(`
+Crush binary not found for ${platform}-${arch}
+
+The platform-specific package "${platformPkg}" was not installed.
+
+This can happen if:
+1. Your platform (${platform}-${arch}) is not supported
+2. npm failed to install the optional dependency
+3. You're using a package manager that doesn't support optionalDependencies
+
+To fix this, try:
+  npm install ${platformPkg}
+
+Or install Crush directly:
+  # macOS
+  brew install charmbracelet/tap/crush
+  
+  # Windows
+  winget install charmbracelet.crush
+  
+  # Linux (Debian/Ubuntu)
+  sudo apt install crush
+  
+  # Or download from:
+  https://github.com/charmbracelet/crush/releases
+
+Supported platforms:
+  - linux-x64, linux-arm64, linux-ia32, linux-arm
+  - darwin-x64, darwin-arm64
+  - win32-x64, win32-arm64, win32-ia32
+`);
+}
+
+/**
+ * Main entry point
+ */
+function main() {
+  const binaryPath = findBinary();
+  
+  if (!binaryPath) {
+    printNotFoundError();
+    process.exit(1);
+  }
+  
+  // Forward all arguments to the binary
+  const args = process.argv.slice(2);
+  
+  // Use spawn for better signal handling and TTY support
+  const child = spawn(binaryPath, args, {
+    stdio: 'inherit',
+    windowsHide: false,
+  });
+  
+  child.on('error', (err) => {
+    console.error(`Failed to execute Crush: ${err.message}`);
+    process.exit(1);
+  });
+  
+  child.on('exit', (code, signal) => {
+    if (signal) {
+      // Re-raise the signal
+      process.kill(process.pid, signal);
+    } else {
+      process.exit(code ?? 1);
+    }
+  });
+  
+  // Forward signals to child process
+  ['SIGINT', 'SIGTERM', 'SIGHUP'].forEach((signal) => {
+    process.on(signal, () => {
+      if (!child.killed) {
+        child.kill(signal);
+      }
+    });
+  });
+}
+
+main();


### PR DESCRIPTION
## Summary

Adds npm distribution using the **optionalDependencies pattern** (like esbuild, turbo, and opencode) instead of postinstall downloads from GitHub.

This enables `npm install @charmland/crush` to work in **corporate/enterprise environments** where:
- `registry.npmjs.org` is allowed (standard for development)
- `github.com` is blocked (common security policy)

Closes #2230

## Changes

- `scripts/npm-optional-deps/build-npm-packages.sh` - Build script that creates platform packages from goreleaser archives
- `scripts/npm-optional-deps/crush-wrapper.js` - JavaScript wrapper that finds and executes the platform binary
- `scripts/npm-optional-deps/README.md` - Documentation
- `.github/workflows/npm-publish.yml` - GitHub Actions workflow to automate publishing

## How it works

Instead of:
```
@charmland/crush (postinstall downloads from GitHub)
```

We create:
```
@charmland/crush (thin wrapper)
  └── optionalDependencies:
      ├── @charmland/crush-linux-x64   (binary embedded)
      ├── @charmland/crush-darwin-arm64 (binary embedded)
      └── ...
```

npm automatically installs only the matching platform package.

## Testing

The workflow can be triggered manually via `workflow_dispatch` or runs automatically on releases.

## References

- esbuild: https://github.com/evanw/esbuild
- opencode: https://github.com/anomalyco/opencode  
- Issue discussion: #2230
