### PR TITLE
fix(lsp): Respect LSP Auto start config

### DIFF
--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -141,6 +141,15 @@ var skipAutoStartCommands = map[string]bool{
 }
 
 func (s *Manager) startServer(ctx context.Context, name, filepath string, server *powernapconfig.ServerConfig) {
+	var (
+		isUserConfigured = s.isUserConfigured(name)
+		autoLSP          = s.cfg.Config().Options.AutoLSP
+	)
+	if !isUserConfigured && autoLSP != nil && !*autoLSP {
+		slog.Debug("Auto-start LSP disabled", "name", name)
+		return
+	}
+
 	cfg := s.buildConfig(name, server)
 	if cfg.Disabled {
 		return
@@ -159,15 +168,7 @@ func (s *Manager) startServer(ctx context.Context, name, filepath string, server
 		}
 	}
 
-	userConfigured := s.isUserConfigured(name)
-
-	autoLSP := s.cfg.Config().Options.AutoLSP
-	if autoLSP != nil && !*autoLSP {
-		slog.Debug("Auto-start LSP disabled", "name", name)
-		return
-	}
-
-	if !userConfigured {
+	if !isUserConfigured {
 		if _, err := exec.LookPath(server.Command); err != nil {
 			slog.Debug("LSP server not installed, skipping", "name", name, "command", server.Command)
 			unavailable.Set(name, struct{}{})


### PR DESCRIPTION
LSP Auto start config was being ignored, this small PR fix the issue and respect the config.


- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [X] I have created a discussion that was approved by a maintainer (for new features).

