### PR TITLE
feat: reload config without restart

### DIFF
--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -71,6 +71,12 @@ func (s *Manager) Clients() *csync.Map[string, *Client] {
 	return s.clients
 }
 
+// SetConfig updates the config used by the manager (e.g. after config reload).
+// Note: Changes to the LSP server list in config only take effect after restart.
+func (s *Manager) SetConfig(cfg *config.Config) {
+	s.cfg = cfg
+}
+
 // SetCallback sets a callback that is invoked when a new LSP
 // client is successfully started. This allows the coordinator to add LSP tools.
 func (s *Manager) SetCallback(cb func(name string, client *Client)) {

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -79,6 +79,8 @@ type (
 		Arguments   []commands.Argument
 		Args        map[string]string // Actual argument values
 	}
+	// ActionReloadConfig is a message to reload configuration from disk.
+	ActionReloadConfig struct{}
 )
 
 // Messages for API key input dialog.

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -457,6 +457,7 @@ func (c *Commands) defaultCommands() []*CommandItem {
 	}
 
 	commands = append(commands,
+		NewCommandItem(c.com.Styles, "reload_config", "Reload Config", "", ActionReloadConfig{}),
 		NewCommandItem(c.com.Styles, "toggle_yolo", "Toggle Yolo Mode", "", ActionToggleYoloMode{}),
 		NewCommandItem(c.com.Styles, "toggle_help", "Toggle Help", "ctrl+g", ActionToggleHelp{}),
 		NewCommandItem(c.com.Styles, "init", "Initialize Project", "", ActionInitializeProject{}),

--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -57,13 +57,14 @@ type KeyMap struct {
 	}
 
 	// Global key maps
-	Quit     key.Binding
-	Help     key.Binding
-	Commands key.Binding
-	Models   key.Binding
-	Suspend  key.Binding
-	Sessions key.Binding
-	Tab      key.Binding
+	Quit         key.Binding
+	ReloadConfig key.Binding
+	Help         key.Binding
+	Commands     key.Binding
+	Models       key.Binding
+	Suspend      key.Binding
+	Sessions     key.Binding
+	Tab          key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
@@ -71,6 +72,10 @@ func DefaultKeyMap() KeyMap {
 		Quit: key.NewBinding(
 			key.WithKeys("ctrl+c"),
 			key.WithHelp("ctrl+c", "quit"),
+		),
+		ReloadConfig: key.NewBinding(
+			key.WithKeys("ctrl+shift+r"),
+			key.WithHelp("ctrl+shift+r", "reload config"),
 		),
 		Help: key.NewBinding(
 			key.WithKeys("ctrl+g"),


### PR DESCRIPTION
Fixes #2228

Summary -

Dynamic Reloading of Config using `/reload` or`Ctrl+Shift+R`
This allows config to be reloaded without reloading the conversation history

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
