### PR TITLE
fix(agent): pass max output tokens to summary stream

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -106,6 +106,18 @@ type Model struct {
 	ModelCfg   config.SelectedModel
 }
 
+// MaxOutputTokens resolves the max output tokens to request from the
+// provider: the user-configured ModelCfg.MaxTokens if set, otherwise the
+// Catwalk default. Returns 0 when neither is configured; callers should
+// treat 0 as "don't send a limit" because some providers (e.g. LM Studio)
+// reject an explicit max_tokens of 0.
+func (m Model) MaxOutputTokens() int64 {
+	if m.ModelCfg.MaxTokens != 0 {
+		return m.ModelCfg.MaxTokens
+	}
+	return m.CatwalkCfg.DefaultMaxTokens
+}
+
 type sessionAgent struct {
 	largeModel         *csync.Value[Model]
 	smallModel         *csync.Value[Model]
@@ -660,10 +672,20 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 
 	summaryPromptText := buildSummaryPrompt(currentSession.Todos)
 
+	// Summarize used to rely on provider defaults, which silently caps
+	// Anthropic at 4096 tokens and truncates long summaries. Resolve the
+	// same max-tokens value Run uses, and only pass a non-zero limit (LM
+	// Studio and some OpenAI-compat endpoints reject an explicit 0).
+	var maxOutputTokens *int64
+	if v := largeModel.MaxOutputTokens(); v > 0 {
+		maxOutputTokens = &v
+	}
+
 	resp, err := agent.Stream(genCtx, fantasy.AgentStreamCall{
 		Prompt:          summaryPromptText,
 		Messages:        aiMsgs,
 		ProviderOptions: opts,
+		MaxOutputTokens: maxOutputTokens,
 		PrepareStep: func(callContext context.Context, options fantasy.PrepareStepFunctionOptions) (_ context.Context, prepared fantasy.PrepareStepResult, err error) {
 			prepared.Messages = options.Messages
 			if systemPromptPrefix != "" {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -160,10 +160,7 @@ func (c *coordinator) Run(ctx context.Context, sessionID string, prompt string, 
 	}
 
 	model := c.currentAgent.Model()
-	maxTokens := model.CatwalkCfg.DefaultMaxTokens
-	if model.ModelCfg.MaxTokens != 0 {
-		maxTokens = model.ModelCfg.MaxTokens
-	}
+	maxTokens := model.MaxOutputTokens()
 
 	if !model.CatwalkCfg.SupportsImages && attachments != nil {
 		// filter out image attachments
@@ -997,10 +994,7 @@ func (c *coordinator) runSubAgent(ctx context.Context, params subAgentParams) (f
 
 	// Get model configuration
 	model := params.Agent.Model()
-	maxTokens := model.CatwalkCfg.DefaultMaxTokens
-	if model.ModelCfg.MaxTokens != 0 {
-		maxTokens = model.ModelCfg.MaxTokens
-	}
+	maxTokens := model.MaxOutputTokens()
 
 	providerCfg, ok := c.cfg.Config().Providers.Get(model.ModelCfg.Provider)
 	if !ok {

--- a/internal/agent/model_test.go
+++ b/internal/agent/model_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/config"
+)
+
+func TestModelMaxOutputTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		m    Model
+		want int64
+	}{
+		{
+			name: "ModelCfg override wins over catwalk default",
+			m: Model{
+				CatwalkCfg: catwalk.Model{DefaultMaxTokens: 4096},
+				ModelCfg:   config.SelectedModel{MaxTokens: 32000},
+			},
+			want: 32000,
+		},
+		{
+			name: "falls back to catwalk default when ModelCfg is zero",
+			m: Model{
+				CatwalkCfg: catwalk.Model{DefaultMaxTokens: 16384},
+			},
+			want: 16384,
+		},
+		{
+			name: "returns zero when neither is configured",
+			m:    Model{},
+			want: 0,
+		},
+		{
+			name: "explicit zero in ModelCfg does not override catwalk default",
+			m: Model{
+				CatwalkCfg: catwalk.Model{DefaultMaxTokens: 8192},
+				ModelCfg:   config.SelectedModel{MaxTokens: 0},
+			},
+			want: 8192,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.m.MaxOutputTokens(); got != tt.want {
+				t.Fatalf("MaxOutputTokens() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Conversation summaries generated by `SessionAgent.Summarize()` are silently truncated at 4096 tokens on Anthropic providers. The root cause is that `Summarize()` never sets `MaxOutputTokens` on the fantasy `AgentStreamCall`, and fantasy's Anthropic provider hardcodes a 4096 fallback when the value is nil.

## Root cause

In `fantasy` v0.21.0:

- `providers/anthropic/anthropic.go:307-311`: `if params.MaxTokens == 0 { params.MaxTokens = 4096 }` — hardcoded fallback.
- `providers/openai/language_model.go` + `responses_language_model.go`: nil is passed straight through to the server, which uses its (typically much larger) default.

That asymmetry is why this bug has been Anthropic-specific and survived in the tree — OpenAI users never saw truncation.

Meanwhile `Run` already resolves `ModelCfg.MaxTokens` / `CatwalkCfg.DefaultMaxTokens` and passes it through (agent.go:267-271), but `Summarize` was missing that step entirely.

## Fix

- Add `Model.MaxOutputTokens() int64` that resolves the limit the same way Run and the coordinator already do: `ModelCfg.MaxTokens` > `CatwalkCfg.DefaultMaxTokens` > `0`.
- `Summarize()` now calls it and sets `AgentStreamCall.MaxOutputTokens` when the resolved value is non-zero. `0` stays unset to preserve LM Studio / OpenAI-compat provider compatibility (some reject `max_tokens: 0`), matching the existing pattern in `Run`.
- Coordinator had two inlined copies of the same fallback; both now call the new method. 6 duplicated lines gone.

## Test plan

- [x] New `TestModelMaxOutputTokens` — table-driven, 4 cases: `ModelCfg` override wins, catwalk default fallback, zero when neither set, explicit-zero-in-`ModelCfg` uses catwalk default.
- [x] Pre-existing `TestRunSubAgent/ModelCfg.MaxTokens_overrides_default` continues to pass, covering the refactored coordinator sites.
- [x] `go test ./internal/agent/...` green.
- [x] `go build ./...` clean.
- [x] `gofmt` clean.

💘 Generated with Crush


Co-Authored-By: Crush <crush@charm.land>