### PR TITLE
fix: skip non-existent command dirs instead of creating them

### DIFF
--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -130,8 +130,8 @@ func loadAll(sources []commandSource) ([]CustomCommand, error) {
 }
 
 func loadFromSource(source commandSource) ([]CustomCommand, error) {
-	if err := ensureDir(source.path); err != nil {
-		return nil, err
+	if _, err := os.Stat(source.path); os.IsNotExist(err) {
+		return nil, nil
 	}
 
 	var commands []CustomCommand
@@ -214,13 +214,6 @@ func getXDGCommandsDir() string {
 		return filepath.Join(xdgHome, "crush", "commands")
 	}
 	return ""
-}
-
-func ensureDir(path string) error {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return os.MkdirAll(path, 0o755)
-	}
-	return nil
 }
 
 func isMarkdownFile(name string) bool {

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -1,0 +1,53 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadFromSource_NonExistentDir(t *testing.T) {
+	t.Parallel()
+
+	dir := filepath.Join(t.TempDir(), "does-not-exist")
+
+	cmds, err := loadFromSource(commandSource{path: dir, prefix: userCommandPrefix})
+	require.NoError(t, err)
+	require.Empty(t, cmds)
+
+	// directory must NOT have been created
+	_, statErr := os.Stat(dir)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestLoadFromSource_ExistingDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "hello.md"), []byte("say hello"), 0o644))
+
+	cmds, err := loadFromSource(commandSource{path: dir, prefix: userCommandPrefix})
+	require.NoError(t, err)
+	require.Len(t, cmds, 1)
+	require.Equal(t, "user:hello", cmds[0].ID)
+	require.Equal(t, "say hello", cmds[0].Content)
+}
+
+func TestLoadAll_MixedSources(t *testing.T) {
+	t.Parallel()
+
+	existing := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(existing, "cmd.md"), []byte("content"), 0o644))
+
+	missing := filepath.Join(t.TempDir(), "nope")
+
+	cmds, err := loadAll([]commandSource{
+		{path: existing, prefix: userCommandPrefix},
+		{path: missing, prefix: projectCommandPrefix},
+	})
+	require.NoError(t, err)
+	require.Len(t, cmds, 1)
+	require.Equal(t, "user:cmd", cmds[0].ID)
+}


### PR DESCRIPTION
Fixes #2526

`loadFromSource()` was calling `ensureDir()` which created `~/.crush/commands`
(and XDG/project equivalents) on every startup, even when the user never put
anything there. Replaced that with an `os.Stat` check that returns early when
the directory doesn't exist.

Removed the now-unused `ensureDir` helper.

Added tests covering: non-existent dir (verifies it isn't created), existing
dir with `.md` files, and mixed sources where only existing dirs contribute
commands.