### PR TITLE
fix: keep original order when filtering models

### DIFF
--- a/internal/ui/dialog/models_list.go
+++ b/internal/ui/dialog/models_list.go
@@ -216,8 +216,10 @@ func (f *ModelsList) VisibleItems() []list.Item {
 		}
 
 		matches := fuzzy.Find(query, names)
+
+		// Sort by original index to preserve order within the group
 		sort.SliceStable(matches, func(i, j int) bool {
-			return matches[i].Score > matches[j].Score
+			return matches[i].Index < matches[j].Index
 		})
 
 		for _, match := range matches {


### PR DESCRIPTION
<details><summary>Original Order</summary>

<img width="675" height="442" alt="Screenshot 2026-03-16 at 14 24 34" src="https://github.com/user-attachments/assets/039c9ce3-870f-49cd-b43d-0cda0d96fbb6" />

</details>

<details><summary>Filtering: Before</summary>

<img width="677" height="439" alt="Screenshot 2026-03-16 at 14 24 56" src="https://github.com/user-attachments/assets/5add6703-6995-45dd-aad7-7fd6bebff430" />

</details>

<details><summary>Filtering: After</summary>

<img width="674" height="440" alt="Screenshot 2026-03-16 at 14 31 57" src="https://github.com/user-attachments/assets/0ac33a42-801c-4bce-9003-7b6816cf0a00" />

</details>



