### PR TITLE
Fix: avoid unsupported terminal capability probe

### DIFF
--- a/internal/ui/common/capabilities.go
+++ b/internal/ui/common/capabilities.go
@@ -127,8 +127,11 @@ func shouldQueryCapabilities(env uv.Environ) bool {
 	if okTermProg && strings.Contains(termProg, osVendorTypeApple) {
 		return false
 	}
-	return (!okTermProg && !okSSHTTY) ||
-		(!strings.Contains(termProg, osVendorTypeApple) && !okSSHTTY) ||
-		// Terminals that do support XTVERSION.
-		xstrings.ContainsAnyOf(termType, kittyTerminals...)
+	if okSSHTTY {
+		return false
+	}
+	if xstrings.ContainsAnyOf(termType, kittyTerminals...) {
+		return true
+	}
+	return okTermProg
 }

--- a/internal/ui/common/capabilities_test.go
+++ b/internal/ui/common/capabilities_test.go
@@ -1,0 +1,23 @@
+package common
+
+import (
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+func TestShouldQueryCapabilities(t *testing.T) {
+	t.Parallel()
+
+	t.Run("does not query unknown xterm terminals", func(t *testing.T) {
+		t.Parallel()
+
+		env := uv.Environ{
+			"TERM=xterm-256color",
+		}
+
+		if shouldQueryCapabilities(env) {
+			t.Fatal("expected unknown xterm terminal not to be queried")
+		}
+	})
+}


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Fixes #2523

# Problem
Crush could leave raw terminal control characters visible after exit on some xterm-256color terminals, especially when quitting quickly with Ctrl+C.

# Root Cause
The terminal capability query path treated unknown non-Apple local terminals as safe to probe, which caused Crush to send a Kitty graphics capability query to terminals that do not support it.

# Solution
Restrict the capability probe to terminals with a known terminal program or explicitly known supported terminal types, while continuing to skip SSH sessions and Apple Terminal. Add a focused regression test covering an unknown xterm-256color environment.

# Testing

env GOCACHE=/tmp/go-build-cache go test ./internal/ui/common -run TestShouldQueryCapabilities -count=1
env GOCACHE=/tmp/go-build-cache go test ./internal/ui/common -count=1