### PR TITLE
feat(skills): add dialog to command palette

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -26,7 +26,6 @@ import (
 	"github.com/charmbracelet/crush/internal/event"
 	"github.com/charmbracelet/crush/internal/filetracker"
 	"github.com/charmbracelet/crush/internal/history"
-	"github.com/charmbracelet/crush/internal/home"
 	"github.com/charmbracelet/crush/internal/hooks"
 	"github.com/charmbracelet/crush/internal/log"
 	"github.com/charmbracelet/crush/internal/lsp"
@@ -76,6 +75,7 @@ type Coordinator interface {
 	Summarize(context.Context, string) error
 	Model() Model
 	UpdateModels(ctx context.Context) error
+	ReadSkill(ctx context.Context, skillID string) ([]byte, skills.SkillReadResult, error)
 }
 
 type coordinator struct {
@@ -990,6 +990,42 @@ func (c *coordinator) retryAfterUnauthorized(ctx context.Context, providerCfg co
 	}
 }
 
+// ReadSkill reads a skill's content by ID from the session-start
+// snapshot and marks it as loaded in the skill tracker.
+func (c *coordinator) ReadSkill(_ context.Context, skillID string) ([]byte, skills.SkillReadResult, error) {
+	for _, skill := range c.activeSkills {
+		if skill.SkillFilePath != skillID {
+			continue
+		}
+
+		var content []byte
+		var err error
+		if skill.Builtin {
+			embeddedPath := "builtin/" + strings.TrimPrefix(skill.SkillFilePath, skills.BuiltinPrefix)
+			content, err = skills.BuiltinFS().ReadFile(embeddedPath)
+			if err != nil {
+				return nil, skills.SkillReadResult{}, fmt.Errorf("read builtin skill %q: %w", skillID, err)
+			}
+		} else {
+			content, err = os.ReadFile(skill.SkillFilePath)
+			if err != nil {
+				return nil, skills.SkillReadResult{}, fmt.Errorf("read skill %q: %w", skillID, err)
+			}
+		}
+
+		c.skillTracker.MarkLoaded(skill.Name)
+
+		result := skills.SkillReadResult{
+			Name:        skill.Name,
+			Description: skill.Description,
+			Builtin:     skill.Builtin,
+		}
+		return content, result, nil
+	}
+
+	return nil, skills.SkillReadResult{}, fmt.Errorf("%w: %s", skills.ErrSkillNotFound, skillID)
+}
+
 func (c *coordinator) isUnauthorized(err error) bool {
 	var providerErr *fantasy.ProviderError
 	return errors.As(err, &providerErr) && providerErr.StatusCode == http.StatusUnauthorized
@@ -1114,38 +1150,7 @@ func (c *coordinator) updateParentSessionCost(ctx context.Context, childSessionI
 // It also emits a single diagnostic log line summarising the outcome to
 // help track skill-loading health over time.
 func discoverSkills(cfg *config.ConfigStore) (allSkills, activeSkills []*skills.Skill) {
-	builtin, builtinStates := skills.DiscoverBuiltinWithStates()
-	discovered := append([]*skills.Skill(nil), builtin...)
-
-	var userStates []*skills.SkillState
-	var userPaths []string
-
-	opts := cfg.Config().Options
-	if opts != nil && len(opts.SkillsPaths) > 0 {
-		userPaths = make([]string, 0, len(opts.SkillsPaths))
-		for _, pth := range opts.SkillsPaths {
-			expanded := home.Long(pth)
-			if strings.HasPrefix(expanded, "$") {
-				if resolved, err := cfg.Resolver().ResolveValue(expanded); err == nil {
-					expanded = resolved
-				}
-			}
-			userPaths = append(userPaths, expanded)
-		}
-		var userSkills []*skills.Skill
-		userSkills, userStates = skills.DiscoverWithStates(userPaths)
-		discovered = append(discovered, userSkills...)
-	}
-
-	allSkills = skills.Deduplicate(discovered)
-	var disabledSkills []string
-	if opts != nil {
-		disabledSkills = opts.DisabledSkills
-	}
-	activeSkills = skills.Filter(allSkills, disabledSkills)
-
-	logDiscoveryStats(builtin, builtinStates, userStates, userPaths, allSkills, activeSkills, disabledSkills)
-	return allSkills, activeSkills
+	return skills.All(cfg), skills.Effective(cfg)
 }
 
 // logTurnSkillUsage emits a per-turn diagnostic line showing which skills
@@ -1186,55 +1191,5 @@ func logTurnSkillUsage(
 		"active_total", len(activeSkills),
 		"loaded_total", len(after),
 		"loaded_this_turn", loadedThisTurn,
-	)
-}
-
-// logDiscoveryStats emits a single structured log line summarising skill
-// discovery for the current session. It is intentionally low-volume: one
-// line per session start.
-func logDiscoveryStats(
-	builtin []*skills.Skill,
-	builtinStates, userStates []*skills.SkillState,
-	userPaths []string,
-	allSkills, activeSkills []*skills.Skill,
-	disabled []string,
-) {
-	countErrors := func(states []*skills.SkillState) int {
-		n := 0
-		for _, s := range states {
-			if s.State == skills.StateError {
-				n++
-			}
-		}
-		return n
-	}
-
-	userOK := 0
-	for _, s := range userStates {
-		if s.State == skills.StateNormal {
-			userOK++
-		}
-	}
-
-	activeNames := make([]string, 0, len(activeSkills))
-	for _, s := range activeSkills {
-		activeNames = append(activeNames, s.Name)
-	}
-
-	xml := skills.ToPromptXML(activeSkills)
-
-	slog.Info("Skill discovery complete",
-		"component", "skills",
-		"builtin_ok", len(builtin),
-		"builtin_errors", countErrors(builtinStates),
-		"user_ok", userOK,
-		"user_errors", countErrors(userStates),
-		"user_paths", len(userPaths),
-		"deduped_total", len(allSkills),
-		"active", len(activeSkills),
-		"disabled", len(disabled),
-		"prompt_bytes", len(xml),
-		"prompt_tok_est", skills.ApproxTokenCount(xml),
-		"active_names", activeNames,
 	)
 }

--- a/internal/agent/prompt/prompt.go
+++ b/internal/agent/prompt/prompt.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -168,33 +167,7 @@ func (p *Prompt) promptData(ctx context.Context, provider, model string, store *
 
 	// Discover and load skills metadata.
 	var availSkillXML string
-
-	// Start with builtin skills.
-	allSkills := skills.DiscoverBuiltin()
-	builtinNames := make(map[string]bool, len(allSkills))
-	for _, s := range allSkills {
-		builtinNames[s.Name] = true
-	}
-
-	// Discover user skills from configured paths.
-	if len(cfg.Options.SkillsPaths) > 0 {
-		expandedPaths := make([]string, 0, len(cfg.Options.SkillsPaths))
-		for _, pth := range cfg.Options.SkillsPaths {
-			expandedPaths = append(expandedPaths, expandPath(pth, store))
-		}
-		for _, userSkill := range skills.Discover(expandedPaths) {
-			if builtinNames[userSkill.Name] {
-				slog.Warn("User skill overrides builtin skill", "name", userSkill.Name)
-			}
-			allSkills = append(allSkills, userSkill)
-		}
-	}
-
-	// Deduplicate: user skills override builtins with the same name.
-	allSkills = skills.Deduplicate(allSkills)
-
-	// Filter out disabled skills.
-	allSkills = skills.Filter(allSkills, cfg.Options.DisabledSkills)
+	allSkills := skills.Effective(store)
 
 	if len(allSkills) > 0 {
 		availSkillXML = skills.ToPromptXML(allSkills)

--- a/internal/agent/prompt/prompt_test.go
+++ b/internal/agent/prompt/prompt_test.go
@@ -1,0 +1,82 @@
+package prompt
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildInjectsSkillsIntoPrompt(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	cfg, err := config.Init(workingDir, "", false)
+	require.NoError(t, err)
+
+	skillRoot := t.TempDir()
+	skillDir := filepath.Join(skillRoot, "example-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: example-skill
+description: Example description.
+---
+Use this skill carefully.
+`), 0o644))
+	cfg.Config().Options.SkillsPaths = []string{skillRoot}
+
+	templateBytes, err := os.ReadFile(filepath.Join("..", "templates", "coder.md.tpl"))
+	require.NoError(t, err)
+
+	p, err := NewPrompt("coder", string(templateBytes))
+	require.NoError(t, err)
+
+	output, err := p.Build(context.Background(), "anthropic", "claude-sonnet-4-5", cfg)
+	require.NoError(t, err)
+	require.Contains(t, output, "<available_skills>")
+	require.Contains(t, output, "example-skill")
+	require.Contains(t, output, "<skills_usage>")
+}
+
+// Not parallel: test calls os.Chdir which affects the whole process.
+func TestBuildRelativeSkillsPathsResolveToCWD(t *testing.T) {
+	workingDir := t.TempDir()
+	cfg, err := config.Init(workingDir, "", false)
+	require.NoError(t, err)
+
+	skillDir := filepath.Join(workingDir, "project-skills", "example-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: example-skill
+description: Example description.
+---
+Use this project skill carefully.
+`), 0o644))
+	cfg.Config().Options.SkillsPaths = []string{"./project-skills"}
+	templateBytes, err := os.ReadFile(filepath.Join("..", "templates", "coder.md.tpl"))
+	require.NoError(t, err)
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	otherDir := t.TempDir()
+	require.NoError(t, os.Chdir(otherDir))
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Errorf("Failed to restore working directory: %v", err)
+		}
+	})
+
+	p, err := NewPrompt("coder", string(templateBytes))
+	require.NoError(t, err)
+
+	// Relative paths resolve against CWD (otherDir), not WorkingDir.
+	// Since the skill files live under workingDir, they should not
+	// appear in the prompt when CWD is otherDir.
+	output, err := p.Build(context.Background(), "anthropic", "claude-sonnet-4-5", cfg)
+	require.NoError(t, err)
+	require.NotContains(t, output, "example-skill",
+		"relative skills_paths should resolve against CWD, not WorkingDir")
+}

--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -10,6 +10,8 @@ import (
 	"github.com/charmbracelet/crush/internal/commands"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/charmbracelet/crush/internal/proto"
+	"github.com/charmbracelet/crush/internal/skills"
 )
 
 // MCPResourceContents holds the contents of an MCP resource returned
@@ -114,6 +116,48 @@ func (b *Backend) InitializePrompt(workspaceID string) (string, error) {
 		return "", err
 	}
 	return agent.InitializePrompt(ws.Cfg)
+}
+
+// ReadSkill reads a skill's content by ID, delegating to the
+// coordinator so that the skill tracker is updated.
+func (b *Backend) ReadSkill(ctx context.Context, workspaceID, skillID string) ([]byte, proto.SkillReadResult, error) {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return nil, proto.SkillReadResult{}, err
+	}
+	if ws.AgentCoordinator == nil {
+		return nil, proto.SkillReadResult{}, errors.New("agent coordinator not initialized")
+	}
+	content, result, err := ws.AgentCoordinator.ReadSkill(ctx, skillID)
+	if err != nil {
+		return nil, proto.SkillReadResult{}, err
+	}
+	return content, proto.SkillReadResult{
+		Name:        result.Name,
+		Description: result.Description,
+		Source:      string(result.Source),
+		Builtin:     result.Builtin,
+	}, nil
+}
+
+// ListSkills returns the effective visible skills for a workspace.
+func (b *Backend) ListSkills(workspaceID string) ([]proto.SkillInfo, error) {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	entries := skills.Catalog(ws.Cfg)
+	result := make([]proto.SkillInfo, len(entries))
+	for i, entry := range entries {
+		result[i] = proto.SkillInfo{
+			ID:          entry.ID,
+			Name:        entry.Name,
+			Description: entry.Description,
+			Label:       entry.Label,
+			Source:      string(entry.Source),
+		}
+	}
+	return result, nil
 }
 
 // EnableDockerMCP validates Docker MCP availability, stages the

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/charmbracelet/crush/internal/proto"
 )
 
 // SetConfigField sets a config key/value pair on the server.
@@ -183,6 +184,42 @@ func (c *Client) GetInitializePrompt(ctx context.Context, id string) (string, er
 		return "", fmt.Errorf("failed to decode init prompt response: %w", err)
 	}
 	return result.Prompt, nil
+}
+
+// ListSkills retrieves the visible skills for a workspace.
+func (c *Client) ListSkills(ctx context.Context, id string) ([]proto.SkillInfo, error) {
+	rsp, err := c.get(ctx, fmt.Sprintf("/workspaces/%s/skills", id), nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list skills: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list skills: status code %d", rsp.StatusCode)
+	}
+	var skills []proto.SkillInfo
+	if err := json.NewDecoder(rsp.Body).Decode(&skills); err != nil {
+		return nil, fmt.Errorf("failed to decode skills: %w", err)
+	}
+	return skills, nil
+}
+
+// ReadSkill reads a skill's content by ID from the server.
+func (c *Client) ReadSkill(ctx context.Context, id, skillID string) (*proto.ReadSkillResponse, error) {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/skills/read", id), nil, jsonBody(proto.ReadSkillRequest{
+		SkillID: skillID,
+	}), http.Header{"Content-Type": []string{"application/json"}})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read skill: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to read skill: status code %d", rsp.StatusCode)
+	}
+	var result proto.ReadSkillResponse
+	if err := json.NewDecoder(rsp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode skill response: %w", err)
+	}
+	return &result, nil
 }
 
 // MCPResourceContents holds the contents of an MCP resource.

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -28,6 +28,35 @@ type Error struct {
 	Message string `json:"message"`
 }
 
+// SkillInfo describes a visible skill exposed to a frontend.
+type SkillInfo struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Label       string `json:"label"`
+	Source      string `json:"source"`
+}
+
+// ReadSkillRequest is the request body for reading a skill's content.
+type ReadSkillRequest struct {
+	SkillID string `json:"skill_id"`
+}
+
+// ReadSkillResponse is the response for reading a skill's content.
+type ReadSkillResponse struct {
+	Content []byte          `json:"content"`
+	Result  SkillReadResult `json:"result"`
+}
+
+// SkillReadResult holds metadata about a skill returned alongside its
+// content.
+type SkillReadResult struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Source      string `json:"source"`
+	Builtin     bool   `json:"builtin"`
+}
+
 // AgentInfo represents information about the agent.
 type AgentInfo struct {
 	IsBusy   bool                 `json:"is_busy"`

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -259,6 +259,57 @@ func (c *controllerV1) handleGetWorkspaceProjectInitPrompt(w http.ResponseWriter
 	jsonEncode(w, proto.ProjectInitPromptResponse{Prompt: prompt})
 }
 
+// handleGetWorkspaceSkills returns the effective visible skills for a workspace.
+//
+//	@Summary		List visible skills
+//	@Tags			skills
+//	@Produce		json
+//	@Param			id	path		string			true	"Workspace ID"
+//	@Success		200	{array}		proto.SkillInfo
+//	@Failure		404	{object}	proto.Error
+//	@Failure		500	{object}	proto.Error
+//	@Router			/workspaces/{id}/skills [get]
+func (c *controllerV1) handleGetWorkspaceSkills(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	skills, err := c.backend.ListSkills(id)
+	if err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	jsonEncode(w, skills)
+}
+
+// handlePostWorkspaceSkillRead reads a skill's content by ID.
+//
+//	@Summary		Read skill content
+//	@Tags			skills
+//	@Accept			json
+//	@Produce		json
+//	@Param			id		path		string					true	"Workspace ID"
+//	@Param			request	body		proto.ReadSkillRequest	true	"Read skill request"
+//	@Success		200		{object}	proto.ReadSkillResponse
+//	@Failure		400		{object}	proto.Error
+//	@Failure		404		{object}	proto.Error
+//	@Failure		500		{object}	proto.Error
+//	@Router			/workspaces/{id}/skills/read [post]
+func (c *controllerV1) handlePostWorkspaceSkillRead(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	var req proto.ReadSkillRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		c.server.logError(r, "Failed to decode request", "error", err)
+		jsonError(w, http.StatusBadRequest, "failed to decode request")
+		return
+	}
+
+	content, result, err := c.backend.ReadSkill(r.Context(), id, req.SkillID)
+	if err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	jsonEncode(w, proto.ReadSkillResponse{Content: content, Result: result})
+}
+
 // handlePostWorkspaceMCPEnableDocker enables the Docker MCP server.
 //
 //	@Summary		Enable Docker MCP

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -157,6 +157,8 @@ func NewServer(cfg *config.ConfigStore, network, address string) *Server {
 	mux.HandleFunc("GET /v1/workspaces/{id}/project/needs-init", c.handleGetWorkspaceProjectNeedsInit)
 	mux.HandleFunc("POST /v1/workspaces/{id}/project/init", c.handlePostWorkspaceProjectInit)
 	mux.HandleFunc("GET /v1/workspaces/{id}/project/init-prompt", c.handleGetWorkspaceProjectInitPrompt)
+	mux.HandleFunc("GET /v1/workspaces/{id}/skills", c.handleGetWorkspaceSkills)
+	mux.HandleFunc("POST /v1/workspaces/{id}/skills/read", c.handlePostWorkspaceSkillRead)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-tools", c.handlePostWorkspaceMCPRefreshTools)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/read-resource", c.handlePostWorkspaceMCPReadResource)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/get-prompt", c.handlePostWorkspaceMCPGetPrompt)

--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -337,3 +337,15 @@ When multiple hooks match, their decisions are aggregated:
 - `CRUSH_GLOBAL_CONFIG` - Override global config location
 - `CRUSH_GLOBAL_DATA` - Override data directory location
 - `CRUSH_SKILLS_DIR` - Override default skills directory
+
+## Viewing docs for the running version
+
+```bash
+crush -v | head -1
+```
+
+This prints something like `crush version VERSION`. Use the version and agentic fetch to get info for the current version when needed.
+
+```
+https://raw.githubusercontent.com/charmbracelet/crush/refs/tags/VERSION/README.md
+```

--- a/internal/skills/catalog.go
+++ b/internal/skills/catalog.go
@@ -1,0 +1,264 @@
+package skills
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/home"
+)
+
+// DiscoverySource provides the configuration surface needed to resolve and
+// discover skills for a workspace.
+type DiscoverySource interface {
+	Config() *config.Config
+	WorkingDir() string
+	Resolver() config.VariableResolver
+}
+
+// SourceType describes where a visible skill comes from.
+type SourceType string
+
+const (
+	SourceSystem  SourceType = "system"
+	SourceUser    SourceType = "user"
+	SourceProject SourceType = "project"
+)
+
+// CatalogEntry describes an effective visible skill.
+type CatalogEntry struct {
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Label       string     `json:"label"`
+	Source      SourceType `json:"source"`
+}
+
+// SkillReadResult holds metadata about a skill returned alongside its
+// content.
+type SkillReadResult struct {
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Source      SourceType `json:"source"`
+	Builtin     bool       `json:"builtin"`
+}
+
+// ErrSkillNotFound is returned when a skill ID is not part of the effective
+// visible skill set.
+var ErrSkillNotFound = errors.New("skill not found")
+
+// ResolvePath expands home directory references and environment variables in a
+// configured skill path. Relative paths are left relative to the process CWD.
+func ResolvePath(src DiscoverySource, path string) string {
+	resolved := home.Long(path)
+	if src != nil && src.Resolver() != nil && strings.Contains(resolved, "$") {
+		expanded, err := src.Resolver().ResolveValue(resolved)
+		if err != nil {
+			slog.Debug("Failed to resolve variables in skill path",
+				"path", resolved, "error", err)
+		} else {
+			resolved = expanded
+		}
+	}
+	return filepath.Clean(resolved)
+}
+
+// ExpandedPaths returns the configured skill roots after applying workspace-
+// relative resolution.
+func ExpandedPaths(src DiscoverySource) []string {
+	if src == nil || src.Config() == nil || src.Config().Options == nil {
+		return nil
+	}
+
+	paths := make([]string, 0, len(src.Config().Options.SkillsPaths))
+	for _, pth := range src.Config().Options.SkillsPaths {
+		paths = append(paths, ResolvePath(src, pth))
+	}
+	return paths
+}
+
+// All returns the full discovered skill set for a workspace after dedup but
+// before disabled-skill filtering. This is the pre-filter list used by the
+// coordinator to feed the skill tracker.
+func All(src DiscoverySource) []*Skill {
+	all, _, _ := effective(src)
+	return all
+}
+
+// Effective returns the visible skill set for a workspace, matching prompt
+// construction semantics: builtin skills, then user/project discovery, then
+// user-over-builtin deduplication, then disabled skill filtering.
+func Effective(src DiscoverySource) []*Skill {
+	_, active, _ := effective(src)
+	return active
+}
+
+// effective is the shared implementation that returns the pre-filter
+// (all) list, the post-filter (active) list, and the expanded paths
+// used during discovery.
+func effective(src DiscoverySource) (all, active []*Skill, paths []string) {
+	allSkills := DiscoverBuiltin()
+	builtinNames := make(map[string]bool, len(allSkills))
+	for _, skill := range allSkills {
+		builtinNames[skill.Name] = true
+	}
+
+	paths = ExpandedPaths(src)
+	userSkills := Discover(paths)
+	sortDiscoveredSkills(paths, userSkills)
+	for _, userSkill := range userSkills {
+		if builtinNames[userSkill.Name] {
+			slog.Warn("User skill overrides builtin skill", "name", userSkill.Name)
+		}
+		allSkills = append(allSkills, userSkill)
+	}
+
+	allSkills = Deduplicate(allSkills)
+
+	if src == nil || src.Config() == nil || src.Config().Options == nil {
+		return allSkills, allSkills, paths
+	}
+	return allSkills, Filter(allSkills, src.Config().Options.DisabledSkills), paths
+}
+
+// Catalog returns the effective visible skills formatted for frontend display.
+func Catalog(src DiscoverySource) []CatalogEntry {
+	_, resolved, skillPaths := effective(src)
+	entries := make([]CatalogEntry, 0, len(resolved))
+	workingDir := ""
+	if src != nil {
+		workingDir = src.WorkingDir()
+	}
+
+	for _, skill := range resolved {
+		label, source := skillLabel(skillPaths, workingDir, skill)
+		entries = append(entries, CatalogEntry{
+			ID:          skill.SkillFilePath,
+			Name:        skill.Name,
+			Description: skill.Description,
+			Label:       label,
+			Source:      source,
+		})
+	}
+
+	return entries
+}
+
+// FindEffective returns the visible skill with the given ID.
+func FindEffective(src DiscoverySource, skillID string) (*Skill, error) {
+	for _, skill := range Effective(src) {
+		if skill.SkillFilePath == skillID {
+			return skill, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: %s", ErrSkillNotFound, skillID)
+}
+
+// ReadContent reads the contents of a visible skill by ID and returns
+// the raw bytes along with metadata about the skill.
+func ReadContent(src DiscoverySource, skillID string) ([]byte, SkillReadResult, error) {
+	skill, err := FindEffective(src, skillID)
+	if err != nil {
+		return nil, SkillReadResult{}, err
+	}
+
+	result := SkillReadResult{
+		Name:        skill.Name,
+		Description: skill.Description,
+		Builtin:     skill.Builtin,
+	}
+
+	if skill.Builtin {
+		embeddedPath := "builtin/" + strings.TrimPrefix(skill.SkillFilePath, BuiltinPrefix)
+		content, err := BuiltinFS().ReadFile(embeddedPath)
+		if err != nil {
+			return nil, SkillReadResult{}, fmt.Errorf("read builtin skill %q: %w", skillID, err)
+		}
+		return content, result, nil
+	}
+
+	content, err := os.ReadFile(skill.SkillFilePath)
+	if err != nil {
+		return nil, SkillReadResult{}, fmt.Errorf("read skill %q: %w", skillID, err)
+	}
+	return content, result, nil
+}
+
+func skillLabel(skillPaths []string, workingDir string, skill *Skill) (string, SourceType) {
+	if skill.Builtin {
+		return string(SourceSystem) + ":" + skill.Name, SourceSystem
+	}
+
+	cleanFile := filepath.Clean(skill.SkillFilePath)
+	for _, base := range skillPaths {
+		cleanBase := filepath.Clean(base)
+		rel, err := filepath.Rel(cleanBase, cleanFile)
+		if err != nil || escapesParent(rel) {
+			continue
+		}
+
+		source := SourceUser
+		prefix := string(SourceUser) + ":"
+		if isProjectSkillPath(cleanBase, workingDir) {
+			source = SourceProject
+			prefix = string(SourceProject) + ":"
+		}
+		return prefix + filepath.Base(filepath.Dir(cleanFile)), source
+	}
+
+	// Fallback: use the parent directory name rather than the full path
+	// so internal directory structure is not exposed to the UI.
+	return string(SourceUser) + ":" + filepath.Base(filepath.Dir(cleanFile)), SourceUser
+}
+
+func escapesParent(rel string) bool {
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func isProjectSkillPath(basePath, workingDir string) bool {
+	if workingDir == "" {
+		return false
+	}
+	absBase, err := filepath.Abs(basePath)
+	if err != nil {
+		return false
+	}
+	absWD, err := filepath.Abs(workingDir)
+	if err != nil {
+		return false
+	}
+	cleanBase := filepath.Clean(absBase)
+	cleanWD := filepath.Clean(absWD)
+	rel, err := filepath.Rel(cleanWD, cleanBase)
+	if err != nil {
+		return false
+	}
+	return !escapesParent(rel)
+}
+
+func sortDiscoveredSkills(skillPaths []string, discovered []*Skill) {
+	sort.SliceStable(discovered, func(i, j int) bool {
+		rootI := matchingSkillRootIndex(skillPaths, discovered[i].SkillFilePath)
+		rootJ := matchingSkillRootIndex(skillPaths, discovered[j].SkillFilePath)
+		if rootI != rootJ {
+			return rootI < rootJ
+		}
+		return filepath.Clean(discovered[i].SkillFilePath) < filepath.Clean(discovered[j].SkillFilePath)
+	})
+}
+
+func matchingSkillRootIndex(skillPaths []string, skillFilePath string) int {
+	cleanFile := filepath.Clean(skillFilePath)
+	for i, root := range skillPaths {
+		rel, err := filepath.Rel(filepath.Clean(root), cleanFile)
+		if err == nil && !escapesParent(rel) {
+			return i
+		}
+	}
+	return len(skillPaths)
+}

--- a/internal/skills/catalog_test.go
+++ b/internal/skills/catalog_test.go
@@ -1,0 +1,158 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type testDiscoverySource struct {
+	cfg        *config.Config
+	workingDir string
+	resolver   config.VariableResolver
+}
+
+func (s *testDiscoverySource) Config() *config.Config {
+	return s.cfg
+}
+
+func (s *testDiscoverySource) WorkingDir() string {
+	return s.workingDir
+}
+
+func (s *testDiscoverySource) Resolver() config.VariableResolver {
+	return s.resolver
+}
+
+// Not parallel: test calls os.Chdir which affects the whole process.
+func TestCatalogRelativeSkillsPathsResolveToCWD(t *testing.T) {
+	workingDir := t.TempDir()
+	createTestSkill(t, filepath.Join(workingDir, "project-skills", "example-skill"), "example-skill", "Project skill.", "project instructions")
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	otherDir := t.TempDir()
+	require.NoError(t, os.Chdir(otherDir))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chdir(wd))
+	})
+
+	// Relative paths resolve against CWD (otherDir), not WorkingDir.
+	// Since the skill files live under workingDir, they should not be
+	// found when CWD is otherDir.
+	entries := Catalog(&testDiscoverySource{
+		cfg:        &config.Config{Options: &config.Options{SkillsPaths: []string{"./project-skills"}}},
+		workingDir: workingDir,
+		resolver:   config.IdentityResolver(),
+	})
+
+	for _, entry := range entries {
+		require.NotEqual(t, "example-skill", entry.Name,
+			"relative skills_paths should resolve against CWD, not WorkingDir")
+	}
+}
+
+func TestEffectiveDeduplicatesAndFiltersVisibleSkills(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	skillsRoot := filepath.Join(workingDir, "skills")
+	createTestSkill(t, filepath.Join(skillsRoot, "crush-config"), "crush-config", "User override.", "override instructions")
+	createTestSkill(t, filepath.Join(skillsRoot, "hidden-skill"), "hidden-skill", "Hidden skill.", "hidden instructions")
+
+	effective := Effective(&testDiscoverySource{
+		cfg: &config.Config{Options: &config.Options{
+			SkillsPaths:    []string{skillsRoot},
+			DisabledSkills: []string{"hidden-skill"},
+		}},
+		workingDir: workingDir,
+		resolver:   config.IdentityResolver(),
+	})
+
+	var crushConfig *Skill
+	for _, skill := range effective {
+		require.NotEqual(t, "hidden-skill", skill.Name)
+		if skill.Name == "crush-config" {
+			crushConfig = skill
+		}
+	}
+
+	require.NotNil(t, crushConfig)
+	require.False(t, crushConfig.Builtin)
+	require.Equal(t, filepath.Join(skillsRoot, "crush-config", SkillFileName), crushConfig.SkillFilePath)
+	require.Equal(t, "User override.", crushConfig.Description)
+}
+
+func TestReadContentUsesEffectiveSkillIDs(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	skillsRoot := filepath.Join(workingDir, "skills")
+	userSkillPath := createTestSkill(t, filepath.Join(skillsRoot, "crush-config"), "crush-config", "User override.", "override instructions")
+
+	src := &testDiscoverySource{
+		cfg:        &config.Config{Options: &config.Options{SkillsPaths: []string{skillsRoot}}},
+		workingDir: workingDir,
+		resolver:   config.IdentityResolver(),
+	}
+
+	content, result, err := ReadContent(src, userSkillPath)
+	require.NoError(t, err)
+	require.Contains(t, string(content), "override instructions")
+	require.Equal(t, "crush-config", result.Name)
+	require.False(t, result.Builtin)
+
+	_, _, err = ReadContent(src, BuiltinPrefix+"crush-config/SKILL.md")
+	require.ErrorIs(t, err, ErrSkillNotFound)
+
+	_, _, err = ReadContent(&testDiscoverySource{cfg: &config.Config{Options: &config.Options{DisabledSkills: []string{"crush-config"}}}}, BuiltinPrefix+"crush-config/SKILL.md")
+	require.ErrorIs(t, err, ErrSkillNotFound)
+}
+
+func TestEffectiveUsesStableConfiguredRootPrecedence(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	rootA := filepath.Join(workingDir, "skills-a")
+	rootB := filepath.Join(workingDir, "skills-b")
+	pathA := createTestSkill(t, filepath.Join(rootA, "shared-skill"), "shared-skill", "Root A skill.", "root a instructions")
+	pathB := createTestSkill(t, filepath.Join(rootB, "shared-skill"), "shared-skill", "Root B skill.", "root b instructions")
+
+	src := &testDiscoverySource{
+		cfg:        &config.Config{Options: &config.Options{SkillsPaths: []string{rootA, rootB}}},
+		workingDir: workingDir,
+		resolver:   config.IdentityResolver(),
+	}
+
+	for range 5 {
+		effective := Effective(src)
+		var shared *Skill
+		for _, skill := range effective {
+			if skill.Name == "shared-skill" {
+				shared = skill
+				break
+			}
+		}
+		require.NotNil(t, shared)
+		require.Equal(t, pathB, shared.SkillFilePath)
+
+		content, _, err := ReadContent(src, pathB)
+		require.NoError(t, err)
+		require.Contains(t, string(content), "root b instructions")
+
+		_, _, err = ReadContent(src, pathA)
+		require.ErrorIs(t, err, ErrSkillNotFound)
+	}
+}
+
+func createTestSkill(t *testing.T, dir, name, description, instructions string) string {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, SkillFileName)
+	content := "---\nname: " + name + "\ndescription: " + description + "\n---\n" + instructions + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}

--- a/internal/swagger/docs.go
+++ b/internal/swagger/docs.go
@@ -1418,6 +1418,74 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaces/{id}/mcp/docker/disable": {
+            "post": {
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Disable Docker MCP",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/mcp/docker/enable": {
+            "post": {
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Enable Docker MCP",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/mcp/get-prompt": {
             "post": {
                 "consumes": [
@@ -2519,6 +2587,107 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/workspaces/{id}/skills": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "List visible skills",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/proto.SkillInfo"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/skills/read": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Read skill content",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Read skill request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.ReadSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.ReadSkillResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -2745,17 +2914,6 @@ const docTemplate = `{
                 }
             }
         },
-        "config.Scope": {
-            "type": "integer",
-            "enum": [
-                0,
-                1
-            ],
-            "x-enum-varnames": [
-                "ScopeGlobal",
-                "ScopeWorkspace"
-            ]
-        },
         "config.SelectedModel": {
             "type": "object",
             "properties": {
@@ -2963,6 +3121,12 @@ const docTemplate = `{
                 "disable_provider_auto_update": {
                     "type": "boolean"
                 },
+                "disabled_skills": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "disabled_tools": {
                     "type": "array",
                     "items": {
@@ -2985,6 +3149,17 @@ const docTemplate = `{
                     "$ref": "#/definitions/config.TUIOptions"
                 }
             }
+        },
+        "github_com_charmbracelet_crush_internal_config.Scope": {
+            "type": "integer",
+            "enum": [
+                0,
+                1
+            ],
+            "x-enum-varnames": [
+                "ScopeGlobal",
+                "ScopeWorkspace"
+            ]
         },
         "github_com_charmbracelet_crush_internal_proto.Message": {
             "type": "object",
@@ -3134,7 +3309,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3148,7 +3323,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/config.SelectedModelType"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3160,7 +3335,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3171,7 +3346,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3182,7 +3357,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3193,7 +3368,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 },
                 "value": {}
             }
@@ -3451,6 +3626,28 @@ const docTemplate = `{
                 }
             }
         },
+        "proto.ReadSkillRequest": {
+            "type": "object",
+            "properties": {
+                "skill_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.ReadSkillResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "result": {
+                    "$ref": "#/definitions/proto.SkillReadResult"
+                }
+            }
+        },
         "proto.ServerControl": {
             "type": "object",
             "properties": {
@@ -3491,6 +3688,43 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "integer"
+                }
+            }
+        },
+        "proto.SkillInfo": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.SkillReadResult": {
+            "type": "object",
+            "properties": {
+                "builtin": {
+                    "type": "boolean"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/swagger/swagger.json
+++ b/internal/swagger/swagger.json
@@ -1411,6 +1411,74 @@
                 }
             }
         },
+        "/workspaces/{id}/mcp/docker/disable": {
+            "post": {
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Disable Docker MCP",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/mcp/docker/enable": {
+            "post": {
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Enable Docker MCP",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/mcp/get-prompt": {
             "post": {
                 "consumes": [
@@ -2512,6 +2580,107 @@
                     }
                 }
             }
+        },
+        "/workspaces/{id}/skills": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "List visible skills",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/proto.SkillInfo"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/skills/read": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Read skill content",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Read skill request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.ReadSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.ReadSkillResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -2738,17 +2907,6 @@
                 }
             }
         },
-        "config.Scope": {
-            "type": "integer",
-            "enum": [
-                0,
-                1
-            ],
-            "x-enum-varnames": [
-                "ScopeGlobal",
-                "ScopeWorkspace"
-            ]
-        },
         "config.SelectedModel": {
             "type": "object",
             "properties": {
@@ -2956,6 +3114,12 @@
                 "disable_provider_auto_update": {
                     "type": "boolean"
                 },
+                "disabled_skills": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "disabled_tools": {
                     "type": "array",
                     "items": {
@@ -2978,6 +3142,17 @@
                     "$ref": "#/definitions/config.TUIOptions"
                 }
             }
+        },
+        "github_com_charmbracelet_crush_internal_config.Scope": {
+            "type": "integer",
+            "enum": [
+                0,
+                1
+            ],
+            "x-enum-varnames": [
+                "ScopeGlobal",
+                "ScopeWorkspace"
+            ]
         },
         "github_com_charmbracelet_crush_internal_proto.Message": {
             "type": "object",
@@ -3127,7 +3302,7 @@
                     "type": "boolean"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3141,7 +3316,7 @@
                     "$ref": "#/definitions/config.SelectedModelType"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3153,7 +3328,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3164,7 +3339,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3175,7 +3350,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3186,7 +3361,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 },
                 "value": {}
             }
@@ -3444,6 +3619,28 @@
                 }
             }
         },
+        "proto.ReadSkillRequest": {
+            "type": "object",
+            "properties": {
+                "skill_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.ReadSkillResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "result": {
+                    "$ref": "#/definitions/proto.SkillReadResult"
+                }
+            }
+        },
         "proto.ServerControl": {
             "type": "object",
             "properties": {
@@ -3484,6 +3681,43 @@
                 },
                 "updated_at": {
                     "type": "integer"
+                }
+            }
+        },
+        "proto.SkillInfo": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.SkillReadResult": {
+            "type": "object",
+            "properties": {
+                "builtin": {
+                    "type": "boolean"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/swagger/swagger.yaml
+++ b/internal/swagger/swagger.yaml
@@ -149,14 +149,6 @@ definitions:
           type: string
         type: array
     type: object
-  config.Scope:
-    enum:
-    - 0
-    - 1
-    type: integer
-    x-enum-varnames:
-    - ScopeGlobal
-    - ScopeWorkspace
   config.SelectedModel:
     properties:
       frequency_penalty:
@@ -303,6 +295,10 @@ definitions:
         type: boolean
       disable_provider_auto_update:
         type: boolean
+      disabled_skills:
+        items:
+          type: string
+        type: array
       disabled_tools:
         items:
           type: string
@@ -318,6 +314,14 @@ definitions:
       tui:
         $ref: '#/definitions/config.TUIOptions'
     type: object
+  github_com_charmbracelet_crush_internal_config.Scope:
+    enum:
+    - 0
+    - 1
+    type: integer
+    x-enum-varnames:
+    - ScopeGlobal
+    - ScopeWorkspace
   github_com_charmbracelet_crush_internal_proto.Message:
     properties:
       created_at:
@@ -419,7 +423,7 @@ definitions:
       enabled:
         type: boolean
       scope:
-        $ref: '#/definitions/config.Scope'
+        $ref: '#/definitions/github_com_charmbracelet_crush_internal_config.Scope'
     type: object
   proto.ConfigModelRequest:
     properties:
@@ -428,7 +432,7 @@ definitions:
       model_type:
         $ref: '#/definitions/config.SelectedModelType'
       scope:
-        $ref: '#/definitions/config.Scope'
+        $ref: '#/definitions/github_com_charmbracelet_crush_internal_config.Scope'
     type: object
   proto.ConfigProviderKeyRequest:
     properties:
@@ -436,28 +440,28 @@ definitions:
       provider_id:
         type: string
       scope:
-        $ref: '#/definitions/config.Scope'
+        $ref: '#/definitions/github_com_charmbracelet_crush_internal_config.Scope'
     type: object
   proto.ConfigRefreshOAuthRequest:
     properties:
       provider_id:
         type: string
       scope:
-        $ref: '#/definitions/config.Scope'
+        $ref: '#/definitions/github_com_charmbracelet_crush_internal_config.Scope'
     type: object
   proto.ConfigRemoveRequest:
     properties:
       key:
         type: string
       scope:
-        $ref: '#/definitions/config.Scope'
+        $ref: '#/definitions/github_com_charmbracelet_crush_internal_config.Scope'
     type: object
   proto.ConfigSetRequest:
     properties:
       key:
         type: string
       scope:
-        $ref: '#/definitions/config.Scope'
+        $ref: '#/definitions/github_com_charmbracelet_crush_internal_config.Scope'
       value: {}
     type: object
   proto.Error:
@@ -630,6 +634,20 @@ definitions:
       needs_init:
         type: boolean
     type: object
+  proto.ReadSkillRequest:
+    properties:
+      skill_id:
+        type: string
+    type: object
+  proto.ReadSkillResponse:
+    properties:
+      content:
+        items:
+          type: integer
+        type: array
+      result:
+        $ref: '#/definitions/proto.SkillReadResult'
+    type: object
   proto.ServerControl:
     properties:
       command:
@@ -657,6 +675,30 @@ definitions:
         type: string
       updated_at:
         type: integer
+    type: object
+  proto.SkillInfo:
+    properties:
+      description:
+        type: string
+      id:
+        type: string
+      label:
+        type: string
+      name:
+        type: string
+      source:
+        type: string
+    type: object
+  proto.SkillReadResult:
+    properties:
+      builtin:
+        type: boolean
+      description:
+        type: string
+      name:
+        type: string
+      source:
+        type: string
     type: object
   proto.VersionInfo:
     properties:
@@ -1635,6 +1677,50 @@ paths:
       summary: Stop all LSP servers
       tags:
       - lsp
+  /workspaces/{id}/mcp/docker/disable:
+    post:
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Disable Docker MCP
+      tags:
+      - mcp
+  /workspaces/{id}/mcp/docker/enable:
+    post:
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Enable Docker MCP
+      tags:
+      - mcp
   /workspaces/{id}/mcp/get-prompt:
     post:
       consumes:
@@ -2358,4 +2444,70 @@ paths:
       summary: Get user messages for session
       tags:
       - sessions
+  /workspaces/{id}/skills:
+    get:
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/proto.SkillInfo'
+            type: array
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: List visible skills
+      tags:
+      - skills
+  /workspaces/{id}/skills/read:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Read skill request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/proto.ReadSkillRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/proto.ReadSkillResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Read skill content
+      tags:
+      - skills
 swagger: "2.0"

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -130,14 +130,13 @@ type ActionFilePickerSelected struct {
 }
 
 // Cmd returns a command that reads the file at path and sends a
-// [message.Attachement] to the program.
+// [message.Attachment] to the program.
 func (a ActionFilePickerSelected) Cmd() tea.Cmd {
-	path := a.Path
-	if path == "" {
+	if a.Path == "" {
 		return nil
 	}
 	return func() tea.Msg {
-		isFileLarge, err := common.IsFileTooBig(path, common.MaxAttachmentSize)
+		isFileLarge, err := common.IsFileTooBig(a.Path, common.MaxAttachmentSize)
 		if err != nil {
 			return util.InfoMsg{
 				Type: util.InfoTypeError,
@@ -151,7 +150,7 @@ func (a ActionFilePickerSelected) Cmd() tea.Cmd {
 			}
 		}
 
-		content, err := os.ReadFile(path)
+		content, err := os.ReadFile(a.Path)
 		if err != nil {
 			return util.InfoMsg{
 				Type: util.InfoTypeError,
@@ -161,11 +160,10 @@ func (a ActionFilePickerSelected) Cmd() tea.Cmd {
 
 		mimeBufferSize := min(512, len(content))
 		mimeType := http.DetectContentType(content[:mimeBufferSize])
-		fileName := filepath.Base(path)
 
 		return message.Attachment{
-			FilePath: path,
-			FileName: fileName,
+			FilePath: a.Path,
+			FileName: filepath.Base(a.Path),
 			MimeType: mimeType,
 			Content:  content,
 		}

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -81,6 +81,12 @@ type (
 		Arguments   []commands.Argument
 		Args        map[string]string // Actual argument values
 	}
+	// ActionAttachSkill is sent when a skill is selected from the skills
+	// dialog to be attached to the conversation.
+	ActionAttachSkill struct {
+		ID   string
+		Name string
+	}
 	// ActionEnableDockerMCP is a message to enable Docker MCP.
 	ActionEnableDockerMCP struct{}
 	// ActionDisableDockerMCP is a message to disable Docker MCP.

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -422,6 +422,7 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		NewCommandItem(c.com.Styles, "new_session", "New Session", "ctrl+n", ActionNewSession{}),
 		NewCommandItem(c.com.Styles, "switch_session", "Sessions", "ctrl+s", ActionOpenDialog{SessionsID}),
 		NewCommandItem(c.com.Styles, "switch_model", "Switch Model", "ctrl+l", ActionOpenDialog{ModelsID}),
+		NewCommandItem(c.com.Styles, "skills", "Skills", "", ActionOpenDialog{SkillsID}),
 	}
 
 	// Only show compact command if there's an active session

--- a/internal/ui/dialog/sessions_item.go
+++ b/internal/ui/dialog/sessions_item.go
@@ -141,34 +141,7 @@ func renderItem(t ListItemStyles, title string, info string, focused bool, width
 	title = ansi.Truncate(title, max(0, lineWidth-infoWidth), "…")
 	titleWidth := lipgloss.Width(title)
 	gap := strings.Repeat(" ", max(0, lineWidth-titleWidth-infoWidth))
-	content := title
-	if m != nil && len(m.MatchedIndexes) > 0 {
-		var lastPos int
-		parts := make([]string, 0)
-		ranges := matchedRanges(m.MatchedIndexes)
-		for _, rng := range ranges {
-			start, stop := bytePosToVisibleCharPos(title, rng)
-			if start > lastPos {
-				parts = append(parts, ansi.Cut(title, lastPos, start))
-			}
-			// NOTE: We're using [ansi.Style] here instead of [lipglosStyle]
-			// because we can control the underline start and stop more
-			// precisely via [ansi.AttrUnderline] and [ansi.AttrNoUnderline]
-			// which only affect the underline attribute without interfering
-			// with other style attributes.
-			parts = append(parts,
-				ansi.NewStyle().Underline(true).String(),
-				ansi.Cut(title, start, stop+1),
-				ansi.NewStyle().Underline(false).String(),
-			)
-			lastPos = stop + 1
-		}
-		if lastPos < ansi.StringWidth(title) {
-			parts = append(parts, ansi.Cut(title, lastPos, ansi.StringWidth(title)))
-		}
-
-		content = strings.Join(parts, "")
-	}
+	content := underlineMatches(title, m)
 
 	content = style.Render(content + gap + infoText)
 	cache[width] = content
@@ -203,6 +176,41 @@ func sessionItems(t *styles.Styles, mode sessionsMode, sessions ...session.Sessi
 	return items
 }
 
+// underlineMatches applies fuzzy-match underline highlighting to a
+// rendered title string. It converts the byte-based match indices into
+// visible character positions and wraps matching runs in ANSI
+// underline sequences.
+func underlineMatches(title string, m *fuzzy.Match) string {
+	if m == nil || len(m.MatchedIndexes) == 0 {
+		return title
+	}
+	var lastPos int
+	parts := make([]string, 0)
+	ranges := matchedRanges(m.MatchedIndexes)
+	for _, rng := range ranges {
+		start, stop := bytePosToVisibleCharPos(title, rng)
+		if start > lastPos {
+			parts = append(parts, ansi.Cut(title, lastPos, start))
+		}
+		// NOTE: We use [ansi.Style] instead of [lipgloss.Style]
+		// because we can control the underline start and stop
+		// more precisely via [ansi.AttrUnderline] and
+		// [ansi.AttrNoUnderline] which only affect the underline
+		// attribute without interfering with other style
+		// attributes.
+		parts = append(parts,
+			ansi.NewStyle().Underline(true).String(),
+			ansi.Cut(title, start, stop+1),
+			ansi.NewStyle().Underline(false).String(),
+		)
+		lastPos = stop + 1
+	}
+	if lastPos < ansi.StringWidth(title) {
+		parts = append(parts, ansi.Cut(title, lastPos, ansi.StringWidth(title)))
+	}
+	return strings.Join(parts, "")
+}
+
 func matchedRanges(in []int) [][2]int {
 	if len(in) == 0 {
 		return [][2]int{}
@@ -221,6 +229,19 @@ func matchedRanges(in []int) [][2]int {
 		}
 	}
 	out = append(out, current)
+	return out
+}
+
+// clipIndices returns only the indices from in that fall within
+// [0, limit). This is used when a fuzzy match is computed against a
+// composite string but highlighting is applied to a prefix only.
+func clipIndices(in []int, limit int) []int {
+	out := make([]int, 0, len(in))
+	for _, idx := range in {
+		if idx < limit {
+			out = append(out, idx)
+		}
+	}
 	return out
 }
 

--- a/internal/ui/dialog/skills.go
+++ b/internal/ui/dialog/skills.go
@@ -1,0 +1,182 @@
+package dialog
+
+import (
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/spinner"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/list"
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+const SkillsID = "skills"
+
+type Skills struct {
+	com     *common.Common
+	input   textinput.Model
+	list    *list.FilterableList
+	spinner spinner.Model
+	loading bool
+	help    help.Model
+	keyMap  struct {
+		Select, UpDown, Next, Previous, Close key.Binding
+	}
+
+	allSkills []skills.CatalogEntry
+}
+
+var _ Dialog = (*Skills)(nil)
+
+func NewSkills(com *common.Common, entries []skills.CatalogEntry) *Skills {
+	s := &Skills{com: com, allSkills: entries}
+	s.help = help.New()
+	s.help.Styles = com.Styles.DialogHelpStyles()
+	s.list = list.NewFilterableList()
+	s.list.Focus()
+	s.list.SetSelected(0)
+	s.input = textinput.New()
+	s.input.SetVirtualCursor(false)
+	s.input.Placeholder = "Type to filter"
+	s.input.SetStyles(com.Styles.TextInput)
+	s.input.Focus()
+	s.keyMap.Select = key.NewBinding(key.WithKeys("enter", "ctrl+y"), key.WithHelp("enter", "confirm"))
+	s.keyMap.UpDown = key.NewBinding(key.WithKeys("up", "down"), key.WithHelp("↑/↓", "choose"))
+	s.keyMap.Next = key.NewBinding(key.WithKeys("down"), key.WithHelp("↓", "next item"))
+	s.keyMap.Previous = key.NewBinding(key.WithKeys("up", "ctrl+p"), key.WithHelp("↑", "previous item"))
+	closeKey := CloseKey
+	closeKey.SetHelp("esc", "cancel")
+	s.keyMap.Close = closeKey
+	s.spinner = spinner.New()
+	s.spinner.Spinner = spinner.Dot
+	s.spinner.Style = com.Styles.Dialog.Spinner
+	s.setAllSkillItems()
+	return s
+}
+
+func (s *Skills) ID() string { return SkillsID }
+
+func (s *Skills) HandleMsg(msg tea.Msg) Action {
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		if s.loading {
+			var cmd tea.Cmd
+			s.spinner, cmd = s.spinner.Update(msg)
+			return ActionCmd{Cmd: cmd}
+		}
+	case tea.KeyPressMsg:
+		if s.loading {
+			if key.Matches(msg, s.keyMap.Close) {
+				return ActionClose{}
+			}
+			return nil
+		}
+		switch {
+		case key.Matches(msg, s.keyMap.Close):
+			return ActionClose{}
+		case key.Matches(msg, s.keyMap.Previous):
+			s.list.Focus()
+			if s.list.IsSelectedFirst() {
+				s.list.SelectLast()
+			} else {
+				s.list.SelectPrev()
+			}
+			s.list.ScrollToSelected()
+		case key.Matches(msg, s.keyMap.Next):
+			s.list.Focus()
+			if s.list.IsSelectedLast() {
+				s.list.SelectFirst()
+			} else {
+				s.list.SelectNext()
+			}
+			s.list.ScrollToSelected()
+		case key.Matches(msg, s.keyMap.Select):
+			if selectedItem := s.list.SelectedItem(); selectedItem != nil {
+				if item, ok := selectedItem.(*SkillItem); ok && item != nil {
+					return item.Action()
+				}
+			}
+		default:
+			prevValue := s.input.Value()
+			var cmd tea.Cmd
+			s.input, cmd = s.input.Update(msg)
+			if newValue := s.input.Value(); newValue != prevValue {
+				s.list.SetFilter(newValue)
+				s.list.ScrollToTop()
+				s.list.SetSelected(0)
+			}
+			return ActionCmd{Cmd: cmd}
+		}
+	}
+	return nil
+}
+
+func (s *Skills) Cursor() *tea.Cursor { return InputCursor(s.com.Styles, s.input.Cursor()) }
+
+func (s *Skills) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	t := s.com.Styles
+	width := max(0, min(defaultDialogMaxWidth, area.Dx()-t.Dialog.View.GetHorizontalBorderSize()))
+	height := max(0, min(defaultDialogHeight, area.Dy()-t.Dialog.View.GetVerticalBorderSize()))
+	innerWidth := width - s.com.Styles.Dialog.View.GetHorizontalFrameSize()
+	heightOffset := t.Dialog.Title.GetVerticalFrameSize() + titleContentHeight +
+		t.Dialog.InputPrompt.GetVerticalFrameSize() + inputContentHeight +
+		t.Dialog.HelpView.GetVerticalFrameSize() +
+		t.Dialog.View.GetVerticalFrameSize()
+	s.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1))
+	s.list.SetSize(innerWidth, max(0, height-heightOffset))
+	s.help.SetWidth(innerWidth)
+	rc := NewRenderContext(t, width)
+	rc.Title = "Skills"
+	rc.TitleInfo = ""
+	rc.AddPart(t.Dialog.InputPrompt.Render(s.input.View()))
+	rc.AddPart(t.Dialog.List.Height(s.list.Height()).Render(s.list.Render()))
+	if s.loading {
+		rc.Help = s.spinner.View() + " Loading skills..."
+	} else {
+		rc.Help = s.help.View(s)
+	}
+	view := rc.Render()
+	cur := s.Cursor()
+	DrawCenterCursor(scr, area, view, cur)
+	return cur
+}
+
+func (s *Skills) ShortHelp() []key.Binding {
+	return []key.Binding{s.keyMap.UpDown, s.keyMap.Select, s.keyMap.Close}
+}
+
+func (s *Skills) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{s.keyMap.Select, s.keyMap.Next, s.keyMap.Previous}, {s.keyMap.Close}}
+}
+
+func (s *Skills) SetSkills(entries []skills.CatalogEntry) {
+	s.allSkills = entries
+	s.setAllSkillItems()
+}
+
+func (s *Skills) setAllSkillItems() {
+	items := make([]list.FilterableItem, 0, len(s.allSkills))
+	for _, entry := range s.allSkills {
+		action := ActionAttachSkill{ID: entry.ID, Name: entry.Name}
+		items = append(items, NewSkillItem(s.com.Styles, entry, action))
+	}
+	query := s.input.Value()
+	s.list.SetItems(items...)
+	s.list.SetFilter(query)
+	s.list.ScrollToTop()
+	s.list.SetSelected(0)
+}
+
+func (s *Skills) StartLoading() tea.Cmd {
+	if s.loading {
+		return nil
+	}
+	s.loading = true
+	return s.spinner.Tick
+}
+
+func (s *Skills) StopLoading() {
+	s.loading = false
+}

--- a/internal/ui/dialog/skills_item.go
+++ b/internal/ui/dialog/skills_item.go
@@ -1,0 +1,92 @@
+package dialog
+
+import (
+	"slices"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/sahilm/fuzzy"
+)
+
+var _ ListItem = &SkillItem{}
+
+type SkillItem struct {
+	entry   skills.CatalogEntry
+	action  Action
+	t       *styles.Styles
+	m       fuzzy.Match
+	cache   map[int]string
+	focused bool
+}
+
+func NewSkillItem(t *styles.Styles, entry skills.CatalogEntry, action Action) *SkillItem {
+	return &SkillItem{entry: entry, action: action, t: t}
+}
+
+func (s *SkillItem) Filter() string {
+	return s.entry.Label + " " + s.entry.Name + " " + s.entry.Description
+}
+
+func (s *SkillItem) ID() string { return s.entry.ID }
+
+func (s *SkillItem) SetFocused(focused bool) {
+	if s.focused != focused {
+		s.cache = nil
+	}
+	s.focused = focused
+}
+
+func (s *SkillItem) SetMatch(m fuzzy.Match) {
+	if s.m.Str == m.Str && s.m.Index == m.Index &&
+		s.m.Score == m.Score && slices.Equal(s.m.MatchedIndexes, m.MatchedIndexes) {
+		return
+	}
+	s.cache = nil
+	s.m = m
+}
+
+func (s *SkillItem) Action() Action { return s.action }
+
+func (s *SkillItem) Render(width int) string {
+	if s.cache == nil {
+		s.cache = make(map[int]string)
+	}
+	if cached, ok := s.cache[width]; ok {
+		return cached
+	}
+
+	var lineStyle, descStyle lipgloss.Style
+	if s.focused {
+		lineStyle = s.t.Dialog.SelectedItem.Width(width)
+		descStyle = s.t.Dialog.SelectedItem.Width(width)
+	} else {
+		lineStyle = s.t.Dialog.NormalItem.Width(width)
+		descStyle = s.t.Dialog.SecondaryText.Width(width)
+	}
+
+	title := ansi.Truncate(s.entry.Label, max(0, width-2), "…")
+
+	// Filter() returns "Label Name Description", so the fuzzy matcher
+	// produces byte indices into that composite string. Only indices
+	// within [0, len(Label)) are valid for highlighting the title;
+	// the rest land in the Name/Description suffix and are dropped.
+	labelLen := len(s.entry.Label)
+	clipped := &fuzzy.Match{MatchedIndexes: clipIndices(s.m.MatchedIndexes, labelLen)}
+	title = underlineMatches(title, clipped)
+
+	description := ansi.Truncate(strings.TrimSpace(s.entry.Description), max(0, width-2), "…")
+	if description == "" {
+		description = " "
+	}
+
+	rendered := lipgloss.JoinVertical(
+		lipgloss.Left,
+		lineStyle.Render(title),
+		descStyle.Render(description),
+	)
+	s.cache[width] = rendered
+	return rendered
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -124,6 +124,11 @@ type (
 	mcpPromptsLoadedMsg struct {
 		Prompts []commands.MCPPrompt
 	}
+	skillsLoadedMsg struct {
+		LoadID int
+		Skills []skills.CatalogEntry
+		Err    error
+	}
 	// mcpStateChangedMsg is sent when there is a change in MCP client states.
 	mcpStateChangedMsg struct {
 		states map[string]mcp.ClientInfo
@@ -246,6 +251,7 @@ type UI struct {
 	// custom commands & mcp commands
 	customCommands []commands.CustomCommand
 	mcpPrompts     []commands.MCPPrompt
+	skillsLoadID   int
 
 	// forceCompactMode tracks whether compact mode is forced by user toggle
 	forceCompactMode bool
@@ -471,6 +477,13 @@ func (m *UI) loadCustomCommands() tea.Cmd {
 	}
 }
 
+func (m *UI) loadSkills(loadID int) tea.Cmd {
+	return func() tea.Msg {
+		skills, err := m.com.Workspace.ListSkills(context.Background())
+		return skillsLoadedMsg{LoadID: loadID, Skills: skills, Err: err}
+	}
+}
+
 // loadMCPrompts loads the MCP prompts asynchronously.
 func (m *UI) loadMCPrompts() tea.Msg {
 	prompts, err := commands.LoadMCPPrompts()
@@ -579,6 +592,21 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		commands, ok := dia.(*dialog.Commands)
 		if ok {
 			commands.SetMCPPrompts(m.mcpPrompts)
+		}
+
+	case skillsLoadedMsg:
+		if msg.LoadID != m.skillsLoadID {
+			break
+		}
+		if loader, ok := m.dialog.Dialog(dialog.SkillsID).(dialog.LoadingDialog); ok {
+			loader.StopLoading()
+		}
+		if msg.Err != nil {
+			cmds = append(cmds, util.ReportError(msg.Err))
+			break
+		}
+		if skillsDialog, ok := m.dialog.Dialog(dialog.SkillsID).(*dialog.Skills); ok {
+			skillsDialog.SetSkills(msg.Skills)
 		}
 
 	case promptHistoryLoadedMsg:
@@ -1522,6 +1550,10 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 				return nil
 			},
 		))
+
+	case dialog.ActionAttachSkill:
+		m.dialog.CloseDialog(dialog.SkillsID)
+		cmds = append(cmds, m.attachSkill(msg.ID, msg.Name))
 
 	case dialog.ActionRunCustomCommand:
 		if len(msg.Arguments) > 0 && msg.Args == nil {
@@ -3122,6 +3154,21 @@ func (m *UI) refreshStyles() {
 	m.chat.InvalidateRenderCaches()
 }
 
+func (m *UI) attachSkill(skillID, name string) tea.Cmd {
+	return func() tea.Msg {
+		content, result, err := m.com.Workspace.ReadSkill(context.Background(), skillID)
+		if err != nil {
+			return util.NewErrorMsg(err)
+		}
+		return message.Attachment{
+			FilePath: skillID,
+			FileName: result.Name,
+			MimeType: "text/markdown",
+			Content:  content,
+		}
+	}
+}
+
 // sendMessage sends a message with the given content and attachments.
 func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.Cmd {
 	if !m.com.Workspace.AgentIsReady() {
@@ -3230,6 +3277,10 @@ func (m *UI) openDialog(id string) tea.Cmd {
 		if cmd := m.openCommandsDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+	case dialog.SkillsID:
+		if cmd := m.openSkillsDialog(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case dialog.ReasoningID:
 		if cmd := m.openReasoningDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -3305,6 +3356,30 @@ func (m *UI) openCommandsDialog() tea.Cmd {
 	m.dialog.OpenDialog(commands)
 
 	return commands.InitialCmd()
+}
+
+// openSkillsDialog opens the skills dialog.
+func (m *UI) openSkillsDialog() tea.Cmd {
+	if m.dialog.ContainsDialog(dialog.SkillsID) {
+		m.dialog.BringToFront(dialog.SkillsID)
+		if skillsDialog, ok := m.dialog.Dialog(dialog.SkillsID).(*dialog.Skills); ok {
+			skillsDialog.SetSkills(nil)
+		}
+	} else {
+		skillsDialog := dialog.NewSkills(m.com, nil)
+		m.dialog.OpenDialog(skillsDialog)
+	}
+	m.skillsLoadID++
+	loadID := m.skillsLoadID
+
+	var cmds []tea.Cmd
+	if loader, ok := m.dialog.Dialog(dialog.SkillsID).(dialog.LoadingDialog); ok {
+		if cmd := loader.StartLoading(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	cmds = append(cmds, m.loadSkills(loadID))
+	return tea.Batch(cmds...)
 }
 
 // openReasoningDialog opens the reasoning effort dialog.

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -18,6 +18,7 @@ import (
 	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/skills"
 )
 
 // AppWorkspace implements the Workspace interface by delegating
@@ -296,6 +297,18 @@ func (w *AppWorkspace) MarkProjectInitialized() error {
 
 func (w *AppWorkspace) InitializePrompt() (string, error) {
 	return agent.InitializePrompt(w.store)
+}
+
+func (w *AppWorkspace) ListSkills(_ context.Context) ([]skills.CatalogEntry, error) {
+	return skills.Catalog(w.store), nil
+}
+
+func (w *AppWorkspace) ReadSkill(ctx context.Context, skillID string) ([]byte, skills.SkillReadResult, error) {
+	if w.app.AgentCoordinator != nil {
+		return w.app.AgentCoordinator.ReadSkill(ctx, skillID)
+	}
+	// Pre-init fallback: read directly without tracker mark.
+	return skills.ReadContent(w.store, skillID)
 }
 
 // -- MCP operations --

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -22,6 +22,7 @@ import (
 	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/skills"
 	"github.com/charmbracelet/x/powernap/pkg/lsp/protocol"
 )
 
@@ -470,6 +471,37 @@ func (w *ClientWorkspace) MarkProjectInitialized() error {
 
 func (w *ClientWorkspace) InitializePrompt() (string, error) {
 	return w.client.GetInitializePrompt(context.Background(), w.workspaceID())
+}
+
+func (w *ClientWorkspace) ListSkills(ctx context.Context) ([]skills.CatalogEntry, error) {
+	entries, err := w.client.ListSkills(ctx, w.workspaceID())
+	if err != nil {
+		return nil, err
+	}
+	result := make([]skills.CatalogEntry, len(entries))
+	for i, entry := range entries {
+		result[i] = skills.CatalogEntry{
+			ID:          entry.ID,
+			Name:        entry.Name,
+			Description: entry.Description,
+			Label:       entry.Label,
+			Source:      skills.SourceType(entry.Source),
+		}
+	}
+	return result, nil
+}
+
+func (w *ClientWorkspace) ReadSkill(ctx context.Context, skillID string) ([]byte, skills.SkillReadResult, error) {
+	resp, err := w.client.ReadSkill(ctx, w.workspaceID(), skillID)
+	if err != nil {
+		return nil, skills.SkillReadResult{}, err
+	}
+	return resp.Content, skills.SkillReadResult{
+		Name:        resp.Result.Name,
+		Description: resp.Result.Description,
+		Source:      skills.SourceType(resp.Result.Source),
+		Builtin:     resp.Result.Builtin,
+	}, nil
 }
 
 // -- MCP operations --

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -18,6 +18,7 @@ import (
 	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/skills"
 )
 
 // LSPClientInfo holds information about an LSP client's state. This is
@@ -127,6 +128,8 @@ type Workspace interface {
 	ProjectNeedsInitialization() (bool, error)
 	MarkProjectInitialized() error
 	InitializePrompt() (string, error)
+	ListSkills(ctx context.Context) ([]skills.CatalogEntry, error)
+	ReadSkill(ctx context.Context, skillID string) ([]byte, skills.SkillReadResult, error)
 
 	// MCP operations (server-side in client mode)
 	MCPGetStates() map[string]mcptools.ClientInfo


### PR DESCRIPTION
Adds a skills browsing dialog to the TUI command palette, letting users discover and attach both builtin and user-configured skills. Also adds some bits to the skill about checking versions and fetching more docs.

Has many changes compared to #2467 that need some polish, so I'm again opening this as a draft before it's quite ready.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
