### PR TITLE
fix: correctly identify context fate in mcp createSession

### DIFF
--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -38,22 +38,8 @@ func parseLevel(level mcp.LoggingLevel) slog.Level {
 	}
 }
 
-// ClientSession wraps an mcp.ClientSession with a context cancel function so
-// that the context created during session establishment is properly cleaned up
-// on close.
-type ClientSession struct {
-	*mcp.ClientSession
-	cancel context.CancelFunc
-}
-
-// Close cancels the session context and then closes the underlying session.
-func (s *ClientSession) Close() error {
-	s.cancel()
-	return s.ClientSession.Close()
-}
-
 var (
-	sessions = csync.NewMap[string, *ClientSession]()
+	sessions = csync.NewMap[string, *mcp.ClientSession]()
 	states   = csync.NewMap[string, ClientInfo]()
 	broker   = pubsub.NewBroker[Event]()
 	initOnce sync.Once
@@ -116,7 +102,7 @@ type ClientInfo struct {
 	Name        string
 	State       State
 	Error       error
-	Client      *ClientSession
+	Client      *mcp.ClientSession
 	Counts      Counts
 	ConnectedAt time.Time
 }
@@ -293,7 +279,7 @@ func DisableSingle(cfg *config.ConfigStore, name string) error {
 	return nil
 }
 
-func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string) (*ClientSession, error) {
+func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string) (*mcp.ClientSession, error) {
 	sess, ok := sessions.Get(name)
 	if !ok {
 		return nil, fmt.Errorf("mcp '%s' not available", name)
@@ -322,7 +308,7 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 }
 
 // updateState updates the state of an MCP client and publishes an event
-func updateState(name string, state State, err error, client *ClientSession, counts Counts) {
+func updateState(name string, state State, err error, client *mcp.ClientSession, counts Counts) {
 	info := ClientInfo{
 		Name:   name,
 		State:  state,
@@ -348,17 +334,15 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 	})
 }
 
-func createSession(ctx context.Context, name string, m config.MCPConfig, resolver config.VariableResolver) (*ClientSession, error) {
+func createSession(ctx context.Context, name string, m config.MCPConfig, resolver config.VariableResolver) (*mcp.ClientSession, error) {
 	timeout := mcpTimeout(m)
-	mcpCtx, cancel := context.WithCancel(ctx)
-	cancelTimer := time.AfterFunc(timeout, cancel)
+	mcpCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 
 	transport, err := createTransport(mcpCtx, m, resolver)
 	if err != nil {
 		updateState(name, StateError, err, nil, Counts{})
 		slog.Error("Error creating MCP client", "error", err, "name", name)
-		cancel()
-		cancelTimer.Stop()
 		return nil, err
 	}
 
@@ -399,14 +383,11 @@ func createSession(ctx context.Context, name string, m config.MCPConfig, resolve
 		err = maybeStdioErr(err, transport)
 		updateState(name, StateError, maybeTimeoutErr(err, timeout), nil, Counts{})
 		slog.Error("MCP client failed to initialize", "error", err, "name", name)
-		cancel()
-		cancelTimer.Stop()
 		return nil, err
 	}
 
-	cancelTimer.Stop()
 	slog.Debug("MCP client initialized", "name", name)
-	return &ClientSession{session, cancel}, nil
+	return session, nil
 }
 
 // maybeStdioErr if a stdio mcp prints an error in non-json format, it'll fail
@@ -431,8 +412,11 @@ func maybeStdioErr(err error, transport mcp.Transport) error {
 }
 
 func maybeTimeoutErr(err error, timeout time.Duration) error {
-	if errors.Is(err, context.Canceled) {
+	if errors.Is(err, context.DeadlineExceeded) {
 		return fmt.Errorf("timed out after %s", timeout)
+	}
+	if errors.Is(err, context.Canceled) {
+		return fmt.Errorf("cancelled")
 	}
 	return err
 }

--- a/internal/agent/tools/mcp/init_test.go
+++ b/internal/agent/tools/mcp/init_test.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"context"
 	"maps"
 	"os"
 	"testing"
@@ -10,7 +9,6 @@ import (
 	"github.com/charmbracelet/crush/internal/env"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/goleak"
 )
 
 // shellResolverWithPath builds a shell resolver whose env carries PATH
@@ -22,34 +20,6 @@ func shellResolverWithPath(t *testing.T, overrides map[string]string) config.Var
 	m := map[string]string{"PATH": os.Getenv("PATH")}
 	maps.Copy(m, overrides)
 	return config.NewShellVariableResolver(env.NewFromMap(m))
-}
-
-func TestMCPSession_CancelOnClose(t *testing.T) {
-	defer goleak.VerifyNone(t)
-
-	serverTransport, clientTransport := mcp.NewInMemoryTransports()
-
-	server := mcp.NewServer(&mcp.Implementation{Name: "test-server"}, nil)
-	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
-	require.NoError(t, err)
-	defer serverSession.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
-	clientSession, err := client.Connect(ctx, clientTransport, nil)
-	require.NoError(t, err)
-
-	sess := &ClientSession{clientSession, cancel}
-
-	// Verify the context is not cancelled before close.
-	require.NoError(t, ctx.Err())
-
-	err = sess.Close()
-	require.NoError(t, err)
-
-	// After Close, the context must be cancelled.
-	require.ErrorIs(t, ctx.Err(), context.Canceled)
 }
 
 // TestCreateTransport_URLResolution pins that m.URL goes through the

--- a/internal/agent/tools/mcp/prompts.go
+++ b/internal/agent/tools/mcp/prompts.go
@@ -67,7 +67,7 @@ func RefreshPrompts(ctx context.Context, name string) {
 	updateState(name, StateConnected, nil, session, prev.Counts)
 }
 
-func getPrompts(ctx context.Context, c *ClientSession) ([]*Prompt, error) {
+func getPrompts(ctx context.Context, c *mcp.ClientSession) ([]*Prompt, error) {
 	if c.InitializeResult().Capabilities.Prompts == nil {
 		return nil, nil
 	}

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -77,7 +77,7 @@ func RefreshResources(ctx context.Context, name string) {
 	updateState(name, StateConnected, nil, session, prev.Counts)
 }
 
-func getResources(ctx context.Context, c *ClientSession) ([]*Resource, error) {
+func getResources(ctx context.Context, c *mcp.ClientSession) ([]*Resource, error) {
 	if c.InitializeResult().Capabilities.Resources == nil {
 		return nil, nil
 	}

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -130,7 +130,7 @@ func RefreshTools(ctx context.Context, cfg *config.ConfigStore, name string) {
 	updateState(name, StateConnected, nil, session, prev.Counts)
 }
 
-func getTools(ctx context.Context, session *ClientSession) ([]*Tool, error) {
+func getTools(ctx context.Context, session *mcp.ClientSession) ([]*Tool, error) {
 	// Always call ListTools to get the actual available tools.
 	// The InitializeResult Capabilities.Tools field may be an empty object {},
 	// which is valid per MCP spec, but we still need to call ListTools to discover tools.


### PR DESCRIPTION
The previous complex `time.AfterFunc` construct caused a deadline exceeded to be identified as a cancellation in `maybeTimeoutErr`. This change uses a `context.WithTimeout` instead to correctly identify timeouts for status messages.

It also removes a test which was tightly coupled to the previous implementation.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- ~[ ] I have created a discussion that was approved by a maintainer (for new features).~ n/a
