### PR TITLE
fix(ui): replace hardcoded cursor offset with style-based calculation

### DIFF
--- a/internal/ui/dialog/api_key_input.go
+++ b/internal/ui/dialog/api_key_input.go
@@ -182,7 +182,7 @@ func (m *APIKeyInput) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	if m.isOnboarding {
 		view := content
-		cur = AdjustOnboardingInputCursor(t, cur)
+		cur = adjustOnboardingInputCursor(t, cur)
 		DrawOnboardingCursor(scr, area, view, cur)
 	} else {
 		view := dialogStyle.Render(content)

--- a/internal/ui/dialog/common.go
+++ b/internal/ui/dialog/common.go
@@ -38,10 +38,10 @@ func InputCursor(t *styles.Styles, cur *tea.Cursor) *tea.Cursor {
 	return cur
 }
 
-// AdjustOnboardingInputCursor removes the dialog view frame offset from an
+// adjustOnboardingInputCursor removes the dialog view frame offset from an
 // input cursor. Onboarding dialogs render without Dialog.View frame, while
 // InputCursor includes that frame offset for regular dialogs.
-func AdjustOnboardingInputCursor(t *styles.Styles, cur *tea.Cursor) *tea.Cursor {
+func adjustOnboardingInputCursor(t *styles.Styles, cur *tea.Cursor) *tea.Cursor {
 	if cur == nil {
 		return nil
 	}

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -292,7 +292,7 @@ func (m *Models) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		rc.TitleInfo = ""
 		rc.IsOnboarding = true
 		view := rc.Render()
-		cur = AdjustOnboardingInputCursor(t, cur)
+		cur = adjustOnboardingInputCursor(t, cur)
 		DrawOnboardingCursor(scr, area, view, cur)
 	} else {
 		view := rc.Render()


### PR DESCRIPTION
## Summary
- Remove FIXME workaround in onboarding dialogs that used hardcoded `cur.Y -= 1` / `cur.X -= 1` to adjust cursor position
- Extract a new `AdjustOnboardingInputCursor` helper that computes the correct offset from `Dialog.View` border/padding/margin
- Eliminate code duplication between `api_key_input.go` and `models.go`

## Test plan
- [ ] Verify onboarding API key input dialog cursor positions correctly
- [ ] Verify onboarding model selection dialog cursor positions correctly
- [ ] Verify non-onboarding dialogs are unaffected

## Snapshot
<img width="2996" height="1576" alt="image" src="https://github.com/user-attachments/assets/3f745c17-6442-4ad0-818e-ad2e5990a60e" />
<img width="2964" height="1596" alt="image" src="https://github.com/user-attachments/assets/183814c6-c11b-4666-87df-eb76a3fea9d3" />
