### PR TITLE
fix(noninteractive): actually use models to generate titles

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -44,7 +44,7 @@ import (
 )
 
 const (
-	defaultSessionName = "Untitled Session"
+	DefaultSessionName = "Untitled Session"
 
 	// Constants for auto-summarization thresholds
 	largeContextWindowThreshold = 200_000
@@ -822,7 +822,7 @@ func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, user
 			// Welp, the large model didn't work either. Use the default
 			// session name and return.
 			slog.Error("Error generating title with large model", "err", err)
-			saveErr := a.sessions.UpdateTitleAndUsage(ctx, sessionID, defaultSessionName, 0, 0, 0)
+			saveErr := a.sessions.UpdateTitleAndUsage(ctx, sessionID, DefaultSessionName, 0, 0, 0)
 			if saveErr != nil {
 				slog.Error("Failed to save session title and usage", "error", saveErr)
 			}
@@ -834,7 +834,7 @@ func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, user
 		// Actually, we didn't get a response so we can't. Use the default
 		// session name and return.
 		slog.Error("Response is nil; can't generate title")
-		saveErr := a.sessions.UpdateTitleAndUsage(ctx, sessionID, defaultSessionName, 0, 0, 0)
+		saveErr := a.sessions.UpdateTitleAndUsage(ctx, sessionID, DefaultSessionName, 0, 0, 0)
 		if saveErr != nil {
 			slog.Error("Failed to save session title and usage", "error", saveErr)
 		}
@@ -849,7 +849,7 @@ func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, user
 	title = thinkTagRegex.ReplaceAllString(title, "")
 
 	title = strings.TrimSpace(title)
-	title = cmp.Or(title, defaultSessionName)
+	title = cmp.Or(title, DefaultSessionName)
 
 	// Calculate usage and cost.
 	var openrouterCost *float64

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -213,18 +213,7 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 
 	defer stopSpinner()
 
-	const maxPromptLengthForTitle = 100
-	const titlePrefix = "Non-interactive: "
-	var titleSuffix string
-
-	if len(prompt) > maxPromptLengthForTitle {
-		titleSuffix = prompt[:maxPromptLengthForTitle] + "..."
-	} else {
-		titleSuffix = prompt
-	}
-	title := titlePrefix + titleSuffix
-
-	sess, err := app.Sessions.Create(ctx, title)
+	sess, err := app.Sessions.Create(ctx, agent.DefaultSessionName)
 	if err != nil {
 		return fmt.Errorf("failed to create session for non-interactive mode: %w", err)
 	}


### PR DESCRIPTION
Prior to this, non-interactive titles would simply be the prompt, which could be multiple lines and would include data piped in.

This revision also removes the "non-interactive:" title prefix as it's irrelevant. Non-interactive sessions can be picked up in the TUI and are treated no different than interactive sessions.
