### PR TITLE
fix(skills): deduplicate skills discovered via symlinked directories

### DIFF
--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -213,12 +213,19 @@ func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
 			if d.IsDir() || d.Name() != SkillFileName {
 				return nil
 			}
+			// Resolve symlinks so that a skill file reachable via multiple
+			// discovery paths (e.g. the project dir and a symlinked user dir
+			// both pointing to the same directory) is only loaded once.
+			realPath := path
+			if resolved, resolveErr := filepath.EvalSymlinks(path); resolveErr == nil {
+				realPath = resolved
+			}
 			mu.Lock()
-			if seen[path] {
+			if seen[realPath] {
 				mu.Unlock()
 				return nil
 			}
-			seen[path] = true
+			seen[realPath] = true
 			mu.Unlock()
 			skill, err := Parse(path)
 			if err != nil {

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -284,6 +284,46 @@ description: Name doesn't match directory.
 	require.True(t, names["skill-two"])
 }
 
+func TestDiscoverDeduplicatesSymlinks(t *testing.T) {
+	// Not parallel: shares global broker with other Discover tests.
+
+	// Build a real skills dir and a symlink to it, simulating the case where
+	// ~/.config/crush/skills is a symlink to a project's .claude/skills.
+	realDir := t.TempDir()
+	skillDir := filepath.Join(realDir, "my-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: my-skill
+description: A test skill.
+---
+# My Skill
+`), 0o644))
+
+	// Create a symlink directory that points to the same real directory.
+	symlinkDir := filepath.Join(t.TempDir(), "skills-link")
+	require.NoError(t, os.Symlink(realDir, symlinkDir))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := SubscribeEvents(ctx)
+
+	// Discover from both the real dir and the symlinked dir.
+	skills := Discover([]string{realDir, symlinkDir})
+
+	evt := <-ch
+	var normalStates int
+	for _, s := range evt.Payload.States {
+		if s.State == StateNormal {
+			normalStates++
+		}
+	}
+
+	// The skill should appear exactly once despite two discovery paths resolving
+	// to the same underlying file.
+	require.Len(t, skills, 1, "expected exactly one skill, got duplicates")
+	require.Equal(t, 1, normalStates, "expected one normal state, got duplicates")
+}
+
 func TestDiscoverEmptyDir(t *testing.T) {
 	// Not parallel: shares global broker with other Discover tests.
 


### PR DESCRIPTION
Fixes #2683

## Problem

When `~/.config/crush/skills` is a symlink to a project's `.claude/skills/` directory, Crush discovers skills via both paths. Since `fastwalk` is run with `Follow: true`, it walks the symlinked directory and reports the files under their symlink-relative paths. The `seen` map was keyed on raw logical paths, so the same physical `SKILL.md` file appeared as two distinct paths — one from each discovery root — causing every skill to be listed twice in the sidebar.

Note: `crush_info` showed the correct count because the skill registry deduplicates by name internally, but the sidebar rendered one row per `SkillState` entry without deduplicating.

## Solution

Before checking or inserting into the `seen` map, resolve each `SKILL.md` path to its real canonical path via `filepath.EvalSymlinks`. Two logical paths that resolve to the same underlying file now share the same `seen` key and only the first is loaded. If `EvalSymlinks` fails (e.g. dangling symlink), the original path is used as fallback so existing behaviour is unchanged.

## Testing

Added `TestDiscoverDeduplicatesSymlinks` which:
1. Creates a real skills directory with one skill
2. Creates a symlink directory pointing to the same real directory
3. Calls `Discover` with both paths
4. Asserts exactly one skill and one normal state are returned (no duplicates)

All existing tests continue to pass.