### PR TITLE
fix(ui): Skill display as loaded despite being disabled in config

### DIFF
--- a/internal/ui/model/skills.go
+++ b/internal/ui/model/skills.go
@@ -58,6 +58,15 @@ func (m *UI) skillStatusItems() []skillStatusItem {
 	var items []skillStatusItem
 	stateNames := make(map[string]struct{}, len(m.skillStates))
 
+	disabledSet := make(map[string]bool)
+	if m.com != nil && m.com.Workspace != nil {
+		if cfg := m.com.Config(); cfg != nil {
+			for _, name := range cfg.Options.DisabledSkills {
+				disabledSet[name] = true
+			}
+		}
+	}
+
 	states := slices.Clone(m.skillStates)
 	slices.SortStableFunc(states, func(a, b *skills.SkillState) int {
 		return strings.Compare(a.Path, b.Path)
@@ -66,6 +75,9 @@ func (m *UI) skillStatusItems() []skillStatusItem {
 		name := state.Name
 		if name == "" {
 			name = filepath.Base(filepath.Dir(state.Path))
+		}
+		if disabledSet[name] {
+			continue
 		}
 		stateNames[name] = struct{}{}
 		icon := t.Resource.OnlineIcon.String()
@@ -85,6 +97,9 @@ func (m *UI) skillStatusItems() []skillStatusItem {
 	})
 	for _, skill := range builtin {
 		if _, ok := stateNames[skill.Name]; ok {
+			continue
+		}
+		if disabledSet[skill.Name] {
 			continue
 		}
 		items = append(items, skillStatusItem{

--- a/internal/ui/model/skills_test.go
+++ b/internal/ui/model/skills_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"testing"
 
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/skills"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	uistyles "github.com/charmbracelet/crush/internal/ui/styles"
@@ -55,4 +56,26 @@ func TestSkillStatusItemsIncludesBuiltinSkills(t *testing.T) {
 		}
 	}
 	require.True(t, hasBuiltin)
+}
+
+func TestSkillStatusItemsExcludesDisabledSkills(t *testing.T) {
+	t.Parallel()
+
+	st := uistyles.DefaultStyles()
+	ui := &UI{
+		com: &common.Common{
+			Styles:    &st,
+			Workspace: &testWorkspace{cfg: &config.Config{Options: &config.Options{DisabledSkills: []string{"go-doc", "crush-config"}}}},
+		},
+		skillStates: []*skills.SkillState{
+			{Name: "go-doc", Path: "/tmp/go-doc/SKILL.md", State: skills.StateNormal},
+		},
+	}
+
+	items := ui.skillStatusItems()
+
+	for _, item := range items {
+		require.NotEqual(t, "go-doc", item.name)
+		require.NotEqual(t, "crush-config", item.name)
+	}
 }


### PR DESCRIPTION
Even when we disable the skills in crush.json they still show in the UI as loaded:

```json
{
  "$schema": "https://raw.githubusercontent.com/charmbracelet/crush/refs/heads/main/schema.json",
  "options": {
    "disabled_tools": ["sourcegraph", "download", "crush_info", "crush_logs"],
    "disabled_skills": ["crush-config", "builtin-skills", "jq", "shell-builtins"],
  }
}
```

<img width="168" height="168" alt="image" src="https://github.com/user-attachments/assets/52f177b0-1d02-4cb9-8d62-9a098eef8c71" />



The sidebar `skillStatusItems()` at  `internal/ui/model/skills.go:56` displays ALL skills from pub/sub events and from the cached builtin skills `cachedBuiltinSkills()` without checking the `disabled_skills` config.

The coordinator and prompt builder correctly filtered disabled skills, but the UI did not.

<img width="165" height="134" alt="image" src="https://github.com/user-attachments/assets/dce8d604-6101-4ae4-aed4-daebd84cdaf8" />

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
