### PR TITLE
Fix 800% CPU usage in large JS monorepo

### DIFF
--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -303,8 +303,10 @@ func hasRootMarkers(dir string, markers []string) bool {
 		return true
 	}
 	for _, pattern := range markers {
-		// Use fsext.GlobWithDoubleStar to find matches
-		matches, _, err := fsext.Glob(pattern, dir, 1)
+		// Use filepath.Glob for a non-recursive check in the root
+		// directory. This avoids walking the entire tree (which is
+		// catastrophic in large monorepos with node_modules, etc.).
+		matches, err := filepath.Glob(filepath.Join(dir, pattern))
 		if err == nil && len(matches) > 0 {
 			return true
 		}


### PR DESCRIPTION
hasRootMarkers()  used  fsext.Glob()  to check for LSP root markers like  package.json  and  go.mod . Under the hood
this launched a recursive fastwalk of the entire working directory with no gitignore filtering, no  node_modules
skipping, and symlink following enabled. This ran every time an LSP server check was triggered (file reads, writes,
edits, session starts).

In large JS monorepos with deep  node_modules  trees, this walked millions of files/directories and consumed 97% of all
sampled CPU time across 8 cores.

Fix: Replace  fsext.Glob()  with  filepath.Glob(filepath.Join(dir, pattern)) . Root markers are always simple filenames
or single-level wildcards ( go.mod ,  package.json ,  *.gpr ) that only exist at the project root — a recursive walk was
never needed.

[pprof.crush.samples.cpu.001.pb.gz](https://github.com/user-attachments/files/25583415/pprof.crush.samples.cpu.001.pb.gz)

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).