### PR TITLE
feat: support Bedrock cross-region inference model IDs and annotate 1M models

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -115,6 +115,25 @@ func mustMarshalConfig(cfg *Config) []byte {
 	return data
 }
 
+// isBedrockAnthropicModel returns true if the model ID is an Anthropic model
+// on AWS Bedrock. This accepts both standard IDs (anthropic.claude-*) and
+// cross-region inference IDs (us.anthropic.claude-*, eu.anthropic.claude-*, etc).
+func isBedrockAnthropicModel(id string) bool {
+	return strings.HasPrefix(id, "anthropic.") || strings.Contains(id, ".anthropic.")
+}
+
+// annotateBedrockModelNames adds a "(1M)" suffix to the display names of
+// Bedrock models that have a 1M context window, so users can identify them
+// in the model selection dropdown.
+func annotateBedrockModelNames(models []catwalk.Model) []catwalk.Model {
+	for i := range models {
+		if models[i].ContextWindow >= 1_000_000 && !strings.Contains(models[i].Name, "1M") {
+			models[i].Name = models[i].Name + " (1M)"
+		}
+	}
+	return models
+}
+
 func PushPopCrushEnv() func() {
 	var found []string
 	for _, ev := range os.Environ() {
@@ -277,10 +296,11 @@ func (c *Config) configureProviders(store *ConfigStore, env env.Env, resolver Va
 				prepared.ExtraParams["region"] = env.Get("AWS_DEFAULT_REGION")
 			}
 			for _, model := range p.Models {
-				if !strings.HasPrefix(model.ID, "anthropic.") {
+				if !isBedrockAnthropicModel(model.ID) {
 					return fmt.Errorf("bedrock provider only supports anthropic models for now, found: %s", model.ID)
 				}
 			}
+			prepared.Models = annotateBedrockModelNames(p.Models)
 		default:
 			// if the provider api or endpoint are missing we skip them
 			v, err := resolver.ResolveValue(p.APIKey)

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -254,6 +254,69 @@ func TestConfig_configureProvidersBedrockWithoutUnsupportedModel(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestConfig_configureProvidersBedrockCrossRegionModel(t *testing.T) {
+	knownProviders := []catwalk.Provider{
+		{
+			ID:          catwalk.InferenceProviderBedrock,
+			APIKey:      "",
+			APIEndpoint: "",
+			Models: []catwalk.Model{{
+				ID: "us.anthropic.claude-opus-4-6-v1:1m",
+			}},
+		},
+	}
+
+	cfg := &Config{}
+	cfg.setDefaults("/tmp", "")
+	env := env.NewFromMap(map[string]string{
+		"AWS_ACCESS_KEY_ID":     "test-key-id",
+		"AWS_SECRET_ACCESS_KEY": "test-secret-key",
+	})
+	resolver := NewEnvironmentVariableResolver(env)
+	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	require.NoError(t, err)
+
+	bedrockProvider, ok := cfg.Providers.Get("bedrock")
+	require.True(t, ok, "Bedrock provider should be present")
+	require.Equal(t, "us.anthropic.claude-opus-4-6-v1:1m", bedrockProvider.Models[0].ID)
+}
+
+func TestAnnotateBedrockModelNames(t *testing.T) {
+	models := []catwalk.Model{
+		{
+			ID:            "anthropic.claude-opus-4-6-v1",
+			Name:          "AWS Claude Opus 4.6",
+			ContextWindow: 1_000_000,
+		},
+		{
+			ID:            "anthropic.claude-sonnet-4-6",
+			Name:          "AWS Claude Sonnet 4.6",
+			ContextWindow: 1_000_000,
+		},
+		{
+			ID:            "anthropic.claude-haiku-4-5-20251001-v1:0",
+			Name:          "AWS Claude Haiku 4.5",
+			ContextWindow: 200_000,
+		},
+	}
+
+	result := annotateBedrockModelNames(models)
+
+	require.Len(t, result, 3)
+	require.Equal(t, "AWS Claude Opus 4.6 (1M)", result[0].Name)
+	require.Equal(t, "AWS Claude Sonnet 4.6 (1M)", result[1].Name)
+	require.Equal(t, "AWS Claude Haiku 4.5", result[2].Name) // no annotation, <1M
+}
+
+func TestIsBedrockAnthropicModel(t *testing.T) {
+	require.True(t, isBedrockAnthropicModel("anthropic.claude-sonnet-4-20250514-v1:0"))
+	require.True(t, isBedrockAnthropicModel("us.anthropic.claude-opus-4-6-v1:1m"))
+	require.True(t, isBedrockAnthropicModel("eu.anthropic.claude-sonnet-4-6:1m"))
+	require.True(t, isBedrockAnthropicModel("ap.anthropic.claude-opus-4-6-v1:1m"))
+	require.False(t, isBedrockAnthropicModel("some-random-model"))
+	require.False(t, isBedrockAnthropicModel("openai.gpt-4"))
+}
+
 func TestConfig_configureProvidersVertexAIWithCredentials(t *testing.T) {
 	knownProviders := []catwalk.Provider{
 		{


### PR DESCRIPTION
## Summary

Picks up the remaining crush-side work from #2321, which was closed after its catwalk/fantasy dependency PRs landed differently.

The 1M context window data for Opus 4.6 and Sonnet 4.6 already exists in catwalk (charmbracelet/catwalk#214, merged into v0.33.2), but crush still rejects cross-region inference model IDs and doesn't surface which models have 1M context in the model picker.

This PR:
- Accept cross-region inference model IDs (`us.anthropic.*`, `eu.anthropic.*`, `ap.anthropic.*`) for the Bedrock provider. Previously these were rejected with `"bedrock provider only supports anthropic models for now"`.
- Annotate Bedrock models that have a 1M context window with "(1M)" in the model picker (e.g. "AWS Claude Opus 4.6 (1M)"), so users can identify them at a glance.

> **Note:** the based tai groot made this wonderful pr at #2321 which also included beta header injection (`context-1m-2025-08-07`), a `context_1m` config flag, and long-context premium pricing. Those are not included here and can be addressed separately.

## Test plan
- [x] `TestConfig_configureProvidersBedrockCrossRegionModel` — cross-region model ID accepted
- [x] `TestAnnotateBedrockModelNames` — 1M models annotated, sub-1M models left alone
- [x] `TestIsBedrockAnthropicModel` — standard and cross-region IDs accepted, non-Anthropic IDs rejected
- [x] Existing Bedrock tests still pass
- [x] `go test -race ./internal/config/` passes