### PR TITLE
update terminal notifier for macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,8 +472,16 @@ focused _and_ your terminal supports reporting the focus state.
 ```
 
 To disable desktop notifications, set `disable_notifications` to `true` in your
-configuration. On macOS, notifications currently lack icons due to platform
-limitations.
+configuration.
+
+On macOS, install `terminal-notifier` for improved notifications:
+
+```bash
+brew install terminal-notifier
+```
+
+With `terminal-notifier` installed, clicking a notification will focus the
+terminal window where Crush is running.
 
 ### Initialization
 

--- a/internal/ui/notification/native_darwin.go
+++ b/internal/ui/notification/native_darwin.go
@@ -3,10 +3,12 @@
 package notification
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/gen2brain/beeep"
 )
@@ -75,8 +77,10 @@ func lookupBundleID(appName string) string {
 	// Try common variations of the app name.
 	variations := []string{appName, strings.TrimSuffix(appName, ".app")}
 	for _, name := range variations {
-		cmd := exec.Command("osascript", "-e", `id of app "`+name+`"`)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		cmd := exec.CommandContext(ctx, "osascript", "-e", `id of app "`+name+`"`)
 		out, err := cmd.Output()
+		cancel()
 		if err == nil {
 			return strings.TrimSpace(string(out))
 		}
@@ -116,7 +120,10 @@ func (b *NativeBackend) sendWithTerminalNotifier(n Notification) error {
 		args = append(args, "-activate", b.terminalBundleID)
 	}
 
-	cmd := exec.Command("terminal-notifier", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "terminal-notifier", args...)
 	if err := cmd.Run(); err != nil {
 		slog.Error("Failed to send notification via terminal-notifier", "error", err)
 		return err

--- a/internal/ui/notification/native_darwin.go
+++ b/internal/ui/notification/native_darwin.go
@@ -1,0 +1,172 @@
+//go:build darwin
+
+package notification
+
+import (
+	_ "embed"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/gen2brain/beeep"
+)
+
+//go:embed crush-icon-solo.png
+var iconData []byte
+
+// terminalBundleIDs maps TERM_PROGRAM values to macOS bundle identifiers.
+var terminalBundleIDs = map[string]string{
+	"Apple_Terminal": "com.apple.Terminal",
+	"ghostty":        "com.mitchellh.ghostty",
+	"iTerm.app":      "com.googlecode.iterm2",
+	"WezTerm":        "org.wezfurlong.wezterm",
+	"kitty":          "net.kovidgoyal.kitty",
+	"Alacritty":      "org.alacritty",
+	"vscode":         "com.microsoft.VSCode",
+	"tmux":           "", // tmux runs inside another terminal
+	"screen":         "", // screen runs inside another terminal
+}
+
+// NativeBackend sends desktop notifications using terminal-notifier on macOS,
+// with the ability to focus the originating terminal when clicked.
+type NativeBackend struct {
+	// terminalBundleID is the bundle ID of the terminal app to activate on click.
+	terminalBundleID string
+	// hasTerminalNotifier indicates if terminal-notifier is available.
+	hasTerminalNotifier bool
+	// iconPath is the path to the icon file for notifications.
+	iconPath string
+	// icon is the notification icon data (unused on darwin, kept for interface compat).
+	icon any
+	// notifyFunc is the fallback function used when terminal-notifier is unavailable.
+	notifyFunc func(title, message string, icon any) error
+}
+
+// NewNativeBackend creates a new native notification backend for macOS.
+// It detects the current terminal and configures notifications to focus it when clicked.
+func NewNativeBackend(icon any) *NativeBackend {
+	beeep.AppName = "Crush"
+
+	b := &NativeBackend{
+		icon:       icon,
+		notifyFunc: beeep.Notify,
+	}
+
+	// Check if terminal-notifier is available.
+	if path, err := exec.LookPath("terminal-notifier"); err == nil {
+		b.hasTerminalNotifier = true
+		slog.Debug("Found terminal-notifier", "path", path)
+
+		// Write the embedded icon to a temp file for terminal-notifier.
+		b.iconPath = writeIconToTemp()
+	}
+
+	// Detect the terminal bundle ID from TERM_PROGRAM.
+	if termProgram := os.Getenv("TERM_PROGRAM"); termProgram != "" {
+		if bundleID, ok := terminalBundleIDs[termProgram]; ok && bundleID != "" {
+			b.terminalBundleID = bundleID
+			slog.Debug("Detected terminal for notifications", "term_program", termProgram, "bundle_id", bundleID)
+		} else if !ok {
+			// Unknown terminal - try to look up its bundle ID dynamically.
+			if bundleID := lookupBundleID(termProgram); bundleID != "" {
+				b.terminalBundleID = bundleID
+				slog.Debug("Looked up terminal bundle ID", "term_program", termProgram, "bundle_id", bundleID)
+			}
+		}
+	}
+
+	return b
+}
+
+// writeIconToTemp writes the embedded icon to a temp file and returns the path.
+func writeIconToTemp() string {
+	tmpDir := os.TempDir()
+	iconPath := filepath.Join(tmpDir, "crush-notification-icon.png")
+
+	// Check if the file already exists and is the right size.
+	if info, err := os.Stat(iconPath); err == nil && info.Size() == int64(len(iconData)) {
+		return iconPath
+	}
+
+	if err := os.WriteFile(iconPath, iconData, 0o644); err != nil {
+		slog.Debug("Failed to write notification icon", "error", err)
+		return ""
+	}
+
+	return iconPath
+}
+
+// lookupBundleID attempts to find the bundle ID for an app name using osascript.
+func lookupBundleID(appName string) string {
+	// Try common variations of the app name.
+	variations := []string{appName, strings.TrimSuffix(appName, ".app")}
+	for _, name := range variations {
+		cmd := exec.Command("osascript", "-e", `id of app "`+name+`"`)
+		out, err := cmd.Output()
+		if err == nil {
+			return strings.TrimSpace(string(out))
+		}
+	}
+	return ""
+}
+
+// Send sends a desktop notification. If terminal-notifier is available and we know
+// the terminal's bundle ID, clicking the notification will focus that terminal.
+func (b *NativeBackend) Send(n Notification) error {
+	slog.Debug("Sending native notification", "title", n.Title, "message", n.Message,
+		"has_terminal_notifier", b.hasTerminalNotifier, "terminal_bundle_id", b.terminalBundleID)
+
+	// Use terminal-notifier if available.
+	if b.hasTerminalNotifier {
+		return b.sendWithTerminalNotifier(n)
+	}
+
+	// Fall back to beeep (which uses osascript on darwin).
+	err := b.notifyFunc(n.Title, n.Message, b.icon)
+	if err != nil {
+		slog.Error("Failed to send notification via beeep", "error", err)
+	}
+	return err
+}
+
+// sendWithTerminalNotifier sends a notification using terminal-notifier.
+func (b *NativeBackend) sendWithTerminalNotifier(n Notification) error {
+	args := []string{
+		"-title", n.Title,
+		"-message", n.Message,
+		"-group", "crush",
+	}
+
+	// If we know the terminal, activate it when the notification is clicked.
+	if b.terminalBundleID != "" {
+		args = append(args, "-activate", b.terminalBundleID)
+	}
+
+	// Add the icon if available.
+	if b.iconPath != "" {
+		args = append(args, "-appIcon", b.iconPath)
+	}
+
+	cmd := exec.Command("terminal-notifier", args...)
+	if err := cmd.Run(); err != nil {
+		slog.Error("Failed to send notification via terminal-notifier", "error", err)
+		return err
+	}
+
+	slog.Debug("Notification sent via terminal-notifier")
+	return nil
+}
+
+// SetNotifyFunc allows replacing the fallback notification function for testing.
+// This also disables terminal-notifier to ensure the fallback is used.
+func (b *NativeBackend) SetNotifyFunc(fn func(title, message string, icon any) error) {
+	b.notifyFunc = fn
+	b.hasTerminalNotifier = false
+}
+
+// ResetNotifyFunc resets the fallback notification function to the default.
+func (b *NativeBackend) ResetNotifyFunc() {
+	b.notifyFunc = beeep.Notify
+}

--- a/internal/ui/notification/native_darwin.go
+++ b/internal/ui/notification/native_darwin.go
@@ -3,18 +3,13 @@
 package notification
 
 import (
-	_ "embed"
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/gen2brain/beeep"
 )
-
-//go:embed crush-icon-solo.png
-var iconData []byte
 
 // terminalBundleIDs maps TERM_PROGRAM values to macOS bundle identifiers.
 var terminalBundleIDs = map[string]string{
@@ -36,8 +31,6 @@ type NativeBackend struct {
 	terminalBundleID string
 	// hasTerminalNotifier indicates if terminal-notifier is available.
 	hasTerminalNotifier bool
-	// iconPath is the path to the icon file for notifications.
-	iconPath string
 	// icon is the notification icon data (unused on darwin, kept for interface compat).
 	icon any
 	// notifyFunc is the fallback function used when terminal-notifier is unavailable.
@@ -58,9 +51,6 @@ func NewNativeBackend(icon any) *NativeBackend {
 	if path, err := exec.LookPath("terminal-notifier"); err == nil {
 		b.hasTerminalNotifier = true
 		slog.Debug("Found terminal-notifier", "path", path)
-
-		// Write the embedded icon to a temp file for terminal-notifier.
-		b.iconPath = writeIconToTemp()
 	}
 
 	// Detect the terminal bundle ID from TERM_PROGRAM.
@@ -78,24 +68,6 @@ func NewNativeBackend(icon any) *NativeBackend {
 	}
 
 	return b
-}
-
-// writeIconToTemp writes the embedded icon to a temp file and returns the path.
-func writeIconToTemp() string {
-	tmpDir := os.TempDir()
-	iconPath := filepath.Join(tmpDir, "crush-notification-icon.png")
-
-	// Check if the file already exists and is the right size.
-	if info, err := os.Stat(iconPath); err == nil && info.Size() == int64(len(iconData)) {
-		return iconPath
-	}
-
-	if err := os.WriteFile(iconPath, iconData, 0o644); err != nil {
-		slog.Debug("Failed to write notification icon", "error", err)
-		return ""
-	}
-
-	return iconPath
 }
 
 // lookupBundleID attempts to find the bundle ID for an app name using osascript.
@@ -142,11 +114,6 @@ func (b *NativeBackend) sendWithTerminalNotifier(n Notification) error {
 	// If we know the terminal, activate it when the notification is clicked.
 	if b.terminalBundleID != "" {
 		args = append(args, "-activate", b.terminalBundleID)
-	}
-
-	// Add the icon if available.
-	if b.iconPath != "" {
-		args = append(args, "-appIcon", b.iconPath)
 	}
 
 	cmd := exec.Command("terminal-notifier", args...)

--- a/internal/ui/notification/native_other.go
+++ b/internal/ui/notification/native_other.go
@@ -1,3 +1,5 @@
+//go:build !darwin
+
 package notification
 
 import (


### PR DESCRIPTION
- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [X] I have created a discussion that was approved by a maintainer (for new features).


When terminal-notifier is installed, uses it in place of the apple script to focus the relevant terminal correctly

Current implementation opens apple scripts dialog instead of focusing terminal on macos, this fixes that (provided it's installed!).

Still safely falls back to oascript impl