### PR TITLE
chore(events): add events for the CLI session series of commands

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -127,6 +127,7 @@ func sessionSetup(cmd *cobra.Command) (context.Context, *sessionServices, func()
 }
 
 func runSessionList(cmd *cobra.Command, _ []string) error {
+	event.SetNonInteractive(true)
 	event.SessionListed(sessionListJSON)
 
 	ctx, svc, cleanup, err := sessionSetup(cmd)
@@ -252,6 +253,7 @@ func resolveSessionID(ctx context.Context, svc session.Service, id string) (sess
 }
 
 func runSessionShow(cmd *cobra.Command, args []string) error {
+	event.SetNonInteractive(true)
 	event.SessionShown(sessionShowJSON)
 
 	ctx, svc, cleanup, err := sessionSetup(cmd)
@@ -278,6 +280,7 @@ func runSessionShow(cmd *cobra.Command, args []string) error {
 }
 
 func runSessionDelete(cmd *cobra.Command, args []string) error {
+	event.SetNonInteractive(true)
 	event.SessionDeletedCommand(sessionDeleteJSON)
 
 	ctx, svc, cleanup, err := sessionSetup(cmd)
@@ -312,6 +315,7 @@ func runSessionDelete(cmd *cobra.Command, args []string) error {
 }
 
 func runSessionRename(cmd *cobra.Command, args []string) error {
+	event.SetNonInteractive(true)
 	event.SessionRenamed(sessionRenameJSON)
 
 	ctx, svc, cleanup, err := sessionSetup(cmd)
@@ -347,6 +351,7 @@ func runSessionRename(cmd *cobra.Command, args []string) error {
 }
 
 func runSessionLast(cmd *cobra.Command, _ []string) error {
+	event.SetNonInteractive(true)
 	event.SessionLastShown(sessionLastJSON)
 
 	ctx, svc, cleanup, err := sessionSetup(cmd)

--- a/internal/event/all.go
+++ b/internal/event/all.go
@@ -63,21 +63,21 @@ func StatsViewed() {
 }
 
 func SessionListed(json bool) {
-	send("session listed", "json", json, "cli", true)
+	send("session listed", "json", json)
 }
 
 func SessionShown(json bool) {
-	send("session shown", "json", json, "cli", true)
+	send("session shown", "json", json)
 }
 
 func SessionLastShown(json bool) {
-	send("session last shown", "json", json, "cli", true)
+	send("session last shown", "json", json)
 }
 
 func SessionDeletedCommand(json bool) {
-	send("session deleted", "json", json, "cli", true)
+	send("session deleted", "json", json)
 }
 
 func SessionRenamed(json bool) {
-	send("session renamed", "json", json, "cli", true)
+	send("session renamed", "json", json)
 }


### PR DESCRIPTION
This revision adds PostHog logging to the `crush session` series of events. Note that we're also noting whether the `--json` flag was used, and additionally, whether these events came from the CLI in order to distinguish the events from those in the TUI.