### PR TITLE
fix(event): guard against panic

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -84,7 +84,7 @@ func send(event string, props ...any) {
 
 // Error logs an error event to PostHog with the error type and message.
 func Error(errToLog any, props ...any) {
-	if client == nil {
+	if client == nil || errToLog == nil {
 		return
 	}
 	posthogErr := client.Enqueue(posthog.NewDefaultException(


### PR DESCRIPTION
This guards against a panic than can occasionally happen if an error meant to be logged is a nil pointer.