### PR TITLE
fix(ui): prompt to quit on ctrl+d

### DIFF
--- a/internal/ui/model/layout_test.go
+++ b/internal/ui/model/layout_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/textarea"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/chat"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
 )
 
 // testMessageItem is a minimal chat item used to populate the chat list
@@ -28,6 +30,7 @@ var _ chat.MessageItem = testMessageItem{}
 // in isolation.
 func newTestUI() *UI {
 	com := common.DefaultCommon(nil)
+	keyMap := DefaultKeyMap()
 
 	ta := textarea.New()
 	ta.SetStyles(com.Styles.TextArea)
@@ -40,14 +43,29 @@ func newTestUI() *UI {
 	ta.Focus()
 
 	u := &UI{
+		keyMap:   keyMap,
 		com:      com,
+		dialog:   dialog.NewOverlay(),
 		status:   NewStatus(com, nil),
 		chat:     NewChat(com),
 		textarea: ta,
-		state:    uiChat,
-		focus:    uiFocusEditor,
-		width:    140,
-		height:   45,
+		attachments: attachments.New(
+			attachments.NewRenderer(
+				com.Styles.Attachments.Normal,
+				com.Styles.Attachments.Deleting,
+				com.Styles.Attachments.Image,
+				com.Styles.Attachments.Text,
+			),
+			attachments.Keymap{
+				DeleteMode: keyMap.Editor.AttachmentDeleteMode,
+				DeleteAll:  keyMap.Editor.DeleteAllAttachments,
+				Escape:     keyMap.Editor.Escape,
+			},
+		),
+		state:  uiChat,
+		focus:  uiFocusEditor,
+		width:  140,
+		height: 45,
 	}
 
 	return u

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1676,6 +1676,10 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		return m.handleDialogMsg(msg)
 	}
 
+	if m.shouldPromptQuitOnEOF(msg) {
+		return m.openQuitDialog()
+	}
+
 	// Handle cancel key when agent is busy.
 	if key.Matches(msg, m.keyMap.Chat.Cancel) {
 		if m.isAgentBusy() {
@@ -2948,6 +2952,22 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 		return nil
 	})
 	return tea.Batch(cmds...)
+}
+
+func (m *UI) shouldPromptQuitOnEOF(msg tea.KeyPressMsg) bool {
+	if msg.String() != "ctrl+d" {
+		return false
+	}
+	if m.focus != uiFocusEditor {
+		return false
+	}
+	if m.state != uiChat && m.state != uiLanding {
+		return false
+	}
+	if m.textarea.Value() != "" || m.completionsOpen {
+		return false
+	}
+	return m.attachments == nil || len(m.attachments.List()) == 0
 }
 
 const cancelTimerDuration = 2 * time.Second

--- a/internal/ui/model/ui_keypress_test.go
+++ b/internal/ui/model/ui_keypress_test.go
@@ -1,0 +1,45 @@
+package model
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleKeyPressMsgCtrlDOpensQuitDialogWhenEditorIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	ui := newTestUI()
+
+	ui.handleKeyPressMsg(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+
+	require.True(t, ui.dialog.ContainsDialog(dialog.QuitID))
+}
+
+func TestHandleKeyPressMsgCtrlDDoesNotOpenQuitDialogWhenEditorHasInput(t *testing.T) {
+	t.Parallel()
+
+	ui := newTestUI()
+	ui.textarea.SetValue("hello")
+
+	ui.handleKeyPressMsg(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+
+	require.False(t, ui.dialog.ContainsDialog(dialog.QuitID))
+}
+
+func TestHandleKeyPressMsgCtrlDDoesNotOpenQuitDialogWhenAttachmentsExist(t *testing.T) {
+	t.Parallel()
+
+	ui := newTestUI()
+	ui.attachments.Update(message.Attachment{
+		FileName: "notes.txt",
+		MimeType: "text/plain",
+	})
+
+	ui.handleKeyPressMsg(tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl})
+
+	require.False(t, ui.dialog.ContainsDialog(dialog.QuitID))
+}


### PR DESCRIPTION
## Summary

Treat `ctrl+d` like EOF in the editor when the prompt is empty by opening the existing quit confirmation dialog.

## Problem

`ctrl+d` is a common REPL EOF shortcut, but Crush currently ignores it in the editor unless the user types `quit` or uses `ctrl+c`.

### Before

1. Start Crush and focus the prompt editor.
2. Leave the prompt empty.
3. Press `ctrl+d`.
4. Nothing happens.

### After

1. Pressing `ctrl+d` with an empty editor opens the existing quit dialog.
2. Existing compact-mode `ctrl+d` details behavior is unchanged outside the empty-editor EOF case.
3. `ctrl+d` does not prompt to quit when there is typed input or pending attachments.

## Changes

- Add a narrow EOF check in key handling for `ctrl+d` while the editor is focused.
- Reuse the existing quit confirmation dialog instead of adding a new quit path.
- Add regression tests for the empty-editor case and guards for typed input and attachments.

## Test Plan

- [x] `go test ./internal/ui/model`

Closes #2428
