### PR TITLE
fix(dialog): use valid key binding name for OAuth success state

### DIFF
--- a/internal/ui/dialog/oauth.go
+++ b/internal/ui/dialog/oauth.go
@@ -332,7 +332,7 @@ func (m *OAuth) ShortHelp() []key.Binding {
 	case OAuthStateSuccess:
 		return []key.Binding{
 			key.NewBinding(
-				key.WithKeys("finish", "ctrl+y", "esc"),
+				key.WithKeys("enter", "ctrl+y", "esc"),
 				key.WithHelp("enter", "finish"),
 			),
 		}


### PR DESCRIPTION
## Summary
- Fix invalid key binding name in OAuth success dialog
- Replace `"finish"` with `"enter"` as `"finish"` is not a valid key name
- This aligns with existing key bindings in the codebase and matches the help text

## Context
The `WithKeys` function expects valid key names (like "enter", "esc", "ctrl+y"). The string "finish" is not recognized and would not work as an intended keyboard shortcut.