### PR TITLE
fix(agent): fix minor bugs in coordinator and view tool

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -472,9 +472,10 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent) ([]fan
 			}
 			if len(tools) == 0 || slices.Contains(tools, tool.MCPToolName()) {
 				filteredTools = append(filteredTools, tool)
+				break
 			}
+			slog.Debug("MCP not allowed", "tool", tool.Name(), "agent", agent.Name)
 		}
-		slog.Debug("MCP not allowed", "tool", tool.Name(), "agent", agent.Name)
 	}
 	slices.SortFunc(filteredTools, func(a, b fantasy.AgentTool) int {
 		return strings.Compare(a.Info().Name, b.Info().Name)
@@ -505,7 +506,7 @@ func (c *coordinator) buildAgentModels(ctx context.Context, isSubAgent bool) (Mo
 
 	smallProviderCfg, ok := c.cfg.Providers.Get(smallModelCfg.Provider)
 	if !ok {
-		return Model{}, Model{}, errors.New("large model provider not configured")
+		return Model{}, Model{}, errors.New("small model provider not configured")
 	}
 
 	smallProvider, err := c.buildProvider(smallProviderCfg, smallModelCfg, true)

--- a/internal/agent/tools/view.go
+++ b/internal/agent/tools/view.go
@@ -175,12 +175,12 @@ func NewViewTool(
 
 			// Read the file content
 			content, lineCount, err := readTextFile(filePath, params.Offset, params.Limit)
+			if err != nil {
+				return fantasy.ToolResponse{}, fmt.Errorf("error reading file: %w", err)
+			}
 			isValidUt8 := utf8.ValidString(content)
 			if !isValidUt8 {
 				return fantasy.NewTextErrorResponse("File content is not valid UTF-8"), nil
-			}
-			if err != nil {
-				return fantasy.ToolResponse{}, fmt.Errorf("error reading file: %w", err)
 			}
 
 			notifyLSPs(ctx, lspManager, filePath)


### PR DESCRIPTION
## Summary
- Fix misleading error message: report "small model provider not configured" instead of "large" when the small model provider is missing
- Fix error handling order in view tool: check `readTextFile` error before UTF-8 validation to avoid validating partial/empty content
- Fix MCP tool filtering: move "MCP not allowed" log into correct branch and `break` after tool is added to prevent duplicate additions

## Test plan
- [ ] Verify small model provider missing error shows correct message
- [ ] Verify view tool returns proper error when file read fails
- [ ] Verify MCP tool filtering logs correctly and doesn't duplicate tools