### PR TITLE
fix(hooks): respect matching directive

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,6 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
-	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -371,7 +370,9 @@ func (t ToolGrep) GetTimeout() time.Duration {
 }
 
 // HookConfig defines a user-configured shell command that fires on a hook
-// event (e.g. PreToolUse).
+// event (e.g. PreToolUse). This is a pure-data struct: matcher compilation
+// is owned by hooks.Runner so a JSON round-trip, merge, or reload can't
+// silently drop compiled state.
 type HookConfig struct {
 	// Regex pattern tested against the tool name. Empty means match all.
 	Matcher string `json:"matcher,omitempty" jsonschema:"description=Regex pattern tested against the tool name. Empty means match all tools."`
@@ -379,15 +380,6 @@ type HookConfig struct {
 	Command string `json:"command" jsonschema:"required,description=Shell command to execute when the hook fires"`
 	// Timeout in seconds. Default 30.
 	Timeout int `json:"timeout,omitempty" jsonschema:"description=Timeout in seconds for the hook command,default=30"`
-
-	// Compiled matcher regex. Not serialized.
-	matcherRegex *regexp.Regexp
-}
-
-// MatcherRegex returns the compiled matcher regex, or nil if no matcher is
-// set.
-func (h *HookConfig) MatcherRegex() *regexp.Regexp {
-	return h.matcherRegex
 }
 
 // TimeoutDuration returns the hook timeout as a time.Duration, defaulting

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -905,8 +905,11 @@ func normalizeHookEvent(name string) string {
 	}
 }
 
-// ValidateHooks normalizes event names and compiles matcher regexes for all
-// configured hooks. Returns an error if any regex is invalid.
+// ValidateHooks normalizes event names and checks that every configured
+// hook has a command and a syntactically valid matcher regex. Matcher
+// compilation used for matching is owned by hooks.Runner; this function
+// only validates up front so the user sees config errors at load time
+// rather than on the first tool call.
 func (c *Config) ValidateHooks() error {
 	// Normalize event name keys.
 	for event, eventHooks := range c.Hooks {
@@ -918,17 +921,15 @@ func (c *Config) ValidateHooks() error {
 	}
 
 	for event, eventHooks := range c.Hooks {
-		for i := range eventHooks {
-			h := &c.Hooks[event][i]
+		for i, h := range eventHooks {
 			if h.Command == "" {
 				return fmt.Errorf("hook %s[%d]: command is required", event, i)
 			}
-			if h.Matcher != "" {
-				re, err := regexp.Compile(h.Matcher)
-				if err != nil {
-					return fmt.Errorf("hook %s[%d]: invalid matcher regex %q: %w", event, i, h.Matcher, err)
-				}
-				h.matcherRegex = re
+			if h.Matcher == "" {
+				continue
+			}
+			if _, err := regexp.Compile(h.Matcher); err != nil {
+				return fmt.Errorf("hook %s[%d]: invalid matcher regex %q: %w", event, i, h.Matcher, err)
 			}
 		}
 	}

--- a/internal/config/reload_hooks_test.go
+++ b/internal/config/reload_hooks_test.go
@@ -1,0 +1,102 @@
+package config_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/hooks"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReloadFromDisk_CompilesHookMatchers is a regression test for a bug
+// where ReloadFromDisk dropped the compiled matcher regex on every hook,
+// causing a matcher like "^bash$" to match every tool call after any
+// SetConfigField-triggered reload.
+//
+// The assertion is phrased in terms of observable Runner behavior (not
+// internal field presence) so it stays valid if the Runner later owns
+// matcher compilation itself.
+func TestReloadFromDisk_CompilesHookMatchers(t *testing.T) {
+	// No t.Parallel(): we Setenv HOME/XDG_CONFIG_HOME to isolate from the
+	// developer's real global config, which may define its own hooks.
+	isolated := t.TempDir()
+	t.Setenv("HOME", isolated)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(isolated, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(isolated, ".local", "share"))
+
+	workDir := t.TempDir()
+	dataDir := t.TempDir()
+	configPath := filepath.Join(workDir, "crush.json")
+	cfgJSON := `{
+        "hooks": {
+            "PreToolUse": [
+                {"matcher": "^bash$", "command": "exit 0"}
+            ]
+        }
+    }`
+	require.NoError(t, os.WriteFile(configPath, []byte(cfgJSON), 0o600))
+
+	store, err := config.Load(workDir, dataDir, false)
+	require.NoError(t, err)
+
+	// Sanity: hook filtering works immediately after Load.
+	assertHookFilters(t, store)
+
+	require.NoError(t, store.ReloadFromDisk(context.Background()))
+
+	// The actual regression check: filtering must still work after a
+	// reload, not silently collapse to match-everything.
+	assertHookFilters(t, store)
+}
+
+// assertHookFilters builds a Runner from the store's current hooks and
+// verifies the "^bash$" matcher rejects a non-bash tool while accepting
+// bash.
+func assertHookFilters(t *testing.T, store *config.ConfigStore) {
+	t.Helper()
+	preHooks := store.Config().Hooks[hooks.EventPreToolUse]
+	require.Len(t, preHooks, 1)
+
+	runner := hooks.NewRunner(preHooks, t.TempDir(), t.TempDir())
+
+	nonMatch, err := runner.Run(context.Background(), hooks.EventPreToolUse, "sess", "view", `{}`)
+	require.NoError(t, err)
+	require.Equal(t, 0, nonMatch.HookCount, "view must not match ^bash$ matcher")
+
+	match, err := runner.Run(context.Background(), hooks.EventPreToolUse, "sess", "bash", `{}`)
+	require.NoError(t, err)
+	require.Equal(t, 1, match.HookCount, "bash must match ^bash$ matcher")
+}
+
+// TestSetConfigField_AutoReload_PreservesHookMatcherFiltering verifies the
+// dominant real-world trigger path: config writes call autoReload,
+// autoReload calls ReloadFromDisk, and hook matching must remain correct.
+func TestSetConfigField_AutoReload_PreservesHookMatcherFiltering(t *testing.T) {
+	isolated := t.TempDir()
+	t.Setenv("HOME", isolated)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(isolated, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(isolated, ".local", "share"))
+
+	workDir := t.TempDir()
+	dataDir := t.TempDir()
+	configPath := filepath.Join(workDir, "crush.json")
+	cfgJSON := `{
+        "hooks": {
+            "PreToolUse": [
+                {"matcher": "^bash$", "command": "exit 0"}
+            ]
+        }
+    }`
+	require.NoError(t, os.WriteFile(configPath, []byte(cfgJSON), 0o600))
+
+	store, err := config.Load(workDir, dataDir, false)
+	require.NoError(t, err)
+	assertHookFilters(t, store)
+
+	require.NoError(t, store.SetConfigField(config.ScopeGlobal, "options.debug", true))
+
+	assertHookFilters(t, store)
+}

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -590,6 +590,12 @@ func (s *ConfigStore) ReloadFromDisk(ctx context.Context) error {
 		}
 	}
 
+	// Validate hooks after all config merging is complete so matcher
+	// regexes are recompiled on the reloaded config (mirrors Load).
+	if err := cfg.ValidateHooks(); err != nil {
+		return fmt.Errorf("invalid hook configuration on reload: %w", err)
+	}
+
 	// Preserve runtime overrides
 	overrides := s.overrides
 

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -373,6 +373,40 @@ func TestRunnerMatcherFiltering(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, DecisionNone, result.Decision)
 	})
+
+	// Runner must compile matchers itself; it cannot rely on
+	// ValidateHooks having run first. This is the guarantee that prevents
+	// the reload-drops-matcher class of bug.
+	t.Run("runner compiles matcher without ValidateHooks", func(t *testing.T) {
+		t.Parallel()
+		raw := []config.HookConfig{
+			{Command: `echo '{"decision":"deny","reason":"blocked"}'`, Matcher: "^bash$"},
+		}
+		r := NewRunner(raw, t.TempDir(), t.TempDir())
+
+		deny, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
+		require.NoError(t, err)
+		require.Equal(t, DecisionDeny, deny.Decision)
+
+		noop, err := r.Run(context.Background(), EventPreToolUse, "sess", "view", `{}`)
+		require.NoError(t, err)
+		require.Equal(t, DecisionNone, noop.Decision)
+	})
+
+	// A matcher that fails to compile at Runner construction must not
+	// degrade to match-everything; the hook is dropped instead.
+	t.Run("runner skips hooks with invalid matcher", func(t *testing.T) {
+		t.Parallel()
+		raw := []config.HookConfig{
+			{Command: `echo '{"decision":"deny","reason":"should not fire"}'`, Matcher: "[invalid"},
+		}
+		r := NewRunner(raw, t.TempDir(), t.TempDir())
+
+		result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
+		require.NoError(t, err)
+		require.Equal(t, DecisionNone, result.Decision)
+		require.Empty(t, r.Hooks())
+	})
 }
 
 func TestValidateHooksInvalidRegex(t *testing.T) {

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log/slog"
 	"os/exec"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -12,25 +13,63 @@ import (
 	"github.com/charmbracelet/crush/internal/config"
 )
 
+// compiledHook pairs a HookConfig with its compiled matcher regex. A nil
+// matcher means "match every tool".
+type compiledHook struct {
+	cfg     config.HookConfig
+	matcher *regexp.Regexp
+}
+
 // Runner executes hook commands and aggregates their results.
 type Runner struct {
-	hooks      []config.HookConfig
+	hooks      []compiledHook
 	cwd        string
 	projectDir string
 }
 
-// NewRunner creates a Runner from the given hook configs.
+// NewRunner creates a Runner from the given hook configs. Each hook's
+// Matcher is compiled here so the Runner is self-sufficient; callers do
+// not have to pre-compile matchers on the config, and reloads or merges
+// that rebuild HookConfig values can't silently strip compiled state.
+//
+// Hooks whose matcher fails to compile are skipped with a warning rather
+// than treated as match-everything. ValidateHooks is expected to have
+// caught syntax errors earlier, so this is defense in depth.
 func NewRunner(hooks []config.HookConfig, cwd, projectDir string) *Runner {
+	compiled := make([]compiledHook, 0, len(hooks))
+	for _, h := range hooks {
+		ch := compiledHook{cfg: h}
+		if h.Matcher != "" {
+			re, err := regexp.Compile(h.Matcher)
+			if err != nil {
+				slog.Warn("Hook matcher failed to compile; skipping hook",
+					"matcher", h.Matcher,
+					"command", h.Command,
+					"error", err,
+				)
+				continue
+			}
+			ch.matcher = re
+		}
+		compiled = append(compiled, ch)
+	}
 	return &Runner{
-		hooks:      hooks,
+		hooks:      compiled,
 		cwd:        cwd,
 		projectDir: projectDir,
 	}
 }
 
-// Hooks returns the hook configs the runner was created with.
+// Hooks returns the hook configs the runner was created with, in config
+// order. Hooks whose matcher failed to compile at construction are
+// omitted. Intended for diagnostics; callers should not rely on ordering
+// or identity beyond that.
 func (r *Runner) Hooks() []config.HookConfig {
-	return r.hooks
+	out := make([]config.HookConfig, len(r.hooks))
+	for i, h := range r.hooks {
+		out[i] = h.cfg
+	}
+	return out
 }
 
 // Run executes all matching hooks for the given event and tool, returning
@@ -93,9 +132,8 @@ func (r *Runner) Run(ctx context.Context, eventName, sessionID, toolName, toolIn
 func (r *Runner) matchingHooks(toolName string) []config.HookConfig {
 	var matched []config.HookConfig
 	for _, h := range r.hooks {
-		re := h.MatcherRegex()
-		if re == nil || re.MatchString(toolName) {
-			matched = append(matched, h)
+		if h.matcher == nil || h.matcher.MatchString(toolName) {
+			matched = append(matched, h.cfg)
 		}
 	}
 	return matched


### PR DESCRIPTION
These revisions fix a bug where `matcher` values in hooks would match all tools.