### PR TITLE
config: support APIURL/APIKEY env overrides with CRUSH_PROVIDER targeting

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"unicode"
 
 	"charm.land/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/agent/hyper"
@@ -208,6 +209,15 @@ func (c *Config) configureProviders(store *ConfigStore, env env.Env, resolver Va
 			}
 		}
 
+		if envBaseURL, envAPIKey := providerEnvOverrides(env, string(p.ID)); envBaseURL != "" || envAPIKey != "" {
+			if envBaseURL != "" {
+				p.APIEndpoint = envBaseURL
+			}
+			if envAPIKey != "" {
+				p.APIKey = envAPIKey
+			}
+		}
+
 		headers := map[string]string{}
 		if len(p.DefaultHeaders) > 0 {
 			maps.Copy(headers, p.DefaultHeaders)
@@ -329,6 +339,15 @@ func (c *Config) configureProviders(store *ConfigStore, env env.Env, resolver Va
 			continue
 		}
 
+		if envBaseURL, envAPIKey := providerEnvOverrides(env, id); envBaseURL != "" || envAPIKey != "" {
+			if envBaseURL != "" {
+				providerConfig.BaseURL = envBaseURL
+			}
+			if envAPIKey != "" {
+				providerConfig.APIKey = envAPIKey
+			}
+		}
+
 		// Make sure the provider ID is set
 		providerConfig.ID = id
 		providerConfig.Name = cmp.Or(providerConfig.Name, id) // Use ID as name if not set
@@ -386,6 +405,61 @@ func (c *Config) configureProviders(store *ConfigStore, env env.Env, resolver Va
 	}
 
 	return nil
+}
+
+func providerEnvOverrides(env env.Env, providerID string) (baseURL string, apiKey string) {
+	id := strings.TrimSpace(strings.ToLower(providerID))
+	if id == "" {
+		return "", ""
+	}
+
+	suffix := providerEnvSuffix(id)
+	baseURL = firstEnvValue(env,
+		"CRUSH_"+suffix+"_BASE_URL",
+		suffix+"_BASE_URL",
+	)
+	apiKey = firstEnvValue(env,
+		"CRUSH_"+suffix+"_API_KEY",
+	)
+
+	target := strings.TrimSpace(strings.ToLower(env.Get("CRUSH_PROVIDER")))
+	if target == "" {
+		target = "openai"
+	}
+	if target == id {
+		baseURL = cmp.Or(baseURL, firstEnvValue(env, "CRUSH_API_URL", "API_URL", "APIURL"))
+		apiKey = cmp.Or(apiKey, firstEnvValue(env, "CRUSH_API_KEY", "API_KEY", "APIKEY"))
+	}
+
+	return strings.TrimSpace(baseURL), strings.TrimSpace(apiKey)
+}
+
+func providerEnvSuffix(providerID string) string {
+	var b strings.Builder
+	b.Grow(len(providerID))
+	lastUnderscore := false
+	for _, r := range providerID {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(unicode.ToUpper(r))
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func firstEnvValue(env env.Env, keys ...string) string {
+	for _, key := range keys {
+		v := strings.TrimSpace(env.Get(key))
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 func (c *Config) setDefaults(workingDir, dataDir string) {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -133,6 +133,96 @@ func TestConfig_configureProvidersWithOverride(t *testing.T) {
 	require.Equal(t, "Updated", pc.Models[0].Name)
 }
 
+func TestConfig_configureProviders_OpenAIBaseURLFromEnv(t *testing.T) {
+	knownProviders := []catwalk.Provider{
+		{
+			ID:          "openai",
+			APIKey:      "$OPENAI_API_KEY",
+			APIEndpoint: "https://api.openai.com/v1",
+			Models: []catwalk.Model{{
+				ID: "test-model",
+			}},
+		},
+	}
+
+	cfg := &Config{}
+	cfg.setDefaults("/tmp", "")
+	env := env.NewFromMap(map[string]string{
+		"OPENAI_API_KEY": "test-key",
+		"OPENAI_BASE_URL": "https://proxy.example.com/v1",
+	})
+	resolver := NewEnvironmentVariableResolver(env)
+	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	require.NoError(t, err)
+
+	pc, ok := cfg.Providers.Get("openai")
+	require.True(t, ok)
+	require.Equal(t, "https://proxy.example.com/v1", pc.BaseURL)
+}
+
+func TestConfig_configureProviders_GlobalAPIEnvTargetsOpenAIDefault(t *testing.T) {
+	knownProviders := []catwalk.Provider{
+		{
+			ID:          "openai",
+			APIKey:      "$OPENAI_API_KEY",
+			APIEndpoint: "https://api.openai.com/v1",
+			Models: []catwalk.Model{{
+				ID: "gpt-test",
+			}},
+		},
+	}
+
+	cfg := &Config{}
+	cfg.setDefaults("/tmp", "")
+	env := env.NewFromMap(map[string]string{
+		"APIKEY": "global-key",
+		"APIURL": "https://global.example.com/v1",
+	})
+	resolver := NewEnvironmentVariableResolver(env)
+	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	require.NoError(t, err)
+
+	pc, ok := cfg.Providers.Get("openai")
+	require.True(t, ok)
+	require.Equal(t, "https://global.example.com/v1", pc.BaseURL)
+	require.Equal(t, "global-key", pc.APIKey)
+}
+
+func TestConfig_configureProviders_GlobalAPIEnvTargetsCustomProvider(t *testing.T) {
+	knownProviders := []catwalk.Provider{
+		{
+			ID:          "openai",
+			APIKey:      "$OPENAI_API_KEY",
+			APIEndpoint: "https://api.openai.com/v1",
+			Models: []catwalk.Model{{ID: "gpt-test"}},
+		},
+	}
+
+	cfg := &Config{
+		Providers: csync.NewMapFrom(map[string]ProviderConfig{
+			"my-provider": {
+				BaseURL: "https://old.example.com/v1",
+				Models:  []catwalk.Model{{ID: "x"}},
+			},
+		}),
+	}
+	cfg.setDefaults("/tmp", "")
+	env := env.NewFromMap(map[string]string{
+		"CRUSH_PROVIDER": "my-provider",
+		"CRUSH_API_KEY":  "custom-key",
+		"CRUSH_API_URL":  "https://custom.example.com/v1",
+		"OPENAI_API_KEY": "openai-key",
+	})
+	resolver := NewEnvironmentVariableResolver(env)
+	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	require.NoError(t, err)
+
+	custom, ok := cfg.Providers.Get("my-provider")
+	require.True(t, ok)
+	require.Equal(t, "https://custom.example.com/v1", custom.BaseURL)
+	require.Equal(t, "custom-key", custom.APIKey)
+}
+
 func TestConfig_configureProvidersWithNewProvider(t *testing.T) {
 	knownProviders := []catwalk.Provider{
 		{


### PR DESCRIPTION
## Summary
This PR adds optional environment-variable overrides for provider endpoint and API key so users can quickly point Crush at a custom gateway without editing config files.

## What changed
- Add provider env override resolution during provider configuration.
- Support generic env vars: `APIURL`/`API_URL`, `APIKEY`/`API_KEY` (and `CRUSH_API_URL`/`CRUSH_API_KEY`).
- Add `CRUSH_PROVIDER=<provider_id>` to target which provider receives generic overrides.
- Default target is `openai` when `CRUSH_PROVIDER` is unset.
- Keep existing `$OPENAI_API_KEY` template behavior intact (no forced replacement).

## Provider-specific env keys
- `CRUSH_<PROVIDER>_BASE_URL`
- `<PROVIDER>_BASE_URL`
- `CRUSH_<PROVIDER>_API_KEY`

## Tests
Added tests in `internal/config/load_test.go`:
- OpenAI base URL override via env
- Generic APIURL/APIKEY targeting default openai
- Generic APIURL/APIKEY targeting a custom provider via `CRUSH_PROVIDER`

All `internal/config` tests pass locally.