### PR TITLE
chore(events): log when crush stats is called

### DIFF
--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/db"
+	"github.com/charmbracelet/crush/internal/event"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
@@ -120,6 +121,8 @@ type HourDayHeatmapPt struct {
 }
 
 func runStats(cmd *cobra.Command, _ []string) error {
+	event.StatsViewed()
+
 	dataDir, _ := cmd.Flags().GetString("data-dir")
 	ctx := cmd.Context()
 

--- a/internal/event/all.go
+++ b/internal/event/all.go
@@ -57,3 +57,7 @@ func TokensUsed(props ...any) {
 		props...,
 	)
 }
+
+func StatsViewed() {
+	send("stats viewed")
+}


### PR DESCRIPTION
Small one to give us some insight into usage around `crush stats`.