### PR TITLE
fix(config): clear incompatible reasoning options when switching models

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -612,10 +612,17 @@ func configureSelectedModels(store *ConfigStore, knownProviders []catwalk.Provid
 			} else {
 				large.MaxTokens = model.DefaultMaxTokens
 			}
-			if largeModelSelected.ReasoningEffort != "" {
-				large.ReasoningEffort = largeModelSelected.ReasoningEffort
+			// Only apply reasoning options if the model supports reasoning.
+			// This prevents options persisted for a reasoning-capable model from
+			// being sent to a model that does not support them (e.g. switching
+			// from an Anthropic/OpenRouter model with thinking enabled back to a
+			// local Ollama model).
+			if model.CanReason {
+				if largeModelSelected.ReasoningEffort != "" {
+					large.ReasoningEffort = largeModelSelected.ReasoningEffort
+				}
+				large.Think = largeModelSelected.Think
 			}
-			large.Think = largeModelSelected.Think
 			if largeModelSelected.Temperature != nil {
 				large.Temperature = largeModelSelected.Temperature
 			}
@@ -656,8 +663,12 @@ func configureSelectedModels(store *ConfigStore, knownProviders []catwalk.Provid
 			} else {
 				small.MaxTokens = model.DefaultMaxTokens
 			}
-			if smallModelSelected.ReasoningEffort != "" {
-				small.ReasoningEffort = smallModelSelected.ReasoningEffort
+			// Only apply reasoning options if the model supports reasoning.
+			if model.CanReason {
+				if smallModelSelected.ReasoningEffort != "" {
+					small.ReasoningEffort = smallModelSelected.ReasoningEffort
+				}
+				small.Think = smallModelSelected.Think
 			}
 			if smallModelSelected.Temperature != nil {
 				small.Temperature = smallModelSelected.Temperature
@@ -674,7 +685,6 @@ func configureSelectedModels(store *ConfigStore, knownProviders []catwalk.Provid
 			if smallModelSelected.PresencePenalty != nil {
 				small.PresencePenalty = smallModelSelected.PresencePenalty
 			}
-			small.Think = smallModelSelected.Think
 		}
 	}
 	c.Models[SelectedModelTypeLarge] = large

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1504,6 +1504,52 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 		require.Equal(t, "openai", large.Provider)
 		require.Equal(t, int64(100), large.MaxTokens)
 	})
+
+	t.Run("should not apply reasoning options to models that do not support reasoning", func(t *testing.T) {
+		// Regression test for: switching from a reasoning-capable model to a
+		// non-reasoning model (e.g. Ollama) should not carry over Think or
+		// ReasoningEffort options from the previous model's config.
+		knownProviders := []catwalk.Provider{
+			{
+				ID:                  "ollama",
+				APIKey:              "abc",
+				DefaultLargeModelID: "llama3",
+				DefaultSmallModelID: "llama3",
+				Models: []catwalk.Model{
+					{
+						ID:               "llama3",
+						DefaultMaxTokens: 4096,
+						CanReason:        false,
+					},
+				},
+			},
+		}
+
+		cfg := &Config{
+			Models: map[SelectedModelType]SelectedModel{
+				"large": {
+					Model:           "llama3",
+					Provider:        "ollama",
+					Think:           true,   // persisted from a previous reasoning-capable model
+					ReasoningEffort: "high", // persisted from a previous reasoning-capable model
+				},
+			},
+		}
+		cfg.setDefaults("/tmp", "")
+		env := env.NewFromMap(map[string]string{})
+		resolver := NewEnvironmentVariableResolver(env)
+		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		require.NoError(t, err)
+
+		err = configureSelectedModels(testStore(cfg), knownProviders, true)
+		require.NoError(t, err)
+		large := cfg.Models[SelectedModelTypeLarge]
+		require.Equal(t, "llama3", large.Model)
+		require.Equal(t, "ollama", large.Provider)
+		// Think and ReasoningEffort must be cleared for a non-reasoning model.
+		require.False(t, large.Think, "Think must not be applied to a model that does not support reasoning")
+		require.Empty(t, large.ReasoningEffort, "ReasoningEffort must not be applied to a model that does not support reasoning")
+	})
 }
 
 func TestConfig_configureProviders_HyperAPIKeyFromEnv(t *testing.T) {


### PR DESCRIPTION
## Problem

When a user switches from a reasoning-capable model (e.g. Claude with thinking enabled, or an OpenRouter model with `reasoning_effort` set) to a model that does not support reasoning (e.g. a local Ollama model), the previously persisted `think` and `reasoning_effort` options are still applied to the new model.

This happens because the config loading strategy uses `jsons.Merge()` — a field-level deep merge — so options written for the old model survive into the new model's effective config. `configureSelectedModels()` then blindly copies `Think` and `ReasoningEffort` from the persisted `SelectedModel` onto the active model config, regardless of whether the target model supports reasoning.

The result is an API error like:

```
model does not support thinking
```

or

```
reasoning_effort is not supported for this model
```

Fixes #2713

## Solution

Guard the `Think` / `ReasoningEffort` assignment in `configureSelectedModels()` behind a `model.CanReason` check for both the large-model and small-model branches. When the active model does not declare reasoning support, the stale options are silently ignored, so no incompatible parameters reach the API.

## Tests

A new sub-test `should not apply reasoning options to models that do not support reasoning` is added to `TestConfig_configureSelectedModels`. It verifies that `Think` and `ReasoningEffort` values persisted in the config are **not** propagated to an active model whose `CanReason` field is `false`.

All existing sub-tests continue to pass.