### PR TITLE
feat(ui/dialog): add mouse click handling for permission buttons and compute hitboxes

### DIFF
--- a/internal/ui/common/button.go
+++ b/internal/ui/common/button.go
@@ -46,11 +46,11 @@ func Button(t *styles.Styles, opts ButtonOpts) string {
 	return text
 }
 
-// ButtonGroup creates a row of selectable buttons
-// Spacing is the separator between buttons
-// Use "  " or similar for horizontal layout
-// Use "\n"  for vertical layout
-// Defaults to "  " (horizontal)
+// ButtonGroup creates a row of selectable buttons.
+// Spacing is the separator between buttons.
+// Use "  " or similar for horizontal layout.
+// Use "\n"  for vertical layout.
+// Defaults to "  " (horizontal).
 func ButtonGroup(t *styles.Styles, buttons []ButtonOpts, spacing string) string {
 	if len(buttons) == 0 {
 		return ""

--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -3,6 +3,7 @@ package dialog
 import (
 	"encoding/json"
 	"fmt"
+	"image"
 	"strings"
 
 	"charm.land/bubbles/v2/help"
@@ -76,6 +77,11 @@ type Permissions struct {
 
 	help   help.Model
 	keyMap permissionsKeyMap
+
+	// Mouse click hitboxes for the three response buttons ("Allow",
+	// "Allow for Session", "Deny"). Computed during Draw().
+	buttonsHitboxesValid bool
+	buttonsHitRects      [3]image.Rectangle
 }
 
 type permissionsKeyMap struct {
@@ -272,6 +278,23 @@ func (p *Permissions) HandleMsg(msg tea.Msg) Action {
 				p.viewport, _ = p.viewport.Update(msg)
 			}
 		}
+	case tea.MouseClickMsg:
+		if msg.Button != tea.MouseLeft || !p.buttonsHitboxesValid {
+			break
+		}
+
+		pt := image.Pt(msg.X, msg.Y)
+		switch {
+		case pt.In(p.buttonsHitRects[0]):
+			p.selectedOption = 0
+			return p.respond(PermissionAllow)
+		case pt.In(p.buttonsHitRects[1]):
+			p.selectedOption = 1
+			return p.respond(PermissionAllowForSession)
+		case pt.In(p.buttonsHitRects[2]):
+			p.selectedOption = 2
+			return p.respond(PermissionDeny)
+		}
 	case tea.MouseWheelMsg:
 		if p.hasDiffView() {
 			switch msg.Button {
@@ -436,7 +459,86 @@ func (p *Permissions) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	parts = append(parts, "", buttons, "", helpView)
 
 	innerContent := lipgloss.JoinVertical(lipgloss.Left, parts...)
-	DrawCenterCursor(scr, area, dialogStyle.Render(innerContent), nil)
+
+	viewStr := dialogStyle.Render(innerContent)
+
+	// Update click hitboxes for the response buttons.
+	p.buttonsHitboxesValid = false
+	// Default to empty rectangles; image.Pt(...).In(...) will return false.
+	p.buttonsHitRects = [3]image.Rectangle{}
+
+	contentIncluded := content != ""
+	contentHeightActual := 0
+	if contentIncluded {
+		contentHeightActual = lipgloss.Height(content)
+	}
+
+	// Measure the rendered dialog so we can convert hitboxes to screen coords.
+	viewW, viewH := lipgloss.Size(viewStr)
+	dialogRect := common.CenterRect(area, viewW, viewH)
+
+	innerMinX := dialogRect.Min.X + dialogStyle.GetHorizontalFrameSize()/2
+	innerMinY := dialogRect.Min.Y + dialogStyle.GetVerticalFrameSize()/2
+
+	// Lines before the buttons block within the inner content.
+	buttonTopInInner := headerHeight + 1
+	if contentIncluded {
+		buttonTopInInner += contentHeightActual + 2
+	}
+
+	// Buttons layout can switch between horizontal and stacked mode.
+	buttonOpts := []common.ButtonOpts{
+		{Text: "Allow", UnderlineIndex: 0, Selected: p.selectedOption == 0},
+		{Text: "Allow for Session", UnderlineIndex: 10, Selected: p.selectedOption == 1},
+		{Text: "Deny", UnderlineIndex: 0, Selected: p.selectedOption == 2},
+	}
+	b0 := common.Button(t, buttonOpts[0])
+	b1 := common.Button(t, buttonOpts[1])
+	b2 := common.Button(t, buttonOpts[2])
+
+	buttonGroupHorizontal := common.ButtonGroup(t, buttonOpts, "  ")
+	buttonsAreStacked := lipgloss.Width(buttonGroupHorizontal) > contentWidth
+
+	const hitboxPad = 1
+	yButtonsTop := innerMinY + buttonTopInInner
+
+	if buttonsAreStacked {
+		y := yButtonsTop
+		buttons := []string{b0, b1, b2}
+		for i, b := range buttons {
+			w := lipgloss.Width(b)
+			h := lipgloss.Height(b)
+			x := innerMinX + (contentWidth-w)/2
+			left := max(0, x-hitboxPad)
+			top := max(0, y-hitboxPad)
+			right := x + w + hitboxPad
+			bottom := y + h + hitboxPad
+			p.buttonsHitRects[i] = image.Rect(left, top, right, bottom)
+			y += h
+		}
+	} else {
+		spacingWidth := lipgloss.Width("  ")
+		buttonGroupWidth := lipgloss.Width(buttonGroupHorizontal)
+		x := innerMinX + (contentWidth - buttonGroupWidth)
+
+		// All three buttons share the same vertical span in horizontal mode.
+		yBottom := yButtonsTop + buttonsHeight
+
+		buttons := []string{b0, b1, b2}
+		for i, b := range buttons {
+			w := lipgloss.Width(b)
+			left := max(0, x-hitboxPad)
+			top := max(0, yButtonsTop-hitboxPad)
+			right := x + w + hitboxPad
+			bottom := yBottom + hitboxPad
+			p.buttonsHitRects[i] = image.Rect(left, top, right, bottom)
+			x += w + spacingWidth
+		}
+	}
+
+	p.buttonsHitboxesValid = true
+
+	DrawCenterCursor(scr, area, viewStr, nil)
 	return nil
 }
 

--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -3,7 +3,6 @@ package dialog
 import (
 	"encoding/json"
 	"fmt"
-	"image"
 	"strings"
 
 	"charm.land/bubbles/v2/help"
@@ -78,10 +77,9 @@ type Permissions struct {
 	help   help.Model
 	keyMap permissionsKeyMap
 
-	// Mouse click hitboxes for the three response buttons ("Allow",
-	// "Allow for Session", "Deny"). Computed during Draw().
-	buttonsHitboxesValid bool
-	buttonsHitRects      [3]image.Rectangle
+	// Compositor for button hit detection. Built during Draw() from
+	// button layers positioned at their screen coordinates.
+	compositor *lipgloss.Compositor
 }
 
 type permissionsKeyMap struct {
@@ -279,21 +277,21 @@ func (p *Permissions) HandleMsg(msg tea.Msg) Action {
 			}
 		}
 	case tea.MouseClickMsg:
-		if msg.Button != tea.MouseLeft || !p.buttonsHitboxesValid {
+		if msg.Button != tea.MouseLeft {
 			break
 		}
-
-		pt := image.Pt(msg.X, msg.Y)
-		switch {
-		case pt.In(p.buttonsHitRects[0]):
-			p.selectedOption = 0
-			return p.respond(PermissionAllow)
-		case pt.In(p.buttonsHitRects[1]):
-			p.selectedOption = 1
-			return p.respond(PermissionAllowForSession)
-		case pt.In(p.buttonsHitRects[2]):
-			p.selectedOption = 2
-			return p.respond(PermissionDeny)
+		if p.compositor != nil {
+			switch p.compositor.Hit(msg.X, msg.Y).ID() {
+			case "allow":
+				p.selectedOption = 0
+				return p.respond(PermissionAllow)
+			case "allow_session":
+				p.selectedOption = 1
+				return p.respond(PermissionAllowForSession)
+			case "deny":
+				p.selectedOption = 2
+				return p.respond(PermissionDeny)
+			}
 		}
 	case tea.MouseWheelMsg:
 		if p.hasDiffView() {
@@ -462,81 +460,8 @@ func (p *Permissions) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	viewStr := dialogStyle.Render(innerContent)
 
-	// Update click hitboxes for the response buttons.
-	p.buttonsHitboxesValid = false
-	// Default to empty rectangles; image.Pt(...).In(...) will return false.
-	p.buttonsHitRects = [3]image.Rectangle{}
-
-	contentIncluded := content != ""
-	contentHeightActual := 0
-	if contentIncluded {
-		contentHeightActual = lipgloss.Height(content)
-	}
-
-	// Measure the rendered dialog so we can convert hitboxes to screen coords.
-	viewW, viewH := lipgloss.Size(viewStr)
-	dialogRect := common.CenterRect(area, viewW, viewH)
-
-	innerMinX := dialogRect.Min.X + dialogStyle.GetHorizontalFrameSize()/2
-	innerMinY := dialogRect.Min.Y + dialogStyle.GetVerticalFrameSize()/2
-
-	// Lines before the buttons block within the inner content.
-	buttonTopInInner := headerHeight + 1
-	if contentIncluded {
-		buttonTopInInner += contentHeightActual + 2
-	}
-
-	// Buttons layout can switch between horizontal and stacked mode.
-	buttonOpts := []common.ButtonOpts{
-		{Text: "Allow", UnderlineIndex: 0, Selected: p.selectedOption == 0},
-		{Text: "Allow for Session", UnderlineIndex: 10, Selected: p.selectedOption == 1},
-		{Text: "Deny", UnderlineIndex: 0, Selected: p.selectedOption == 2},
-	}
-	b0 := common.Button(t, buttonOpts[0])
-	b1 := common.Button(t, buttonOpts[1])
-	b2 := common.Button(t, buttonOpts[2])
-
-	buttonGroupHorizontal := common.ButtonGroup(t, buttonOpts, "  ")
-	buttonsAreStacked := lipgloss.Width(buttonGroupHorizontal) > contentWidth
-
-	const hitboxPad = 1
-	yButtonsTop := innerMinY + buttonTopInInner
-
-	if buttonsAreStacked {
-		y := yButtonsTop
-		buttons := []string{b0, b1, b2}
-		for i, b := range buttons {
-			w := lipgloss.Width(b)
-			h := lipgloss.Height(b)
-			x := innerMinX + (contentWidth-w)/2
-			left := max(0, x-hitboxPad)
-			top := max(0, y-hitboxPad)
-			right := x + w + hitboxPad
-			bottom := y + h + hitboxPad
-			p.buttonsHitRects[i] = image.Rect(left, top, right, bottom)
-			y += h
-		}
-	} else {
-		spacingWidth := lipgloss.Width("  ")
-		buttonGroupWidth := lipgloss.Width(buttonGroupHorizontal)
-		x := innerMinX + (contentWidth - buttonGroupWidth)
-
-		// All three buttons share the same vertical span in horizontal mode.
-		yBottom := yButtonsTop + buttonsHeight
-
-		buttons := []string{b0, b1, b2}
-		for i, b := range buttons {
-			w := lipgloss.Width(b)
-			left := max(0, x-hitboxPad)
-			top := max(0, yButtonsTop-hitboxPad)
-			right := x + w + hitboxPad
-			bottom := yBottom + hitboxPad
-			p.buttonsHitRects[i] = image.Rect(left, top, right, bottom)
-			x += w + spacingWidth
-		}
-	}
-
-	p.buttonsHitboxesValid = true
+	// Build compositor for button hit detection using lipgloss layers.
+	p.buildButtonCompositor(t, area, viewStr, dialogStyle, contentWidth, content, headerHeight)
 
 	DrawCenterCursor(scr, area, viewStr, nil)
 	return nil
@@ -831,12 +756,21 @@ func (p *Permissions) renderContentPanel(content string, width int) string {
 	return panelStyle.Width(width).Render(content)
 }
 
-func (p *Permissions) renderButtons(contentWidth int) string {
-	buttons := []common.ButtonOpts{
+// permissionButtonIDs maps button index to the layer ID used for hit
+// detection. This is the single source of truth shared by renderButtons
+// and buildButtonCompositor.
+var permissionButtonIDs = [3]string{"allow", "allow_session", "deny"}
+
+func (p *Permissions) buttonOpts() []common.ButtonOpts {
+	return []common.ButtonOpts{
 		{Text: "Allow", UnderlineIndex: 0, Selected: p.selectedOption == 0},
 		{Text: "Allow for Session", UnderlineIndex: 10, Selected: p.selectedOption == 1},
 		{Text: "Deny", UnderlineIndex: 0, Selected: p.selectedOption == 2},
 	}
+}
+
+func (p *Permissions) renderButtons(contentWidth int) string {
+	buttons := p.buttonOpts()
 
 	content := common.ButtonGroup(p.com.Styles, buttons, "  ")
 
@@ -853,6 +787,67 @@ func (p *Permissions) renderButtons(contentWidth int) string {
 		Width(contentWidth).
 		Align(lipgloss.Right).
 		Render(content)
+}
+
+// buildButtonCompositor creates a lipgloss Compositor with a layer per
+// button so that Compositor.Hit can identify which button was clicked.
+func (p *Permissions) buildButtonCompositor(
+	t *styles.Styles,
+	area uv.Rectangle,
+	viewStr string,
+	dialogStyle lipgloss.Style,
+	contentWidth int,
+	content string,
+	headerHeight int,
+) {
+	contentIncluded := content != ""
+	contentHeightActual := 0
+	if contentIncluded {
+		contentHeightActual = lipgloss.Height(content)
+	}
+
+	viewW, viewH := lipgloss.Size(viewStr)
+	dialogRect := common.CenterRect(area, viewW, viewH)
+
+	innerMinX := dialogRect.Min.X + dialogStyle.GetHorizontalFrameSize()/2
+	innerMinY := dialogRect.Min.Y + dialogStyle.GetVerticalFrameSize()/2
+
+	buttonTopInInner := headerHeight + 1
+	if contentIncluded {
+		buttonTopInInner += contentHeightActual + 2
+	}
+
+	opts := p.buttonOpts()
+	yButtonsTop := innerMinY + buttonTopInInner
+
+	buttonGroupHorizontal := common.ButtonGroup(t, opts, "  ")
+	buttonsAreStacked := lipgloss.Width(buttonGroupHorizontal) > contentWidth
+
+	var layers []*lipgloss.Layer
+	if buttonsAreStacked {
+		y := yButtonsTop
+		for i, o := range opts {
+			b := common.Button(t, o)
+			w := lipgloss.Width(b)
+			h := lipgloss.Height(b)
+			x := innerMinX + (contentWidth-w)/2
+			layers = append(layers, lipgloss.NewLayer(b).X(x).Y(y).ID(permissionButtonIDs[i]))
+			y += h
+		}
+	} else {
+		spacingWidth := lipgloss.Width("  ")
+		buttonGroupWidth := lipgloss.Width(buttonGroupHorizontal)
+		x := innerMinX + (contentWidth - buttonGroupWidth)
+
+		for i, o := range opts {
+			b := common.Button(t, o)
+			w := lipgloss.Width(b)
+			layers = append(layers, lipgloss.NewLayer(b).X(x).Y(yButtonsTop).ID(permissionButtonIDs[i]))
+			x += w + spacingWidth
+		}
+	}
+
+	p.compositor = lipgloss.NewCompositor(layers...)
 }
 
 func (p *Permissions) canScroll() bool {

--- a/internal/ui/dialog/quit.go
+++ b/internal/ui/dialog/quit.go
@@ -1,8 +1,6 @@
 package dialog
 
 import (
-	"image"
-
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -27,10 +25,9 @@ type Quit struct {
 		Quit key.Binding
 	}
 
-	// Mouse click hitboxes for the two response buttons ("Yep!",
-	// "Nope"). Computed during Draw().
-	buttonsHitboxesValid bool
-	buttonsHitRects      [2]image.Rectangle
+	// Compositor for button hit detection. Built during Draw() from
+	// button layers positioned at their screen coordinates.
+	compositor *lipgloss.Compositor
 }
 
 var _ Dialog = (*Quit)(nil)
@@ -96,15 +93,16 @@ func (q *Quit) HandleMsg(msg tea.Msg) Action {
 			return ActionClose{}
 		}
 	case tea.MouseClickMsg:
-		if msg.Button != tea.MouseLeft || !q.buttonsHitboxesValid {
+		if msg.Button != tea.MouseLeft {
 			break
 		}
-		pt := image.Pt(msg.X, msg.Y)
-		switch {
-		case pt.In(q.buttonsHitRects[0]):
-			return ActionQuit{}
-		case pt.In(q.buttonsHitRects[1]):
-			return ActionClose{}
+		if q.compositor != nil {
+			switch q.compositor.Hit(msg.X, msg.Y).ID() {
+			case "yep":
+				return ActionQuit{}
+			case "nope":
+				return ActionClose{}
+			}
 		}
 	}
 
@@ -131,12 +129,9 @@ func (q *Quit) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	view := q.com.Styles.Dialog.Quit.Frame.Render(content)
 
-	// Compute click hitboxes for the response buttons.
-	q.buttonsHitboxesValid = false
-	q.buttonsHitRects = [2]image.Rectangle{}
-
-	viewW, _ := lipgloss.Size(view)
-	dialogRect := common.CenterRect(area, viewW, lipgloss.Height(view))
+	// Build compositor for button hit detection using lipgloss layers.
+	viewW, viewH := lipgloss.Size(view)
+	dialogRect := common.CenterRect(area, viewW, viewH)
 
 	frameStyle := q.com.Styles.Dialog.Quit.Frame
 	innerMinX := dialogRect.Min.X + frameStyle.GetHorizontalFrameSize()/2
@@ -144,8 +139,7 @@ func (q *Quit) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	// Buttons are at line 2 within inner content (question=0,
 	// blank=1, buttons=2).
-	buttonTopInInner := 2
-	yButtonsTop := innerMinY + buttonTopInInner
+	yButtonsTop := innerMinY + 2
 
 	b0 := common.Button(q.com.Styles, buttonOpts[0])
 	b1 := common.Button(q.com.Styles, buttonOpts[1])
@@ -157,22 +151,10 @@ func (q *Quit) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	contentW := lipgloss.Width(content)
 	buttonStartX := innerMinX + (contentW-buttonGroupW)/2
 
-	const hitboxPad = 1
-	x := buttonStartX
-	q.buttonsHitRects[0] = image.Rect(
-		max(0, x-hitboxPad),
-		max(0, yButtonsTop-hitboxPad),
-		x+w0+hitboxPad,
-		yButtonsTop+lipgloss.Height(b0)+hitboxPad,
+	q.compositor = lipgloss.NewCompositor(
+		lipgloss.NewLayer(b0).X(buttonStartX).Y(yButtonsTop).ID("yep"),
+		lipgloss.NewLayer(b1).X(buttonStartX+w0+spacingW).Y(yButtonsTop).ID("nope"),
 	)
-	x += w0 + spacingW
-	q.buttonsHitRects[1] = image.Rect(
-		max(0, x-hitboxPad),
-		max(0, yButtonsTop-hitboxPad),
-		x+w1+hitboxPad,
-		yButtonsTop+lipgloss.Height(b1)+hitboxPad,
-	)
-	q.buttonsHitboxesValid = true
 
 	DrawCenter(scr, area, view)
 	return nil

--- a/internal/ui/dialog/quit.go
+++ b/internal/ui/dialog/quit.go
@@ -1,6 +1,8 @@
 package dialog
 
 import (
+	"image"
+
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -24,6 +26,11 @@ type Quit struct {
 		Close,
 		Quit key.Binding
 	}
+
+	// Mouse click hitboxes for the two response buttons ("Yep!",
+	// "Nope"). Computed during Draw().
+	buttonsHitboxesValid bool
+	buttonsHitRects      [2]image.Rectangle
 }
 
 var _ Dialog = (*Quit)(nil)
@@ -88,6 +95,17 @@ func (q *Quit) HandleMsg(msg tea.Msg) Action {
 		case key.Matches(msg, q.keyMap.No, q.keyMap.Close):
 			return ActionClose{}
 		}
+	case tea.MouseClickMsg:
+		if msg.Button != tea.MouseLeft || !q.buttonsHitboxesValid {
+			break
+		}
+		pt := image.Pt(msg.X, msg.Y)
+		switch {
+		case pt.In(q.buttonsHitRects[0]):
+			return ActionQuit{}
+		case pt.In(q.buttonsHitRects[1]):
+			return ActionClose{}
+		}
 	}
 
 	return nil
@@ -112,6 +130,50 @@ func (q *Quit) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	)
 
 	view := q.com.Styles.Dialog.Quit.Frame.Render(content)
+
+	// Compute click hitboxes for the response buttons.
+	q.buttonsHitboxesValid = false
+	q.buttonsHitRects = [2]image.Rectangle{}
+
+	viewW, _ := lipgloss.Size(view)
+	dialogRect := common.CenterRect(area, viewW, lipgloss.Height(view))
+
+	frameStyle := q.com.Styles.Dialog.Quit.Frame
+	innerMinX := dialogRect.Min.X + frameStyle.GetHorizontalFrameSize()/2
+	innerMinY := dialogRect.Min.Y + frameStyle.GetVerticalFrameSize()/2
+
+	// Buttons are at line 2 within inner content (question=0,
+	// blank=1, buttons=2).
+	buttonTopInInner := 2
+	yButtonsTop := innerMinY + buttonTopInInner
+
+	b0 := common.Button(q.com.Styles, buttonOpts[0])
+	b1 := common.Button(q.com.Styles, buttonOpts[1])
+	w0 := lipgloss.Width(b0)
+	w1 := lipgloss.Width(b1)
+	spacingW := lipgloss.Width(" ")
+	buttonGroupW := w0 + spacingW + w1
+
+	contentW := lipgloss.Width(content)
+	buttonStartX := innerMinX + (contentW-buttonGroupW)/2
+
+	const hitboxPad = 1
+	x := buttonStartX
+	q.buttonsHitRects[0] = image.Rect(
+		max(0, x-hitboxPad),
+		max(0, yButtonsTop-hitboxPad),
+		x+w0+hitboxPad,
+		yButtonsTop+lipgloss.Height(b0)+hitboxPad,
+	)
+	x += w0 + spacingW
+	q.buttonsHitRects[1] = image.Rect(
+		max(0, x-hitboxPad),
+		max(0, yButtonsTop-hitboxPad),
+		x+w1+hitboxPad,
+		yButtonsTop+lipgloss.Height(b1)+hitboxPad,
+	)
+	q.buttonsHitboxesValid = true
+
 	DrawCenter(scr, area, view)
 	return nil
 }

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -603,10 +603,15 @@ func (m *Chat) HandleDelayedClick(msg DelayedClickMsg) bool {
 	selectedItem := m.list.SelectedItem()
 	if clickable, ok := selectedItem.(list.MouseClickable); ok {
 		handled := clickable.HandleMouseClick(ansi.MouseButton1, msg.X, msg.Y)
-		// Toggle expansion if applicable.
-		if expandable, ok := selectedItem.(chat.Expandable); ok {
-			if !expandable.ToggleExpanded() {
-				m.ScrollToIndex(m.list.Selected())
+		// Toggle expansion only when the item signalled it handled the
+		// click. Items like AssistantMessageItem only report handled when
+		// the click is on their expandable region, so this avoids
+		// toggling expansion for clicks outside the clickable area.
+		if handled {
+			if expandable, ok := selectedItem.(chat.Expandable); ok {
+				if !expandable.ToggleExpanded() {
+					m.ScrollToIndex(m.list.Selected())
+				}
 			}
 		}
 		if m.AtBottom() {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -701,7 +701,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.MouseClickMsg:
 		// Pass mouse events to dialogs first if any are open.
 		if m.dialog.HasDialogs() {
-			m.dialog.Update(msg)
+			if cmd := m.handleDialogMsg(msg); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
 			return m, tea.Batch(cmds...)
 		}
 


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

## Summary
Permission requests in the TUI used to work with the keyboard, but clicking the "Allow / Allow for Session / Deny" buttons didn't trigger a response. This makes the dialog buttons clickable with the mouse.

## Changes
- Route `tea.MouseClickMsg` dialog actions through the main UI update loop (so dialog responses returned from click handling are actually applied).
- Add mouse click handling to the permissions dialog by computing simple hitboxes for the three response buttons during `Draw()`.

## Testing
- Automated: `go test ./internal/ui/...`
- Manual:
  1. Trigger a tool that requires permission
  2. Click `Allow`, `Allow for Session`, and `Deny` and confirm the permission is applied

Closes: #2397 