### PR TITLE
fix(ui): always clean up external editor temp file

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2611,13 +2611,14 @@ func (m *UI) openEditor(value string) tea.Cmd {
 	if err != nil {
 		return util.ReportError(err)
 	}
+	tmpPath := tmpfile.Name()
 	defer tmpfile.Close() //nolint:errcheck
 	if _, err := tmpfile.WriteString(value); err != nil {
 		return util.ReportError(err)
 	}
 	cmd, err := editor.Command(
 		"crush",
-		tmpfile.Name(),
+		tmpPath,
 		editor.AtPosition(
 			m.textarea.Line()+1,
 			m.textarea.Column()+1,
@@ -2627,17 +2628,20 @@ func (m *UI) openEditor(value string) tea.Cmd {
 		return util.ReportError(err)
 	}
 	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		defer func() {
+			_ = os.Remove(tmpPath)
+		}()
+
 		if err != nil {
 			return util.ReportError(err)
 		}
-		content, err := os.ReadFile(tmpfile.Name())
+		content, err := os.ReadFile(tmpPath)
 		if err != nil {
 			return util.ReportError(err)
 		}
 		if len(content) == 0 {
 			return util.ReportWarn("Message is empty")
 		}
-		os.Remove(tmpfile.Name())
 		return openEditorMsg{
 			Text: strings.TrimSpace(string(content)),
 		}


### PR DESCRIPTION
## Summary

This PR fixes a temp file cleanup issue in the external editor flow (`openEditor`) in `internal/ui/model/ui.go`.

Previously, the temp file (`msg_*.md`) was only removed on the success path.  
If the editor process failed, reading failed, or the edited content was empty, the function returned early and could leave temp files behind.

This change ensures the temp file is always cleaned up by using a deferred `os.Remove` in the `tea.ExecProcess` callback, covering all return paths.

## What Changed

- Introduced `tmpPath := tmpfile.Name()` for clearer reuse.
- Replaced repeated `tmpfile.Name()` calls with `tmpPath`.
- Added deferred cleanup in callback:
  - `defer func() { _ = os.Remove(tmpPath) }()`
- Removed success-only cleanup call at the end of the callback.

## Why

This prevents stale temp files from accumulating in error/empty-message scenarios and makes resource cleanup behavior deterministic.

## Test Plan

- [x] Run unit tests for related package:
  - `go test ./internal/ui/model`
- [x] Manual check: successful editor flow still works.
- [x] Manual check: empty message path returns warning and does not leave temp files.
- [x] Manual check: editor failure path returns error and does not leave temp files.

## Risk / Impact

- Low risk.
- Change is isolated to temp file lifecycle in `openEditor`.
- No behavior changes to message parsing or UI state transitions, only cleanup reliability.