### PR TITLE
fix: ensure `SystemPromptPrefix` is applied when creating new `SessionAgent`

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -424,6 +424,9 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		if err != nil {
 			return err
 		}
+		if largeProviderCfg.SystemPromptPrefix != "" {
+			systemPrompt = largeProviderCfg.SystemPromptPrefix + systemPrompt
+		}
 		result.SetSystemPrompt(systemPrompt)
 		return nil
 	})


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features): not a new feature, but a fix ([context](https://discord.com/channels/1032368467246075914/1404900884550516866/1498219684204515409))
