### PR TITLE
fix(tools/job_kill): use longer job_kill desc to improve reliability

### DIFF
--- a/internal/agent/tools/job_kill.go
+++ b/internal/agent/tools/job_kill.go
@@ -29,7 +29,7 @@ type JobKillResponseMetadata struct {
 func NewJobKillTool() fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		JobKillToolName,
-		FirstLineDescription(jobKillDescription),
+		string(jobKillDescription),
 		func(ctx context.Context, params JobKillParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if params.ShellID == "" {
 				return fantasy.NewTextErrorResponse("missing shell_id"), nil

--- a/internal/agent/tools/job_kill.md
+++ b/internal/agent/tools/job_kill.md
@@ -1,4 +1,4 @@
-Terminate a background shell process by ID; shell ID becomes invalid after killing.
+Terminate a background shell process.
 
 <usage>
 - Provide the shell ID returned from a background bash execution


### PR DESCRIPTION
This restores the longer job kill description, which works better with some LLMs.