### PR TITLE
fix: initialize lsp manager callback to prevent nil pointer panic

### DIFF
--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -59,9 +59,10 @@ func NewManager(cfg *config.Config) *Manager {
 	}
 
 	return &Manager{
-		clients: csync.NewMap[string, *Client](),
-		cfg:     cfg,
-		manager: manager,
+		clients:  csync.NewMap[string, *Client](),
+		cfg:      cfg,
+		manager:  manager,
+		callback: func(string, *Client) {}, // default no-op callback
 	}
 }
 


### PR DESCRIPTION
The `callback` field was `nil` when the app returned early before `SetCallback` was called, causing a segfault in `startServer`.

💘 Generated with Crush

Assisted-by: Claude Opus 4.6 via Crush <crush@charm.land>

---

* Reported on https://github.com/charmbracelet/crush/issues/2255#issuecomment-3957118176
