### PR TITLE
feat(skills): load from project config folder

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -414,6 +414,12 @@ func (c *Config) setDefaults(workingDir, dataDir string) {
 		}
 	}
 
+	// Add project-local skills directory if not already present.
+	projectSkillsDir := filepath.Join(c.Options.DataDirectory, "skills")
+	if !slices.Contains(c.Options.SkillsPaths, projectSkillsDir) {
+		c.Options.SkillsPaths = append(c.Options.SkillsPaths, projectSkillsDir)
+	}
+
 	if str, ok := os.LookupEnv("CRUSH_DISABLE_PROVIDER_AUTO_UPDATE"); ok {
 		c.Options.DisableProviderAutoUpdate, _ = strconv.ParseBool(str)
 	}


### PR DESCRIPTION
* Closes #2420

Loading skills from the project .crush/skills directory, in addition to existing path, improves compatibility with other tools, such as Claude Code.

Assisted-by: Claude Opus 4.6 via Crush [crush@charm.land](mailto:crush@charm.land)

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
