### PR TITLE
fix(agent): retry title generation with large model on empty output

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -54,6 +54,15 @@ const (
 	largeContextWindowThreshold = 200_000
 	largeContextWindowBuffer    = 20_000
 	smallContextWindowRatio     = 0.2
+
+	// smallTitleMaxTokens caps the small-model title call. 256 is enough
+	// for a one-line title and leaves headroom for "non-reasoning" models
+	// that still burn output tokens on hidden reasoning (e.g. GPT-5 mini).
+	smallTitleMaxTokens int64 = 256
+
+	// fallbackTitleMaxTokens is used when the large model's catwalk config
+	// doesn't advertise a default token limit.
+	fallbackTitleMaxTokens int64 = 1024
 )
 
 var userAgent = fmt.Sprintf("Charm-Crush/%s (https://charm.land/crush)", version.Version)
@@ -919,7 +928,7 @@ func (a *sessionAgent) getSessionMessages(ctx context.Context, session session.S
 	return msgs, nil
 }
 
-// generateTitle generates a session titled based on the initial prompt.
+// generateTitle generates a session title based on the initial prompt.
 func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, userPrompt string) {
 	if userPrompt == "" {
 		return
@@ -929,7 +938,7 @@ func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, user
 	largeModel := a.largeModel.Get()
 	systemPromptPrefix := a.systemPromptPrefix.Get()
 
-	var maxOutputTokens int64 = 40
+	maxOutputTokens := smallTitleMaxTokens
 	if smallModel.CatwalkCfg.CanReason {
 		maxOutputTokens = smallModel.CatwalkCfg.DefaultMaxTokens
 	}
@@ -964,22 +973,39 @@ func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, user
 		slog.Debug("Generated title with small model")
 	} else {
 		// It didn't work. Let's try with the big model.
-		slog.Error("Error generating title with small model; trying big model", "err", err)
+		slog.Error("Error generating title with small model; trying big model", "error", err)
 		model = largeModel
-		agent = newAgent(model.Model, titlePrompt, maxOutputTokens)
+		agent = newAgent(model.Model, titlePrompt, cmp.Or(largeModel.CatwalkCfg.DefaultMaxTokens, fallbackTitleMaxTokens))
 		resp, err = agent.Stream(ctx, streamCall)
 		if err == nil {
 			slog.Debug("Generated title with large model")
 		} else {
 			// Welp, the large model didn't work either. Use the default
 			// session name and return.
-			slog.Error("Error generating title with large model", "err", err)
+			slog.Error("Error generating title with large model", "error", err)
 			saveErr := a.sessions.Rename(ctx, sessionID, DefaultSessionName)
 			if saveErr != nil {
 				slog.Error("Failed to save session title", "error", saveErr)
 			}
 			return
 		}
+	}
+
+	// Reasoning-heavy models (e.g. GPT-5 mini) may finish cleanly while
+	// burning the entire output budget on hidden reasoning and emit empty
+	// visible text. Retry with the large model before giving up, but only
+	// if it's a different model and actually returns something usable.
+	if model.CatwalkCfg.ID != largeModel.CatwalkCfg.ID && !isUsableTitleResponse(resp) {
+		retryAgent := newAgent(largeModel.Model, titlePrompt, cmp.Or(largeModel.CatwalkCfg.DefaultMaxTokens, fallbackTitleMaxTokens))
+		retryResp, retryErr := retryAgent.Stream(ctx, streamCall)
+		if retryErr != nil {
+			slog.Error("Large model fallback failed after unusable small model response", "error", retryErr)
+		} else if isUsableTitleResponse(retryResp) {
+			model = largeModel
+			resp = retryResp
+		}
+		// Otherwise both models returned empty content; fall through and
+		// let the default-title path below handle it.
 	}
 
 	if resp == nil {
@@ -1038,6 +1064,18 @@ func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, user
 		slog.Error("Failed to save session title and usage", "error", saveErr)
 		return
 	}
+}
+
+// isUsableTitleResponse reports whether a stream response carries visible
+// text we can turn into a title. Reasoning-heavy models (e.g. GPT-5 mini)
+// may finish cleanly with finish_reason=stop while spending every output
+// token on hidden reasoning, leaving the visible content empty. Treat any
+// empty response as unusable so callers can fall back to a larger model.
+func isUsableTitleResponse(resp *fantasy.AgentResult) bool {
+	if resp == nil {
+		return false
+	}
+	return strings.TrimSpace(resp.Response.Content.Text()) != ""
 }
 
 func (a *sessionAgent) openrouterCost(metadata fantasy.ProviderMetadata) *float64 {


### PR DESCRIPTION
## Motivation

After switching the small model to a reasoning-capable Copilot model (e.g. `gpt-5.4-mini`), every new session was getting saved as "Untitled Session". The title-generation call succeeded at the HTTP level, but the model burned its entire output budget on hidden reasoning and emitted zero visible tokens, so the cleaned title was empty and we fell back to the default name. We are fixing ~> https://github.com/charmbracelet/crush/issues/1189 

Two things conspired to make this universal:
1. The small-model title call was hard-capped at 40 output tokens, which is not enough headroom for any model that emits reasoning tokens.
2. The extra-headroom branch was gated on `CatwalkCfg.CanReason`, but that flag is `false` for models like `gpt-5.4-mini` that still reason internally, so the cap was never raised.

## Description

Raise the base small-model title cap to 256 tokens and, when the small model still returns empty visible text, retry once with the large model before giving up. The retry only runs if the large model is actually a different model from the one that just failed.

## Changes
- Add `smallTitleMaxTokens` (256) and `fallbackTitleMaxTokens` (1024) constants with documentation for why they exist.
- Replace the hard-coded `40`-token small-model cap with `smallTitleMaxTokens`.
- Fix a latent bug where the error-path fallback to the large model inherited the small model's token cap; use the large model's catwalk `DefaultMaxTokens` (or `fallbackTitleMaxTokens` when unknown) instead.
- Add `isUsableTitleResponse` helper and retry the title call with the large model when the small model returns empty text, guarded against pointless same-model retries.
- Drive-by: fix doc typo (`"session titled"` → `"session title"`) and normalize inconsistent `"err"` slog keys to `"error"` in the touched lines.

## Trade-offs

- **Why not gate on `finish_reason`?** It's unreliable: the same model returns `finish_reason=length` or `stop` across runs with identical empty visible text. The only robust signal is `strings.TrimSpace(resp.Response.Content.Text()) == ""`.
- **Why not drop the `CanReason` branch entirely?** Keeping it preserves the higher cap for models correctly marked as reasoning in catwalk; the new 256-token base just stops the non-reasoning path from truncating quietly.
- **Cost**: worst case we make two title calls instead of one. Mitigated by only retrying when the small call produced nothing usable and by skipping the retry when small == large model.
- **No regression test yet**: recording a VCR cassette requires Copilot OAuth wiring in `common_test.go`; deferred to a follow-up rather than blocking the fix.