### PR TITLE
fix: make reasoning effort dialog smaller

### DIFF
--- a/internal/ui/dialog/reasoning.go
+++ b/internal/ui/dialog/reasoning.go
@@ -20,8 +20,8 @@ import (
 const (
 	// ReasoningID is the identifier for the reasoning effort dialog.
 	ReasoningID              = "reasoning"
-	reasoningDialogMaxWidth  = 80
-	reasoningDialogMaxHeight = 12
+	reasoningDialogMaxWidth  = 50
+	reasoningDialogMaxHeight = 10
 )
 
 // Reasoning represents a dialog for selecting reasoning effort.


### PR DESCRIPTION
Before, it was even wider than the commands dialog, which looked weird.

<details><summary>Before</summary>
<p>

<img width="742" height="288" alt="Screenshot 2026-02-18 at 10 04 01" src="https://github.com/user-attachments/assets/f86d3450-be6f-4d80-a460-999fd51ee848" />

</p>
</details> 


<details><summary>After</summary>
<p>

<img width="470" height="242" alt="Screenshot 2026-02-18 at 10 10 28" src="https://github.com/user-attachments/assets/e0501a35-2797-47d9-8f53-4a05b1bc581f" />

</p>
</details> 



