### PR TITLE
feat(bash): set `CRUSH=1`, `AGENT=crush` and `AI_AGENT=crush`

### DIFF
--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -82,6 +82,14 @@ func NewShell(opts *Options) *Shell {
 		env = os.Environ()
 	}
 
+	// Allow tools to detect execution by Crush.
+	env = append(
+		env,
+		"CRUSH=1",
+		"AGENT=crush",
+		"AI_AGENT=crush",
+	)
+
 	logger := opts.Logger
 	if logger == nil {
 		logger = noopLogger{}


### PR DESCRIPTION
These ENVs can be used by tools to detect if they are being executed by Crush, via the Bash tool.