### PR TITLE
fix(grep): stop regex fallback after cancellation

### DIFF
--- a/internal/agent/tools/grep.go
+++ b/internal/agent/tools/grep.go
@@ -172,9 +172,17 @@ func NewGrepTool(workingDir string, config config.ToolGrep) fantasy.AgentTool {
 }
 
 func searchFiles(ctx context.Context, pattern, rootPath, include string, limit int) ([]grepMatch, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, false, err
+	}
+
 	matches, err := searchWithRipgrep(ctx, pattern, rootPath, include)
 	if err != nil {
-		matches, err = searchFilesWithRegex(pattern, rootPath, include)
+		if err := ctx.Err(); err != nil {
+			return nil, false, err
+		}
+
+		matches, err = searchFilesWithRegex(ctx, pattern, rootPath, include)
 		if err != nil {
 			return nil, false, err
 		}
@@ -261,7 +269,11 @@ type ripgrepMatch struct {
 	} `json:"data"`
 }
 
-func searchFilesWithRegex(pattern, rootPath, include string) ([]grepMatch, error) {
+func searchFilesWithRegex(ctx context.Context, pattern, rootPath, include string) ([]grepMatch, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	matches := []grepMatch{}
 
 	// Use cached regex compilation
@@ -285,6 +297,9 @@ func searchFilesWithRegex(pattern, rootPath, include string) ([]grepMatch, error
 	err = filepath.Walk(rootPath, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return nil // Skip errors
+		}
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 
 		if info.IsDir() {
@@ -310,8 +325,11 @@ func searchFilesWithRegex(pattern, rootPath, include string) ([]grepMatch, error
 			return nil
 		}
 
-		match, lineNum, charNum, lineText, err := fileContainsPattern(path, regex)
+		match, lineNum, charNum, lineText, err := fileContainsPattern(ctx, path, regex)
 		if err != nil {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			return nil // Skip files we can't read
 		}
 
@@ -334,11 +352,18 @@ func searchFilesWithRegex(pattern, rootPath, include string) ([]grepMatch, error
 	if err != nil {
 		return nil, err
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	return matches, nil
 }
 
-func fileContainsPattern(filePath string, pattern *regexp.Regexp) (bool, int, int, string, error) {
+func fileContainsPattern(ctx context.Context, filePath string, pattern *regexp.Regexp) (bool, int, int, string, error) {
+	if err := ctx.Err(); err != nil {
+		return false, 0, 0, "", err
+	}
+
 	// Only search text files.
 	if !isTextFile(filePath) {
 		return false, 0, 0, "", nil
@@ -353,12 +378,20 @@ func fileContainsPattern(filePath string, pattern *regexp.Regexp) (bool, int, in
 	scanner := bufio.NewScanner(file)
 	lineNum := 0
 	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return false, 0, 0, "", err
+		}
+
 		lineNum++
 		line := scanner.Text()
 		if loc := pattern.FindStringIndex(line); loc != nil {
 			charNum := loc[0] + 1
 			return true, lineNum, charNum, line, nil
 		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return false, 0, 0, "", err
 	}
 
 	return false, 0, 0, "", scanner.Err()

--- a/internal/agent/tools/grep_test.go
+++ b/internal/agent/tools/grep_test.go
@@ -1,10 +1,14 @@
 package tools
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -84,10 +88,10 @@ func TestGrepWithIgnoreFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".crushignore"), []byte(crushignoreContent), 0o644))
 
 	// Test both implementations
-	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
+	for name, fn := range map[string]func(context.Context, string, string, string) ([]grepMatch, error){
 		"regex": searchFilesWithRegex,
-		"rg": func(pattern, path, include string) ([]grepMatch, error) {
-			return searchWithRipgrep(t.Context(), pattern, path, include)
+		"rg": func(ctx context.Context, pattern, path, include string) ([]grepMatch, error) {
+			return searchWithRipgrep(ctx, pattern, path, include)
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -97,7 +101,7 @@ func TestGrepWithIgnoreFiles(t *testing.T) {
 				t.Skip("rg is not in $PATH")
 			}
 
-			matches, err := fn("hello world", tempDir, "")
+			matches, err := fn(t.Context(), "hello world", tempDir, "")
 			require.NoError(t, err)
 
 			// Convert matches to a set of file paths for easier testing
@@ -144,10 +148,10 @@ func TestSearchImplementations(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".gitignore"), []byte("file4.txt\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".crushignore"), []byte("file5.txt\n"), 0o644))
 
-	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
+	for name, fn := range map[string]func(context.Context, string, string, string) ([]grepMatch, error){
 		"regex": searchFilesWithRegex,
-		"rg": func(pattern, path, include string) ([]grepMatch, error) {
-			return searchWithRipgrep(t.Context(), pattern, path, include)
+		"rg": func(ctx context.Context, pattern, path, include string) ([]grepMatch, error) {
+			return searchWithRipgrep(ctx, pattern, path, include)
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -157,7 +161,7 @@ func TestSearchImplementations(t *testing.T) {
 				t.Skip("rg is not in $PATH")
 			}
 
-			matches, err := fn("hello world", tempDir, "")
+			matches, err := fn(t.Context(), "hello world", tempDir, "")
 			require.NoError(t, err)
 
 			require.Equal(t, len(matches), 4)
@@ -173,6 +177,36 @@ func TestSearchImplementations(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSearchFilesWithRegex_CanceledContext(t *testing.T) {
+	tempDir := t.TempDir()
+
+	for i := range 200 {
+		path := filepath.Join(tempDir, "dir", "nested", fmt.Sprintf("file-%03d.txt", i))
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("hello world\n"), 0o644))
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := searchFilesWithRegex(ctx, "hello", tempDir, "")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSearchFilesWithRegex_DeadlineExceededDuringScan(t *testing.T) {
+	tempDir := t.TempDir()
+
+	largeFile := filepath.Join(tempDir, "large.txt")
+	content := bytes.Repeat([]byte("this line does not contain the pattern\n"), 2_000_000)
+	require.NoError(t, os.WriteFile(largeFile, content, 0o644))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Millisecond)
+	t.Cleanup(cancel)
+
+	_, err := searchFilesWithRegex(ctx, "needle", tempDir, "*.txt")
+	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 // Benchmark to show performance improvement
@@ -395,10 +429,10 @@ func TestColumnMatch(t *testing.T) {
 	t.Parallel()
 
 	// Test both implementations
-	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
+	for name, fn := range map[string]func(context.Context, string, string, string) ([]grepMatch, error){
 		"regex": searchFilesWithRegex,
-		"rg": func(pattern, path, include string) ([]grepMatch, error) {
-			return searchWithRipgrep(t.Context(), pattern, path, include)
+		"rg": func(ctx context.Context, pattern, path, include string) ([]grepMatch, error) {
+			return searchWithRipgrep(ctx, pattern, path, include)
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -408,7 +442,7 @@ func TestColumnMatch(t *testing.T) {
 				t.Skip("rg is not in $PATH")
 			}
 
-			matches, err := fn("THIS", "./testdata/", "")
+			matches, err := fn(t.Context(), "THIS", "./testdata/", "")
 			require.NoError(t, err)
 			require.Len(t, matches, 1)
 			match := matches[0]


### PR DESCRIPTION
Fixes #1855

## Summary

- propagate the tool context into grep's regex fallback instead of treating it like an unbounded local search
- stop `filepath.Walk` and file scanning as soon as the search context is canceled or times out
- add regression coverage for both already-canceled and mid-scan deadline-exceeded contexts

## Reproduction

When `rg` is unavailable or fails, grep falls back to `searchFilesWithRegex()`. Before this change that path ignored the caller context, so a canceled grep request could keep walking files and scanning contents until the fallback finished.

## Test plan

- [x] `go test ./internal/agent/tools -run TestSearchFilesWithRegex_(CanceledContext|DeadlineExceededDuringScan)`
- [x] `go test ./internal/agent/tools`