### PR TITLE
fix: prevent glob/grep from searching outside working dir and fix agentic fetch file paths

### DIFF
--- a/internal/agent/agentic_fetch_tool.go
+++ b/internal/agent/agentic_fetch_tool.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"charm.land/fantasy"
@@ -128,7 +129,7 @@ func (c *coordinator) agenticFetchTool(_ context.Context, client *http.Client) (
 					}
 					tempFile.Close()
 
-					fullPrompt = fmt.Sprintf("%s\n\nThe web page from %s has been saved to: %s\n\nUse the view and grep tools to analyze this file and extract the requested information.", params.Prompt, params.URL, tempFilePath)
+					fullPrompt = fmt.Sprintf("%s\n\nThe web page from %s has been saved to: %s\n\nUse the view and grep tools to analyze this file and extract the requested information.", params.Prompt, params.URL, filepath.Base(tempFilePath))
 				} else {
 					fullPrompt = fmt.Sprintf("%s\n\nWeb page URL: %s\n\n<webpage_content>\n%s\n</webpage_content>", params.Prompt, params.URL, content)
 				}

--- a/internal/agent/tools/glob.go
+++ b/internal/agent/tools/glob.go
@@ -42,6 +42,13 @@ func NewGlobTool(workingDir string) fantasy.AgentTool {
 
 			searchPath := cmp.Or(params.Path, workingDir)
 
+			// Clamp search path to working directory to prevent
+			// searching the entire filesystem.
+			searchPath, err := clampToWorkingDir(workingDir, searchPath)
+			if err != nil {
+				return fantasy.NewTextErrorResponse(err.Error()), nil
+			}
+
 			files, truncated, err := globFiles(ctx, params.Pattern, searchPath, 100)
 			if err != nil {
 				return fantasy.ToolResponse{}, fmt.Errorf("error finding files: %w", err)
@@ -79,7 +86,7 @@ func globFiles(ctx context.Context, pattern, searchPath string, limit int) ([]st
 		slog.Warn("Ripgrep execution failed, falling back to doublestar", "error", err)
 	}
 
-	return fsext.GlobGitignoreAware(pattern, searchPath, limit)
+	return fsext.GlobGitignoreAware(ctx, pattern, searchPath, limit)
 }
 
 func runRipgrep(cmd *exec.Cmd, searchRoot string, limit int) ([]string, error) {

--- a/internal/agent/tools/grep.go
+++ b/internal/agent/tools/grep.go
@@ -118,6 +118,13 @@ func NewGrepTool(workingDir string, config config.ToolGrep) fantasy.AgentTool {
 
 			searchPath := cmp.Or(params.Path, workingDir)
 
+			// Clamp search path to working directory to prevent
+			// searching the entire filesystem.
+			searchPath, err := clampToWorkingDir(workingDir, searchPath)
+			if err != nil {
+				return fantasy.NewTextErrorResponse(err.Error()), nil
+			}
+
 			searchCtx, cancel := context.WithTimeout(ctx, config.GetTimeout())
 			defer cancel()
 

--- a/internal/agent/tools/pathutil.go
+++ b/internal/agent/tools/pathutil.go
@@ -1,0 +1,31 @@
+package tools
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// clampToWorkingDir ensures the search path is within the working directory.
+// This prevents tools from accidentally searching the entire filesystem.
+func clampToWorkingDir(workingDir, searchPath string) (string, error) {
+	absWorkingDir, err := filepath.Abs(workingDir)
+	if err != nil {
+		return "", fmt.Errorf("error resolving working directory: %w", err)
+	}
+
+	absSearchPath, err := filepath.Abs(searchPath)
+	if err != nil {
+		return "", fmt.Errorf("error resolving search path: %w", err)
+	}
+
+	rel, err := filepath.Rel(absWorkingDir, absSearchPath)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return "", fmt.Errorf(
+			"search path %q is outside the working directory %q, please use a path within the project",
+			searchPath, workingDir,
+		)
+	}
+
+	return absSearchPath, nil
+}

--- a/internal/agent/tools/pathutil_test.go
+++ b/internal/agent/tools/pathutil_test.go
@@ -1,0 +1,51 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClampToWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allows path within working dir", func(t *testing.T) {
+		t.Parallel()
+		workDir := t.TempDir()
+		result, err := clampToWorkingDir(workDir, workDir+"/subdir")
+		require.NoError(t, err)
+		require.Equal(t, workDir+"/subdir", result)
+	})
+
+	t.Run("allows working dir itself", func(t *testing.T) {
+		t.Parallel()
+		workDir := t.TempDir()
+		result, err := clampToWorkingDir(workDir, workDir)
+		require.NoError(t, err)
+		require.Equal(t, workDir, result)
+	})
+
+	t.Run("rejects root path", func(t *testing.T) {
+		t.Parallel()
+		workDir := t.TempDir()
+		_, err := clampToWorkingDir(workDir, "/")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "outside the working directory")
+	})
+
+	t.Run("rejects parent traversal", func(t *testing.T) {
+		t.Parallel()
+		workDir := t.TempDir()
+		_, err := clampToWorkingDir(workDir, workDir+"/../..")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "outside the working directory")
+	})
+
+	t.Run("rejects unrelated absolute path", func(t *testing.T) {
+		t.Parallel()
+		workDir := t.TempDir()
+		_, err := clampToWorkingDir(workDir, "/etc")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "outside the working directory")
+	})
+}

--- a/internal/agent/tools/rg.go
+++ b/internal/agent/tools/rg.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/charmbracelet/crush/internal/log"
 )
@@ -34,7 +35,9 @@ func getRgCmd(ctx context.Context, globPattern string) *exec.Cmd {
 		}
 		args = append(args, "--glob", globPattern)
 	}
-	return exec.CommandContext(ctx, name, args...)
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.WaitDelay = 3 * time.Second
+	return cmd
 }
 
 func getRgSearchCmd(ctx context.Context, pattern, path, include string) *exec.Cmd {
@@ -49,5 +52,7 @@ func getRgSearchCmd(ctx context.Context, pattern, path, include string) *exec.Cm
 	}
 	args = append(args, path)
 
-	return exec.CommandContext(ctx, name, args...)
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.WaitDelay = 3 * time.Second
+	return cmd
 }

--- a/internal/agent/tools/web_fetch.go
+++ b/internal/agent/tools/web_fetch.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -61,7 +62,7 @@ func NewWebFetchTool(workingDir string, client *http.Client) fantasy.AgentTool {
 				}
 
 				fmt.Fprintf(&result, "Fetched content from %s (large page)\n\n", params.URL)
-				fmt.Fprintf(&result, "Content saved to: %s\n\n", tempFilePath)
+				fmt.Fprintf(&result, "Content saved to: %s\n\n", filepath.Base(tempFilePath))
 				result.WriteString("Use the view and grep tools to analyze this file.")
 			} else {
 				fmt.Fprintf(&result, "Fetched content from %s:\n\n", params.URL)

--- a/internal/fsext/fileutil.go
+++ b/internal/fsext/fileutil.go
@@ -1,6 +1,7 @@
 package fsext
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -86,15 +87,15 @@ func (w *FastGlobWalker) ShouldSkipDir(path string) bool {
 //
 // Does not respect gitignore.
 func Glob(pattern string, cwd string, limit int) ([]string, bool, error) {
-	return globWithDoubleStar(pattern, cwd, limit, false)
+	return globWithDoubleStar(context.Background(), pattern, cwd, limit, false)
 }
 
 // GlobGitignoreAware globs files respecting gitignore.
-func GlobGitignoreAware(pattern string, cwd string, limit int) ([]string, bool, error) {
-	return globWithDoubleStar(pattern, cwd, limit, true)
+func GlobGitignoreAware(ctx context.Context, pattern string, cwd string, limit int) ([]string, bool, error) {
+	return globWithDoubleStar(ctx, pattern, cwd, limit, true)
 }
 
-func globWithDoubleStar(pattern, searchPath string, limit int, gitignore bool) ([]string, bool, error) {
+func globWithDoubleStar(ctx context.Context, pattern, searchPath string, limit int, gitignore bool) ([]string, bool, error) {
 	// Normalize pattern to forward slashes on Windows so their config can use
 	// backslashes
 	pattern = filepath.ToSlash(pattern)
@@ -107,6 +108,13 @@ func globWithDoubleStar(pattern, searchPath string, limit int, gitignore bool) (
 		Sort:    fastwalk.SortFilesFirst,
 	}
 	err := fastwalk.Walk(&conf, searchPath, func(path string, d os.DirEntry, err error) error {
+		// Check context cancellation.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
 		if err != nil {
 			return nil // Skip files we can't access
 		}

--- a/internal/fsext/fileutil_test.go
+++ b/internal/fsext/fileutil_test.go
@@ -1,6 +1,7 @@
 package fsext
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,7 +25,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test content"), 0o644))
 		}
 
-		matches, truncated, err := GlobGitignoreAware("**/main.go", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "**/main.go", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -47,7 +48,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package main"), 0o644))
 		require.NoError(t, os.WriteFile(pkgFile, []byte("test"), 0o644))
 
-		matches, truncated, err := GlobGitignoreAware("pkg", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "pkg", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -66,7 +67,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.MkdirAll(dir, 0o755))
 		}
 
-		matches, truncated, err := GlobGitignoreAware("**/pkg", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "**/pkg", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -95,7 +96,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("package main"), 0o644))
 		}
 
-		matches, truncated, err := GlobGitignoreAware("pkg/**", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "pkg/**", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -124,7 +125,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 		}
 
-		matches, truncated, err := GlobGitignoreAware("**/*.txt", testDir, 5)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "**/*.txt", testDir, 5)
 		require.NoError(t, err)
 		require.True(t, truncated, "Expected truncation with limit")
 		require.Len(t, matches, 5, "Expected exactly 5 matches with limit")
@@ -143,7 +144,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 		}
 
-		matches, truncated, err := GlobGitignoreAware("a/b/c/file1.txt", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "a/b/c/file1.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -171,7 +172,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.NoError(t, os.Chtimes(file2, m2, m2))
 		require.NoError(t, os.Chtimes(file3, m3, m3))
 
-		matches, truncated, err := GlobGitignoreAware("*.txt", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "*.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -181,7 +182,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 	t.Run("handles empty directory", func(t *testing.T) {
 		testDir := t.TempDir()
 
-		matches, truncated, err := GlobGitignoreAware("**", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "**", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		// Even empty directories should return the directory itself
@@ -191,7 +192,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 	t.Run("handles non-existent search path", func(t *testing.T) {
 		nonExistentDir := filepath.Join(t.TempDir(), "does", "not", "exist")
 
-		matches, truncated, err := GlobGitignoreAware("**", nonExistentDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "**", nonExistentDir, 0)
 		require.Error(t, err, "Should return error for non-existent search path")
 		require.False(t, truncated)
 		require.Empty(t, matches)
@@ -219,17 +220,17 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		ignoredFileInDir := filepath.Join(testDir, "backup", "old.txt")
 		require.NoError(t, os.WriteFile(ignoredFileInDir, []byte("old content"), 0o644))
 
-		matches, truncated, err := GlobGitignoreAware("*.tmp", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "*.tmp", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Empty(t, matches, "Expected no matches for '*.tmp' pattern (should be ignored)")
 
-		matches, truncated, err = GlobGitignoreAware("backup", testDir, 0)
+		matches, truncated, err = GlobGitignoreAware(context.Background(), "backup", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Empty(t, matches, "Expected no matches for 'backup' pattern (should be ignored)")
 
-		matches, truncated, err = GlobGitignoreAware("*.txt", testDir, 0)
+		matches, truncated, err = GlobGitignoreAware(context.Background(), "*.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Equal(t, []string{goodFile}, matches)
@@ -257,7 +258,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.NoError(t, os.Chtimes(middleDir, tMiddle, tMiddle))
 		require.NoError(t, os.Chtimes(oldestFile, tNewest, tNewest))
 
-		matches, truncated, err := GlobGitignoreAware("*.rs", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "*.rs", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Len(t, matches, 3)


### PR DESCRIPTION

## Summary

- **Agentic fetch file path fix**: Use `filepath.Base` for temp file paths so the sub-agent resolves `page-*.md` files relative to its working directory instead of trying to view absolute paths that don't exist from its perspective
- **Glob/Grep path clamping**: Add `clampToWorkingDir()` to both tools so the LLM can't pass `path: "/"` and trigger a full filesystem walk with `rg`
- **Context cancellation in fastwalk fallback**: `GlobWithDoubleStar` now checks `ctx.Done()` on each entry, so cancelling a request stops the fallback walker immediately instead of letting it run forever
- **WaitDelay on rg commands**: Prevents `cmd.Output()`/`CombinedOutput()` from hanging indefinitely after SIGKILL by adding a 3-second WaitDelay

## Test plan

- [x] Existing `TestGlobWithDoubleStar` tests pass (updated to pass `context.Context`)
- [x] New `TestClampToWorkingDir` validates path clamping accepts subdirs and rejects `/`, `..`, and unrelated paths
- [x] All `internal/fsext`, `internal/agent/tools`, and `internal/lsp` tests pass
- [x] Full `go build ./...` succeeds


🐘 Generated with Crush