### PR TITLE
Fix command aliases/args parsing and empty tool-call input normalization

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -384,7 +384,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 			toolCall := message.ToolCall{
 				ID:               tc.ToolCallID,
 				Name:             tc.ToolName,
-				Input:            tc.Input,
+				Input:            normalizeToolCallInput(tc.Input),
 				ProviderExecuted: false,
 				Finished:         true,
 			}
@@ -613,6 +613,13 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 	firstQueuedMessage := queuedMessages[0]
 	a.messageQueue.Set(call.SessionID, queuedMessages[1:])
 	return a.Run(ctx, firstQueuedMessage)
+}
+
+func normalizeToolCallInput(input string) string {
+	if strings.TrimSpace(input) == "" {
+		return "{}"
+	}
+	return input
 }
 
 func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fantasy.ProviderOptions) error {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -793,3 +793,11 @@ func TestPreparePrompt_OrphanedToolUseMixed(t *testing.T) {
 	}
 	require.Equal(t, 1, syntheticCount, "expected exactly one synthetic result for the orphaned call")
 }
+
+func TestNormalizeToolCallInput(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "{}", normalizeToolCallInput(""))
+	require.Equal(t, "{}", normalizeToolCallInput("   \n\t "))
+	require.Equal(t, `{"file_path":"a.txt","content":"hello"}`, normalizeToolCallInput(`{"file_path":"a.txt","content":"hello"}`))
+}

--- a/internal/commands/commands.go
+++ b/internal/commands/commands.go
@@ -14,7 +14,7 @@ import (
 	"github.com/charmbracelet/crush/internal/home"
 )
 
-var namedArgPattern = regexp.MustCompile(`\$([A-Z][A-Z0-9_]*)`)
+var namedArgPattern = regexp.MustCompile(`\$([\p{L}_][\p{L}\p{N}_]*)`)
 
 const (
 	userCommandPrefix    = "user:"

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -51,3 +51,16 @@ func TestLoadAll_MixedSources(t *testing.T) {
 	require.Len(t, cmds, 1)
 	require.Equal(t, "user:cmd", cmds[0].ID)
 }
+
+func TestExtractArgNames_UnicodePlaceholders(t *testing.T) {
+	t.Parallel()
+
+	content := "run $DATA_DIR then $数据目录 and $ДАННЫЕ_1 and $ÅR2 and $DATA_DIR again"
+
+	args := extractArgNames(content)
+	require.Len(t, args, 4)
+	require.Equal(t, "DATA_DIR", args[0].ID)
+	require.Equal(t, "数据目录", args[1].ID)
+	require.Equal(t, "ДАННЫЕ_1", args[2].ID)
+	require.Equal(t, "ÅR2", args[3].ID)
+}

--- a/internal/message/content.go
+++ b/internal/message/content.go
@@ -142,6 +142,13 @@ type Message struct {
 	IsSummaryMessage bool
 }
 
+func normalizeToolCallInput(input string) string {
+	if strings.TrimSpace(input) == "" {
+		return "{}"
+	}
+	return input
+}
+
 func (m *Message) Content() TextContent {
 	for _, part := range m.Parts {
 		if c, ok := part.(TextContent); ok {
@@ -530,7 +537,7 @@ func (m *Message) ToAIMessage() []fantasy.Message {
 			parts = append(parts, fantasy.ToolCallPart{
 				ToolCallID:       call.ID,
 				ToolName:         call.Name,
-				Input:            call.Input,
+				Input:            normalizeToolCallInput(call.Input),
 				ProviderExecuted: call.ProviderExecuted,
 			})
 		}

--- a/internal/message/content_test.go
+++ b/internal/message/content_test.go
@@ -140,3 +140,26 @@ func BenchmarkPromptWithTextAttachments(b *testing.B) {
 		})
 	}
 }
+
+func TestToAIMessage_EmptyToolCallInputIsNormalized(t *testing.T) {
+	t.Parallel()
+
+	msg := &Message{
+		Role: Assistant,
+		Parts: []ContentPart{
+			ToolCall{
+				ID:    "call_1",
+				Name:  "write",
+				Input: "",
+			},
+		},
+	}
+
+	messages := msg.ToAIMessage()
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].Content, 1)
+
+	part, ok := messages[0].Content[0].(fantasy.ToolCallPart)
+	require.True(t, ok)
+	require.Equal(t, "{}", part.Input)
+}

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -524,6 +524,7 @@ func (c *Commands) defaultCommands() []*CommandItem {
 	commands = append(commands, NewCommandItem(c.com.Styles, "toggle_transparent", transparentLabel, "", ActionToggleTransparentBackground{}))
 
 	commands = append(commands,
+		NewCommandItem(c.com.Styles, "exit", "Exit", "", tea.QuitMsg{}),
 		NewCommandItem(c.com.Styles, "quit", "Quit", "ctrl+c", tea.QuitMsg{}),
 	)
 


### PR DESCRIPTION
## Summary
- add an `exit` command alias in the command dialog that maps to the same quit action as `quit`
- allow Unicode command placeholders (e.g. `$数据目录`, `$ДАННЫЕ_1`) in user commands
- normalize empty/whitespace tool-call inputs to `{}` before replaying/sending history to avoid malformed tool-call payload loops

## Tests
- `go test ./internal/ui/... -count=1`
- `go test ./internal/commands -count=1`
- `go test ./internal/message -count=1`
- `go test ./internal/agent -run 'TestNormalizeToolCallInput|TestPreparePrompt_OrphanedToolUse|TestPreparePrompt_OrphanedToolUseMixed' -count=1`
