### PR TITLE
fix(ui): format xhigh as X-High (not Xhigh)

### DIFF
--- a/internal/ui/common/elements.go
+++ b/internal/ui/common/elements.go
@@ -10,6 +10,8 @@ import (
 	"github.com/charmbracelet/crush/internal/home"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/x/ansi"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // PrettyPath formats a file path with home directory shortening and applies
@@ -17,6 +19,14 @@ import (
 func PrettyPath(t *styles.Styles, path string, width int) string {
 	formatted := home.Short(path)
 	return t.Muted.Width(width).Render(formatted)
+}
+
+// FormatReasoningEffort formats a reasoning effort level for display.
+func FormatReasoningEffort(effort string) string {
+	if effort == "xhigh" {
+		return "X-High"
+	}
+	return cases.Title(language.English).String(effort)
 }
 
 // ModelContextInfo contains token usage and cost information for a model.

--- a/internal/ui/dialog/reasoning.go
+++ b/internal/ui/dialog/reasoning.go
@@ -13,8 +13,6 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/sahilm/fuzzy"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 const (
@@ -241,13 +239,12 @@ func (r *Reasoning) setReasoningItems() error {
 		currentEffort = model.DefaultReasoningEffort
 	}
 
-	caser := cases.Title(language.English)
 	items := make([]list.FilterableItem, 0, len(model.ReasoningLevels))
 	selectedIndex := 0
 	for i, effort := range model.ReasoningLevels {
 		item := &ReasoningItem{
 			effort:    effort,
-			title:     caser.String(effort),
+			title:     common.FormatReasoningEffort(effort),
 			isCurrent: effort == currentEffort,
 			t:         r.com.Styles,
 		}

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -9,8 +9,6 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/logo"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/ultraviolet/layout"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 )
 
 // modelInfo renders the current model information including reasoning
@@ -35,9 +33,8 @@ func (m *UI) modelInfo(width int) string {
 						reasoningInfo = "Thinking Off"
 					}
 				} else {
-					formatter := cases.Title(language.English, cases.NoLower)
 					reasoningEffort := cmp.Or(model.ModelCfg.ReasoningEffort, model.CatwalkCfg.DefaultReasoningEffort)
-					reasoningInfo = formatter.String(fmt.Sprintf("Reasoning %s", reasoningEffort))
+					reasoningInfo = fmt.Sprintf("Reasoning %s", common.FormatReasoningEffort(reasoningEffort))
 				}
 			}
 		}


### PR DESCRIPTION
This is a small change to format "xhigh" reasoning as "X-High" instead of "Xhigh".