### PR TITLE
fix(agent): properly track tool execution completion state

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -362,13 +362,14 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 				Name:             tc.ToolName,
 				Input:            tc.Input,
 				ProviderExecuted: false,
-				Finished:         true,
+				Finished:         false,
 			}
 			currentAssistant.AddToolCall(toolCall)
 			return a.messages.Update(genCtx, *currentAssistant)
 		},
 		OnToolResult: func(result fantasy.ToolResultContent) error {
 			toolResult := a.convertToToolResult(result)
+			currentAssistant.FinishToolCall(result.ToolCallID)
 			_, createMsgErr := a.messages.Create(genCtx, currentAssistant.SessionID, message.CreateMessageParams{
 				Role: message.Tool,
 				Parts: []message.ContentPart{


### PR DESCRIPTION
The Finished flag on ToolCall was being set to true when the tool call was created, not when execution completed. This caused the chat to stop processing messages since the Finished state never changed after the tool result arrived.

Now the tool call starts with Finished: false, and FinishToolCall is called in OnToolResult to properly mark completion when the result arrives. This allows the UI to correctly stop the animation and resume chat processing.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).

## Test plan

- [x] Agent tests pass (TestHasRepeatedToolCalls, TestGetToolInteractionSignature)
- [ ] Use a provider that calls tools
- [ ] Start a conversation that triggers tool calls
- [ ] **Before:** Chat intermittently stops responding, spinner runs indefinitely
- [ ] **After:** Chat continues processing, spinner stops when tool result appears