### PR TITLE
fix(ui): properly truncate info message

### DIFF
--- a/internal/ui/model/status.go
+++ b/internal/ui/model/status.go
@@ -100,9 +100,12 @@ func (s *Status) Draw(scr uv.Screen, area uv.Rectangle) {
 	}
 
 	ind := indStyle.String()
-	messageWidth := max(0, area.Dx()-lipgloss.Width(ind)-msgStyle.GetHorizontalPadding())
-	msg := ansi.Truncate(s.msg.Msg, messageWidth, "…")
-	msg += strings.Repeat(" ", max(0, messageWidth-lipgloss.Width(msg)))
+	indWidth := lipgloss.Width(ind)
+	msg := strings.Join(strings.Split(s.msg.Msg, "\n"), " ")
+	msgWidth := lipgloss.Width(msg)
+	msg = ansi.Truncate(msg, area.Dx()-indWidth-msgWidth, "…")
+	padWidth := max(0, area.Dx()-indWidth-msgWidth)
+	msg += strings.Repeat(" ", padWidth)
 	info := msgStyle.Render(msg)
 
 	// Draw the info message over the help view


### PR DESCRIPTION
Before:

<img width="805" height="102" alt="image" src="https://github.com/user-attachments/assets/0e0a6022-1936-4c74-bf6b-5aea77e6b0db" />

After:

<img width="860" height="96" alt="image" src="https://github.com/user-attachments/assets/2d910497-c164-41d2-b84f-9c41049d9363" />
