### PR TITLE
fix(db): cap SQLite pool to one writer to prevent NOTADB corruption

### DIFF
--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -45,6 +45,18 @@ func Connect(ctx context.Context, dataDir string) (*sql.DB, error) {
 		return nil, err
 	}
 
+	// SQLite is a single-writer database. Parallel sub-agents (session,
+	// message, history, and filetracker services share this *sql.DB)
+	// previously opened an unbounded number of concurrent SQLite handles
+	// through Go's default pool. Interleaved WAL frames + auto-checkpoints
+	// from those handles, combined with mid-checkpoint cancellation
+	// (context cancel, SIGINT, OOM), desynced the main DB file from the
+	// WAL and surfaced at next open as SQLITE_NOTADB (26) — making the
+	// project session unrecoverable without deleting .crush/crush.db.
+	// Cap the pool at one writer; busy_timeout (30s) queues concurrent
+	// callers while this handle is in use.
+	db.SetMaxOpenConns(1)
+
 	if err = db.PingContext(ctx); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("failed to connect to database: %w", err)


### PR DESCRIPTION
Refs charmbracelet/crush#2682.

## Problem

The `*sql.DB` built by `db.Connect` is shared by every service (session, message, history, filetracker) and every sub-agent. Parallel sub-agents plus Go's default unlimited `MaxOpenConns` let multiple concurrent SQLite handles interleave WAL frames and auto-checkpoints. Mid-checkpoint cancellation (context cancel, SIGINT, OOM) then desyncs the main DB file from the WAL, producing `file is not a database` (`SQLITE_NOTADB 26`) on next open — bricking the project session until `.crush/crush.db` is deleted.

## Fix

`db.SetMaxOpenConns(1)` so SQLite sees a single serial writer. The existing `busy_timeout` (30s) queues concurrent callers behind the single connection, so nothing at call sites needs to change.

## Test

`go build ./internal/db/...` clean; package has no existing tests.