### PR TITLE
fix(ui): fix dialog box shift when session rename is active

### DIFF
--- a/internal/ui/dialog/sessions_item.go
+++ b/internal/ui/dialog/sessions_item.go
@@ -91,7 +91,8 @@ func (s *SessionItem) Render(width int) string {
 		styles.ItemBlurred = s.t.Dialog.Sessions.RenamingItemBlurred
 		styles.ItemFocused = s.t.Dialog.Sessions.RenamingingItemFocused
 		if s.focused {
-			inputWidth := width - styles.InfoTextFocused.GetHorizontalFrameSize()
+			const cursorPadding = 1
+			inputWidth := max(0, width-styles.ItemFocused.GetHorizontalFrameSize()-cursorPadding)
 			s.updateTitleInput.SetWidth(inputWidth)
 			s.updateTitleInput.Placeholder = ansi.Truncate(s.Title, width, "…")
 			return styles.ItemFocused.Render(s.updateTitleInput.View())


### PR DESCRIPTION
This fixes a small bug where the UI would shift slightly when the session rename dialogue is active.