### PR TITLE
feat(agent): add toolcall detection wrapper for openai-compat provide…

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -562,9 +562,7 @@ func (c *coordinator) buildAgentModels(ctx context.Context, isSubAgent bool) (Mo
 		return Model{}, Model{}, err
 	}
 
-	// Wrap openai-compat models to detect tool calls emitted as plain text.
-	// Some local model servers (e.g. Ollama) return tool call JSON in the
-	// text content field instead of using the structured tool_calls field.
+	// Wrap openai-compat models to detect tool call JSON emitted as plain text (e.g. Ollama).
 	if largeProviderCfg.Type == openaicompat.Name {
 		largeModel = newToolCallDetectingModel(largeModel)
 	}

--- a/internal/agent/toolcall_detect.go
+++ b/internal/agent/toolcall_detect.go
@@ -12,11 +12,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// toolCallDetectingModel wraps a fantasy.LanguageModel to detect tool call
-// JSON emitted as plain text content. Some local model servers (e.g. Ollama)
-// return tool call JSON in the text content field instead of the structured
-// tool_calls field. This wrapper detects that pattern and converts the text
-// into proper tool call stream events so the agent loop can execute them.
+// toolCallDetectingModel detects tool call JSON emitted as plain text by local model servers (e.g. Ollama) and converts it into proper tool call events.
 type toolCallDetectingModel struct {
 	inner fantasy.LanguageModel
 }
@@ -36,9 +32,7 @@ func (m *toolCallDetectingModel) StreamObject(ctx context.Context, call fantasy.
 	return m.inner.StreamObject(ctx, call)
 }
 
-// Generate wraps the non-streaming path. If the response is text-only and
-// parses as tool call JSON with known tool names, replace the text content
-// with proper ToolCallContent entries.
+// Generate converts text-only responses containing tool call JSON into proper ToolCallContent entries.
 func (m *toolCallDetectingModel) Generate(ctx context.Context, call fantasy.Call) (*fantasy.Response, error) {
 	resp, err := m.inner.Generate(ctx, call)
 	if err != nil {
@@ -46,23 +40,16 @@ func (m *toolCallDetectingModel) Generate(ctx context.Context, call fantasy.Call
 	}
 
 	resolver := newToolNameResolver(call)
-	if resolver == nil {
+	if resolver == nil || len(resp.Content.ToolCalls()) > 0 {
 		return resp, nil
 	}
 
-	// Only attempt conversion when the response is pure text (no tool calls).
-	if len(resp.Content.ToolCalls()) > 0 {
-		return resp, nil
-	}
-
-	text := resp.Content.Text()
-	parsed := parseToolCallsFromText(text, resolver)
+	parsed := parseToolCallsFromText(resp.Content.Text(), resolver)
 	if len(parsed) == 0 {
 		return resp, nil
 	}
 
 	slog.Debug("Detected tool call JSON in text content (non-streaming)", "count", len(parsed))
-
 	content := make([]fantasy.Content, 0, len(parsed))
 	for _, tc := range parsed {
 		content = append(content, fantasy.ToolCallContent{
@@ -76,9 +63,7 @@ func (m *toolCallDetectingModel) Generate(ctx context.Context, call fantasy.Call
 	return resp, nil
 }
 
-// Stream wraps the streaming path. It buffers text events and, once text
-// ends, checks whether the accumulated text is tool call JSON. If so it
-// emits tool call events instead of the buffered text events.
+// Stream buffers text events and converts accumulated tool call JSON into tool call stream events on TextEnd.
 func (m *toolCallDetectingModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
 	inner, err := m.inner.Stream(ctx, call)
 	if err != nil {
@@ -95,6 +80,17 @@ func (m *toolCallDetectingModel) Stream(ctx context.Context, call fantasy.Call) 
 		var buffered []fantasy.StreamPart
 		buffering := true
 		detectedToolCalls := false
+
+		flush := func() bool {
+			for _, p := range buffered {
+				if !yield(p) {
+					return false
+				}
+			}
+			buffered = nil
+			buffering = false
+			return true
+		}
 
 		for part := range inner {
 			if !buffering {
@@ -119,94 +115,56 @@ func (m *toolCallDetectingModel) Stream(ctx context.Context, call fantasy.Call) 
 				if len(parsed) > 0 {
 					slog.Debug("Detected tool call JSON in text content (streaming)", "count", len(parsed))
 					detectedToolCalls = true
+					buffered = nil
+					buffering = false
 					for _, tc := range parsed {
-						if !yield(fantasy.StreamPart{
-							Type:         fantasy.StreamPartTypeToolInputStart,
-							ID:           tc.id,
-							ToolCallName: tc.name,
-						}) {
-							return
-						}
-						if !yield(fantasy.StreamPart{
-							Type:  fantasy.StreamPartTypeToolInputDelta,
-							ID:    tc.id,
-							Delta: tc.args,
-						}) {
-							return
-						}
-						if !yield(fantasy.StreamPart{
-							Type: fantasy.StreamPartTypeToolInputEnd,
-							ID:   tc.id,
-						}) {
-							return
-						}
-						if !yield(fantasy.StreamPart{
-							Type:          fantasy.StreamPartTypeToolCall,
-							ID:            tc.id,
-							ToolCallName:  tc.name,
-							ToolCallInput: tc.args,
-						}) {
-							return
+						for _, p := range []fantasy.StreamPart{
+							{Type: fantasy.StreamPartTypeToolInputStart, ID: tc.id, ToolCallName: tc.name},
+							{Type: fantasy.StreamPartTypeToolInputDelta, ID: tc.id, Delta: tc.args},
+							{Type: fantasy.StreamPartTypeToolInputEnd, ID: tc.id},
+							{Type: fantasy.StreamPartTypeToolCall, ID: tc.id, ToolCallName: tc.name, ToolCallInput: tc.args},
+						} {
+							if !yield(p) {
+								return
+							}
 						}
 					}
 				} else {
-					// Not tool calls — flush buffered text events.
-					for _, p := range buffered {
-						if !yield(p) {
-							return
-						}
+					if !flush() {
+						return
 					}
 					if !yield(part) {
 						return
 					}
 				}
-				buffered = nil
-				buffering = false
 
 			default:
-				// Non-text events (reasoning, native tool calls, errors,
-				// finish, etc.) pass through immediately and stop buffering.
-				for _, p := range buffered {
-					if !yield(p) {
-						return
-					}
+				if !flush() {
+					return
 				}
-				buffered = nil
-				buffering = false
 				if !yield(part) {
 					return
 				}
 			}
 		}
 
-		// If the stream ended while still buffering (no TextEnd received),
-		// flush whatever we have.
-		for _, p := range buffered {
-			if !yield(p) {
-				return
-			}
-		}
+		flush()
 	}, nil
 }
 
-// parsedToolCall holds a single parsed tool call extracted from text.
 type parsedToolCall struct {
 	id   string
 	name string
 	args string
 }
 
-// toolCallJSON is the JSON shape local models typically emit.
 type toolCallJSON struct {
 	Name      string          `json:"name"`
 	Arguments json.RawMessage `json:"arguments"`
 }
 
-// codeBlockRe matches markdown fenced code blocks (```json ... ``` or ``` ... ```).
 var codeBlockRe = regexp.MustCompile("(?s)^\\s*```(?:json|JSON)?\\s*\n?(.*?)\\s*```\\s*$")
 
-// stripCodeFence removes a markdown fenced code block wrapper if present.
-// Local models frequently wrap tool call JSON in ```json ... ``` blocks.
 func stripCodeFence(text string) string {
 	if m := codeBlockRe.FindStringSubmatch(text); len(m) > 1 {
 		return strings.TrimSpace(m[1])
@@ -214,20 +172,9 @@ func stripCodeFence(text string) string {
 	return text
 }
 
-// parseToolCallsFromText attempts to parse text as tool call JSON. It returns
-// nil if the text is not valid tool call JSON or if any tool name is not in
-// the known set. It handles markdown code fences and case-insensitive tool
-// name matching.
+// parseToolCallsFromText parses text as tool call JSON, returning nil if invalid or any tool name is unknown.
 func parseToolCallsFromText(text string, resolver *toolNameResolver) []parsedToolCall {
-	trimmed := strings.TrimSpace(text)
-	if len(trimmed) == 0 {
-		return nil
-	}
-
-	// Strip markdown code fences if present.
-	trimmed = stripCodeFence(trimmed)
-
-	// Must start with { or [ to be candidate JSON.
+	trimmed := stripCodeFence(strings.TrimSpace(text))
 	if len(trimmed) == 0 || (trimmed[0] != '{' && trimmed[0] != '[') {
 		return nil
 	}
@@ -251,33 +198,24 @@ func parseToolCallsFromText(text string, resolver *toolNameResolver) []parsedToo
 
 	result := make([]parsedToolCall, 0, len(candidates))
 	for _, c := range candidates {
-		resolvedName := resolver.resolve(c.Name)
-		if resolvedName == "" {
-			// If any candidate has an unknown name, reject the entire batch
-			// to avoid false positives.
-			return nil
+		resolved := resolver.resolve(c.Name)
+		if resolved == "" {
+			return nil // unknown name — reject entire batch to avoid false positives
 		}
 		result = append(result, parsedToolCall{
 			id:   fmt.Sprintf("call_%s", uuid.NewString()),
-			name: resolvedName,
+			name: resolved,
 			args: normalizeArguments(c.Arguments),
 		})
 	}
 	return result
 }
 
-// toolNameResolver maps model-emitted tool names to canonical registered names.
-// It handles exact matches, case-insensitive matches, and description-based
-// aliases (e.g. a model emitting "Read" can be resolved to the "view" tool
-// whose description starts with "Reads").
+// toolNameResolver maps model-emitted tool names to canonical names via exact match, case-insensitive match, or description-based alias (e.g. "Read" -> "view").
 type toolNameResolver struct {
-	// nameMap maps lowercased lookup keys to canonical tool names.
-	// Keys include the tool name itself and aliases derived from the
-	// first word of the tool description.
 	nameMap map[string]string
 }
 
-// newToolNameResolver builds a resolver from the tools in a fantasy.Call.
 func newToolNameResolver(call fantasy.Call) *toolNameResolver {
 	if len(call.Tools) == 0 {
 		return nil
@@ -289,14 +227,9 @@ func newToolNameResolver(call fantasy.Call) *toolNameResolver {
 		if name == "" {
 			continue
 		}
-
-		// Register the canonical name (lowercased).
 		nameMap[strings.ToLower(name)] = name
 
-		// Register an alias from the first word of the description.
-		// Small models often emit the description verb as the tool name
-		// (e.g. "Read" instead of "view" for a tool described as "Reads
-		// and displays file contents...").
+		// Models often emit the description verb as the tool name (e.g. "Read" for "view").
 		ft, ok := t.(fantasy.FunctionTool)
 		if !ok || ft.Description == "" {
 			continue
@@ -309,57 +242,39 @@ func newToolNameResolver(call fantasy.Call) *toolNameResolver {
 		if alias == "" || alias == strings.ToLower(name) {
 			continue
 		}
-		// Only register if unambiguous (no collision with another tool).
 		if _, exists := nameMap[alias]; !exists {
 			nameMap[alias] = name
 		} else if nameMap[alias] != name {
-			// Collision — remove the alias to avoid wrong matches.
-			delete(nameMap, alias)
+			delete(nameMap, alias) // collision — remove to avoid wrong matches
 		}
 	}
 
 	return &toolNameResolver{nameMap: nameMap}
 }
 
-// resolve maps a model-emitted name to the canonical tool name.
-// Returns "" if no match is found.
 func (r *toolNameResolver) resolve(name string) string {
 	if name == "" {
 		return ""
 	}
-	lower := normalizeVerb(name)
-	if canonical, ok := r.nameMap[lower]; ok {
+	if canonical, ok := r.nameMap[normalizeVerb(name)]; ok {
 		return canonical
 	}
 	return ""
 }
 
-// normalizeVerb lowercases a word and strips common English verb suffixes
-// so that "Reads", "Read", "reads" all normalize to "read".
+// normalizeVerb lowercases and strips trailing "s" so "Reads", "Read", "reads" all become "read".
 func normalizeVerb(word string) string {
-	lower := strings.ToLower(strings.TrimSpace(word))
-	// Strip trailing "s" (Reads -> Read, Creates -> Create, Executes -> Execute).
-	lower = strings.TrimSuffix(lower, "s")
-	return lower
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(word)), "s")
 }
 
-// normalizeArguments handles both object arguments and stringified JSON
-// arguments. Some models emit {"arguments":"{\"key\":\"value\"}"} instead
-// of {"arguments":{"key":"value"}}.
+// normalizeArguments unwraps stringified JSON arguments into proper JSON objects.
 func normalizeArguments(raw json.RawMessage) string {
 	if len(raw) == 0 {
 		return "{}"
 	}
-
-	// Try to unmarshal as a string (stringified JSON).
 	var s string
-	if json.Unmarshal(raw, &s) == nil {
-		// Verify the string is valid JSON before returning it.
-		if json.Valid([]byte(s)) {
-			return s
-		}
+	if json.Unmarshal(raw, &s) == nil && json.Valid([]byte(s)) {
+		return s
 	}
-
-	// Already an object/array — return as-is.
 	return string(raw)
 }

--- a/internal/agent/toolcall_detect_test.go
+++ b/internal/agent/toolcall_detect_test.go
@@ -115,7 +115,6 @@ func TestParseToolCallsFromText(t *testing.T) {
 			wantCount: 1,
 			wantNames: []string{"view"},
 		},
-		// Markdown code fence tests.
 		{
 			name:      "json code fence",
 			text:      "```json\n{\"name\":\"view\",\"arguments\":{\"file_path\":\"./go.mod\"}}\n```",
@@ -145,7 +144,6 @@ func TestParseToolCallsFromText(t *testing.T) {
 			wantCount: 2,
 			wantNames: []string{"view", "grep"},
 		},
-		// Case-insensitive tool name tests.
 		{
 			name:      "capitalized tool name",
 			text:      `{"name":"View","arguments":{"file_path":"main.go"}}`,
@@ -164,7 +162,6 @@ func TestParseToolCallsFromText(t *testing.T) {
 			wantCount: 1,
 			wantNames: []string{"view"},
 		},
-		// Description-based alias tests (model uses description verb as name).
 		{
 			name:      "description alias Read -> view",
 			text:      `{"name":"Read","arguments":{"file_path":"./go.mod"}}`,
@@ -291,7 +288,6 @@ func TestToolNameResolver(t *testing.T) {
 func TestToolNameResolver_DescriptionCollision(t *testing.T) {
 	t.Parallel()
 
-	// Both tools have descriptions starting with "Fast" — alias should be skipped.
 	resolver := newToolNameResolver(fantasy.Call{
 		Tools: []fantasy.Tool{
 			fantasy.FunctionTool{Name: "grep", Description: "Fast content search"},
@@ -299,9 +295,7 @@ func TestToolNameResolver_DescriptionCollision(t *testing.T) {
 		},
 	})
 
-	// "Fast" is ambiguous, should not resolve.
 	require.Equal(t, "", resolver.resolve("Fast"))
-	// Exact names still work.
 	require.Equal(t, "grep", resolver.resolve("grep"))
 	require.Equal(t, "glob", resolver.resolve("glob"))
 }
@@ -376,7 +370,6 @@ func TestNormalizeVerb(t *testing.T) {
 	}
 }
 
-// fakeLanguageModel is a minimal test double for fantasy.LanguageModel.
 type fakeLanguageModel struct {
 	generateResp *fantasy.Response
 	streamParts  []fantasy.StreamPart
@@ -531,7 +524,6 @@ func TestToolCallDetectingModel_Stream(t *testing.T) {
 			parts = append(parts, part)
 		}
 
-		// Should have: ToolInputStart, ToolInputDelta, ToolInputEnd, ToolCall, Finish.
 		require.Len(t, parts, 5)
 		require.Equal(t, fantasy.StreamPartTypeToolInputStart, parts[0].Type)
 		require.Equal(t, "view", parts[0].ToolCallName)


### PR DESCRIPTION
###  Summary

Local models served through Ollama's OpenAI-compatible endpoint put tool call JSON in the text content field instead of the structured `tool_calls` field. The fantasy library only reads `tool_calls`, so the JSON just shows up as plain text and tools never actually run.

This PR adds a `LanguageModel` wrapper that intercepts text output from openai-compat providers, checks if it looks like tool call JSON with known tool names, and converts it into proper tool call events.

<img width="1463" height="795" alt="test" src="https://github.com/user-attachments/assets/d78dc4f1-f5b0-44d7-a470-5530dd57a588" />

### What it handles

- Raw JSON tool calls in text content
- JSON wrapped in markdown code fences (`` ```json ... ``` ``)
- Case-insensitive tool name matching (`View` → `view`)
- Description-based aliases (`Read` → `view`, `Execute` → `bash`)
- Stringified arguments (`"arguments": "{\"key\":\"value\"}"`)

### Files changed

- `internal/agent/toolcall_detect.go` - the wrapper implementation
- `internal/agent/toolcall_detect_test.go` - 50+ test cases
- `internal/agent/coordinator.go` - wires up the wrapper for openai-compat providers

### Notes

- Only wraps the large model (small model does summarization, no tool calling)
- Rejects the entire batch if any tool name is unknown to avoid false positives
- Tested end-to-end with `qwen2.5-coder:7b` on Ollama

###

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

### Closes: #2073 