### PR TITLE
feat: add toggle status bar option

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -200,6 +200,7 @@ type LSPConfig struct {
 type TUIOptions struct {
 	CompactMode bool   `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
 	DiffMode    string `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
+	HideStatus  bool   `json:"hide_status,omitempty" jsonschema:"description=Hide the status bar (help keybindings and notifications) at the bottom of the TUI,default=false"`
 	// Here we can add themes later or any TUI related options
 	//
 
@@ -477,6 +478,14 @@ func (c *Config) SetCompactMode(enabled bool) error {
 	}
 	c.Options.TUI.CompactMode = enabled
 	return c.SetConfigField("options.tui.compact_mode", enabled)
+}
+
+func (c *Config) SetHideStatus(enabled bool) error {
+	if c.Options == nil {
+		c.Options = &Options{}
+	}
+	c.Options.TUI.HideStatus = enabled
+	return c.SetConfigField("options.tui.hide_status", enabled)
 }
 
 func (c *Config) Resolve(key string) (string, error) {

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -47,6 +47,7 @@ type (
 	ActionNewSession        struct{}
 	ActionToggleHelp        struct{}
 	ActionToggleCompactMode struct{}
+	ActionToggleStatusBar   struct{}
 	ActionToggleThinking    struct{}
 	ActionTogglePills       struct{}
 	ActionExternalEditor    struct{}

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -426,6 +426,7 @@ func (c *Commands) defaultCommands() []*CommandItem {
 	if c.windowWidth >= sidebarCompactModeBreakpoint && c.hasSession {
 		commands = append(commands, NewCommandItem(c.com.Styles, "toggle_sidebar", "Toggle Sidebar", "", ActionToggleCompactMode{}))
 	}
+	commands = append(commands, NewCommandItem(c.com.Styles, "toggle_status_bar", "Toggle Status Bar", "", ActionToggleStatusBar{}))
 	if c.hasSession {
 		cfg := c.com.Config()
 		agentCfg := cfg.Agents[config.AgentCoder]

--- a/schema.json
+++ b/schema.json
@@ -650,6 +650,11 @@
           ],
           "description": "Diff mode for the TUI interface"
         },
+        "hide_status": {
+          "type": "boolean",
+          "description": "Hide the status bar (help keybindings and notifications) at the bottom of the TUI",
+          "default": false
+        },
         "completions": {
           "$ref": "#/$defs/Completions",
           "description": "Completions UI options"


### PR DESCRIPTION
## Summary

Add the ability to show/hide the status bar (help keybindings and notifications) at the bottom of the TUI.

- Add `hide_status` option to TUI config (`crush.json`) for persistent default
- Add "Toggle Status Bar" command to the command palette for runtime toggling
- When hidden, the space is reclaimed by the main content area

## Configuration

```json
{
  "options": {
    "tui": {
      "hide_status": true
    }
  }
}
```

Or toggle at runtime via the command palette (`/` or `ctrl+p` → "Toggle Status Bar").

## Changes

- `internal/config/config.go` — Add `HideStatus` field to `TUIOptions`, add `SetHideStatus` method
- `internal/ui/dialog/actions.go` — Add `ActionToggleStatusBar` action
- `internal/ui/dialog/commands.go` — Add "Toggle Status Bar" to command palette
- `internal/ui/model/ui.go` — Add `hideStatusBar` state, `toggleStatusBar()` method, skip status bar in `Draw()` and `generateLayout()` when hidden
- `schema.json` — Add `hide_status` field definition