### PR TITLE
fix(app): fix goroutine leak, shutdown context, and model matching

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -246,6 +246,7 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 			done <- response{
 				err: fmt.Errorf("failed to start agent processing stream: %w", err),
 			}
+			return
 		}
 		done <- response{
 			result: result,
@@ -551,7 +552,7 @@ func (app *App) Shutdown() {
 	var wg sync.WaitGroup
 
 	// Shared shutdown context for all timeout-bounded cleanup.
-	shutdownCtx, cancel := context.WithTimeout(app.globalCtx, 5*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(app.globalCtx), 5*time.Second)
 	defer cancel()
 
 	// Send exit event

--- a/internal/app/lsp_events.go
+++ b/internal/app/lsp_events.go
@@ -67,6 +67,8 @@ func updateLSPState(name string, state lsp.ServerState, err error, client *lsp.C
 	}
 	if state == lsp.StateReady {
 		info.ConnectedAt = time.Now()
+	} else if existing, ok := lspStates.Get(name); ok {
+		info.ConnectedAt = existing.ConnectedAt
 	}
 	lspStates.Set(name, info)
 

--- a/internal/app/provider.go
+++ b/internal/app/provider.go
@@ -70,8 +70,8 @@ func findModels(providers map[string]config.ProviderConfig, largeModel, smallMod
 }
 
 func filter(modelFilter, providerFilter, model, provider string) bool {
-	return modelFilter != "" && model == modelFilter &&
-		(providerFilter == "" || provider == providerFilter)
+	return modelFilter != "" && strings.EqualFold(model, modelFilter) &&
+		(providerFilter == "" || strings.EqualFold(provider, providerFilter))
 }
 
 // Validate and return a single match.


### PR DESCRIPTION
## Summary

- **Fix goroutine leak in `RunNonInteractive`**: Added missing `return` after error send to `done` channel, preventing double-send and potential goroutine leak when context is cancelled.
- **Fix shutdown context**: Replaced `app.globalCtx` (which is already cancelled by signal handler) with `context.WithoutCancel(app.globalCtx)` to ensure cleanup functions get the full 5-second graceful shutdown window while preserving tracing context.
- **Fix case-insensitive model matching**: Changed `==` to `strings.EqualFold` in `filter()` to match the documented behavior ("Model matching is case-insensitive").
- **Preserve LSP `ConnectedAt` across state transitions**: When LSP state changes from `Ready` to another state, the `ConnectedAt` timestamp is now preserved from the existing record instead of being lost.

## Test plan

- [x] Verify non-interactive mode handles agent errors without goroutine leaks
- [x] Verify graceful shutdown completes cleanup within 5s after Ctrl+C
- [x] Verify model matching works with different casing (e.g. `GPT-4o` matches `gpt-4o`)
- [x] Verify LSP `ConnectedAt` is retained when server state transitions away from `Ready`