### PR TITLE
fix(events): remove redundant posthog exit event

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -75,9 +75,6 @@ crush run --verbose "Generate a README for this project"
 
 		return app.RunNonInteractive(ctx, os.Stdout, prompt, largeModel, smallModel, quiet || verbose)
 	},
-	PostRun: func(cmd *cobra.Command, args []string) {
-		event.AppExited()
-	},
 }
 
 func init() {


### PR DESCRIPTION
Prior to this revision we get errors when exiting _every_ time, because `defer app.Shutdown()` shuts logs the exit (logging the event), then the exit event is called again in Cobra's `PostRun` hook, which fails because the app has already shut down.

Before:

<img width="1183" height="197" alt="image" src="https://github.com/user-attachments/assets/2a336b5f-b50a-4f67-b1c5-9fd072693e9b" />

After:

<img width="792" height="170" alt="image" src="https://github.com/user-attachments/assets/c75de7e5-29ea-42fd-b2f9-6f0cdcad45c4" />