### PR TITLE
feat(commands): load Claude Code commands from .claude/commands

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -18,6 +18,7 @@ var namedArgPattern = regexp.MustCompile(`\$([A-Z][A-Z0-9_]*)`)
 const (
 	userCommandPrefix    = "user:"
 	projectCommandPrefix = "project:"
+	claudeCommandPrefix  = "claude:"
 )
 
 // Argument represents a command argument with its metadata.
@@ -47,8 +48,10 @@ type CustomCommand struct {
 }
 
 type commandSource struct {
-	path   string
-	prefix string
+	path        string
+	prefix      string
+	createDir   bool // Create directory if it doesn't exist.
+	frontmatter bool // Strip YAML frontmatter from command content.
 }
 
 // LoadCustomCommands loads custom commands from multiple sources including
@@ -92,26 +95,48 @@ func LoadMCPPrompts() ([]MCPPrompt, error) {
 func buildCommandSources(cfg *config.Config) []commandSource {
 	var sources []commandSource
 
+	homeDir := home.Dir()
+	projectDir := filepath.Dir(cfg.Options.DataDirectory)
+
 	// XDG config directory
 	if dir := getXDGCommandsDir(); dir != "" {
 		sources = append(sources, commandSource{
-			path:   dir,
-			prefix: userCommandPrefix,
+			path:      dir,
+			prefix:    userCommandPrefix,
+			createDir: true,
 		})
 	}
 
 	// Home directory
-	if home := home.Dir(); home != "" {
+	if homeDir != "" {
 		sources = append(sources, commandSource{
-			path:   filepath.Join(home, ".crush", "commands"),
-			prefix: userCommandPrefix,
+			path:      filepath.Join(homeDir, ".crush", "commands"),
+			prefix:    userCommandPrefix,
+			createDir: true,
 		})
 	}
 
 	// Project directory
 	sources = append(sources, commandSource{
-		path:   filepath.Join(cfg.Options.DataDirectory, "commands"),
-		prefix: projectCommandPrefix,
+		path:      filepath.Join(cfg.Options.DataDirectory, "commands"),
+		prefix:    projectCommandPrefix,
+		createDir: true,
+	})
+
+	// Claude Code global commands (~/.claude/commands)
+	if homeDir != "" {
+		sources = append(sources, commandSource{
+			path:        filepath.Join(homeDir, ".claude", "commands"),
+			prefix:      claudeCommandPrefix,
+			frontmatter: true,
+		})
+	}
+
+	// Claude Code project commands (<project>/.claude/commands)
+	sources = append(sources, commandSource{
+		path:        filepath.Join(projectDir, ".claude", "commands"),
+		prefix:      claudeCommandPrefix,
+		frontmatter: true,
 	})
 
 	return sources
@@ -130,8 +155,12 @@ func loadAll(sources []commandSource) ([]CustomCommand, error) {
 }
 
 func loadFromSource(source commandSource) ([]CustomCommand, error) {
-	if err := ensureDir(source.path); err != nil {
-		return nil, err
+	if source.createDir {
+		if err := ensureDir(source.path); err != nil {
+			return nil, err
+		}
+	} else if _, err := os.Stat(source.path); err != nil {
+		return nil, nil
 	}
 
 	var commands []CustomCommand
@@ -141,7 +170,7 @@ func loadFromSource(source commandSource) ([]CustomCommand, error) {
 			return err
 		}
 
-		cmd, err := loadCommand(path, source.path, source.prefix)
+		cmd, err := loadCommand(path, source)
 		if err != nil {
 			return nil // Skip invalid files
 		}
@@ -153,19 +182,24 @@ func loadFromSource(source commandSource) ([]CustomCommand, error) {
 	return commands, err
 }
 
-func loadCommand(path, baseDir, prefix string) (CustomCommand, error) {
-	content, err := os.ReadFile(path)
+func loadCommand(path string, source commandSource) (CustomCommand, error) {
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return CustomCommand{}, err
 	}
 
-	id := buildCommandID(path, baseDir, prefix)
+	content := string(raw)
+	if source.frontmatter {
+		content = stripFrontmatter(content)
+	}
+
+	id := buildCommandID(path, source.path, source.prefix)
 
 	return CustomCommand{
 		ID:        id,
 		Name:      id,
-		Content:   string(content),
-		Arguments: extractArgNames(string(content)),
+		Content:   content,
+		Arguments: extractArgNames(content),
 	}, nil
 }
 
@@ -214,6 +248,18 @@ func getXDGCommandsDir() string {
 		return filepath.Join(xdgHome, "crush", "commands")
 	}
 	return ""
+}
+
+func stripFrontmatter(content string) string {
+	if !strings.HasPrefix(content, "---") {
+		return content
+	}
+	rest := content[3:]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return content
+	}
+	return strings.TrimSpace(rest[end+4:])
 }
 
 func ensureDir(path string) error {

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -1,0 +1,211 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+)
+
+func TestStripFrontmatter(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no frontmatter",
+			input:    "just some content",
+			expected: "just some content",
+		},
+		{
+			name:     "with frontmatter",
+			input:    "---\ndescription: Review code\n---\nReview the following code",
+			expected: "Review the following code",
+		},
+		{
+			name:     "with empty frontmatter",
+			input:    "---\n---\nContent after empty frontmatter",
+			expected: "Content after empty frontmatter",
+		},
+		{
+			name:     "unclosed frontmatter",
+			input:    "---\ndescription: broken\nno closing delimiter",
+			expected: "---\ndescription: broken\nno closing delimiter",
+		},
+		{
+			name:     "frontmatter with multiple fields",
+			input:    "---\ndescription: My command\nallowed-tools: bash, grep\n---\nDo the thing with $ARGUMENTS",
+			expected: "Do the thing with $ARGUMENTS",
+		},
+		{
+			name:     "content starting with triple dash but not frontmatter",
+			input:    "--- not frontmatter",
+			expected: "--- not frontmatter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripFrontmatter(tt.input)
+			if got != tt.expected {
+				t.Errorf("stripFrontmatter() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLoadCommand_ClaudeFormat(t *testing.T) {
+	dir := t.TempDir()
+	content := "---\ndescription: Review code changes\n---\nReview the code in $FILE and suggest improvements"
+	if err := os.WriteFile(filepath.Join(dir, "review.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	source := commandSource{
+		path:        dir,
+		prefix:      claudeCommandPrefix,
+		frontmatter: true,
+	}
+
+	cmd, err := loadCommand(filepath.Join(dir, "review.md"), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cmd.ID != "claude:review" {
+		t.Errorf("ID = %q, want %q", cmd.ID, "claude:review")
+	}
+	if cmd.Content != "Review the code in $FILE and suggest improvements" {
+		t.Errorf("Content = %q, want frontmatter stripped", cmd.Content)
+	}
+	if len(cmd.Arguments) != 1 || cmd.Arguments[0].ID != "FILE" {
+		t.Errorf("Arguments = %v, want single FILE arg", cmd.Arguments)
+	}
+}
+
+func TestLoadCommand_CrushFormat(t *testing.T) {
+	dir := t.TempDir()
+	content := "Review the code in $FILE and suggest improvements"
+	if err := os.WriteFile(filepath.Join(dir, "review.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	source := commandSource{
+		path:   dir,
+		prefix: userCommandPrefix,
+	}
+
+	cmd, err := loadCommand(filepath.Join(dir, "review.md"), source)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cmd.ID != "user:review" {
+		t.Errorf("ID = %q, want %q", cmd.ID, "user:review")
+	}
+	if cmd.Content != content {
+		t.Errorf("Content = %q, want original content preserved", cmd.Content)
+	}
+}
+
+func TestLoadFromSource_ClaudeDir(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude", "commands")
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	files := map[string]string{
+		"review.md":     "---\ndescription: Review\n---\nReview $ARGUMENTS",
+		"deploy.md":     "Deploy to $ENVIRONMENT",
+		"git/commit.md": "---\ndescription: Commit helper\n---\nCommit with message: $MESSAGE",
+	}
+	for name, content := range files {
+		path := filepath.Join(claudeDir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	source := commandSource{
+		path:        claudeDir,
+		prefix:      claudeCommandPrefix,
+		frontmatter: true,
+	}
+
+	cmds, err := loadFromSource(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cmds) != 3 {
+		t.Fatalf("got %d commands, want 3", len(cmds))
+	}
+
+	byID := make(map[string]CustomCommand)
+	for _, cmd := range cmds {
+		byID[cmd.ID] = cmd
+	}
+
+	if cmd, ok := byID["claude:review"]; !ok {
+		t.Error("missing claude:review command")
+	} else if cmd.Content != "Review $ARGUMENTS" {
+		t.Errorf("claude:review content = %q, want frontmatter stripped", cmd.Content)
+	}
+
+	if cmd, ok := byID["claude:deploy"]; !ok {
+		t.Error("missing claude:deploy command")
+	} else if cmd.Content != "Deploy to $ENVIRONMENT" {
+		t.Errorf("claude:deploy content = %q, no frontmatter to strip", cmd.Content)
+	}
+
+	if _, ok := byID["claude:git:commit"]; !ok {
+		t.Error("missing claude:git:commit command (nested directory)")
+	}
+}
+
+func TestLoadFromSource_MissingDir(t *testing.T) {
+	source := commandSource{
+		path:   filepath.Join(t.TempDir(), "nonexistent"),
+		prefix: claudeCommandPrefix,
+	}
+
+	cmds, err := loadFromSource(source)
+	if err != nil {
+		t.Fatalf("unexpected error for missing dir: %v", err)
+	}
+	if len(cmds) != 0 {
+		t.Errorf("got %d commands for missing dir, want 0", len(cmds))
+	}
+}
+
+func TestBuildCommandSources_IncludesClaudeDirs(t *testing.T) {
+	cfg := &config.Config{
+		Options: &config.Options{
+			DataDirectory: filepath.Join(t.TempDir(), ".crush"),
+		},
+	}
+
+	sources := buildCommandSources(cfg)
+
+	var hasClaude bool
+	for _, s := range sources {
+		if s.prefix == claudeCommandPrefix {
+			hasClaude = true
+			if !s.frontmatter {
+				t.Error("Claude source missing frontmatter flag")
+			}
+			if s.createDir {
+				t.Error("Claude source should not create directories")
+			}
+		}
+	}
+	if !hasClaude {
+		t.Error("no Claude command sources found")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds support for loading custom commands from Claude Code's `.claude/commands/` directories (`~/.claude/commands/` for global, `<project>/.claude/commands/` for project-level)
- Claude commands appear with a `claude:` prefix in the command palette alongside existing `user:` and `project:` commands
- YAML frontmatter (used by Claude Code for metadata) is automatically stripped from command content

## Motivation

Many developers use both Crush and Claude Code. Claude Code stores reusable prompt commands as `.md` files in `.claude/commands/` directories. This change lets Crush discover and use those same commands natively, so users can maintain a single set of commands that work across both tools.

The implementation is minimal — two new source directories in the existing command loading pipeline, a frontmatter stripping utility, and a `createDir` flag to avoid creating `.claude/` directories that don't already exist.

## Changes

**`internal/commands/commands.go`**:
- Added `claude:` command prefix and two new sources in `buildCommandSources()` for `~/.claude/commands/` (global) and `<project>/.claude/commands/` (project)
- Added `createDir` field to `commandSource` — Crush-native directories are created if missing; Claude directories are only read if they already exist
- Added `frontmatter` field to `commandSource` — when set, YAML frontmatter is stripped from command content before use
- Added `stripFrontmatter()` utility function

**`internal/commands/commands_test.go`** (new):
- Tests for frontmatter stripping (6 cases: no frontmatter, valid, empty, unclosed, multi-field, non-frontmatter dashes)
- Tests for loading Claude-format and Crush-format commands
- Tests for directory walking, missing directories, and source configuration

## Claude Code command format

```markdown
---
description: Review code changes
---
Review the code in $FILE and suggest improvements
```

The `$FILE` placeholder is automatically detected as a named argument by the existing `extractArgNames` logic — no special handling needed.