### PR TITLE
fix(lsp): respect SingleFileSupport so single-file servers start without root markers

### DIFF
--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -49,7 +49,7 @@ func NewManager(cfg *config.ConfigStore) *Manager {
 		// HACK: the user might have the command name in their config instead
 		// of the actual name. Find and use the correct name.
 		actualName := resolveServerName(manager, name)
-		manager.AddServer(actualName, &powernapconfig.ServerConfig{
+		serverCfg := &powernapconfig.ServerConfig{
 			Command:     clientConfig.Command,
 			Args:        clientConfig.Args,
 			Environment: clientConfig.Env,
@@ -57,7 +57,16 @@ func NewManager(cfg *config.ConfigStore) *Manager {
 			RootMarkers: clientConfig.RootMarkers,
 			InitOptions: clientConfig.InitOptions,
 			Settings:    clientConfig.Options,
-		})
+		}
+		// Preserve capability flags from defaults when the user overrides
+		// a known server: those are populated by powernap's curated
+		// allowlists, not user config, so a bare `command:` override would
+		// otherwise zero them out.
+		if defaultCfg, ok := manager.GetServer(actualName); ok {
+			serverCfg.SingleFileSupport = defaultCfg.SingleFileSupport
+			serverCfg.EnableSnippets = defaultCfg.EnableSnippets
+		}
+		manager.AddServer(actualName, serverCfg)
 	}
 
 	return &Manager{
@@ -347,7 +356,7 @@ func hasRootMarkers(dir string, markers []string) bool {
 
 func handles(server *powernapconfig.ServerConfig, filePath, workDir string) bool {
 	return handlesFiletype(server.Command, server.FileTypes, filePath) &&
-		hasRootMarkers(workDir, server.RootMarkers)
+		(server.SingleFileSupport || hasRootMarkers(workDir, server.RootMarkers))
 }
 
 // KillAll force-kills all the LSP clients.

--- a/internal/lsp/manager_singlefile_test.go
+++ b/internal/lsp/manager_singlefile_test.go
@@ -1,0 +1,38 @@
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	powernapconfig "github.com/charmbracelet/x/powernap/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandlesRespectsSingleFileSupport(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	pyFile := filepath.Join(tmp, "main.py")
+	require.NoError(t, os.WriteFile(pyFile, []byte("x = 1\n"), 0o644))
+
+	server := &powernapconfig.ServerConfig{
+		Command:           "pyright-langserver",
+		FileTypes:         []string{"python"},
+		RootMarkers:       []string{".git"},
+		SingleFileSupport: true,
+	}
+	require.True(t, handles(server, pyFile, tmp), "single-file-capable server should handle file when no root markers present")
+
+	server.SingleFileSupport = false
+	require.False(t, handles(server, pyFile, tmp), "non-single-file server should be skipped when no root markers present")
+}
+
+func TestNewManagerPreservesDefaultSingleFileSupport(t *testing.T) {
+	t.Parallel()
+	cfg := &config.Config{LSP: config.LSPs{"pyright": {Command: "pyright-langserver"}}}
+	mgr := NewManager(config.NewTestStore(cfg))
+	s, ok := mgr.manager.GetServer("pyright")
+	require.True(t, ok, "pyright should be registered")
+	require.True(t, s.SingleFileSupport, "SingleFileSupport must survive user override of a known default")
+}

--- a/internal/lsp/manager_singlefile_test.go
+++ b/internal/lsp/manager_singlefile_test.go
@@ -28,11 +28,22 @@ func TestHandlesRespectsSingleFileSupport(t *testing.T) {
 	require.False(t, handles(server, pyFile, tmp), "non-single-file server should be skipped when no root markers present")
 }
 
-func TestNewManagerPreservesDefaultSingleFileSupport(t *testing.T) {
+func TestNewManagerPreservesDefaultCapabilityFlags(t *testing.T) {
 	t.Parallel()
+
+	// Read the curated defaults rather than hardcoding them, so the test still
+	// means "the override preserved them" if powernap's allowlist changes.
+	defaults := powernapconfig.NewManager()
+	defaults.LoadDefaults()
+	defaultPyright, ok := defaults.GetServer("pyright")
+	require.True(t, ok, "pyright should be registered in powernap's defaults")
+
 	cfg := &config.Config{LSP: config.LSPs{"pyright": {Command: "pyright-langserver"}}}
 	mgr := NewManager(config.NewTestStore(cfg))
 	s, ok := mgr.manager.GetServer("pyright")
 	require.True(t, ok, "pyright should be registered")
-	require.True(t, s.SingleFileSupport, "SingleFileSupport must survive user override of a known default")
+	require.Equal(t, defaultPyright.SingleFileSupport, s.SingleFileSupport,
+		"SingleFileSupport must survive user override of a known default")
+	require.Equal(t, defaultPyright.EnableSnippets, s.EnableSnippets,
+		"EnableSnippets must survive user override of a known default")
 }


### PR DESCRIPTION
Related to #1751.

## Status

This PR fixes a real, demonstrable defect that matches the maintainer's
stated hunch on the issue ("it is not matching any of the root markers
of the lsp"), but I want to be upfront that **it may not fully cover
the reporter's specific configuration path** — see "Scope notes" below.
Closing #1751 is at maintainers' discretion; I'm continuing to
investigate the reporter's symptom separately.

## Problem

powernap ships `SingleFileSupport: true` for a curated set of language
servers that can operate on standalone files (pyright, pylsp, cssls,
html, lua_ls, marksman, gopls, ts_ls, ruff, taplo, yamlls, zls, etc.).
Crush never reads that flag, so those servers are silently skipped
whenever the working directory lacks a project-root marker.

A second, smaller defect alongside it: when a user override matches a
known default server (`resolveServerName` finds it), the loop in
`NewManager` rebuilds the powernap `ServerConfig` from scratch and
loses `SingleFileSupport` and `EnableSnippets` since those flags don't
come from user config.

## Fix

Two small changes in `internal/lsp/manager.go`:

1. `handles()` now treats `SingleFileSupport` as a bypass for the
   root-marker check:

   ```go
   return handlesFiletype(...) &&
       (server.SingleFileSupport || hasRootMarkers(workDir, server.RootMarkers))
   ```

2. `NewManager` carries `SingleFileSupport` and `EnableSnippets`
   forward from the powernap default when a user override resolves to a
   known server:

   ```go
   if defaultCfg, ok := manager.GetServer(actualName); ok {
       serverCfg.SingleFileSupport = defaultCfg.SingleFileSupport
       serverCfg.EnableSnippets    = defaultCfg.EnableSnippets
   }
   ```

## Tests

`internal/lsp/manager_singlefile_test.go` adds two regressions:

- `TestHandlesRespectsSingleFileSupport` — single-file-capable server
  with unmatched root markers must be accepted; same server with
  `SingleFileSupport: false` must still be rejected.
- `TestNewManagerPreservesDefaultSingleFileSupport` — bare
  `command: pyright-langserver` user override must keep the powernap
  default's `SingleFileSupport: true`.

Both fail on `main` and pass with the patch. Full `internal/lsp/...`
(42 tests) and `go build ./...` are green.

## Scope notes

- `handles` has only one call site (`startServer`) and `SingleFileSupport`
  has no other consumers in crush, so blast radius is limited to the
  servers powernap explicitly marks as single-file-capable.
- Preserving `EnableSnippets` is functionally a no-op (capability-
  negotiation flag) but symmetric with `SingleFileSupport` and avoids
  losing it on user override.
- **The reporter's specific config in #1751 is unaffected by this fix.**
  Their override uses `"command": "python3"` (not the powernap default
  `pylsp`), so `resolveServerName` falls through and registers the
  entry under its custom name. With empty `FileTypes` and empty
  `RootMarkers`, `handles()` already returns true today — meaning the
  server should already start, and the symptom ("only CSS LSP is ever
  called") suggests a routing/dispatch bug downstream of `handles()`,
  not a startup bug. I'm continuing to investigate that separately.

## Who this fix benefits

Users relying on default powernap servers (pyright, pylsp, cssls, etc.)
without user overrides, working in directories that lack a project-root
marker (`.git`, `pyproject.toml`, `package.json`, ...). Today those
servers initialize but are silently filtered out at the `handles()`
gate. With this fix they start as intended.
