### PR TITLE
fix(config): honor initialize_as context files

### DIFF
--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
-	"strings"
 
 	"github.com/charmbracelet/crush/internal/fsext"
+	"github.com/charmbracelet/crush/internal/home"
 )
 
 const (
@@ -43,7 +42,7 @@ func ProjectNeedsInitialization(store *ConfigStore) (bool, error) {
 		return false, fmt.Errorf("failed to check init flag file: %w", err)
 	}
 
-	someContextFileExists, err := contextPathsExist(store.WorkingDir())
+	someContextFileExists, err := contextPathsExist(store)
 	if err != nil {
 		return false, fmt.Errorf("failed to check for context files: %w", err)
 	}
@@ -63,32 +62,39 @@ func ProjectNeedsInitialization(store *ConfigStore) (bool, error) {
 	return true, nil
 }
 
-func contextPathsExist(dir string) (bool, error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false, err
+func contextPathsExist(store *ConfigStore) (bool, error) {
+	if store == nil {
+		return false, fmt.Errorf("config not loaded")
 	}
 
-	// Create a slice of lowercase filenames for lookup with slices.Contains
-	var files []string
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			files = append(files, strings.ToLower(entry.Name()))
+	for _, path := range store.Config().Options.ContextPaths {
+		resolvedPath, err := resolveContextPath(store, path)
+		if err != nil {
+			return false, err
 		}
-	}
-
-	// Check if any of the default context paths exist in the directory
-	for _, path := range defaultContextPaths {
-		// Extract just the filename from the path
-		_, filename := filepath.Split(path)
-		filename = strings.ToLower(filename)
-
-		if slices.Contains(files, filename) {
+		if _, err := os.Stat(resolvedPath); err == nil {
 			return true, nil
+		} else if !os.IsNotExist(err) {
+			return false, err
 		}
 	}
 
 	return false, nil
+}
+
+func resolveContextPath(store *ConfigStore, path string) (string, error) {
+	path = home.Long(path)
+	if len(path) > 0 && path[0] == '$' {
+		resolved, err := store.Resolve(path)
+		if err != nil {
+			return "", err
+		}
+		path = resolved
+	}
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+	return filepath.Join(store.WorkingDir(), path), nil
 }
 
 // dirHasNoVisibleFiles returns true if the directory has no files/dirs after applying ignore rules.

--- a/internal/config/init_test.go
+++ b/internal/config/init_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectNeedsInitializationRespectsInitializeAsPath(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	dataDir := filepath.Join(workingDir, ".crush")
+
+	require.NoError(t, os.WriteFile(filepath.Join(workingDir, ".gitignore"), []byte("bazel-bin\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workingDir, "main.go"), []byte("package main\n"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(workingDir, "bazel-bin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workingDir, "bazel-bin", "AGENTS.md"), []byte("# Context\n"), 0o644))
+
+	cfg := &Config{
+		Options: &Options{
+			InitializeAs: "bazel-bin/AGENTS.md",
+		},
+	}
+	cfg.setDefaults(workingDir, dataDir)
+
+	store := testStore(cfg)
+	store.workingDir = workingDir
+
+	needsInitialization, err := ProjectNeedsInitialization(store)
+	require.NoError(t, err)
+	require.False(t, needsInitialization)
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -402,8 +402,12 @@ func (c *Config) setDefaults(workingDir, dataDir string) {
 	// Apply defaults to LSP configurations
 	c.applyLSPDefaults()
 
-	// Add the default context paths if they are not already present
+	c.Options.InitializeAs = cmp.Or(c.Options.InitializeAs, defaultInitializeAs)
+
+	// Add the default context paths and the initialization target if they are
+	// not already present.
 	c.Options.ContextPaths = append(defaultContextPaths, c.Options.ContextPaths...)
+	c.Options.ContextPaths = append(c.Options.ContextPaths, c.Options.InitializeAs)
 	slices.Sort(c.Options.ContextPaths)
 	c.Options.ContextPaths = slices.Compact(c.Options.ContextPaths)
 
@@ -442,7 +446,6 @@ func (c *Config) setDefaults(workingDir, dataDir string) {
 			c.Options.Attribution.TrailerStyle = TrailerStyleAssistedBy
 		}
 	}
-	c.Options.InitializeAs = cmp.Or(c.Options.InitializeAs, defaultInitializeAs)
 }
 
 // applyLSPDefaults applies default values from powernap to LSP configurations

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -60,6 +60,21 @@ func TestConfig_setDefaults(t *testing.T) {
 	}
 }
 
+func TestConfig_setDefaultsIncludesCustomInitializeAsInContextPaths(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{
+		Options: &Options{
+			InitializeAs: "docs/LLMs.md",
+		},
+	}
+
+	cfg.setDefaults("/tmp", "")
+
+	require.Equal(t, "docs/LLMs.md", cfg.Options.InitializeAs)
+	require.Contains(t, cfg.Options.ContextPaths, "docs/LLMs.md")
+}
+
 func TestConfig_configureProviders(t *testing.T) {
 	knownProviders := []catwalk.Provider{
 		{


### PR DESCRIPTION
## Summary

Fix custom `initialize_as` paths so Crush treats them as real context files after initialization.

## Problem

Crush only used `initialize_as` when writing the file during project initialization.
It did not add that path to the context files it loads later, and the initialization check only looked for root-level default filenames.

That meant custom paths like `bazel-bin/AGENTS.md` or `docs/LLMs.md` could exist and still be ignored.

### Before

1. Set `"options": { "initialize_as": "bazel-bin/AGENTS.md" }`.
2. Initialize the project so Crush writes that file.
3. Restart Crush.
4. Crush still treats the project as uninitialized or fails to load the generated context from that path.

### After

1. The configured `initialize_as` path is added to the effective context paths during config load.
2. Initialization checks resolve configured context paths directly, so nested or ignored-directory paths are recognized.

## Changes

- Add `initialize_as` to the default context path set during config loading.
- Resolve and stat configured context paths when deciding whether a project already has context files.
- Add regression tests for custom initialize targets, including an ignored-directory case.

## Test Plan

- [x] `go test ./internal/config`

Closes #2452
