### PR TITLE
feat(filetracker): read vs context inclusion tracking with session epochs

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -670,6 +670,7 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	currentSession.SummaryMessageID = summaryMessage.ID
 	currentSession.CompletionTokens = usage.OutputTokens
 	currentSession.PromptTokens = 0
+	currentSession.ContextEpoch++
 	_, err = a.sessions.Save(genCtx, currentSession)
 	return err
 }

--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -119,7 +119,7 @@ func testEnv(t *testing.T) fakeEnv {
 
 	permissions := permission.NewPermissionService(workingDir, true, []string{})
 	history := history.NewService(q, conn)
-	filetrackerService := filetracker.NewService(q)
+	filetrackerService := filetracker.NewService(q, sessions, workingDir)
 	lspClients := csync.NewMap[string, *lsp.Client]()
 
 	t.Cleanup(func() {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -89,7 +89,7 @@ func New(ctx context.Context, conn *sql.DB, cfg *config.Config) (*App, error) {
 		Messages:    messages,
 		History:     files,
 		Permissions: permission.NewPermissionService(cfg.WorkingDir(), skipPermissionsRequests, allowedTools),
-		FileTracker: filetracker.NewService(q),
+		FileTracker: filetracker.NewService(q, sessions, cfg.WorkingDir()),
 		LSPManager:  lsp.NewManager(cfg),
 
 		globalCtx: ctx,

--- a/internal/db/migrations/20260221000000_add_context_epoch_and_file_tracking_fields.sql
+++ b/internal/db/migrations/20260221000000_add_context_epoch_and_file_tracking_fields.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE sessions ADD COLUMN context_epoch INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE read_files ADD COLUMN last_read_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE read_files ADD COLUMN last_read_mtime_ns INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE read_files ADD COLUMN last_read_size INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE read_files ADD COLUMN last_included_at INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE read_files ADD COLUMN last_included_mtime_ns INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE read_files ADD COLUMN last_included_size INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE read_files ADD COLUMN last_included_epoch INTEGER NOT NULL DEFAULT 0;
+
+UPDATE read_files
+SET last_read_at = read_at
+WHERE read_at > 0 AND last_read_at = 0;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE sessions DROP COLUMN context_epoch;
+
+ALTER TABLE read_files DROP COLUMN last_included_epoch;
+ALTER TABLE read_files DROP COLUMN last_included_size;
+ALTER TABLE read_files DROP COLUMN last_included_mtime_ns;
+ALTER TABLE read_files DROP COLUMN last_included_at;
+ALTER TABLE read_files DROP COLUMN last_read_size;
+ALTER TABLE read_files DROP COLUMN last_read_mtime_ns;
+ALTER TABLE read_files DROP COLUMN last_read_at;
+-- +goose StatementEnd

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -32,9 +32,16 @@ type Message struct {
 }
 
 type ReadFile struct {
-	SessionID string `json:"session_id"`
-	Path      string `json:"path"`
-	ReadAt    int64  `json:"read_at"` // Unix timestamp when file was last read
+	SessionID           string `json:"session_id"`
+	Path                string `json:"path"`
+	ReadAt              int64  `json:"read_at"`
+	LastReadAt          int64  `json:"last_read_at"`
+	LastReadMtimeNs     int64  `json:"last_read_mtime_ns"`
+	LastReadSize        int64  `json:"last_read_size"`
+	LastIncludedAt      int64  `json:"last_included_at"`
+	LastIncludedMtimeNs int64  `json:"last_included_mtime_ns"`
+	LastIncludedSize    int64  `json:"last_included_size"`
+	LastIncludedEpoch   int64  `json:"last_included_epoch"`
 }
 
 type Session struct {
@@ -49,4 +56,5 @@ type Session struct {
 	CreatedAt        int64          `json:"created_at"`
 	SummaryMessageID sql.NullString `json:"summary_message_id"`
 	Todos            sql.NullString `json:"todos"`
+	ContextEpoch     int64          `json:"context_epoch"`
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -40,6 +40,7 @@ type Querier interface {
 	ListSessionReadFiles(ctx context.Context, sessionID string) ([]ReadFile, error)
 	ListSessions(ctx context.Context) ([]Session, error)
 	ListUserMessagesBySession(ctx context.Context, sessionID string) ([]Message, error)
+	RecordFileIncludedInContext(ctx context.Context, arg RecordFileIncludedInContextParams) error
 	RecordFileRead(ctx context.Context, arg RecordFileReadParams) error
 	UpdateMessage(ctx context.Context, arg UpdateMessageParams) error
 	UpdateSession(ctx context.Context, arg UpdateSessionParams) (Session, error)

--- a/internal/db/sql/read_files.sql
+++ b/internal/db/sql/read_files.sql
@@ -2,13 +2,46 @@
 INSERT INTO read_files (
     session_id,
     path,
-    read_at
+    read_at,
+    last_read_at,
+    last_read_mtime_ns,
+    last_read_size
 ) VALUES (
     ?,
     ?,
-    strftime('%s', 'now')
+    strftime('%s', 'now'),
+    strftime('%s', 'now'),
+    ?,
+    ?
 ) ON CONFLICT(path, session_id) DO UPDATE SET
-    read_at = excluded.read_at;
+    read_at = excluded.read_at,
+    last_read_at = excluded.last_read_at,
+    last_read_mtime_ns = excluded.last_read_mtime_ns,
+    last_read_size = excluded.last_read_size;
+
+-- name: RecordFileIncludedInContext :exec
+INSERT INTO read_files (
+    session_id,
+    path,
+    read_at,
+    last_included_at,
+    last_included_mtime_ns,
+    last_included_size,
+    last_included_epoch
+) VALUES (
+    ?,
+    ?,
+    strftime('%s', 'now'),
+    strftime('%s', 'now'),
+    ?,
+    ?,
+    ?
+) ON CONFLICT(path, session_id) DO UPDATE SET
+    read_at = excluded.read_at,
+    last_included_at = excluded.last_included_at,
+    last_included_mtime_ns = excluded.last_included_mtime_ns,
+    last_included_size = excluded.last_included_size,
+    last_included_epoch = excluded.last_included_epoch;
 
 -- name: GetFileRead :one
 SELECT * FROM read_files
@@ -17,4 +50,5 @@ WHERE session_id = ? AND path = ? LIMIT 1;
 -- name: ListSessionReadFiles :many
 SELECT * FROM read_files
 WHERE session_id = ?
-ORDER BY read_at DESC;
+  AND (last_read_at > 0 OR last_included_at > 0)
+ORDER BY MAX(last_read_at, last_included_at) DESC;

--- a/internal/db/sql/sessions.sql
+++ b/internal/db/sql/sessions.sql
@@ -7,6 +7,7 @@ INSERT INTO sessions (
     prompt_tokens,
     completion_tokens,
     cost,
+    context_epoch,
     summary_message_id,
     updated_at,
     created_at
@@ -18,6 +19,7 @@ INSERT INTO sessions (
     ?,
     ?,
     ?,
+    0,
     null,
     strftime('%s', 'now'),
     strftime('%s', 'now')
@@ -42,6 +44,7 @@ SET
     completion_tokens = ?,
     summary_message_id = ?,
     cost = ?,
+    context_epoch = ?,
     todos = ?
 WHERE id = ?
 RETURNING *;

--- a/internal/filetracker/read_snapshot.go
+++ b/internal/filetracker/read_snapshot.go
@@ -1,0 +1,37 @@
+package filetracker
+
+import (
+	"fmt"
+	"os"
+)
+
+type Snapshot struct {
+	SizeBytes    int64
+	ModTimeNanos int64
+}
+
+func SnapshotFromPath(path string) (Snapshot, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	if info.IsDir() {
+		return Snapshot{}, fmt.Errorf("path is a directory: %s", path)
+	}
+	return Snapshot{
+		SizeBytes:    info.Size(),
+		ModTimeNanos: info.ModTime().UnixNano(),
+	}, nil
+}
+
+func ReadFileWithSnapshot(path string) ([]byte, Snapshot, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, Snapshot{}, err
+	}
+	snapshot, err := SnapshotFromPath(path)
+	if err != nil {
+		return nil, Snapshot{}, err
+	}
+	return content, snapshot, nil
+}

--- a/internal/filetracker/service.go
+++ b/internal/filetracker/service.go
@@ -1,93 +1,171 @@
-// Package filetracker provides functionality to track file reads in sessions.
 package filetracker
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
-	"time"
+	"strings"
 
 	"github.com/charmbracelet/crush/internal/db"
+	"github.com/charmbracelet/crush/internal/session"
 )
 
-// Service defines the interface for tracking file reads in sessions.
 type Service interface {
-	// RecordRead records when a file was read.
-	RecordRead(ctx context.Context, sessionID, path string)
-
-	// LastReadTime returns when a file was last read.
-	// Returns zero time if never read.
-	LastReadTime(ctx context.Context, sessionID, path string) time.Time
-
-	// ListReadFiles returns the paths of all files read in a session.
+	RecordRead(ctx context.Context, sessionID, path string, snapshot Snapshot) error
+	RecordIncludedInContext(ctx context.Context, sessionID, path string, snapshot Snapshot) error
+	ChangedSinceRead(ctx context.Context, sessionID, path string) (bool, error)
+	InCurrentContext(ctx context.Context, sessionID, path string) (bool, error)
 	ListReadFiles(ctx context.Context, sessionID string) ([]string, error)
 }
 
 type service struct {
-	q *db.Queries
+	q          *db.Queries
+	sessions   session.Service
+	workingDir string
 }
 
-// NewService creates a new file tracker service.
-func NewService(q *db.Queries) Service {
-	return &service{q: q}
-}
-
-// RecordRead records when a file was read.
-func (s *service) RecordRead(ctx context.Context, sessionID, path string) {
-	if err := s.q.RecordFileRead(ctx, db.RecordFileReadParams{
-		SessionID: sessionID,
-		Path:      relpath(path),
-	}); err != nil {
-		slog.Error("Error recording file read", "error", err, "file", path)
+func NewService(q *db.Queries, sessions session.Service, workingDir string) Service {
+	absWorkingDir := workingDir
+	if absWorkingDir == "" {
+		absWorkingDir, _ = os.Getwd()
 	}
+	absWorkingDir = filepath.Clean(absWorkingDir)
+	return &service{q: q, sessions: sessions, workingDir: absWorkingDir}
 }
 
-// LastReadTime returns when a file was last read.
-// Returns zero time if never read.
-func (s *service) LastReadTime(ctx context.Context, sessionID, path string) time.Time {
-	readFile, err := s.q.GetFileRead(ctx, db.GetFileReadParams{
-		SessionID: sessionID,
-		Path:      relpath(path),
+func (s *service) RecordRead(ctx context.Context, sessionID, path string, snapshot Snapshot) error {
+	canonicalPath := s.canonicalPath(path)
+	return s.q.RecordFileRead(ctx, db.RecordFileReadParams{
+		SessionID:       sessionID,
+		Path:            canonicalPath,
+		LastReadMtimeNs: snapshot.ModTimeNanos,
+		LastReadSize:    snapshot.SizeBytes,
 	})
-	if err != nil {
-		return time.Time{}
-	}
-
-	return time.Unix(readFile.ReadAt, 0)
 }
 
-func relpath(path string) string {
-	path = filepath.Clean(path)
-	basepath, err := os.Getwd()
+func (s *service) RecordIncludedInContext(ctx context.Context, sessionID, path string, snapshot Snapshot) error {
+	sess, err := s.sessions.Get(ctx, sessionID)
 	if err != nil {
-		slog.Warn("Error getting basepath", "error", err)
-		return path
+		return fmt.Errorf("getting session for inclusion: %w", err)
 	}
-	relpath, err := filepath.Rel(basepath, path)
-	if err != nil {
-		slog.Warn("Error getting relpath", "error", err)
-		return path
-	}
-	return relpath
+	canonicalPath := s.canonicalPath(path)
+	return s.q.RecordFileIncludedInContext(ctx, db.RecordFileIncludedInContextParams{
+		SessionID:           sessionID,
+		Path:                canonicalPath,
+		LastIncludedMtimeNs: snapshot.ModTimeNanos,
+		LastIncludedSize:    snapshot.SizeBytes,
+		LastIncludedEpoch:   sess.ContextEpoch,
+	})
 }
 
-// ListReadFiles returns the paths of all files read in a session.
+func (s *service) ChangedSinceRead(ctx context.Context, sessionID, path string) (bool, error) {
+	record, ok, err := s.getRecord(ctx, sessionID, path)
+	if err != nil {
+		return false, err
+	}
+	if !ok || record.LastReadAt == 0 {
+		return true, nil
+	}
+
+	current, err := SnapshotFromPath(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+		return false, err
+	}
+
+	changed := current.ModTimeNanos != record.LastReadMtimeNs ||
+		current.SizeBytes != record.LastReadSize
+	return changed, nil
+}
+
+func (s *service) InCurrentContext(ctx context.Context, sessionID, path string) (bool, error) {
+	record, ok, err := s.getRecord(ctx, sessionID, path)
+	if err != nil {
+		return false, err
+	}
+	if !ok || record.LastIncludedAt == 0 {
+		return false, nil
+	}
+
+	sess, err := s.sessions.Get(ctx, sessionID)
+	if err != nil {
+		return false, fmt.Errorf("getting session for context check: %w", err)
+	}
+	if record.LastIncludedEpoch != sess.ContextEpoch {
+		return false, nil
+	}
+
+	current, err := SnapshotFromPath(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	fresh := current.ModTimeNanos == record.LastIncludedMtimeNs &&
+		current.SizeBytes == record.LastIncludedSize
+	return fresh, nil
+}
+
 func (s *service) ListReadFiles(ctx context.Context, sessionID string) ([]string, error) {
 	readFiles, err := s.q.ListSessionReadFiles(ctx, sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("listing read files: %w", err)
 	}
 
-	basepath, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("getting working directory: %w", err)
-	}
-
 	paths := make([]string, 0, len(readFiles))
 	for _, rf := range readFiles {
-		paths = append(paths, filepath.Join(basepath, rf.Path))
+		paths = append(paths, s.expandPath(rf.Path))
 	}
 	return paths, nil
+}
+
+func (s *service) getRecord(ctx context.Context, sessionID, path string) (db.ReadFile, bool, error) {
+	record, err := s.q.GetFileRead(ctx, db.GetFileReadParams{
+		SessionID: sessionID,
+		Path:      s.canonicalPath(path),
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return db.ReadFile{}, false, nil
+		}
+		return db.ReadFile{}, false, err
+	}
+	return record, true, nil
+}
+
+func (s *service) canonicalPath(path string) string {
+	absPath := path
+	if !filepath.IsAbs(absPath) {
+		absPath = filepath.Join(s.workingDir, absPath)
+	}
+	absPath = filepath.Clean(absPath)
+
+	relPath, err := filepath.Rel(s.workingDir, absPath)
+	if err != nil {
+		return absPath
+	}
+	if relPath == "." {
+		return relPath
+	}
+	if relPath == ".." {
+		return absPath
+	}
+	if strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+		return absPath
+	}
+	return relPath
+}
+
+func (s *service) expandPath(path string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Clean(filepath.Join(s.workingDir, path))
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -45,6 +45,7 @@ type Session struct {
 	MessageCount     int64
 	PromptTokens     int64
 	CompletionTokens int64
+	ContextEpoch     int64
 	SummaryMessageID string
 	Cost             float64
 	Todos            []Todo
@@ -168,6 +169,7 @@ func (s *service) Save(ctx context.Context, session Session) (Session, error) {
 		Title:            session.Title,
 		PromptTokens:     session.PromptTokens,
 		CompletionTokens: session.CompletionTokens,
+		ContextEpoch:     session.ContextEpoch,
 		SummaryMessageID: sql.NullString{
 			String: session.SummaryMessageID,
 			Valid:  session.SummaryMessageID != "",
@@ -222,6 +224,7 @@ func (s service) fromDBItem(item db.Session) Session {
 		MessageCount:     item.MessageCount,
 		PromptTokens:     item.PromptTokens,
 		CompletionTokens: item.CompletionTokens,
+		ContextEpoch:     item.ContextEpoch,
 		SummaryMessageID: item.SummaryMessageID.String,
 		Cost:             item.Cost,
 		Todos:            todos,

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -2,8 +2,7 @@ package dialog
 
 import (
 	"fmt"
-	"net/http"
-	"os"
+	"mime"
 	"path/filepath"
 
 	tea "charm.land/bubbletea/v2"
@@ -145,23 +144,16 @@ func (a ActionFilePickerSelected) Cmd() tea.Cmd {
 			}
 		}
 
-		content, err := os.ReadFile(path)
-		if err != nil {
-			return util.InfoMsg{
-				Type: util.InfoTypeError,
-				Msg:  fmt.Sprintf("unable to read the image: %v", err),
-			}
+		mimeType := mime.TypeByExtension(filepath.Ext(path))
+		if mimeType == "" {
+			mimeType = "application/octet-stream"
 		}
-
-		mimeBufferSize := min(512, len(content))
-		mimeType := http.DetectContentType(content[:mimeBufferSize])
 		fileName := filepath.Base(path)
 
 		return message.Attachment{
 			FilePath: path,
 			FileName: fileName,
 			MimeType: mimeType,
-			Content:  content,
 		}
 	}
 }


### PR DESCRIPTION
Make file freshness and context-presence checks explicit by splitting "read" events from "included in context" events and tying context validity to a session-owned epoch bumped during compaction/summarization.

This fixes false positives where files were treated as still available/current when they were not, including:
- files read by tools counted as if they were in model context
- pre-send read bookkeeping marking files as read even if a send failed
- files previously included in a session assumed still in context after compaction
- reattach decisions skipping files based on session history rather than current context

Also:
- switch attachments to path placeholders that are read at send time so the latest on-disk bytes are used. Record read/inclusion only after successful send
- migrate tool guards to `ChangedSinceRead`
- add `InCurrentContext` checks for context-window validity
- canonicalize file paths so relative/absolute references map predictably

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
