### PR TITLE
fix(csync): use pointer receiver for JSONSchemaAlias

### DIFF
--- a/internal/csync/maps.go
+++ b/internal/csync/maps.go
@@ -131,7 +131,7 @@ var (
 	_ json.Marshaler   = &Map[string, any]{}
 )
 
-func (Map[K, V]) JSONSchemaAlias() any { //nolint
+func (*Map[K, V]) JSONSchemaAlias() any { //nolint
 	m := map[K]V{}
 	return m
 }

--- a/internal/csync/maps.go
+++ b/internal/csync/maps.go
@@ -131,7 +131,7 @@ var (
 	_ json.Marshaler   = &Map[string, any]{}
 )
 
-func (*Map[K, V]) JSONSchemaAlias() any { //nolint
+func (*Map[K, V]) JSONSchemaAlias() any {
 	m := map[K]V{}
 	return m
 }


### PR DESCRIPTION
## Summary
- Changed `JSONSchemaAlias()` method receiver from value `(Map[K, V])` to pointer `(*Map[K, V])`

## Details
The `JSONSchemaAlias()` method now uses a pointer receiver for consistency with other `Map` methods that use pointer receivers for interface satisfaction (e.g., `json.Marshaler`).

This is a minor consistency fix that aligns the receiver type with the rest of the `Map` type's interface implementations.