### PR TITLE
fix(event): prevent panic on non-string telemetry keys

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -127,7 +127,11 @@ func pairsToProps(props ...any) posthog.Properties {
 	}
 
 	for i := 0; i < len(props); i += 2 {
-		key := props[i].(string)
+		key, ok := props[i].(string)
+		if !ok {
+			slog.Error("Event property key must be a string", "key", props[i], "index", i)
+			continue
+		}
 		value := props[i+1]
 		p = p.Set(key, value)
 	}

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -4,7 +4,10 @@ package event
 // scenarios. These tests will not log anything.
 
 import (
+	"reflect"
 	"testing"
+
+	"github.com/posthog/posthog-go"
 )
 
 func TestError(t *testing.T) {
@@ -56,6 +59,33 @@ func TestError(t *testing.T) {
 			"severity", "high",
 			"source", "unit-test",
 		)
+	})
+}
+
+func TestPairsToProps(t *testing.T) {
+	t.Run("sets valid key value pairs", func(t *testing.T) {
+		got := pairsToProps("foo", "bar", "count", 3)
+		want := posthog.NewProperties().
+			Set("foo", "bar").
+			Set("count", 3)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("pairsToProps() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("returns empty properties for odd pairs", func(t *testing.T) {
+		got := pairsToProps("foo", "bar", "count")
+		if len(got) != 0 {
+			t.Fatalf("pairsToProps() should return empty properties, got %#v", got)
+		}
+	})
+
+	t.Run("ignores non-string key and continues", func(t *testing.T) {
+		got := pairsToProps(123, "bad", "ok", true)
+		want := posthog.NewProperties().Set("ok", true)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("pairsToProps() = %#v, want %#v", got, want)
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary

This PR hardens telemetry property handling in `internal/event/event.go` by preventing panics when invalid property keys are passed to `pairsToProps`.

### What changed

- Updated `pairsToProps(props ...any)` to safely type-check property keys:
  - Replaced direct type assertion `props[i].(string)` with guarded assertion.
  - If a key is not a string, the function now logs an error and skips that pair instead of panicking.
- Added unit tests in `internal/event/event_test.go`:
  - `sets valid key value pairs`
  - `returns empty properties for odd pairs`
  - `ignores non-string key and continues`

## Why

`pairsToProps` previously used a hard type assertion for keys.  
If a non-string key was ever passed, it could panic and potentially interrupt telemetry/event flow.  
This change makes the event pipeline more defensive and resilient while preserving existing behavior for valid inputs.

## Scope

- Files changed:
  - `internal/event/event.go`
  - `internal/event/event_test.go`
- No behavior changes for valid key-value inputs.
- Invalid key types are now handled gracefully (log + skip).

## Test Plan

- [x] Run package tests:

```bash
go test ./internal/event
