### PR TITLE
docs: fix and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ nix-shell -p '(import <nur> { pkgs = import <nixpkgs> {}; }).repos.charmbracelet
 ### NixOS & Home Manager Module Usage via NUR
 
 Crush provides NixOS and Home Manager modules via NUR.
-You can use these modules directly in your flake by importing them from NUR. Since it auto detects whether its a home manager or nixos context you can use the import the exact same way :)
+You can use these modules directly in your flake by importing them from NUR. Since it auto detects whether it's a home manager or nixos context you can use the import the exact same way :)
 
 ```nix
 {

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -195,7 +195,7 @@ func Initialize(ctx context.Context, permissions permission.Service, cfg *config
 			}()
 
 			if err := initClient(ctx, cfg, name, m, cfg.Resolver()); err != nil {
-				slog.Debug("failed to initialize mcp client", "name", name, "error", err)
+				slog.Debug("Failed to initialize MCP client", "name", name, "error", err)
 			}
 		}(name, m)
 	}
@@ -223,7 +223,7 @@ func InitializeSingle(ctx context.Context, name string, cfg *config.ConfigStore)
 
 	if m.Disabled {
 		updateState(name, StateDisabled, nil, nil, Counts{})
-		slog.Debug("skipping disabled mcp", "name", name)
+		slog.Debug("Skipping disabled MCP", "name", name)
 		return nil
 	}
 
@@ -277,7 +277,7 @@ func DisableSingle(cfg *config.ConfigStore, name string) error {
 			!errors.Is(err, io.EOF) &&
 			!errors.Is(err, context.Canceled) &&
 			err.Error() != "signal: killed" {
-			slog.Warn("error closing mcp session", "name", name, "error", err)
+			slog.Warn("Error closing MCP session", "name", name, "error", err)
 		}
 		sessions.Del(name)
 	}
@@ -289,7 +289,7 @@ func DisableSingle(cfg *config.ConfigStore, name string) error {
 	// Update state to disabled.
 	updateState(name, StateDisabled, nil, nil, Counts{})
 
-	slog.Info("Disabled mcp client", "name", name)
+	slog.Info("Disabled MCP client", "name", name)
 	return nil
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -340,7 +340,7 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 
 				part := content[readBytes:]
 				// Trim leading whitespace. Sometimes the LLM includes leading
-				// formatting and intentation, which we don't want here.
+				// formatting and indentation, which we don't want here.
 				if readBytes == 0 {
 					part = strings.TrimLeft(part, " \t")
 				}


### PR DESCRIPTION
## Summary
- docs(app): Fix mistyped words 
- docs(init): Fix capitalization in sentences and abbreviation
- docs(readme): Fix missing apostrophe