### PR TITLE
fix(agent): pass correct model config to small provider builder

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -508,7 +508,7 @@ func (c *coordinator) buildAgentModels(ctx context.Context, isSubAgent bool) (Mo
 		return Model{}, Model{}, errors.New("large model provider not configured")
 	}
 
-	smallProvider, err := c.buildProvider(smallProviderCfg, largeModelCfg, true)
+	smallProvider, err := c.buildProvider(smallProviderCfg, smallModelCfg, true)
 	if err != nil {
 		return Model{}, Model{}, err
 	}


### PR DESCRIPTION
When building the small model provider, we were incorrectly passing largeModelCfg instead of smallModelCfg to buildProvider. This caused isAnthropicThinking to check the wrong model config, preventing the small model from enabling Anthropic thinking mode even when configured.

Fixes #2141

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
