### PR TITLE
fix: detect Ghostty light backgrounds

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -215,8 +215,7 @@ type LSPConfig struct {
 type TUIOptions struct {
 	CompactMode bool   `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
 	DiffMode    string `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
-	// Here we can add themes later or any TUI related options
-	//
+	Theme       string `json:"theme,omitempty" jsonschema:"description=Color theme for the TUI interface,enum=auto,enum=dark,enum=light,default=auto"`
 
 	Completions Completions `json:"completions,omitzero" jsonschema:"description=Completions UI options"`
 	Transparent *bool       `json:"transparent,omitempty" jsonschema:"description=Enable transparent background for the TUI interface,default=false"`

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -53,6 +53,7 @@ type (
 	ActionToggleYoloMode              struct{}
 	ActionToggleNotifications         struct{}
 	ActionToggleTransparentBackground struct{}
+	ActionToggleTheme                 struct{}
 	ActionInitializeProject           struct{}
 	ActionSummarize                   struct {
 		SessionID string

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -523,6 +523,13 @@ func (c *Commands) defaultCommands() []*CommandItem {
 	}
 	commands = append(commands, NewCommandItem(c.com.Styles, "toggle_transparent", transparentLabel, "", ActionToggleTransparentBackground{}))
 
+	// Add theme toggle.
+	themeLabel := "Switch to Light Theme"
+	if cfg != nil && cfg.Options != nil && cfg.Options.TUI.Theme == "light" {
+		themeLabel = "Switch to Dark Theme"
+	}
+	commands = append(commands, NewCommandItem(c.com.Styles, "toggle_theme", themeLabel, "", ActionToggleTheme{}))
+
 	commands = append(commands,
 		NewCommandItem(c.com.Styles, "quit", "Quit", "ctrl+c", tea.QuitMsg{}).WithAliases("exit"),
 	)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -182,6 +182,9 @@ type UI struct {
 
 	isTransparent bool
 
+	// theme is the current theme mode: "auto", "dark", or "light".
+	theme string
+
 	focus uiFocusState
 	state uiState
 
@@ -376,6 +379,12 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 	// enable transparent mode
 	ui.isTransparent = opts.TUI.Transparent != nil && *opts.TUI.Transparent
 
+	// set initial theme from config
+	ui.theme = opts.TUI.Theme
+	if ui.theme == "" {
+		ui.theme = "auto"
+	}
+
 	return ui
 }
 
@@ -398,12 +407,48 @@ func (m *UI) Init() tea.Cmd {
 	if m.com.IsHyper() {
 		cmds = append(cmds, m.fetchHyperCredits())
 	}
-	cmds = append(cmds, tea.RequestBackgroundColor)
+	if m.theme == "auto" {
+		cmds = append(cmds, tea.RequestBackgroundColor)
+	} else {
+		cmds = append(cmds, m.applyThemeFromConfig())
+	}
 	return tea.Batch(cmds...)
 }
 
 func (m *UI) applyBackgroundTheme(hasDarkBackground bool) {
-	s := styles.ThemeForBackground(hasDarkBackground)
+	if m.theme != "auto" {
+		return
+	}
+	s := styles.ThemeForBackground(hasDarkBackground, m.providerID())
+	*m.com.Styles = s
+	common.InvalidateMarkdownRendererCache()
+	m.refreshStyles()
+}
+
+// providerID returns the provider ID of the currently selected large model.
+func (m *UI) providerID() string {
+	cfg := m.com.Config()
+	if cfg == nil {
+		return ""
+	}
+	return cfg.Models[config.SelectedModelTypeLarge].Provider
+}
+
+// applyThemeFromConfig returns a command that applies the theme based on the
+// configured theme value.
+func (m *UI) applyThemeFromConfig() tea.Cmd {
+	return func() tea.Msg {
+		m.applyForcedTheme()
+		return nil
+	}
+}
+
+// applyForcedTheme applies the theme based on the configured non-auto theme.
+func (m *UI) applyForcedTheme() {
+	if m.theme == "auto" {
+		return
+	}
+	s := styles.ThemeForBackground(m.theme == "dark", m.providerID())
 	*m.com.Styles = s
 	common.InvalidateMarkdownRendererCache()
 	m.refreshStyles()
@@ -1458,6 +1503,34 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 				status = "enabled"
 			}
 			return util.NewInfoMsg("Transparent background " + status)
+		})
+		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionToggleTheme:
+		cmds = append(cmds, func() tea.Msg {
+			cfg := m.com.Config()
+			if cfg == nil {
+				return util.ReportError(errors.New("configuration not found"))()
+			}
+
+			theme := cfg.Options.TUI.Theme
+			if theme == "" {
+				theme = "auto"
+			}
+			var newTheme string
+			switch theme {
+			case "auto", "dark":
+				newTheme = "light"
+			default:
+				newTheme = "dark"
+			}
+			if err := m.com.Workspace.SetConfigField(config.ScopeGlobal, "options.tui.theme", newTheme); err != nil {
+				return util.ReportError(err)()
+			}
+
+			m.theme = newTheme
+			m.applyForcedTheme()
+			m.updateLayoutAndSize()
+			return util.NewInfoMsg("Theme set to " + newTheme)
 		})
 		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionQuit:

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -398,7 +398,15 @@ func (m *UI) Init() tea.Cmd {
 	if m.com.IsHyper() {
 		cmds = append(cmds, m.fetchHyperCredits())
 	}
+	cmds = append(cmds, tea.RequestBackgroundColor)
 	return tea.Batch(cmds...)
+}
+
+func (m *UI) applyBackgroundTheme(hasDarkBackground bool) {
+	s := styles.ThemeForBackground(hasDarkBackground)
+	*m.com.Styles = s
+	common.InvalidateMarkdownRendererCache()
+	m.refreshStyles()
 }
 
 // loadInitialSession loads the initial session if one was specified on startup.
@@ -503,6 +511,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.sendProgressBar = slices.Contains(msg, "WT_SESSION")
 		}
 		cmds = append(cmds, common.QueryCmd(uv.Environ(msg)))
+	case tea.BackgroundColorMsg:
+		m.applyBackgroundTheme(msg.IsDark())
+		m.updateLayoutAndSize()
 	case tea.ModeReportMsg:
 		if m.caps.ReportFocusEvents {
 			m.notifyBackend = notification.NewNativeBackend(notification.Icon)

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -54,6 +54,14 @@ type quickStyleOpts struct {
 	success           color.Color
 	successMoreSubtle color.Color
 	successMostSubtle color.Color
+
+	// Diff colors.
+	diffInsertFG     color.Color
+	diffInsertBGCode color.Color
+	diffInsertBGNum  color.Color
+	diffDeleteFG     color.Color
+	diffDeleteBGCode color.Color
+	diffDeleteBGNum  color.Color
 }
 
 // quickStyle builds the default Styles (that is, the default theme, Charmtone
@@ -333,7 +341,7 @@ func quickStyle(o quickStyleOpts) Styles {
 
 	// QuietMarkdown style - muted colors on subtle background for thinking content.
 	plainBg := hex(o.bgLeastVisible)
-	plainFg := hex(o.fgMoreSubtle)
+	plainFg := hex(o.fgMostSubtle)
 	s.QuietMarkdown = ansi.StyleConfig{
 		Document: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
@@ -529,23 +537,23 @@ func quickStyle(o quickStyleOpts) Styles {
 		},
 		InsertLine: diffview.LineStyle{
 			LineNumber: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#629657")).
-				Background(lipgloss.Color("#2b322a")),
+				Foreground(o.diffInsertFG).
+				Background(o.diffInsertBGNum),
 			Symbol: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#629657")).
-				Background(lipgloss.Color("#323931")),
+				Foreground(o.diffInsertFG).
+				Background(o.diffInsertBGCode),
 			Code: lipgloss.NewStyle().
-				Background(lipgloss.Color("#323931")),
+				Background(o.diffInsertBGCode),
 		},
 		DeleteLine: diffview.LineStyle{
 			LineNumber: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#a45c59")).
-				Background(lipgloss.Color("#312929")),
+				Foreground(o.diffDeleteFG).
+				Background(o.diffDeleteBGNum),
 			Symbol: lipgloss.NewStyle().
-				Foreground(lipgloss.Color("#a45c59")).
-				Background(lipgloss.Color("#383030")),
+				Foreground(o.diffDeleteFG).
+				Background(o.diffDeleteBGCode),
 			Code: lipgloss.NewStyle().
-				Background(lipgloss.Color("#383030")),
+				Background(o.diffDeleteBGCode),
 		},
 		Filename: diffview.LineStyle{
 			LineNumber: lipgloss.NewStyle().
@@ -807,8 +815,8 @@ func quickStyle(o quickStyleOpts) Styles {
 
 	// Thinking section styles
 	s.Messages.ThinkingBox = subtle.Background(o.bgLeastVisible)
-	s.Messages.ThinkingTruncationHint = muted
-	s.Messages.ThinkingFooterTitle = muted
+	s.Messages.ThinkingTruncationHint = subtle
+	s.Messages.ThinkingFooterTitle = subtle
 	s.Messages.ThinkingFooterDuration = subtle
 
 	// Text selection.
@@ -902,12 +910,12 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Dialog.Sessions.InfoFocused = lipgloss.NewStyle().Foreground(o.fgBase)
 
 	s.Status.Help = lipgloss.NewStyle().Padding(0, 1)
-	s.Status.SuccessIndicator = base.Foreground(o.bgLessVisible).Background(o.success).Padding(0, 1).Bold(true).SetString("OKAY!")
+	s.Status.SuccessIndicator = base.Foreground(o.bgBase).Background(o.success).Padding(0, 1).Bold(true).SetString("OKAY!")
 	s.Status.InfoIndicator = s.Status.SuccessIndicator
 	s.Status.UpdateIndicator = s.Status.SuccessIndicator.SetString("HEY!")
 	s.Status.WarnIndicator = s.Status.SuccessIndicator.Foreground(o.bgMostVisible).Background(o.warning).SetString("WARNING")
 	s.Status.ErrorIndicator = s.Status.SuccessIndicator.Foreground(o.bgBase).Background(o.destructive).SetString("ERROR")
-	s.Status.SuccessMessage = base.Foreground(o.bgLessVisible).Background(o.successMostSubtle).Padding(0, 1)
+	s.Status.SuccessMessage = base.Foreground(o.bgBase).Background(o.successMostSubtle).Padding(0, 1)
 	s.Status.InfoMessage = s.Status.SuccessMessage
 	s.Status.UpdateMessage = s.Status.SuccessMessage
 	s.Status.WarnMessage = s.Status.SuccessMessage.Foreground(o.bgMostVisible).Background(o.warningSubtle)

--- a/internal/ui/styles/styles_test.go
+++ b/internal/ui/styles/styles_test.go
@@ -10,8 +10,8 @@ import (
 func TestThemeForBackground(t *testing.T) {
 	t.Parallel()
 
-	dark := ThemeForBackground(true)
-	light := ThemeForBackground(false)
+	dark := ThemeForBackground(true, "")
+	light := ThemeForBackground(false, "")
 
 	require.Equal(t, charmtone.Pepper, dark.Background)
 	require.Equal(t, charmtone.Salt, light.Background)

--- a/internal/ui/styles/styles_test.go
+++ b/internal/ui/styles/styles_test.go
@@ -1,0 +1,18 @@
+package styles
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/exp/charmtone"
+	"github.com/stretchr/testify/require"
+)
+
+func TestThemeForBackground(t *testing.T) {
+	t.Parallel()
+
+	dark := ThemeForBackground(true)
+	light := ThemeForBackground(false)
+
+	require.Equal(t, charmtone.Pepper, dark.Background)
+	require.Equal(t, charmtone.Salt, light.Background)
+}

--- a/internal/ui/styles/themes.go
+++ b/internal/ui/styles/themes.go
@@ -1,6 +1,9 @@
 package styles
 
-import "github.com/charmbracelet/x/exp/charmtone"
+import (
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/exp/charmtone"
+)
 
 // ThemeForProvider returns the Styles associated with the given provider
 // ID. Unknown or empty provider IDs yield the default Charmtone Pantera
@@ -16,10 +19,10 @@ func ThemeForProvider(providerID string) Styles {
 
 // ThemeForBackground returns the theme tuned for the terminal background
 // brightness. When hasDarkBackground is false, the light theme is returned;
-// otherwise, the dark theme is returned.
-func ThemeForBackground(hasDarkBackground bool) Styles {
+// otherwise, the dark theme matching the given provider is returned.
+func ThemeForBackground(hasDarkBackground bool, providerID string) Styles {
 	if hasDarkBackground {
-		return CharmtonePantera()
+		return ThemeForProvider(providerID)
 	}
 	return CharmtoneDaylight()
 }
@@ -30,34 +33,41 @@ func CharmtoneDaylight() Styles {
 	return quickStyle(quickStyleOpts{
 		primary:   charmtone.Charple,
 		secondary: charmtone.Dolly,
-		accent:    charmtone.Bok,
+		accent:    charmtone.Pickle,
 		keyword:   charmtone.Blush,
 
 		fgBase:       charmtone.Pepper,
-		fgMoreSubtle: charmtone.Charcoal,
-		fgSubtle:     charmtone.Oyster,
+		fgSubtle:     charmtone.Charcoal,
+		fgMoreSubtle: charmtone.Oyster,
 		fgMostSubtle: charmtone.Iron,
 
 		onPrimary: charmtone.Salt,
 
 		bgBase:         charmtone.Salt,
 		bgLeastVisible: charmtone.Ash,
-		bgLessVisible:  charmtone.Anchovy,
-		bgMostVisible:  charmtone.Charcoal,
+		bgLessVisible:  charmtone.Smoke,
+		bgMostVisible:  charmtone.Squid,
 
 		separator: charmtone.Anchovy,
 
 		destructive:       charmtone.Coral,
 		error:             charmtone.Sriracha,
-		warningSubtle:     charmtone.Zest,
+		warningSubtle:     charmtone.Tang,
 		warning:           charmtone.Mustard,
-		busy:              charmtone.Citron,
+		busy:              charmtone.Yam,
 		info:              charmtone.Malibu,
 		infoMoreSubtle:    charmtone.Sardine,
 		infoMostSubtle:    charmtone.Damson,
-		success:           charmtone.Julep,
-		successMoreSubtle: charmtone.Bok,
+		success:           charmtone.Pickle,
+		successMoreSubtle: charmtone.Pickle,
 		successMostSubtle: charmtone.Guac,
+
+		diffInsertFG:     lipgloss.Color("#5a7555"),
+		diffInsertBGCode: lipgloss.Color("#bfdbbc"),
+		diffInsertBGNum:  lipgloss.Color("#b7ceb3"),
+		diffDeleteFG:     lipgloss.Color("#ad6866"),
+		diffDeleteBGCode: lipgloss.Color("#e0bebe"),
+		diffDeleteBGNum:  lipgloss.Color("#d3baba"),
 	})
 }
 
@@ -95,6 +105,13 @@ func CharmtonePantera() Styles {
 		success:           charmtone.Julep,
 		successMoreSubtle: charmtone.Bok,
 		successMostSubtle: charmtone.Guac,
+
+		diffInsertFG:     lipgloss.Color("#629657"),
+		diffInsertBGCode: lipgloss.Color("#323931"),
+		diffInsertBGNum:  lipgloss.Color("#2b322a"),
+		diffDeleteFG:     lipgloss.Color("#a45c59"),
+		diffDeleteBGCode: lipgloss.Color("#383030"),
+		diffDeleteBGNum:  lipgloss.Color("#312929"),
 	})
 }
 
@@ -130,5 +147,12 @@ func HypercrushObsidiana() Styles {
 		success:           charmtone.Julep,
 		successMoreSubtle: charmtone.Bok,
 		successMostSubtle: charmtone.Guac,
+
+		diffInsertFG:     lipgloss.Color("#629657"),
+		diffInsertBGCode: lipgloss.Color("#323931"),
+		diffInsertBGNum:  lipgloss.Color("#2b322a"),
+		diffDeleteFG:     lipgloss.Color("#a45c59"),
+		diffDeleteBGCode: lipgloss.Color("#383030"),
+		diffDeleteBGNum:  lipgloss.Color("#312929"),
 	})
 }

--- a/internal/ui/styles/themes.go
+++ b/internal/ui/styles/themes.go
@@ -14,6 +14,53 @@ func ThemeForProvider(providerID string) Styles {
 	}
 }
 
+// ThemeForBackground returns the theme tuned for the terminal background
+// brightness. When hasDarkBackground is false, the light theme is returned;
+// otherwise, the dark theme is returned.
+func ThemeForBackground(hasDarkBackground bool) Styles {
+	if hasDarkBackground {
+		return CharmtonePantera()
+	}
+	return CharmtoneDaylight()
+}
+
+// CharmtoneDaylight returns the Charmtone light theme for terminals with
+// light backgrounds.
+func CharmtoneDaylight() Styles {
+	return quickStyle(quickStyleOpts{
+		primary:   charmtone.Charple,
+		secondary: charmtone.Dolly,
+		accent:    charmtone.Bok,
+		keyword:   charmtone.Blush,
+
+		fgBase:       charmtone.Pepper,
+		fgMoreSubtle: charmtone.Charcoal,
+		fgSubtle:     charmtone.Oyster,
+		fgMostSubtle: charmtone.Iron,
+
+		onPrimary: charmtone.Salt,
+
+		bgBase:         charmtone.Salt,
+		bgLeastVisible: charmtone.Ash,
+		bgLessVisible:  charmtone.Anchovy,
+		bgMostVisible:  charmtone.Charcoal,
+
+		separator: charmtone.Anchovy,
+
+		destructive:       charmtone.Coral,
+		error:             charmtone.Sriracha,
+		warningSubtle:     charmtone.Zest,
+		warning:           charmtone.Mustard,
+		busy:              charmtone.Citron,
+		info:              charmtone.Malibu,
+		infoMoreSubtle:    charmtone.Sardine,
+		infoMostSubtle:    charmtone.Damson,
+		success:           charmtone.Julep,
+		successMoreSubtle: charmtone.Bok,
+		successMostSubtle: charmtone.Guac,
+	})
+}
+
 // CharmtonePantera returns the Charmtone dark theme. It's the default style
 // for the UI.
 func CharmtonePantera() Styles {


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Fixes #2513

# Problem
Crush renders the TUI with dark-theme colors in Ghostty even when Ghostty is using a light terminal theme. This makes the interface hard to read on light backgrounds and breaks automatic theme detection for affected users.

# Root Cause
The UI always initialized with the default dark palette and did not request or react to the terminal background color during startup. As a result, Ghostty’s reported light background was never used to select the correct styles.

# Solution
The fix requests the terminal background color during UI initialization, adds a background-aware default style constructor, and reapplies the shared UI styles when Bubble Tea reports a light background. This keeps the change minimal, follows the existing centralized styling pattern, and avoids unrelated theming changes.

<img width="1837" height="821" alt="Screenshot from 2026-04-01 15-03-39" src="https://github.com/user-attachments/assets/59714eec-ac67-4b34-825a-7c90dd2fd813" />

# Testing
Ran go test ./... successfully. Added a focused test for light and dark background style selection in internal/ui/styles/styles_test.go to verify the new style path and help prevent regressions.

# Note
- Minimal and focused change
- No unrelated modifications
- Follows project conventions