### PR TITLE
docs(readme): mention `AVIAN_API_KEY`

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ That said, you can also set environment variables for preferred providers.
 | `OPENROUTER_API_KEY`        | OpenRouter                                         |
 | `IONET_API_KEY`             | io.net                                             |
 | `GROQ_API_KEY`              | Groq                                               |
+| `AVIAN_API_KEY`             | Avian                                              |
 | `VERTEXAI_PROJECT`          | Google Cloud VertexAI (Gemini)                     |
 | `VERTEXAI_LOCATION`         | Google Cloud VertexAI (Gemini)                     |
 | `AWS_ACCESS_KEY_ID`         | Amazon Bedrock (Claude)                            |


### PR DESCRIPTION
## Summary

Add [Avian](https://avian.io) as a supported LLM provider in Crush.

Avian is an OpenAI-compatible inference API at `https://api.avian.io/v1` offering:
- DeepSeek V3.2 (164K context)
- Kimi K2.5 (128K context)
- GLM-5 (128K context)
- MiniMax M2.5 (1M context)

The Avian provider definition was already added to **charmbracelet/catwalk** in #196, which is included in the catwalk version currently pinned by Crush (v0.33.2). This PR adds the `AVIAN_API_KEY` environment variable to the README provider table so users can discover and configure it.

## Changes

- Add `AVIAN_API_KEY` to the environment variables table in `README.md`

No Go code changes are needed — Avian uses the `openai-compat` provider type and is fully defined in the catwalk dependency.