### PR TITLE
fix(lsp): fix multiple bugs in LSP client lifecycle and handlers

### DIFF
--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -277,10 +277,6 @@ func (c *Client) WaitForServerReady(ctx context.Context) error {
 	// Set initial state
 	c.SetServerState(StateStarting)
 
-	// Create a context with timeout
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
 	// Try to ping the server with a simple request
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
@@ -495,14 +491,9 @@ func (c *Client) RegisterServerRequestHandler(method string, handler transport.H
 
 // openKeyConfigFiles opens important configuration files that help initialize the server.
 func (c *Client) openKeyConfigFiles(ctx context.Context) {
-	wd, err := os.Getwd()
-	if err != nil {
-		return
-	}
-
 	// Try to open each file, ignoring errors if they don't exist
 	for _, file := range c.config.RootMarkers {
-		file = filepath.Join(wd, file)
+		file = filepath.Join(c.cwd, file)
 		if _, err := os.Stat(file); err == nil {
 			// File exists, try to open it
 			if err := c.OpenFile(ctx, file); err != nil {

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -81,7 +81,7 @@ func notifyFileWatchRegistration(id string, watchers []protocol.FileSystemWatche
 func HandleServerMessage(_ context.Context, method string, params json.RawMessage) {
 	var msg protocol.ShowMessageParams
 	if err := json.Unmarshal(params, &msg); err != nil {
-		slog.Debug("Server message", "type", msg.Type, "message", msg.Message)
+		slog.Debug("Error unmarshal server message", "error", err)
 		return
 	}
 

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -228,6 +228,7 @@ func (s *Manager) startServer(ctx context.Context, name, filepath string, server
 	if _, err := client.Initialize(initCtx, s.cfg.WorkingDir()); err != nil {
 		slog.Error("LSP client initialization failed", "name", name, "error", err)
 		client.Close(ctx)
+		s.clients.Del(name)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- **Dead client leak**: When `Initialize` fails in `startServer`, the client was closed but left in the map, permanently blocking future startup attempts for that LSP server. Now properly removed from map on failure.
- **Wrong working directory**: `openKeyConfigFiles` used `os.Getwd()` instead of the client's `cwd` field, which could resolve to incorrect paths.
- **Broken error logging**: `HandleServerMessage` logged zero-value struct fields on unmarshal failure instead of the actual error.
- **Redundant hardcoded timeout**: `WaitForServerReady` created an inner 30s timeout that could override the caller's configurable timeout.

## Test plan
- [ ] Verify LSP server can recover after transient initialization failure
- [ ] Verify root marker config files are opened from correct workspace directory
- [ ] Verify server message unmarshal errors are logged correctly
- [ ] Run existing tests: `go test ./internal/lsp/...`