### PR TITLE
feat(cli/session): show skill metadata

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -460,10 +460,10 @@ func outputSessionHuman(ctx context.Context, sess session.Session, msgs []*messa
 	if len(skills) > 0 {
 		skillNames := make([]string, len(skills))
 		for i, s := range skills {
-			timestamp := time.Unix(sess.CreatedAt, 0).Format("15:04:05")
+			timestamp := time.Unix(sess.CreatedAt, 0).Format("15:04:05 -0700")
 			if s.LoadedAt != "" {
 				if t, err := time.Parse(time.RFC3339, s.LoadedAt); err == nil {
-					timestamp = t.Format("15:04:05")
+					timestamp = t.Format("15:04:05 -0700")
 				}
 			}
 			skillNames[i] = fmt.Sprintf("%s (%s)", s.Name, timestamp)


### PR DESCRIPTION
This revision adds metadata about skills used to `crush session show` and `crush session last`.

<img width="710" height="317" alt="skills" src="https://github.com/user-attachments/assets/1be7d299-fc22-4241-b47b-09530e73eaa9" />

```jsonc
{
  "meta": {
    "id": "…",
    // ...
    "skills": [
      {
        "name": "crush-config",
        "description": "Configure Crush settings including providers, LSPs, MCPs, skills...",
        "loaded_at": "2026-12-31T11:00:00-04:00"
      }
    ]
  },
  "messages": [/* ... */]
}
```

Among other things, this will help to evaluate https://github.com/charmbracelet/crush/pull/2466.