### PR TITLE
fix(build): remove legacy windows build tag

### DIFF
--- a/internal/client/dial_other.go
+++ b/internal/client/dial_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package client
 

--- a/internal/cmd/root_other.go
+++ b/internal/cmd/root_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package cmd
 

--- a/internal/cmd/server_other.go
+++ b/internal/cmd/server_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package cmd
 

--- a/internal/server/net_other.go
+++ b/internal/server/net_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package server
 


### PR DESCRIPTION
Removed the legacy  `// +build !windows`, since the new `//go:build !windows` already does the job.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
