### PR TITLE
fix: suppress message when clipboard is empty

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3131,13 +3131,13 @@ func (m *UI) pasteImageFromClipboard() tea.Msg {
 
 	textData, textErr := readClipboard(clipboardFormatText)
 	if textErr != nil || len(textData) == 0 {
-		return util.NewInfoMsg("Clipboard is empty or does not contain an image")
+		return nil // Clipboard is empty or does not contain an image
 	}
 
 	path := strings.TrimSpace(string(textData))
 	path = strings.ReplaceAll(path, "\\ ", " ")
 	if _, statErr := os.Stat(path); statErr != nil {
-		return util.NewInfoMsg("Clipboard does not contain an image or valid file path")
+		return nil // Clipboard does not contain an image or valid file path
 	}
 
 	lowerPath := strings.ToLower(path)


### PR DESCRIPTION
This is Rio on Windows, if you press `ctrl+v` instead of `ctrl+shift+v`.

This message is not useful at all if there is nothing on clipboard or not a valid path, so we can probably just supress it.

<img width="1698" height="1108" alt="image" src="https://github.com/user-attachments/assets/96be2f00-93e7-427f-af76-3c749f3090b5" />
