### PR TITLE
fix(lsp): enforce workspace boundary for workspace edits

### DIFF
--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -195,7 +195,7 @@ func (c *Client) createPowernapClient() error {
 
 // registerHandlers registers the standard LSP notification and request handlers.
 func (c *Client) registerHandlers() {
-	c.RegisterServerRequestHandler("workspace/applyEdit", HandleApplyEdit(c.client.GetOffsetEncoding()))
+	c.RegisterServerRequestHandler("workspace/applyEdit", HandleApplyEdit(c.client.GetOffsetEncoding(), c.cwd))
 	c.RegisterServerRequestHandler("workspace/configuration", HandleWorkspaceConfiguration)
 	c.RegisterServerRequestHandler("client/registerCapability", HandleRegisterCapability)
 	c.RegisterNotificationHandler("window/showMessage", func(ctx context.Context, method string, params json.RawMessage) {

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -45,14 +45,14 @@ func HandleRegisterCapability(_ context.Context, _ string, params json.RawMessag
 }
 
 // HandleApplyEdit handles workspace edit requests
-func HandleApplyEdit(encoding powernap.OffsetEncoding) func(_ context.Context, _ string, params json.RawMessage) (any, error) {
+func HandleApplyEdit(encoding powernap.OffsetEncoding, workspaceRoot string) func(_ context.Context, _ string, params json.RawMessage) (any, error) {
 	return func(_ context.Context, _ string, params json.RawMessage) (any, error) {
 		var edit protocol.ApplyWorkspaceEditParams
 		if err := json.Unmarshal(params, &edit); err != nil {
 			return nil, err
 		}
 
-		err := util.ApplyWorkspaceEdit(edit.Edit, encoding)
+		err := util.ApplyWorkspaceEdit(edit.Edit, encoding, workspaceRoot)
 		if err != nil {
 			slog.Error("Error applying workspace edit", "error", err)
 			return protocol.ApplyWorkspaceEditResult{Applied: false, FailureReason: err.Error()}, nil

--- a/internal/lsp/util/edit.go
+++ b/internal/lsp/util/edit.go
@@ -15,19 +15,24 @@ import (
 )
 
 func normalizeURIPath(path string) string {
-	// On Windows, LSP URIs often decode to "/C:/path/to/file".
-	// filepath treats this as a relative path and filepath.Abs may produce
-	// "D:\\C:\\..." depending on current drive. Strip the leading slash so
-	// it becomes a valid absolute Windows path.
-	if runtime.GOOS == "windows" &&
-		len(path) >= 4 &&
-		path[0] == '/' &&
+	if runtime.GOOS != "windows" {
+		return filepath.Clean(filepath.FromSlash(path))
+	}
+
+	// On Windows, LSP DocumentURI.Path() returns paths such as
+	// "\C:\Users\..." or "/C:/Users/..." (a leading separator before the
+	// drive letter). filepath.Abs treats those as relative and prefixes the
+	// current drive, producing "D:\C:\Users\...". Strip the leading
+	// separator so the path starts with a drive letter.
+	path = filepath.FromSlash(path)
+	if len(path) >= 4 &&
+		(path[0] == '\\' || path[0] == '/') &&
 		((path[1] >= 'A' && path[1] <= 'Z') || (path[1] >= 'a' && path[1] <= 'z')) &&
 		path[2] == ':' &&
-		path[3] == '/' {
+		(path[3] == '\\' || path[3] == '/') {
 		path = path[1:]
 	}
-	return filepath.Clean(filepath.FromSlash(path))
+	return filepath.Clean(path)
 }
 
 func validateWorkspacePath(uri protocol.DocumentURI, workspaceRoot string) (string, error) {

--- a/internal/lsp/util/edit.go
+++ b/internal/lsp/util/edit.go
@@ -4,17 +4,38 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/charmbracelet/crush/internal/fsext"
 	powernap "github.com/charmbracelet/x/powernap/pkg/lsp"
 	"github.com/charmbracelet/x/powernap/pkg/lsp/protocol"
 )
 
-func applyTextEdits(uri protocol.DocumentURI, edits []protocol.TextEdit, encoding powernap.OffsetEncoding) error {
+func validateWorkspacePath(uri protocol.DocumentURI, workspaceRoot string) (string, error) {
 	path, err := uri.Path()
 	if err != nil {
-		return fmt.Errorf("invalid URI: %w", err)
+		return "", fmt.Errorf("invalid URI: %w", err)
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve absolute path: %w", err)
+	}
+	root, err := filepath.Abs(workspaceRoot)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve workspace root: %w", err)
+	}
+	if !fsext.HasPrefix(absPath, root) {
+		return "", fmt.Errorf("path %q is outside workspace root %q", absPath, root)
+	}
+	return absPath, nil
+}
+
+func applyTextEdits(uri protocol.DocumentURI, edits []protocol.TextEdit, encoding powernap.OffsetEncoding, workspaceRoot string) error {
+	path, err := validateWorkspacePath(uri, workspaceRoot)
+	if err != nil {
+		return err
 	}
 
 	// Read the file content
@@ -168,11 +189,11 @@ func applyTextEdit(lines []string, edit protocol.TextEdit, encoding powernap.Off
 }
 
 // applyDocumentChange applies a DocumentChange (create/rename/delete operations)
-func applyDocumentChange(change protocol.DocumentChange, encoding powernap.OffsetEncoding) error {
+func applyDocumentChange(change protocol.DocumentChange, encoding powernap.OffsetEncoding, workspaceRoot string) error {
 	if change.CreateFile != nil {
-		path, err := change.CreateFile.URI.Path()
+		path, err := validateWorkspacePath(change.CreateFile.URI, workspaceRoot)
 		if err != nil {
-			return fmt.Errorf("invalid URI: %w", err)
+			return err
 		}
 
 		if change.CreateFile.Options != nil {
@@ -190,9 +211,9 @@ func applyDocumentChange(change protocol.DocumentChange, encoding powernap.Offse
 	}
 
 	if change.DeleteFile != nil {
-		path, err := change.DeleteFile.URI.Path()
+		path, err := validateWorkspacePath(change.DeleteFile.URI, workspaceRoot)
 		if err != nil {
-			return fmt.Errorf("invalid URI: %w", err)
+			return err
 		}
 
 		if change.DeleteFile.Options != nil && change.DeleteFile.Options.Recursive {
@@ -210,12 +231,12 @@ func applyDocumentChange(change protocol.DocumentChange, encoding powernap.Offse
 		var newPath, oldPath string
 		var err error
 
-		oldPath, err = change.RenameFile.OldURI.Path()
+		oldPath, err = validateWorkspacePath(change.RenameFile.OldURI, workspaceRoot)
 		if err != nil {
 			return err
 		}
 
-		newPath, err = change.RenameFile.NewURI.Path()
+		newPath, err = validateWorkspacePath(change.RenameFile.NewURI, workspaceRoot)
 		if err != nil {
 			return err
 		}
@@ -241,7 +262,7 @@ func applyDocumentChange(change protocol.DocumentChange, encoding powernap.Offse
 				return fmt.Errorf("invalid edit type: %w", err)
 			}
 		}
-		return applyTextEdits(change.TextDocumentEdit.TextDocument.URI, textEdits, encoding)
+		return applyTextEdits(change.TextDocumentEdit.TextDocument.URI, textEdits, encoding, workspaceRoot)
 	}
 
 	return nil
@@ -266,17 +287,17 @@ func utf32ToByteOffset(lineText string, codepointOffset uint32) int {
 // ApplyWorkspaceEdit applies the given WorkspaceEdit to the filesystem.
 // The encoding parameter specifies the position encoding used by the LSP server
 // (UTF8, UTF16, or UTF32). This affects how character offsets are interpreted.
-func ApplyWorkspaceEdit(edit protocol.WorkspaceEdit, encoding powernap.OffsetEncoding) error {
+func ApplyWorkspaceEdit(edit protocol.WorkspaceEdit, encoding powernap.OffsetEncoding, workspaceRoot string) error {
 	// Handle Changes field
 	for uri, textEdits := range edit.Changes {
-		if err := applyTextEdits(uri, textEdits, encoding); err != nil {
+		if err := applyTextEdits(uri, textEdits, encoding, workspaceRoot); err != nil {
 			return fmt.Errorf("failed to apply text edits: %w", err)
 		}
 	}
 
 	// Handle DocumentChanges field
 	for _, change := range edit.DocumentChanges {
-		if err := applyDocumentChange(change, encoding); err != nil {
+		if err := applyDocumentChange(change, encoding, workspaceRoot); err != nil {
 			return fmt.Errorf("failed to apply document change: %w", err)
 		}
 	}

--- a/internal/lsp/util/edit.go
+++ b/internal/lsp/util/edit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -13,11 +14,31 @@ import (
 	"github.com/charmbracelet/x/powernap/pkg/lsp/protocol"
 )
 
+func normalizeURIPath(path string) string {
+	// On Windows, LSP URIs often decode to "/C:/path/to/file".
+	// filepath treats this as a relative path and filepath.Abs may produce
+	// "D:\\C:\\..." depending on current drive. Strip the leading slash so
+	// it becomes a valid absolute Windows path.
+	if runtime.GOOS == "windows" &&
+		len(path) >= 4 &&
+		path[0] == '/' &&
+		((path[1] >= 'A' && path[1] <= 'Z') || (path[1] >= 'a' && path[1] <= 'z')) &&
+		path[2] == ':' &&
+		path[3] == '/' {
+		path = path[1:]
+	}
+	return filepath.Clean(filepath.FromSlash(path))
+}
+
 func validateWorkspacePath(uri protocol.DocumentURI, workspaceRoot string) (string, error) {
 	path, err := uri.Path()
 	if err != nil {
 		return "", fmt.Errorf("invalid URI: %w", err)
 	}
+	path = normalizeURIPath(path)
+
+	workspaceRoot = normalizeURIPath(workspaceRoot)
+
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve absolute path: %w", err)

--- a/internal/lsp/util/edit_test.go
+++ b/internal/lsp/util/edit_test.go
@@ -378,17 +378,12 @@ func TestRangesOverlap(t *testing.T) {
 }
 
 func TestApplyWorkspaceEdit_BoundaryEnforcement(t *testing.T) {
-	t.Parallel()
-
-	workspace := t.TempDir()
-	insideFile := filepath.Join(workspace, "inside.txt")
-	require.NoError(t, os.WriteFile(insideFile, []byte("hello"), 0o644))
-
-	outsideDir := t.TempDir()
-	outsideFile := filepath.Join(outsideDir, "outside.txt")
-	require.NoError(t, os.WriteFile(outsideFile, []byte("outside"), 0o644))
-
 	t.Run("allows edits inside workspace", func(t *testing.T) {
+		t.Parallel()
+		workspace := t.TempDir()
+		insideFile := filepath.Join(workspace, "inside.txt")
+		require.NoError(t, os.WriteFile(insideFile, []byte("hello"), 0o644))
+
 		edit := protocol.WorkspaceEdit{
 			Changes: map[protocol.DocumentURI][]protocol.TextEdit{
 				protocol.URIFromPath(insideFile): {
@@ -412,6 +407,12 @@ func TestApplyWorkspaceEdit_BoundaryEnforcement(t *testing.T) {
 	})
 
 	t.Run("rejects text edits outside workspace", func(t *testing.T) {
+		t.Parallel()
+		workspace := t.TempDir()
+		outsideDir := t.TempDir()
+		outsideFile := filepath.Join(outsideDir, "outside.txt")
+		require.NoError(t, os.WriteFile(outsideFile, []byte("outside"), 0o644))
+
 		edit := protocol.WorkspaceEdit{
 			Changes: map[protocol.DocumentURI][]protocol.TextEdit{
 				protocol.URIFromPath(outsideFile): {
@@ -432,6 +433,10 @@ func TestApplyWorkspaceEdit_BoundaryEnforcement(t *testing.T) {
 	})
 
 	t.Run("rejects recursive delete outside workspace", func(t *testing.T) {
+		t.Parallel()
+		workspace := t.TempDir()
+		outsideDir := t.TempDir()
+
 		edit := protocol.WorkspaceEdit{
 			DocumentChanges: []protocol.DocumentChange{
 				{
@@ -453,6 +458,9 @@ func TestApplyWorkspaceEdit_BoundaryEnforcement(t *testing.T) {
 	})
 
 	t.Run("rejects rename when target outside workspace", func(t *testing.T) {
+		t.Parallel()
+		workspace := t.TempDir()
+		outsideDir := t.TempDir()
 		renameSource := filepath.Join(workspace, "rename.txt")
 		require.NoError(t, os.WriteFile(renameSource, []byte("rename"), 0o644))
 

--- a/internal/lsp/util/edit_test.go
+++ b/internal/lsp/util/edit_test.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	powernap "github.com/charmbracelet/x/powernap/pkg/lsp"
@@ -373,4 +375,102 @@ func TestRangesOverlap(t *testing.T) {
 			require.Equal(t, tt.want, got2, "rangesOverlap(r2, r1) symmetry")
 		})
 	}
+}
+
+func TestApplyWorkspaceEdit_BoundaryEnforcement(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	insideFile := filepath.Join(workspace, "inside.txt")
+	require.NoError(t, os.WriteFile(insideFile, []byte("hello"), 0o644))
+
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "outside.txt")
+	require.NoError(t, os.WriteFile(outsideFile, []byte("outside"), 0o644))
+
+	t.Run("allows edits inside workspace", func(t *testing.T) {
+		edit := protocol.WorkspaceEdit{
+			Changes: map[protocol.DocumentURI][]protocol.TextEdit{
+				protocol.URIFromPath(insideFile): {
+					{
+						Range: protocol.Range{
+							Start: protocol.Position{Line: 0, Character: 0},
+							End:   protocol.Position{Line: 0, Character: 5},
+						},
+						NewText: "world",
+					},
+				},
+			},
+		}
+
+		err := ApplyWorkspaceEdit(edit, powernap.UTF8, workspace)
+		require.NoError(t, err)
+
+		content, err := os.ReadFile(insideFile)
+		require.NoError(t, err)
+		require.Equal(t, "world", string(content))
+	})
+
+	t.Run("rejects text edits outside workspace", func(t *testing.T) {
+		edit := protocol.WorkspaceEdit{
+			Changes: map[protocol.DocumentURI][]protocol.TextEdit{
+				protocol.URIFromPath(outsideFile): {
+					{
+						Range: protocol.Range{
+							Start: protocol.Position{Line: 0, Character: 0},
+							End:   protocol.Position{Line: 0, Character: 7},
+						},
+						NewText: "blocked",
+					},
+				},
+			},
+		}
+
+		err := ApplyWorkspaceEdit(edit, powernap.UTF8, workspace)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "outside workspace root")
+	})
+
+	t.Run("rejects recursive delete outside workspace", func(t *testing.T) {
+		edit := protocol.WorkspaceEdit{
+			DocumentChanges: []protocol.DocumentChange{
+				{
+					DeleteFile: &protocol.DeleteFile{
+						URI: protocol.URIFromPath(outsideDir),
+						Options: &protocol.DeleteFileOptions{
+							Recursive: true,
+						},
+					},
+				},
+			},
+		}
+
+		err := ApplyWorkspaceEdit(edit, powernap.UTF8, workspace)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "outside workspace root")
+		_, statErr := os.Stat(outsideDir)
+		require.NoError(t, statErr)
+	})
+
+	t.Run("rejects rename when target outside workspace", func(t *testing.T) {
+		renameSource := filepath.Join(workspace, "rename.txt")
+		require.NoError(t, os.WriteFile(renameSource, []byte("rename"), 0o644))
+
+		edit := protocol.WorkspaceEdit{
+			DocumentChanges: []protocol.DocumentChange{
+				{
+					RenameFile: &protocol.RenameFile{
+						OldURI: protocol.URIFromPath(renameSource),
+						NewURI: protocol.URIFromPath(filepath.Join(outsideDir, "renamed.txt")),
+					},
+				},
+			},
+		}
+
+		err := ApplyWorkspaceEdit(edit, powernap.UTF8, workspace)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "outside workspace root")
+		_, statErr := os.Stat(renameSource)
+		require.NoError(t, statErr)
+	})
 }

--- a/internal/lsp/util/edit_test.go
+++ b/internal/lsp/util/edit_test.go
@@ -12,12 +12,16 @@ import (
 )
 
 func TestNormalizeURIPath(t *testing.T) {
+	t.Parallel()
+
 	t.Run("normalizes slash-separated paths", func(t *testing.T) {
+		t.Parallel()
 		got := normalizeURIPath("foo/bar/baz.txt")
 		require.Equal(t, filepath.Clean(filepath.FromSlash("foo/bar/baz.txt")), got)
 	})
 
 	t.Run("windows drive URI path", func(t *testing.T) {
+		t.Parallel()
 		if runtime.GOOS != "windows" {
 			t.Skip("windows-only normalization behavior")
 		}
@@ -394,6 +398,8 @@ func TestRangesOverlap(t *testing.T) {
 }
 
 func TestApplyWorkspaceEdit_BoundaryEnforcement(t *testing.T) {
+	t.Parallel()
+
 	t.Run("allows edits inside workspace", func(t *testing.T) {
 		t.Parallel()
 		workspace := t.TempDir()

--- a/internal/lsp/util/edit_test.go
+++ b/internal/lsp/util/edit_test.go
@@ -3,12 +3,28 @@ package util
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	powernap "github.com/charmbracelet/x/powernap/pkg/lsp"
 	"github.com/charmbracelet/x/powernap/pkg/lsp/protocol"
 	"github.com/stretchr/testify/require"
 )
+
+func TestNormalizeURIPath(t *testing.T) {
+	t.Run("normalizes slash-separated paths", func(t *testing.T) {
+		got := normalizeURIPath("foo/bar/baz.txt")
+		require.Equal(t, filepath.Clean(filepath.FromSlash("foo/bar/baz.txt")), got)
+	})
+
+	t.Run("windows drive URI path", func(t *testing.T) {
+		if runtime.GOOS != "windows" {
+			t.Skip("windows-only normalization behavior")
+		}
+		got := normalizeURIPath("/C:/Users/test/file.txt")
+		require.Equal(t, filepath.Clean(`C:\Users\test\file.txt`), got)
+	})
+}
 
 func TestPositionToByteOffset(t *testing.T) {
 	tests := []struct {

--- a/internal/lsp/util/edit_test.go
+++ b/internal/lsp/util/edit_test.go
@@ -20,12 +20,21 @@ func TestNormalizeURIPath(t *testing.T) {
 		require.Equal(t, filepath.Clean(filepath.FromSlash("foo/bar/baz.txt")), got)
 	})
 
-	t.Run("windows drive URI path", func(t *testing.T) {
+	t.Run("windows drive URI path forward slash", func(t *testing.T) {
 		t.Parallel()
 		if runtime.GOOS != "windows" {
 			t.Skip("windows-only normalization behavior")
 		}
 		got := normalizeURIPath("/C:/Users/test/file.txt")
+		require.Equal(t, filepath.Clean(`C:\Users\test\file.txt`), got)
+	})
+
+	t.Run("windows drive URI path backslash", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS != "windows" {
+			t.Skip("windows-only normalization behavior")
+		}
+		got := normalizeURIPath(`\C:\Users\test\file.txt`)
 		require.Equal(t, filepath.Clean(`C:\Users\test\file.txt`), got)
 	})
 }


### PR DESCRIPTION
## Summary

This PR enforces workspace boundary checks before applying LSP `workspace/applyEdit` operations.

All edit paths are now validated to ensure they stay within the current workspace root before any filesystem mutation is performed.

## What changed

- Added workspace path validation in `internal/lsp/util/edit.go`:
  - Resolve URI path
  - Normalize to absolute path
  - Verify path is under `workspaceRoot`
  - Reject out-of-workspace paths with explicit error
- Updated edit application flow to require `workspaceRoot`:
  - `ApplyWorkspaceEdit(...)`
  - `applyTextEdits(...)`
  - `applyDocumentChange(...)`
- Updated handler/client wiring:
  - `HandleApplyEdit(...)` now accepts `workspaceRoot`
  - `client.registerHandlers()` passes `c.cwd` to apply-edit handler
- Added boundary-focused tests in `internal/lsp/util/edit_test.go`:
  - Allows edits inside workspace
  - Rejects text edits outside workspace
  - Rejects recursive delete outside workspace
  - Rejects rename when target is outside workspace

## Why

Previously, filesystem operations from LSP workspace edits could be applied without strict workspace boundary enforcement.  
This creates a safety risk if an LSP server returns unexpected or malicious paths.

This change ensures only in-workspace paths can be mutated.

## Test plan

- [x] `go test ./internal/lsp/...`
- [x] `go test ./...`
- [x] Added new boundary enforcement tests for edit/create/delete/rename scenarios

## Impact

- Expected behavior for valid in-workspace edits is unchanged.
- Out-of-workspace edits are now rejected by design.