### PR TITLE
fix(tui): remove duplicate ctrl+g help binding in FullHelp

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2308,11 +2308,6 @@ func (m *UI) FullHelp() [][]key.Binding {
 					},
 				)
 			}
-			binds = append(binds,
-				[]key.Binding{
-					help,
-				},
-			)
 		}
 	}
 


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

## Summary
 
Fix duplicate "ctrl+g less" keybinding displayed in the expanded help view when no session is selected (e.g. at
startup on the landing screen).

## Problem

In `FullHelp()`, when the UI state is `uiLanding` with no active session (`default` case, `m.session == nil`), the
`help` binding was appended twice:

1. Inside the `default` block (line 2311-2315)
2. Unconditionally at the end of the method (line 2319-2324)

## Fix

Removed the redundant `help` binding append inside the `default` / `session == nil` block, since it is already added
unconditionally at the end of `FullHelp()`.

## Screenshots

### Before

<img width="856" height="117" alt="image" src="https://github.com/user-attachments/assets/18b62e34-2ff1-430b-9195-9c13cccf4b6f" />

### After

<img width="717" height="107" alt="image" src="https://github.com/user-attachments/assets/a9363212-4013-44de-b64d-a67d37dd3641" />

## Test plan

- [ ] Start Crush with no active session
- [ ] Press `ctrl+g` to expand help
- [ ] Verify "ctrl+g less" appears exactly once
- [ ] Verify help toggle still works correctly (expanded/collapsed)
- [ ] `go test ./...` passes