### PR TITLE
fix(hyper): fix re-authorization flow not triggering on certain conditions

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -186,7 +186,9 @@ func (c *coordinator) Run(ctx context.Context, sessionID string, prompt string, 
 	if providerCfg.OAuthToken != nil && providerCfg.OAuthToken.IsExpired() {
 		slog.Debug("Token needs to be refreshed", "provider", providerCfg.ID)
 		if err := c.refreshOAuth2Token(ctx, providerCfg); err != nil {
-			return nil, err
+			// NOTE(@andreynering): We don't return here because the event handling to ask the user to reauthenticate
+			// depends on the flow below. If refresh fails, proceed with the token we have.
+			slog.Error("Failed to refresh OAuth2 token. Proceeding with existing token.", "error", err)
 		}
 	}
 


### PR DESCRIPTION
We attempt to refresh tokens in two scenarios:

* Pro-actively, when we expiration date passed before a request
* Reactively, when we try a request but a 401 was returned

The error / event handling that shows a dialog asking the user to re-authenticate is dependent on code that runs for the second scenario. This means that the dialog might not show on the first scenario, if refreshing the token fails.

If refreshing a token fails, continue with the previous token. Let it fail and the 401 will trigger a re-authorization dialog.

I caught this because I was switching between local vs. prod Hyper a lot.