### PR TITLE
feat(cmd): add `crush skills list` command with group-by-source support

### DIFF
--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"text/tabwriter"
 
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/tree"
@@ -164,15 +165,18 @@ func outputSkillsTree(cmd *cobra.Command, all []*skills.Skill, disabledSet map[s
 }
 
 func outputSkillsFlat(cmd *cobra.Command, all []*skills.Skill, disabledSet map[string]bool, projectDirs []string) error {
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 	for _, s := range all {
 		src := skills.ClassifySource(s, projectDirs)
 		status := "enabled"
 		if disabledSet[s.Name] {
 			status = "disabled"
 		}
-		cmd.Printf("%s\t%s\t%s\n", s.Name, strings.ToLower(string(src)), status)
+		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\n", s.Name, strings.ToLower(string(src)), status); err != nil {
+			return err
+		}
 	}
-	return nil
+	return w.Flush()
 }
 
 type skillJSON struct {

--- a/internal/cmd/skills.go
+++ b/internal/cmd/skills.go
@@ -1,0 +1,206 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/tree"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/home"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/x/exp/charmtone"
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+)
+
+var skillsCmd = &cobra.Command{
+	Use:     "skills",
+	Aliases: []string{"skill"},
+	Short:   "Manage skills",
+	Long:    "Manage Agent Skills (SKILL.md) for extending Crush capabilities.",
+}
+
+var (
+	skillsListFlat bool
+	skillsListJSON bool
+)
+
+var skillsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all discovered skills",
+	Long:  `List all discovered skills, grouped by source (builtin, project, user).`,
+	Example: `  # List all skills grouped by source
+  crush skills list
+
+  # List all skills in flat format
+  crush skills list --flat
+
+  # Output in JSON format
+  crush skills list --json
+
+  # Search skills by name
+  crush skills list pdf`,
+	Args: cobra.ArbitraryArgs,
+	RunE: runSkillsList,
+}
+
+func init() {
+	skillsListCmd.Flags().BoolVar(&skillsListFlat, "flat", false, "Show skills as a flat list instead of grouped by source")
+	skillsListCmd.Flags().BoolVar(&skillsListJSON, "json", false, "Output in JSON format")
+	skillsCmd.AddCommand(skillsListCmd)
+	rootCmd.AddCommand(skillsCmd)
+}
+
+func runSkillsList(cmd *cobra.Command, args []string) error {
+	cwd, err := ResolveCwd(cmd)
+	if err != nil {
+		return err
+	}
+
+	dataDir, _ := cmd.Flags().GetString("data-dir")
+	debug, _ := cmd.Flags().GetBool("debug")
+
+	cfg, err := config.Init(cwd, dataDir, debug)
+	if err != nil {
+		return err
+	}
+
+	allSkills, disabledSkills := discoverAllSkills(cfg)
+
+	// Build disabled set for display.
+	disabledSet := make(map[string]bool, len(disabledSkills))
+	for _, name := range disabledSkills {
+		disabledSet[name] = true
+	}
+
+	// Apply search filter.
+	term := strings.ToLower(strings.Join(args, " "))
+	if term != "" {
+		allSkills = filterSkills(allSkills, term)
+	}
+
+	if len(allSkills) == 0 {
+		if term != "" {
+			return fmt.Errorf("no skills found matching %q", term)
+		}
+		return fmt.Errorf("no skills found")
+	}
+
+	projectDirs := config.ProjectSkillsDir(cwd)
+
+	if skillsListJSON {
+		return outputSkillsJSON(cmd, allSkills, disabledSet, projectDirs)
+	}
+
+	if skillsListFlat || !isatty.IsTerminal(os.Stdout.Fd()) {
+		return outputSkillsFlat(cmd, allSkills, disabledSet, projectDirs)
+	}
+
+	return outputSkillsTree(cmd, allSkills, disabledSet, projectDirs)
+}
+
+// discoverAllSkills runs the skill discovery pipeline and returns the
+// deduplicated list plus the disabled skill names.
+func discoverAllSkills(cfg *config.ConfigStore) ([]*skills.Skill, []string) {
+	discovered := skills.DiscoverBuiltin()
+
+	opts := cfg.Config().Options
+	if opts != nil && len(opts.SkillsPaths) > 0 {
+		expandedPaths := make([]string, 0, len(opts.SkillsPaths))
+		for _, pth := range opts.SkillsPaths {
+			expandedPaths = append(expandedPaths, home.Long(pth))
+		}
+		discovered = append(discovered, skills.Discover(expandedPaths)...)
+	}
+
+	allSkills := skills.Deduplicate(discovered)
+
+	var disabled []string
+	if opts != nil {
+		disabled = opts.DisabledSkills
+	}
+	return allSkills, disabled
+}
+
+func filterSkills(all []*skills.Skill, term string) []*skills.Skill {
+	lower := strings.ToLower(term)
+	var result []*skills.Skill
+	for _, s := range all {
+		if strings.Contains(strings.ToLower(s.Name), lower) ||
+			strings.Contains(strings.ToLower(s.Description), lower) {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+func outputSkillsTree(cmd *cobra.Command, all []*skills.Skill, disabledSet map[string]bool, projectDirs []string) error {
+	groups := skills.GroupBySource(all, projectDirs)
+
+	headerStyle := lipgloss.NewStyle().Foreground(charmtone.Malibu)
+	disabledStyle := lipgloss.NewStyle().Foreground(charmtone.Damson)
+
+	t := tree.New()
+	for _, g := range groups {
+		groupNode := tree.Root(headerStyle.Render(string(g.Source)))
+		for _, s := range g.Skills {
+			label := s.Name
+			if s.Description != "" {
+				label += " — " + s.Description
+			}
+			if disabledSet[s.Name] {
+				label += " " + disabledStyle.Render("(disabled)")
+			}
+			groupNode.Child(label)
+		}
+		t.Child(groupNode)
+	}
+
+	cmd.Println(t)
+	return nil
+}
+
+func outputSkillsFlat(cmd *cobra.Command, all []*skills.Skill, disabledSet map[string]bool, projectDirs []string) error {
+	for _, s := range all {
+		src := skills.ClassifySource(s, projectDirs)
+		status := "enabled"
+		if disabledSet[s.Name] {
+			status = "disabled"
+		}
+		cmd.Printf("%s\t%s\t%s\n", s.Name, strings.ToLower(string(src)), status)
+	}
+	return nil
+}
+
+type skillJSON struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Source      string `json:"source"`
+	Status      string `json:"status"`
+	Path        string `json:"path"`
+}
+
+func outputSkillsJSON(cmd *cobra.Command, all []*skills.Skill, disabledSet map[string]bool, projectDirs []string) error {
+	output := make([]skillJSON, 0, len(all))
+	for _, s := range all {
+		src := skills.ClassifySource(s, projectDirs)
+		status := "enabled"
+		if disabledSet[s.Name] {
+			status = "disabled"
+		}
+		output = append(output, skillJSON{
+			Name:        s.Name,
+			Description: s.Description,
+			Source:      strings.ToLower(string(src)),
+			Status:      status,
+			Path:        s.SkillFilePath,
+		})
+	}
+
+	enc := json.NewEncoder(cmd.OutOrStdout())
+	enc.SetEscapeHTML(false)
+	return enc.Encode(output)
+}

--- a/internal/cmd/skills_test.go
+++ b/internal/cmd/skills_test.go
@@ -124,6 +124,39 @@ func TestOutputSkillsFlat(t *testing.T) {
 	require.Contains(t, lines[1], "disabled")
 }
 
+func TestOutputSkillsFlatAlignment(t *testing.T) {
+	t.Parallel()
+
+	all := []*skills.Skill{
+		{Name: "crush-config", Builtin: true, Path: "crush://skills/crush-config"},
+		{Name: "slack-gif-creator", Builtin: false, Path: "/home/user/.config/crush/skills/slack-gif-creator"},
+		{Name: "pdf", Builtin: false, Path: "/work/.crush/skills/pdf"},
+	}
+	disabledSet := map[string]bool{}
+	projectDirs := []string{"/work/.crush/skills"}
+
+	cmd := newTestCmd()
+	err := outputSkillsFlat(cmd, all, disabledSet, projectDirs)
+	require.NoError(t, err)
+
+	output := cmdOutput(cmd)
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	require.Len(t, lines, 3)
+
+	// All source columns should start at the same position (aligned by tabwriter).
+	sourceCol := strings.Index(lines[0], "builtin")
+	require.Greater(t, sourceCol, 0, "source column should be present")
+	require.Equal(t, sourceCol, strings.Index(lines[1], "user"), "source columns should be aligned")
+	require.Equal(t, sourceCol, strings.Index(lines[2], "project"), "source columns should be aligned")
+
+	// All status columns should also be aligned.
+	statusCol0 := strings.Index(lines[0], "enabled")
+	statusCol1 := strings.Index(lines[1], "enabled")
+	statusCol2 := strings.Index(lines[2], "enabled")
+	require.Equal(t, statusCol0, statusCol1, "status columns should be aligned")
+	require.Equal(t, statusCol0, statusCol2, "status columns should be aligned")
+}
+
 func TestOutputSkillsTree(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/skills_test.go
+++ b/internal/cmd/skills_test.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetOut(new(bytes.Buffer))
+	cmd.SetErr(new(bytes.Buffer))
+	return cmd
+}
+
+func cmdOutput(cmd *cobra.Command) string {
+	return cmd.OutOrStdout().(*bytes.Buffer).String()
+}
+
+func TestFilterSkills(t *testing.T) {
+	t.Parallel()
+
+	all := []*skills.Skill{
+		{Name: "pdf-processing", Description: "Extracts text from PDFs"},
+		{Name: "commit", Description: "Create git commits"},
+		{Name: "review-pr", Description: "Review pull requests"},
+	}
+
+	tests := []struct {
+		name    string
+		term    string
+		wantLen int
+		wantHas string
+	}{
+		{"match by name", "pdf", 1, "pdf-processing"},
+		{"match by description", "git", 1, "commit"},
+		{"no match", "xyz", 0, ""},
+		{"case insensitive", "PDF", 1, "pdf-processing"},
+		{"multiple matches", "pr", 2, "review-pr"}, // review-pr and pdf-processing
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := filterSkills(all, tt.term)
+			require.Len(t, result, tt.wantLen)
+			if tt.wantHas != "" {
+				var found bool
+				for _, s := range result {
+					if s.Name == tt.wantHas {
+						found = true
+					}
+				}
+				require.True(t, found, "expected to find %q in results", tt.wantHas)
+			}
+		})
+	}
+}
+
+func TestOutputSkillsJSON(t *testing.T) {
+	t.Parallel()
+
+	all := []*skills.Skill{
+		{Name: "crush-config", Description: "Configure crush", Builtin: true, Path: "crush://skills/crush-config", SkillFilePath: "crush://skills/crush-config/SKILL.md"},
+		{Name: "local-lint", Description: "Project linter", Builtin: false, Path: "/work/.crush/skills/local-lint", SkillFilePath: "/work/.crush/skills/local-lint/SKILL.md"},
+		{Name: "deploy", Description: "Deploy tool", Builtin: false, Path: "/home/user/.config/crush/skills/deploy", SkillFilePath: "/home/user/.config/crush/skills/deploy/SKILL.md"},
+	}
+	disabledSet := map[string]bool{"deploy": true}
+	projectDirs := []string{"/work/.crush/skills"}
+
+	cmd := newTestCmd()
+	err := outputSkillsJSON(cmd, all, disabledSet, projectDirs)
+	require.NoError(t, err)
+
+	var result []skillJSON
+	require.NoError(t, json.Unmarshal([]byte(cmdOutput(cmd)), &result))
+
+	require.Len(t, result, 3)
+
+	// Verify source classification.
+	byName := make(map[string]skillJSON)
+	for _, s := range result {
+		byName[s.Name] = s
+	}
+
+	require.Equal(t, "builtin", byName["crush-config"].Source)
+	require.Equal(t, "enabled", byName["crush-config"].Status)
+
+	require.Equal(t, "project", byName["local-lint"].Source)
+	require.Equal(t, "enabled", byName["local-lint"].Status)
+
+	require.Equal(t, "user", byName["deploy"].Source)
+	require.Equal(t, "disabled", byName["deploy"].Status)
+}
+
+func TestOutputSkillsFlat(t *testing.T) {
+	t.Parallel()
+
+	all := []*skills.Skill{
+		{Name: "crush-config", Builtin: true, Path: "crush://skills/crush-config"},
+		{Name: "deploy", Builtin: false, Path: "/home/user/.config/crush/skills/deploy"},
+	}
+	disabledSet := map[string]bool{"deploy": true}
+
+	cmd := newTestCmd()
+	err := outputSkillsFlat(cmd, all, disabledSet, nil)
+	require.NoError(t, err)
+
+	output := cmdOutput(cmd)
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	require.Len(t, lines, 2)
+
+	require.Contains(t, lines[0], "crush-config")
+	require.Contains(t, lines[0], "builtin")
+	require.Contains(t, lines[0], "enabled")
+
+	require.Contains(t, lines[1], "deploy")
+	require.Contains(t, lines[1], "user")
+	require.Contains(t, lines[1], "disabled")
+}
+
+func TestOutputSkillsTree(t *testing.T) {
+	t.Parallel()
+
+	all := []*skills.Skill{
+		{Name: "crush-config", Description: "Configure crush", Builtin: true, Path: "crush://skills/crush-config"},
+		{Name: "local-lint", Description: "Project linter", Builtin: false, Path: "/work/.crush/skills/local-lint"},
+		{Name: "deploy", Description: "Deploy tool", Builtin: false, Path: "/home/user/.config/crush/skills/deploy"},
+	}
+	disabledSet := map[string]bool{"deploy": true}
+	projectDirs := []string{"/work/.crush/skills"}
+
+	cmd := newTestCmd()
+	err := outputSkillsTree(cmd, all, disabledSet, projectDirs)
+	require.NoError(t, err)
+
+	output := cmdOutput(cmd)
+
+	// Verify group headers are present.
+	require.Contains(t, output, "Builtin")
+	require.Contains(t, output, "Project")
+	require.Contains(t, output, "User")
+
+	// Verify skill entries.
+	require.Contains(t, output, "crush-config")
+	require.Contains(t, output, "local-lint")
+	require.Contains(t, output, "deploy")
+
+	// Verify disabled annotation.
+	require.Contains(t, output, "(disabled)")
+}
+
+func TestOutputSkillsTreeSingleGroup(t *testing.T) {
+	t.Parallel()
+
+	all := []*skills.Skill{
+		{Name: "crush-config", Description: "Configure crush", Builtin: true, Path: "crush://skills/crush-config"},
+	}
+
+	cmd := newTestCmd()
+	err := outputSkillsTree(cmd, all, nil, nil)
+	require.NoError(t, err)
+
+	output := cmdOutput(cmd)
+	require.Contains(t, output, "Builtin")
+	require.Contains(t, output, "crush-config")
+	require.NotContains(t, output, "Project")
+	require.NotContains(t, output, "User")
+}

--- a/internal/skills/group.go
+++ b/internal/skills/group.go
@@ -1,0 +1,64 @@
+package skills
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Source represents the origin category of a skill.
+type Source string
+
+const (
+	SourceBuiltin Source = "Builtin"
+	SourceProject Source = "Project"
+	SourceUser    Source = "User"
+)
+
+// SourceGroup holds a source label and the skills that belong to it.
+type SourceGroup struct {
+	Source Source
+	Skills []*Skill
+}
+
+// GroupBySource partitions skills by origin. projectDirs lists the
+// project-level skill directories so that non-builtin skills found
+// under one of those directories are classified as Project rather than
+// User. The returned slice is ordered Builtin, Project, User, and
+// skills within each group are sorted by name. Empty groups are omitted.
+func GroupBySource(all []*Skill, projectDirs []string) []SourceGroup {
+	groups := map[Source][]*Skill{}
+
+	for _, s := range all {
+		src := ClassifySource(s, projectDirs)
+		groups[src] = append(groups[src], s)
+	}
+
+	for src := range groups {
+		sort.Slice(groups[src], func(i, j int) bool {
+			return strings.ToLower(groups[src][i].Name) < strings.ToLower(groups[src][j].Name)
+		})
+	}
+
+	var result []SourceGroup
+	for _, src := range []Source{SourceBuiltin, SourceProject, SourceUser} {
+		if len(groups[src]) > 0 {
+			result = append(result, SourceGroup{Source: src, Skills: groups[src]})
+		}
+	}
+	return result
+}
+
+// ClassifySource determines the source category for a single skill.
+func ClassifySource(s *Skill, projectDirs []string) Source {
+	if s.Builtin {
+		return SourceBuiltin
+	}
+	for _, dir := range projectDirs {
+		cleaned := filepath.Clean(dir)
+		if cleaned != "" && strings.HasPrefix(filepath.Clean(s.Path), cleaned) {
+			return SourceProject
+		}
+	}
+	return SourceUser
+}

--- a/internal/skills/group_test.go
+++ b/internal/skills/group_test.go
@@ -1,0 +1,133 @@
+package skills
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifySource(t *testing.T) {
+	t.Parallel()
+
+	projectDirs := []string{"/work/project/.crush/skills", "/work/project/.agents/skills"}
+
+	tests := []struct {
+		name  string
+		skill *Skill
+		want  Source
+	}{
+		{
+			name:  "builtin skill",
+			skill: &Skill{Name: "crush-config", Builtin: true, Path: "crush://skills/crush-config"},
+			want:  SourceBuiltin,
+		},
+		{
+			name:  "project skill",
+			skill: &Skill{Name: "local-lint", Builtin: false, Path: "/work/project/.crush/skills/local-lint"},
+			want:  SourceProject,
+		},
+		{
+			name:  "project skill in agents dir",
+			skill: &Skill{Name: "my-agent", Builtin: false, Path: "/work/project/.agents/skills/my-agent"},
+			want:  SourceProject,
+		},
+		{
+			name:  "user skill",
+			skill: &Skill{Name: "custom-deploy", Builtin: false, Path: "/home/user/.config/crush/skills/custom-deploy"},
+			want:  SourceUser,
+		},
+		{
+			name:  "user skill from custom path",
+			skill: &Skill{Name: "pdf-tool", Builtin: false, Path: "/opt/skills/pdf-tool"},
+			want:  SourceUser,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ClassifySource(tt.skill, projectDirs)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestClassifySourceEmptyProjectDirs(t *testing.T) {
+	t.Parallel()
+
+	s := &Skill{Name: "my-skill", Builtin: false, Path: "/some/path/my-skill"}
+	got := ClassifySource(s, nil)
+	require.Equal(t, SourceUser, got)
+}
+
+func TestGroupBySource(t *testing.T) {
+	t.Parallel()
+
+	projectDirs := []string{"/work/project/.crush/skills"}
+
+	all := []*Skill{
+		{Name: "commit", Builtin: true, Path: "crush://skills/commit"},
+		{Name: "review-pr", Builtin: true, Path: "crush://skills/review-pr"},
+		{Name: "local-lint", Builtin: false, Path: "/work/project/.crush/skills/local-lint"},
+		{Name: "deploy", Builtin: false, Path: "/home/user/.config/crush/skills/deploy"},
+		{Name: "analyze", Builtin: false, Path: "/home/user/.config/crush/skills/analyze"},
+	}
+
+	groups := GroupBySource(all, projectDirs)
+
+	require.Len(t, groups, 3)
+
+	// Builtin group first.
+	require.Equal(t, SourceBuiltin, groups[0].Source)
+	require.Len(t, groups[0].Skills, 2)
+	require.Equal(t, "commit", groups[0].Skills[0].Name)
+	require.Equal(t, "review-pr", groups[0].Skills[1].Name)
+
+	// Project group second.
+	require.Equal(t, SourceProject, groups[1].Source)
+	require.Len(t, groups[1].Skills, 1)
+	require.Equal(t, "local-lint", groups[1].Skills[0].Name)
+
+	// User group last.
+	require.Equal(t, SourceUser, groups[2].Source)
+	require.Len(t, groups[2].Skills, 2)
+	require.Equal(t, "analyze", groups[2].Skills[0].Name)
+	require.Equal(t, "deploy", groups[2].Skills[1].Name)
+}
+
+func TestGroupBySourceEmptyGroups(t *testing.T) {
+	t.Parallel()
+
+	// Only builtin skills — Project and User groups should be omitted.
+	all := []*Skill{
+		{Name: "crush-config", Builtin: true, Path: "crush://skills/crush-config"},
+	}
+
+	groups := GroupBySource(all, nil)
+	require.Len(t, groups, 1)
+	require.Equal(t, SourceBuiltin, groups[0].Source)
+}
+
+func TestGroupBySourceEmpty(t *testing.T) {
+	t.Parallel()
+
+	groups := GroupBySource(nil, nil)
+	require.Empty(t, groups)
+}
+
+func TestGroupBySourceSortOrder(t *testing.T) {
+	t.Parallel()
+
+	// Skills are given out of order; groups should sort them by name.
+	all := []*Skill{
+		{Name: "zebra", Builtin: true, Path: "crush://skills/zebra"},
+		{Name: "alpha", Builtin: true, Path: "crush://skills/alpha"},
+		{Name: "middle", Builtin: true, Path: "crush://skills/middle"},
+	}
+
+	groups := GroupBySource(all, nil)
+	require.Len(t, groups, 1)
+	require.Equal(t, "alpha", groups[0].Skills[0].Name)
+	require.Equal(t, "middle", groups[0].Skills[1].Name)
+	require.Equal(t, "zebra", groups[0].Skills[2].Name)
+}


### PR DESCRIPTION
## Summary

- Add `crush skills list` subcommand that groups discovered skills by source: **Builtin**, **Project**, and **User**
- Support `--flat` flag for flat list output and `--json` for machine-readable output
- Positional args filter skills by name or description (case-insensitive)
- Non-TTY output automatically falls back to flat format for piping
- Follows existing `crush models` tree pattern and `session list` styling conventions (charmtone.Malibu / Damson)

## New files

- `internal/skills/group.go` — `GroupBySource` and `ClassifySource` grouping logic
- `internal/skills/group_test.go` — 6 test cases for classification and grouping
- `internal/cmd/skills.go` — CLI command implementation
- `internal/cmd/skills_test.go` — 5 test cases for filtering and output formatting

## Example output

```
├── Builtin
│   └── crush-config — Configure Crush settings...
└── Project
    └── my-skill — A project-specific skill
```

## Test plan

### Automated tests

- [x] `go vet ./internal/skills/ ./internal/cmd/` — passes
- [x] `go build ./...` — passes
- [x] `go test ./internal/skills/ ./internal/cmd/ -count=1` — all 28 tests pass

### Manual testing

**Tree output (TTY default):**
```bash
$ crush skills list
├── Builtin
│   └── crush-config — Configure Crush settings including providers, LSPs, MCPs, skills, permissions, and behavior options...
└── Project
    └── test-skill — A test skill for verifying group-by-source feature.
```

**Flat output:**
```bash
$ crush skills list --flat
crush-config    builtin    enabled
test-skill      project    enabled
```

**JSON output:**
```bash
$ crush skills list --json
[{"name":"crush-config","description":"Configure Crush settings...","source":"builtin","status":"enabled","path":"crush://skills/crush-config/SKILL.md"}]
```

**Search filter (match):**
```bash
$ crush skills list config
└── Builtin
    └── crush-config — Configure Crush settings...
```

**Search filter (no match):**
```bash
$ crush skills list xyz
ERROR
No skills found matching "xyz".
```

**Non-TTY pipe fallback:**
```bash
$ crush skills list | cat
crush-config    builtin    enabled
```

### Project-level skill verification

```bash
# Create a project-level skill
mkdir -p .crush/skills/test-skill
cat > .crush/skills/test-skill/SKILL.md << 'EOF'
---
name: test-skill
description: A test skill for verifying group-by-source feature.
---

# Test Skill

This is a test skill.
EOF

# Verify it appears under "Project" group
crush skills list

# Clean up
rm -rf .crush/skills/test-skill
```

Related to https://github.com/charmbracelet/crush/issues/2608