### PR TITLE
feat: enable real-time reasoning display and implement thinking visibility toggle

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -479,7 +479,7 @@ func outputSessionHuman(ctx context.Context, sess session.Session, msgs []*messa
 
 	first := true
 	for _, msg := range msgs {
-		items := chat.ExtractMessageItems(&sty, msg, toolResults)
+		items := chat.ExtractMessageItems(&sty, msg, toolResults, true)
 		for _, item := range items {
 			if !first {
 				fmt.Fprintln(&buf)

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -32,17 +32,19 @@ type AssistantMessageItem struct {
 	sty               *styles.Styles
 	anim              *anim.Anim
 	thinkingExpanded  bool
-	thinkingBoxHeight int // Tracks the rendered thinking box height for click detection.
+	thinkingBoxHeight int  // Tracks the rendered thinking box height for click detection.
+	showThinking      bool // Controls visibility of reasoning content
 }
 
 // NewAssistantMessageItem creates a new AssistantMessageItem.
-func NewAssistantMessageItem(sty *styles.Styles, message *message.Message) MessageItem {
+func NewAssistantMessageItem(sty *styles.Styles, message *message.Message, showThinking bool) MessageItem {
 	a := &AssistantMessageItem{
 		highlightableMessageItem: defaultHighlighter(sty),
 		cachedMessageItem:        &cachedMessageItem{},
 		focusableMessageItem:     &focusableMessageItem{},
 		message:                  message,
 		sty:                      sty,
+		showThinking:             showThinking,
 	}
 
 	a.anim = anim.New(anim.Settings{
@@ -86,12 +88,21 @@ func (a *AssistantMessageItem) RawRender(width int) string {
 		spinner = a.renderSpinning()
 	}
 
-	content, height, ok := a.getCachedRender(cappedWidth)
-	if !ok {
+	// Bypass cache during streaming to ensure real-time updates
+	var content string
+	var height int
+	if a.isSpinning() {
 		content = a.renderMessageContent(cappedWidth)
 		height = lipgloss.Height(content)
-		// cache the rendered content
-		a.setCachedRender(content, cappedWidth, height)
+	} else {
+		var ok bool
+		content, height, ok = a.getCachedRender(cappedWidth)
+		if !ok {
+			content = a.renderMessageContent(cappedWidth)
+			height = lipgloss.Height(content)
+			// cache the rendered content
+			a.setCachedRender(content, cappedWidth, height)
+		}
 	}
 
 	highlightedContent := a.renderHighlighted(content, cappedWidth, height)
@@ -131,8 +142,8 @@ func (a *AssistantMessageItem) renderMessageContent(width int) string {
 	var messageParts []string
 	thinking := strings.TrimSpace(a.message.ReasoningContent().Thinking)
 	content := strings.TrimSpace(a.message.Content().Text)
-	// if the massage has reasoning content add that first
-	if thinking != "" {
+	// if the message has reasoning content add that first (respecting visibility toggle)
+	if thinking != "" && a.showThinking {
 		messageParts = append(messageParts, a.renderThinking(a.message.ReasoningContent().Thinking, width))
 	}
 

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -262,7 +262,8 @@ func cappedMessageWidth(availableWidth int) int {
 //
 // For assistant messages with tool calls, pass a toolResults map to link results.
 // Use BuildToolResultMap to create this map from all messages in a session.
-func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults map[string]message.ToolResult) []MessageItem {
+// The showThinking parameter controls whether reasoning content is visible.
+func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults map[string]message.ToolResult, showThinking bool) []MessageItem {
 	switch msg.Role {
 	case message.User:
 		r := attachments.NewRenderer(
@@ -275,7 +276,7 @@ func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults m
 	case message.Assistant:
 		var items []MessageItem
 		if ShouldRenderAssistantMessage(msg) {
-			items = append(items, NewAssistantMessageItem(sty, msg))
+			items = append(items, NewAssistantMessageItem(sty, msg, showThinking))
 		}
 		for _, tc := range msg.ToolCalls() {
 			var result *message.ToolResult

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -48,6 +48,7 @@ type (
 	ActionToggleHelp                  struct{}
 	ActionToggleCompactMode           struct{}
 	ActionToggleThinking              struct{}
+	ActionToggleThinkingVisibility    struct{} // Toggle display of reasoning content in UI
 	ActionTogglePills                 struct{}
 	ActionExternalEditor              struct{}
 	ActionToggleYoloMode              struct{}

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -454,6 +454,11 @@ func (c *Commands) defaultCommands() []*CommandItem {
 			}
 		}
 	}
+
+	// Universal toggle for hiding/showing reasoning content in UI (works with any model)
+	if c.hasSession {
+		commands = append(commands, NewCommandItem(c.com.Styles, "toggle_thinking_visibility", "Hide/Show Thinking", "", ActionToggleThinkingVisibility{}))
+	}
 	// Only show toggle compact mode command if window width is larger than compact breakpoint (120)
 	if c.windowWidth >= sidebarCompactModeBreakpoint && c.hasSession {
 		commands = append(commands, NewCommandItem(c.com.Styles, "toggle_sidebar", "Toggle Sidebar", "", ActionToggleCompactMode{}))

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -250,6 +250,9 @@ type UI struct {
 	promptQueue        int
 	pillsView          string
 
+	// showThinking controls visibility of reasoning content in the UI
+	showThinking bool
+
 	// Todo spinner
 	todoSpinner    spinner.Model
 	todoIsSpinning bool
@@ -327,6 +330,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 		notifyWindowFocused: true,
 		initialSessionID:    initialSessionID,
 		continueLastSession: continueLast,
+		showThinking:        true, // Default to showing reasoning content
 	}
 
 	status := NewStatus(com, ui)
@@ -894,6 +898,19 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
+// refreshMessages refreshes the current session messages to apply UI state changes
+// (like showThinking toggle) without reloading from the database.
+func (m *UI) refreshMessages() tea.Cmd {
+	if m.session == nil {
+		return nil
+	}
+	msgs, err := m.com.Workspace.ListMessages(context.Background(), m.session.ID)
+	if err != nil {
+		return util.ReportError(err)
+	}
+	return m.setSessionMessages(msgs)
+}
+
 // setSessionMessages sets the messages for the current session in the chat
 func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 	var cmds []tea.Cmd
@@ -913,15 +930,15 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 		switch msg.Role {
 		case message.User:
 			m.lastUserMessageTime = msg.CreatedAt
-			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap)...)
+			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap, m.showThinking)...)
 		case message.Assistant:
-			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap)...)
+			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap, m.showThinking)...)
 			if msg.FinishPart() != nil && msg.FinishPart().Reason == message.FinishReasonEndTurn {
 				infoItem := chat.NewAssistantInfoItem(m.com.Styles, msg, m.com.Config(), time.Unix(m.lastUserMessageTime, 0))
 				items = append(items, infoItem)
 			}
 		default:
-			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap)...)
+			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap, m.showThinking)...)
 		}
 	}
 
@@ -980,7 +997,7 @@ func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
 		// Extract nested tool items.
 		var nestedTools []chat.ToolMessageItem
 		for _, nestedMsg := range nestedMsgPtrs {
-			nestedItems := chat.ExtractMessageItems(m.com.Styles, nestedMsg, nestedToolResultMap)
+			nestedItems := chat.ExtractMessageItems(m.com.Styles, nestedMsg, nestedToolResultMap, m.showThinking)
 			for _, nestedItem := range nestedItems {
 				if nestedToolItem, ok := nestedItem.(chat.ToolMessageItem); ok {
 					// Mark nested tools as simple (compact) rendering.
@@ -1018,7 +1035,7 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 	switch msg.Role {
 	case message.User:
 		m.lastUserMessageTime = msg.CreatedAt
-		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil)
+		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil, m.showThinking)
 		for _, item := range items {
 			if animatable, ok := item.(chat.Animatable); ok {
 				if cmd := animatable.StartAnimation(); cmd != nil {
@@ -1031,7 +1048,7 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 			cmds = append(cmds, cmd)
 		}
 	case message.Assistant:
-		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil)
+		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil, m.showThinking)
 		for _, item := range items {
 			if animatable, ok := item.(chat.Animatable); ok {
 				if cmd := animatable.StartAnimation(); cmd != nil {
@@ -1383,6 +1400,18 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			}
 			return util.NewInfoMsg("Thinking mode " + status)
 		})
+		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionToggleThinkingVisibility:
+		m.showThinking = !m.showThinking
+		status := "hidden"
+		if m.showThinking {
+			status = "visible"
+		}
+		cmds = append(cmds, func() tea.Msg {
+			return util.NewInfoMsg("Thinking content " + status)
+		})
+		// Refresh chat to apply visibility change
+		cmds = append(cmds, m.refreshMessages())
 		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionToggleTransparentBackground:
 		cmds = append(cmds, func() tea.Msg {


### PR DESCRIPTION
This PR fixes two related issues with reasoning/thinking content in the TUI.

Problem 1: Real-time display broken

Reasoning content from models (Claude, DeepSeek, etc.) was not visible during streaming. The render cache in RawRender() was keyed only by width, so:

1. First render caches empty content
2. Subsequent renders hit cache and return stale empty content
3. Reasoning content that arrives via SetMessage() never gets displayed

Solution: Bypass cache during generation

- Check isSpinning() before using cache
- When spinning, render fresh content every frame
- When done, use cache normally for performance

Problem 2: Hide/Show Thinking toggle non-functional

The command palette had a "Hide/Show Thinking" menu item but no implementation. Selecting it did nothing.

Solution: Implement the missing handler

- Add showThinking bool to UI struct (default true)
- Implement ActionToggleThinkingVisibility handler
- Add refreshMessages() helper to reload chat view
- Pass showThinking through ExtractMessageItems() and NewAssistantMessageItem()
- Only render thinking block when showThinking is true

Usage:

Press Ctrl+P then select "Hide/Show Thinking" to toggle visibility. The chat refreshes immediately.

Files modified:

- internal/ui/model/ui.go - UI state, cache fix, action handler, refresh helper
- internal/ui/chat/assistant.go - Cache bypass logic, showThinking flag, conditional render
- internal/ui/chat/messages.go - ExtractMessageItems signature
- internal/cmd/session.go - Updated call site
- internal/ui/dialog/actions.go - ActionToggleThinkingVisibility struct
- internal/ui/dialog/commands.go - Command palette item
