### PR TITLE
feat: super yolo

### DIFF
--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -188,6 +188,12 @@ func blockFuncs() []shell.BlockFunc {
 	}
 }
 
+// isDangerousCommand checks if a command is considered dangerous and requires
+// explicit user approval even in YOLO mode.
+func isDangerousCommand(command string) bool {
+	return shell.IsCommandBlocked(command, blockFuncs())
+}
+
 func NewBashTool(permissions permission.Service, workingDir string, attribution *config.Attribution, modelName string) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		BashToolName,
@@ -217,6 +223,9 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 				return fantasy.ToolResponse{}, fmt.Errorf("session ID is required for executing shell command")
 			}
 			if !isSafeReadOnly {
+				// Check if the command is dangerous.
+				isDangerous := isDangerousCommand(params.Command)
+
 				p, err := permissions.Request(ctx,
 					permission.CreatePermissionRequest{
 						SessionID:   sessionID,
@@ -226,6 +235,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 						Action:      "execute",
 						Description: fmt.Sprintf("Execute command: %s", params.Command),
 						Params:      BashPermissionsParams(params),
+						Dangerous:   isDangerous,
 					},
 				)
 				if err != nil {
@@ -242,7 +252,8 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 				bgManager := shell.GetBackgroundShellManager()
 				bgManager.Cleanup()
 				// Use background context so it continues after tool returns
-				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+				// No block functions - permission check handles dangerous commands
+				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, nil, params.Command, params.Description)
 				if err != nil {
 					return fantasy.ToolResponse{}, fmt.Errorf("error starting background shell: %w", err)
 				}
@@ -297,7 +308,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 			// Start with detached context so it can survive if moved to background
 			bgManager := shell.GetBackgroundShellManager()
 			bgManager.Cleanup()
-			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, nil, params.Command, params.Description)
 			if err != nil {
 				return fantasy.ToolResponse{}, fmt.Errorf("error starting shell: %w", err)
 			}

--- a/internal/agent/tools/bash.tpl
+++ b/internal/agent/tools/bash.tpl
@@ -8,7 +8,7 @@ Common shell builtins and core utils available on Windows.
 
 <execution_steps>
 1. Directory Verification: If creating directories/files, use LS tool to verify parent exists
-2. Security Check: Banned commands ({{ .BannedCommands }}) return error - explain to user. Safe read-only commands execute without prompts
+2. Security Check: Dangerous commands ({{ .BannedCommands }}) require explicit user approval with a warning popup, even in YOLO mode. Safe read-only commands execute without prompts
 3. Command Execution: Execute with proper quoting, capture output
 4. Auto-Background: Commands exceeding 1 minute (default, configurable via `auto_background_after`) automatically move to background and return shell ID
 5. Output Processing: Truncate if exceeds {{ .MaxOutputLength }} characters

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -36,6 +36,12 @@ func (m *mockBashPermissionService) SkipRequests() bool {
 	return false
 }
 
+func (m *mockBashPermissionService) SetPermissionMode(mode permission.PermissionMode) {}
+
+func (m *mockBashPermissionService) PermissionMode() permission.PermissionMode {
+	return permission.PermissionModeNormal
+}
+
 func (m *mockBashPermissionService) SubscribeNotifications(ctx context.Context) <-chan pubsub.Event[permission.PermissionNotification] {
 	return make(<-chan pubsub.Event[permission.PermissionNotification])
 }

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/shell"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,6 +38,87 @@ func (m *mockBashPermissionService) SkipRequests() bool {
 
 func (m *mockBashPermissionService) SubscribeNotifications(ctx context.Context) <-chan pubsub.Event[permission.PermissionNotification] {
 	return make(<-chan pubsub.Event[permission.PermissionNotification])
+}
+
+func TestIsDangerousCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		command   string
+		dangerous bool
+	}{
+		{
+			name:      "simple banned command - curl",
+			command:   "curl https://example.com",
+			dangerous: true,
+		},
+		{
+			name:      "simple banned command - sudo",
+			command:   "sudo apt-get update",
+			dangerous: true,
+		},
+		{
+			name:      "npm global install with --global",
+			command:   "npm install --global typescript",
+			dangerous: true,
+		},
+		{
+			name:      "npm global install with -g",
+			command:   "npm install -g typescript",
+			dangerous: true,
+		},
+		{
+			name:      "npm local install",
+			command:   "npm install typescript",
+			dangerous: false,
+		},
+		{
+			name:      "go test with -exec",
+			command:   "go test -exec ./malicious ./...",
+			dangerous: true,
+		},
+		{
+			name:      "go test without -exec",
+			command:   "go test ./...",
+			dangerous: false,
+		},
+		{
+			name:      "safe command - ls",
+			command:   "ls -la",
+			dangerous: false,
+		},
+		{
+			name:      "safe command - echo",
+			command:   "echo hello",
+			dangerous: false,
+		},
+		{
+			name:      "safe command - git",
+			command:   "git status",
+			dangerous: false,
+		},
+		{
+			name:      "pip install with --user",
+			command:   "pip install --user requests",
+			dangerous: true,
+		},
+		{
+			name:      "pip install without --user",
+			command:   "pip install requests",
+			dangerous: false,
+		},
+		{
+			name:      "brew install",
+			command:   "brew install wget",
+			dangerous: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isDangerousCommand(tt.command)
+			assert.Equal(t, tt.dangerous, result, "command: %s", tt.command)
+		})
+	}
 }
 
 func TestBashTool_DefaultAutoBackgroundThreshold(t *testing.T) {

--- a/internal/agent/tools/multiedit_test.go
+++ b/internal/agent/tools/multiedit_test.go
@@ -34,6 +34,12 @@ func (m *mockPermissionService) SkipRequests() bool {
 	return false
 }
 
+func (m *mockPermissionService) SetPermissionMode(mode permission.PermissionMode) {}
+
+func (m *mockPermissionService) PermissionMode() permission.PermissionMode {
+	return permission.PermissionModeNormal
+}
+
 func (m *mockPermissionService) SubscribeNotifications(ctx context.Context) <-chan pubsub.Event[permission.PermissionNotification] {
 	return make(<-chan pubsub.Event[permission.PermissionNotification])
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -52,7 +52,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Debug")
 	rootCmd.PersistentFlags().StringVarP(&clientHost, "host", "H", server.DefaultHost(), "Connect to a specific crush server host (for advanced users)")
 	rootCmd.Flags().BoolP("help", "h", false, "Help")
-	rootCmd.Flags().BoolP("yolo", "y", false, "Automatically accept all permissions (dangerous mode)")
+	rootCmd.Flags().BoolP("yolo", "y", false, "Auto-approve non-dangerous commands, prompt for dangerous ones")
 	rootCmd.Flags().StringP("session", "s", "", "Continue a previous session by ID")
 	rootCmd.Flags().BoolP("continue", "C", false, "Continue the most recent session")
 	rootCmd.MarkFlagsMutuallyExclusive("session", "continue")

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -23,6 +23,7 @@ type CreatePermissionRequest struct {
 	Action      string `json:"action"`
 	Params      any    `json:"params"`
 	Path        string `json:"path"`
+	Dangerous   bool   `json:"dangerous"`
 }
 
 type PermissionNotification struct {
@@ -40,6 +41,7 @@ type PermissionRequest struct {
 	Action      string `json:"action"`
 	Params      any    `json:"params"`
 	Path        string `json:"path"`
+	Dangerous   bool   `json:"dangerous"`
 }
 
 type Service interface {
@@ -130,7 +132,9 @@ func (s *permissionService) Deny(permission PermissionRequest) {
 }
 
 func (s *permissionService) Request(ctx context.Context, opts CreatePermissionRequest) (bool, error) {
-	if s.skip {
+	// In skip (yolo) mode, auto-approve non-dangerous commands but still
+	// prompt for dangerous ones.
+	if s.skip && !opts.Dangerous {
 		return true, nil
 	}
 
@@ -181,6 +185,7 @@ func (s *permissionService) Request(ctx context.Context, opts CreatePermissionRe
 		Description: opts.Description,
 		Action:      opts.Action,
 		Params:      opts.Params,
+		Dangerous:   opts.Dangerous,
 	}
 
 	s.sessionPermissionsMu.RLock()

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -15,6 +15,20 @@ import (
 
 var ErrorPermissionDenied = errors.New("user denied permission")
 
+// PermissionMode represents the current permission mode.
+type PermissionMode int
+
+const (
+	// PermissionModeNormal prompts for all non-safe commands.
+	PermissionModeNormal PermissionMode = iota
+	// PermissionModeYolo auto-approves non-dangerous commands, prompts for
+	// dangerous ones.
+	PermissionModeYolo
+	// PermissionModeSuperYolo auto-approves everything including dangerous
+	// commands.
+	PermissionModeSuperYolo
+)
+
 type CreatePermissionRequest struct {
 	SessionID   string `json:"session_id"`
 	ToolCallID  string `json:"tool_call_id"`
@@ -53,6 +67,8 @@ type Service interface {
 	AutoApproveSession(sessionID string)
 	SetSkipRequests(skip bool)
 	SkipRequests() bool
+	SetPermissionMode(mode PermissionMode)
+	PermissionMode() PermissionMode
 	SubscribeNotifications(ctx context.Context) <-chan pubsub.Event[PermissionNotification]
 }
 
@@ -67,7 +83,9 @@ type permissionService struct {
 	autoApproveSessions   map[string]bool
 	autoApproveSessionsMu sync.RWMutex
 	skip                  bool
+	superSkip             bool
 	allowedTools          []string
+	mode                  PermissionMode
 
 	// used to make sure we only process one request at a time
 	requestMu       sync.Mutex
@@ -132,8 +150,12 @@ func (s *permissionService) Deny(permission PermissionRequest) {
 }
 
 func (s *permissionService) Request(ctx context.Context, opts CreatePermissionRequest) (bool, error) {
-	// In skip (yolo) mode, auto-approve non-dangerous commands but still
-	// prompt for dangerous ones.
+	// Super yolo mode: auto-approve everything including dangerous commands.
+	if s.superSkip {
+		return true, nil
+	}
+	// Yolo mode: auto-approve non-dangerous commands but still prompt for
+	// dangerous ones.
 	if s.skip && !opts.Dangerous {
 		return true, nil
 	}
@@ -238,7 +260,30 @@ func (s *permissionService) SkipRequests() bool {
 	return s.skip
 }
 
+func (s *permissionService) SetPermissionMode(mode PermissionMode) {
+	s.mode = mode
+	switch mode {
+	case PermissionModeNormal:
+		s.skip = false
+		s.superSkip = false
+	case PermissionModeYolo:
+		s.skip = true
+		s.superSkip = false
+	case PermissionModeSuperYolo:
+		s.skip = true
+		s.superSkip = true
+	}
+}
+
+func (s *permissionService) PermissionMode() PermissionMode {
+	return s.mode
+}
+
 func NewPermissionService(workingDir string, skip bool, allowedTools []string) Service {
+	mode := PermissionModeNormal
+	if skip {
+		mode = PermissionModeYolo
+	}
 	return &permissionService{
 		Broker:              pubsub.NewBroker[PermissionRequest](),
 		notificationBroker:  pubsub.NewBroker[PermissionNotification](),
@@ -246,6 +291,7 @@ func NewPermissionService(workingDir string, skip bool, allowedTools []string) S
 		sessionPermissions:  make([]PermissionRequest, 0),
 		autoApproveSessions: make(map[string]bool),
 		skip:                skip,
+		mode:                mode,
 		allowedTools:        allowedTools,
 		pendingRequests:     csync.NewMap[string, chan bool](),
 	}

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -124,6 +124,39 @@ func TestPermissionService_SkipMode(t *testing.T) {
 		service.Grant(event.Payload)
 		<-done
 	})
+
+	t.Run("super yolo mode auto-approves dangerous commands", func(t *testing.T) {
+		service := NewPermissionService("/tmp", true, []string{})
+		service.SetPermissionMode(PermissionModeSuperYolo)
+
+		result, err := service.Request(t.Context(), CreatePermissionRequest{
+			SessionID:   "test-session",
+			ToolName:    "bash",
+			Action:      "execute",
+			Description: "dangerous command",
+			Path:        "/tmp",
+			Dangerous:   true,
+		})
+		require.NoError(t, err)
+		assert.True(t, result, "expected dangerous permission to be granted in super yolo mode")
+	})
+
+	t.Run("permission mode cycling", func(t *testing.T) {
+		service := NewPermissionService("/tmp", false, []string{})
+		assert.Equal(t, PermissionModeNormal, service.PermissionMode())
+
+		service.SetPermissionMode(PermissionModeYolo)
+		assert.Equal(t, PermissionModeYolo, service.PermissionMode())
+		assert.True(t, service.SkipRequests())
+
+		service.SetPermissionMode(PermissionModeSuperYolo)
+		assert.Equal(t, PermissionModeSuperYolo, service.PermissionMode())
+		assert.True(t, service.SkipRequests())
+
+		service.SetPermissionMode(PermissionModeNormal)
+		assert.Equal(t, PermissionModeNormal, service.PermissionMode())
+		assert.False(t, service.SkipRequests())
+	})
 }
 
 func TestPermissionService_SequentialProperties(t *testing.T) {

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -80,21 +80,50 @@ func TestPermissionService_AllowedCommands(t *testing.T) {
 }
 
 func TestPermissionService_SkipMode(t *testing.T) {
-	service := NewPermissionService("/tmp", true, []string{})
+	t.Run("skip mode auto-approves non-dangerous commands", func(t *testing.T) {
+		service := NewPermissionService("/tmp", true, []string{})
 
-	result, err := service.Request(t.Context(), CreatePermissionRequest{
-		SessionID:   "test-session",
-		ToolName:    "bash",
-		Action:      "execute",
-		Description: "test command",
-		Path:        "/tmp",
+		result, err := service.Request(t.Context(), CreatePermissionRequest{
+			SessionID:   "test-session",
+			ToolName:    "bash",
+			Action:      "execute",
+			Description: "test command",
+			Path:        "/tmp",
+			Dangerous:   false,
+		})
+		require.NoError(t, err)
+		assert.True(t, result, "expected permission to be granted in skip mode")
 	})
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if !result {
-		t.Error("expected permission to be granted in skip mode")
-	}
+
+	t.Run("skip mode prompts for dangerous commands", func(t *testing.T) {
+		service := NewPermissionService("/tmp", true, []string{})
+
+		done := make(chan struct{})
+		go func() {
+			result, err := service.Request(t.Context(), CreatePermissionRequest{
+				SessionID:   "test-session",
+				ToolCallID:  "test-call",
+				ToolName:    "bash",
+				Action:      "execute",
+				Description: "dangerous command",
+				Path:        "/tmp",
+				Dangerous:   true,
+			})
+			require.NoError(t, err)
+			assert.True(t, result)
+			close(done)
+		}()
+
+		// Wait for permission request to be published.
+		events := service.Subscribe(t.Context())
+		event := <-events
+		assert.Equal(t, "bash", event.Payload.ToolName)
+		assert.True(t, event.Payload.Dangerous)
+
+		// Grant the permission.
+		service.Grant(event.Payload)
+		<-done
+	})
 }
 
 func TestPermissionService_SequentialProperties(t *testing.T) {

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -226,6 +226,44 @@ func splitArgsFlags(parts []string) (args []string, flags []string) {
 	return args, flags
 }
 
+// IsCommandBlocked checks if a command string would be blocked by the given
+// block functions. This is useful for detecting dangerous commands before
+// execution.
+func IsCommandBlocked(command string, blockFuncs []BlockFunc) bool {
+	line, err := syntax.NewParser().Parse(strings.NewReader(command), "")
+	if err != nil {
+		// If we can't parse it, consider it potentially dangerous.
+		return true
+	}
+
+	blocked := false
+	syntax.Walk(line, func(node syntax.Node) bool {
+		callExpr, ok := node.(*syntax.CallExpr)
+		if !ok {
+			return true
+		}
+		args := make([]string, 0, len(callExpr.Args))
+		for _, arg := range callExpr.Args {
+			for _, part := range arg.Parts {
+				lit, ok := part.(*syntax.Lit)
+				if !ok {
+					continue
+				}
+				args = append(args, lit.Value)
+			}
+		}
+		for _, blockFunc := range blockFuncs {
+			if blockFunc(args) {
+				blocked = true
+				return false
+			}
+		}
+		return true
+	})
+
+	return blocked
+}
+
 func (s *Shell) blockHandler() func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
 	return func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
 		return func(ctx context.Context, args []string) error {

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -51,6 +51,7 @@ type (
 	ActionTogglePills                 struct{}
 	ActionExternalEditor              struct{}
 	ActionToggleYoloMode              struct{}
+	ActionToggleSuperYoloMode         struct{}
 	ActionToggleNotifications         struct{}
 	ActionToggleTransparentBackground struct{}
 	ActionInitializeProject           struct{}

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -512,6 +512,7 @@ func (c *Commands) defaultCommands() []*CommandItem {
 
 	commands = append(commands,
 		NewCommandItem(c.com.Styles, "toggle_yolo", "Toggle Yolo Mode", "", ActionToggleYoloMode{}),
+		NewCommandItem(c.com.Styles, "toggle_super_yolo", "Toggle Super Yolo Mode", "", ActionToggleSuperYoloMode{}),
 		NewCommandItem(c.com.Styles, "toggle_help", "Toggle Help", "ctrl+g", ActionToggleHelp{}),
 		NewCommandItem(c.com.Styles, "init", "Initialize Project", "", ActionInitializeProject{}),
 	)

--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -446,11 +446,26 @@ func (p *Permissions) renderHeader(contentWidth int) string {
 	title := common.DialogTitle(t, "Permission Required", contentWidth-t.Dialog.Title.GetHorizontalFrameSize(), t.Primary, t.Secondary)
 	title = t.Dialog.Title.Render(title)
 
+	lines := []string{title, ""}
+
+	// Add warning for dangerous commands.
+	if p.permission.Dangerous {
+		warningTag := t.Base.
+			Foreground(t.BgOverlay).
+			Background(t.Yellow).
+			Padding(0, 1).
+			Render("WARNING")
+		warningIcon := t.Base.Foreground(t.Warning).Render("⚠")
+		warningMsg := t.Base.Foreground(t.FgHalfMuted).Render(" Potentially dangerous command")
+		warningLine := lipgloss.JoinHorizontal(lipgloss.Left, warningIcon, " ", warningTag, warningMsg)
+		lines = append(lines, warningLine, "")
+	}
+
 	// Tool info.
 	toolLine := p.renderToolName(contentWidth)
 	pathLine := p.renderKeyValue("Path", fsext.PrettyPath(p.permission.Path), contentWidth)
 
-	lines := []string{title, "", toolLine, pathLine}
+	lines = append(lines, toolLine, pathLine)
 
 	// Add tool-specific header info.
 	switch p.permission.ToolName {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -331,7 +331,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 
 	status := NewStatus(com, ui)
 
-	ui.setEditorPrompt(false)
+	ui.setEditorPrompt(com.Workspace.PermissionMode())
 	ui.randomizePlaceholders()
 	ui.textarea.Placeholder = ui.readyPlaceholder
 	ui.status = status
@@ -883,7 +883,10 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.textarea.Placeholder = m.readyPlaceholder
 		}
-		if m.com.Workspace.PermissionSkipRequests() {
+		switch m.com.Workspace.PermissionMode() {
+		case permission.PermissionModeSuperYolo:
+			m.textarea.Placeholder = "Super yolo mode!"
+		case permission.PermissionModeYolo:
 			m.textarea.Placeholder = "Yolo mode!"
 		}
 	}
@@ -1299,9 +1302,20 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 
 	// Command dialog messages.
 	case dialog.ActionToggleYoloMode:
-		yolo := !m.com.Workspace.PermissionSkipRequests()
-		m.com.Workspace.PermissionSetSkipRequests(yolo)
-		m.setEditorPrompt(yolo)
+		if m.com.Workspace.PermissionMode() == permission.PermissionModeYolo {
+			m.com.Workspace.PermissionSetMode(permission.PermissionModeNormal)
+		} else {
+			m.com.Workspace.PermissionSetMode(permission.PermissionModeYolo)
+		}
+		m.setEditorPrompt(m.com.Workspace.PermissionMode())
+		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionToggleSuperYoloMode:
+		if m.com.Workspace.PermissionMode() == permission.PermissionModeSuperYolo {
+			m.com.Workspace.PermissionSetMode(permission.PermissionModeNormal)
+		} else {
+			m.com.Workspace.PermissionSetMode(permission.PermissionModeSuperYolo)
+		}
+		m.setEditorPrompt(m.com.Workspace.PermissionMode())
 		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionToggleNotifications:
 		cfg := m.com.Config()
@@ -2724,14 +2738,17 @@ func (m *UI) openEditor(value string) tea.Cmd {
 	})
 }
 
-// setEditorPrompt configures the textarea prompt function based on whether
-// yolo mode is enabled.
-func (m *UI) setEditorPrompt(yolo bool) {
-	if yolo {
+// setEditorPrompt configures the textarea prompt function based on the current
+// permission mode.
+func (m *UI) setEditorPrompt(mode permission.PermissionMode) {
+	switch mode {
+	case permission.PermissionModeSuperYolo:
+		m.textarea.SetPromptFunc(4, m.superYoloPromptFunc)
+	case permission.PermissionModeYolo:
 		m.textarea.SetPromptFunc(4, m.yoloPromptFunc)
-		return
+	default:
+		m.textarea.SetPromptFunc(4, m.normalPromptFunc)
 	}
-	m.textarea.SetPromptFunc(4, m.normalPromptFunc)
 }
 
 // normalPromptFunc returns the normal editor prompt style ("  > " on first
@@ -2765,6 +2782,23 @@ func (m *UI) yoloPromptFunc(info textarea.PromptInfo) string {
 		return t.EditorPromptYoloDotsFocused.Render()
 	}
 	return t.EditorPromptYoloDotsBlurred.Render()
+}
+
+// superYoloPromptFunc returns the super yolo mode editor prompt style with red
+// warning icon and red dots.
+func (m *UI) superYoloPromptFunc(info textarea.PromptInfo) string {
+	t := m.com.Styles
+	if info.LineNumber == 0 {
+		if info.Focused {
+			return t.EditorPromptSuperYoloIconFocused.Render()
+		} else {
+			return t.EditorPromptSuperYoloIconBlurred.Render()
+		}
+	}
+	if info.Focused {
+		return t.EditorPromptSuperYoloDotsFocused.Render()
+	}
+	return t.EditorPromptSuperYoloDotsBlurred.Render()
 }
 
 // closeCompletions closes the completions popup and resets state.

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -144,12 +144,16 @@ type Styles struct {
 	BorderBlur  lipgloss.Style
 
 	// Editor
-	EditorPromptNormalFocused   lipgloss.Style
-	EditorPromptNormalBlurred   lipgloss.Style
-	EditorPromptYoloIconFocused lipgloss.Style
-	EditorPromptYoloIconBlurred lipgloss.Style
-	EditorPromptYoloDotsFocused lipgloss.Style
-	EditorPromptYoloDotsBlurred lipgloss.Style
+	EditorPromptNormalFocused        lipgloss.Style
+	EditorPromptNormalBlurred        lipgloss.Style
+	EditorPromptYoloIconFocused      lipgloss.Style
+	EditorPromptYoloIconBlurred      lipgloss.Style
+	EditorPromptYoloDotsFocused      lipgloss.Style
+	EditorPromptYoloDotsBlurred      lipgloss.Style
+	EditorPromptSuperYoloIconFocused lipgloss.Style
+	EditorPromptSuperYoloIconBlurred lipgloss.Style
+	EditorPromptSuperYoloDotsFocused lipgloss.Style
+	EditorPromptSuperYoloDotsBlurred lipgloss.Style
 
 	// Radio
 	RadioOn  lipgloss.Style
@@ -1212,6 +1216,13 @@ func DefaultStyles() Styles {
 	s.EditorPromptYoloIconBlurred = s.EditorPromptYoloIconFocused.Foreground(charmtone.Pepper).Background(charmtone.Squid)
 	s.EditorPromptYoloDotsFocused = lipgloss.NewStyle().MarginRight(1).Foreground(charmtone.Zest).SetString(":::")
 	s.EditorPromptYoloDotsBlurred = s.EditorPromptYoloDotsFocused.Foreground(charmtone.Squid)
+
+	// Super Yolo: red background " # " icon (focused) / dark background (blurred)
+	s.EditorPromptSuperYoloIconFocused = lipgloss.NewStyle().MarginRight(1).Foreground(white).Background(red).Bold(true).SetString(" # ")
+	s.EditorPromptSuperYoloIconBlurred = s.EditorPromptSuperYoloIconFocused.Foreground(charmtone.Pepper).Background(charmtone.Squid)
+	// Super Yolo: red ":::" dots (focused) / dark dots (blurred)
+	s.EditorPromptSuperYoloDotsFocused = lipgloss.NewStyle().MarginRight(1).Foreground(red).SetString(":::")
+	s.EditorPromptSuperYoloDotsBlurred = s.EditorPromptSuperYoloDotsFocused.Foreground(charmtone.Squid)
 
 	s.RadioOn = s.HalfMuted.SetString(RadioOn)
 	s.RadioOff = s.HalfMuted.SetString(RadioOff)

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -187,6 +187,14 @@ func (w *AppWorkspace) PermissionSetSkipRequests(skip bool) {
 	w.app.Permissions.SetSkipRequests(skip)
 }
 
+func (w *AppWorkspace) PermissionMode() permission.PermissionMode {
+	return w.app.Permissions.PermissionMode()
+}
+
+func (w *AppWorkspace) PermissionSetMode(mode permission.PermissionMode) {
+	w.app.Permissions.SetPermissionMode(mode)
+}
+
 // -- FileTracker --
 
 func (w *AppWorkspace) FileTrackerRecordRead(ctx context.Context, sessionID, path string) {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -304,6 +304,19 @@ func (w *ClientWorkspace) PermissionSetSkipRequests(skip bool) {
 	_ = w.client.SetPermissionsSkipRequests(context.Background(), w.workspaceID(), skip)
 }
 
+func (w *ClientWorkspace) PermissionMode() permission.PermissionMode {
+	skip, err := w.client.GetPermissionsSkipRequests(context.Background(), w.workspaceID())
+	if err != nil || !skip {
+		return permission.PermissionModeNormal
+	}
+	return permission.PermissionModeYolo
+}
+
+func (w *ClientWorkspace) PermissionSetMode(mode permission.PermissionMode) {
+	skip := mode != permission.PermissionModeNormal
+	_ = w.client.SetPermissionsSkipRequests(context.Background(), w.workspaceID(), skip)
+}
+
 // -- FileTracker --
 
 func (w *ClientWorkspace) FileTrackerRecordRead(ctx context.Context, sessionID, path string) {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -94,6 +94,8 @@ type Workspace interface {
 	PermissionDeny(perm permission.PermissionRequest)
 	PermissionSkipRequests() bool
 	PermissionSetSkipRequests(skip bool)
+	PermissionMode() permission.PermissionMode
+	PermissionSetMode(mode permission.PermissionMode)
 
 	// FileTracker
 	FileTrackerRecordRead(ctx context.Context, sessionID, path string)


### PR DESCRIPTION
In YOLO mode, dangerous commands (curl, sudo, package managers, etc.) now prompt the user with a warning banner instead of being silently auto-approved. Previously blocked commands now execute after approval instead of returning an error. Non-dangerous commands are still auto-approved in YOLO mode.

If the user wishes, they can also enable super yollo mode, which bypasses the prompts

https://github.com/user-attachments/assets/06f9003c-08cf-489c-84dc-f5f4ec0574a7

Closes: https://github.com/charmbracelet/crush/issues/2463
Closes: https://github.com/charmbracelet/crush/issues/1451