### PR TITLE
fix(tui): complete file picker dialog action

### DIFF
--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -464,7 +464,7 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		model := cfgPrime.GetModelByType(agentCfg.Model)
 		if model != nil && model.SupportsImages {
 			commands = append(commands, NewCommandItem(c.com.Styles, "file_picker", "Open File Picker", "ctrl+f", ActionOpenDialog{
-				// TODO: Pass in the file picker dialog id
+				DialogID: FilePickerID,
 			}))
 		}
 	}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2949,6 +2949,10 @@ func (m *UI) openDialog(id string) tea.Cmd {
 		if cmd := m.openReasoningDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+	case dialog.FilePickerID:
+		if cmd := m.openFilesDialog(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case dialog.QuitID:
 		if cmd := m.openQuitDialog(); cmd != nil {
 			cmds = append(cmds, cmd)


### PR DESCRIPTION
## Summary

Complete the file picker dialog functionality by adding the missing DialogID field and case handler.

## Problem

The file picker command was created with a TODO comment indicating the DialogID field was not set:
- In `commands.go` line 467, `ActionOpenDialog` was missing the `DialogID: FilePickerID` field
- In `ui.go`, the `openDialog()` function had no case handler for `dialog.FilePickerID`

This meant the "Open File Picker" command (ctrl+f) would not properly open the file picker dialog.

## Fix

1. Set `DialogID: FilePickerID` in the `ActionOpenDialog` struct (commands.go:467)
2. Add `case dialog.FilePickerID:` handler in `openDialog()` function (ui.go:2952-2955)
3. Remove the TODO comment

## Screenshots
1. / or ctrl+p
<img width="2998" height="1578" alt="image" src="https://github.com/user-attachments/assets/c8ecdbc4-c487-4b7e-ada3-20a6cb383a8d" />
2. choose `Open File Picker`. It works well
<img width="2974" height="1620" alt="image" src="https://github.com/user-attachments/assets/85c4aaad-a80d-4e71-a5aa-2714e2180aa4" />


## Test plan

- [ ] Start Crush with a model that supports images
- [ ] Press `ctrl+f` to open file picker
- [ ] Verify file picker dialog opens correctly
- [ ] Verify file picker can be closed with ESC
- [ ] `go test ./...` passes