### PR TITLE
feat: Quick Quit Options for Shell

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,8 +198,9 @@ type LSPConfig struct {
 }
 
 type TUIOptions struct {
-	CompactMode bool   `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
-	DiffMode    string `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
+	CompactMode  bool   `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
+	DiffMode     string `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
+	QuickQuitKey string `json:"quick_quit_key,omitempty" jsonschema:"description=Keybinding for instant quit without confirmation (e.g. ctrl+q). Set to empty or disabled to turn off,default=ctrl+q"`
 	// Here we can add themes later or any TUI related options
 	//
 

--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -57,13 +57,14 @@ type KeyMap struct {
 	}
 
 	// Global key maps
-	Quit     key.Binding
-	Help     key.Binding
-	Commands key.Binding
-	Models   key.Binding
-	Suspend  key.Binding
-	Sessions key.Binding
-	Tab      key.Binding
+	Quit      key.Binding
+	QuickQuit key.Binding
+	Help      key.Binding
+	Commands  key.Binding
+	Models    key.Binding
+	Suspend   key.Binding
+	Sessions  key.Binding
+	Tab       key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
@@ -71,6 +72,10 @@ func DefaultKeyMap() KeyMap {
 		Quit: key.NewBinding(
 			key.WithKeys("ctrl+c"),
 			key.WithHelp("ctrl+c", "quit"),
+		),
+		QuickQuit: key.NewBinding(
+			key.WithKeys("ctrl+q"),
+			key.WithHelp("ctrl+q", "quick quit"),
 		),
 		Help: key.NewBinding(
 			key.WithKeys("ctrl+g"),


### PR DESCRIPTION
Fixes #2283 

Quick Quit Option for Shell using Ctrl+Q
Works for both Linux and MacOS

Tested using MacOS M4 and with Lima

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
