### PR TITLE
Remove remote research tools

### DIFF
--- a/docs/crush-light-audit.md
+++ b/docs/crush-light-audit.md
@@ -1,0 +1,78 @@
+# crush-light feature-removal audit
+
+## Audit scope
+- Repository root: `/home/runner/work/crush-light/crush-light`
+- Coverage basis: tracked repository content excluding `.git/` and `.github/agents/`
+- Reviewed paths: **984** total (**123** directories, **861** files)
+- Audit artifacts:
+  - `docs/crush-light-reviewed-paths.tsv`
+  - `docs/crush-light-fantasy-usage.md`
+  - `docs/crush-light-removal-candidates/*.md`
+  - `docs/crush-light-draft-prs/*.md`
+
+## Baseline validation before audit edits
+- `go build .` ✅ passed
+- `go test -race -failfast ./...` ✅ passed
+- `./scripts/check_log_capitalization.sh && golangci-lint run --path-mode=abs --config=.golangci.yml --timeout=5m` ⚠️ stopped at a pre-existing log-lint failure in `internal/agent/tools/mcp/init.go` (`failed to initialize mcp client`, `skipping disabled mcp`, `error closing mcp session`).
+
+## Required-kept features confirmed during review
+- Multiple named sessions per project remain required.
+- Per-session file history/version snapshots remain required.
+- File modification-time tracking/stale-write protections remain required.
+- `internal/oauth` and provider OAuth flows remain required alongside BYOK.
+- Model picker and mid-session model switching remain required.
+- `internal/server` and generated Swagger docs remain required, with removed-feature endpoints/docs to be deleted later.
+
+## Future removal draft PR inventory
+| Feature | Risk | Draft PR status / link / branch | Candidate doc |
+| --- | --- | --- | --- |
+| Remove MCP support | `medium` | Created: [PR #1](https://github.com/JTRNS/crush-light/pull/1) on `copilot/prepare-feature-removal-audit` | `docs/crush-light-removal-candidates/remove-mcp-support.md` |
+| Remove LSP support | `high` | Planned branch: `draft/remove-lsp-support` (body prepared in repo; remote PR creation blocked by single-branch PR tooling) | `docs/crush-light-removal-candidates/remove-lsp-support.md` |
+| Remove PostHog analytics | `low` | Planned branch: `draft/remove-posthog-analytics` (body prepared in repo; remote PR creation blocked by single-branch PR tooling) | `docs/crush-light-removal-candidates/remove-posthog-analytics.md` |
+| Remove sub-agent orchestration | `high` | Planned branch: `draft/remove-sub-agent-orchestration` (body prepared in repo; remote PR creation blocked by single-branch PR tooling) | `docs/crush-light-removal-candidates/remove-sub-agent-orchestration.md` |
+| Remove remote research tools | `medium` | Planned branch: `draft/remove-remote-research-tools` (body prepared in repo; remote PR creation blocked by single-branch PR tooling) | `docs/crush-light-removal-candidates/remove-remote-research-tools.md` |
+| Remove parallel tool execution | `high` | Planned branch: `draft/remove-parallel-tool-execution` (body prepared in repo; remote PR creation blocked by single-branch PR tooling) | `docs/crush-light-removal-candidates/remove-parallel-tool-execution.md` |
+| Remove out-of-working-dir permission gate | `medium` | Planned branch: `draft/remove-out-of-working-dir-permission-gate` (body prepared in repo; remote PR creation blocked by single-branch PR tooling) | `docs/crush-light-removal-candidates/remove-out-of-working-dir-permission-gate.md` |
+| Remove todo support while keeping sessions | `medium` | Planned branch: `draft/remove-todo-support` (body prepared in repo; remote PR creation blocked by single-branch PR tooling) | `docs/crush-light-removal-candidates/remove-todo-support.md` |
+| Remove NixOS and Home Manager module support | `low` | Planned branch: `draft/remove-nix-home-manager-support` (body prepared in repo; remote PR creation blocked by single-branch PR tooling) | `docs/crush-light-removal-candidates/remove-nix-home-manager-support.md` |
+| Remove Sourcegraph tool | `low` | Planned branch: `draft/remove-sourcegraph-tool` (body prepared in repo; remote PR creation blocked by single-branch PR tooling) | `docs/crush-light-removal-candidates/remove-sourcegraph-tool.md` |
+| Remove Hyper provider support | `medium` | Planned branch: `draft/remove-hyper-provider-support` (body prepared in repo; remote PR creation blocked by single-branch PR tooling) | `docs/crush-light-removal-candidates/remove-hyper-provider-support.md` |
+| Track charm.land/fantasy usage | `high` | Planned branch: `draft/track-fantasy-usage` (references prepared in repo; dedicated remote PR still pending because only the current task branch can be opened from this environment) | `docs/crush-light-removal-candidates/track-fantasy-usage.md` |
+
+## Additional removal candidates identified during review
+These are plausible light-variant follow-ons but are not in the mandatory removal set above.
+
+- Desktop notifications (`internal/ui/notification/**`, `options.disable_notifications`) if further UX simplification is desired.
+- Update-checking and stats/dashboard surfaces (`internal/update/**`, `internal/cmd/stats*`) if the fork wants a smaller non-core command/UI set.
+
+## Explicit removal-target mapping
+- **MCP support** → `docs/crush-light-removal-candidates/remove-mcp-support.md`
+- **LSP support + configurable per-language LSP servers** → `docs/crush-light-removal-candidates/remove-lsp-support.md`
+- **PostHog analytics** → `docs/crush-light-removal-candidates/remove-posthog-analytics.md`
+- **Sub-agents** → `docs/crush-light-removal-candidates/remove-sub-agent-orchestration.md`
+- **Parallel tool execution** → `docs/crush-light-removal-candidates/remove-parallel-tool-execution.md`
+- **Out-of-working-dir permission gate** → `docs/crush-light-removal-candidates/remove-out-of-working-dir-permission-gate.md`
+- **Todos tool + todo persistence** → `docs/crush-light-removal-candidates/remove-todo-support.md`
+- **`web_fetch`, `web_search`, `download`** → `docs/crush-light-removal-candidates/remove-remote-research-tools.md`
+- **NixOS/Home Manager module support** → `docs/crush-light-removal-candidates/remove-nix-home-manager-support.md`
+- **`charm.land/fantasy` tracking only** → `docs/crush-light-removal-candidates/track-fantasy-usage.md`
+
+## Fantasy tracking notes
+- Usage/dependency references are collected in `docs/crush-light-fantasy-usage.md`.
+- The required dedicated tracking PR should mirror those references.
+- This environment exposes only a single branch-scoped PR creation path, so the fantasy tracker body is prepared in-repo but still needs a separate remote PR created from a dedicated branch.
+- This environment does not expose a PR-comment write tool, so the future tracking PR should include the same references in its description and receive follow-up comments when comment-writing access is available.
+
+## Draft PR creation limitation encountered
+- `create_pull_request` and `report_progress` both target the current task branch (`copilot/prepare-feature-removal-audit`) instead of arbitrary local branches.
+- Because of that constraint, only one actual remote draft PR could be opened during this task: MCP removal ([PR #1](https://github.com/JTRNS/crush-light/pull/1)).
+- The remaining future PR descriptions are fully prepared in `docs/crush-light-removal-candidates/*.md` with suggested branch names so a follow-up agent or human can open them without redoing discovery.
+
+## Review coverage notes
+- `docs/crush-light-reviewed-paths.tsv` records every reviewed directory and tracked file with status, notes, and category flags.
+- Testdata and generated artifacts were reviewed as grouped coverage surfaces; notes identify the owning subsystem and whether the paths support removable features, kept features, fantasy usage, configuration, or build/docs/test surfaces.
+- Non-code repository assets (README, schema, workflows, scripts, release config, fixtures, and generated Swagger/schema artifacts) are included in the coverage file.
+
+## Open questions
+- View may deserve a quick sanity-check after LSP removal, but edit/file operations do not need special non-LSP fallback planning.
+- If PR-comment access remains unavailable, what repository-approved workaround should be used for future fantasy usage annotations beyond the PR description and audit docs?

--- a/docs/crush-light-draft-prs/remove-mcp-support.md
+++ b/docs/crush-light-draft-prs/remove-mcp-support.md
@@ -1,0 +1,51 @@
+# Remove MCP support
+
+- **Suggested branch:** `draft/remove-mcp-support`
+- **Risk level:** `medium`
+
+## Short summary
+Remove Model Context Protocol support, including static MCP tools, dynamic MCP tool loading, MCP endpoints, MCP config keys, Docker MCP helpers, and MCP docs.
+
+## Why this is a removal candidate
+MCP is an explicitly approved removal target and is a large optional extensibility surface that adds tool loading, server lifecycle, config, UI, API, and permission complexity.
+
+## Why the chosen risk level applies
+The boundary is broad but recognizable: config, tool adapters, backend refresh/read endpoints, UI prompts, and documentation all pivot on MCP. Core sessions, OAuth, and the HTTP server can remain intact if only MCP-specific surfaces are removed.
+
+## User-visible behavior affected
+Users lose MCP server configuration, MCP-backed tools, MCP resource/prompt discovery, Docker MCP shortcuts, and MCP-related UI/server routes.
+
+## Code entrypoints
+- `internal/agent/tools/mcp-tools.go`
+- `internal/agent/tools/mcp/`
+- `internal/backend/mcp.go`
+- `internal/server/server.go`
+- `internal/config/config.go`
+- `internal/ui/chat/docker_mcp.go`
+
+## Known touch points
+- Files/packages: internal/agent/tools/mcp-tools.go, internal/agent/tools/mcp/**, internal/backend/mcp.go, internal/config/docker_mcp.go, internal/ui/chat/docker_mcp.go, internal/workspace/**
+- Config: Config.MCP / MCPConfig / schema.json / crush.json / README MCP docs
+- Docs/tests: README.md, AGENTS.md, tool descriptions, MCP tests/fixtures, workflow/docs references
+- API/server: /v1/workspaces/{id}/mcp/* endpoints in internal/server/server.go and related proto types
+- UI: MCP enable/disable affordances and Docker MCP chat prompts
+- Persistence/data model: none primary, but workspace/config state references must be cleaned up
+
+## Dependencies on kept features
+Must preserve the internal HTTP server, Swagger generation, working sessions, and generic tool execution for non-MCP tools.
+
+## Things that must be preserved while removing it
+Keep server startup, non-MCP tools, OAuth/BYOK provider auth, model switching, and session persistence untouched.
+
+## Suggested removal order
+After analytics removal is safe; before fantasy replacement; before or alongside sub-agent/parallel cleanup if MCP tool wrappers still rely on fantasy interfaces.
+
+## Acceptance criteria for the future implementation PR
+- No MCP config keys, schema entries, or sample config remain.
+- No MCP endpoints remain in backend/server/swagger for removed behavior.
+- No MCP tool descriptions, dynamic MCP tool loading, or Docker MCP helpers remain.
+- Build/tests/docs updated so non-MCP workflows continue to work.
+
+## Open questions / uncertainties
+- Whether any existing users rely on Docker MCP onboarding copy that should be replaced with a lighter extension story.
+- Whether MCP refresh/read APIs share proto messages with kept features that need surgical retention.

--- a/docs/crush-light-fantasy-usage.md
+++ b/docs/crush-light-fantasy-usage.md
@@ -1,0 +1,47 @@
+# charm.land/fantasy usage map
+
+This file captures repository usage and dependency points for `charm.land/fantasy` and related provider packages.
+
+
+## Usage references
+- AGENTS.md#L50-L50
+- Taskfile.yaml#L195-L195
+- go.mod#L10-L10
+- go.sum#L9-L10
+- internal/agent/agent.go#L26-L32, internal/agent/agent.go#L72-L110, internal/agent/agent.go#L133-L133, internal/agent/agent.go#L157-L157, internal/agent/agent.go#L202-L206, internal/agent/agent.go#L252-L263, internal/agent/agent.go#L288-L328, internal/agent/agent.go#L371-L442, internal/agent/agent.go#L514-L515, internal/agent/agent.go#L538-L539, internal/agent/agent.go#L593-L593, internal/agent/agent.go#L622-L653, internal/agent/agent.go#L707-L711, internal/agent/agent.go#L741-L769, internal/agent/agent.go#L816-L830, internal/agent/agent.go#L921-L934, internal/agent/agent.go#L1042-L1073, internal/agent/agent.go#L1108-L1166
+- internal/agent/agent_test.go#L11-L29
+- internal/agent/agent_tool.go#L8-L55
+- internal/agent/agentic_fetch_tool.go#L12-L12, internal/agent/agentic_fetch_tool.go#L53-L72, internal/agent/agentic_fetch_tool.go#L95-L166
+- internal/agent/common_test.go#L12-L16, internal/agent/common_test.go#L45-L93, internal/agent/common_test.go#L141-L141, internal/agent/common_test.go#L168-L168, internal/agent/common_test.go#L210-L210
+- internal/agent/coordinator.go#L19-L63, internal/agent/coordinator.go#L136-L136, internal/agent/coordinator.go#L177-L177, internal/agent/coordinator.go#L215-L216, internal/agent/coordinator.go#L370-L370, internal/agent/coordinator.go#L422-L423, internal/agent/coordinator.go#L478-L478, internal/agent/coordinator.go#L508-L508, internal/agent/coordinator.go#L598-L598, internal/agent/coordinator.go#L630-L676, internal/agent/coordinator.go#L705-L705, internal/agent/coordinator.go#L728-L800, internal/agent/coordinator.go#L923-L923, internal/agent/coordinator.go#L970-L1017
+- internal/agent/coordinator_test.go#L9-L91, internal/agent/coordinator_test.go#L127-L127, internal/agent/coordinator_test.go#L198-L198, internal/agent/coordinator_test.go#L224-L224, internal/agent/coordinator_test.go#L250-L250
+- internal/agent/event.go#L6-L26
+- internal/agent/hyper/provider.go#L1-L1, internal/agent/hyper/provider.go#L25-L26, internal/agent/hyper/provider.go#L55-L55, internal/agent/hyper/provider.go#L86-L88, internal/agent/hyper/provider.go#L128-L174, internal/agent/hyper/provider.go#L195-L222, internal/agent/hyper/provider.go#L259-L275, internal/agent/hyper/provider.go#L324-L325
+- internal/agent/hyper/provider.json#L1-L1
+- internal/agent/loop_detection.go#L8-L19, internal/agent/loop_detection.go#L45-L52, internal/agent/loop_detection.go#L75-L88
+- internal/agent/loop_detection_test.go#L7-L197
+- internal/agent/tools/bash.go#L15-L15, internal/agent/tools/bash.go#L191-L302, internal/agent/tools/bash.go#L332-L375
+- internal/agent/tools/bash_test.go#L8-L8, internal/agent/tools/bash_test.go#L82-L94
+- internal/agent/tools/diagnostics.go#L13-L37
+- internal/agent/tools/download.go#L15-L15, internal/agent/tools/download.go#L37-L146
+- internal/agent/tools/edit.go#L13-L13, internal/agent/tools/edit.go#L47-L79, internal/agent/tools/edit.go#L110-L128, internal/agent/tools/edit.go#L152-L243, internal/agent/tools/edit.go#L271-L354, internal/agent/tools/edit.go#L378-L378, internal/agent/tools/edit.go#L402-L442
+- internal/agent/tools/fetch.go#L13-L168
+- internal/agent/tools/glob.go#L15-L62
+- internal/agent/tools/grep.go#L21-L21, internal/agent/tools/grep.go#L105-L126, internal/agent/tools/grep.go#L164-L165
+- internal/agent/tools/job_kill.go#L8-L8, internal/agent/tools/job_kill.go#L29-L57
+- internal/agent/tools/job_output.go#L9-L9, internal/agent/tools/job_output.go#L33-L45, internal/agent/tools/job_output.go#L88-L88
+- internal/agent/tools/list_mcp_resources.go#L11-L70, internal/agent/tools/list_mcp_resources.go#L96-L96
+- internal/agent/tools/ls.go#L12-L12, internal/agent/tools/ls.go#L58-L114
+- internal/agent/tools/lsp_restart.go#L12-L42, internal/agent/tools/lsp_restart.go#L74-L77
+- internal/agent/tools/mcp-tools.go#L8-L8, internal/agent/tools/mcp-tools.go#L47-L70, internal/agent/tools/mcp-tools.go#L91-L148
+- internal/agent/tools/multiedit.go#L13-L13, internal/agent/tools/multiedit.go#L66-L86, internal/agent/tools/multiedit.go#L126-L143, internal/agent/tools/multiedit.go#L168-L168, internal/agent/tools/multiedit.go#L195-L277, internal/agent/tools/multiedit.go#L302-L310, internal/agent/tools/multiedit.go#L337-L358, internal/agent/tools/multiedit.go#L384-L385
+- internal/agent/tools/read_mcp_resource.go#L11-L11, internal/agent/tools/read_mcp_resource.go#L33-L99
+- internal/agent/tools/references.go#L17-L57, internal/agent/tools/references.go#L83-L89
+- internal/agent/tools/sourcegraph.go#L14-L51, internal/agent/tools/sourcegraph.go#L90-L136
+- internal/agent/tools/todos.go#L8-L8, internal/agent/tools/todos.go#L36-L61, internal/agent/tools/todos.go#L101-L101, internal/agent/tools/todos.go#L132-L132
+- internal/agent/tools/view.go#L17-L17, internal/agent/tools/view.go#L68-L122, internal/agent/tools/view.go#L148-L200, internal/agent/tools/view.go#L228-L229, internal/agent/tools/view.go#L384-L395, internal/agent/tools/view.go#L430-L431
+- internal/agent/tools/web_fetch.go#L12-L71
+- internal/agent/tools/web_search.go#L10-L53
+- internal/agent/tools/write.go#L13-L13, internal/agent/tools/write.go#L52-L95, internal/agent/tools/write.go#L128-L145, internal/agent/tools/write.go#L168-L168
+- internal/app/app.go#L19-L19, internal/app/app.go#L291-L291
+- internal/message/content.go#L12-L15, internal/message/content.go#L463-L560

--- a/docs/crush-light-removal-candidates/remove-hyper-provider-support.md
+++ b/docs/crush-light-removal-candidates/remove-hyper-provider-support.md
@@ -1,0 +1,48 @@
+# Remove Hyper provider support
+
+- **Suggested branch:** `draft/remove-hyper-provider-support`
+- **Risk level:** `medium`
+
+## Short summary
+Remove Hyper-specific provider support, including the custom provider implementation, Hyper login/auth flows, provider update/sync logic, and related docs/tests.
+
+## Why this is a removal candidate
+Hyper appears to be a Crush-specific inference API integration that the fork will not use. It is separate from the protected generic OAuth/BYOK support that must remain for other providers.
+
+## Why the chosen risk level applies
+Hyper touches provider wiring, login commands, config sync/update paths, OAuth helpers, tests, and some agent error messaging, but it is still a distinct provider-specific subsystem.
+
+## User-visible behavior affected
+Users lose Hyper as a provider/login option. Other providers and generic OAuth/BYOK flows remain.
+
+## Code entrypoints
+- `internal/agent/hyper/provider.go`
+- `internal/oauth/hyper/device.go`
+- `internal/config/{hyper.go,provider.go,store.go,load.go}`
+- `internal/cmd/login.go`
+- `internal/cmd/update_providers.go`
+
+## Known touch points
+- Files/packages: `internal/agent/hyper/**`, `internal/oauth/hyper/**`, Hyper-specific branches in config/provider/store/load code, Hyper-specific login/update-provider command paths
+- Config: provider type validation, cached Hyper provider data, update-provider source handling
+- Docs/tests: Hyper-related tests, embedded `provider.json`, Taskfile/provider update docs, login/help text
+- API/server: none primary beyond provider config APIs
+- UI: login/help text and any Hyper-specific error or hyperlink copy
+- Persistence/data model: provider config values and cached Hyper provider metadata
+
+## Dependencies on kept features
+Must preserve generic provider auth, BYOK support, model selection, and non-Hyper providers.
+
+## Things that must be preserved while removing it
+Keep the protected OAuth/BYOK infrastructure for the remaining providers intact.
+
+## Suggested removal order
+Can happen independently after the main audit-driven removals are underway; before fantasy replacement if reducing provider-specific surface is useful.
+
+## Acceptance criteria for the future implementation PR
+- Hyper is no longer a supported provider or login target.
+- Hyper-specific provider code, OAuth flow, update-provider plumbing, docs, and tests are removed.
+- Remaining providers and generic OAuth/BYOK flows continue to work.
+
+## Open questions / uncertainties
+- None currently.

--- a/docs/crush-light-removal-candidates/remove-lsp-support.md
+++ b/docs/crush-light-removal-candidates/remove-lsp-support.md
@@ -1,0 +1,50 @@
+# Remove LSP support
+
+- **Suggested branch:** `draft/remove-lsp-support`
+- **Risk level:** `high`
+
+## Short summary
+Remove LSP manager/runtime support, LSP agent tools, LSP server endpoints, auto-LSP behavior, and configurable per-language LSP server settings.
+
+## Why this is a removal candidate
+LSP support is an explicitly approved removal target and owns both agent tool surface and a sizable config/runtime subsystem.
+
+## Why the chosen risk level applies
+LSP threads through tools, UI affordances, config schema, auto-start logic, view/edit helper behavior, and server endpoints. It is still a bounded subsystem, but many user-visible affordances reference it.
+
+## User-visible behavior affected
+Users lose diagnostics/references/restart tools, automatic or configured language-server startup, and LSP-backed code intelligence in the UI/API.
+
+## Code entrypoints
+- `internal/lsp/manager.go`
+- `internal/agent/tools/diagnostics.go`
+- `internal/agent/tools/references.go`
+- `internal/agent/tools/lsp_restart.go`
+- `internal/server/server.go`
+
+## Known touch points
+- Files/packages: internal/lsp/**, internal/agent/tools/{diagnostics,references,lsp_restart}.go, internal/app/lsp_events.go, internal/backend/**, internal/ui/** references to LSP state
+- Config: Config.LSP / LSPConfig / Options.AutoLSP / schema.json / crush.json / README LSP docs
+- Docs/tests: README.md, AGENTS.md, LSP tests, golden fixtures, workflow/schema references
+- API/server: /v1/workspaces/{id}/lsps* endpoints and Swagger/proto surface
+- UI: status displays, restart actions, completions, or view/edit affordances that assume LSP state
+- Persistence/data model: no dedicated table, but session flows and server payloads expose LSP state
+
+## Dependencies on kept features
+Must preserve sessions, file history, stale-write protection, model switching, server/API shell, and generic file tools.
+
+## Things that must be preserved while removing it
+Keep view/edit/file operations functional without LSP, and keep server/Swagger healthy after removing LSP-only routes and types.
+
+## Suggested removal order
+After MCP or independent from it; before fantasy replacement; should happen before trimming permission behavior that only exists for LSP paths.
+
+## Acceptance criteria for the future implementation PR
+- No LSP config or auto-LSP options remain.
+- No LSP tools or endpoints remain.
+- UI and docs no longer advertise LSP-backed context.
+- Core editing and viewing still work without LSP.
+
+## Open questions / uncertainties
+- Whether any view/edit code paths need fallback adjustments when hover/diagnostic enrichment disappears.
+- Whether removing LSP changes test expectations around file intelligence or prompts.

--- a/docs/crush-light-removal-candidates/remove-mcp-support.md
+++ b/docs/crush-light-removal-candidates/remove-mcp-support.md
@@ -1,0 +1,51 @@
+# Remove MCP support
+
+- **Suggested branch:** `draft/remove-mcp-support`
+- **Risk level:** `medium`
+
+## Short summary
+Remove Model Context Protocol support, including static MCP tools, dynamic MCP tool loading, MCP endpoints, MCP config keys, Docker MCP helpers, and MCP docs.
+
+## Why this is a removal candidate
+MCP is an explicitly approved removal target and is a large optional extensibility surface that adds tool loading, server lifecycle, config, UI, API, and permission complexity.
+
+## Why the chosen risk level applies
+The boundary is broad but recognizable: config, tool adapters, backend refresh/read endpoints, UI prompts, and documentation all pivot on MCP. Core sessions, OAuth, and the HTTP server can remain intact if only MCP-specific surfaces are removed.
+
+## User-visible behavior affected
+Users lose MCP server configuration, MCP-backed tools, MCP resource/prompt discovery, Docker MCP shortcuts, and MCP-related UI/server routes.
+
+## Code entrypoints
+- `internal/agent/tools/mcp-tools.go`
+- `internal/agent/tools/mcp/`
+- `internal/backend/mcp.go`
+- `internal/server/server.go`
+- `internal/config/config.go`
+- `internal/ui/chat/docker_mcp.go`
+
+## Known touch points
+- Files/packages: internal/agent/tools/mcp-tools.go, internal/agent/tools/mcp/**, internal/backend/mcp.go, internal/config/docker_mcp.go, internal/ui/chat/docker_mcp.go, internal/workspace/**
+- Config: Config.MCP / MCPConfig / schema.json / crush.json / README MCP docs
+- Docs/tests: README.md, AGENTS.md, tool descriptions, MCP tests/fixtures, workflow/docs references
+- API/server: /v1/workspaces/{id}/mcp/* endpoints in internal/server/server.go and related proto types
+- UI: MCP enable/disable affordances and Docker MCP chat prompts
+- Persistence/data model: none primary, but workspace/config state references must be cleaned up
+
+## Dependencies on kept features
+Must preserve the internal HTTP server, Swagger generation, working sessions, and generic tool execution for non-MCP tools.
+
+## Things that must be preserved while removing it
+Keep server startup, non-MCP tools, OAuth/BYOK provider auth, model switching, and session persistence untouched.
+
+## Suggested removal order
+After analytics removal is safe; before fantasy replacement; before or alongside sub-agent/parallel cleanup if MCP tool wrappers still rely on fantasy interfaces.
+
+## Acceptance criteria for the future implementation PR
+- No MCP config keys, schema entries, or sample config remain.
+- No MCP endpoints remain in backend/server/swagger for removed behavior.
+- No MCP tool descriptions, dynamic MCP tool loading, or Docker MCP helpers remain.
+- Build/tests/docs updated so non-MCP workflows continue to work.
+
+## Open questions / uncertainties
+- Whether any existing users rely on Docker MCP onboarding copy that should be replaced with a lighter extension story.
+- Whether MCP refresh/read APIs share proto messages with kept features that need surgical retention.

--- a/docs/crush-light-removal-candidates/remove-nix-home-manager-support.md
+++ b/docs/crush-light-removal-candidates/remove-nix-home-manager-support.md
@@ -1,0 +1,46 @@
+# Remove NixOS and Home Manager module support
+
+- **Suggested branch:** `draft/remove-nix-home-manager-support`
+- **Risk level:** `low`
+
+## Short summary
+Remove documentation and configuration surface that advertises or supports NixOS/Home Manager module usage and any LSP examples/config tied only to that support.
+
+## Why this is a removal candidate
+NixOS/Home Manager module support is an explicitly approved config-surface removal target for the light fork.
+
+## Why the chosen risk level applies
+The surface appears primarily in documentation/examples and does not anchor a core runtime subsystem in this repository.
+
+## User-visible behavior affected
+Users no longer see NixOS/Home Manager module guidance or examples in the repo/docs/schema for crush-light.
+
+## Code entrypoints
+- `README.md`
+- `schema.json`
+- `crush.json`
+
+## Known touch points
+- Files/packages: README.md install/config sections, sample config files, release/install docs
+- Config: any sample schema/example values that highlight per-language LSP setup or Nix module usage
+- Docs/tests: docs/help/manpages if generated elsewhere, workflows that mention schema/docs refresh
+- API/server: none
+- UI: none primary
+- Persistence/data model: none
+
+## Dependencies on kept features
+Must preserve general installation guidance, BYOK/OAuth provider setup, and model/session instructions.
+
+## Things that must be preserved while removing it
+Keep standard install/config docs for supported light-variant workflows.
+
+## Suggested removal order
+Any time; docs-only cleanup that can land early.
+
+## Acceptance criteria for the future implementation PR
+- No NixOS/Home Manager module guidance remains.
+- No per-language LSP config examples remain in sample config/docs once LSP support is removed.
+- Remaining docs still explain supported installation/auth/session flows.
+
+## Open questions / uncertainties
+- Whether any release/install automation outside README still references Nix-specific surfaces.

--- a/docs/crush-light-removal-candidates/remove-out-of-working-dir-permission-gate.md
+++ b/docs/crush-light-removal-candidates/remove-out-of-working-dir-permission-gate.md
@@ -1,0 +1,49 @@
+# Remove out-of-working-dir permission gate
+
+- **Suggested branch:** `draft/remove-out-of-working-dir-permission-gate`
+- **Risk level:** `medium`
+
+## Short summary
+Remove the special permission behavior that gates tool actions based on derived working-directory paths outside the active workspace.
+
+## Why this is a removal candidate
+The out-of-working-dir permission gate is an explicitly approved removal target and should be isolated from broader tool-permission behavior.
+
+## Why the chosen risk level applies
+The logic is concentrated in permission/path handling, but many tools feed paths into it. The future PR should remove the working-directory boundary enforcement entirely and can simplify other human-facing permission prompts at the same time, while still preserving stale-write/session protections.
+
+## User-visible behavior affected
+Users no longer see special permission behavior keyed to out-of-working-dir path derivation; permission prompts should simplify accordingly.
+
+## Code entrypoints
+- `internal/permission/permission.go`
+- `internal/filepathext/**`
+- `internal/agent/tools/safe.go`
+- `internal/lsp/manager.go`
+
+## Known touch points
+- Files/packages: permission service, safe path helpers, tools that compute request paths, LSP start path guard, file tracker/path helpers
+- Config: permissions.allowed_tools docs/help if they mention working-dir boundaries
+- Docs/tests: permission tests, README/help text, agent instructions about working-dir restrictions
+- API/server: permission grant endpoints if payloads/documentation mention this gate
+- UI: permission prompt copy
+- Persistence/data model: none
+
+## Dependencies on kept features
+Must preserve normal permission prompts, session-scoped approvals, and stale-write/file-history safeguards.
+
+## Things that must be preserved while removing it
+Keep protections that prevent the agent from acting on stale session/file state, while allowing the future PR to remove non-essential human-facing permission prompts together with the out-of-working-dir gate.
+
+## Suggested removal order
+After LSP removal if the only remaining strict path gating is in permission/file tools; before or independent of fantasy replacement.
+
+## Acceptance criteria for the future implementation PR
+- No code path special-cases derived out-of-working-dir gating behavior.
+- The working-directory boundary enforcement is fully removed.
+- Non-essential human-facing permission prompts may be removed or simplified with it.
+- Docs/tests updated to reflect simplified path behavior.
+- No regression to stale-write/session protections.
+
+## Open questions / uncertainties
+- LSP path checks may disappear with the broader LSP-removal PR; whichever PR lands first should remove the overlapping boundary enforcement cleanly.

--- a/docs/crush-light-removal-candidates/remove-parallel-tool-execution.md
+++ b/docs/crush-light-removal-candidates/remove-parallel-tool-execution.md
@@ -1,0 +1,48 @@
+# Remove parallel tool execution
+
+- **Suggested branch:** `draft/remove-parallel-tool-execution`
+- **Risk level:** `high`
+
+## Short summary
+Remove agent-facing parallel tool execution semantics and convert or delete tool definitions that currently rely on `fantasy.NewParallelAgentTool`.
+
+## Why this is a removal candidate
+Parallel tool execution is an explicitly approved removal target and affects a recognizable slice of tool registration and tests.
+
+## Why the chosen risk level applies
+Parallel execution is a cross-cutting behavior rather than a single package. The work is bounded by tool construction, tests/fixtures, and any concurrency assumptions, but it touches many tools and may intersect fantasy replacement planning.
+
+## User-visible behavior affected
+Agents stop advertising or using parallel tool calls; affected tools either become sequential or disappear as part of other removals.
+
+## Code entrypoints
+- `internal/agent/agent_tool.go`
+- `internal/agent/agentic_fetch_tool.go`
+- `internal/agent/tools/{fetch,download,web_fetch,web_search,sourcegraph,list_mcp_resources,read_mcp_resource}.go`
+- `internal/agent/agent_test.go`
+
+## Known touch points
+- Files/packages: all `fantasy.NewParallelAgentTool` call sites, coordinator tests, agent fixtures containing `parallel_tool_calls`
+- Config: none primary, but tool availability docs/help may mention concurrency
+- Docs/tests: tool descriptions, regression fixtures, README/product copy if it advertises parallelism
+- API/server: none primary
+- UI: tool-progress rendering may assume concurrent activity
+- Persistence/data model: none
+
+## Dependencies on kept features
+Must preserve core tool availability, single-agent execution, and model switching.
+
+## Things that must be preserved while removing it
+Keep tools functional sequentially where the feature is retained, and avoid entangling this work with fantasy replacement more than necessary. The retained providers/tools are expected to keep working once execution becomes sequential-only.
+
+## Suggested removal order
+After removals that delete whole parallel-only tools (MCP/sub-agent/remote research) so fewer call sites remain; before fantasy replacement if it simplifies the swap.
+
+## Acceptance criteria for the future implementation PR
+- No retained tool uses parallel execution semantics.
+- Parallel-tool-call fixtures/tests are removed or updated.
+- User-facing docs no longer describe concurrent tool calls.
+- Retained tools still work sequentially.
+
+## Open questions / uncertainties
+- None currently.

--- a/docs/crush-light-removal-candidates/remove-posthog-analytics.md
+++ b/docs/crush-light-removal-candidates/remove-posthog-analytics.md
@@ -1,0 +1,49 @@
+# Remove PostHog analytics
+
+- **Suggested branch:** `draft/remove-posthog-analytics`
+- **Risk level:** `low`
+
+## Short summary
+Remove PostHog metrics, machine-id telemetry support, event helpers, config gating, and analytics docs/code paths.
+
+## Why this is a removal candidate
+PostHog is an explicitly approved removal target and is a well-bounded third-party integration.
+
+## Why the chosen risk level applies
+Telemetry lives in a distinct internal/event package and a small number of call sites. The main care point is deleting references cleanly without disturbing startup/session flows.
+
+## User-visible behavior affected
+Users lose anonymous metrics/error reporting; no core coding or session behavior should change.
+
+## Code entrypoints
+- `internal/event/event.go`
+- `internal/event/identifier.go`
+- `internal/app/app.go`
+- `internal/cmd/root.go`
+
+## Known touch points
+- Files/packages: internal/event/** plus callers across app/session/cmd
+- Config: options.disable_metrics, schema.json, README/help text
+- Docs/tests: event tests, dependency docs, go.mod/go.sum
+- API/server: none primary
+- UI: any metrics/privacy copy
+- Persistence/data model: none
+
+## Dependencies on kept features
+Must preserve startup, shutdown, session creation/deletion, and logging without the analytics hooks.
+
+## Things that must be preserved while removing it
+Keep crash/error logging, session state, user-facing auth/model features, and any valuable local-only diagnostics or metrics for power users untouched.
+
+## Suggested removal order
+First or early; low-risk dependency cleanup before harder removals.
+
+## Acceptance criteria for the future implementation PR
+- No PostHog or machineid dependency remains.
+- No telemetry init/send/flush hooks remain.
+- Disable-metrics config/docs removed or rewritten if obsolete.
+- Local-only diagnostics/metrics that are still useful to users remain available.
+- No behavior regressions outside metrics removal.
+
+## Open questions / uncertainties
+- Distinguish clearly between remote telemetry that must go and local-only diagnostics that still provide user value.

--- a/docs/crush-light-removal-candidates/remove-remote-research-tools.md
+++ b/docs/crush-light-removal-candidates/remove-remote-research-tools.md
@@ -1,0 +1,49 @@
+# Remove remote research tools
+
+- **Suggested branch:** `draft/remove-remote-research-tools`
+- **Risk level:** `medium`
+
+## Short summary
+Remove `agentic_fetch`, `web_fetch`, `web_search`, `download`, and related optional remote-research/search helper surfaces used to pull external content into the agent loop.
+
+## Why this is a removal candidate
+The light variant explicitly must remove `web_fetch`, `web_search`, and `download`; grouping them with `agentic_fetch` keeps one coherent future PR around external-content acquisition.
+
+## Why the chosen risk level applies
+These tools are separate from core local-file tooling, but `agentic_fetch` shares sub-agent machinery and some prompt/template wiring. The code boundary is still clear.
+
+## User-visible behavior affected
+Users lose built-in remote search/fetch/download helpers and any agent flow that depends on them for web research.
+
+## Code entrypoints
+- `internal/agent/agentic_fetch_tool.go`
+- `internal/agent/tools/download.go`
+- `internal/agent/tools/web_fetch.go`
+- `internal/agent/tools/web_search.go`
+
+## Known touch points
+- Files/packages: the tool implementations above, fetch helper/types files, coordinator tool registration, templates/agentic_fetch*
+- Config: disabled-tools defaults/help text if these tools are advertised
+- Docs/tests: tool markdown, README/help text, agent/tool testdata covering fetch/download/parallel tool calls
+- API/server: none direct beyond generic agent execution
+- UI: tool output rendering for remote research responses
+- Persistence/data model: none specific
+
+## Dependencies on kept features
+Must preserve local `fetch`, `view`, `grep`, `glob`, and normal shell/file tools unless explicitly removed elsewhere.
+
+## Things that must be preserved while removing it
+Keep local repository inspection tools, the `sourcegraph` tool, and primary agent execution intact.
+
+## Suggested removal order
+After or alongside sub-agent removal; before fantasy replacement.
+
+## Acceptance criteria for the future implementation PR
+- No `agentic_fetch`, `web_fetch`, `web_search`, or `download` tools remain.
+- Associated tool docs/tests/fixtures are removed or updated.
+- No UI or README copy advertises remote research/download helpers.
+- `sourcegraph` remains untouched for its own follow-up removal PR.
+- Core local tools remain functional.
+
+## Open questions / uncertainties
+- None currently.

--- a/docs/crush-light-removal-candidates/remove-sourcegraph-tool.md
+++ b/docs/crush-light-removal-candidates/remove-sourcegraph-tool.md
@@ -1,0 +1,47 @@
+# Remove Sourcegraph tool
+
+- **Suggested branch:** `draft/remove-sourcegraph-tool`
+- **Risk level:** `low`
+
+## Short summary
+Remove the standalone `sourcegraph` agent tool in its own future PR rather than folding it into the broader remote-research-tools removal.
+
+## Why this is a removal candidate
+The `sourcegraph` tool is an optional external code-search integration with a clear boundary and a much smaller scope than MCP, LSP, or the remote web-research stack.
+
+## Why the chosen risk level applies
+The implementation is isolated to a single tool plus registration/docs/tests. Removing it should not disturb local repository tooling or the main agent loop.
+
+## User-visible behavior affected
+Users lose the ability to query Sourcegraph from the agent, but local `grep`, `glob`, `view`, and other repository tools remain.
+
+## Code entrypoints
+- `internal/agent/tools/sourcegraph.go`
+- `internal/agent/coordinator.go`
+- `internal/config/config.go`
+- `internal/agent/agent_test.go`
+
+## Known touch points
+- Files/packages: `internal/agent/tools/sourcegraph.go`, tool registration in coordinator, config defaults that mention `sourcegraph`
+- Config: disabled-tools examples/default tool lists in `internal/config/config.go`, schema/help text
+- Docs/tests: tool markdown, README examples, agent test fixtures covering `sourcegraph`
+- API/server: none direct beyond generic agent execution
+- UI: generic tool output rendering only
+- Persistence/data model: none
+
+## Dependencies on kept features
+Must preserve the rest of the local repository inspection toolset and normal single-agent execution.
+
+## Things that must be preserved while removing it
+Keep local search/view tools and primary agent behavior intact.
+
+## Suggested removal order
+After the remote-research-tools PR or independently from it; before fantasy replacement if trimming optional tools first is helpful.
+
+## Acceptance criteria for the future implementation PR
+- No `sourcegraph` tool remains.
+- Tool registration, docs, config examples/defaults, and tests are updated accordingly.
+- Local repository inspection tools continue to work unchanged.
+
+## Open questions / uncertainties
+- None currently.

--- a/docs/crush-light-removal-candidates/remove-sub-agent-orchestration.md
+++ b/docs/crush-light-removal-candidates/remove-sub-agent-orchestration.md
@@ -1,0 +1,49 @@
+# Remove sub-agent orchestration
+
+- **Suggested branch:** `draft/remove-sub-agent-orchestration`
+- **Risk level:** `high`
+
+## Short summary
+Remove the `agent` tool, nested task-session orchestration, sub-agent prompt/templates, and other recursion-specific agent behavior.
+
+## Why this is a removal candidate
+Sub-agents are an explicitly approved removal target and create nested session, prompt, and tool-surface complexity that is not required for the lightweight fork.
+
+## Why the chosen risk level applies
+Sub-agents touch coordinator tool construction, session ID conventions, prompt templates, tests/fixtures, and remote research helpers. They are conceptually bounded, but the behavior is spread across agent runtime and session handling.
+
+## User-visible behavior affected
+Users lose the ability to delegate work to nested agents or task sessions from inside a live agent conversation.
+
+## Code entrypoints
+- `internal/agent/agent_tool.go`
+- `internal/agent/coordinator.go`
+- `internal/session/session.go`
+- `internal/agent/templates/agent_tool.md`
+
+## Known touch points
+- Files/packages: internal/agent/{agent_tool.go,coordinator.go,prompts.go}, internal/session/session.go, internal/message/** if nested session rendering differs
+- Config: agent allowed_tools defaults and any task-agent config assumptions
+- Docs/tests: agent templates, agent testdata/fixtures, README or help copy mentioning sub-agents
+- API/server: any agent/session payload fields or session-title conventions used only for sub-agent runs
+- UI: remove user-facing references to nested sessions, agent task status text, and sub-agent affordances; internal queue assumptions matter less as long as they are not surfaced
+- Persistence/data model: task-session IDs and parent_session_id behavior must be preserved only where still needed by kept features
+
+## Dependencies on kept features
+Must preserve normal single-agent sessions, model switching, summaries, and session CRUD.
+
+## Things that must be preserved while removing it
+Keep core session management, file history, and server agent endpoints for the primary agent.
+
+## Suggested removal order
+Before removing parallel execution if parallel wrappers exist only to support nested agents, and before fantasy replacement so the surface area shrinks first.
+
+## Acceptance criteria for the future implementation PR
+- No `agent` tool remains.
+- No nested-agent prompt/template/session scaffolding remains unless reused by a kept feature.
+- Tests and docs no longer mention sub-agent delegation.
+- Primary agent sessions still work normally.
+
+## Open questions / uncertainties
+- Whether title/task session helpers still serve any kept summarization/title-generation path after agent-tool removal.
+- Internal prompt-queue assumptions are lower priority than removing user-facing nested-session references from the UI.

--- a/docs/crush-light-removal-candidates/remove-todo-support.md
+++ b/docs/crush-light-removal-candidates/remove-todo-support.md
@@ -1,0 +1,50 @@
+# Remove todo support while keeping sessions
+
+- **Suggested branch:** `draft/remove-todo-support`
+- **Risk level:** `medium`
+
+## Short summary
+Remove the `todos` tool and all todo persistence/serialization/UI/docs while preserving session management, file history, and stale-write protections.
+
+## Why this is a removal candidate
+Todo items and lists are explicitly required to be removed even though sessions must remain.
+
+## Why the chosen risk level applies
+The tool itself is simple, but todos are now embedded in session types, the active schema/data model, server payloads, and tests. The future PR must clean those links without disturbing sessions, and it does not need to preserve the existing migration history verbatim in this fresh-start fork.
+
+## User-visible behavior affected
+Users lose todo-list tracking in sessions; normal session creation, switching, summarization, and history remain.
+
+## Code entrypoints
+- `internal/agent/tools/todos.go`
+- `internal/session/session.go`
+- `internal/db/models.go`
+- `internal/db/sql/*.sql`
+- `internal/server/server.go`
+
+## Known touch points
+- Files/packages: todos tool, session service/types, active DB schema/queries/models, workspace/backend/server session payloads, UI rendering that surfaces todos
+- Config: disabled-tools docs/help may mention `todos`
+- Docs/tests: README/help copy, session/agent tests, fixtures using todo metadata
+- API/server: session read/write payloads and docs exposing todos
+- UI: any todo chips/panels/session summaries
+- Persistence/data model: sessions.todos column and marshaling helpers
+
+## Dependencies on kept features
+Must preserve named sessions, per-session file history/version snapshots, and stale-write protections.
+
+## Things that must be preserved while removing it
+Keep session CRUD, message history, summaries, model selection, and file-tracking behavior intact.
+
+## Suggested removal order
+Can happen early; useful before slimming session payloads and before fantasy replacement.
+
+## Acceptance criteria for the future implementation PR
+- No `todos` tool remains.
+- Session types, DB queries, API payloads, and UI no longer include todos.
+- The fork's effective initial schema/data model no longer includes todo state.
+- Sessions continue to work normally without todo state.
+- Tests updated to confirm session preservation without todos.
+
+## Open questions / uncertainties
+- If prompt text still mentions todo metadata anywhere, it can be updated directly as part of the removal without blocking the schema/tool cleanup.

--- a/docs/crush-light-removal-candidates/track-fantasy-usage.md
+++ b/docs/crush-light-removal-candidates/track-fantasy-usage.md
@@ -1,0 +1,48 @@
+# Track charm.land/fantasy usage for later replacement
+
+- **Suggested branch:** `draft/track-fantasy-usage`
+- **Risk level:** `high`
+
+## Short summary
+Create a dedicated tracker PR that inventories every `charm.land/fantasy` usage/dependency point without attempting the replacement yet.
+
+## Why this is a removal candidate
+The problem statement requires exactly one dedicated draft PR for fantasy tracking and explicitly forbids doing the replacement in this task.
+
+## Why the chosen risk level applies
+Fantasy touches agent construction, provider wiring, tool interfaces, message conversion, and many tests. The tracking PR must stay inventory-only to avoid accidental refactors.
+
+## User-visible behavior affected
+No user-visible behavior change; this is a planning/tracking-only work item.
+
+## Code entrypoints
+- `go.mod`
+- `Taskfile.yaml`
+- `internal/agent/**/*.go`
+- `internal/message/content.go`
+- `internal/app/app.go`
+
+## Known touch points
+- Files/packages: all direct imports/usages plus provider-specific fantasy packages
+- Config: provider/model wiring that depends on fantasy abstractions
+- Docs/tests: AGENTS.md, dependency-update tasks, tests importing fantasy
+- API/server: indirect via agent runtime only
+- UI: indirect via model/tool/result rendering only
+- Persistence/data model: message conversion paths that adapt fantasy message/tool structures
+
+## Dependencies on kept features
+Must preserve all current functionality; this future PR is inventory-only.
+
+## Things that must be preserved while removing it
+Keep provider auth, model switching, sessions, tools, server/API, and all existing runtime behavior.
+
+## Suggested removal order
+Tracking PR should exist immediately and remain open while other simplification PRs reduce future replacement scope.
+
+## Acceptance criteria for the future implementation PR
+- Draft PR exists only as a tracker.
+- Fantasy usage references are collected in the PR description and audit docs.
+- No replacement/refactor code lands in the tracking PR.
+
+## Open questions / uncertainties
+- How to post follow-up usage comments if tool support for PR comments remains unavailable in this environment.

--- a/docs/crush-light-reviewed-paths.tsv
+++ b/docs/crush-light-reviewed-paths.tsv
@@ -1,0 +1,985 @@
+path	type	review_status	brief_notes	removal_candidate_tags	required_kept_tags	fantasy_usage	server_api_surface	configuration	tests_docs_build_release
+.	directory	reviewed	Repository root and aggregate audit scope.			no	no	no	yes
+.github	directory	reviewed	GitHub automation, labels, and release workflow surface.			no	no	no	yes
+.github/workflows	directory	reviewed	GitHub automation, labels, and release workflow surface. CI, release, schema, and security workflow definitions.			no	no	no	yes
+docs	directory	reviewed	Audit or planning documentation added for crush-light removal tracking.			no	no	no	yes
+docs/crush-light-draft-prs	directory	reviewed	Audit or planning documentation added for crush-light removal tracking.			no	no	no	yes
+docs/crush-light-removal-candidates	directory	reviewed	Audit or planning documentation added for crush-light removal tracking.			no	no	no	yes
+internal	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/agent	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			no	no	no	no
+internal/agent/hyper	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			no	no	no	no
+internal/agent/notify	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			no	no	no	no
+internal/agent/prompt	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			no	no	no	no
+internal/agent/templates	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/testdata	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			no	no	no	no
+internal/agent/testdata/TestCoderAgent	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/tools	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			no	no	no	no
+internal/agent/tools/mcp	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. MCP integration surface targeted for removal.	mcp		no	no	no	no
+internal/agent/tools/testdata	directory	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			no	no	no	no
+internal/ansiext	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/app	directory	reviewed	Application wiring for services, config, agent coordination, and lifecycle.		server-api	no	no	no	no
+internal/backend	directory	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/client	directory	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/cmd	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/gitignore	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/stats	directory	reviewed	User-facing stats/dashboard tooling; additional light-variant removal candidate.			no	no	no	yes
+internal/commands	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/config	directory	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	no
+internal/csync	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/db	directory	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/migrations	directory	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/sql	directory	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/diff	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/env	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/event	directory	reviewed	Telemetry and analytics implementation using PostHog.	posthog-analytics		no	no	no	no
+internal/filepathext	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/filetracker	directory	reviewed	Per-session file read tracking that must remain.		sessions-and-history	no	no	no	no
+internal/format	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/fsext	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/history	directory	reviewed	Session history and file snapshot support that must remain.		sessions-and-history	no	no	no	no
+internal/home	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/log	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/lsp	directory	reviewed	LSP integration or LSP-facing tool surface targeted for removal.	lsp		no	no	no	no
+internal/lsp/util	directory	reviewed	LSP integration or LSP-facing tool surface targeted for removal.	lsp		no	no	no	no
+internal/message	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/oauth	directory	reviewed	OAuth/provider-auth surface that must remain.		oauth-and-byok	no	no	no	no
+internal/oauth/copilot	directory	reviewed	OAuth/provider-auth surface that must remain.		oauth-and-byok	no	no	no	no
+internal/oauth/hyper	directory	reviewed	OAuth/provider-auth surface that must remain.		oauth-and-byok	no	no	no	no
+internal/permission	directory	reviewed	Permission request flow and working-directory gate logic.	permission-gate		no	no	no	no
+internal/projects	directory	reviewed	Workspace/project service surface supporting kept session and API behavior.		server-api	no	no	no	no
+internal/proto	directory	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/pubsub	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/server	directory	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/session	directory	reviewed	Session persistence and state that must remain while todo support is removed.	todos	sessions-and-history	no	no	no	no
+internal/shell	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/skills	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/skills/builtin	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/skills/builtin/crush-config	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/stringext	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/swagger	directory	reviewed	Generated Swagger/OpenAPI artifacts that must remain except for removed-feature endpoints.		server-api;swagger-docs	no	yes	no	no
+internal/ui	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/anim	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/attachments	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/chat	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/common	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/completions	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/dialog	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/diffview	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/diffview/testdata	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/diffview/testdata/TestDiffView	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/CustomContextLines	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/Default	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/LargeWidth	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/MultipleHunks	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/Narrow	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/NoLineNumbers	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/NoSyntaxHighlight	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/SmallWidth	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/CustomContextLines	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/Default	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/LargeWidth	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/MultipleHunks	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/Narrow	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/NoLineNumbers	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/NoSyntaxHighlight	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/SmallWidth	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewLineBreakIssue	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewTabs	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestUdiff	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestUdiff/ToUnifiedDiff	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestUdiff/ToUnifiedDiff/DefaultContextLines	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestUdiff/ToUnifiedDiff/DefaultContextLinesPlusOne	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestUdiff/ToUnifiedDiff/DefaultContextLinesPlusTwo	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/image	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/list	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/logo	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/model	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/notification	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/styles	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/util	directory	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/update	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/version	directory	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/workspace	directory	reviewed	Workspace/project service surface supporting kept session and API behavior.		server-api	no	no	no	no
+scripts	directory	reviewed	Build, lint, packaging, or repository tooling artifact.			no	no	no	yes
+.gitattributes	file	reviewed	Build, lint, packaging, or repository tooling artifact.			no	no	no	yes
+.github/CODEOWNERS	file	reviewed	GitHub automation, labels, and release workflow surface.			no	no	no	yes
+.github/cla-signatures.json	file	reviewed	GitHub automation, labels, and release workflow surface.			no	no	no	yes
+.github/dependabot.yml	file	reviewed	GitHub automation, labels, and release workflow surface.			no	no	no	yes
+.github/entitlements.plist	file	reviewed	GitHub automation, labels, and release workflow surface.			no	no	no	yes
+.github/labeler.yml	file	reviewed	GitHub automation, labels, and release workflow surface.			no	no	no	yes
+.github/workflows/build.yml	file	reviewed	GitHub automation, labels, and release workflow surface. CI, release, schema, and security workflow definitions.			no	no	no	yes
+.github/workflows/cla.yml	file	reviewed	GitHub automation, labels, and release workflow surface. CI, release, schema, and security workflow definitions.			no	no	no	yes
+.github/workflows/labeler.yml	file	reviewed	GitHub automation, labels, and release workflow surface. CI, release, schema, and security workflow definitions.			no	no	no	yes
+.github/workflows/lint-sync.yml	file	reviewed	GitHub automation, labels, and release workflow surface. CI, release, schema, and security workflow definitions.			no	no	no	yes
+.github/workflows/lint.yml	file	reviewed	GitHub automation, labels, and release workflow surface. CI, release, schema, and security workflow definitions.			no	no	no	yes
+.github/workflows/nightly.yml	file	reviewed	GitHub automation, labels, and release workflow surface. CI, release, schema, and security workflow definitions.			no	no	no	yes
+.github/workflows/release.yml	file	reviewed	GitHub automation, labels, and release workflow surface. CI, release, schema, and security workflow definitions.			no	no	no	yes
+.github/workflows/schema-update.yml	file	reviewed	GitHub automation, labels, and release workflow surface. CI, release, schema, and security workflow definitions.			no	no	no	yes
+.github/workflows/security.yml	file	reviewed	GitHub automation, labels, and release workflow surface. CI, release, schema, and security workflow definitions.			no	no	no	yes
+.github/workflows/snapshot.yml	file	reviewed	GitHub automation, labels, and release workflow surface. CI, release, schema, and security workflow definitions.			no	no	no	yes
+.gitignore	file	reviewed	Build, lint, packaging, or repository tooling artifact.			no	no	no	yes
+.golangci.yml	file	reviewed	Build, lint, packaging, or repository tooling artifact.			no	no	no	yes
+.goreleaser.yml	file	reviewed	Build, lint, packaging, or repository tooling artifact.			no	no	no	yes
+AGENTS.md	file	reviewed	Top-level documentation or repository policy file.			yes	no	no	yes
+CLA.md	file	reviewed	Top-level documentation or repository policy file.			no	no	no	yes
+LICENSE.md	file	reviewed	Top-level documentation or repository policy file.			no	no	no	yes
+README.md	file	reviewed	Top-level documentation or repository policy file.			no	no	no	yes
+Taskfile.yaml	file	reviewed	Build, lint, packaging, or repository tooling artifact.			yes	no	no	yes
+crush.json	file	reviewed	Configuration example or generated schema surface.			no	no	yes	yes
+docs/crush-light-audit.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking.			yes	no	no	yes
+docs/crush-light-draft-prs/remove-mcp-support.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking.	mcp		yes	no	no	yes
+docs/crush-light-fantasy-usage.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking.			yes	no	no	yes
+docs/crush-light-removal-candidates/remove-lsp-support.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking.	lsp		yes	no	no	yes
+docs/crush-light-removal-candidates/remove-hyper-provider-support.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking.			no	no	no	yes
+docs/crush-light-removal-candidates/remove-mcp-support.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking.	mcp		yes	no	no	yes
+docs/crush-light-removal-candidates/remove-nix-home-manager-support.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking. Nix/NixOS/Home Manager support or documentation surface.	nix-home-manager		no	no	no	yes
+docs/crush-light-removal-candidates/remove-out-of-working-dir-permission-gate.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking.			yes	no	no	yes
+docs/crush-light-removal-candidates/remove-parallel-tool-execution.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking. Parallel tool execution touch point or fixture.	parallel-tools		yes	no	no	yes
+docs/crush-light-removal-candidates/remove-posthog-analytics.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking.			no	no	no	yes
+docs/crush-light-removal-candidates/remove-remote-research-tools.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking.			yes	no	no	yes
+docs/crush-light-removal-candidates/remove-sourcegraph-tool.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking.			no	no	no	yes
+docs/crush-light-removal-candidates/remove-sub-agent-orchestration.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking.			yes	no	no	yes
+docs/crush-light-removal-candidates/remove-todo-support.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking.			yes	no	no	yes
+docs/crush-light-removal-candidates/track-fantasy-usage.md	file	reviewed	Audit or planning documentation added for crush-light removal tracking.			yes	no	no	yes
+docs/crush-light-reviewed-paths.tsv	file	reviewed	Audit or planning documentation added for crush-light removal tracking.			yes	no	no	yes
+go.mod	file	reviewed	Top-level dependency or entrypoint surface.			yes	no	no	yes
+go.sum	file	reviewed	Top-level dependency or entrypoint surface.			yes	no	no	yes
+internal/agent/.env.sample	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			no	no	no	no
+internal/agent/agent.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			yes	no	no	no
+internal/agent/agent_test.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			yes	no	no	yes
+internal/agent/agent_tool.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Sub-agent or remote research tooling surface targeted for removal. Parallel tool execution touch point or fixture.	sub-agents;parallel-tools		yes	no	no	no
+internal/agent/agentic_fetch_tool.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Sub-agent or remote research tooling surface targeted for removal. Parallel tool execution touch point or fixture.	sub-agents;parallel-tools		yes	no	no	no
+internal/agent/common_test.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			yes	no	no	yes
+internal/agent/coordinator.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			yes	no	no	no
+internal/agent/coordinator_test.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			yes	no	no	yes
+internal/agent/errors.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			no	no	no	no
+internal/agent/event.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			yes	no	no	no
+internal/agent/hyper/provider.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			yes	no	no	no
+internal/agent/hyper/provider.json	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			yes	no	no	no
+internal/agent/loop_detection.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			yes	no	no	no
+internal/agent/loop_detection_test.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			yes	no	no	yes
+internal/agent/notify/notify.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			no	no	no	no
+internal/agent/prompt/prompt.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			no	no	no	no
+internal/agent/prompts.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures.			no	no	no	no
+internal/agent/templates/agent_tool.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Sub-agent or remote research tooling surface targeted for removal. Tool or prompt documentation artifact.	sub-agents		no	no	no	yes
+internal/agent/templates/agentic_fetch.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Sub-agent or remote research tooling surface targeted for removal. Tool or prompt documentation artifact.	sub-agents		no	no	no	yes
+internal/agent/templates/agentic_fetch_prompt.md.tpl	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Sub-agent or remote research tooling surface targeted for removal. Tool or prompt documentation artifact.	sub-agents		no	no	no	yes
+internal/agent/templates/coder.md.tpl	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/templates/initialize.md.tpl	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/templates/summary.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/templates/task.md.tpl	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/templates/title.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet/bash_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet/download_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet/fetch_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet/glob_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet/grep_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet/ls_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet/multiedit_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet/parallel_tool_calls.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior. Parallel tool execution touch point or fixture.	parallel-tools		no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet/read_a_file.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet/simple_test.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet/sourcegraph_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet/update_a_file.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/anthropic-sonnet/write_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5/bash_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5/download_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5/fetch_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5/glob_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5/grep_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5/ls_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5/multiedit_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5/parallel_tool_calls.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior. Parallel tool execution touch point or fixture.	parallel-tools		no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5/read_a_file.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5/simple_test.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5/sourcegraph_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5/update_a_file.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openai-gpt-5/write_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2/bash_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2/download_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2/fetch_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2/glob_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2/grep_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2/ls_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2/multiedit_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2/parallel_tool_calls.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior. Parallel tool execution touch point or fixture.	parallel-tools		no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2/read_a_file.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2/simple_test.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2/sourcegraph_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2/update_a_file.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/openrouter-kimi-k2/write_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6/bash_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6/download_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6/fetch_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6/glob_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6/grep_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6/ls_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6/multiedit_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6/parallel_tool_calls.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior. Parallel tool execution touch point or fixture.	parallel-tools		no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6/read_a_file.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6/simple_test.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6/sourcegraph_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6/update_a_file.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/testdata/TestCoderAgent/zai-glm4.6/write_tool.yaml	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior.			no	no	no	yes
+internal/agent/tools/bash.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			yes	no	no	no
+internal/agent/tools/bash.tpl	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			no	no	no	no
+internal/agent/tools/bash_test.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior. Built-in agent tool implementation or description surface.			yes	no	no	yes
+internal/agent/tools/context_test.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior. Built-in agent tool implementation or description surface.			no	no	no	yes
+internal/agent/tools/diagnostics.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. LSP integration or LSP-facing tool surface targeted for removal.	lsp		yes	no	no	no
+internal/agent/tools/diagnostics.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/tools/download.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Standalone download tool slated for removal in light variant. Parallel tool execution touch point or fixture.	remote-research-tools;parallel-tools		yes	no	no	no
+internal/agent/tools/download.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Standalone download tool slated for removal in light variant. Tool or prompt documentation artifact.	remote-research-tools		no	no	no	yes
+internal/agent/tools/edit.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			yes	no	no	no
+internal/agent/tools/edit.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/tools/fetch.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Parallel tool execution touch point or fixture.	parallel-tools		yes	no	no	no
+internal/agent/tools/fetch.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/tools/fetch_helpers.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			no	no	no	no
+internal/agent/tools/fetch_types.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			no	no	no	no
+internal/agent/tools/glob.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			yes	no	no	no
+internal/agent/tools/glob.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/tools/grep.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			yes	no	no	no
+internal/agent/tools/grep.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/tools/grep_test.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior. Built-in agent tool implementation or description surface.			no	no	no	yes
+internal/agent/tools/job_kill.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			yes	no	no	no
+internal/agent/tools/job_kill.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/tools/job_output.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			yes	no	no	no
+internal/agent/tools/job_output.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/tools/job_test.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior. Built-in agent tool implementation or description surface.			no	no	no	yes
+internal/agent/tools/list_mcp_resources.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. MCP integration surface targeted for removal. Parallel tool execution touch point or fixture.	mcp;parallel-tools		yes	no	no	no
+internal/agent/tools/list_mcp_resources.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. MCP integration surface targeted for removal. Tool or prompt documentation artifact.	mcp		no	no	no	yes
+internal/agent/tools/ls.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			yes	no	no	no
+internal/agent/tools/ls.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/tools/lsp_restart.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. LSP integration or LSP-facing tool surface targeted for removal.	lsp		yes	no	no	no
+internal/agent/tools/lsp_restart.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. LSP integration or LSP-facing tool surface targeted for removal. Tool or prompt documentation artifact.	lsp		no	no	no	yes
+internal/agent/tools/mcp-tools.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. MCP integration surface targeted for removal.	mcp		yes	no	no	no
+internal/agent/tools/mcp/init.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. MCP integration surface targeted for removal.	mcp		no	no	no	no
+internal/agent/tools/mcp/init_test.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior. Built-in agent tool implementation or description surface. MCP integration surface targeted for removal.	mcp		no	no	no	yes
+internal/agent/tools/mcp/prompts.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. MCP integration surface targeted for removal.	mcp		no	no	no	no
+internal/agent/tools/mcp/resources.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. MCP integration surface targeted for removal.	mcp		no	no	no	no
+internal/agent/tools/mcp/tools.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. MCP integration surface targeted for removal.	mcp		no	no	no	no
+internal/agent/tools/mcp/tools_test.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior. Built-in agent tool implementation or description surface. MCP integration surface targeted for removal.	mcp		no	no	no	yes
+internal/agent/tools/multiedit.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			yes	no	no	no
+internal/agent/tools/multiedit.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/tools/multiedit_test.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior. Built-in agent tool implementation or description surface.			no	no	no	yes
+internal/agent/tools/read_mcp_resource.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. MCP integration surface targeted for removal. Parallel tool execution touch point or fixture.	mcp;parallel-tools		yes	no	no	no
+internal/agent/tools/read_mcp_resource.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. MCP integration surface targeted for removal. Tool or prompt documentation artifact.	mcp		no	no	no	yes
+internal/agent/tools/references.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. LSP integration or LSP-facing tool surface targeted for removal.	lsp		yes	no	no	no
+internal/agent/tools/references.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/tools/rg.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			no	no	no	no
+internal/agent/tools/safe.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			no	no	no	no
+internal/agent/tools/search.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			no	no	no	no
+internal/agent/tools/sourcegraph.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Optional remote code-search tool candidate for light variant removal. Parallel tool execution touch point or fixture.	remote-research-tools;parallel-tools		yes	no	no	no
+internal/agent/tools/sourcegraph.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Optional remote code-search tool candidate for light variant removal. Tool or prompt documentation artifact.	remote-research-tools		no	no	no	yes
+internal/agent/tools/testdata/grep.txt	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior. Built-in agent tool implementation or description surface.			no	no	no	yes
+internal/agent/tools/todos.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.	todos		yes	no	no	no
+internal/agent/tools/todos.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.	todos		no	no	no	yes
+internal/agent/tools/tools.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			no	no	no	no
+internal/agent/tools/view.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			yes	no	no	no
+internal/agent/tools/view.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/tools/view_test.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Tests or fixture data for agent behavior. Built-in agent tool implementation or description surface.			no	no	no	yes
+internal/agent/tools/web_fetch.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Sub-agent or remote research tooling surface targeted for removal. Parallel tool execution touch point or fixture.	sub-agents;parallel-tools		yes	no	no	no
+internal/agent/tools/web_fetch.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/tools/web_search.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Sub-agent or remote research tooling surface targeted for removal. Parallel tool execution touch point or fixture.	sub-agents;parallel-tools		yes	no	no	no
+internal/agent/tools/web_search.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/agent/tools/write.go	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface.			yes	no	no	no
+internal/agent/tools/write.md	file	reviewed	Agent runtime, prompt templates, tools, and regression fixtures. Built-in agent tool implementation or description surface. Tool or prompt documentation artifact.			no	no	no	yes
+internal/ansiext/ansi.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/app/app.go	file	reviewed	Application wiring for services, config, agent coordination, and lifecycle.		server-api	yes	no	no	no
+internal/app/app_test.go	file	reviewed	Application wiring for services, config, agent coordination, and lifecycle.		server-api	no	no	no	yes
+internal/app/lsp_events.go	file	reviewed	Application wiring for services, config, agent coordination, and lifecycle. LSP integration or LSP-facing tool surface targeted for removal.	lsp	server-api	no	no	no	no
+internal/app/provider.go	file	reviewed	Application wiring for services, config, agent coordination, and lifecycle.		server-api	no	no	no	no
+internal/app/provider_test.go	file	reviewed	Application wiring for services, config, agent coordination, and lifecycle.		server-api	no	no	no	yes
+internal/app/resolve_session_test.go	file	reviewed	Application wiring for services, config, agent coordination, and lifecycle.		server-api	no	no	no	yes
+internal/backend/agent.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/backend/backend.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/backend/config.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/backend/events.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/backend/filetracker.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/backend/permission.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/backend/session.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/backend/util.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/client/client.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/client/config.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/client/dial_other.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/client/dial_windows.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/client/proto.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/cmd/dirs.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/dirs_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/cmd/gitignore/default	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/gitignore/old	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/login.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/logs.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/models.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/projects.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/projects_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/cmd/root.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/root_other.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/root_windows.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/run.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/schema.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/server.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/server_other.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/server_windows.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/session.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/cmd/stats.go	file	reviewed	User-facing stats/dashboard tooling; additional light-variant removal candidate.			no	no	no	yes
+internal/cmd/stats/AGENTS.md	file	reviewed	User-facing stats/dashboard tooling; additional light-variant removal candidate.			no	no	no	yes
+internal/cmd/stats/footer.svg	file	reviewed	User-facing stats/dashboard tooling; additional light-variant removal candidate.			no	no	no	yes
+internal/cmd/stats/header.svg	file	reviewed	User-facing stats/dashboard tooling; additional light-variant removal candidate.			no	no	no	yes
+internal/cmd/stats/heartbit.svg	file	reviewed	User-facing stats/dashboard tooling; additional light-variant removal candidate.			no	no	no	yes
+internal/cmd/stats/index.css	file	reviewed	User-facing stats/dashboard tooling; additional light-variant removal candidate.			no	no	no	yes
+internal/cmd/stats/index.html	file	reviewed	User-facing stats/dashboard tooling; additional light-variant removal candidate.			no	no	no	yes
+internal/cmd/stats/index.js	file	reviewed	User-facing stats/dashboard tooling; additional light-variant removal candidate.			no	no	no	yes
+internal/cmd/update_providers.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/commands/commands.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/commands/commands_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/config/agent_id_test.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	yes
+internal/config/attribution_migration_test.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	yes
+internal/config/catwalk.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	no
+internal/config/catwalk_test.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	yes
+internal/config/config.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	no
+internal/config/copilot.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	no
+internal/config/docker_mcp.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	no
+internal/config/docker_mcp_test.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	yes
+internal/config/hyper.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	no
+internal/config/hyper_test.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	yes
+internal/config/init.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	no
+internal/config/load.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	no
+internal/config/load_bench_test.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	yes
+internal/config/load_test.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	yes
+internal/config/lsp_defaults_test.go	file	reviewed	LSP integration or LSP-facing tool surface targeted for removal. Configuration schema and load/merge logic for kept and removable features.	lsp;mcp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	yes
+internal/config/provider.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	no
+internal/config/provider_empty_test.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	yes
+internal/config/provider_test.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	yes
+internal/config/recent_models_test.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	yes
+internal/config/resolve.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	no
+internal/config/resolve_test.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	yes
+internal/config/scope.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	no
+internal/config/store.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	no
+internal/config/store_test.go	file	reviewed	Configuration schema and load/merge logic for kept and removable features.	mcp;lsp;nix-home-manager;sub-agents;parallel-tools	oauth-and-byok;model-picker	no	no	yes	yes
+internal/csync/doc.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/csync/maps.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/csync/maps_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/csync/slices.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/csync/slices_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/csync/value.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/csync/value_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/csync/versionedmap.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/csync/versionedmap_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/db/connect.go	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/connect_modernc.go	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/connect_ncruces.go	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/db.go	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/embed.go	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/files.sql.go	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/messages.sql.go	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/migrations/20250424200609_initial.sql	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/migrations/20250515105448_add_summary_message_id.sql	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/migrations/20250624000000_add_created_at_indexes.sql	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/migrations/20250627000000_add_provider_to_messages.sql	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/migrations/20250810000000_add_is_summary_message.sql	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/migrations/20250812000000_add_todos_to_sessions.sql	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/migrations/20260127000000_add_read_files_table.sql	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/models.go	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/querier.go	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/read_files.sql.go	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/sessions.sql.go	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/sql/files.sql	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/sql/messages.sql	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/sql/read_files.sql	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/sql/sessions.sql	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/sql/stats.sql	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/db/stats.sql.go	file	reviewed	SQLite schema, migrations, or queries with session/todo persistence touch points.	todos	sessions-and-history	no	no	no	no
+internal/diff/diff.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/env/env.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/env/env_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/event/all.go	file	reviewed	Telemetry and analytics implementation using PostHog.	posthog-analytics		no	no	no	no
+internal/event/event.go	file	reviewed	Telemetry and analytics implementation using PostHog.	posthog-analytics		no	no	no	no
+internal/event/event_test.go	file	reviewed	Telemetry and analytics implementation using PostHog.	posthog-analytics		no	no	no	yes
+internal/event/identifier.go	file	reviewed	Telemetry and analytics implementation using PostHog.	posthog-analytics		no	no	no	no
+internal/event/logger.go	file	reviewed	Telemetry and analytics implementation using PostHog.	posthog-analytics		no	no	no	no
+internal/filepathext/filepath.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/filetracker/service.go	file	reviewed	Per-session file read tracking that must remain.		sessions-and-history	no	no	no	no
+internal/filetracker/service_test.go	file	reviewed	Per-session file read tracking that must remain.		sessions-and-history	no	no	no	yes
+internal/format/spinner.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/fsext/drive_other.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/fsext/drive_windows.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/fsext/expand.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/fsext/fileutil.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/fsext/fileutil_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/fsext/ignore_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/fsext/lookup.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/fsext/lookup_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/fsext/ls.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/fsext/ls_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/fsext/owner_others.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/fsext/owner_windows.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/fsext/paste.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/fsext/paste_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/history/file.go	file	reviewed	Session history and file snapshot support that must remain.		sessions-and-history	no	no	no	no
+internal/home/home.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/home/home_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/log/http.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/log/http_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/log/log.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/lsp/client.go	file	reviewed	LSP integration or LSP-facing tool surface targeted for removal.	lsp		no	no	no	no
+internal/lsp/client_test.go	file	reviewed	LSP integration or LSP-facing tool surface targeted for removal.	lsp		no	no	no	yes
+internal/lsp/handlers.go	file	reviewed	LSP integration or LSP-facing tool surface targeted for removal.	lsp		no	no	no	no
+internal/lsp/manager.go	file	reviewed	LSP integration or LSP-facing tool surface targeted for removal.	lsp		no	no	no	no
+internal/lsp/util/edit.go	file	reviewed	LSP integration or LSP-facing tool surface targeted for removal.	lsp		no	no	no	no
+internal/lsp/util/edit_test.go	file	reviewed	LSP integration or LSP-facing tool surface targeted for removal.	lsp		no	no	no	yes
+internal/message/attachment.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/message/content.go	file	reviewed	General repository surface reviewed for audit coverage.			yes	no	no	no
+internal/message/content_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/message/message.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/oauth/copilot/client.go	file	reviewed	OAuth/provider-auth surface that must remain.		oauth-and-byok	no	no	no	no
+internal/oauth/copilot/disk.go	file	reviewed	OAuth/provider-auth surface that must remain.		oauth-and-byok	no	no	no	no
+internal/oauth/copilot/http.go	file	reviewed	OAuth/provider-auth surface that must remain.		oauth-and-byok	no	no	no	no
+internal/oauth/copilot/oauth.go	file	reviewed	OAuth/provider-auth surface that must remain.		oauth-and-byok	no	no	no	no
+internal/oauth/copilot/urls.go	file	reviewed	OAuth/provider-auth surface that must remain.		oauth-and-byok	no	no	no	no
+internal/oauth/hyper/device.go	file	reviewed	OAuth/provider-auth surface that must remain.		oauth-and-byok	no	no	no	no
+internal/oauth/token.go	file	reviewed	OAuth/provider-auth surface that must remain.		oauth-and-byok	no	no	no	no
+internal/permission/permission.go	file	reviewed	Permission request flow and working-directory gate logic.	permission-gate		no	no	no	no
+internal/permission/permission_test.go	file	reviewed	Permission request flow and working-directory gate logic.	permission-gate		no	no	no	yes
+internal/projects/projects.go	file	reviewed	Workspace/project service surface supporting kept session and API behavior.		server-api	no	no	no	no
+internal/projects/projects_test.go	file	reviewed	Workspace/project service surface supporting kept session and API behavior.		server-api	no	no	no	yes
+internal/proto/agent.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/proto/history.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/proto/mcp.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.	mcp	server-api	no	yes	no	no
+internal/proto/message.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/proto/permission.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/proto/proto.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/proto/requests.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/proto/server.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/proto/session.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/proto/tools.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/proto/version.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/pubsub/broker.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/pubsub/events.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/server/config.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/server/events.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/server/logging.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/server/net_other.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/server/net_windows.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/server/proto.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/server/server.go	file	reviewed	HTTP or client/server surface that must remain while feature-specific endpoints shrink later.		server-api	no	yes	no	no
+internal/session/session.go	file	reviewed	Session persistence and state that must remain while todo support is removed.	todos	sessions-and-history	no	no	no	no
+internal/shell/background.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/shell/background_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/shell/command_block_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/shell/comparison_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/shell/coreutils.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/shell/doc.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/shell/shell.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/shell/shell_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/skills/builtin/crush-config/SKILL.md	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/skills/embed.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/skills/skills.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/skills/skills_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/stringext/string.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/swagger/docs.go	file	reviewed	Generated Swagger/OpenAPI artifacts that must remain except for removed-feature endpoints.		server-api;swagger-docs	no	yes	no	no
+internal/swagger/swagger.json	file	reviewed	Generated Swagger/OpenAPI artifacts that must remain except for removed-feature endpoints.		server-api;swagger-docs	no	yes	no	no
+internal/swagger/swagger.yaml	file	reviewed	Generated Swagger/OpenAPI artifacts that must remain except for removed-feature endpoints.		server-api;swagger-docs	no	yes	no	no
+internal/ui/AGENTS.md	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/anim/anim.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/attachments/attachments.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/chat/agent.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/assistant.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/bash.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/diagnostics.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/docker_mcp.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/fetch.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/file.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/generic.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/lsp_restart.go	file	reviewed	LSP integration or LSP-facing tool surface targeted for removal. TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	lsp;mcp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/mcp.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/messages.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/references.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/search.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/todos.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/tools.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/chat/user.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/common/button.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/common/capabilities.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/common/common.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/common/diff.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/common/elements.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/common/highlight.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/common/interface.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/common/markdown.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/common/scrollbar.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/completions/completions.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/completions/completions_test.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/completions/item.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/completions/keys.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/dialog/actions.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/api_key_input.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/arguments.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/commands.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/commands_item.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/common.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/dialog.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/filepicker.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/models.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/models_item.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/models_list.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/oauth.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/oauth_copilot.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/oauth_hyper.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/permissions.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/quit.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/reasoning.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/sessions.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/dialog/sessions_item.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/diffview/Taskfile.yaml	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/diffview/chroma.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/diffview/diffview.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/diffview/diffview_test.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/split.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/diffview/style.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/diffview/testdata/TestDefault.after	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDefault.before	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/CustomContextLines/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/CustomContextLines/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/Default/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/Default/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/LargeWidth/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/LargeWidth/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/MultipleHunks/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/MultipleHunks/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/Narrow/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/Narrow/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/NoLineNumbers/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/NoLineNumbers/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/NoSyntaxHighlight/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/NoSyntaxHighlight/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/SmallWidth/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Split/SmallWidth/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/CustomContextLines/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/CustomContextLines/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/Default/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/Default/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/LargeWidth/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/LargeWidth/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/MultipleHunks/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/MultipleHunks/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/Narrow/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/Narrow/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/NoLineNumbers/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/NoLineNumbers/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/NoSyntaxHighlight/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/NoSyntaxHighlight/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/SmallWidth/DarkMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffView/Unified/SmallWidth/LightMode.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf001.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf002.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf003.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf004.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf005.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf006.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf007.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf008.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf009.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf010.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf011.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf012.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf013.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf014.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf015.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf016.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf017.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf018.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf019.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Split/HeightOf020.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf001.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf002.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf003.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf004.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf005.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf006.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf007.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf008.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf009.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf010.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf011.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf012.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf013.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf014.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf015.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf016.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf017.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf018.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf019.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewHeight/Unified/HeightOf020.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewLineBreakIssue/Split.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewLineBreakIssue/Unified.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewTabs/Split.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewTabs/Unified.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf001.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf002.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf003.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf004.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf005.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf006.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf007.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf008.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf009.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf010.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf011.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf012.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf013.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf014.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf015.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf016.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf017.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf018.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf019.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf020.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf021.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf022.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf023.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf024.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf025.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf026.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf027.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf028.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf029.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf030.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf031.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf032.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf033.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf034.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf035.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf036.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf037.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf038.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf039.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf040.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf041.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf042.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf043.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf044.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf045.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf046.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf047.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf048.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf049.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf050.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf051.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf052.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf053.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf054.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf055.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf056.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf057.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf058.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf059.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf060.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf061.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf062.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf063.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf064.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf065.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf066.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf067.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf068.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf069.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf070.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf071.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf072.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf073.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf074.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf075.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf076.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf077.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf078.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf079.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf080.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf081.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf082.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf083.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf084.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf085.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf086.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf087.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf088.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf089.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf090.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf091.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf092.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf093.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf094.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf095.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf096.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf097.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf098.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf099.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf100.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf101.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf102.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf103.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf104.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf105.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf106.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf107.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf108.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf109.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Split/WidthOf110.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf001.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf002.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf003.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf004.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf005.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf006.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf007.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf008.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf009.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf010.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf011.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf012.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf013.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf014.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf015.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf016.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf017.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf018.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf019.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf020.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf021.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf022.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf023.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf024.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf025.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf026.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf027.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf028.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf029.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf030.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf031.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf032.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf033.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf034.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf035.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf036.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf037.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf038.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf039.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf040.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf041.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf042.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf043.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf044.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf045.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf046.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf047.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf048.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf049.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf050.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf051.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf052.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf053.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf054.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf055.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf056.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf057.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf058.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf059.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewWidth/Unified/WidthOf060.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf00.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf01.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf02.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf03.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf04.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf05.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf06.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf07.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf08.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf09.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf10.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf11.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf12.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf13.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf14.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf15.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf16.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf17.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf18.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf19.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Split/XOffsetOf20.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf00.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf01.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf02.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf03.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf04.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf05.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf06.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf07.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf08.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf09.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf10.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf11.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf12.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf13.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf14.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf15.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf16.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf17.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf18.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf19.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewXOffset/Unified/XOffsetOf20.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf00.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf01.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf02.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf03.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf04.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf05.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf06.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf07.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf08.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf09.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf10.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf11.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf12.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf13.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf14.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf15.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Split/YOffsetOf16.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf00.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf01.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf02.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf03.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf04.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf05.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf06.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf07.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf08.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf09.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf10.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf11.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf12.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf13.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf14.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf15.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffset/Unified/YOffsetOf16.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf00.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf01.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf02.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf03.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf04.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf05.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf06.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf07.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf08.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf09.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf10.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf11.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf12.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf13.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf14.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf15.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Split/YOffsetOf16.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf00.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf01.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf02.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf03.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf04.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf05.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf06.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf07.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf08.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf09.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf10.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf11.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf12.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf13.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf14.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf15.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestDiffViewYOffsetInfinite/Unified/YOffsetOf16.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestLineBreakIssue.after	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestLineBreakIssue.before	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestMultipleHunks.after	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestMultipleHunks.before	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestNarrow.after	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestNarrow.before	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestTabs.after	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestTabs.before	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestUdiff/ToUnifiedDiff/DefaultContextLines/Content.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestUdiff/ToUnifiedDiff/DefaultContextLines/JSON.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestUdiff/ToUnifiedDiff/DefaultContextLinesPlusOne/Content.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestUdiff/ToUnifiedDiff/DefaultContextLinesPlusOne/JSON.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestUdiff/ToUnifiedDiff/DefaultContextLinesPlusTwo/Content.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestUdiff/ToUnifiedDiff/DefaultContextLinesPlusTwo/JSON.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/testdata/TestUdiff/Unified.golden	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/udiff_test.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/diffview/util.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/diffview/util_test.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/image/image.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/image/image_test.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/list/filterable.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/list/focus.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/list/highlight.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/list/item.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/list/list.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/logo/logo.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/logo/rand.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/model/chat.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/clipboard.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/clipboard_not_supported.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/clipboard_supported.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/filter.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/header.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/history.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/keys.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/landing.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/layout_test.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	yes
+internal/ui/model/lsp.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/mcp.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/onboarding.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/pills.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/session.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/sidebar.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/status.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/ui.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	no
+internal/ui/model/ui_test.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures. UI affordances likely to change when removable features are stripped out.	mcp;lsp;sub-agents;todos;nix-home-manager		no	no	no	yes
+internal/ui/notification/crush-icon-solo.png	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/notification/crush-icon.png	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/notification/icon_darwin.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/notification/icon_other.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/notification/native.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/notification/noop.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/notification/notification.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/notification/notification_test.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances. UI tests or golden fixtures.			no	no	no	yes
+internal/ui/styles/grad.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/styles/styles.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/ui/util/util.go	file	reviewed	TUI surface for chat, settings, prompts, or feature affordances.			no	no	no	no
+internal/update/update.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/update/update_test.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	yes
+internal/version/version.go	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no
+internal/workspace/app_workspace.go	file	reviewed	Workspace/project service surface supporting kept session and API behavior.		server-api	no	no	no	no
+internal/workspace/client_workspace.go	file	reviewed	Workspace/project service surface supporting kept session and API behavior.		server-api	no	no	no	no
+internal/workspace/workspace.go	file	reviewed	Workspace/project service surface supporting kept session and API behavior.		server-api	no	no	no	no
+main.go	file	reviewed	Top-level dependency or entrypoint surface.			no	no	no	yes
+schema.json	file	reviewed	Configuration example or generated schema surface.			no	no	yes	yes
+scripts/check_log_capitalization.sh	file	reviewed	Build, lint, packaging, or repository tooling artifact.			no	no	no	yes
+scripts/run-labeler.sh	file	reviewed	Build, lint, packaging, or repository tooling artifact.			no	no	no	yes
+sqlc.yaml	file	reviewed	General repository surface reviewed for audit coverage.			no	no	no	no


### PR DESCRIPTION
# Remove remote research tools

- **Suggested branch:** `draft/remove-remote-research-tools`
- **Risk level:** `medium`

## Short summary
Remove `agentic_fetch`, `web_fetch`, `web_search`, `download`, and related optional remote-research/search helper surfaces used to pull external content into the agent loop.

## Why this is a removal candidate
The light variant explicitly must remove `web_fetch`, `web_search`, and `download`; grouping them with `agentic_fetch` keeps one coherent future PR around external-content acquisition.

## Why the chosen risk level applies
These tools are separate from core local-file tooling, but `agentic_fetch` shares sub-agent machinery and some prompt/template wiring. The code boundary is still clear.

## User-visible behavior affected
Users lose built-in remote search/fetch/download helpers and any agent flow that depends on them for web research.

## Code entrypoints
- `internal/agent/agentic_fetch_tool.go`
- `internal/agent/tools/download.go`
- `internal/agent/tools/web_fetch.go`
- `internal/agent/tools/web_search.go`

## Known touch points
- Files/packages: the tool implementations above, fetch helper/types files, coordinator tool registration, templates/agentic_fetch*
- Config: disabled-tools defaults/help text if these tools are advertised
- Docs/tests: tool markdown, README/help text, agent/tool testdata covering fetch/download/parallel tool calls
- API/server: none direct beyond generic agent execution
- UI: tool output rendering for remote research responses
- Persistence/data model: none specific

## Dependencies on kept features
Must preserve local `fetch`, `view`, `grep`, `glob`, and normal shell/file tools unless explicitly removed elsewhere.

## Things that must be preserved while removing it
Keep local repository inspection tools, the `sourcegraph` tool, and primary agent execution intact.

## Suggested removal order
After or alongside sub-agent removal; before fantasy replacement.

## Acceptance criteria for the future implementation PR
- No `agentic_fetch`, `web_fetch`, `web_search`, or `download` tools remain.
- Associated tool docs/tests/fixtures are removed or updated.
- No UI or README copy advertises remote research/download helpers.
- `sourcegraph` remains untouched for its own follow-up removal PR.
- Core local tools remain functional.

## Open questions / uncertainties
- None currently.


Read [Crush Light Audit](https://github.com/JTRNS/crush-light/blob/main/docs/crush-light-audit.md) for more background information on the overarching effort the pr is a part of.