### PR TITLE
fix(agent): implement OnRetry logging with structured retry fields

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -378,7 +378,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 			return a.messages.Update(ctx, *currentAssistant)
 		},
 		OnRetry: func(err *fantasy.ProviderError, delay time.Duration) {
-			// TODO: implement
+			slog.Warn("Provider request failed, retrying", providerRetryLogFields(err, delay)...)
 		},
 		OnToolCall: func(tc fantasy.ToolCallContent) error {
 			toolCall := message.ToolCall{
@@ -1317,4 +1317,21 @@ func buildSummaryPrompt(todos []session.Todo) string {
 		sb.WriteString("Instruct the resuming assistant to use the `todos` tool to continue tracking progress on these tasks.")
 	}
 	return sb.String()
+}
+
+func providerRetryLogFields(err *fantasy.ProviderError, delay time.Duration) []any {
+	fields := []any{
+		"retry_delay", delay.String(),
+	}
+	if err == nil {
+		return fields
+	}
+	fields = append(fields, "status_code", err.StatusCode)
+	if err.Title != "" {
+		fields = append(fields, "title", err.Title)
+	}
+	if err.Message != "" {
+		fields = append(fields, "message", err.Message)
+	}
+	return fields
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"charm.land/fantasy"
 	"charm.land/x/vcr"
@@ -792,4 +793,35 @@ func TestPreparePrompt_OrphanedToolUseMixed(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, syntheticCount, "expected exactly one synthetic result for the orphaned call")
+}
+
+func TestProviderRetryLogFields(t *testing.T) {
+	t.Run("nil provider error", func(t *testing.T) {
+		fields := providerRetryLogFields(nil, 2*time.Second)
+		require.Equal(t, []any{"retry_delay", "2s"}, fields)
+	})
+
+	t.Run("provider error with title and message", func(t *testing.T) {
+		fields := providerRetryLogFields(&fantasy.ProviderError{
+			StatusCode: 429,
+			Title:      "rate limit",
+			Message:    "too many requests",
+		}, 1500*time.Millisecond)
+		require.Equal(t, []any{
+			"retry_delay", "1.5s",
+			"status_code", 429,
+			"title", "rate limit",
+			"message", "too many requests",
+		}, fields)
+	})
+
+	t.Run("provider error without optional strings", func(t *testing.T) {
+		fields := providerRetryLogFields(&fantasy.ProviderError{
+			StatusCode: 503,
+		}, time.Second)
+		require.Equal(t, []any{
+			"retry_delay", "1s",
+			"status_code", 503,
+		}, fields)
+	})
 }


### PR DESCRIPTION
## Summary

Implement `OnRetry` handling in the agent stream flow by adding structured retry logging for provider retries.

This fills the previous TODO and improves retry observability without changing retry behavior.

## What changed

- Implemented `OnRetry` callback in `internal/agent/agent.go`:
  - Logs a warning when provider retry occurs
  - Includes structured fields for retry diagnostics
- Added helper function to build retry log fields:
  - `providerRetryLogFields(err *fantasy.ProviderError, delay time.Duration) []any`
- Added unit tests in `internal/agent/agent_test.go`:
  - nil provider error case
  - provider error with `status/title/message`
  - provider error with only `status`

## Why

Previously, retry events had no implementation and no observable output (`TODO: implement`), making provider retry issues hard to diagnose in production.

This change improves operational visibility and debugging confidence.

## Behavior impact

- No change to retry policy, retry count, retry delay, or control flow.
- No change to tool execution or message persistence logic.
- This is observability-only behavior.

## Test plan

- [x] `go test ./internal/agent -run "TestProviderRetryLogFields|TestPreparePrompt_OrphanedToolUse|TestPreparePrompt_OrphanedToolUseMixed"`
