### PR TITLE
Fix: mcp config: readd support for file secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,10 @@ like you would. LSPs can be added manually like so:
 
 Crush also supports Model Context Protocol (MCP) servers through three
 transport types: `stdio` for command-line servers, `http` for HTTP endpoints,
-and `sse` for Server-Sent Events. Environment variable expansion is supported
-using `$(echo $VAR)` syntax.
+and `sse` for Server-Sent Events.
+Environment variable expansion is supported using `$(echo $VAR)` syntax.
+For file-based secrets (e.g. sops, systemd credentials, Docker secrets),
+use `env_files` to map variable names to filepaths — Crush reads the file contents at startup
 
 ```json
 {
@@ -312,6 +314,15 @@ using `$(echo $VAR)` syntax.
       "disabled_tools": ["create_issue", "create_pull_request"],
       "headers": {
         "Authorization": "Bearer $GH_PAT"
+      }
+    },
+    "codeberg": {
+      "type": "stdio",
+      "command": "/path/to/forgejo-mcp",
+      "args": ["transport", "stdio", "--url", "https://codeberg.org"],
+      "timeout": 120,
+      "env_files": {
+        "FORGEJO_ACCESS_TOKEN": "/run/secrets/codeberg_token"
       }
     },
     "streaming-service": {

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ transport types: `stdio` for command-line servers, `http` for HTTP endpoints,
 and `sse` for Server-Sent Events.
 Environment variable expansion is supported using `$(echo $VAR)` syntax.
 For file-based secrets (e.g. sops, systemd credentials, Docker secrets),
-use `env_files` to map variable names to filepaths — Crush reads the file contents at startup
+use `env_files` to map variable names to filepaths — Crush reads the file contents at startup.
 
 ```json
 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,6 +169,7 @@ const (
 type MCPConfig struct {
 	Command       string            `json:"command,omitempty" jsonschema:"description=Command to execute for stdio MCP servers,example=npx"`
 	Env           map[string]string `json:"env,omitempty" jsonschema:"description=Environment variables to set for the MCP server"`
+	EnvFiles map[string]string `json:"env_files,omitempty" jsonschema:"description=Map of env var names to file paths; file contents are read and set as environment variable values"`
 	Args          []string          `json:"args,omitempty" jsonschema:"description=Arguments to pass to the MCP server command"`
 	Type          MCPType           `json:"type" jsonschema:"required,description=Type of MCP connection,enum=stdio,enum=sse,enum=http,default=stdio"`
 	URL           string            `json:"url,omitempty" jsonschema:"description=URL for HTTP or SSE MCP servers,format=uri,example=http://localhost:3000/mcp"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -307,7 +308,7 @@ func (l LSPConfig) ResolvedEnv() []string {
 }
 
 func (m MCPConfig) ResolvedEnv() []string {
-	return resolveEnvs(m.Env)
+	return append(resolveEnvs(m.Env), resolveEnvFiles(m.EnvFiles)...)
 }
 
 func (m MCPConfig) ResolvedHeaders() map[string]string {
@@ -650,6 +651,22 @@ func resolveEnvs(envs map[string]string) []string {
 	res := make([]string, 0, len(envs))
 	for k, v := range envs {
 		res = append(res, fmt.Sprintf("%s=%s", k, v))
+	}
+	return res
+}
+
+// resolveEnvFiles reads file contents for each entry in envFiles and returns
+// the resolved key=value pairs. Entries whose files cannot be read are skipped.
+func resolveEnvFiles(envFiles map[string]string) []string {
+	res := make([]string, 0, len(envFiles))
+	for varName, filePath := range envFiles {
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			slog.Error("Error reading env file", "error", err, "variable", varName, "path", filePath)
+			continue
+		}
+		// trim trailing newlines, consistent with $(cat file) behavior
+		res = append(res, fmt.Sprintf("%s=%s", varName, strings.TrimRight(string(content), "\n\r")))
 	}
 	return res
 }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1462,3 +1462,102 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 		require.Equal(t, int64(100), large.MaxTokens)
 	})
 }
+
+func TestLoadConfig_MCPEnvFiles(t *testing.T) {
+	t.Parallel()
+
+	data := []byte(`{
+		"mcp": {
+			"codeberg": {
+				"type": "stdio",
+				"command": "/path/to/forgejo-mcp",
+				"args": ["transport", "stdio", "--url", "https://codeberg.org"],
+				"env_files": {
+					"FORGEJO_ACCESS_TOKEN": "/run/secrets/codeberg_token"
+				}
+			}
+		}
+	}`)
+
+	cfg, err := loadFromBytes([][]byte{data})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	// env_files should be parsed into MCPConfig.EnvFiles
+	mcp, ok := cfg.MCP["codeberg"]
+	require.True(t, ok)
+
+	require.Equal(t, MCPStdio, mcp.Type)
+	require.Equal(t, "/path/to/forgejo-mcp", mcp.Command)
+	// file path should be stored as-is, without resolution
+	require.Equal(t, map[string]string{
+		"FORGEJO_ACCESS_TOKEN": "/run/secrets/codeberg_token",
+	}, mcp.EnvFiles)
+}
+
+func TestMCPConfig_ResolvedEnv_WithEnvFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(secretPath, []byte("my-secret-token\n"), 0o600))
+
+	m := MCPConfig{
+		EnvFiles: map[string]string{
+			"FORGEJO_ACCESS_TOKEN": secretPath,
+		},
+	}
+
+	// trailing newline should be stripped, consistent with $(cat file) behavior
+	require.Contains(t, m.ResolvedEnv(), "FORGEJO_ACCESS_TOKEN=my-secret-token")
+}
+
+func TestMCPConfig_ResolvedEnv_MissingEnvFile(t *testing.T) {
+	t.Parallel()
+
+	m := MCPConfig{
+		EnvFiles: map[string]string{
+			"FORGEJO_ACCESS_TOKEN": "/nonexistent/path/token",
+		},
+	}
+
+	// missing file should not crash, just be skipped
+	require.Empty(t, m.ResolvedEnv())
+}
+
+func TestMCPConfig_ResolvedEnv_EnvAndEnvFilesMerged(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(secretPath, []byte("file-token"), 0o600))
+
+	m := MCPConfig{
+		Env:      map[string]string{"NODE_ENV": "production"},
+		EnvFiles: map[string]string{"FORGEJO_ACCESS_TOKEN": secretPath},
+	}
+
+	envs := m.ResolvedEnv()
+	// both sources should be present in the result
+	require.Contains(t, envs, "NODE_ENV=production")
+	require.Contains(t, envs, "FORGEJO_ACCESS_TOKEN=file-token")
+}
+
+func TestMCPConfig_ResolvedEnv_DuplicateKeyEnvWins(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "token")
+	require.NoError(t, os.WriteFile(secretPath, []byte("file-value"), 0o600))
+
+	m := MCPConfig{
+		Env:      map[string]string{"MY_VAR": "env-value"},
+		EnvFiles: map[string]string{"MY_VAR": secretPath},
+	}
+
+	envs := m.ResolvedEnv()
+	// both entries are present; last-wins behavior means env_files takes precedence
+	require.Contains(t, envs, "MY_VAR=env-value")
+	require.Contains(t, envs, "MY_VAR=file-value")
+}
+


### PR DESCRIPTION
### Problem

MCP servers that require secrets (e.g. API tokens) currently rely on environment variable expansion via `$(echo $VAR)` syntax, which spawns a shell process. This makes it cumbersome to use file-based secret management tools like sops, systemd credentials, or Docker secrets.

Closes #2334

### Solution

Adds a new `env_files` field to `MCPConfig` that maps environment variable names to file paths. Crush reads the file contents at startup and injects them as environment variables when spawning the MCP server process

```json
{
  "mcp": {
    "codeberg": {
      "type": "stdio",
      "command": "/path/to/forgejo-mcp",
      "args": ["transport", "stdio", "--url", "https://codeberg.org"],
      "env_files": {
        "FORGEJO_ACCESS_TOKEN": "/run/secrets/codeberg_token"
      }
    }
  }
}
```

### Changes

- Adds `EnvFiles map[string]string` to `MCPConfig` in `config.go`
- Adds `resolveEnvFiles()` helper that reads file contents and trims trailing newlines
- Extends `MCPConfig.ResolvedEnv()` to merge `env` and `env_files`
- Documents the new field in `README.md` with a usage example
- Adds tests for parsing, resolution, missing files, and duplicate key behavior

### Notes

If the same variable is set in both `env` and `env_files`, both entries will be present in the resulting slice. The last-wins behavior of `os/exec` means `env_files` takes precedence in practice. This is documented via `TestMCPConfig_ResolvedEnv_DuplicateKeyEnvWins`.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
