### PR TITLE
fix: refresh TUI when session is updated by an external process

### DIFF
--- a/internal/ui/model/session.go
+++ b/internal/ui/model/session.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -242,6 +243,49 @@ func (m *UI) startLSPs(paths []string) tea.Cmd {
 		ctx := context.Background()
 		for _, path := range paths {
 			m.com.Workspace.LSPStart(ctx, path)
+		}
+		return nil
+	}
+}
+
+// externalUpdateInterval is how often the TUI polls for session changes made
+// by other processes (e.g. crush run -C in a separate terminal).
+const externalUpdateInterval = time.Second
+
+// checkExternalUpdateMsg is a repeating tick used to detect cross-process
+// session changes.
+type checkExternalUpdateMsg struct{}
+
+// externalSessionChangedMsg is returned when the active session has been
+// updated by an external process.
+type externalSessionChangedMsg struct {
+	sessionID string
+}
+
+// scheduleExternalUpdateCheck returns a command that fires checkExternalUpdateMsg
+// after externalUpdateInterval.
+func scheduleExternalUpdateCheck() tea.Cmd {
+	return tea.Tick(externalUpdateInterval, func(time.Time) tea.Msg {
+		return checkExternalUpdateMsg{}
+	})
+}
+
+// checkExternalSessionUpdate queries the workspace for the current session's
+// updated_at timestamp. If it has advanced beyond the cached value, it signals
+// that a full reload is needed.
+func (m *UI) checkExternalSessionUpdate() tea.Cmd {
+	sessionID := m.session.ID
+	knownUpdatedAt := m.session.UpdatedAt
+	return func() tea.Msg {
+		sess, err := m.com.Workspace.GetSession(context.Background(), sessionID)
+		if err != nil {
+			slog.Debug("External update check: failed to get session", "session_id", sessionID, "error", err)
+			return nil
+		}
+		if sess.UpdatedAt > knownUpdatedAt {
+			slog.Debug("External session update detected", "session_id", sessionID,
+				"known_updated_at", knownUpdatedAt, "new_updated_at", sess.UpdatedAt)
+			return externalSessionChangedMsg{sessionID: sessionID}
 		}
 		return nil
 	}

--- a/internal/ui/model/session_test.go
+++ b/internal/ui/model/session_test.go
@@ -1,0 +1,110 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+// sessionWorkspace extends testWorkspace with a controllable GetSession.
+type sessionWorkspace struct {
+	workspace.Workspace
+	getSession func(ctx context.Context, id string) (session.Session, error)
+}
+
+func (w *sessionWorkspace) Config() *config.Config { return nil }
+
+func (w *sessionWorkspace) GetSession(ctx context.Context, id string) (session.Session, error) {
+	return w.getSession(ctx, id)
+}
+
+func newTestUIWithSession(t *testing.T, sess session.Session, getSession func(context.Context, string) (session.Session, error)) *UI {
+	t.Helper()
+	return &UI{
+		com: &common.Common{
+			Workspace: &sessionWorkspace{
+				getSession: getSession,
+			},
+		},
+		session: &sess,
+	}
+}
+
+func TestCheckExternalSessionUpdate_DetectsChange(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "test-session-id"
+	cached := session.Session{ID: sessionID, UpdatedAt: 100}
+	updated := session.Session{ID: sessionID, UpdatedAt: 200}
+
+	ui := newTestUIWithSession(t, cached, func(_ context.Context, id string) (session.Session, error) {
+		require.Equal(t, sessionID, id)
+		return updated, nil
+	})
+
+	cmd := ui.checkExternalSessionUpdate()
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	changed, ok := msg.(externalSessionChangedMsg)
+	require.True(t, ok, "expected externalSessionChangedMsg, got %T", msg)
+	require.Equal(t, sessionID, changed.sessionID)
+}
+
+func TestCheckExternalSessionUpdate_NoChangeWhenTimestampUnchanged(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "test-session-id"
+	cached := session.Session{ID: sessionID, UpdatedAt: 100}
+
+	ui := newTestUIWithSession(t, cached, func(_ context.Context, _ string) (session.Session, error) {
+		return cached, nil
+	})
+
+	cmd := ui.checkExternalSessionUpdate()
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	require.Nil(t, msg, "expected nil when session timestamp is unchanged")
+}
+
+func TestCheckExternalSessionUpdate_NoChangeWhenTimestampGoesBack(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "test-session-id"
+	cached := session.Session{ID: sessionID, UpdatedAt: 100}
+	older := session.Session{ID: sessionID, UpdatedAt: 50}
+
+	ui := newTestUIWithSession(t, cached, func(_ context.Context, _ string) (session.Session, error) {
+		return older, nil
+	})
+
+	cmd := ui.checkExternalSessionUpdate()
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	require.Nil(t, msg, "expected nil when remote timestamp is not newer than cached")
+}
+
+func TestCheckExternalSessionUpdate_SilentOnError(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "test-session-id"
+	cached := session.Session{ID: sessionID, UpdatedAt: 100}
+
+	ui := newTestUIWithSession(t, cached, func(_ context.Context, _ string) (session.Session, error) {
+		return session.Session{}, errors.New("db unavailable")
+	})
+
+	cmd := ui.checkExternalSessionUpdate()
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	require.Nil(t, msg, "expected nil when GetSession returns an error")
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -373,6 +373,8 @@ func (m *UI) Init() tea.Cmd {
 	if cmd := m.loadInitialSession(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
+	// Start polling for session changes made by external processes.
+	cmds = append(cmds, scheduleExternalUpdateCheck())
 	return tea.Batch(cmds...)
 }
 
@@ -563,6 +565,19 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case closeDialogMsg:
 		m.dialog.CloseFrontDialog()
+
+	case checkExternalUpdateMsg:
+		// Only probe the DB when the in-process agent is idle; when it is
+		// running, the pubsub broker already delivers updates inline.
+		if m.hasSession() && !m.isAgentBusy() {
+			cmds = append(cmds, m.checkExternalSessionUpdate())
+		}
+		cmds = append(cmds, scheduleExternalUpdateCheck())
+
+	case externalSessionChangedMsg:
+		if m.hasSession() && m.session.ID == msg.sessionID {
+			cmds = append(cmds, m.loadSession(msg.sessionID))
+		}
 
 	case pubsub.Event[session.Session]:
 		if msg.Type == pubsub.DeletedEvent {


### PR DESCRIPTION
## Problem

  When `crush run --continue` is invoked in a second terminal while an
  interactive session is open, the TUI never reflects the new messages
  unless the user manually switches to another session and back. The
  pubsub broker that drives TUI updates is in-process only — writes made
  to SQLite by a separate `crush run` process are invisible to it.

  ## Reproduction

  1. Open an interactive session and send at least one message so a
     session exists.
  2. Note the session title or ID from the header.
  3. Without closing the TUI, open a second terminal and run:

crush run --continue "Append the word HELLO to your last response"

  4. Watch the TUI in the first terminal — the new assistant message does
  not appear.
  5. Press Ctrl+S, select the same session, and return — the message now
  appears, confirming the data was written but the TUI missed the
  update.

  ## Fix

  Add a 1-second polling loop to the TUI that compares the active
  session's `updated_at` timestamp against its cached value. When the
  timestamp advances and the in-process agent is idle (the pubsub broker
  already covers the live case), a full `loadSession()` reload is
  triggered, fetching all new messages from the DB.

  The check is intentionally skipped while `isAgentBusy()` is true to
  avoid rebuilding the chat list while the in-process agent is
  mid-stream.

  ## Changes

  - `internal/ui/model/session.go` — polling types
  (`checkExternalUpdateMsg`, `externalSessionChangedMsg`),
  `scheduleExternalUpdateCheck()`, and `checkExternalSessionUpdate()`
  - `internal/ui/model/ui.go` — start the poll in `Init()`, handle both
  tick messages in `Update()`

  ## Tests

  Four unit tests in `internal/ui/model/session_test.go` covering:
  - Change detected when `updated_at` advances
  - No reload when timestamp is unchanged
  - No reload when remote timestamp is older than cached
  - Silent no-op when `GetSession` returns an error