### PR TITLE
fix: use small model for task agent instead of large

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -527,7 +527,7 @@ func (c *Config) SetupAgents() {
 			ID:           AgentTask,
 			Name:         "Task",
 			Description:  "An agent that helps with searching for context and finding implementation details.",
-			Model:        SelectedModelTypeLarge,
+			Model:        SelectedModelTypeSmall,
 			ContextPaths: c.Options.ContextPaths,
 			AllowedTools: resolveReadOnlyTools(allowedTools),
 			// NO MCPs or LSPs by default


### PR DESCRIPTION
## Summary

- Fix `SetupAgents()` in `internal/config/config.go` to use `SelectedModelTypeSmall` for the task agent instead of `SelectedModelTypeLarge`
- The task agent is a read-only sub-agent used for search and retrieval (tools: glob, grep, ls, sourcegraph, view). It doesn't need the large model — the small model is more cost-effective and faster for these tasks
- Previously, users who configured a `small` model in `crush.json` had it completely ignored for sub-agents

## Context

- Closes #427
- Related #2501 (requests per-call model override)
- Similar to #914 (attempted fix, never merged)

## Test plan

- [x] Verified `AgentCoder` still uses `SelectedModelTypeLarge` (unchanged)
- [x] Verified `AgentTask` now uses `SelectedModelTypeSmall`
- [x] Existing tests in `load_test.go` (lines 464-498) still pass — they assert allowed tools, not model types
- [ ] Manual test: spawn task agent and verify it routes to the small model