### PR TITLE
fix: support local models with unknown max_tokens and context window

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -249,12 +249,17 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 
 	var currentAssistant *message.Message
 	var shouldSummarize bool
+	// Don't send MaxOutputTokens if 0 — some providers (e.g. LM Studio) reject it
+	var maxOutputTokens *int64
+	if call.MaxOutputTokens > 0 {
+		maxOutputTokens = &call.MaxOutputTokens
+	}
 	result, err := agent.Stream(genCtx, fantasy.AgentStreamCall{
 		Prompt:           message.PromptWithTextAttachments(call.Prompt, call.Attachments),
 		Files:            files,
 		Messages:         history,
 		ProviderOptions:  call.ProviderOptions,
-		MaxOutputTokens:  &call.MaxOutputTokens,
+		MaxOutputTokens:  maxOutputTokens,
 		TopP:             call.TopP,
 		Temperature:      call.Temperature,
 		PresencePenalty:  call.PresencePenalty,
@@ -425,6 +430,11 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 		StopWhen: []fantasy.StopCondition{
 			func(_ []fantasy.StepResult) bool {
 				cw := int64(largeModel.CatwalkCfg.ContextWindow)
+				// If context window is unknown (0), skip auto-summarize
+				// to avoid immediately truncating custom/local models.
+				if cw == 0 {
+					return false
+				}
 				tokens := currentSession.CompletionTokens + currentSession.PromptTokens
 				remaining := cw - tokens
 				var threshold int64


### PR DESCRIPTION
## Summary

Two fixes for local/custom model compatibility (LM Studio, Ollama, llama.cpp):

- **max_tokens:0 rejection** — Custom models not in catwalk have `DefaultMaxTokens=0`, which gets sent as `max_tokens:0`. LM Studio rejects this. Fix: only send `MaxOutputTokens` when positive.
- **Immediate session reset** — Custom models have `ContextWindow=0`, making remaining tokens negative, which immediately triggers auto-summarize. Sessions reset with "previous session was interrupted because it got too long" after the first response. Fix: skip auto-summarize when context window is unknown.

## Related Issues

- Fixes #1218 (regression — the original fix in #1532 was for schema validation, but the API request still sends 0)
- Relates to #1583 (protective layer for context window)
- Relates to #1591 (restore default context window)
- Relates to #2546 (no longer works with latest LM Studio)

## Testing

Tested with:
- LM Studio v0.4.x + Qwen3-Coder-Next (80B MoE)
- Both fixes verified: no max_tokens error, sessions no longer reset immediately

## Changes

- `internal/agent/agent.go`: Skip sending `MaxOutputTokens` when 0, skip auto-summarize when `ContextWindow` is 0