### PR TITLE
fix: remove minimax api key validate

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -550,10 +550,6 @@ func (c *ProviderConfig) TestConnection(resolver VariableResolver) error {
 	switch providerID {
 	case catwalk.InferenceProviderMiniMax, catwalk.InferenceProviderMiniMaxChina:
 		// NOTE: MiniMax has no good endpoint we can use to validate the API key.
-		// Let's at least check the pattern.
-		// if !strings.HasPrefix(apiKey, "sk-") {
-		// 	return fmt.Errorf("invalid API key format for provider %s", c.ID)
-		// }
 		return nil
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -551,9 +551,9 @@ func (c *ProviderConfig) TestConnection(resolver VariableResolver) error {
 	case catwalk.InferenceProviderMiniMax, catwalk.InferenceProviderMiniMaxChina:
 		// NOTE: MiniMax has no good endpoint we can use to validate the API key.
 		// Let's at least check the pattern.
-		if !strings.HasPrefix(apiKey, "sk-") {
-			return fmt.Errorf("invalid API key format for provider %s", c.ID)
-		}
+		// if !strings.HasPrefix(apiKey, "sk-") {
+		// 	return fmt.Errorf("invalid API key format for provider %s", c.ID)
+		// }
 		return nil
 	}
 


### PR DESCRIPTION
MiniMax token plan API keys don't always follow the "sk-" prefix pattern, so the validation was causing unnecessary errors for valid keys.


<img width="1846" height="668" alt="image" src="https://github.com/user-attachments/assets/41e26fcc-687b-429b-a24d-97c7881a5968" />


💘 Generated with Crush

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
