### PR TITLE
fix(agent,ui): persist terminal finish for Run and Summarize + scoped spinner stall-guard

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -452,7 +452,11 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 				return sessionErr
 			}
 			currentSession = updatedSession
-			return a.messages.Update(genCtx, *currentAssistant)
+			// Use parent ctx so the terminal finish part still lands even if
+			// genCtx was cancelled right after the stream finished. fantasy
+			// swallows the error returned here, so a failed Update would
+			// otherwise leave the UI spinner running forever.
+			return a.messages.Update(ctx, *currentAssistant)
 		},
 		StopWhen: []fantasy.StopCondition{
 			func(_ []fantasy.StepResult) bool {
@@ -592,6 +596,13 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 		return nil, err
 	}
 
+	// Defense in depth: if the stream returned no error but the assistant
+	// message never got a terminal finish part persisted (fantasy swallows
+	// OnStepFinish errors, and that callback's Update can fail when genCtx
+	// was cancelled right after stream completion), write one with a
+	// detached ctx so the UI spinner always stops.
+	a.ensureAssistantFinished(call.SessionID, currentAssistant)
+
 	if shouldSummarize {
 		a.activeRequests.Del(call.SessionID)
 		if summarizeErr := a.Summarize(genCtx, call.SessionID, call.ProviderOptions); summarizeErr != nil {
@@ -634,6 +645,28 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 	firstQueuedMessage := queuedMessages[0]
 	a.messageQueue.Set(call.SessionID, queuedMessages[1:])
 	return a.Run(ctx, firstQueuedMessage)
+}
+
+// ensureAssistantFinished is a defense-in-depth fallback: if the assistant
+// message from a successful stream has no terminal finish part persisted —
+// which can happen when fantasy swallows an OnStepFinish error and the
+// underlying Update failed because genCtx was cancelled right after stream
+// completion — write FinishReasonEndTurn with a detached ctx so the UI
+// spinner cannot hang. No-ops for nil or already-finished messages.
+func (a *sessionAgent) ensureAssistantFinished(sessionID string, assistant *message.Message) {
+	if assistant == nil || assistant.IsFinished() {
+		return
+	}
+	slog.Warn("Run completed without persisted finish part; writing fallback terminal state",
+		"session_id", sessionID,
+		"message_id", assistant.ID)
+	assistant.AddFinish(message.FinishReasonEndTurn, "", "")
+	if err := a.messages.Update(context.Background(), *assistant); err != nil {
+		slog.Error("Run terminal-state fallback write failed; spinner may hang",
+			"session_id", sessionID,
+			"message_id", assistant.ID,
+			"err", err)
+	}
 }
 
 func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fantasy.ProviderOptions) error {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -53,7 +53,18 @@ const (
 	largeContextWindowThreshold = 200_000
 	largeContextWindowBuffer    = 20_000
 	smallContextWindowRatio     = 0.2
+
+	// summarizeRequestKeySuffix namespaces the summarize cancel func in
+	// activeRequests so a concurrent Run and Summarize on the same session
+	// cannot clobber each other's cancel registration.
+	summarizeRequestKeySuffix = "-summarize"
 )
+
+// summarizeRequestKey returns the activeRequests key used to register the
+// summarize cancel func for a given session.
+func summarizeRequestKey(sessionID string) string {
+	return sessionID + summarizeRequestKeySuffix
+}
 
 var userAgent = fmt.Sprintf("Charm-Crush/%s (https://charm.land/crush)", version.Version)
 
@@ -650,8 +661,9 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	aiMsgs, _ := a.preparePrompt(msgs, largeModel.CatwalkCfg.SupportsImages)
 
 	genCtx, cancel := context.WithCancel(ctx)
-	a.activeRequests.Set(sessionID, cancel)
-	defer a.activeRequests.Del(sessionID)
+	summarizeKey := summarizeRequestKey(sessionID)
+	a.activeRequests.Set(summarizeKey, cancel)
+	defer a.activeRequests.Del(summarizeKey)
 	defer cancel()
 
 	agent := fantasy.NewAgent(largeModel.Model,
@@ -704,8 +716,26 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		isCancelErr := errors.Is(err, context.Canceled)
 		if isCancelErr {
 			// User cancelled summarize we need to remove the summary message.
-			deleteErr := a.messages.Delete(ctx, summaryMessage.ID)
-			return deleteErr
+			// Use a detached ctx because the parent ctx that caused the
+			// cancellation may also be done.
+			if deleteErr := a.messages.Delete(context.Background(), summaryMessage.ID); deleteErr != nil {
+				slog.Warn("summarize cancel cleanup failed",
+					"session_id", sessionID,
+					"message_id", summaryMessage.ID,
+					"err", deleteErr)
+				return deleteErr
+			}
+			return nil
+		}
+		// Non-cancel stream error: persist a terminal finish part so the UI
+		// leaves the spinning state. Use a detached ctx because genCtx may be
+		// cancelled and the whole point is for the user to see the failure.
+		summaryMessage.AddFinish(message.FinishReasonError, err.Error(), "")
+		if updErr := a.messages.Update(context.Background(), summaryMessage); updErr != nil {
+			slog.Error("summarize terminal-state write failed; spinner may hang",
+				"session_id", sessionID,
+				"message_id", summaryMessage.ID,
+				"err", updErr)
 		}
 		// Mark the summary message as finished with an error so the UI
 		// stops spinning.
@@ -717,8 +747,15 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	}
 
 	summaryMessage.AddFinish(message.FinishReasonEndTurn, "", "")
-	err = a.messages.Update(genCtx, summaryMessage)
-	if err != nil {
+	// Use a detached ctx for the final terminal-state Update: if the parent
+	// ctx was cancelled right after the stream finished, genCtx would also be
+	// done and the finish part would never reach the database, leaving the
+	// UI spinner running forever.
+	if err := a.messages.Update(context.Background(), summaryMessage); err != nil {
+		slog.Error("summarize final update failed; spinner may hang",
+			"session_id", sessionID,
+			"message_id", summaryMessage.ID,
+			"err", err)
 		return err
 	}
 
@@ -1148,7 +1185,7 @@ func (a *sessionAgent) Cancel(sessionID string) {
 	}
 
 	// Also check for summarize requests.
-	if cancel, ok := a.activeRequests.Get(sessionID + "-summarize"); ok && cancel != nil {
+	if cancel, ok := a.activeRequests.Get(summarizeRequestKey(sessionID)); ok && cancel != nil {
 		slog.Debug("Summarize cancellation initiated", "session_id", sessionID)
 		cancel()
 	}
@@ -1171,7 +1208,10 @@ func (a *sessionAgent) CancelAll() {
 		return
 	}
 	for key := range a.activeRequests.Seq2() {
-		a.Cancel(key) // key is sessionID
+		// Translate summarize keys back to their session ID so Cancel hits
+		// both the run and summarize cancel funcs for that session.
+		sessionID := strings.TrimSuffix(key, summarizeRequestKeySuffix)
+		a.Cancel(sessionID)
 	}
 
 	timeout := time.After(5 * time.Second)
@@ -1197,7 +1237,12 @@ func (a *sessionAgent) IsBusy() bool {
 }
 
 func (a *sessionAgent) IsSessionBusy(sessionID string) bool {
-	_, busy := a.activeRequests.Get(sessionID)
+	if _, busy := a.activeRequests.Get(sessionID); busy {
+		return true
+	}
+	// A running summarize also counts as busy so we never launch a concurrent
+	// generation against the same session.
+	_, busy := a.activeRequests.Get(summarizeRequestKey(sessionID))
 	return busy
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -601,7 +601,12 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 	// OnStepFinish errors, and that callback's Update can fail when genCtx
 	// was cancelled right after stream completion), write one with a
 	// detached ctx so the UI spinner always stops.
-	a.ensureAssistantFinished(call.SessionID, currentAssistant)
+	if currentAssistant != nil && !currentAssistant.IsFinished() {
+		slog.Warn("Run completed without persisted finish part; writing fallback terminal state",
+			"session_id", call.SessionID,
+			"message_id", currentAssistant.ID)
+	}
+	a.persistTerminalFinish(call.SessionID, currentAssistant, message.FinishReasonEndTurn, "")
 
 	if shouldSummarize {
 		a.activeRequests.Del(call.SessionID)
@@ -647,24 +652,23 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 	return a.Run(ctx, firstQueuedMessage)
 }
 
-// ensureAssistantFinished is a defense-in-depth fallback: if the assistant
-// message from a successful stream has no terminal finish part persisted —
-// which can happen when fantasy swallows an OnStepFinish error and the
-// underlying Update failed because genCtx was cancelled right after stream
-// completion — write FinishReasonEndTurn with a detached ctx so the UI
-// spinner cannot hang. No-ops for nil or already-finished messages.
-func (a *sessionAgent) ensureAssistantFinished(sessionID string, assistant *message.Message) {
-	if assistant == nil || assistant.IsFinished() {
+// persistTerminalFinish appends a finish part to an assistant-role message
+// and flushes it to the database using a detached context. It is the single
+// entry point for closing out a message's lifecycle so the UI spinner
+// cannot hang on a cancelled genCtx. No-ops on nil or already-finished
+// messages. Errors from the underlying Update are logged but not returned
+// — callers are at terminal points where a write failure must not block
+// further bookkeeping.
+func (a *sessionAgent) persistTerminalFinish(sessionID string, msg *message.Message, reason message.FinishReason, errTitle string) {
+	if msg == nil || msg.IsFinished() {
 		return
 	}
-	slog.Warn("Run completed without persisted finish part; writing fallback terminal state",
-		"session_id", sessionID,
-		"message_id", assistant.ID)
-	assistant.AddFinish(message.FinishReasonEndTurn, "", "")
-	if err := a.messages.Update(context.Background(), *assistant); err != nil {
-		slog.Error("Run terminal-state fallback write failed; spinner may hang",
+	msg.AddFinish(reason, errTitle, "")
+	if err := a.messages.Update(context.Background(), *msg); err != nil {
+		slog.Error("terminal-state write failed; spinner may hang",
 			"session_id", sessionID,
-			"message_id", assistant.ID,
+			"message_id", msg.ID,
+			"reason", string(reason),
 			"err", err)
 	}
 }
@@ -761,36 +765,14 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 			return nil
 		}
 		// Non-cancel stream error: persist a terminal finish part so the UI
-		// leaves the spinning state. Use a detached ctx because genCtx may be
-		// cancelled and the whole point is for the user to see the failure.
-		summaryMessage.AddFinish(message.FinishReasonError, err.Error(), "")
-		if updErr := a.messages.Update(context.Background(), summaryMessage); updErr != nil {
-			slog.Error("summarize terminal-state write failed; spinner may hang",
-				"session_id", sessionID,
-				"message_id", summaryMessage.ID,
-				"err", updErr)
-		}
-		// Mark the summary message as finished with an error so the UI
-		// stops spinning.
-		summaryMessage.AddFinish(message.FinishReasonError, "Summarization Error", err.Error())
-		if updateErr := a.messages.Update(ctx, summaryMessage); updateErr != nil {
-			return updateErr
-		}
+		// leaves the spinning state.
+		a.persistTerminalFinish(sessionID, &summaryMessage, message.FinishReasonError, err.Error())
 		return err
 	}
 
-	summaryMessage.AddFinish(message.FinishReasonEndTurn, "", "")
-	// Use a detached ctx for the final terminal-state Update: if the parent
-	// ctx was cancelled right after the stream finished, genCtx would also be
-	// done and the finish part would never reach the database, leaving the
-	// UI spinner running forever.
-	if err := a.messages.Update(context.Background(), summaryMessage); err != nil {
-		slog.Error("summarize final update failed; spinner may hang",
-			"session_id", sessionID,
-			"message_id", summaryMessage.ID,
-			"err", err)
-		return err
-	}
+	// Final terminal-state write: go through the helper so a cancelled
+	// genCtx cannot swallow the finish part and leave the spinner running.
+	a.persistTerminalFinish(sessionID, &summaryMessage, message.FinishReasonEndTurn, "")
 
 	var openrouterCost *float64
 	for _, step := range resp.Steps {

--- a/internal/agent/busy_test.go
+++ b/internal/agent/busy_test.go
@@ -100,11 +100,11 @@ func TestCancelAllTranslatesSummarizeKeyToSessionID(t *testing.T) {
 	}
 }
 
-// TestEnsureAssistantFinishedWritesFallback verifies the defense-in-depth
-// fallback: when Run's stream returns nil but the assistant message has no
-// terminal finish part, ensureAssistantFinished must append one so the UI
-// spinner stops.
-func TestEnsureAssistantFinishedWritesFallback(t *testing.T) {
+// TestPersistTerminalFinishWritesFallback verifies the helper: when an
+// assistant message has no terminal finish part, persistTerminalFinish must
+// append one and flush it so the UI spinner stops. Covers Run's success
+// fallback and Summarize's success path.
+func TestPersistTerminalFinishWritesFallback(t *testing.T) {
 	t.Parallel()
 
 	env := testEnv(t)
@@ -120,7 +120,7 @@ func TestEnsureAssistantFinishedWritesFallback(t *testing.T) {
 	require.False(t, msg.IsFinished(), "precondition: message must start unfinished")
 
 	a := &sessionAgent{messages: env.messages}
-	a.ensureAssistantFinished(sess.ID, &msg)
+	a.persistTerminalFinish(sess.ID, &msg, message.FinishReasonEndTurn, "")
 
 	// The in-memory msg now has the finish part, and the DB must reflect it.
 	require.True(t, msg.IsFinished(), "in-memory message should be finished after fallback")
@@ -131,10 +131,39 @@ func TestEnsureAssistantFinishedWritesFallback(t *testing.T) {
 	require.Equal(t, message.FinishReasonEndTurn, persisted.FinishPart().Reason)
 }
 
-// TestEnsureAssistantFinishedNoOpWhenAlreadyFinished verifies the fallback
-// is idempotent: if a finish part is already present it must not be
-// duplicated or overwritten.
-func TestEnsureAssistantFinishedNoOpWhenAlreadyFinished(t *testing.T) {
+// TestPersistTerminalFinishWritesErrorReason verifies that passing an error
+// title surfaces through the finish part. Covers Summarize's non-cancel
+// error path.
+func TestPersistTerminalFinishWritesErrorReason(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	sess, err := env.sessions.Create(t.Context(), "test")
+	require.NoError(t, err)
+
+	msg, err := env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role:     message.Assistant,
+		Model:    "test",
+		Provider: "test",
+	})
+	require.NoError(t, err)
+
+	a := &sessionAgent{messages: env.messages}
+	a.persistTerminalFinish(sess.ID, &msg, message.FinishReasonError, "boom")
+
+	persisted, err := env.messages.Get(t.Context(), msg.ID)
+	require.NoError(t, err)
+	finish := persisted.FinishPart()
+	require.NotNil(t, finish)
+	require.Equal(t, message.FinishReasonError, finish.Reason)
+	require.Equal(t, "boom", finish.Message)
+}
+
+// TestPersistTerminalFinishNoOpWhenAlreadyFinished verifies idempotency:
+// if a finish part is already present it must not be duplicated or
+// overwritten. This is what lets callers invoke the helper on paths where
+// fantasy's OnStepFinish may or may not have already written a finish.
+func TestPersistTerminalFinishNoOpWhenAlreadyFinished(t *testing.T) {
 	t.Parallel()
 
 	env := testEnv(t)
@@ -151,7 +180,9 @@ func TestEnsureAssistantFinishedNoOpWhenAlreadyFinished(t *testing.T) {
 	require.NoError(t, env.messages.Update(t.Context(), msg))
 
 	a := &sessionAgent{messages: env.messages}
-	a.ensureAssistantFinished(sess.ID, &msg)
+	// Even with a conflicting EndTurn request the existing Error finish
+	// must stand.
+	a.persistTerminalFinish(sess.ID, &msg, message.FinishReasonEndTurn, "")
 
 	persisted, err := env.messages.Get(t.Context(), msg.ID)
 	require.NoError(t, err)
@@ -163,11 +194,12 @@ func TestEnsureAssistantFinishedNoOpWhenAlreadyFinished(t *testing.T) {
 		"existing finish message must not be overwritten")
 }
 
-// TestEnsureAssistantFinishedNilIsSafe documents that the helper tolerates
-// a nil assistant pointer — Run may bail out before creating the message.
-func TestEnsureAssistantFinishedNilIsSafe(t *testing.T) {
+// TestPersistTerminalFinishNilIsSafe documents that the helper tolerates a
+// nil message pointer — Run may bail out before creating the assistant
+// message.
+func TestPersistTerminalFinishNilIsSafe(t *testing.T) {
 	t.Parallel()
 
 	a := &sessionAgent{}
-	a.ensureAssistantFinished("sess", nil) // must not panic
+	a.persistTerminalFinish("sess", nil, message.FinishReasonEndTurn, "") // must not panic
 }

--- a/internal/agent/busy_test.go
+++ b/internal/agent/busy_test.go
@@ -1,0 +1,99 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/csync"
+)
+
+// TestIsSessionBusyAcrossKeys verifies that a running summarize counts as
+// busy for the same session (preventing concurrent generations) without
+// leaking into other sessions.
+func TestIsSessionBusyAcrossKeys(t *testing.T) {
+	t.Parallel()
+
+	a := &sessionAgent{activeRequests: csync.NewMap[string, context.CancelFunc]()}
+	noop := context.CancelFunc(func() {})
+
+	if a.IsSessionBusy("s1") {
+		t.Fatalf("empty agent must not be busy")
+	}
+
+	a.activeRequests.Set("s1", noop)
+	if !a.IsSessionBusy("s1") {
+		t.Fatalf("busy when regular request key is set")
+	}
+	a.activeRequests.Del("s1")
+
+	a.activeRequests.Set(summarizeRequestKey("s1"), noop)
+	if !a.IsSessionBusy("s1") {
+		t.Fatalf("busy when summarize key is set — prevents concurrent generations during summary")
+	}
+	if a.IsSessionBusy("s2") {
+		t.Fatalf("summarize key for s1 must not leak into s2 busy check")
+	}
+}
+
+// TestSummarizeRequestKey guards the key format because Cancel and
+// CancelAll trim the suffix to recover the session ID.
+func TestSummarizeRequestKey(t *testing.T) {
+	t.Parallel()
+
+	got := summarizeRequestKey("abc")
+	want := "abc" + summarizeRequestKeySuffix
+	if got != want {
+		t.Fatalf("summarizeRequestKey(abc) = %q, want %q", got, want)
+	}
+}
+
+// TestCancelCancelsBothRunAndSummarize verifies Cancel triggers cancel funcs
+// for both the Run and Summarize slots on the same session — a regression
+// guard for the previous behavior where the summarize cancel func was only
+// reachable through the literal "sessionID-summarize" key.
+func TestCancelCancelsBothRunAndSummarize(t *testing.T) {
+	t.Parallel()
+
+	a := &sessionAgent{
+		activeRequests: csync.NewMap[string, context.CancelFunc](),
+		messageQueue:   csync.NewMap[string, []SessionAgentCall](),
+	}
+
+	var runCalled, summarizeCalled bool
+	a.activeRequests.Set("sess", func() { runCalled = true })
+	a.activeRequests.Set(summarizeRequestKey("sess"), func() { summarizeCalled = true })
+
+	a.Cancel("sess")
+
+	if !runCalled {
+		t.Errorf("Run cancel func was not invoked by Cancel")
+	}
+	if !summarizeCalled {
+		t.Errorf("Summarize cancel func was not invoked by Cancel")
+	}
+}
+
+// TestCancelAllTranslatesSummarizeKeyToSessionID verifies CancelAll does not
+// pass the suffixed summarize key as a session ID to Cancel, which would
+// miss the run cancel func. We set only a summarize key; CancelAll must
+// still invoke it.
+func TestCancelAllTranslatesSummarizeKeyToSessionID(t *testing.T) {
+	t.Parallel()
+
+	a := &sessionAgent{
+		activeRequests: csync.NewMap[string, context.CancelFunc](),
+		messageQueue:   csync.NewMap[string, []SessionAgentCall](),
+	}
+
+	var summarizeCalled bool
+	a.activeRequests.Set(summarizeRequestKey("sess"), func() {
+		summarizeCalled = true
+		a.activeRequests.Del(summarizeRequestKey("sess"))
+	})
+
+	a.CancelAll()
+
+	if !summarizeCalled {
+		t.Errorf("Summarize cancel func must be invoked by CancelAll even when only the summarize key is set")
+	}
+}

--- a/internal/agent/busy_test.go
+++ b/internal/agent/busy_test.go
@@ -105,8 +105,9 @@ func TestCancelAllTranslatesSummarizeKeyToSessionID(t *testing.T) {
 // append one and flush it so the UI spinner stops. Covers Run's success
 // fallback and Summarize's success path.
 func TestPersistTerminalFinishWritesFallback(t *testing.T) {
-	t.Parallel()
-
+	// Not t.Parallel(): testEnv calls db.Connect, which calls the package-
+	// global goose.SetDialect — see the other testEnv-using tests in this
+	// package which likewise run serially.
 	env := testEnv(t)
 	sess, err := env.sessions.Create(t.Context(), "test")
 	require.NoError(t, err)
@@ -135,8 +136,7 @@ func TestPersistTerminalFinishWritesFallback(t *testing.T) {
 // title surfaces through the finish part. Covers Summarize's non-cancel
 // error path.
 func TestPersistTerminalFinishWritesErrorReason(t *testing.T) {
-	t.Parallel()
-
+	// Not t.Parallel(); see TestPersistTerminalFinishWritesFallback.
 	env := testEnv(t)
 	sess, err := env.sessions.Create(t.Context(), "test")
 	require.NoError(t, err)
@@ -164,8 +164,7 @@ func TestPersistTerminalFinishWritesErrorReason(t *testing.T) {
 // overwritten. This is what lets callers invoke the helper on paths where
 // fantasy's OnStepFinish may or may not have already written a finish.
 func TestPersistTerminalFinishNoOpWhenAlreadyFinished(t *testing.T) {
-	t.Parallel()
-
+	// Not t.Parallel(); see TestPersistTerminalFinishWritesFallback.
 	env := testEnv(t)
 	sess, err := env.sessions.Create(t.Context(), "test")
 	require.NoError(t, err)

--- a/internal/agent/busy_test.go
+++ b/internal/agent/busy_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/stretchr/testify/require"
 )
 
 // TestIsSessionBusyAcrossKeys verifies that a running summarize counts as
@@ -96,4 +98,76 @@ func TestCancelAllTranslatesSummarizeKeyToSessionID(t *testing.T) {
 	if !summarizeCalled {
 		t.Errorf("Summarize cancel func must be invoked by CancelAll even when only the summarize key is set")
 	}
+}
+
+// TestEnsureAssistantFinishedWritesFallback verifies the defense-in-depth
+// fallback: when Run's stream returns nil but the assistant message has no
+// terminal finish part, ensureAssistantFinished must append one so the UI
+// spinner stops.
+func TestEnsureAssistantFinishedWritesFallback(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	sess, err := env.sessions.Create(t.Context(), "test")
+	require.NoError(t, err)
+
+	msg, err := env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role:     message.Assistant,
+		Model:    "test",
+		Provider: "test",
+	})
+	require.NoError(t, err)
+	require.False(t, msg.IsFinished(), "precondition: message must start unfinished")
+
+	a := &sessionAgent{messages: env.messages}
+	a.ensureAssistantFinished(sess.ID, &msg)
+
+	// The in-memory msg now has the finish part, and the DB must reflect it.
+	require.True(t, msg.IsFinished(), "in-memory message should be finished after fallback")
+
+	persisted, err := env.messages.Get(t.Context(), msg.ID)
+	require.NoError(t, err)
+	require.True(t, persisted.IsFinished(), "persisted message must have a finish part")
+	require.Equal(t, message.FinishReasonEndTurn, persisted.FinishPart().Reason)
+}
+
+// TestEnsureAssistantFinishedNoOpWhenAlreadyFinished verifies the fallback
+// is idempotent: if a finish part is already present it must not be
+// duplicated or overwritten.
+func TestEnsureAssistantFinishedNoOpWhenAlreadyFinished(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	sess, err := env.sessions.Create(t.Context(), "test")
+	require.NoError(t, err)
+
+	msg, err := env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role:     message.Assistant,
+		Model:    "test",
+		Provider: "test",
+	})
+	require.NoError(t, err)
+	msg.AddFinish(message.FinishReasonError, "boom", "details")
+	require.NoError(t, env.messages.Update(t.Context(), msg))
+
+	a := &sessionAgent{messages: env.messages}
+	a.ensureAssistantFinished(sess.ID, &msg)
+
+	persisted, err := env.messages.Get(t.Context(), msg.ID)
+	require.NoError(t, err)
+	finish := persisted.FinishPart()
+	require.NotNil(t, finish)
+	require.Equal(t, message.FinishReasonError, finish.Reason,
+		"existing finish reason must not be overwritten")
+	require.Equal(t, "boom", finish.Message,
+		"existing finish message must not be overwritten")
+}
+
+// TestEnsureAssistantFinishedNilIsSafe documents that the helper tolerates
+// a nil assistant pointer — Run may bail out before creating the message.
+func TestEnsureAssistantFinishedNilIsSafe(t *testing.T) {
+	t.Parallel()
+
+	a := &sessionAgent{}
+	a.ensureAssistantFinished("sess", nil) // must not panic
 }

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -2,7 +2,9 @@ package chat
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -20,6 +22,15 @@ const assistantMessageTruncateFormat = "… (%d lines hidden) [click or space to
 // maxCollapsedThinkingHeight defines the maximum height of the thinking
 const maxCollapsedThinkingHeight = 10
 
+// summarySpinnerStallTimeout forces the spinner off when a summary message
+// has not been updated for this long. This is a defense-in-depth guard for
+// the Summarize path: if the agent fails to persist a terminal finish part
+// (e.g. the genCtx is cancelled between stream completion and the final
+// Update), the UI would otherwise keep spinning forever. Scoped to summary
+// messages only so normal assistant streams — which can legitimately run
+// for a long time on reasoning-heavy models — are never affected.
+const summarySpinnerStallTimeout = 5 * time.Minute
+
 // AssistantMessageItem represents an assistant message in the chat UI.
 //
 // This item includes thinking, and the content but does not include the tool calls.
@@ -32,7 +43,8 @@ type AssistantMessageItem struct {
 	sty               *styles.Styles
 	anim              *anim.Anim
 	thinkingExpanded  bool
-	thinkingBoxHeight int // Tracks the rendered thinking box height for click detection.
+	thinkingBoxHeight int  // Tracks the rendered thinking box height for click detection.
+	stallLogged       bool // Ensures summary stall-guard telemetry fires at most once per message.
 }
 
 var _ Expandable = (*AssistantMessageItem)(nil)
@@ -237,7 +249,31 @@ func (a *AssistantMessageItem) isSpinning() bool {
 	isFinished := a.message.IsFinished()
 	hasContent := strings.TrimSpace(a.message.Content().Text) != ""
 	hasToolCalls := len(a.message.ToolCalls()) > 0
-	return (isThinking || !isFinished) && !hasContent && !hasToolCalls
+	if !((isThinking || !isFinished) && !hasContent && !hasToolCalls) {
+		return false
+	}
+	// Stall-guard: only applied to summary messages. The Summarize path has
+	// a narrow window where a terminal finish part can fail to persist,
+	// leaving the spinner running indefinitely. Normal assistant streams are
+	// driven by the agent loop and always emit a finish part, so they are
+	// left alone.
+	if a.message.IsSummaryMessage {
+		ts := a.message.UpdatedAt
+		if ts == 0 {
+			ts = a.message.CreatedAt
+		}
+		if ts > 0 && time.Since(time.Unix(ts, 0)) > summarySpinnerStallTimeout {
+			if !a.stallLogged {
+				slog.Warn("summary spinner stall-guard tripped; treating message as finished",
+					"message_id", a.message.ID,
+					"session_id", a.message.SessionID,
+					"stale", time.Since(time.Unix(ts, 0)).String())
+				a.stallLogged = true
+			}
+			return false
+		}
+	}
+	return true
 }
 
 // SetMessage is used to update the underlying message.
@@ -245,6 +281,7 @@ func (a *AssistantMessageItem) SetMessage(message *message.Message) tea.Cmd {
 	wasSpinning := a.isSpinning()
 	a.message = message
 	a.clearCache()
+	a.stallLogged = false
 	if !wasSpinning && a.isSpinning() {
 		return a.StartAnimation()
 	}

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -249,7 +249,7 @@ func (a *AssistantMessageItem) isSpinning() bool {
 	isFinished := a.message.IsFinished()
 	hasContent := strings.TrimSpace(a.message.Content().Text) != ""
 	hasToolCalls := len(a.message.ToolCalls()) > 0
-	if !((isThinking || !isFinished) && !hasContent && !hasToolCalls) {
+	if (!isThinking && isFinished) || hasContent || hasToolCalls {
 		return false
 	}
 	// Stall-guard: only applied to summary messages. The Summarize path has

--- a/internal/ui/chat/assistant_test.go
+++ b/internal/ui/chat/assistant_test.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
@@ -51,4 +52,144 @@ func TestAssistantMessageItemHandleMouseClick(t *testing.T) {
 	// Non-left button is ignored.
 	require.False(t, item.HandleMouseClick(ansi.MouseRight, 0, 2))
 	require.False(t, item.thinkingExpanded)
+}
+
+func TestAssistantIsSpinning(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().Unix()
+	stale := time.Now().Add(-2 * summarySpinnerStallTimeout).Unix()
+
+	tests := []struct {
+		name string
+		msg  message.Message
+		want bool
+	}{
+		{
+			name: "pending empty assistant message within window keeps spinning",
+			msg:  message.Message{ID: "m", UpdatedAt: now, CreatedAt: now},
+			want: true,
+		},
+		{
+			name: "non-summary pending message is not subject to stall-guard",
+			msg:  message.Message{ID: "m", UpdatedAt: stale, CreatedAt: stale},
+			want: true,
+		},
+		{
+			name: "has text content stops spinner",
+			msg: message.Message{
+				ID:        "m",
+				UpdatedAt: now,
+				Parts:     []message.ContentPart{message.TextContent{Text: "hello"}},
+			},
+			want: false,
+		},
+		{
+			name: "has tool calls stops spinner",
+			msg: message.Message{
+				ID:    "m",
+				Parts: []message.ContentPart{message.ToolCall{ID: "t1"}},
+			},
+			want: false,
+		},
+		{
+			name: "finished normally stops spinner",
+			msg: message.Message{
+				ID: "m",
+				Parts: []message.ContentPart{
+					message.Finish{Reason: message.FinishReasonEndTurn},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "finished with error stops spinner",
+			msg: message.Message{
+				ID: "m",
+				Parts: []message.ContentPart{
+					message.Finish{Reason: message.FinishReasonError, Message: "boom"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "thinking only, within window",
+			msg: message.Message{
+				ID:        "m",
+				UpdatedAt: now,
+				Parts:     []message.ContentPart{message.ReasoningContent{Thinking: "hmm"}},
+			},
+			want: true,
+		},
+		{
+			name: "stale summary message trips stall-guard",
+			msg: message.Message{
+				ID:               "m",
+				IsSummaryMessage: true,
+				UpdatedAt:        stale,
+				CreatedAt:        stale,
+			},
+			want: false,
+		},
+		{
+			name: "summary falls back to CreatedAt when UpdatedAt is zero",
+			msg: message.Message{
+				ID:               "m",
+				IsSummaryMessage: true,
+				CreatedAt:        stale,
+			},
+			want: false,
+		},
+		{
+			name: "fresh summary keeps spinning",
+			msg: message.Message{
+				ID:               "m",
+				IsSummaryMessage: true,
+				UpdatedAt:        now,
+				CreatedAt:        now,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := &AssistantMessageItem{message: &tt.msg}
+			if got := a.isSpinning(); got != tt.want {
+				t.Fatalf("isSpinning() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAssistantSetMessageResetsStallLogged(t *testing.T) {
+	t.Parallel()
+
+	stale := time.Now().Add(-2 * summarySpinnerStallTimeout).Unix()
+	a := &AssistantMessageItem{
+		cachedMessageItem: &cachedMessageItem{},
+		message: &message.Message{
+			ID:               "m",
+			IsSummaryMessage: true,
+			UpdatedAt:        stale,
+			CreatedAt:        stale,
+		},
+	}
+
+	// Trip the stall-guard so the flag is set.
+	_ = a.isSpinning()
+	if !a.stallLogged {
+		t.Fatalf("expected stallLogged=true after stale summary isSpinning call")
+	}
+
+	// A fresh update should clear the flag so a future stall can log again.
+	a.SetMessage(&message.Message{
+		ID:               "m",
+		IsSummaryMessage: true,
+		UpdatedAt:        time.Now().Unix(),
+	})
+	if a.stallLogged {
+		t.Fatalf("expected stallLogged=false after SetMessage")
+	}
 }


### PR DESCRIPTION
## Summary

Three commits, all targeted at the same class of bug: **the chat spinner gets stuck on forever** because an assistant or summary message never persists a terminal finish part. Two root-cause fixes (Run, Summarize) and one scoped UI stall-guard as defense in depth.

### 1. `fix(agent)`: persist terminal finish for summary and namespace cancel key

The `Summarize` flow had three narrow windows where the summary message would be left without a terminal finish part, permanently keeping `IsFinished()==false` and the spinner running:

- **Final success `Update`** used `genCtx`. If the parent ctx was cancelled just after the stream finished, `genCtx` was done and the finish never reached the DB. Now uses `context.Background()` — this is a tiny, must-happen terminal write that should not be tied to request lifetime.
- **Non-cancel stream error** returned without ever calling `AddFinish`. Now writes `FinishReasonError` with a detached ctx so the user sees the failure and the spinner stops.
- **Cancel path** used `ctx` (the already-cancelled parent) to delete the summary message. Switched to detached ctx and added a `slog.Warn` on cleanup failure.

While here, also cleaned up cancel-key handling:

- The `-summarize` suffix on `activeRequests` keys is now a named constant (`summarizeRequestKeySuffix`) with a `summarizeRequestKey(sessionID)` helper. Previously `Summarize` registered its cancel under `sessionID` (colliding with `Run`), while `Cancel` looked it up under the literal `sessionID + \"-summarize\"` — the summarize cancel func was effectively unreachable.
- `Summarize` now registers under the namespaced key so concurrent `Run` and `Summarize` on the same session cannot clobber each other's cancel registration.
- `IsSessionBusy` checks both keys — a running summarize prevents a concurrent generation on the same session.
- `CancelAll` trims the suffix before calling `Cancel`, otherwise a suffixed key gets treated as a session ID and the actual run cancel func is missed.

### 2. `fix(agent)`: persist terminal finish for Run success path

Symmetrical root-cause fix for `Run`. The terminal finish part is only written by fantasy's `OnStepFinish` callback, and two things conspire:

- `fantasy@v0.21.0` silently discards the error returned by `OnStepFinish` (`_ = opts.OnStepFinish(result.StepResult)`), so a failed `Update` never surfaces as a stream error.
- That callback's `Update` used `genCtx`. A parent-ctx cancellation right after the stream completes (user cancel, app shutdown) makes `genCtx` done and the finish never lands.

Together: `Stream` returns nil, Run takes the success branch, and the assistant message stays unfinished forever. Fix:

- Switch `OnStepFinish`'s `Update` from `genCtx` to the parent `ctx`, consistent with how tool-call / tool-result updates already work in the same function.
- After `Stream` returns with no error, call a new `ensureAssistantFinished` helper that appends `FinishReasonEndTurn` with a detached ctx when the message still has no finish part. Idempotent, nil-safe, and logs a `Warn` when it actually has to intervene.

### 3. `fix(ui)`: scoped stall-guard for summary spinner

Even with both root causes fixed, a future regression could reintroduce the hang. Added a 5-minute stall-guard in `AssistantMessageItem.isSpinning()` that only applies to `IsSummaryMessage == true`. A one-shot `slog.Warn` fires when it trips so the underlying cause stays observable. Normal assistant streams (which can legitimately run for many minutes on reasoning-heavy models) are untouched.

## Why scope the UI guard to summary only

Regular `Run()` can now fall through to `ensureAssistantFinished`; the symptom class is closed at the source. The UI guard stays focused on the narrow summary case (shorter, bounded, and the original reported symptom) so slow reasoning models on normal assistant streams are never falsely stopped.

## Test plan

- [x] `go test ./internal/agent/... ./internal/ui/chat/...` — all pass.
- [x] New tests:
  - `TestIsSessionBusyAcrossKeys`: busy when either run or summarize key is set; no cross-session leakage.
  - `TestSummarizeRequestKey`: key-format contract.
  - `TestCancelCancelsBothRunAndSummarize`: Cancel hits both slots.
  - `TestCancelAllTranslatesSummarizeKeyToSessionID`: regression guard for the suffix-translation fix in `CancelAll`.
  - `TestEnsureAssistantFinishedWritesFallback`: Run fallback actually appends a finish part and persists it.
  - `TestEnsureAssistantFinishedNoOpWhenAlreadyFinished`: fallback is idempotent — never overwrites an existing finish reason.
  - `TestEnsureAssistantFinishedNilIsSafe`: tolerates nil assistant (Run can bail before creating the message).
  - `TestAssistantIsSpinning` table: fresh/stale summary, non-summary pending is not affected, `UpdatedAt==0` falls back to `CreatedAt`, existing finished/has-content/has-tool-calls branches preserved.
  - `TestAssistantSetMessageResetsStallLogged`: stall-logged flag resets on new message.
- [x] `gofmt` clean, `go build ./...` clean.

💘 Generated with Crush


Co-Authored-By: Crush <crush@charm.land>