### PR TITLE
fix(ui): refresh todo pills on every session update

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -580,13 +580,21 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			break
 		}
 		if m.session != nil && msg.Payload.ID == m.session.ID {
-			prevHasInProgress := hasInProgressTodo(m.session.Todos)
 			m.session = &msg.Payload
-			if !prevHasInProgress && hasInProgressTodo(m.session.Todos) {
+			// Start the spinner if a todo just entered in_progress while the
+			// agent is busy.
+			if hasInProgressTodo(m.session.Todos) && m.isAgentBusy() && !m.todoIsSpinning {
 				m.todoIsSpinning = true
 				cmds = append(cmds, m.todoSpinner.Tick)
-				m.updateLayoutAndSize()
 			}
+			// Stop the spinner if the agent is no longer busy.
+			if m.todoIsSpinning && !m.isAgentBusy() {
+				m.todoIsSpinning = false
+			}
+			// Any todo change (added, completed, reordered, content edited)
+			// must re-render the pills; otherwise the panel stays stale
+			// until an unrelated event triggers a redraw.
+			m.renderPills()
 		}
 	case pubsub.Event[message.Message]:
 		// Check if this is a child session message for an agent tool.


### PR DESCRIPTION
## Summary

The top-of-chat todo pills panel goes stale and does not reflect todo state changes until an unrelated event triggers a redraw.

## Root cause

`internal/ui/model/ui.go` handles `pubsub.Event[session.Session]` by only re-rendering the pills when a todo transitions from "no in_progress" to "has in_progress":

```go
prevHasInProgress := hasInProgressTodo(m.session.Todos)
m.session = &msg.Payload
if !prevHasInProgress && hasInProgressTodo(m.session.Todos) {
    m.todoIsSpinning = true
    cmds = append(cmds, m.todoSpinner.Tick)
    m.updateLayoutAndSize()  // the only path that calls renderPills()
}
```

Every other transition silently skips the render:

- `pending → completed` (and `in_progress → completed`, the most common completion path)
- Todos added where none of them start as `in_progress`
- Reorders, status-only edits, content edits
- Final "all completed" state (the spinner also stays on because shutoff lives only in the message-event branch)

The panel then stays stale until a new message arrives, the window is resized, or the spinner happens to tick — whichever comes first.

The sibling `pubsub.Event[message.Message]` branch already gets this right: it gates the spinner on `isAgentBusy()` and calls `m.renderPills()` unconditionally at the end.

## Fix

Mirror the message-event branch in the session-event branch:

- Always call `m.renderPills()` when the current session updates.
- Gate spinner start on `hasInProgressTodo && isAgentBusy() && !todoIsSpinning` (matches message branch).
- Stop the spinner when `isAgentBusy()` is false (previously the shutoff was only wired into the message branch).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/ui/... -count=1` green (including existing pills / ui model tests)

## Not in scope

Two adjacent latent issues noted during investigation that are left for follow-ups:

- `internal/pubsub/broker.go:103-109` silently drops events on full (64-slot) subscriber buffer — would need buffer sizing and/or at-least-once logging.
- `internal/ui/model/ui.go:1057-1063` discards a tool result when its parent tool-call item is not yet in the chat — would need a short retry queue.

Both are race-conditional and broader in scope; this PR keeps the fix strictly to the deterministic "pills panel stale on common todo transitions" bug.

💘 Generated with Crush


Co-Authored-By: Crush <crush@charm.land>