### PR TITLE
feat: split-pane tree, tab manager, and cross-platform PTY

### DIFF
--- a/internal/pty/pty.go
+++ b/internal/pty/pty.go
@@ -1,0 +1,188 @@
+// Package pty provides a cross-platform pseudo-terminal abstraction.
+// On Windows it uses ConPTY via direct CreateProcessW syscall.
+// On Unix it uses POSIX openpty via creack/pty (planned).
+package pty
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"sync"
+)
+
+// PTY represents a pseudo-terminal connected to a child process.
+type PTY struct {
+	mu     sync.Mutex
+	cmd    *exec.Cmd      // used on Unix
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	closed bool
+
+	// Platform-specific handle (ConPTY HPCON on Windows, *os.File on Unix).
+	handle interface{}
+
+	// Windows: direct process handle from CreateProcessW (stored as uintptr for cross-platform compilation).
+	procHandle uintptr
+
+	// Cached exit code from Wait.
+	exitCode int
+	exited   bool
+
+	// Size tracking.
+	cols, rows int
+}
+
+// Options configures PTY creation.
+type Options struct {
+	// Command to run. Defaults to the user's shell.
+	Command string
+	// Args for the command.
+	Args []string
+	// Dir is the working directory.
+	Dir string
+	// Env is additional environment variables.
+	Env []string
+	// Initial terminal size.
+	Cols int
+	Rows int
+}
+
+// DefaultShell returns the default shell for the current platform.
+func DefaultShell() string {
+	if runtime.GOOS == "windows" {
+		if ps, err := exec.LookPath("pwsh.exe"); err == nil {
+			return ps
+		}
+		return "powershell.exe"
+	}
+	if shell := os.Getenv("SHELL"); shell != "" {
+		return shell
+	}
+	return "/bin/sh"
+}
+
+// New creates a new PTY with the given options. The child process is started
+// immediately. Call Close() to terminate.
+func New(opts Options) (*PTY, error) {
+	if opts.Command == "" {
+		opts.Command = DefaultShell()
+	}
+	if opts.Cols <= 0 {
+		opts.Cols = 80
+	}
+	if opts.Rows <= 0 {
+		opts.Rows = 24
+	}
+
+	return newPlatformPTY(opts)
+}
+
+// Read reads from the PTY output (child process stdout+stderr).
+func (p *PTY) Read(buf []byte) (int, error) {
+	return p.stdout.Read(buf)
+}
+
+// Write writes to the PTY input (child process stdin).
+func (p *PTY) Write(data []byte) (int, error) {
+	return p.stdin.Write(data)
+}
+
+// WriteString writes a string to the PTY input.
+func (p *PTY) WriteString(s string) (int, error) {
+	return p.Write([]byte(s))
+}
+
+// Resize changes the PTY dimensions.
+func (p *PTY) Resize(cols, rows int) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return fmt.Errorf("pty is closed")
+	}
+	p.cols = cols
+	p.rows = rows
+	return p.resizePlatform(cols, rows)
+}
+
+// Size returns the current PTY dimensions.
+func (p *PTY) Size() (cols, rows int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.cols, p.rows
+}
+
+// Close terminates the child process and releases PTY resources.
+func (p *PTY) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+
+	if p.stdin != nil {
+		p.stdin.Close()
+	}
+
+	// Kill via exec.Cmd (Unix) or direct handle (Windows).
+	if p.cmd != nil && p.cmd.Process != nil {
+		_ = p.cmd.Process.Kill()
+		_ = p.cmd.Wait()
+	}
+
+	return p.closePlatform()
+}
+
+// Wait waits for the child process to exit and returns its exit code.
+func (p *PTY) Wait() (int, error) {
+	p.mu.Lock()
+	if p.exited {
+		code := p.exitCode
+		p.mu.Unlock()
+		return code, nil
+	}
+	p.mu.Unlock()
+
+	if p.cmd != nil {
+		// Unix path: use exec.Cmd.Wait.
+		err := p.cmd.Wait()
+		p.mu.Lock()
+		p.exited = true
+		if err != nil {
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				p.exitCode = exitErr.ExitCode()
+			} else {
+				p.exitCode = -1
+			}
+		}
+		code := p.exitCode
+		p.mu.Unlock()
+		return code, err
+	}
+
+	// Windows path: wait on process handle.
+	if p.procHandle != 0 {
+		code, err := p.waitPlatform()
+		if err != nil {
+			return -1, err
+		}
+		p.mu.Lock()
+		p.exited = true
+		p.exitCode = code
+		p.mu.Unlock()
+		return code, nil
+	}
+
+	return -1, fmt.Errorf("no process to wait on")
+}
+
+// IsRunning returns true if the child process is still running.
+func (p *PTY) IsRunning() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return !p.exited && !p.closed
+}

--- a/internal/pty/pty_unix.go
+++ b/internal/pty/pty_unix.go
@@ -1,0 +1,58 @@
+//go:build !windows
+
+package pty
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/creack/pty"
+)
+
+func newPlatformPTY(opts Options) (*PTY, error) {
+	cmd := exec.Command(opts.Command, opts.Args...)
+	cmd.Dir = opts.Dir
+	cmd.Env = append(os.Environ(), opts.Env...)
+
+	winSize := &pty.Winsize{
+		Rows: uint16(opts.Rows),
+		Cols: uint16(opts.Cols),
+	}
+
+	ptmx, err := pty.StartWithSize(cmd, winSize)
+	if err != nil {
+		return nil, fmt.Errorf("start pty: %w", err)
+	}
+
+	return &PTY{
+		cmd:    cmd,
+		stdin:  ptmx,
+		stdout: ptmx,
+		handle: ptmx,
+		cols:   opts.Cols,
+		rows:   opts.Rows,
+	}, nil
+}
+
+func (p *PTY) waitPlatform() (int, error) {
+	return -1, fmt.Errorf("waitPlatform not used on Unix — use cmd.Wait()")
+}
+
+func (p *PTY) resizePlatform(cols, rows int) error {
+	f, ok := p.handle.(*os.File)
+	if !ok {
+		return fmt.Errorf("invalid PTY handle")
+	}
+	return pty.Setsize(f, &pty.Winsize{
+		Rows: uint16(rows),
+		Cols: uint16(cols),
+	})
+}
+
+func (p *PTY) closePlatform() error {
+	if f, ok := p.handle.(*os.File); ok {
+		return f.Close()
+	}
+	return nil
+}

--- a/internal/pty/pty_windows.go
+++ b/internal/pty/pty_windows.go
@@ -1,0 +1,228 @@
+//go:build windows
+
+package pty
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+	"unicode/utf16"
+	"unsafe"
+)
+
+var (
+	kernel32                   = syscall.NewLazyDLL("kernel32.dll")
+	procCreatePseudoConsole    = kernel32.NewProc("CreatePseudoConsole")
+	procResizePseudoConsole    = kernel32.NewProc("ResizePseudoConsole")
+	procClosePseudoConsole     = kernel32.NewProc("ClosePseudoConsole")
+	procInitializeProcThreadAL = kernel32.NewProc("InitializeProcThreadAttributeList")
+	procUpdateProcThreadAttr   = kernel32.NewProc("UpdateProcThreadAttribute")
+	procDeleteProcThreadAL     = kernel32.NewProc("DeleteProcThreadAttributeList")
+	procCreateProcessW         = kernel32.NewProc("CreateProcessW")
+)
+
+const (
+	_PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE = 0x00020016
+	_EXTENDED_STARTUPINFO_PRESENT        = 0x00080000
+)
+
+// coord matches Win32 COORD: X in low 16 bits, Y in high 16 bits (little-endian x86/ARM).
+type coord struct {
+	x, y int16
+}
+
+func coordToDWORD(c coord) uintptr {
+	return uintptr(*(*uint32)(unsafe.Pointer(&c)))
+}
+
+// startupInfoEx matches Win32 STARTUPINFOEXW.
+type startupInfoEx struct {
+	startupInfo   syscall.StartupInfo
+	lpAttributeList uintptr
+}
+
+func newPlatformPTY(opts Options) (*PTY, error) {
+	// Create pipes for PTY I/O.
+	ptyInR, ptyInW, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("create input pipe: %w", err)
+	}
+	ptyOutR, ptyOutW, err := os.Pipe()
+	if err != nil {
+		ptyInR.Close()
+		ptyInW.Close()
+		return nil, fmt.Errorf("create output pipe: %w", err)
+	}
+
+	// Create the pseudo console.
+	size := coord{x: int16(opts.Cols), y: int16(opts.Rows)}
+	var hPC syscall.Handle
+
+	r, _, err := procCreatePseudoConsole.Call(
+		coordToDWORD(size),
+		ptyInR.Fd(),
+		ptyOutW.Fd(),
+		0,
+		uintptr(unsafe.Pointer(&hPC)),
+	)
+	if r != 0 {
+		ptyInR.Close()
+		ptyInW.Close()
+		ptyOutR.Close()
+		ptyOutW.Close()
+		return nil, fmt.Errorf("CreatePseudoConsole failed: HRESULT 0x%x: %w", r, err)
+	}
+
+	// Close the pipe ends that the ConPTY now owns.
+	ptyInR.Close()
+	ptyOutW.Close()
+
+	// Initialize process thread attribute list for ConPTY.
+	// First call: query required size.
+	var attrListSize uintptr
+	procInitializeProcThreadAL.Call(0, 1, 0, 0, uintptr(unsafe.Pointer(&attrListSize)))
+
+	attrListBuf := make([]byte, attrListSize)
+	attrListPtr := uintptr(unsafe.Pointer(&attrListBuf[0]))
+
+	r, _, err = procInitializeProcThreadAL.Call(attrListPtr, 1, 0, 0, uintptr(unsafe.Pointer(&attrListSize)))
+	if r == 0 {
+		procClosePseudoConsole.Call(uintptr(hPC))
+		ptyInW.Close()
+		ptyOutR.Close()
+		return nil, fmt.Errorf("InitializeProcThreadAttributeList failed: %w", err)
+	}
+
+	// Bind the ConPTY handle to the attribute list.
+	r, _, err = procUpdateProcThreadAttr.Call(
+		attrListPtr,
+		0,
+		_PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+		uintptr(hPC),
+		unsafe.Sizeof(hPC),
+		0, 0,
+	)
+	if r == 0 {
+		procDeleteProcThreadAL.Call(attrListPtr)
+		procClosePseudoConsole.Call(uintptr(hPC))
+		ptyInW.Close()
+		ptyOutR.Close()
+		return nil, fmt.Errorf("UpdateProcThreadAttribute failed: %w", err)
+	}
+
+	// Build command line string.
+	cmdLine := opts.Command
+	if len(opts.Args) > 0 {
+		cmdLine += " " + strings.Join(opts.Args, " ")
+	}
+	cmdLineUTF16, _ := syscall.UTF16PtrFromString(cmdLine)
+
+	// Build environment block.
+	env := os.Environ()
+	env = append(env, opts.Env...)
+	envBlock := buildEnvBlock(env)
+
+	// Build working directory.
+	var cwdPtr *uint16
+	if opts.Dir != "" {
+		cwdPtr, _ = syscall.UTF16PtrFromString(opts.Dir)
+	}
+
+	// Create STARTUPINFOEXW with the attribute list.
+	// This is the critical part — exec.Command cannot do this.
+	si := startupInfoEx{}
+	si.startupInfo.Cb = uint32(unsafe.Sizeof(si))
+	si.lpAttributeList = attrListPtr
+
+	var pi syscall.ProcessInformation
+
+	r, _, err = procCreateProcessW.Call(
+		0, // lpApplicationName — use command line
+		uintptr(unsafe.Pointer(cmdLineUTF16)),
+		0, // lpProcessAttributes
+		0, // lpThreadAttributes
+		0, // bInheritHandles — ConPTY manages the handles
+		_EXTENDED_STARTUPINFO_PRESENT|syscall.CREATE_UNICODE_ENVIRONMENT,
+		uintptr(unsafe.Pointer(&envBlock[0])),
+		uintptr(unsafe.Pointer(cwdPtr)),
+		uintptr(unsafe.Pointer(&si)),
+		uintptr(unsafe.Pointer(&pi)),
+	)
+	if r == 0 {
+		procDeleteProcThreadAL.Call(attrListPtr)
+		procClosePseudoConsole.Call(uintptr(hPC))
+		ptyInW.Close()
+		ptyOutR.Close()
+		return nil, fmt.Errorf("CreateProcessW failed: %w", err)
+	}
+
+	// Clean up attribute list and thread handle — we only need the process handle.
+	procDeleteProcThreadAL.Call(attrListPtr)
+	syscall.CloseHandle(pi.Thread)
+
+	return &PTY{
+		cmd:    nil, // not using exec.Cmd — we manage the process directly
+		stdin:  ptyInW,
+		stdout: ptyOutR,
+		handle: hPC,
+		cols:   opts.Cols,
+		rows:   opts.Rows,
+		procHandle: uintptr(pi.Process),
+	}, nil
+}
+
+func (p *PTY) resizePlatform(cols, rows int) error {
+	hPC, ok := p.handle.(syscall.Handle)
+	if !ok {
+		return fmt.Errorf("invalid ConPTY handle")
+	}
+	size := coord{x: int16(cols), y: int16(rows)}
+	r, _, err := procResizePseudoConsole.Call(uintptr(hPC), coordToDWORD(size))
+	if r != 0 {
+		return fmt.Errorf("ResizePseudoConsole failed: HRESULT 0x%x: %w", r, err)
+	}
+	return nil
+}
+
+func (p *PTY) waitPlatform() (int, error) {
+	h := syscall.Handle(p.procHandle)
+	s, err := syscall.WaitForSingleObject(h, syscall.INFINITE)
+	if err != nil {
+		return -1, fmt.Errorf("WaitForSingleObject: %w", err)
+	}
+	if s != syscall.WAIT_OBJECT_0 {
+		return -1, fmt.Errorf("unexpected wait result: %d", s)
+	}
+	var exitCode uint32
+	if err := syscall.GetExitCodeProcess(h, &exitCode); err != nil {
+		return -1, fmt.Errorf("GetExitCodeProcess: %w", err)
+	}
+	return int(exitCode), nil
+}
+
+func (p *PTY) closePlatform() error {
+	if hPC, ok := p.handle.(syscall.Handle); ok {
+		procClosePseudoConsole.Call(uintptr(hPC))
+	}
+	if p.stdout != nil {
+		p.stdout.Close()
+	}
+	if p.procHandle != 0 {
+		h := syscall.Handle(p.procHandle)
+		syscall.TerminateProcess(h, 1)
+		syscall.CloseHandle(h)
+	}
+	return nil
+}
+
+// buildEnvBlock creates a Windows environment block (null-separated, double-null-terminated UTF-16).
+func buildEnvBlock(env []string) []uint16 {
+	var block []uint16
+	for _, e := range env {
+		block = append(block, utf16.Encode([]rune(e))...)
+		block = append(block, 0)
+	}
+	block = append(block, 0) // double null terminator
+	return block
+}

--- a/internal/split/dirty.go
+++ b/internal/split/dirty.go
@@ -1,0 +1,131 @@
+package split
+
+import "sync"
+
+// DirtyTracker tracks which panes have changed since the last render.
+// This enables selective re-rendering — only dirty panes need to be redrawn.
+type DirtyTracker struct {
+	mu      sync.Mutex
+	dirty   map[string]bool
+	renders map[string]string // cached render output per pane
+}
+
+// NewDirtyTracker creates a new dirty tracker.
+func NewDirtyTracker() *DirtyTracker {
+	return &DirtyTracker{
+		dirty:   make(map[string]bool),
+		renders: make(map[string]string),
+	}
+}
+
+// MarkDirty marks a pane as needing re-render.
+func (d *DirtyTracker) MarkDirty(paneID string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.dirty[paneID] = true
+}
+
+// MarkAllDirty marks all tracked panes as dirty (e.g., on resize).
+func (d *DirtyTracker) MarkAllDirty() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for id := range d.dirty {
+		d.dirty[id] = true
+	}
+}
+
+// IsDirty returns true if the pane needs re-rendering.
+func (d *DirtyTracker) IsDirty(paneID string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.dirty[paneID]
+}
+
+// ClearDirty marks a pane as clean after rendering.
+func (d *DirtyTracker) ClearDirty(paneID string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.dirty[paneID] = false
+}
+
+// DirtyPanes returns all pane IDs that need re-rendering.
+func (d *DirtyTracker) DirtyPanes() []string {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	var result []string
+	for id, isDirty := range d.dirty {
+		if isDirty {
+			result = append(result, id)
+		}
+	}
+	return result
+}
+
+// DirtyCount returns the number of dirty panes.
+func (d *DirtyTracker) DirtyCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	count := 0
+	for _, isDirty := range d.dirty {
+		if isDirty {
+			count++
+		}
+	}
+	return count
+}
+
+// SetCachedRender stores the rendered output for a pane.
+func (d *DirtyTracker) SetCachedRender(paneID, rendered string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.renders[paneID] = rendered
+	d.dirty[paneID] = false
+}
+
+// GetCachedRender returns the cached render for a pane, or empty string if none.
+func (d *DirtyTracker) GetCachedRender(paneID string) (string, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	r, ok := d.renders[paneID]
+	return r, ok
+}
+
+// Remove removes a pane from tracking.
+func (d *DirtyTracker) Remove(paneID string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.dirty, paneID)
+	delete(d.renders, paneID)
+}
+
+// Track begins tracking a new pane (starts dirty).
+func (d *DirtyTracker) Track(paneID string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.dirty[paneID] = true
+}
+
+// RenderStats returns rendering performance stats.
+type RenderStats struct {
+	TotalPanes  int
+	DirtyPanes  int
+	CachedPanes int
+}
+
+// Stats returns current rendering stats.
+func (d *DirtyTracker) Stats() RenderStats {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	stats := RenderStats{
+		TotalPanes: len(d.dirty),
+	}
+	for _, isDirty := range d.dirty {
+		if isDirty {
+			stats.DirtyPanes++
+		} else {
+			stats.CachedPanes++
+		}
+	}
+	return stats
+}

--- a/internal/split/dirty_test.go
+++ b/internal/split/dirty_test.go
@@ -1,0 +1,132 @@
+package split
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirtyTrackerBasic(t *testing.T) {
+	t.Parallel()
+	d := NewDirtyTracker()
+
+	d.Track("p1")
+	d.Track("p2")
+	d.Track("p3")
+
+	// All start dirty.
+	require.True(t, d.IsDirty("p1"))
+	require.True(t, d.IsDirty("p2"))
+	require.True(t, d.IsDirty("p3"))
+	require.Equal(t, 3, d.DirtyCount())
+
+	// Clear one.
+	d.ClearDirty("p1")
+	require.False(t, d.IsDirty("p1"))
+	require.Equal(t, 2, d.DirtyCount())
+
+	// Mark dirty again.
+	d.MarkDirty("p1")
+	require.True(t, d.IsDirty("p1"))
+}
+
+func TestDirtyTrackerMarkAllDirty(t *testing.T) {
+	t.Parallel()
+	d := NewDirtyTracker()
+
+	d.Track("p1")
+	d.Track("p2")
+	d.ClearDirty("p1")
+	d.ClearDirty("p2")
+	require.Equal(t, 0, d.DirtyCount())
+
+	d.MarkAllDirty()
+	require.Equal(t, 2, d.DirtyCount())
+}
+
+func TestDirtyTrackerCachedRender(t *testing.T) {
+	t.Parallel()
+	d := NewDirtyTracker()
+
+	d.Track("p1")
+	require.True(t, d.IsDirty("p1"))
+
+	d.SetCachedRender("p1", "rendered content")
+	require.False(t, d.IsDirty("p1")) // SetCachedRender clears dirty
+
+	cached, ok := d.GetCachedRender("p1")
+	require.True(t, ok)
+	require.Equal(t, "rendered content", cached)
+
+	// Non-existent pane.
+	_, ok = d.GetCachedRender("nonexistent")
+	require.False(t, ok)
+}
+
+func TestDirtyTrackerRemove(t *testing.T) {
+	t.Parallel()
+	d := NewDirtyTracker()
+
+	d.Track("p1")
+	d.SetCachedRender("p1", "content")
+
+	d.Remove("p1")
+	require.False(t, d.IsDirty("p1"))
+	_, ok := d.GetCachedRender("p1")
+	require.False(t, ok)
+}
+
+func TestDirtyTrackerDirtyPanes(t *testing.T) {
+	t.Parallel()
+	d := NewDirtyTracker()
+
+	d.Track("p1")
+	d.Track("p2")
+	d.Track("p3")
+	d.ClearDirty("p2")
+
+	dirty := d.DirtyPanes()
+	require.Len(t, dirty, 2)
+	require.Contains(t, dirty, "p1")
+	require.Contains(t, dirty, "p3")
+}
+
+func TestDirtyTrackerStats(t *testing.T) {
+	t.Parallel()
+	d := NewDirtyTracker()
+
+	d.Track("p1")
+	d.Track("p2")
+	d.Track("p3")
+	d.ClearDirty("p1")
+
+	stats := d.Stats()
+	require.Equal(t, 3, stats.TotalPanes)
+	require.Equal(t, 2, stats.DirtyPanes)
+	require.Equal(t, 1, stats.CachedPanes)
+}
+
+func TestDirtyTrackerConcurrent(t *testing.T) {
+	t.Parallel()
+	d := NewDirtyTracker()
+
+	// Concurrent writes shouldn't race.
+	done := make(chan struct{})
+	for i := range 20 {
+		go func(id int) {
+			pane := "p" + string(rune('0'+id%10))
+			d.Track(pane)
+			d.MarkDirty(pane)
+			d.IsDirty(pane)
+			d.ClearDirty(pane)
+			d.SetCachedRender(pane, "x")
+			d.GetCachedRender(pane)
+			d.DirtyPanes()
+			d.Stats()
+			done <- struct{}{}
+		}(i)
+	}
+	for range 20 {
+		<-done
+	}
+}

--- a/internal/split/layout.go
+++ b/internal/split/layout.go
@@ -1,0 +1,180 @@
+package split
+
+// Rect represents a rectangular area in terminal coordinates.
+type Rect struct {
+	X, Y          int
+	Width, Height int
+}
+
+// PaneLayout maps a pane ID to its computed rectangle.
+type PaneLayout struct {
+	PaneID string
+	Rect   Rect
+}
+
+// Layout resolves a split tree into absolute pane rectangles given a total
+// available width and height. The minimum pane dimension is 1 column / 1 row.
+func Layout(root *Node, width, height int) []PaneLayout {
+	if root == nil {
+		return nil
+	}
+	return layoutRecursive(root, Rect{X: 0, Y: 0, Width: width, Height: height})
+}
+
+func layoutRecursive(node *Node, area Rect) []PaneLayout {
+	if node.IsLeaf() {
+		return []PaneLayout{{PaneID: node.Leaf.PaneID, Rect: area}}
+	}
+
+	if !node.IsSplit() {
+		return nil
+	}
+
+	s := node.Split
+	aRect, bRect := splitRect(area, s.Dir, s.Ratio)
+	a := layoutRecursive(s.A, aRect)
+	b := layoutRecursive(s.B, bRect)
+	return append(a, b...)
+}
+
+// splitRect divides a rectangle according to direction and ratio.
+// Allocates at least 1 column/row to each side.
+func splitRect(area Rect, dir Direction, ratio float64) (Rect, Rect) {
+	var a, b Rect
+
+	switch dir {
+	case Horizontal:
+		// Split left/right.
+		aWidth := int(float64(area.Width) * ratio)
+		if aWidth < 1 {
+			aWidth = 1
+		}
+		if aWidth >= area.Width {
+			aWidth = area.Width - 1
+		}
+		bWidth := area.Width - aWidth
+
+		a = Rect{X: area.X, Y: area.Y, Width: aWidth, Height: area.Height}
+		b = Rect{X: area.X + aWidth, Y: area.Y, Width: bWidth, Height: area.Height}
+
+	case Vertical:
+		// Split top/bottom.
+		aHeight := int(float64(area.Height) * ratio)
+		if aHeight < 1 {
+			aHeight = 1
+		}
+		if aHeight >= area.Height {
+			aHeight = area.Height - 1
+		}
+		bHeight := area.Height - aHeight
+
+		a = Rect{X: area.X, Y: area.Y, Width: area.Width, Height: aHeight}
+		b = Rect{X: area.X, Y: area.Y + aHeight, Width: area.Width, Height: bHeight}
+	}
+
+	return a, b
+}
+
+// LayoutWithDividers is like Layout but reserves 1 column/row for split dividers.
+// This ensures panes don't overlap with visual divider lines.
+func LayoutWithDividers(root *Node, width, height int) []PaneLayout {
+	if root == nil {
+		return nil
+	}
+	return layoutWithDividersRecursive(root, Rect{X: 0, Y: 0, Width: width, Height: height})
+}
+
+func layoutWithDividersRecursive(node *Node, area Rect) []PaneLayout {
+	if node.IsLeaf() {
+		return []PaneLayout{{PaneID: node.Leaf.PaneID, Rect: area}}
+	}
+
+	if !node.IsSplit() {
+		return nil
+	}
+
+	s := node.Split
+	aRect, bRect := splitRectWithDivider(area, s.Dir, s.Ratio)
+	a := layoutWithDividersRecursive(s.A, aRect)
+	b := layoutWithDividersRecursive(s.B, bRect)
+	return append(a, b...)
+}
+
+// splitGeometry computes the positions of child A, the divider, and child B.
+// Single source of truth — used by both LayoutWithDividers and Dividers.
+func splitGeometry(area Rect, dir Direction, ratio float64) (aRect, divider, bRect Rect) {
+	const dividerSize = 1
+
+	switch dir {
+	case Horizontal:
+		if area.Width < 3 {
+			return Rect{X: area.X, Y: area.Y, Width: area.Width, Height: area.Height},
+				Rect{}, // no divider
+				Rect{X: area.X + area.Width, Y: area.Y, Width: 0, Height: area.Height}
+		}
+		usable := area.Width - dividerSize
+		aWidth := int(float64(usable) * ratio)
+		if aWidth < 1 {
+			aWidth = 1
+		}
+		if aWidth >= usable {
+			aWidth = usable - 1
+		}
+		bWidth := usable - aWidth
+		aRect = Rect{X: area.X, Y: area.Y, Width: aWidth, Height: area.Height}
+		divider = Rect{X: area.X + aWidth, Y: area.Y, Width: 1, Height: area.Height}
+		bRect = Rect{X: area.X + aWidth + dividerSize, Y: area.Y, Width: bWidth, Height: area.Height}
+
+	case Vertical:
+		if area.Height < 3 {
+			return Rect{X: area.X, Y: area.Y, Width: area.Width, Height: area.Height},
+				Rect{},
+				Rect{X: area.X, Y: area.Y + area.Height, Width: area.Width, Height: 0}
+		}
+		usable := area.Height - dividerSize
+		aHeight := int(float64(usable) * ratio)
+		if aHeight < 1 {
+			aHeight = 1
+		}
+		if aHeight >= usable {
+			aHeight = usable - 1
+		}
+		bHeight := usable - aHeight
+		aRect = Rect{X: area.X, Y: area.Y, Width: area.Width, Height: aHeight}
+		divider = Rect{X: area.X, Y: area.Y + aHeight, Width: area.Width, Height: 1}
+		bRect = Rect{X: area.X, Y: area.Y + aHeight + dividerSize, Width: area.Width, Height: bHeight}
+	}
+	return
+}
+
+// splitRectWithDivider is a convenience wrapper returning just the two child rects.
+func splitRectWithDivider(area Rect, dir Direction, ratio float64) (Rect, Rect) {
+	a, _, b := splitGeometry(area, dir, ratio)
+	return a, b
+}
+
+// Dividers returns the positions of all divider lines in the layout.
+// Each divider is a Rect with either Width=1 (vertical divider) or Height=1 (horizontal).
+func Dividers(root *Node, width, height int) []Rect {
+	if root == nil {
+		return nil
+	}
+	return dividersRecursive(root, Rect{X: 0, Y: 0, Width: width, Height: height})
+}
+
+func dividersRecursive(node *Node, area Rect) []Rect {
+	if node.IsLeaf() {
+		return nil
+	}
+	if !node.IsSplit() {
+		return nil
+	}
+
+	s := node.Split
+	aRect, divider, bRect := splitGeometry(area, s.Dir, s.Ratio)
+
+	result := []Rect{divider}
+	result = append(result, dividersRecursive(s.A, aRect)...)
+	result = append(result, dividersRecursive(s.B, bRect)...)
+	return result
+}

--- a/internal/split/layout_test.go
+++ b/internal/split/layout_test.go
@@ -1,0 +1,242 @@
+package split
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLayoutWithDividersHorizontal(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Horizontal, 0.5, NewLeaf("left"), NewLeaf("right"))
+	layouts := LayoutWithDividers(root, 80, 24)
+	require.Len(t, layouts, 2)
+
+	left := layouts[0]
+	right := layouts[1]
+
+	// Widths should sum to total minus 1 (divider).
+	require.Equal(t, 79, left.Rect.Width+right.Rect.Width)
+
+	// Gap of 1 column between them (the divider).
+	require.Equal(t, left.Rect.X+left.Rect.Width+1, right.Rect.X)
+}
+
+func TestLayoutWithDividersVertical(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Vertical, 0.5, NewLeaf("top"), NewLeaf("bottom"))
+	layouts := LayoutWithDividers(root, 80, 24)
+	require.Len(t, layouts, 2)
+
+	top := layouts[0]
+	bottom := layouts[1]
+
+	// Heights should sum to total minus 1 (divider).
+	require.Equal(t, 23, top.Rect.Height+bottom.Rect.Height)
+
+	// Gap of 1 row between them.
+	require.Equal(t, top.Rect.Y+top.Rect.Height+1, bottom.Rect.Y)
+}
+
+func TestDividersHorizontal(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Horizontal, 0.5, NewLeaf("left"), NewLeaf("right"))
+	divs := Dividers(root, 80, 24)
+	require.Len(t, divs, 1)
+
+	div := divs[0]
+	// Vertical divider line: 1 column wide, full height.
+	require.Equal(t, 1, div.Width)
+	require.Equal(t, 24, div.Height)
+}
+
+func TestDividersVertical(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Vertical, 0.5, NewLeaf("top"), NewLeaf("bottom"))
+	divs := Dividers(root, 80, 24)
+	require.Len(t, divs, 1)
+
+	div := divs[0]
+	// Horizontal divider line: full width, 1 row tall.
+	require.Equal(t, 80, div.Width)
+	require.Equal(t, 1, div.Height)
+}
+
+func TestDividersNestedSplits(t *testing.T) {
+	t.Parallel()
+	// left | (top-right / bottom-right)
+	right := NewSplit(Vertical, 0.5, NewLeaf("tr"), NewLeaf("br"))
+	root := NewSplit(Horizontal, 0.5, NewLeaf("left"), right)
+
+	divs := Dividers(root, 80, 24)
+	// One vertical divider between left and right, one horizontal inside right.
+	require.Len(t, divs, 2)
+}
+
+func TestLayoutDeepTree(t *testing.T) {
+	t.Parallel()
+	// Four panes in a 2x2 grid:
+	// p1 | p2
+	// -------
+	// p3 | p4
+	topRow := NewSplit(Horizontal, 0.5, NewLeaf("p1"), NewLeaf("p2"))
+	botRow := NewSplit(Horizontal, 0.5, NewLeaf("p3"), NewLeaf("p4"))
+	root := NewSplit(Vertical, 0.5, topRow, botRow)
+
+	layouts := LayoutWithDividers(root, 80, 24)
+	require.Len(t, layouts, 4)
+
+	ids := make([]string, len(layouts))
+	for i, l := range layouts {
+		ids[i] = l.PaneID
+	}
+	require.Equal(t, []string{"p1", "p2", "p3", "p4"}, ids)
+
+	// All panes should have positive dimensions.
+	for _, l := range layouts {
+		require.Greater(t, l.Rect.Width, 0, "pane %s width", l.PaneID)
+		require.Greater(t, l.Rect.Height, 0, "pane %s height", l.PaneID)
+	}
+}
+
+func TestLayoutMinimumDimensions(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Horizontal, 0.5, NewLeaf("a"), NewLeaf("b"))
+
+	// Even with tiny area, each pane gets at least 1 column.
+	layouts := Layout(root, 2, 1)
+	require.Len(t, layouts, 2)
+	require.GreaterOrEqual(t, layouts[0].Rect.Width, 1)
+	require.GreaterOrEqual(t, layouts[1].Rect.Width, 1)
+}
+
+func TestSplitGeometrySmallArea(t *testing.T) {
+	t.Parallel()
+	// Width < 3 should degrade gracefully (no divider, B gets zero width).
+	area := Rect{X: 0, Y: 0, Width: 2, Height: 10}
+	a, div, b := splitGeometry(area, Horizontal, 0.5)
+
+	require.Equal(t, 2, a.Width)
+	require.Equal(t, 0, div.Width)
+	require.Equal(t, 0, b.Width)
+}
+
+func TestSplitGeometrySmallAreaVertical(t *testing.T) {
+	t.Parallel()
+	// Height < 3 should degrade gracefully.
+	area := Rect{X: 0, Y: 0, Width: 80, Height: 2}
+	a, div, b := splitGeometry(area, Vertical, 0.5)
+
+	require.Equal(t, 2, a.Height)
+	require.Equal(t, 0, div.Height)
+	require.Equal(t, 0, b.Height)
+}
+
+func TestSplitGeometryExtremeRatio(t *testing.T) {
+	t.Parallel()
+	area := Rect{X: 0, Y: 0, Width: 80, Height: 24}
+
+	// Near-zero ratio: A gets minimum 1 column.
+	a, _, b := splitGeometry(area, Horizontal, 0.01)
+	require.GreaterOrEqual(t, a.Width, 1)
+	require.Greater(t, b.Width, 0)
+
+	// Near-one ratio: B gets minimum 1 column.
+	a2, _, b2 := splitGeometry(area, Horizontal, 0.99)
+	require.Greater(t, a2.Width, 0)
+	require.GreaterOrEqual(t, b2.Width, 1)
+}
+
+func TestDividerPositionConsistency(t *testing.T) {
+	t.Parallel()
+	// Verify divider sits exactly between the two pane rects.
+	root := NewSplit(Horizontal, 0.5, NewLeaf("a"), NewLeaf("b"))
+	layouts := LayoutWithDividers(root, 80, 24)
+	divs := Dividers(root, 80, 24)
+
+	require.Len(t, layouts, 2)
+	require.Len(t, divs, 1)
+
+	left := layouts[0]
+	right := layouts[1]
+	div := divs[0]
+
+	// Divider should start right after left pane.
+	require.Equal(t, left.Rect.X+left.Rect.Width, div.X)
+	// Right pane should start right after divider.
+	require.Equal(t, div.X+div.Width, right.Rect.X)
+	// Total should equal 80.
+	require.Equal(t, 80, left.Rect.Width+div.Width+right.Rect.Width)
+}
+
+func TestDividerPositionConsistencyVertical(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Vertical, 0.5, NewLeaf("a"), NewLeaf("b"))
+	layouts := LayoutWithDividers(root, 80, 24)
+	divs := Dividers(root, 80, 24)
+
+	require.Len(t, layouts, 2)
+	require.Len(t, divs, 1)
+
+	top := layouts[0]
+	bottom := layouts[1]
+	div := divs[0]
+
+	require.Equal(t, top.Rect.Y+top.Rect.Height, div.Y)
+	require.Equal(t, div.Y+div.Height, bottom.Rect.Y)
+	require.Equal(t, 24, top.Rect.Height+div.Height+bottom.Rect.Height)
+}
+
+func TestLayoutWithDividersNoOverlap(t *testing.T) {
+	t.Parallel()
+	// 3 panes: left | (top-right / bottom-right)
+	right := NewSplit(Vertical, 0.5, NewLeaf("tr"), NewLeaf("br"))
+	root := NewSplit(Horizontal, 0.5, NewLeaf("left"), right)
+
+	layouts := LayoutWithDividers(root, 120, 40)
+	divs := Dividers(root, 120, 40)
+
+	// No pane should overlap any divider.
+	for _, pl := range layouts {
+		for _, d := range divs {
+			overlapX := pl.Rect.X < d.X+d.Width && pl.Rect.X+pl.Rect.Width > d.X
+			overlapY := pl.Rect.Y < d.Y+d.Height && pl.Rect.Y+pl.Rect.Height > d.Y
+			if overlapX && overlapY {
+				t.Errorf("pane %s overlaps divider at (%d,%d %dx%d)",
+					pl.PaneID, d.X, d.Y, d.Width, d.Height)
+			}
+		}
+	}
+
+	// No two panes should overlap each other.
+	for i := 0; i < len(layouts); i++ {
+		for j := i + 1; j < len(layouts); j++ {
+			a := layouts[i].Rect
+			b := layouts[j].Rect
+			overlapX := a.X < b.X+b.Width && a.X+a.Width > b.X
+			overlapY := a.Y < b.Y+b.Height && a.Y+a.Height > b.Y
+			if overlapX && overlapY {
+				t.Errorf("pane %s overlaps pane %s", layouts[i].PaneID, layouts[j].PaneID)
+			}
+		}
+	}
+}
+
+func TestLayoutVariousRatios(t *testing.T) {
+	t.Parallel()
+	ratios := []float64{0.1, 0.25, 0.33, 0.5, 0.66, 0.75, 0.9}
+	for _, ratio := range ratios {
+		root := NewSplit(Horizontal, ratio, NewLeaf("a"), NewLeaf("b"))
+		layouts := LayoutWithDividers(root, 100, 50)
+		require.Len(t, layouts, 2, "ratio %f", ratio)
+
+		// Both panes must have positive dimensions.
+		require.Greater(t, layouts[0].Rect.Width, 0, "left pane width at ratio %f", ratio)
+		require.Greater(t, layouts[1].Rect.Width, 0, "right pane width at ratio %f", ratio)
+
+		divs := Dividers(root, 100, 50)
+		require.Len(t, divs, 1)
+		total := layouts[0].Rect.Width + divs[0].Width + layouts[1].Rect.Width
+		require.Equal(t, 100, total, "total width at ratio %f", ratio)
+	}
+}

--- a/internal/split/tree.go
+++ b/internal/split/tree.go
@@ -1,0 +1,219 @@
+// Package split implements a binary tree layout engine for terminal split panes.
+// Each leaf is a pane, each internal node is a horizontal or vertical split
+// with a configurable ratio.
+package split
+
+import "fmt"
+
+// Direction defines the split orientation.
+type Direction int
+
+const (
+	Horizontal Direction = iota // split left/right
+	Vertical                    // split top/bottom
+)
+
+func (d Direction) String() string {
+	if d == Horizontal {
+		return "H"
+	}
+	return "V"
+}
+
+// Node is a node in the split tree — either a Split (internal) or a Leaf (terminal pane).
+type Node struct {
+	// If Leaf is non-nil, this is a leaf node (a pane).
+	Leaf *Leaf
+
+	// If Split is non-nil, this is an internal split node.
+	Split *SplitNode
+}
+
+// IsLeaf returns true if this node is a leaf (pane).
+func (n *Node) IsLeaf() bool {
+	return n.Leaf != nil
+}
+
+// IsSplit returns true if this node is an internal split.
+func (n *Node) IsSplit() bool {
+	return n.Split != nil
+}
+
+// Leaf represents a terminal pane (the actual content area).
+type Leaf struct {
+	// PaneID uniquely identifies this pane.
+	PaneID string
+}
+
+// SplitNode represents an internal split dividing space between two children.
+type SplitNode struct {
+	// Dir is the split direction.
+	Dir Direction
+
+	// Ratio is the fraction of space allocated to child A (0.0-1.0).
+	Ratio float64
+
+	// A is the first child (left or top).
+	A *Node
+
+	// B is the second child (right or bottom).
+	B *Node
+}
+
+// NewLeaf creates a new leaf node with the given pane ID.
+func NewLeaf(paneID string) *Node {
+	return &Node{Leaf: &Leaf{PaneID: paneID}}
+}
+
+// NewSplit creates a new split node.
+func NewSplit(dir Direction, ratio float64, a, b *Node) *Node {
+	if ratio <= 0 || ratio >= 1 {
+		ratio = 0.5
+	}
+	return &Node{Split: &SplitNode{Dir: dir, Ratio: ratio, A: a, B: b}}
+}
+
+// SplitLeaf finds the leaf with the given paneID and splits it into two panes.
+// The original pane becomes child A, and a new pane with newPaneID becomes child B.
+// Returns an error if the pane is not found.
+func SplitLeaf(root *Node, paneID string, dir Direction, newPaneID string) error {
+	return splitLeafRecursive(root, paneID, dir, newPaneID)
+}
+
+func splitLeafRecursive(node *Node, paneID string, dir Direction, newPaneID string) error {
+	if node.IsLeaf() {
+		if node.Leaf.PaneID == paneID {
+			// Convert this leaf into a split with original + new pane.
+			original := &Leaf{PaneID: paneID}
+			newLeaf := &Leaf{PaneID: newPaneID}
+			node.Leaf = nil
+			node.Split = &SplitNode{
+				Dir:   dir,
+				Ratio: 0.5,
+				A:     &Node{Leaf: original},
+				B:     &Node{Leaf: newLeaf},
+			}
+			return nil
+		}
+		return fmt.Errorf("pane %q not found", paneID)
+	}
+
+	if node.IsSplit() {
+		if err := splitLeafRecursive(node.Split.A, paneID, dir, newPaneID); err == nil {
+			return nil
+		}
+		return splitLeafRecursive(node.Split.B, paneID, dir, newPaneID)
+	}
+
+	return fmt.Errorf("pane %q not found", paneID)
+}
+
+// RemoveLeaf removes a pane from the tree by its ID. The parent split collapses,
+// and the sibling takes over the parent's space. Returns an error if the pane
+// is not found or is the only pane (root leaf).
+func RemoveLeaf(root *Node, paneID string) error {
+	if root.IsLeaf() {
+		if root.Leaf.PaneID == paneID {
+			return fmt.Errorf("cannot remove the only pane")
+		}
+		return fmt.Errorf("pane %q not found", paneID)
+	}
+	return removeLeafRecursive(root, paneID)
+}
+
+func removeLeafRecursive(node *Node, paneID string) error {
+	if !node.IsSplit() {
+		return fmt.Errorf("pane %q not found", paneID)
+	}
+
+	s := node.Split
+
+	// Check if A is the target leaf.
+	if s.A.IsLeaf() && s.A.Leaf.PaneID == paneID {
+		// Promote B to this node's position.
+		*node = *s.B
+		return nil
+	}
+
+	// Check if B is the target leaf.
+	if s.B.IsLeaf() && s.B.Leaf.PaneID == paneID {
+		// Promote A to this node's position.
+		*node = *s.A
+		return nil
+	}
+
+	// Recurse into children.
+	if err := removeLeafRecursive(s.A, paneID); err == nil {
+		return nil
+	}
+	return removeLeafRecursive(s.B, paneID)
+}
+
+// FindLeaf returns the leaf node with the given paneID, or nil.
+func FindLeaf(root *Node, paneID string) *Leaf {
+	if root.IsLeaf() {
+		if root.Leaf.PaneID == paneID {
+			return root.Leaf
+		}
+		return nil
+	}
+	if root.IsSplit() {
+		if l := FindLeaf(root.Split.A, paneID); l != nil {
+			return l
+		}
+		return FindLeaf(root.Split.B, paneID)
+	}
+	return nil
+}
+
+// AllLeaves returns all leaf pane IDs in depth-first order.
+func AllLeaves(root *Node) []string {
+	if root.IsLeaf() {
+		return []string{root.Leaf.PaneID}
+	}
+	if root.IsSplit() {
+		a := AllLeaves(root.Split.A)
+		b := AllLeaves(root.Split.B)
+		return append(a, b...)
+	}
+	return nil
+}
+
+// LeafCount returns the number of leaf panes in the tree. Zero allocations.
+func LeafCount(root *Node) int {
+	if root == nil {
+		return 0
+	}
+	if root.IsLeaf() {
+		return 1
+	}
+	if root.IsSplit() {
+		return LeafCount(root.Split.A) + LeafCount(root.Split.B)
+	}
+	return 0
+}
+
+// SetRatio sets the split ratio for the split that contains the given paneID
+// as a direct child. Returns an error if not found.
+func SetRatio(root *Node, paneID string, ratio float64) error {
+	if ratio <= 0 || ratio >= 1 {
+		return fmt.Errorf("ratio must be between 0 and 1 exclusive, got %f", ratio)
+	}
+	return setRatioRecursive(root, paneID, ratio)
+}
+
+func setRatioRecursive(node *Node, paneID string, ratio float64) error {
+	if !node.IsSplit() {
+		return fmt.Errorf("pane %q not found in any split", paneID)
+	}
+	s := node.Split
+	if (s.A.IsLeaf() && s.A.Leaf.PaneID == paneID) ||
+		(s.B.IsLeaf() && s.B.Leaf.PaneID == paneID) {
+		s.Ratio = ratio
+		return nil
+	}
+	if err := setRatioRecursive(s.A, paneID, ratio); err == nil {
+		return nil
+	}
+	return setRatioRecursive(s.B, paneID, ratio)
+}

--- a/internal/split/tree_test.go
+++ b/internal/split/tree_test.go
@@ -1,0 +1,265 @@
+package split
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLeaf(t *testing.T) {
+	t.Parallel()
+	n := NewLeaf("p1")
+	require.True(t, n.IsLeaf())
+	require.False(t, n.IsSplit())
+	require.Equal(t, "p1", n.Leaf.PaneID)
+}
+
+func TestNewSplit(t *testing.T) {
+	t.Parallel()
+	a := NewLeaf("p1")
+	b := NewLeaf("p2")
+	s := NewSplit(Horizontal, 0.5, a, b)
+	require.True(t, s.IsSplit())
+	require.False(t, s.IsLeaf())
+	require.Equal(t, Horizontal, s.Split.Dir)
+	require.InDelta(t, 0.5, s.Split.Ratio, 0.001)
+}
+
+func TestNewSplitClampsBadRatio(t *testing.T) {
+	t.Parallel()
+	s := NewSplit(Vertical, 0.0, NewLeaf("a"), NewLeaf("b"))
+	require.InDelta(t, 0.5, s.Split.Ratio, 0.001)
+
+	s2 := NewSplit(Vertical, 1.0, NewLeaf("a"), NewLeaf("b"))
+	require.InDelta(t, 0.5, s2.Split.Ratio, 0.001)
+}
+
+func TestSplitLeaf(t *testing.T) {
+	t.Parallel()
+	root := NewLeaf("p1")
+
+	err := SplitLeaf(root, "p1", Horizontal, "p2")
+	require.NoError(t, err)
+	require.True(t, root.IsSplit())
+	require.Equal(t, Horizontal, root.Split.Dir)
+	require.Equal(t, "p1", root.Split.A.Leaf.PaneID)
+	require.Equal(t, "p2", root.Split.B.Leaf.PaneID)
+}
+
+func TestSplitLeafDeep(t *testing.T) {
+	t.Parallel()
+	root := NewLeaf("p1")
+
+	require.NoError(t, SplitLeaf(root, "p1", Horizontal, "p2"))
+	require.NoError(t, SplitLeaf(root, "p2", Vertical, "p3"))
+
+	leaves := AllLeaves(root)
+	require.Equal(t, []string{"p1", "p2", "p3"}, leaves)
+	require.Equal(t, 3, LeafCount(root))
+}
+
+func TestSplitLeafNotFound(t *testing.T) {
+	t.Parallel()
+	root := NewLeaf("p1")
+	err := SplitLeaf(root, "nonexistent", Horizontal, "p2")
+	require.Error(t, err)
+}
+
+func TestRemoveLeaf(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Horizontal, 0.5, NewLeaf("p1"), NewLeaf("p2"))
+
+	err := RemoveLeaf(root, "p1")
+	require.NoError(t, err)
+	require.True(t, root.IsLeaf())
+	require.Equal(t, "p2", root.Leaf.PaneID)
+}
+
+func TestRemoveLeafFromB(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Horizontal, 0.5, NewLeaf("p1"), NewLeaf("p2"))
+
+	err := RemoveLeaf(root, "p2")
+	require.NoError(t, err)
+	require.True(t, root.IsLeaf())
+	require.Equal(t, "p1", root.Leaf.PaneID)
+}
+
+func TestRemoveLeafDeep(t *testing.T) {
+	t.Parallel()
+	// Build: H(p1, V(p2, p3))
+	root := NewSplit(Horizontal, 0.5,
+		NewLeaf("p1"),
+		NewSplit(Vertical, 0.5, NewLeaf("p2"), NewLeaf("p3")),
+	)
+
+	err := RemoveLeaf(root, "p2")
+	require.NoError(t, err)
+	// Should collapse to H(p1, p3)
+	require.True(t, root.IsSplit())
+	leaves := AllLeaves(root)
+	require.Equal(t, []string{"p1", "p3"}, leaves)
+}
+
+func TestRemoveOnlyPane(t *testing.T) {
+	t.Parallel()
+	root := NewLeaf("p1")
+	err := RemoveLeaf(root, "p1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot remove the only pane")
+}
+
+func TestRemoveLeafNotFound(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Horizontal, 0.5, NewLeaf("p1"), NewLeaf("p2"))
+	err := RemoveLeaf(root, "nonexistent")
+	require.Error(t, err)
+}
+
+func TestFindLeaf(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Horizontal, 0.5,
+		NewLeaf("p1"),
+		NewSplit(Vertical, 0.5, NewLeaf("p2"), NewLeaf("p3")),
+	)
+
+	require.NotNil(t, FindLeaf(root, "p1"))
+	require.NotNil(t, FindLeaf(root, "p2"))
+	require.NotNil(t, FindLeaf(root, "p3"))
+	require.Nil(t, FindLeaf(root, "nonexistent"))
+}
+
+func TestAllLeaves(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Vertical, 0.5,
+		NewSplit(Horizontal, 0.5, NewLeaf("a"), NewLeaf("b")),
+		NewSplit(Horizontal, 0.5, NewLeaf("c"), NewLeaf("d")),
+	)
+	require.Equal(t, []string{"a", "b", "c", "d"}, AllLeaves(root))
+}
+
+func TestSetRatio(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Horizontal, 0.5, NewLeaf("p1"), NewLeaf("p2"))
+
+	require.NoError(t, SetRatio(root, "p1", 0.3))
+	require.InDelta(t, 0.3, root.Split.Ratio, 0.001)
+
+	require.NoError(t, SetRatio(root, "p2", 0.7))
+	require.InDelta(t, 0.7, root.Split.Ratio, 0.001)
+}
+
+func TestSetRatioInvalid(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Horizontal, 0.5, NewLeaf("p1"), NewLeaf("p2"))
+	require.Error(t, SetRatio(root, "p1", 0.0))
+	require.Error(t, SetRatio(root, "p1", 1.0))
+	require.Error(t, SetRatio(root, "p1", -0.5))
+}
+
+func TestLayout(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Horizontal, 0.5, NewLeaf("p1"), NewLeaf("p2"))
+
+	layouts := Layout(root, 100, 50)
+	require.Len(t, layouts, 2)
+	require.Equal(t, "p1", layouts[0].PaneID)
+	require.Equal(t, "p2", layouts[1].PaneID)
+
+	// p1 gets left half, p2 gets right half.
+	require.Equal(t, 0, layouts[0].Rect.X)
+	require.Equal(t, 50, layouts[0].Rect.Width)
+	require.Equal(t, 50, layouts[1].Rect.X)
+	require.Equal(t, 50, layouts[1].Rect.Width)
+}
+
+func TestLayoutVertical(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Vertical, 0.5, NewLeaf("top"), NewLeaf("bottom"))
+
+	layouts := Layout(root, 80, 40)
+	require.Len(t, layouts, 2)
+	require.Equal(t, 0, layouts[0].Rect.Y)
+	require.Equal(t, 20, layouts[0].Rect.Height)
+	require.Equal(t, 20, layouts[1].Rect.Y)
+	require.Equal(t, 20, layouts[1].Rect.Height)
+}
+
+func TestLayoutWithDividers(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Horizontal, 0.5, NewLeaf("p1"), NewLeaf("p2"))
+
+	layouts := LayoutWithDividers(root, 101, 50)
+	require.Len(t, layouts, 2)
+
+	// Total width minus 1 divider = 100 usable, split 50/50.
+	require.Equal(t, 50, layouts[0].Rect.Width)
+	require.Equal(t, 50, layouts[1].Rect.Width)
+	// p2 starts after p1 + 1 divider.
+	require.Equal(t, 51, layouts[1].Rect.X)
+}
+
+func TestLayoutSingleLeaf(t *testing.T) {
+	t.Parallel()
+	root := NewLeaf("only")
+	layouts := Layout(root, 80, 40)
+	require.Len(t, layouts, 1)
+	require.Equal(t, Rect{X: 0, Y: 0, Width: 80, Height: 40}, layouts[0].Rect)
+}
+
+func TestLayoutNil(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, Layout(nil, 80, 40))
+}
+
+func TestDividers(t *testing.T) {
+	t.Parallel()
+	root := NewSplit(Horizontal, 0.5, NewLeaf("p1"), NewLeaf("p2"))
+
+	dividers := Dividers(root, 101, 50)
+	require.Len(t, dividers, 1)
+	require.Equal(t, 1, dividers[0].Width)
+	require.Equal(t, 50, dividers[0].Height)
+}
+
+func TestDividersComplex(t *testing.T) {
+	t.Parallel()
+	// H(p1, V(p2, p3)) — one vertical divider + one horizontal divider.
+	root := NewSplit(Horizontal, 0.5,
+		NewLeaf("p1"),
+		NewSplit(Vertical, 0.5, NewLeaf("p2"), NewLeaf("p3")),
+	)
+
+	dividers := Dividers(root, 101, 51)
+	require.Len(t, dividers, 2)
+}
+
+func TestDirectionString(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "H", Horizontal.String())
+	require.Equal(t, "V", Vertical.String())
+}
+
+func TestStressManySplits(t *testing.T) {
+	t.Parallel()
+	root := NewLeaf("p0")
+	for i := 1; i <= 20; i++ {
+		paneID := "p" + string(rune('0'+i%10)) + string(rune('0'+i/10))
+		target := AllLeaves(root)[0]
+		require.NoError(t, SplitLeaf(root, target, Direction(i%2), paneID))
+	}
+	require.Equal(t, 21, LeafCount(root))
+
+	layouts := LayoutWithDividers(root, 200, 100)
+	require.Len(t, layouts, 21)
+
+	// All panes have non-negative dimensions. Some may be zero when the
+	// area is too small for a divider (graceful degradation).
+	for _, l := range layouts {
+		require.GreaterOrEqual(t, l.Rect.Width, 0, "pane %s has negative width", l.PaneID)
+		require.GreaterOrEqual(t, l.Rect.Height, 0, "pane %s has negative height", l.PaneID)
+	}
+	// At least the first few panes should have real area.
+	require.Greater(t, layouts[0].Rect.Width, 0)
+	require.Greater(t, layouts[0].Rect.Height, 0)
+}

--- a/internal/tabmgr/persistence.go
+++ b/internal/tabmgr/persistence.go
@@ -1,0 +1,247 @@
+package tabmgr
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/split"
+)
+
+const (
+	sessionFileName    = "sessions.json"
+	saveDebounceDelay  = 2 * time.Second
+)
+
+// SessionLayout is the serializable representation of a tab layout.
+type SessionLayout struct {
+	Version   int              `json:"version"`
+	ActiveTab int              `json:"active_tab"`
+	Tabs      []SessionTab     `json:"tabs"`
+	SavedAt   string           `json:"saved_at"`
+}
+
+// SessionTab is the serializable representation of a single tab.
+type SessionTab struct {
+	ID        string           `json:"id"`
+	Name      string           `json:"name"`
+	CWD       string           `json:"cwd"`
+	SplitTree *SessionNode     `json:"split_tree"`
+}
+
+// SessionNode is the serializable representation of a split tree node.
+type SessionNode struct {
+	// Leaf fields (non-nil if this is a pane).
+	PaneID   string `json:"pane_id,omitempty"`
+	PaneType string `json:"pane_type,omitempty"` // "session" or "shell"
+	PaneCWD  string `json:"pane_cwd,omitempty"`  // pane working directory
+
+	// Per-pane session and model state (leaf nodes only).
+	SessionID     string `json:"session_id,omitempty"`
+	ModelProvider string `json:"model_provider,omitempty"`
+	ModelID       string `json:"model_id,omitempty"`
+
+	// Split fields (non-nil if this is a split).
+	Dir   string       `json:"dir,omitempty"` // "H" or "V"
+	Ratio float64      `json:"ratio,omitempty"`
+	A     *SessionNode `json:"a,omitempty"`
+	B     *SessionNode `json:"b,omitempty"`
+}
+
+// Persistence handles saving and loading tab layouts.
+type Persistence struct {
+	dataDir string
+	mu      sync.Mutex
+	timer   *time.Timer
+}
+
+// NewPersistence creates a new persistence handler for the given data directory.
+func NewPersistence(dataDir string) *Persistence {
+	return &Persistence{dataDir: dataDir}
+}
+
+// SaveLayout saves the current tab manager state to disk.
+func (p *Persistence) SaveLayout(mgr *TabManager) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	layout := SessionLayout{
+		Version:   1,
+		ActiveTab: mgr.ActiveIndex(),
+		SavedAt:   time.Now().UTC().Format(time.RFC3339),
+	}
+
+	for _, tab := range mgr.Tabs() {
+		st := SessionTab{
+			ID:   tab.ID,
+			Name: tab.Name,
+			CWD:  tab.CWD,
+		}
+		st.SplitTree = serializeNode(tab.SplitRoot, tab.Panes)
+		layout.Tabs = append(layout.Tabs, st)
+	}
+
+	data, err := json.MarshalIndent(layout, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal session layout: %w", err)
+	}
+
+	path := filepath.Join(p.dataDir, sessionFileName)
+	if err := os.MkdirAll(p.dataDir, 0o755); err != nil {
+		return fmt.Errorf("create data dir: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write session file: %w", err)
+	}
+
+	return nil
+}
+
+// SaveLayoutDebounced saves the layout with a debounce delay.
+// Multiple rapid calls within the delay window result in a single save.
+func (p *Persistence) SaveLayoutDebounced(mgr *TabManager) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.timer != nil {
+		p.timer.Stop()
+	}
+	p.timer = time.AfterFunc(saveDebounceDelay, func() {
+		if err := p.SaveLayout(mgr); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to save session layout: %v\n", err)
+		}
+	})
+}
+
+// LoadLayout loads a previously saved tab layout and reconstructs tabs.
+// Returns nil and no error if no saved layout exists.
+func (p *Persistence) LoadLayout() (*SessionLayout, error) {
+	path := filepath.Join(p.dataDir, sessionFileName)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read session file: %w", err)
+	}
+
+	var layout SessionLayout
+	if err := json.Unmarshal(data, &layout); err != nil {
+		return nil, fmt.Errorf("unmarshal session layout: %w", err)
+	}
+
+	if layout.Version != 1 {
+		return nil, fmt.Errorf("unsupported session layout version: %d", layout.Version)
+	}
+
+	return &layout, nil
+}
+
+// RestoreTabs reconstructs a TabManager from a saved layout.
+func (p *Persistence) RestoreTabs(layout *SessionLayout) *TabManager {
+	mgr := New()
+
+	for _, st := range layout.Tabs {
+		// Create the tab with a default pane first.
+		tab := mgr.AddTab(st.Name, st.CWD, PaneSession)
+
+		// If we have a saved split tree, reconstruct it.
+		if st.SplitTree != nil {
+			root, panes := deserializeNode(st.SplitTree)
+			if root != nil {
+				tab.SplitRoot = root
+				tab.Panes = panes
+				// Set focus to the first pane.
+				leaves := split.AllLeaves(root)
+				if len(leaves) > 0 {
+					tab.FocusedPane = leaves[0]
+				}
+			}
+		}
+	}
+
+	// Restore active tab.
+	if layout.ActiveTab >= 0 && layout.ActiveTab < mgr.Len() {
+		mgr.SelectTab(layout.ActiveTab)
+	}
+
+	return mgr
+}
+
+func serializeNode(node *split.Node, panes map[string]*PaneMeta) *SessionNode {
+	if node == nil {
+		return nil
+	}
+
+	if node.IsLeaf() {
+		sn := &SessionNode{
+			PaneID:   node.Leaf.PaneID,
+			PaneType: "session",
+		}
+		if meta, ok := panes[node.Leaf.PaneID]; ok {
+			sn.PaneType = meta.Type.String()
+			sn.PaneCWD = meta.CWD
+			sn.SessionID = meta.SessionID
+			sn.ModelProvider = meta.ModelProvider
+			sn.ModelID = meta.ModelID
+		}
+		return sn
+	}
+
+	if node.IsSplit() {
+		return &SessionNode{
+			Dir:   node.Split.Dir.String(),
+			Ratio: node.Split.Ratio,
+			A:     serializeNode(node.Split.A, panes),
+			B:     serializeNode(node.Split.B, panes),
+		}
+	}
+
+	return nil
+}
+
+func deserializeNode(sn *SessionNode) (*split.Node, map[string]*PaneMeta) {
+	panes := make(map[string]*PaneMeta)
+	node := deserializeNodeRecursive(sn, panes)
+	return node, panes
+}
+
+func deserializeNodeRecursive(sn *SessionNode, panes map[string]*PaneMeta) *split.Node {
+	if sn == nil {
+		return nil
+	}
+
+	// Leaf node.
+	if sn.PaneID != "" {
+		paneType := PaneSession
+		if sn.PaneType == "shell" {
+			paneType = PaneShell
+		}
+		panes[sn.PaneID] = &PaneMeta{
+			ID:            sn.PaneID,
+			Type:          paneType,
+			CWD:           sn.PaneCWD,
+			SessionID:     sn.SessionID,
+			ModelProvider: sn.ModelProvider,
+			ModelID:       sn.ModelID,
+		}
+		return split.NewLeaf(sn.PaneID)
+	}
+
+	// Split node.
+	if sn.A != nil && sn.B != nil {
+		dir := split.Horizontal
+		if sn.Dir == "V" {
+			dir = split.Vertical
+		}
+		a := deserializeNodeRecursive(sn.A, panes)
+		b := deserializeNodeRecursive(sn.B, panes)
+		return split.NewSplit(dir, sn.Ratio, a, b)
+	}
+
+	return nil
+}

--- a/internal/tabmgr/persistence_test.go
+++ b/internal/tabmgr/persistence_test.go
@@ -1,0 +1,217 @@
+package tabmgr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/split"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPersistenceSaveAndLoad(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := NewPersistence(dir)
+
+	mgr := New()
+	tab1 := mgr.AddTab("main", "/project", PaneSession)
+	tab1.GitBranch = "main"
+	tab1.GitDirty = true
+	tab1.SplitFocused(split.Horizontal, PaneShell)
+
+	mgr.AddTab("shell", "/tmp", PaneShell)
+
+	require.NoError(t, mgr.SelectTab(0))
+
+	// Save.
+	err := p.SaveLayout(mgr)
+	require.NoError(t, err)
+
+	// Verify file exists.
+	_, err = os.Stat(filepath.Join(dir, sessionFileName))
+	require.NoError(t, err)
+
+	// Load.
+	layout, err := p.LoadLayout()
+	require.NoError(t, err)
+	require.NotNil(t, layout)
+	require.Equal(t, 1, layout.Version)
+	require.Equal(t, 0, layout.ActiveTab)
+	require.Len(t, layout.Tabs, 2)
+
+	// Check tab 1.
+	require.Equal(t, "main", layout.Tabs[0].Name)
+	require.Equal(t, "/project", layout.Tabs[0].CWD)
+	require.NotNil(t, layout.Tabs[0].SplitTree)
+	require.Equal(t, "H", layout.Tabs[0].SplitTree.Dir)
+
+	// Check tab 2.
+	require.Equal(t, "shell", layout.Tabs[1].Name)
+}
+
+func TestPersistenceRestore(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := NewPersistence(dir)
+
+	// Create and save original.
+	mgr := New()
+	tab := mgr.AddTab("project", "/code", PaneSession)
+	tab.SplitFocused(split.Vertical, PaneShell)
+	mgr.AddTab("other", "/other", PaneShell)
+	require.NoError(t, mgr.SelectTab(1))
+
+	require.NoError(t, p.SaveLayout(mgr))
+
+	// Restore.
+	layout, err := p.LoadLayout()
+	require.NoError(t, err)
+
+	restored := p.RestoreTabs(layout)
+	require.Equal(t, 2, restored.Len())
+	require.Equal(t, 1, restored.ActiveIndex())
+
+	// First tab should have 2 panes.
+	tab0 := restored.GetTab(0)
+	require.Equal(t, "project", tab0.Name)
+	require.Equal(t, "/code", tab0.CWD)
+	require.Equal(t, 2, tab0.PaneCount())
+
+	// Second tab should have 1 pane.
+	tab1 := restored.GetTab(1)
+	require.Equal(t, "other", tab1.Name)
+	require.Equal(t, 1, tab1.PaneCount())
+}
+
+func TestPersistenceLoadNonexistent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := NewPersistence(dir)
+
+	layout, err := p.LoadLayout()
+	require.NoError(t, err)
+	require.Nil(t, layout)
+}
+
+func TestPersistenceLoadCorrupt(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := NewPersistence(dir)
+
+	os.WriteFile(filepath.Join(dir, sessionFileName), []byte("{invalid json"), 0o644)
+
+	_, err := p.LoadLayout()
+	require.Error(t, err)
+}
+
+func TestPersistenceLoadWrongVersion(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := NewPersistence(dir)
+
+	os.WriteFile(filepath.Join(dir, sessionFileName), []byte(`{"version":99}`), 0o644)
+
+	_, err := p.LoadLayout()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported")
+}
+
+func TestPersistencePaneTypes(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := NewPersistence(dir)
+
+	mgr := New()
+	tab := mgr.AddTab("test", "/test", PaneSession)
+	tab.SplitFocused(split.Horizontal, PaneShell)
+
+	require.NoError(t, p.SaveLayout(mgr))
+
+	layout, err := p.LoadLayout()
+	require.NoError(t, err)
+
+	// Check that pane types are preserved.
+	tree := layout.Tabs[0].SplitTree
+	require.Equal(t, "session", tree.A.PaneType)
+	require.Equal(t, "shell", tree.B.PaneType)
+
+	// Restore and verify.
+	restored := p.RestoreTabs(layout)
+	tab0 := restored.GetTab(0)
+	for _, meta := range tab0.Panes {
+		if meta.Type == PaneShell {
+			require.Equal(t, PaneShell, meta.Type)
+		}
+	}
+}
+
+func TestPersistenceSessionAndModelFields(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := NewPersistence(dir)
+
+	mgr := New()
+	tab := mgr.AddTab("project", "/code", PaneSession)
+
+	// Inject session/model metadata directly into the pane meta.
+	for _, meta := range tab.Panes {
+		meta.SessionID = "sess-abc123"
+		meta.ModelProvider = "anthropic"
+		meta.ModelID = "claude-opus-4-5"
+	}
+
+	require.NoError(t, p.SaveLayout(mgr))
+
+	layout, err := p.LoadLayout()
+	require.NoError(t, err)
+	require.NotNil(t, layout)
+
+	// Verify the serialized node has the fields.
+	tree := layout.Tabs[0].SplitTree
+	require.Equal(t, "sess-abc123", tree.SessionID)
+	require.Equal(t, "anthropic", tree.ModelProvider)
+	require.Equal(t, "claude-opus-4-5", tree.ModelID)
+
+	// Restore and verify the fields come back on PaneMeta.
+	restored := p.RestoreTabs(layout)
+	tab0 := restored.GetTab(0)
+	for _, meta := range tab0.Panes {
+		require.Equal(t, "sess-abc123", meta.SessionID)
+		require.Equal(t, "anthropic", meta.ModelProvider)
+		require.Equal(t, "claude-opus-4-5", meta.ModelID)
+	}
+}
+
+func TestSerializeDeserializeRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Build a complex tree: H(session, V(shell, session))
+	root := split.NewSplit(split.Horizontal, 0.6,
+		split.NewLeaf("p1"),
+		split.NewSplit(split.Vertical, 0.4,
+			split.NewLeaf("p2"),
+			split.NewLeaf("p3"),
+		),
+	)
+	panes := map[string]*PaneMeta{
+		"p1": {ID: "p1", Type: PaneSession},
+		"p2": {ID: "p2", Type: PaneShell},
+		"p3": {ID: "p3", Type: PaneSession},
+	}
+
+	// Serialize.
+	sn := serializeNode(root, panes)
+	require.Equal(t, "H", sn.Dir)
+	require.InDelta(t, 0.6, sn.Ratio, 0.001)
+	require.Equal(t, "session", sn.A.PaneType)
+	require.Equal(t, "V", sn.B.Dir)
+
+	// Deserialize.
+	restored, restoredPanes := deserializeNode(sn)
+	require.Equal(t, 3, split.LeafCount(restored))
+	require.Len(t, restoredPanes, 3)
+	require.Equal(t, PaneSession, restoredPanes["p1"].Type)
+	require.Equal(t, PaneShell, restoredPanes["p2"].Type)
+	require.Equal(t, PaneSession, restoredPanes["p3"].Type)
+}

--- a/internal/tabmgr/tab.go
+++ b/internal/tabmgr/tab.go
@@ -1,0 +1,244 @@
+// Package tabmgr manages terminal tabs, each owning a split-pane tree
+// and metadata (git branch, working directory, pane type).
+package tabmgr
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/charmbracelet/crush/internal/split"
+)
+
+// PaneType identifies what kind of content a pane holds.
+type PaneType int
+
+const (
+	PaneSession PaneType = iota // Chat session
+	PaneShell                   // Raw terminal shell (bash/PowerShell)
+)
+
+func (p PaneType) String() string {
+	switch p {
+	case PaneSession:
+		return "session"
+	case PaneShell:
+		return "shell"
+	default:
+		return "unknown"
+	}
+}
+
+var tabIDCounter atomic.Int64
+
+func nextTabID() string {
+	n := tabIDCounter.Add(1)
+	return fmt.Sprintf("tab-%d", n)
+}
+
+var paneIDCounter atomic.Int64
+
+func nextPaneID() string {
+	n := paneIDCounter.Add(1)
+	return fmt.Sprintf("pane-%d", n)
+}
+
+// Tab represents a single tab in the multiplexer.
+type Tab struct {
+	// mu protects GitBranch and GitDirty which are written by the background
+	// git watcher goroutine and read by the UI render goroutine.
+	mu sync.RWMutex
+
+	// ID uniquely identifies this tab.
+	ID string
+
+	// Name is the display name for this tab.
+	Name string
+
+	// CWD is the working directory for this tab.
+	CWD string
+
+	// GitBranch is the current git branch name (empty if not a git repo).
+	// Protected by mu.
+	GitBranch string
+
+	// GitDirty is true if the working tree has uncommitted changes.
+	// Protected by mu.
+	GitDirty bool
+
+	// SplitRoot is the root of this tab's pane split tree.
+	SplitRoot *split.Node
+
+	// FocusedPane is the ID of the currently focused pane within this tab.
+	FocusedPane string
+
+	// Panes maps pane IDs to their metadata.
+	Panes map[string]*PaneMeta
+
+	// cachedLeaves caches the depth-first pane order. Invalidated on split/close.
+	cachedLeaves []string
+}
+
+// SetGitStatus updates the git status fields atomically.
+func (t *Tab) SetGitStatus(branch string, dirty bool) {
+	t.mu.Lock()
+	t.GitBranch = branch
+	t.GitDirty = dirty
+	t.mu.Unlock()
+}
+
+// GetGitStatus reads the git status fields atomically.
+func (t *Tab) GetGitStatus() (branch string, dirty bool) {
+	t.mu.RLock()
+	branch = t.GitBranch
+	dirty = t.GitDirty
+	t.mu.RUnlock()
+	return
+}
+
+// PaneMeta holds metadata about a specific pane within a tab.
+type PaneMeta struct {
+	ID       string
+	Type     PaneType
+	Title    string // optional display title
+	CWD      string // pane-specific working directory (may differ from tab CWD)
+
+	// SessionID is the database session ID for chat panes (empty if no session).
+	SessionID string
+	// ModelProvider is the per-pane model provider override (empty = global).
+	ModelProvider string
+	// ModelID is the per-pane model ID override (empty = global).
+	ModelID string
+}
+
+// NewTab creates a new tab with a single pane.
+func NewTab(name, cwd string, paneType PaneType) *Tab {
+	tabID := nextTabID()
+	paneID := nextPaneID()
+
+	tab := &Tab{
+		ID:          tabID,
+		Name:        name,
+		CWD:         cwd,
+		SplitRoot:   split.NewLeaf(paneID),
+		FocusedPane: paneID,
+		Panes: map[string]*PaneMeta{
+			paneID: {
+				ID:   paneID,
+				Type: paneType,
+				CWD:  cwd,
+			},
+		},
+	}
+	return tab
+}
+
+// leaves returns the cached leaf order, recomputing if invalidated.
+func (t *Tab) leaves() []string {
+	if t.cachedLeaves == nil {
+		t.cachedLeaves = split.AllLeaves(t.SplitRoot)
+	}
+	return t.cachedLeaves
+}
+
+// invalidateLeafCache clears the cached leaf order.
+func (t *Tab) invalidateLeafCache() {
+	t.cachedLeaves = nil
+}
+
+// SplitFocused splits the currently focused pane in the given direction,
+// creating a new pane of the specified type.
+func (t *Tab) SplitFocused(dir split.Direction, paneType PaneType) (string, error) {
+	if t.FocusedPane == "" {
+		return "", fmt.Errorf("no focused pane")
+	}
+	return t.SplitPane(t.FocusedPane, dir, paneType)
+}
+
+// SplitPane splits the pane with the given ID, creating a new pane.
+func (t *Tab) SplitPane(paneID string, dir split.Direction, paneType PaneType) (string, error) {
+	newPaneID := nextPaneID()
+	// SplitLeaf returns an error if paneID is not found — no pre-check needed.
+	if err := split.SplitLeaf(t.SplitRoot, paneID, dir, newPaneID); err != nil {
+		return "", err
+	}
+	t.invalidateLeafCache()
+
+	cwd := t.CWD
+	if existing, ok := t.Panes[paneID]; ok {
+		cwd = existing.CWD
+	}
+
+	t.Panes[newPaneID] = &PaneMeta{
+		ID:   newPaneID,
+		Type: paneType,
+		CWD:  cwd,
+	}
+
+	return newPaneID, nil
+}
+
+// ClosePane removes a pane from the tab. If it was the focused pane,
+// focus moves to the first remaining pane. Returns an error if it's the
+// only pane (use CloseTab instead).
+func (t *Tab) ClosePane(paneID string) error {
+	if err := split.RemoveLeaf(t.SplitRoot, paneID); err != nil {
+		return err
+	}
+	delete(t.Panes, paneID)
+	t.invalidateLeafCache()
+
+	if t.FocusedPane == paneID {
+		leaves := split.AllLeaves(t.SplitRoot)
+		if len(leaves) > 0 {
+			t.FocusedPane = leaves[0]
+		} else {
+			t.FocusedPane = ""
+		}
+	}
+	return nil
+}
+
+// PaneCount returns the number of panes in this tab.
+func (t *Tab) PaneCount() int {
+	return split.LeafCount(t.SplitRoot)
+}
+
+// Layout computes pane rectangles for the given dimensions.
+func (t *Tab) Layout(width, height int) []split.PaneLayout {
+	return split.LayoutWithDividers(t.SplitRoot, width, height)
+}
+
+// Dividers computes divider positions for the given dimensions.
+func (t *Tab) Dividers(width, height int) []split.Rect {
+	return split.Dividers(t.SplitRoot, width, height)
+}
+
+// FocusNext moves focus to the next pane in depth-first order (wraps around).
+func (t *Tab) FocusNext() string {
+	return t.focusCycle(1)
+}
+
+// FocusPrev moves focus to the previous pane in depth-first order (wraps around).
+func (t *Tab) FocusPrev() string {
+	return t.focusCycle(-1)
+}
+
+func (t *Tab) focusCycle(delta int) string {
+	leaves := t.leaves()
+	if len(leaves) == 0 {
+		return ""
+	}
+
+	current := -1
+	for i, id := range leaves {
+		if id == t.FocusedPane {
+			current = i
+			break
+		}
+	}
+
+	next := (current + delta + len(leaves)) % len(leaves)
+	t.FocusedPane = leaves[next]
+	return t.FocusedPane
+}

--- a/internal/tabmgr/tab_layout_test.go
+++ b/internal/tabmgr/tab_layout_test.go
@@ -1,0 +1,193 @@
+package tabmgr
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/split"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTabLayoutSinglePane(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+	layouts := tab.Layout(120, 40)
+	require.Len(t, layouts, 1)
+	require.Equal(t, tab.FocusedPane, layouts[0].PaneID)
+	require.Equal(t, split.Rect{X: 0, Y: 0, Width: 120, Height: 40}, layouts[0].Rect)
+}
+
+func TestTabLayoutAfterSplit(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+	origPane := tab.FocusedPane
+
+	newPaneID, err := tab.SplitFocused(split.Vertical, PaneSession)
+	require.NoError(t, err)
+
+	layouts := tab.Layout(120, 40)
+	require.Len(t, layouts, 2)
+
+	// Both panes should have positive dimensions.
+	for _, l := range layouts {
+		require.Greater(t, l.Rect.Width, 0, "pane %s width", l.PaneID)
+		require.Greater(t, l.Rect.Height, 0, "pane %s height", l.PaneID)
+	}
+
+	// Pane IDs should match the original and new.
+	ids := []string{layouts[0].PaneID, layouts[1].PaneID}
+	require.Contains(t, ids, origPane)
+	require.Contains(t, ids, newPaneID)
+}
+
+func TestTabDividersSinglePane(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+	divs := tab.Dividers(120, 40)
+	require.Empty(t, divs)
+}
+
+func TestTabDividersAfterHorizontalSplit(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+
+	_, err := tab.SplitFocused(split.Horizontal, PaneSession)
+	require.NoError(t, err)
+
+	divs := tab.Dividers(120, 40)
+	require.Len(t, divs, 1)
+
+	div := divs[0]
+	// Vertical divider: 1 col wide, full height.
+	require.Equal(t, 1, div.Width)
+	require.Equal(t, 40, div.Height)
+}
+
+func TestTabDividersAfterVerticalSplit(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+
+	_, err := tab.SplitFocused(split.Vertical, PaneSession)
+	require.NoError(t, err)
+
+	divs := tab.Dividers(120, 40)
+	require.Len(t, divs, 1)
+
+	div := divs[0]
+	// Horizontal divider: full width, 1 row tall.
+	require.Equal(t, 120, div.Width)
+	require.Equal(t, 1, div.Height)
+}
+
+func TestTabLayoutThreePanes(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+
+	// Split focused (vertical), then split one of them (horizontal).
+	_, err := tab.SplitFocused(split.Vertical, PaneSession)
+	require.NoError(t, err)
+	_, err = tab.SplitFocused(split.Horizontal, PaneShell)
+	require.NoError(t, err)
+
+	require.Equal(t, 3, tab.PaneCount())
+
+	layouts := tab.Layout(120, 40)
+	require.Len(t, layouts, 3)
+
+	divs := tab.Dividers(120, 40)
+	require.Len(t, divs, 2)
+
+	// No pane overlaps any divider.
+	for _, pl := range layouts {
+		for _, d := range divs {
+			overlapX := pl.Rect.X < d.X+d.Width && pl.Rect.X+pl.Rect.Width > d.X
+			overlapY := pl.Rect.Y < d.Y+d.Height && pl.Rect.Y+pl.Rect.Height > d.Y
+			if overlapX && overlapY {
+				t.Errorf("pane %s overlaps divider at (%d,%d %dx%d)",
+					pl.PaneID, d.X, d.Y, d.Width, d.Height)
+			}
+		}
+	}
+}
+
+func TestTabLayoutFocusCyclePreservesLayout(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+	_, err := tab.SplitFocused(split.Horizontal, PaneSession)
+	require.NoError(t, err)
+
+	layoutBefore := tab.Layout(80, 24)
+	tab.FocusNext()
+	layoutAfter := tab.Layout(80, 24)
+
+	// Layout rectangles shouldn't change when focus moves.
+	require.Equal(t, len(layoutBefore), len(layoutAfter))
+	for i := range layoutBefore {
+		require.Equal(t, layoutBefore[i].Rect, layoutAfter[i].Rect)
+		require.Equal(t, layoutBefore[i].PaneID, layoutAfter[i].PaneID)
+	}
+}
+
+func TestTabLayoutAfterClosePane(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+
+	newID, err := tab.SplitFocused(split.Horizontal, PaneSession)
+	require.NoError(t, err)
+	require.Equal(t, 2, tab.PaneCount())
+
+	err = tab.ClosePane(newID)
+	require.NoError(t, err)
+	require.Equal(t, 1, tab.PaneCount())
+
+	// Back to single pane: fills entire area.
+	layouts := tab.Layout(120, 40)
+	require.Len(t, layouts, 1)
+	require.Equal(t, split.Rect{X: 0, Y: 0, Width: 120, Height: 40}, layouts[0].Rect)
+
+	divs := tab.Dividers(120, 40)
+	require.Empty(t, divs)
+}
+
+func TestTabLayoutMixedPaneTypes(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+
+	shellID, err := tab.SplitFocused(split.Horizontal, PaneShell)
+	require.NoError(t, err)
+
+	// Verify pane metadata preserved through layout.
+	meta := tab.Panes[shellID]
+	require.NotNil(t, meta)
+	require.Equal(t, PaneShell, meta.Type)
+
+	layouts := tab.Layout(100, 30)
+	require.Len(t, layouts, 2)
+
+	// Find the shell pane in layouts.
+	found := false
+	for _, l := range layouts {
+		if l.PaneID == shellID {
+			found = true
+			require.Greater(t, l.Rect.Width, 0)
+			require.Greater(t, l.Rect.Height, 0)
+		}
+	}
+	require.True(t, found, "shell pane should appear in layout")
+}
+
+func TestTabManagerActiveTabLayout(t *testing.T) {
+	t.Parallel()
+	tm := New()
+	tab1 := tm.AddTab("tab1", "/tmp", PaneSession)
+
+	_, err := tab1.SplitFocused(split.Horizontal, PaneSession)
+	require.NoError(t, err)
+
+	// Active tab should be tab1.
+	active := tm.ActiveTab()
+	require.NotNil(t, active)
+	require.Equal(t, tab1.ID, active.ID)
+
+	layouts := active.Layout(80, 24)
+	require.Len(t, layouts, 2)
+}

--- a/internal/tabmgr/tabmgr.go
+++ b/internal/tabmgr/tabmgr.go
@@ -1,0 +1,224 @@
+package tabmgr
+
+import (
+	"fmt"
+	"sync"
+)
+
+// TabManager manages a list of tabs with an active tab selection.
+type TabManager struct {
+	mu        sync.RWMutex
+	tabs      []*Tab
+	activeIdx int
+}
+
+// New creates a new TabManager with no tabs.
+func New() *TabManager {
+	return &TabManager{}
+}
+
+// AddTab appends a new tab and returns it. The new tab becomes active.
+func (m *TabManager) AddTab(name, cwd string, paneType PaneType) *Tab {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tab := NewTab(name, cwd, paneType)
+	m.tabs = append(m.tabs, tab)
+	m.activeIdx = len(m.tabs) - 1
+	return tab
+}
+
+// CloseTab removes the tab at the given index. Returns an error if the index
+// is out of range. If the active tab is closed, the previous tab becomes active
+// (or the next one if closing the first tab).
+func (m *TabManager) CloseTab(idx int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if idx < 0 || idx >= len(m.tabs) {
+		return fmt.Errorf("tab index %d out of range [0, %d)", idx, len(m.tabs))
+	}
+
+	m.tabs = append(m.tabs[:idx], m.tabs[idx+1:]...)
+
+	if len(m.tabs) == 0 {
+		m.activeIdx = 0
+		return nil
+	}
+
+	if m.activeIdx >= len(m.tabs) {
+		m.activeIdx = len(m.tabs) - 1
+	} else if m.activeIdx > idx {
+		m.activeIdx--
+	}
+
+	return nil
+}
+
+// CloseActiveTab closes the currently active tab. The operation is atomic —
+// no TOCTOU race between reading the active index and closing.
+func (m *TabManager) CloseActiveTab() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	idx := m.activeIdx
+	if idx < 0 || idx >= len(m.tabs) {
+		return fmt.Errorf("no active tab")
+	}
+
+	m.tabs = append(m.tabs[:idx], m.tabs[idx+1:]...)
+
+	if len(m.tabs) == 0 {
+		m.activeIdx = 0
+		return nil
+	}
+	if m.activeIdx >= len(m.tabs) {
+		m.activeIdx = len(m.tabs) - 1
+	} else if m.activeIdx > idx {
+		m.activeIdx--
+	}
+	return nil
+}
+
+// SelectTab sets the active tab by index.
+func (m *TabManager) SelectTab(idx int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if idx < 0 || idx >= len(m.tabs) {
+		return fmt.Errorf("tab index %d out of range [0, %d)", idx, len(m.tabs))
+	}
+	m.activeIdx = idx
+	return nil
+}
+
+// SelectTabByID sets the active tab by tab ID.
+func (m *TabManager) SelectTabByID(tabID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for i, t := range m.tabs {
+		if t.ID == tabID {
+			m.activeIdx = i
+			return nil
+		}
+	}
+	return fmt.Errorf("tab %q not found", tabID)
+}
+
+// NextTab cycles to the next tab (wraps around).
+func (m *TabManager) NextTab() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(m.tabs) == 0 {
+		return
+	}
+	m.activeIdx = (m.activeIdx + 1) % len(m.tabs)
+}
+
+// PrevTab cycles to the previous tab (wraps around).
+func (m *TabManager) PrevTab() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(m.tabs) == 0 {
+		return
+	}
+	m.activeIdx = (m.activeIdx - 1 + len(m.tabs)) % len(m.tabs)
+}
+
+// MoveTabUp moves the active tab one position up in the list.
+func (m *TabManager) MoveTabUp() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.activeIdx <= 0 || len(m.tabs) < 2 {
+		return
+	}
+	m.tabs[m.activeIdx], m.tabs[m.activeIdx-1] = m.tabs[m.activeIdx-1], m.tabs[m.activeIdx]
+	m.activeIdx--
+}
+
+// MoveTabDown moves the active tab one position down in the list.
+func (m *TabManager) MoveTabDown() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.activeIdx >= len(m.tabs)-1 || len(m.tabs) < 2 {
+		return
+	}
+	m.tabs[m.activeIdx], m.tabs[m.activeIdx+1] = m.tabs[m.activeIdx+1], m.tabs[m.activeIdx]
+	m.activeIdx++
+}
+
+// ActiveTab returns the currently active tab, or nil if no tabs exist.
+func (m *TabManager) ActiveTab() *Tab {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(m.tabs) == 0 {
+		return nil
+	}
+	return m.tabs[m.activeIdx]
+}
+
+// ActiveIndex returns the index of the active tab.
+func (m *TabManager) ActiveIndex() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.activeIdx
+}
+
+// Tabs returns a copy of the tab list (safe for iteration).
+func (m *TabManager) Tabs() []*Tab {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]*Tab, len(m.tabs))
+	copy(result, m.tabs)
+	return result
+}
+
+// Len returns the number of tabs.
+func (m *TabManager) Len() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.tabs)
+}
+
+// GetTab returns the tab at the given index.
+func (m *TabManager) GetTab(idx int) *Tab {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if idx < 0 || idx >= len(m.tabs) {
+		return nil
+	}
+	return m.tabs[idx]
+}
+
+// FindTab returns the tab with the given ID, or nil.
+func (m *TabManager) FindTab(tabID string) *Tab {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, t := range m.tabs {
+		if t.ID == tabID {
+			return t
+		}
+	}
+	return nil
+}
+
+// RenameTab renames the tab at the given index.
+func (m *TabManager) RenameTab(idx int, name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if idx < 0 || idx >= len(m.tabs) {
+		return fmt.Errorf("tab index %d out of range", idx)
+	}
+	m.tabs[idx].Name = name
+	return nil
+}

--- a/internal/tabmgr/tabmgr_test.go
+++ b/internal/tabmgr/tabmgr_test.go
@@ -1,0 +1,317 @@
+package tabmgr
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/split"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTab(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("main", "/home/user/project", PaneSession)
+
+	require.NotEmpty(t, tab.ID)
+	require.Equal(t, "main", tab.Name)
+	require.Equal(t, "/home/user/project", tab.CWD)
+	require.Equal(t, 1, tab.PaneCount())
+	require.NotEmpty(t, tab.FocusedPane)
+	require.Len(t, tab.Panes, 1)
+
+	meta := tab.Panes[tab.FocusedPane]
+	require.Equal(t, PaneSession, meta.Type)
+}
+
+func TestTabSplitFocused(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+
+	newID, err := tab.SplitFocused(split.Horizontal, PaneShell)
+	require.NoError(t, err)
+	require.NotEmpty(t, newID)
+	require.Equal(t, 2, tab.PaneCount())
+
+	meta := tab.Panes[newID]
+	require.Equal(t, PaneShell, meta.Type)
+	require.Equal(t, "/tmp", meta.CWD)
+}
+
+func TestTabSplitPane(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+	firstPane := tab.FocusedPane
+
+	p2, err := tab.SplitPane(firstPane, split.Vertical, PaneShell)
+	require.NoError(t, err)
+
+	p3, err := tab.SplitPane(p2, split.Horizontal, PaneSession)
+	require.NoError(t, err)
+
+	require.Equal(t, 3, tab.PaneCount())
+	require.NotNil(t, tab.Panes[firstPane])
+	require.NotNil(t, tab.Panes[p2])
+	require.NotNil(t, tab.Panes[p3])
+}
+
+func TestTabSplitPaneNotFound(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+	_, err := tab.SplitPane("nonexistent", split.Horizontal, PaneShell)
+	require.Error(t, err)
+}
+
+func TestTabClosePane(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+	firstPane := tab.FocusedPane
+
+	p2, _ := tab.SplitFocused(split.Horizontal, PaneShell)
+
+	// Close the original pane.
+	err := tab.ClosePane(firstPane)
+	require.NoError(t, err)
+	require.Equal(t, 1, tab.PaneCount())
+	require.Equal(t, p2, tab.FocusedPane)
+	require.Nil(t, tab.Panes[firstPane])
+}
+
+func TestTabClosePaneOnlyPaneErrors(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+	err := tab.ClosePane(tab.FocusedPane)
+	require.Error(t, err)
+}
+
+func TestTabFocusCycle(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+	first := tab.FocusedPane
+
+	p2, _ := tab.SplitFocused(split.Horizontal, PaneShell)
+	p3, _ := tab.SplitPane(p2, split.Vertical, PaneSession)
+
+	// Focus is still on first pane.
+	tab.FocusedPane = first
+
+	// Cycle forward.
+	require.Equal(t, p2, tab.FocusNext())
+	require.Equal(t, p3, tab.FocusNext())
+	require.Equal(t, first, tab.FocusNext()) // wraps
+
+	// Cycle backward.
+	require.Equal(t, p3, tab.FocusPrev())
+	require.Equal(t, p2, tab.FocusPrev())
+	require.Equal(t, first, tab.FocusPrev()) // wraps
+}
+
+func TestTabLayout(t *testing.T) {
+	t.Parallel()
+	tab := NewTab("test", "/tmp", PaneSession)
+	tab.SplitFocused(split.Horizontal, PaneShell)
+
+	layouts := tab.Layout(100, 50)
+	require.Len(t, layouts, 2)
+
+	dividers := tab.Dividers(100, 50)
+	require.Len(t, dividers, 1)
+}
+
+func TestPaneTypeString(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "session", PaneSession.String())
+	require.Equal(t, "shell", PaneShell.String())
+}
+
+// --- TabManager tests ---
+
+func TestTabManagerAddTab(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+
+	tab1 := mgr.AddTab("main", "/project", PaneSession)
+	require.Equal(t, 1, mgr.Len())
+	require.Equal(t, tab1, mgr.ActiveTab())
+	require.Equal(t, 0, mgr.ActiveIndex())
+
+	tab2 := mgr.AddTab("shell", "/tmp", PaneShell)
+	require.Equal(t, 2, mgr.Len())
+	require.Equal(t, tab2, mgr.ActiveTab())
+	require.Equal(t, 1, mgr.ActiveIndex())
+}
+
+func TestTabManagerCloseTab(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+	mgr.AddTab("a", "/a", PaneSession)
+	mgr.AddTab("b", "/b", PaneSession)
+	mgr.AddTab("c", "/c", PaneSession)
+
+	// Active is tab 2 (index 2). Close it.
+	err := mgr.CloseActiveTab()
+	require.NoError(t, err)
+	require.Equal(t, 2, mgr.Len())
+	require.Equal(t, "b", mgr.ActiveTab().Name)
+}
+
+func TestTabManagerCloseFirstTab(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+	mgr.AddTab("a", "/a", PaneSession)
+	mgr.AddTab("b", "/b", PaneSession)
+
+	require.NoError(t, mgr.SelectTab(0))
+	require.NoError(t, mgr.CloseTab(0))
+	require.Equal(t, 1, mgr.Len())
+	require.Equal(t, "b", mgr.ActiveTab().Name)
+	require.Equal(t, 0, mgr.ActiveIndex())
+}
+
+func TestTabManagerCloseAllTabs(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+	mgr.AddTab("a", "/a", PaneSession)
+
+	require.NoError(t, mgr.CloseTab(0))
+	require.Equal(t, 0, mgr.Len())
+	require.Nil(t, mgr.ActiveTab())
+}
+
+func TestTabManagerCloseTabOutOfRange(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+	require.Error(t, mgr.CloseTab(0))
+	require.Error(t, mgr.CloseTab(-1))
+}
+
+func TestTabManagerSelectTab(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+	mgr.AddTab("a", "/a", PaneSession)
+	mgr.AddTab("b", "/b", PaneSession)
+	mgr.AddTab("c", "/c", PaneSession)
+
+	require.NoError(t, mgr.SelectTab(0))
+	require.Equal(t, "a", mgr.ActiveTab().Name)
+
+	require.NoError(t, mgr.SelectTab(2))
+	require.Equal(t, "c", mgr.ActiveTab().Name)
+
+	require.Error(t, mgr.SelectTab(5))
+}
+
+func TestTabManagerSelectTabByID(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+	tab1 := mgr.AddTab("a", "/a", PaneSession)
+	mgr.AddTab("b", "/b", PaneSession)
+
+	require.NoError(t, mgr.SelectTabByID(tab1.ID))
+	require.Equal(t, "a", mgr.ActiveTab().Name)
+
+	require.Error(t, mgr.SelectTabByID("nonexistent"))
+}
+
+func TestTabManagerNextPrev(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+	mgr.AddTab("a", "/a", PaneSession)
+	mgr.AddTab("b", "/b", PaneSession)
+	mgr.AddTab("c", "/c", PaneSession)
+
+	require.NoError(t, mgr.SelectTab(0))
+
+	mgr.NextTab()
+	require.Equal(t, "b", mgr.ActiveTab().Name)
+	mgr.NextTab()
+	require.Equal(t, "c", mgr.ActiveTab().Name)
+	mgr.NextTab()
+	require.Equal(t, "a", mgr.ActiveTab().Name) // wraps
+
+	mgr.PrevTab()
+	require.Equal(t, "c", mgr.ActiveTab().Name) // wraps back
+}
+
+func TestTabManagerMoveTab(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+	mgr.AddTab("a", "/a", PaneSession)
+	mgr.AddTab("b", "/b", PaneSession)
+	mgr.AddTab("c", "/c", PaneSession)
+
+	// Active is "c" at index 2. Move up.
+	mgr.MoveTabUp()
+	require.Equal(t, 1, mgr.ActiveIndex())
+	require.Equal(t, "c", mgr.ActiveTab().Name)
+
+	tabs := mgr.Tabs()
+	require.Equal(t, "a", tabs[0].Name)
+	require.Equal(t, "c", tabs[1].Name)
+	require.Equal(t, "b", tabs[2].Name)
+
+	// Move back down.
+	mgr.MoveTabDown()
+	require.Equal(t, 2, mgr.ActiveIndex())
+	tabs = mgr.Tabs()
+	require.Equal(t, "a", tabs[0].Name)
+	require.Equal(t, "b", tabs[1].Name)
+	require.Equal(t, "c", tabs[2].Name)
+}
+
+func TestTabManagerMoveTabEdges(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+	mgr.AddTab("a", "/a", PaneSession)
+	mgr.AddTab("b", "/b", PaneSession)
+
+	// Select first, move up (no-op).
+	require.NoError(t, mgr.SelectTab(0))
+	mgr.MoveTabUp()
+	require.Equal(t, 0, mgr.ActiveIndex())
+
+	// Select last, move down (no-op).
+	require.NoError(t, mgr.SelectTab(1))
+	mgr.MoveTabDown()
+	require.Equal(t, 1, mgr.ActiveIndex())
+}
+
+func TestTabManagerFindTab(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+	tab := mgr.AddTab("test", "/test", PaneSession)
+
+	require.Equal(t, tab, mgr.FindTab(tab.ID))
+	require.Nil(t, mgr.FindTab("nonexistent"))
+}
+
+func TestTabManagerGetTab(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+	tab := mgr.AddTab("test", "/test", PaneSession)
+
+	require.Equal(t, tab, mgr.GetTab(0))
+	require.Nil(t, mgr.GetTab(1))
+	require.Nil(t, mgr.GetTab(-1))
+}
+
+func TestTabManagerRename(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+	mgr.AddTab("old", "/test", PaneSession)
+
+	require.NoError(t, mgr.RenameTab(0, "new"))
+	require.Equal(t, "new", mgr.GetTab(0).Name)
+	require.Error(t, mgr.RenameTab(5, "bad"))
+}
+
+func TestTabManagerEmpty(t *testing.T) {
+	t.Parallel()
+	mgr := New()
+	require.Equal(t, 0, mgr.Len())
+	require.Nil(t, mgr.ActiveTab())
+
+	// Operations on empty manager should not panic.
+	mgr.NextTab()
+	mgr.PrevTab()
+	mgr.MoveTabUp()
+	mgr.MoveTabDown()
+}


### PR DESCRIPTION
## Summary

Three foundational packages for terminal multiplexing — enabling independent split panes, each capable of hosting its own session, shell, or agent.

- **`internal/split/`** — Binary split tree for pane layout computation with divider gaps and dirty tracking
- **`internal/tabmgr/`** — Tab manager owning split trees per tab, with pane lifecycle, focus cycling, and JSON persistence
- **`internal/pty/`** — Cross-platform PTY abstraction (ConPTY on Windows via direct syscall, no cgo required)

## Motivation

The existing UI has session management but no multiplexing. These packages provide the infrastructure to support multiple independent panes within a single process — parallel AI conversations, mixed session/shell panes, per-pane model selection, and workspace persistence.

All three packages are self-contained with no UI dependencies, making them safe to integrate incrementally.

## What's included

| Package | Files | Tests | Description |
|---------|-------|-------|-------------|
| `internal/split/` | `tree.go`, `layout.go`, `dirty.go` | 43 | Binary tree splits, layout computation, render optimization |
| `internal/tabmgr/` | `tab.go`, `tabmgr.go`, `persistence.go` | 42 | Tab/pane lifecycle, focus management, JSON save/restore |
| `internal/pty/` | `pty.go`, `pty_windows.go`, `pty_unix.go` | — | ConPTY (Windows), creack/pty stub (Unix), resize/wait/close |

## Test plan

- [x] `go test ./internal/split/ -v -count=1` — 43 tests pass
- [x] `go test ./internal/tabmgr/ -v -count=1` — 42 tests pass  
- [x] `go build ./...` — full project compiles cleanly with new packages
- [ ] Integration with UI model (separate PR after this lands)