### PR TITLE
feat: support Moonshot and Moonshot China API keys in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ That said, you can also set environment variables for preferred providers.
 | `CEREBRAS_API_KEY`          | Cerebras                                           |
 | `OPENROUTER_API_KEY`        | OpenRouter                                         |
 | `IONET_API_KEY`             | io.net                                             |
+| `MOONSHOT_API_KEY`          | Kimi (Moonshot, international / platform.moonshot.ai) |
+| `MOONSHOT_CN_API_KEY`      | Kimi (Moonshot, China / platform.moonshot.cn)        |
 | `GROQ_API_KEY`              | Groq                                               |
 | `AVIAN_API_KEY`             | Avian                                              |
 | `OPENCODE_API_KEY`          | OpenCode Zen & Go                                  |
@@ -205,6 +207,8 @@ That said, you can also set environment variables for preferred providers.
 | `AZURE_OPENAI_API_ENDPOINT` | Azure OpenAI models                                |
 | `AZURE_OPENAI_API_KEY`      | Azure OpenAI models (optional when using Entra ID) |
 | `AZURE_OPENAI_API_VERSION`  | Azure OpenAI models                                |
+
+`KIMI_API_KEY` is an alias for `MOONSHOT_API_KEY` (international). `KIMI_CN_API_KEY` is an alias for `MOONSHOT_CN_API_KEY` (China). Pick the provider `moonshot` or `moonshot-cn` in the UI to match your key.
 
 ### Subscriptions
 

--- a/go.mod
+++ b/go.mod
@@ -218,3 +218,5 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
+
+replace charm.land/catwalk => github.com/ne275/catwalk v0.0.0-20260423090449-7d8389d0fddc

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ charm.land/bubbles/v2 v2.1.0 h1:YSnNh5cPYlYjPxRrzs5VEn3vwhtEn3jVGRBT3M7/I0g=
 charm.land/bubbles/v2 v2.1.0/go.mod h1:l97h4hym2hvWBVfmJDtrEHHCtkIKeTEb3TTJ4ZOB3wY=
 charm.land/bubbletea/v2 v2.0.6 h1:UHN/91OyuhaOFGSrBXQ/hMZD8IO1Uc4BvHlgHXL2WJo=
 charm.land/bubbletea/v2 v2.0.6/go.mod h1:MH/D8ZLlN3op37vQvijKuU29g3rqTp+aQapURFonF9g=
-charm.land/catwalk v0.37.9 h1:lTBfycSQN8HhapKpuGiP25abrd89Gydnu6oMumE+pkU=
-charm.land/catwalk v0.37.9/go.mod h1:IvMXm7qMKvYuWWlN5A4dA0bTgYg4clG1GAeU9/NlY0w=
 charm.land/fang/v2 v2.0.1 h1:zQCM8JQJ1JnQX/66B5jlCYBUxL2as5JXQZ2KJ6EL0mY=
 charm.land/fang/v2 v2.0.1/go.mod h1:S1GmkpcvK+OB5w9caywUnJcsMew45Ot8FXqoz8ALrII=
 charm.land/fantasy v0.20.0 h1:puadUHRbcyo10o2HpzTamX5+Mrz+0/xj9K4XWLCGbIw=
@@ -324,6 +322,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/ncruces/julianday v1.0.0 h1:fH0OKwa7NWvniGQtxdJRxAgkBMolni2BjDHaWTxqt7M=
 github.com/ncruces/julianday v1.0.0/go.mod h1:Dusn2KvZrrovOMJuOt0TNXL6tB7U2E8kvza5fFc9G7g=
+github.com/ne275/catwalk v0.0.0-20260423090449-7d8389d0fddc h1:b0LAZZQP5pvyTBJ4AhuV0B8aMK7cfVtuYL2u3GGJbmc=
+github.com/ne275/catwalk v0.0.0-20260423090449-7d8389d0fddc/go.mod h1:IvMXm7qMKvYuWWlN5A4dA0bTgYg4clG1GAeU9/NlY0w=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6Oo2LfFZAehjjQMERAvZLEDnQ=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -309,6 +309,36 @@ func (c *Config) configureProviders(store *ConfigStore, env env.Env, resolver Va
 					continue
 				}
 			}
+		case catwalk.InferenceProviderMoonshot:
+			apiKey := cmp.Or(env.Get("MOONSHOT_API_KEY"), env.Get("KIMI_API_KEY"))
+			if apiKey != "" {
+				prepared.APIKey = apiKey
+				prepared.APIKeyTemplate = apiKey
+			} else {
+				v, err := resolver.ResolveValue(p.APIKey)
+				if v == "" || err != nil {
+					if configExists {
+						slog.Warn("Skipping Moonshot provider due to missing API key", "provider", p.ID)
+						c.Providers.Del(string(p.ID))
+					}
+					continue
+				}
+			}
+		case catwalk.InferenceProviderMoonshotChina:
+			apiKey := cmp.Or(env.Get("MOONSHOT_CN_API_KEY"), env.Get("KIMI_CN_API_KEY"))
+			if apiKey != "" {
+				prepared.APIKey = apiKey
+				prepared.APIKeyTemplate = apiKey
+			} else {
+				v, err := resolver.ResolveValue(p.APIKey)
+				if v == "" || err != nil {
+					if configExists {
+						slog.Warn("Skipping Moonshot China provider due to missing API key", "provider", p.ID)
+						c.Providers.Del(string(p.ID))
+					}
+					continue
+				}
+			}
 		default:
 			// if the provider api or endpoint are missing we skip them
 			v, err := resolver.ResolveValue(p.APIKey)

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1589,3 +1589,95 @@ func TestConfig_configureProviders_HyperAPIKeyFromConfigOverrides(t *testing.T) 
 	require.True(t, ok, "Hyper provider should be configured")
 	require.Equal(t, "env-api-key", pc.APIKey)
 }
+
+func TestConfig_configureProviders_MoonshotAPIKeyFromEnv(t *testing.T) {
+	knownProviders := []catwalk.Provider{
+		{
+			ID:                  catwalk.InferenceProviderMoonshot,
+			APIKey:              "",
+			Type:                catwalk.TypeOpenAICompat,
+			APIEndpoint:         "https://api.moonshot.ai/v1",
+			DefaultLargeModelID: "kimi-k2.6",
+			DefaultSmallModelID: "kimi-k2.5",
+			Models: []catwalk.Model{
+				{ID: "kimi-k2.6", DefaultMaxTokens: 1000},
+				{ID: "kimi-k2.5", DefaultMaxTokens: 500},
+			},
+		},
+	}
+
+	cfg := &Config{}
+	cfg.setDefaults("/tmp", "")
+	env := env.NewFromMap(map[string]string{
+		"MOONSHOT_API_KEY": "env-moonshot-key",
+	})
+	resolver := NewEnvironmentVariableResolver(env)
+	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	require.NoError(t, err)
+	require.Equal(t, 1, cfg.Providers.Len())
+
+	pc, ok := cfg.Providers.Get("moonshot")
+	require.True(t, ok, "Moonshot provider should be configured")
+	require.Equal(t, "env-moonshot-key", pc.APIKey)
+	require.Equal(t, "env-moonshot-key", pc.APIKeyTemplate)
+}
+
+func TestConfig_configureProviders_MoonshotAPIKeyFromKimiEnv(t *testing.T) {
+	knownProviders := []catwalk.Provider{
+		{
+			ID:                  catwalk.InferenceProviderMoonshot,
+			APIKey:              "",
+			Type:                catwalk.TypeOpenAICompat,
+			APIEndpoint:         "https://api.moonshot.ai/v1",
+			DefaultLargeModelID: "kimi-k2.6",
+			DefaultSmallModelID: "kimi-k2.5",
+			Models: []catwalk.Model{
+				{ID: "kimi-k2.6", DefaultMaxTokens: 1000},
+				{ID: "kimi-k2.5", DefaultMaxTokens: 500},
+			},
+		},
+	}
+
+	cfg := &Config{}
+	cfg.setDefaults("/tmp", "")
+	env := env.NewFromMap(map[string]string{
+		"KIMI_API_KEY": "env-kimi-alias-key",
+	})
+	resolver := NewEnvironmentVariableResolver(env)
+	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	require.NoError(t, err)
+
+	pc, ok := cfg.Providers.Get("moonshot")
+	require.True(t, ok, "Moonshot provider should be configured")
+	require.Equal(t, "env-kimi-alias-key", pc.APIKey)
+}
+
+func TestConfig_configureProviders_MoonshotCNAPIKeyFromEnv(t *testing.T) {
+	knownProviders := []catwalk.Provider{
+		{
+			ID:                  catwalk.InferenceProviderMoonshotChina,
+			APIKey:              "",
+			Type:                catwalk.TypeOpenAICompat,
+			APIEndpoint:         "https://api.moonshot.cn/v1",
+			DefaultLargeModelID: "kimi-k2.6",
+			DefaultSmallModelID: "kimi-k2.5",
+			Models: []catwalk.Model{
+				{ID: "kimi-k2.6", DefaultMaxTokens: 1000},
+				{ID: "kimi-k2.5", DefaultMaxTokens: 500},
+			},
+		},
+	}
+
+	cfg := &Config{}
+	cfg.setDefaults("/tmp", "")
+	env := env.NewFromMap(map[string]string{
+		"MOONSHOT_CN_API_KEY": "env-cn-key",
+	})
+	resolver := NewEnvironmentVariableResolver(env)
+	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	require.NoError(t, err)
+
+	pc, ok := cfg.Providers.Get("moonshot-cn")
+	require.True(t, ok, "Moonshot China provider should be configured")
+	require.Equal(t, "env-cn-key", pc.APIKey)
+}


### PR DESCRIPTION
## Summary
- In `internal/config/load.go`, resolve API keys for **`InferenceProviderMoonshot`** (`MOONSHOT_API_KEY` / `KIMI_API_KEY`) and **`InferenceProviderMoonshotChina`** (`MOONSHOT_CN_API_KEY` / `KIMI_CN_API_KEY`), matching the two Catwalk provider IDs.
- README: document the env vars and that users pick provider `moonshot` or `moonshot-cn` in the UI.
- Tests: `TestConfig_configureProviders_Moonshot*` and `TestConfig_configureProviders_MoonshotCNAPIKeyFromEnv`.

## Catwalk dependency
- This PR temporarily pins `charm.land/catwalk` to a **replace** of `github.com/ne275/catwalk` at commit `7d8389d0fddccdddd76340b63bcc5d66c66e165b` so CI can run without a published `charm.land/catwalk` tag.

**After** [charmbracelet/catwalk#(your PR)] is merged and released, this should be updated to an official `charm.land/catwalk` version and the `replace` removed (or a single `go get` bump).

## Order
1. Merge / release **catwalk** with `moonshot` + `moonshot-cn`.
2. Bump `charm.land/catwalk` in **crush** and drop the fork `replace` (or replace with the official module version).

## Test plan
- [x] `go test ./internal/config/ -run Moonshot`
- [x] `go build .`