### PR TITLE
fix(commands): add timeout context for MCP prompt retrieval

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/config"
@@ -228,8 +229,12 @@ func isMarkdownFile(name string) bool {
 }
 
 func GetMCPPrompt(cfg *config.ConfigStore, clientID, promptID string, args map[string]string) (string, error) {
-	// TODO: we should pass the context down
-	result, err := mcp.GetPromptMessages(context.Background(), cfg, clientID, promptID, args)
+	// Create a context with timeout since tea.Cmd doesn't support context passing.
+	// The MCP client has its own timeout, but this provides an additional safeguard.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := mcp.GetPromptMessages(ctx, cfg, clientID, promptID, args)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary

  - Add a 30-second timeout context to `GetMCPPrompt` function to prevent indefinite hanging when fetching MCP prompts
  - The previous implementation used `context.Background()` without any timeout protection
  - Since `tea.Cmd` doesn't support context passing (it's `func() Msg`), we cannot propagate context from the caller, so
we create a timeout context within the function itself
  - This follows the same pattern already used in `oauth_copilot.go` and `oauth_hyper.go` (30-second timeout)

  ## Changes

  - `internal/commands/commands.go`: Added `time` import and wrapped the context with `context.WithTimeout(context.
Background(), 30*time.Second)`
