### PR TITLE
ci: allow `MIT-0` dependencies

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -89,4 +89,4 @@ jobs:
       - uses: actions/dependency-review-action@05fe4576374b728f0c523d6a13d64c25081e0803 # v4.8.3
         with:
           fail-on-severity: critical
-          allow-licenses: BSD-2-Clause, BSD-3-Clause, MIT, Apache-2.0, MPL-2.0, ISC, LicenseRef-scancode-google-patent-license-golang, Unlicense
+          allow-licenses: BSD-2-Clause, BSD-3-Clause, MIT, MIT-0, Apache-2.0, MPL-2.0, ISC, LicenseRef-scancode-google-patent-license-golang, Unlicense


### PR DESCRIPTION
One of our indirect dependencies switched to "MIT-0". This is even more permissive than MIT, so totally valid for us.

* https://github.com/segmentio/asm/pull/86

Check failure:

* https://github.com/charmbracelet/crush/pull/2290
* https://github.com/charmbracelet/crush/actions/runs/22323633569/job/64588201366?pr=2290

About the license:

* https://github.com/aws/mit-0
* https://opensource.org/license/mit-0