### PR TITLE
fix(ui): fix AtBottom() early exit not accounting for offsetLine

### DIFF
--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -82,9 +82,11 @@ func (l *List) AtBottom() bool {
 	}
 
 	// Calculate the height from offsetIdx to the end.
+	// l.offsetLine is the number of lines of the item at offsetIdx that are
+	// scrolled out of view, so the effective visible height is totalHeight-l.offsetLine.
 	var totalHeight int
 	for idx := l.offsetIdx; idx < len(l.items); idx++ {
-		if totalHeight > l.height {
+		if totalHeight-l.offsetLine > l.height {
 			// No need to calculate further, we're already past the viewport height
 			return false
 		}


### PR DESCRIPTION
Fixes #2481

## Problem

Auto-follow mode sometimes stops working even after manually scrolling back to the bottom. The internal follow state gets out of sync with the visual scroll position.

## Root Cause

The `AtBottom()` method in `internal/ui/list/list.go` has an early-exit optimization that compares `totalHeight` against `l.height` directly:

```go
if totalHeight > l.height {
    return false
}
```

However, `l.offsetLine` represents lines of the first visible item that are scrolled **off-screen** above the viewport. The actual visible content height is `totalHeight - l.offsetLine`. The early exit didn't account for this offset, so when `l.offsetLine > 0`:

- `totalHeight` could exceed `l.height` while `totalHeight - l.offsetLine <= l.height` (truly at bottom)
- The premature `return false` caused `AtBottom()` to incorrectly report "not at bottom"

Since `chat.go`'s `ScrollBy()` re-enables follow mode only when `AtBottom()` returns `true`, this bug prevented follow mode from being restored after scrolling back to the bottom via incremental scrolling (e.g. trackpad).

## Solution

Change the early-exit condition to account for `l.offsetLine`:

```go
if totalHeight-l.offsetLine > l.height {
    return false
}
```

This matches the condition used in the final `return` statement, making them consistent.

## Testing

Manually verified:
1. Open a long Crush session with many messages
2. Scroll up with trackpad
3. Scroll back down to the bottom incrementally (not using an explicit "scroll to bottom" key)
4. New output now correctly resumes auto-following