### PR TITLE
feat(agent): allow user to configure agent model size

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -592,7 +592,7 @@ type Config struct {
 
 	Hooks map[string][]HookConfig `json:"hooks,omitempty" jsonschema:"description=User-defined shell commands that fire on hook events (e.g. PreToolUse)"`
 
-	Agents map[string]Agent `json:"-"`
+	Agents map[string]Agent `json:"agents,omitempty" jsonschema:"description=Agent configurations"`
 }
 
 func (c *Config) EnabledProviders() []ProviderConfig {
@@ -715,12 +715,21 @@ func filterSlice(data []string, mask []string, include bool) []string {
 func (c *Config) SetupAgents() {
 	allowedTools := resolveAllowedTools(allToolNames(), c.Options.DisabledTools)
 
+	coderModel := SelectedModelTypeLarge
+	if agentCfg, ok := c.Agents[AgentCoder]; ok && agentCfg.Model != "" {
+		coderModel = agentCfg.Model
+	}
+	taskModel := SelectedModelTypeLarge
+	if agentCfg, ok := c.Agents[AgentTask]; ok && agentCfg.Model != "" {
+		taskModel = agentCfg.Model
+	}
+
 	agents := map[string]Agent{
 		AgentCoder: {
 			ID:           AgentCoder,
 			Name:         "Coder",
 			Description:  "An agent that helps with executing coding tasks.",
-			Model:        SelectedModelTypeLarge,
+			Model:        coderModel,
 			ContextPaths: c.Options.ContextPaths,
 			AllowedTools: allowedTools,
 		},
@@ -729,7 +738,7 @@ func (c *Config) SetupAgents() {
 			ID:           AgentTask,
 			Name:         "Task",
 			Description:  "An agent that helps with searching for context and finding implementation details.",
-			Model:        SelectedModelTypeLarge,
+			Model:        taskModel,
 			ContextPaths: c.Options.ContextPaths,
 			AllowedTools: resolveReadOnlyTools(allowedTools),
 			// NO MCPs or LSPs by default

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -22,6 +22,22 @@ func TestMain(m *testing.M) {
 	os.Exit(exitVal)
 }
 
+func TestConfig_LoadAgentsFromJSON(t *testing.T) {
+	data := []byte(`{"agents": {"task": {"model": "small"}, "coder": {"model": "large"}}}`)
+
+	loadedConfig, err := loadFromBytes([][]byte{data})
+	require.NoError(t, err)
+	require.NotNil(t, loadedConfig)
+
+	taskAgent, ok := loadedConfig.Agents[AgentTask]
+	require.True(t, ok)
+	assert.Equal(t, SelectedModelTypeSmall, taskAgent.Model)
+
+	coderAgent, ok := loadedConfig.Agents[AgentCoder]
+	require.True(t, ok)
+	assert.Equal(t, SelectedModelTypeLarge, coderAgent.Model)
+}
+
 func TestConfig_LoadFromBytes(t *testing.T) {
 	data1 := []byte(`{"providers": {"openai": {"api_key": "key1", "base_url": "https://api.openai.com/v1"}}}`)
 	data2 := []byte(`{"providers": {"openai": {"api_key": "key2", "base_url": "https://api.openai.com/v2"}}}`)
@@ -733,6 +749,47 @@ func TestConfig_setupAgentsWithDisabledTools(t *testing.T) {
 	taskAgent, ok := cfg.Agents[AgentTask]
 	require.True(t, ok)
 	assert.Equal(t, []string{"glob", "ls", "sourcegraph", "view"}, taskAgent.AllowedTools)
+}
+
+func TestConfig_setupAgentsWithModelConfig(t *testing.T) {
+	cfg := &Config{
+		Agents: map[string]Agent{
+			AgentTask: {
+				Model: SelectedModelTypeSmall,
+			},
+		},
+		Options: &Options{
+			DisabledTools: []string{},
+		},
+	}
+
+	cfg.SetupAgents()
+
+	coderAgent, ok := cfg.Agents[AgentCoder]
+	require.True(t, ok)
+	assert.Equal(t, SelectedModelTypeLarge, coderAgent.Model)
+
+	taskAgent, ok := cfg.Agents[AgentTask]
+	require.True(t, ok)
+	assert.Equal(t, SelectedModelTypeSmall, taskAgent.Model)
+}
+
+func TestConfig_setupAgentsWithNoModelConfig(t *testing.T) {
+	cfg := &Config{
+		Options: &Options{
+			DisabledTools: []string{},
+		},
+	}
+
+	cfg.SetupAgents()
+
+	coderAgent, ok := cfg.Agents[AgentCoder]
+	require.True(t, ok)
+	assert.Equal(t, SelectedModelTypeLarge, coderAgent.Model)
+
+	taskAgent, ok := cfg.Agents[AgentTask]
+	require.True(t, ok)
+	assert.Equal(t, SelectedModelTypeLarge, taskAgent.Model)
 }
 
 func TestConfig_setupAgentsWithEveryReadOnlyToolDisabled(t *testing.T) {

--- a/schema.json
+++ b/schema.json
@@ -141,6 +141,16 @@
           "$ref": "#/$defs/Tools",
           "description": "Tool configurations"
         },
+        "hooks": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/$defs/HookConfig"
+            },
+            "type": "array"
+          },
+          "type": "object",
+          "description": "User-defined shell commands that fire on hook events (e.g. PreToolUse)"
+        },
         "agents": {
           "additionalProperties": {
             "$ref": "#/$defs/Agent"
@@ -150,9 +160,28 @@
         }
       },
       "additionalProperties": false,
+      "type": "object"
+    },
+    "HookConfig": {
+      "properties": {
+        "matcher": {
+          "type": "string",
+          "description": "Regex pattern tested against the tool name. Empty means match all tools."
+        },
+        "command": {
+          "type": "string",
+          "description": "Shell command to execute when the hook fires"
+        },
+        "timeout": {
+          "type": "integer",
+          "description": "Timeout in seconds for the hook command",
+          "default": 30
+        }
+      },
+      "additionalProperties": false,
       "type": "object",
       "required": [
-        "tools"
+        "command"
       ]
     },
     "LSPConfig": {
@@ -293,6 +322,16 @@
           "type": "array",
           "description": "List of tools from this MCP server to disable"
         },
+        "enabled_tools": {
+          "items": {
+            "type": "string",
+            "examples": [
+              "get-library-doc"
+            ]
+          },
+          "type": "array",
+          "description": "Allow list of tools from this MCP server"
+        },
         "timeout": {
           "type": "integer",
           "description": "Timeout in seconds for MCP server connections",
@@ -380,8 +419,7 @@
         "context_window",
         "default_max_tokens",
         "can_reason",
-        "supports_attachments",
-        "options"
+        "supports_attachments"
       ]
     },
     "ModelOptions": {
@@ -453,7 +491,7 @@
         },
         "data_directory": {
           "type": "string",
-          "description": "Directory for storing application data (relative to working directory)",
+          "description": "Directory for storing application data. Relative paths are resolved against the working directory; absolute paths are used as-is.",
           "default": ".crush",
           "examples": [
             ".crush"
@@ -477,7 +515,7 @@
         },
         "disable_default_providers": {
           "type": "boolean",
-          "description": "Ignore all default/embedded providers. When enabled",
+          "description": "Ignore all default/embedded providers. When enabled, providers must be fully specified in the config file with base_url, models, and api_key - no merging with defaults occurs",
           "default": false
         },
         "attribution": {
@@ -612,11 +650,15 @@
         },
         "extra_body": {
           "type": "object",
-          "description": "Additional fields to include in request bodies"
+          "description": "Additional fields to include in request bodies, only works with openai-compatible providers"
         },
         "provider_options": {
           "type": "object",
           "description": "Additional provider-specific options for this provider"
+        },
+        "flat_rate": {
+          "type": "boolean",
+          "description": "Flat-rate mode for this provider"
         },
         "models": {
           "items": {
@@ -734,10 +776,7 @@
         }
       },
       "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "completions"
-      ]
+      "type": "object"
     },
     "Token": {
       "properties": {
@@ -805,11 +844,7 @@
         }
       },
       "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "ls",
-        "grep"
-      ]
+      "type": "object"
     }
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -3,6 +3,57 @@
   "$id": "https://github.com/charmbracelet/crush/internal/config/config",
   "$ref": "#/$defs/Config",
   "$defs": {
+    "Agent": {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "model": {
+          "type": "string",
+          "enum": [
+            "large",
+            "small"
+          ],
+          "description": "The model type to use for this agent",
+          "default": "large"
+        },
+        "allowed_tools": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "allowed_mcp": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "object"
+        },
+        "context_paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "model"
+      ]
+    },
     "Attribution": {
       "properties": {
         "trailer_style": {
@@ -90,40 +141,18 @@
           "$ref": "#/$defs/Tools",
           "description": "Tool configurations"
         },
-        "hooks": {
+        "agents": {
           "additionalProperties": {
-            "items": {
-              "$ref": "#/$defs/HookConfig"
-            },
-            "type": "array"
+            "$ref": "#/$defs/Agent"
           },
           "type": "object",
-          "description": "User-defined shell commands that fire on hook events (e.g. PreToolUse)"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object"
-    },
-    "HookConfig": {
-      "properties": {
-        "matcher": {
-          "type": "string",
-          "description": "Regex pattern tested against the tool name. Empty means match all tools."
-        },
-        "command": {
-          "type": "string",
-          "description": "Shell command to execute when the hook fires"
-        },
-        "timeout": {
-          "type": "integer",
-          "description": "Timeout in seconds for the hook command",
-          "default": 30
+          "description": "Agent configurations"
         }
       },
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "command"
+        "tools"
       ]
     },
     "LSPConfig": {
@@ -264,16 +293,6 @@
           "type": "array",
           "description": "List of tools from this MCP server to disable"
         },
-        "enabled_tools": {
-          "items": {
-            "type": "string",
-            "examples": [
-              "get-library-doc"
-            ]
-          },
-          "type": "array",
-          "description": "Allow list of tools from this MCP server"
-        },
         "timeout": {
           "type": "integer",
           "description": "Timeout in seconds for MCP server connections",
@@ -361,7 +380,8 @@
         "context_window",
         "default_max_tokens",
         "can_reason",
-        "supports_attachments"
+        "supports_attachments",
+        "options"
       ]
     },
     "ModelOptions": {
@@ -433,7 +453,7 @@
         },
         "data_directory": {
           "type": "string",
-          "description": "Directory for storing application data. Relative paths are resolved against the working directory; absolute paths are used as-is.",
+          "description": "Directory for storing application data (relative to working directory)",
           "default": ".crush",
           "examples": [
             ".crush"
@@ -457,7 +477,7 @@
         },
         "disable_default_providers": {
           "type": "boolean",
-          "description": "Ignore all default/embedded providers. When enabled, providers must be fully specified in the config file with base_url, models, and api_key - no merging with defaults occurs",
+          "description": "Ignore all default/embedded providers. When enabled",
           "default": false
         },
         "attribution": {
@@ -592,15 +612,11 @@
         },
         "extra_body": {
           "type": "object",
-          "description": "Additional fields to include in request bodies, only works with openai-compatible providers"
+          "description": "Additional fields to include in request bodies"
         },
         "provider_options": {
           "type": "object",
           "description": "Additional provider-specific options for this provider"
-        },
-        "flat_rate": {
-          "type": "boolean",
-          "description": "Flat-rate mode for this provider"
         },
         "models": {
           "items": {
@@ -718,7 +734,10 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "required": [
+        "completions"
+      ]
     },
     "Token": {
       "properties": {
@@ -786,7 +805,11 @@
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "required": [
+        "ls",
+        "grep"
+      ]
     }
   }
 }


### PR DESCRIPTION
On Discord, we frequently have users asking about the `Task Agent` using the `large` model, and we have a lot of issues and PRs requesting to change this.

Maybe we should allow the user to configure what they want to use for the Task Agent and Coder Agent? (like @meowgorithm mentioned on #2365)

We can already parse the `Model` from the `config.json`, we just need to remove the `json:"-"` and properly initialize the model size.

I kept the default `AgentTask` as `SelectedModelTypeLarge`, so there is no change if the user does not configure it to use the `small` one.

Example:

```json
{
  "$schema": "https://charm.land/crush.json",
  "agents": {
    "task": {
      "model": "small"
    },
    "coder": {
      "model": "large"
    }
  }
}
```


Related: #914, #2555, #2365, #2364, #2616
Closes: #2501, #427

---

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
