### PR TITLE
fix: proper validate io.net api keys

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -799,11 +799,6 @@ func (c *ProviderConfig) TestConnection(resolver VariableResolver) error {
 			return fmt.Errorf("invalid API key format for provider %s", c.ID)
 		}
 		return nil
-	case catwalk.InferenceProviderIoNet:
-		if !strings.HasPrefix(apiKey, "io-") {
-			return fmt.Errorf("invalid API key format for provider %s", c.ID)
-		}
-		return nil
 	}
 
 	switch c.Type {


### PR DESCRIPTION
They changed the `/models` endpoint so it actually validates the API key header if given.