### PR TITLE
fix(lsp): score-based client selection so catch-all LSPs don't steal files

### DIFF
--- a/internal/agent/tools/lsp_helpers.go
+++ b/internal/agent/tools/lsp_helpers.go
@@ -90,17 +90,17 @@ func resolveSymbolResults(ctx context.Context, lspManager *lsp.Manager, symbol, 
 	return results, nil
 }
 
-// findLSPClient returns the first LSP client that handles the given file path.
+// findLSPClient returns the LSP client that best handles the given file path.
+//
+// Selection is by match score rather than iteration order: a catch-all server
+// (one with no configured FileTypes) matches every file, so first-match would
+// hand it files that a more specific server should own, and which server won
+// depended on map ordering.
 func findLSPClient(lspManager *lsp.Manager, filePath string) *lsp.Client {
 	if abs, err := filepath.Abs(filePath); err == nil {
 		filePath = abs
 	}
-	for c := range lspManager.Clients().Seq() {
-		if c.HandlesFile(filePath) {
-			return c
-		}
-	}
-	return nil
+	return lspManager.BestClientFor(filePath)
 }
 
 // collectAffectedFiles extracts all unique file paths from a WorkspaceEdit.

--- a/internal/agent/tools/references.go
+++ b/internal/agent/tools/references.go
@@ -100,14 +100,7 @@ func find(ctx context.Context, lspManager *lsp.Manager, symbol string, match gre
 		return nil, fmt.Errorf("failed to get absolute path: %s", err)
 	}
 
-	var client *lsp.Client
-	for c := range lspManager.Clients().Seq() {
-		if c.HandlesFile(absPath) {
-			client = c
-			break
-		}
-	}
-
+	client := lspManager.BestClientFor(absPath)
 	if client == nil {
 		slog.Warn("No LSP clients to handle", "path", match.path)
 		return nil, nil

--- a/internal/lsp/best_client_test.go
+++ b/internal/lsp/best_client_test.go
@@ -1,0 +1,122 @@
+package lsp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/stretchr/testify/require"
+)
+
+func newScoreTestClient(name, cwd string, fileTypes []string) *Client {
+	c := newTestClient()
+	c.name = name
+	c.cwd = cwd
+	c.fileTypes = fileTypes
+	return c
+}
+
+func newScoreTestManager(clients ...*Client) *Manager {
+	m := &Manager{clients: csync.NewMap[string, *Client]()}
+	for _, c := range clients {
+		m.clients.Set(c.name, c)
+	}
+	return m
+}
+
+func TestMatchScore(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	pyFile := filepath.Join(tmp, "main.py")
+	require.NoError(t, os.WriteFile(pyFile, []byte("x = 1\n"), 0o644))
+
+	other := t.TempDir()
+	outsidePy := filepath.Join(other, "out.py")
+	require.NoError(t, os.WriteFile(outsidePy, []byte("x"), 0o644))
+
+	cases := []struct {
+		name      string
+		client    *Client
+		path      string
+		wantScore int
+	}{
+		{"explicit ext match", newScoreTestClient("py", tmp, []string{"py"}), pyFile, 2},
+		{"empty filetypes is catch-all", newScoreTestClient("any", tmp, nil), pyFile, 1},
+		{"explicit but mismatched", newScoreTestClient("rs", tmp, []string{"rs"}), pyFile, 0},
+		{"outside workspace", newScoreTestClient("py", tmp, []string{"py"}), outsidePy, 0},
+		{"nil client", (*Client)(nil), pyFile, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.wantScore, tc.client.MatchScore(tc.path))
+		})
+	}
+}
+
+// Reproduces #1751-style routing: when multiple LSPs are configured with
+// empty FileTypes (e.g. because the user wrote `extensions:` instead of
+// `filetypes:` and the field was silently dropped), a catch-all client
+// must not steal a file from a client that explicitly claims the
+// extension. Without scoring, this passed or failed by map iteration
+// order — repeating the assertion many times catches the race.
+func TestBestClientForPrefersSpecificMatchOverCatchAll(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	pyFile := filepath.Join(tmp, "main.py")
+	require.NoError(t, os.WriteFile(pyFile, []byte("x = 1\n"), 0o644))
+
+	catchAll := newScoreTestClient("css", tmp, nil)
+	pyClient := newScoreTestClient("python", tmp, []string{"py"})
+	mgr := newScoreTestManager(catchAll, pyClient)
+
+	for range 100 {
+		require.Same(t, pyClient, mgr.BestClientFor(pyFile),
+			"explicit python match must beat catch-all CSS regardless of map iteration order")
+	}
+}
+
+func TestBestClientForFallsBackToCatchAll(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	txtFile := filepath.Join(tmp, "notes.txt")
+	require.NoError(t, os.WriteFile(txtFile, []byte("x"), 0o644))
+
+	catchAll := newScoreTestClient("anything", tmp, nil)
+	pyClient := newScoreTestClient("python", tmp, []string{"py"})
+	mgr := newScoreTestManager(catchAll, pyClient)
+
+	require.Same(t, catchAll, mgr.BestClientFor(txtFile),
+		"catch-all should still serve files no explicit client claims")
+}
+
+func TestBestClientForReturnsNilWhenNothingHandlesPath(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	other := t.TempDir()
+	pyFile := filepath.Join(other, "out.py")
+	require.NoError(t, os.WriteFile(pyFile, []byte("x"), 0o644))
+
+	pyClient := newScoreTestClient("python", tmp, []string{"py"})
+	mgr := newScoreTestManager(pyClient)
+
+	require.Nil(t, mgr.BestClientFor(pyFile))
+}
+
+func TestBestClientForDeterministicTiebreak(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	pyFile := filepath.Join(tmp, "main.py")
+	require.NoError(t, os.WriteFile(pyFile, []byte("x"), 0o644))
+
+	// Two equally specific clients (both score 2). Tiebreak picks the
+	// alphabetically smaller name so the choice is stable.
+	zPython := newScoreTestClient("zpython", tmp, []string{"py"})
+	aPython := newScoreTestClient("apython", tmp, []string{"py"})
+	mgr := newScoreTestManager(zPython, aPython)
+
+	for range 100 {
+		require.Same(t, aPython, mgr.BestClientFor(pyFile))
+	}
+}

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -345,14 +345,35 @@ type OpenFileInfo struct {
 // HandlesFile checks if this LSP client handles the given file based on its
 // extension and whether it's within the working directory.
 func (c *Client) HandlesFile(path string) bool {
+	return c.MatchScore(path) > 0
+}
+
+// MatchScore returns how strongly this client claims to handle the given
+// path. Higher scores beat lower scores for tools that must pick a single
+// client (e.g. lsp_references):
+//
+//	0 — outside the client's workspace, or FileTypes is set but doesn't match
+//	1 — inside the workspace and the client has no FileTypes (catch-all)
+//	2 — inside the workspace and FileTypes explicitly names the extension or
+//	    detected language
+//
+// Tools that broadcast to every matching client (e.g. lsp_diagnostics)
+// should keep using HandlesFile, since any non-zero score is "willing".
+func (c *Client) MatchScore(path string) int {
 	if c == nil {
-		return false
+		return 0
 	}
 	if !fsext.HasPrefix(path, c.cwd) {
 		slog.Debug("File outside workspace", "name", c.name, "file", path, "workDir", c.cwd)
-		return false
+		return 0
 	}
-	return handlesFiletype(c.name, c.fileTypes, path)
+	if len(c.fileTypes) == 0 {
+		return 1
+	}
+	if handlesFiletype(c.name, c.fileTypes, path) {
+		return 2
+	}
+	return 0
 }
 
 // OpenFile opens a file in the LSP server.

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -388,14 +388,35 @@ type OpenFileInfo struct {
 // HandlesFile checks if this LSP client handles the given file based on its
 // extension and whether it's within the working directory.
 func (c *Client) HandlesFile(path string) bool {
+	return c.MatchScore(path) > 0
+}
+
+// MatchScore returns how strongly this client claims to handle the given
+// path. Higher scores beat lower scores for tools that must pick a single
+// client (e.g. lsp_references):
+//
+//	0 — outside the client's workspace, or FileTypes is set but doesn't match
+//	1 — inside the workspace and the client has no FileTypes (catch-all)
+//	2 — inside the workspace and FileTypes explicitly names the extension or
+//	    detected language
+//
+// Tools that broadcast to every matching client (e.g. lsp_diagnostics)
+// should keep using HandlesFile, since any non-zero score is "willing".
+func (c *Client) MatchScore(path string) int {
 	if c == nil {
-		return false
+		return 0
 	}
 	if !fsext.HasPrefix(path, c.cwd) {
 		slog.Debug("File outside workspace", "name", c.name, "file", path, "workDir", c.cwd)
-		return false
+		return 0
 	}
-	return handlesFiletype(c.name, c.fileTypes, path)
+	if len(c.fileTypes) == 0 {
+		return 1
+	}
+	if handlesFiletype(c.name, c.fileTypes, path) {
+		return 2
+	}
+	return 0
 }
 
 // OpenFile opens a file in the LSP server.

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -75,6 +75,39 @@ func (s *Manager) Clients() *csync.Map[string, *Client] {
 	return s.clients
 }
 
+// BestClientFor returns the LSP client best suited to handle the given
+// path, preferring clients whose FileTypes explicitly match over
+// clients that act as catch-alls (no FileTypes set). Returns nil when
+// no client is willing to handle the path.
+//
+// Use this from tools that must pick a single client (lsp_references).
+// Tools that broadcast to every willing client (lsp_diagnostics,
+// notifyLSPs) should iterate Clients() directly with HandlesFile.
+//
+// Ties are broken by client name so the choice is deterministic across
+// runs — Go's map iteration order is randomized, and without a tiebreak
+// the same workspace would route to different clients on different
+// invocations.
+func (s *Manager) BestClientFor(path string) *Client {
+	var (
+		best     *Client
+		bestName string
+	)
+	bestScore := 0
+	for name, c := range s.clients.Seq2() {
+		score := c.MatchScore(path)
+		if score == 0 {
+			continue
+		}
+		if score > bestScore || (score == bestScore && (best == nil || name < bestName)) {
+			best = c
+			bestScore = score
+			bestName = name
+		}
+	}
+	return best
+}
+
 // SetCallback sets a callback that is invoked when a new LSP
 // client is successfully started. This allows the coordinator to add LSP tools.
 func (s *Manager) SetCallback(cb func(name string, client *Client)) {

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -77,6 +77,39 @@ func (s *Manager) Clients() *csync.Map[string, *Client] {
 	return s.clients
 }
 
+// BestClientFor returns the LSP client best suited to handle the given
+// path, preferring clients whose FileTypes explicitly match over
+// clients that act as catch-alls (no FileTypes set). Returns nil when
+// no client is willing to handle the path.
+//
+// Use this from tools that must pick a single client (lsp_references).
+// Tools that broadcast to every willing client (lsp_diagnostics,
+// notifyLSPs) should iterate Clients() directly with HandlesFile.
+//
+// Ties are broken by client name so the choice is deterministic across
+// runs — Go's map iteration order is randomized, and without a tiebreak
+// the same workspace would route to different clients on different
+// invocations.
+func (s *Manager) BestClientFor(path string) *Client {
+	var (
+		best     *Client
+		bestName string
+	)
+	bestScore := 0
+	for name, c := range s.clients.Seq2() {
+		score := c.MatchScore(path)
+		if score == 0 {
+			continue
+		}
+		if score > bestScore || (score == bestScore && (best == nil || name < bestName)) {
+			best = c
+			bestScore = score
+			bestName = name
+		}
+	}
+	return best
+}
+
 // SetCallback sets a callback that is invoked when a new LSP
 // client is successfully started. This allows the coordinator to add LSP tools.
 func (s *Manager) SetCallback(cb func(name string, client *Client)) {


### PR DESCRIPTION
Likely fixes #1751.

## Symptom

The reporter has HTML, CSS, JS, and Python LSPs configured. All four
initialize successfully (green badges), but only the CSS LSP is ever
"called" — including when editing Python files. Crush updates and the
Windows→Linux move are red herrings; the routing race is the real cause
and would have always been latent.

## Root cause

`findLSPClient` (`internal/agent/tools/lsp_helpers.go`) picked the first
matching client out of a `csync.Map` iteration:

```go
for c := range lspManager.Clients().Seq() {
    if c.HandlesFile(absPath) {
        client = c
        break
    }
}
```

Two things compound to make this fail:

1. **Empty `FileTypes` is a catch-all.** `handlesFiletype()` returns
   true when `len(fileTypes) == 0`, so a client whose FileTypes ended
   up empty claims every file. That's exactly what happens when a user
   writes `"extensions": [...]` (a key the schema doesn't know about,
   silently dropped during JSON unmarshal) — the field intended to
   scope the LSP gets quietly ignored.
2. **Go map iteration is randomised.** With several catch-all clients
   in `Clients()`, the "winner" of `find()` depends on map order, so
   on the reporter's machine the CSS catch-all consistently won every
   file. That looks like "only CSS is called."

## Fix

Replace first-match-wins with score-based selection.

- `Client.MatchScore(path) int` — `2` for explicit FileTypes match,
  `1` for catch-all (empty FileTypes inside the workspace), `0`
  otherwise. `HandlesFile` becomes `MatchScore > 0`, so broadcast tools
  (`lsp_diagnostics`, `notifyLSPs`) are unchanged.
- `Manager.BestClientFor(path) *Client` — returns the highest-scoring
  client, ties broken by client name so the choice is deterministic.
- `findLSPClient` calls `BestClientFor` instead of the racey loop.

```go
func findLSPClient(lspManager *lsp.Manager, filePath string) *lsp.Client {
	if abs, err := filepath.Abs(filePath); err == nil {
		filePath = abs
	}
	return lspManager.BestClientFor(filePath)
}
```

## Tests

`internal/lsp/best_client_test.go` adds:

- `TestMatchScore` — explicit-match → 2, catch-all → 1, mismatched
  explicit → 0, outside workspace → 0, nil client → 0.
- `TestBestClientForPrefersSpecificMatchOverCatchAll` — repeats the
  assertion 100× to catch any leftover map-order leak.
- `TestBestClientForFallsBackToCatchAll` — when no explicit client
  claims a path, the catch-all still serves it.
- `TestBestClientForReturnsNilWhenNothingHandlesPath`.
- `TestBestClientForDeterministicTiebreak` — equal-specificity ties
  resolve the same way every iteration.

Full `internal/lsp/...` (57 tests) and `internal/agent/...` (507
tests) pass. `go build ./...` and `go vet` are green. Note the repo now
requires Go 1.26.6.

## Scope notes

- This PR changes the *single-client* selection path only, which since
  the `lsp_helpers.go` refactor is one shared function. Every tool that
  resolves a symbol to one client benefits: references, definition,
  rename and call hierarchy. Tools that broadcast to every willing
  client (`lsp_diagnostics`, `notifyLSPs`, `openInLSPs`) keep their
  existing iterate-all behaviour through `HandlesFile`.
- The deeper "extensions vs filetypes" config schema mismatch is a
  separate problem worth fixing (either by aliasing `extensions` to
  `FileTypes` in `LSPConfig`, or by warning when a user-configured LSP
  has empty `FileTypes`). I'd be happy to send that as a follow-up if
  you'd like — it's adjacent but orthogonal, and felt out of scope for
  this PR.
- A complementary PR for a different symptom of the same issue
  (default servers being silently filtered out by missing root markers)
  is in #2749. The two are independent and can land in either order.

