### PR TITLE
feat: add aliases: `crush r` -> `crush run`, `crush s` -> `crush session`

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -14,8 +14,9 @@ import (
 )
 
 var runCmd = &cobra.Command{
-	Use:   "run [prompt...]",
-	Short: "Run a single non-interactive prompt",
+	Aliases: []string{"r"},
+	Use:     "run [prompt...]",
+	Short:   "Run a single non-interactive prompt",
 	Long: `Run a single prompt in non-interactive mode and exit.
 The prompt can be provided as arguments or piped from stdin.`,
 	Example: `

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -30,7 +30,7 @@ import (
 
 var sessionCmd = &cobra.Command{
 	Use:     "session",
-	Aliases: []string{"sessions"},
+	Aliases: []string{"sessions", "s"},
 	Short:   "Manage sessions",
 	Long:    "Manage Crush sessions. Agents can use --json for machine-readable output.",
 }


### PR DESCRIPTION
This is a proposal, you don't necessarily need to agree with it.

I find `crush session` particularly long to type, so `crush s` make sense to me.