### PR TITLE
chore(ui): add toggle for transparent bg to palette

### DIFF
--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -151,6 +151,15 @@ func (s *ConfigStore) SetCompactMode(scope Scope, enabled bool) error {
 	return s.SetConfigField(scope, "options.tui.compact_mode", enabled)
 }
 
+// SetTransparentBackground sets the transparent background setting and persists it.
+func (s *ConfigStore) SetTransparentBackground(scope Scope, enabled bool) error {
+	if s.config.Options == nil {
+		s.config.Options = &Options{}
+	}
+	s.config.Options.TUI.Transparent = &enabled
+	return s.SetConfigField(scope, "options.tui.transparent", enabled)
+}
+
 // SetProviderAPIKey sets the API key for a provider and persists it.
 func (s *ConfigStore) SetProviderAPIKey(scope Scope, providerID string, apiKey any) error {
 	var providerConfig ProviderConfig

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -44,20 +44,21 @@ type ActionSelectModel struct {
 
 // Messages for commands
 type (
-	ActionNewSession          struct{}
-	ActionToggleHelp          struct{}
-	ActionToggleCompactMode   struct{}
-	ActionToggleThinking      struct{}
-	ActionTogglePills         struct{}
-	ActionExternalEditor      struct{}
-	ActionToggleYoloMode      struct{}
-	ActionToggleNotifications struct{}
-	// ActionInitializeProject is a message to initialize a project.
-	ActionInitializeProject struct{}
-	ActionSummarize         struct {
+	ActionNewSession                  struct{}
+	ActionToggleHelp                  struct{}
+	ActionToggleCompactMode           struct{}
+	ActionToggleThinking              struct{}
+	ActionTogglePills                 struct{}
+	ActionExternalEditor              struct{}
+	ActionToggleYoloMode              struct{}
+	ActionToggleNotifications         struct{}
+	ActionToggleTransparentBackground struct{}
+	ActionInitializeProject           struct{}
+	ActionSummarize                   struct {
 		SessionID string
 	}
-	// ActionSelectReasoningEffort is a message indicating a reasoning effort has been selected.
+	// ActionSelectReasoningEffort is a message indicating a reasoning effort
+	// has been selected.
 	ActionSelectReasoningEffort struct {
 		Effort string
 	}

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -427,9 +427,9 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		commands = append(commands, NewCommandItem(c.com.Styles, "toggle_sidebar", "Toggle Sidebar", "", ActionToggleCompactMode{}))
 	}
 	if c.hasSession {
-		cfg := c.com.Config()
-		agentCfg := cfg.Agents[config.AgentCoder]
-		model := cfg.GetModelByType(agentCfg.Model)
+		cfgPrime := c.com.Config()
+		agentCfg := cfgPrime.Agents[config.AgentCoder]
+		model := cfgPrime.GetModelByType(agentCfg.Model)
 		if model != nil && model.SupportsImages {
 			commands = append(commands, NewCommandItem(c.com.Styles, "file_picker", "Open File Picker", "ctrl+f", ActionOpenDialog{
 				// TODO: Pass in the file picker dialog id
@@ -472,6 +472,16 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		NewCommandItem(c.com.Styles, "toggle_yolo", "Toggle Yolo Mode", "", ActionToggleYoloMode{}),
 		NewCommandItem(c.com.Styles, "toggle_help", "Toggle Help", "ctrl+g", ActionToggleHelp{}),
 		NewCommandItem(c.com.Styles, "init", "Initialize Project", "", ActionInitializeProject{}),
+	)
+
+	// Add transparent background toggle.
+	transparentLabel := "Disable Background Color"
+	if cfg != nil && cfg.Options != nil && cfg.Options.TUI.Transparent != nil && *cfg.Options.TUI.Transparent {
+		transparentLabel = "Enable Background Color"
+	}
+	commands = append(commands, NewCommandItem(c.com.Styles, "toggle_transparent", transparentLabel, "", ActionToggleTransparentBackground{}))
+
+	commands = append(commands,
 		NewCommandItem(c.com.Styles, "quit", "Quit", "ctrl+c", tea.QuitMsg{}),
 	)
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1328,6 +1328,27 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			return util.NewInfoMsg("Thinking mode " + status)
 		})
 		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionToggleTransparentBackground:
+		cmds = append(cmds, func() tea.Msg {
+			cfg := m.com.Config()
+			if cfg == nil {
+				return util.ReportError(errors.New("configuration not found"))()
+			}
+
+			isTransparent := cfg.Options != nil && cfg.Options.TUI.Transparent != nil && *cfg.Options.TUI.Transparent
+			newValue := !isTransparent
+			if err := m.com.Store().SetTransparentBackground(config.ScopeGlobal, newValue); err != nil {
+				return util.ReportError(err)()
+			}
+			m.isTransparent = newValue
+
+			status := "disabled"
+			if newValue {
+				status = "enabled"
+			}
+			return util.NewInfoMsg("Transparent background " + status)
+		})
+		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionQuit:
 		cmds = append(cmds, tea.Quit)
 	case dialog.ActionInitializeProject:


### PR DESCRIPTION
Not too long ago @caarlos0 added a command to enable transparent background. This PR wires up that setting to the command palette. That's it.

Note: I changed the language here to "enable/disable background color" which I think may be clearer than "enable/disable transparent background. If we think this language is a good idea we could consider deprecating the "transparent" one and adding a new one called "show-background-color" — essentially renaming.

<img width="597" height="402" alt="image" src="https://github.com/user-attachments/assets/5abcd42c-661b-42c9-ae91-6704557dc86c" />

<img width="601" height="409" alt="image" src="https://github.com/user-attachments/assets/a925a4ce-df2c-438b-980c-21e0a8c769f6" />