### PR TITLE
fix(ui): fix cases where compact header and footer bleed off screen

### DIFF
--- a/internal/ui/model/header.go
+++ b/internal/ui/model/header.go
@@ -17,10 +17,11 @@ import (
 )
 
 const (
-	headerDiag     = "╱"
-	minHeaderDiags = 3
-	leftPadding    = 1
-	rightPadding   = 1
+	headerDiag           = "╱"
+	minHeaderDiags       = 3
+	leftPadding          = 1
+	rightPadding         = 1
+	diagToDetailsSpacing = 1 // space between diagonal pattern and details section
 )
 
 type header struct {
@@ -73,7 +74,7 @@ func (h *header) drawHeader(
 	var b strings.Builder
 	b.WriteString(h.compactLogo)
 
-	availDetailWidth := width - leftPadding - rightPadding - lipgloss.Width(b.String()) - minHeaderDiags
+	availDetailWidth := width - leftPadding - rightPadding - lipgloss.Width(b.String()) - minHeaderDiags - diagToDetailsSpacing
 	details := renderHeaderDetails(
 		h.com,
 		session,
@@ -86,7 +87,8 @@ func (h *header) drawHeader(
 		lipgloss.Width(b.String()) -
 		lipgloss.Width(details) -
 		leftPadding -
-		rightPadding
+		rightPadding -
+		diagToDetailsSpacing
 
 	if remainingWidth > 0 {
 		b.WriteString(t.Header.Diagonals.Render(
@@ -143,8 +145,8 @@ func renderHeaderDetails(
 	const dirTrimLimit = 4
 	cfg := com.Config()
 	cwd := fsext.DirTrim(fsext.PrettyPath(cfg.WorkingDir()), dirTrimLimit)
-	cwd = ansi.Truncate(cwd, max(0, availWidth-lipgloss.Width(metadata)), "…")
 	cwd = t.Header.WorkingDir.Render(cwd)
 
-	return cwd + metadata
+	result := cwd + metadata
+	return ansi.Truncate(result, max(0, availWidth), "…")
 }

--- a/internal/ui/model/status.go
+++ b/internal/ui/model/status.go
@@ -46,7 +46,9 @@ func (s *Status) ClearInfoMsg() {
 
 // SetWidth sets the width of the status bar and help view.
 func (s *Status) SetWidth(width int) {
-	s.help.SetWidth(width)
+	helpStyle := s.com.Styles.Status.Help
+	horizontalPadding := helpStyle.GetPaddingLeft() + helpStyle.GetPaddingRight()
+	s.help.SetWidth(width - horizontalPadding)
 }
 
 // ShowingAll returns whether the full help view is shown.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1815,7 +1815,7 @@ func (m *UI) drawHeader(scr uv.Screen, area uv.Rectangle) {
 		m.session,
 		m.isCompact,
 		m.detailsOpen,
-		m.width,
+		area.Dx(),
 	)
 }
 


### PR DESCRIPTION
This fixes cases where footer and compact header could bleed off screen due to incorrect calcs.

<img width="1864" height="612" alt="image" src="https://github.com/user-attachments/assets/7783854d-ba10-4f30-a13b-b361a63aa352" />

Before in the front, after in the back.