### PR TITLE
Feat/configurable banned commands

### DIFF
--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -207,7 +207,7 @@ func coderAgent(r *vcr.Recorder, env fakeEnv, large, small fantasy.LanguageModel
 	}
 
 	allTools := []fantasy.AgentTool{
-		tools.NewBashTool(env.permissions, env.workingDir, cfg.Config().Options.Attribution, modelName),
+		tools.NewBashTool(env.permissions, env.workingDir, cfg.Config().Options.Attribution, modelName, cfg.Config().Options.BannedCommands),
 		tools.NewDownloadTool(env.permissions, env.workingDir, r.GetDefaultClient()),
 		tools.NewEditTool(nil, env.permissions, env.history, *env.filetracker, env.workingDir),
 		tools.NewMultiEditTool(nil, env.permissions, env.history, *env.filetracker, env.workingDir),

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -446,7 +446,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent) ([]fan
 	}
 
 	allTools = append(allTools,
-		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Options.Attribution, modelName),
+		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Options.Attribution, modelName, c.cfg.Config().Options.BannedCommands),
 		tools.NewJobOutputTool(),
 		tools.NewJobKillTool(),
 		tools.NewDownloadTool(c.permissions, c.cfg.WorkingDir(), nil),

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -68,7 +68,7 @@ type bashDescriptionData struct {
 	ModelName       string
 }
 
-var bannedCommands = []string{
+var DefaultBannedCommands = []string{
 	// Network/Download tools
 	"alias",
 	"aria2c",
@@ -141,7 +141,10 @@ var bannedCommands = []string{
 	"ufw",
 }
 
-func bashDescription(attribution *config.Attribution, modelName string) string {
+func bashDescription(attribution *config.Attribution, modelName string, bannedCommands []string) string {
+	if len(bannedCommands) == 0 {
+		bannedCommands = DefaultBannedCommands
+	}
 	bannedCommandsStr := strings.Join(bannedCommands, ", ")
 	var out bytes.Buffer
 	if err := bashDescriptionTpl.Execute(&out, bashDescriptionData{
@@ -156,7 +159,10 @@ func bashDescription(attribution *config.Attribution, modelName string) string {
 	return out.String()
 }
 
-func blockFuncs() []shell.BlockFunc {
+func blockFuncs(bannedCommands []string) []shell.BlockFunc {
+	if len(bannedCommands) == 0 {
+		bannedCommands = DefaultBannedCommands
+	}
 	return []shell.BlockFunc{
 		shell.CommandsBlocker(bannedCommands),
 
@@ -188,10 +194,10 @@ func blockFuncs() []shell.BlockFunc {
 	}
 }
 
-func NewBashTool(permissions permission.Service, workingDir string, attribution *config.Attribution, modelName string) fantasy.AgentTool {
+func NewBashTool(permissions permission.Service, workingDir string, attribution *config.Attribution, modelName string, bannedCommands []string) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		BashToolName,
-		string(bashDescription(attribution, modelName)),
+		string(bashDescription(attribution, modelName, bannedCommands)),
 		func(ctx context.Context, params BashParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if params.Command == "" {
 				return fantasy.NewTextErrorResponse("missing command"), nil
@@ -242,7 +248,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 				bgManager := shell.GetBackgroundShellManager()
 				bgManager.Cleanup()
 				// Use background context so it continues after tool returns
-				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(bannedCommands), params.Command, params.Description)
 				if err != nil {
 					return fantasy.ToolResponse{}, fmt.Errorf("error starting background shell: %w", err)
 				}
@@ -297,7 +303,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 			// Start with detached context so it can survive if moved to background
 			bgManager := shell.GetBackgroundShellManager()
 			bgManager.Cleanup()
-			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(bannedCommands), params.Command, params.Description)
 			if err != nil {
 				return fantasy.ToolResponse{}, fmt.Errorf("error starting shell: %w", err)
 			}

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -153,7 +153,7 @@ func bashDescription(attribution *config.Attribution, modelName string, bannedCo
 		Attribution:     *attribution,
 		ModelName:       modelName,
 	}); err != nil {
-		// this should never happen.
+		// This should never happen.
 		panic("failed to execute bash description template: " + err.Error())
 	}
 	return out.String()

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -107,18 +107,18 @@ func TestBashTool_CustomBannedCommands(t *testing.T) {
 	permissions := &mockBashPermissionService{Broker: pubsub.NewBroker[permission.PermissionRequest]()}
 	attribution := &config.Attribution{TrailerStyle: config.TrailerStyleNone}
 
-	// Create a tool with custom banned commands
+	// Create a tool with custom banned commands.
 	tool := NewBashTool(permissions, workingDir, attribution, "test-model", []string{"ls", "whoami"})
 	ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
 
-	// Running "ls" should fail
+	// Running "ls" should fail.
 	resp := runBashTool(t, tool, ctx, BashParams{
 		Command: "ls",
 	})
 	require.False(t, resp.IsError)
 	require.Contains(t, resp.Content, "not allowed")
 
-	// Running "echo" should succeed (it's not in our custom list)
+	// Running "echo" should succeed (it's not in our custom list).
 	resp = runBashTool(t, tool, ctx, BashParams{
 		Command: "echo hello",
 	})

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -82,7 +82,7 @@ func TestBashTool_CustomAutoBackgroundThreshold(t *testing.T) {
 func newBashToolForTest(workingDir string) fantasy.AgentTool {
 	permissions := &mockBashPermissionService{Broker: pubsub.NewBroker[permission.PermissionRequest]()}
 	attribution := &config.Attribution{TrailerStyle: config.TrailerStyleNone}
-	return NewBashTool(permissions, workingDir, attribution, "test-model")
+	return NewBashTool(permissions, workingDir, attribution, "test-model", nil)
 }
 
 func runBashTool(t *testing.T, tool fantasy.AgentTool, ctx context.Context, params BashParams) fantasy.ToolResponse {
@@ -100,4 +100,28 @@ func runBashTool(t *testing.T, tool fantasy.AgentTool, ctx context.Context, para
 	resp, err := tool.Run(ctx, call)
 	require.NoError(t, err)
 	return resp
+}
+
+func TestBashTool_CustomBannedCommands(t *testing.T) {
+	workingDir := t.TempDir()
+	permissions := &mockBashPermissionService{Broker: pubsub.NewBroker[permission.PermissionRequest]()}
+	attribution := &config.Attribution{TrailerStyle: config.TrailerStyleNone}
+
+	// Create a tool with custom banned commands
+	tool := NewBashTool(permissions, workingDir, attribution, "test-model", []string{"ls", "whoami"})
+	ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+
+	// Running "ls" should fail
+	resp := runBashTool(t, tool, ctx, BashParams{
+		Command: "ls",
+	})
+	require.False(t, resp.IsError)
+	require.Contains(t, resp.Content, "not allowed")
+
+	// Running "echo" should succeed (it's not in our custom list)
+	resp = runBashTool(t, tool, ctx, BashParams{
+		Command: "echo hello",
+	})
+	require.False(t, resp.IsError)
+	require.Contains(t, resp.Content, "hello")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -257,6 +257,7 @@ type Options struct {
 	AutoLSP                   *bool        `json:"auto_lsp,omitempty" jsonschema:"description=Automatically setup LSPs based on root markers,default=true"`
 	Progress                  *bool        `json:"progress,omitempty" jsonschema:"description=Show indeterminate progress updates during long operations,default=true"`
 	DisableNotifications      bool         `json:"disable_notifications,omitempty" jsonschema:"description=Disable desktop notifications,default=false"`
+	BannedCommands            []string     `json:"banned_commands,omitempty" jsonschema:"description=List of shell commands that are forbidden from being executed by the agent,example=rm,example=sudo,example=ssh"`
 }
 
 type MCPs map[string]MCPConfig


### PR DESCRIPTION
### **Description**
This PR allows users to customize the list of banned shell commands via `crush.json`. It replaces the hardcoded restrictions with a configurable option while maintaining safe defaults.

### **Key Changes**
- Added `banned_commands` to `options` in the configuration.
- Updated the [bash](cci:1://file:///Users/sriwilliamsai/crush/internal/agent/tools/bash.go:143:0-159:1) tool to respect user-defined restrictions.
- Added a new unit test to verify custom banning logic.

### **Verification**
- All tests passed: `go test ./...`
- Added and passed: [TestBashTool_CustomBannedCommands](cci:1://file:///Users/sriwilliamsai/crush/internal/agent/tools/bash_test.go:104:0-126:1)

---