### PR TITLE
fix(mcp): expand environment variables in stdio MCP server args

### DIFF
--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -447,7 +447,17 @@ func createTransport(ctx context.Context, m config.MCPConfig, resolver config.Va
 		if strings.TrimSpace(command) == "" {
 			return nil, fmt.Errorf("mcp stdio config requires a non-empty 'command' field")
 		}
-		cmd := exec.CommandContext(ctx, home.Long(command), m.Args...)
+		resolvedArgs := make([]string, len(m.Args))
+		for i, arg := range m.Args {
+			resolved, resolveErr := resolver.ResolveValue(arg)
+			if resolveErr != nil {
+				slog.Error("Error resolving MCP arg", "error", resolveErr, "arg", arg)
+				resolvedArgs[i] = arg
+				continue
+			}
+			resolvedArgs[i] = resolved
+		}
+		cmd := exec.CommandContext(ctx, home.Long(command), resolvedArgs...)
 		cmd.Env = append(os.Environ(), m.ResolvedEnv()...)
 		return &mcp.CommandTransport{
 			Command: cmd,


### PR DESCRIPTION
Fixes #2684

## Problem

Environment variables in the `args` array of a stdio MCP server config are passed to the subprocess verbatim without expansion. For example, a config like:

```json
"vestige": {
    "type": "stdio",
    "command": "vestige-mcp",
    "args": ["--data-dir", "$VESTIGE_DB"]
}
```

would launch `vestige-mcp --data-dir '$VESTIGE_DB'` instead of substituting the actual value of `$VESTIGE_DB`.

## Solution

Apply `resolver.ResolveValue` to each arg in the args array, using the same resolver that already expands env vars in the `command` field. Expansion errors are logged and the original arg is kept as a fallback, consistent with the behaviour of `ResolvedHeaders`.

This brings args into line with the `command` field (already resolved) and the `env`/`headers` fields (resolved via their `Resolved*` methods).

## Testing

- Existing MCP tests pass (`go test ./internal/agent/tools/mcp/...`)
- Manually verified that args without `$` are passed through unchanged (no performance impact for the common case)