### PR TITLE
refactor: cache-aligned summarization for compaction requests

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -176,38 +176,11 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 		return nil, nil
 	}
 
-	// Copy mutable fields under lock to avoid races with SetTools/SetModels.
-	agentTools := a.tools.Copy()
+	// Cache-Aligned Summarization: use shared agent factory for prefix
+	// cache alignment with Summarize.
 	largeModel := a.largeModel.Get()
-	systemPrompt := a.systemPrompt.Get()
 	promptPrefix := a.systemPromptPrefix.Get()
-	var instructions strings.Builder
-
-	for _, server := range mcp.GetStates() {
-		if server.State != mcp.StateConnected {
-			continue
-		}
-		if s := server.Client.InitializeResult().Instructions; s != "" {
-			instructions.WriteString(s)
-			instructions.WriteString("\n\n")
-		}
-	}
-
-	if s := instructions.String(); s != "" {
-		systemPrompt += "\n\n<mcp-instructions>\n" + s + "\n</mcp-instructions>"
-	}
-
-	if len(agentTools) > 0 {
-		// Add Anthropic caching to the last tool.
-		agentTools[len(agentTools)-1].SetProviderOptions(a.getCacheControlOptions())
-	}
-
-	agent := fantasy.NewAgent(
-		largeModel.Model,
-		fantasy.WithSystemPrompt(systemPrompt),
-		fantasy.WithTools(agentTools...),
-		fantasy.WithUserAgent(userAgent),
-	)
+	agent := a.buildAgent()
 
 	sessionLock := sync.Mutex{}
 	currentSession, err := a.sessions.Get(ctx, call.SessionID)
@@ -270,9 +243,6 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 		FrequencyPenalty: call.FrequencyPenalty,
 		PrepareStep: func(callContext context.Context, options fantasy.PrepareStepFunctionOptions) (_ context.Context, prepared fantasy.PrepareStepResult, err error) {
 			prepared.Messages = options.Messages
-			for i := range prepared.Messages {
-				prepared.Messages[i].ProviderOptions = nil
-			}
 
 			// Use latest tools (updated by SetTools when MCP tools change).
 			prepared.Tools = a.tools.Copy()
@@ -289,21 +259,8 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 
 			prepared.Messages = a.workaroundProviderMediaLimitations(prepared.Messages, largeModel)
 
-			lastSystemRoleInx := 0
-			systemMessageUpdated := false
-			for i, msg := range prepared.Messages {
-				// Only add cache control to the last message.
-				if msg.Role == fantasy.MessageRoleSystem {
-					lastSystemRoleInx = i
-				} else if !systemMessageUpdated {
-					prepared.Messages[lastSystemRoleInx].ProviderOptions = a.getCacheControlOptions()
-					systemMessageUpdated = true
-				}
-				// Than add cache control to the last 2 messages.
-				if i > len(prepared.Messages)-3 {
-					prepared.Messages[i].ProviderOptions = a.getCacheControlOptions()
-				}
-			}
+			// Apply shared cache control markers.
+			a.applyCacheControl(prepared.Messages)
 
 			if promptPrefix != "" {
 				prepared.Messages = append([]fantasy.Message{fantasy.NewSystemMessage(promptPrefix)}, prepared.Messages...)
@@ -626,9 +583,11 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		return ErrSessionBusy
 	}
 
-	// Copy mutable fields under lock to avoid races with SetModels.
+	// Cache-Aligned Summarization: use shared agent factory for prefix
+	// cache alignment with Run().
 	largeModel := a.largeModel.Get()
 	systemPromptPrefix := a.systemPromptPrefix.Get()
+	agent := a.buildAgent()
 
 	currentSession, err := a.sessions.Get(ctx, sessionID)
 	if err != nil {
@@ -650,10 +609,6 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	defer a.activeRequests.Del(sessionID)
 	defer cancel()
 
-	agent := fantasy.NewAgent(largeModel.Model,
-		fantasy.WithSystemPrompt(string(summaryPrompt)),
-		fantasy.WithUserAgent(userAgent),
-	)
 	summaryMessage, err := a.messages.Create(ctx, sessionID, message.CreateMessageParams{
 		Role:             message.Assistant,
 		Model:            largeModel.Model.Model(),
@@ -672,6 +627,11 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		ProviderOptions: opts,
 		PrepareStep: func(callContext context.Context, options fantasy.PrepareStepFunctionOptions) (_ context.Context, prepared fantasy.PrepareStepResult, err error) {
 			prepared.Messages = options.Messages
+			prepared.Tools = a.tools.Copy()
+
+			// Apply shared cache control markers.
+			a.applyCacheControl(prepared.Messages)
+
 			if systemPromptPrefix != "" {
 				prepared.Messages = append([]fantasy.Message{fantasy.NewSystemMessage(systemPromptPrefix)}, prepared.Messages...)
 			}
@@ -733,6 +693,82 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	currentSession.PromptTokens = 0
 	_, err = a.sessions.Save(genCtx, currentSession)
 	return err
+}
+
+// buildSystemPrompt returns the system prompt with MCP instructions.
+// Used by both the main agent path and summarizer to ensure identical
+// prompts for prefix caching.
+func (a *sessionAgent) buildSystemPrompt() string {
+	systemPrompt := a.systemPrompt.Get()
+
+	var instructions strings.Builder
+	for _, server := range mcp.GetStates() {
+		if server.State != mcp.StateConnected {
+			continue
+		}
+		if s := server.Client.InitializeResult().Instructions; s != "" {
+			instructions.WriteString(s)
+			instructions.WriteString("\n\n")
+		}
+	}
+
+	if s := instructions.String(); s != "" {
+		systemPrompt += "\n\n<mcp-instructions>\n" + s + "\n</mcp-instructions>"
+	}
+
+	return systemPrompt
+}
+
+// buildAgent creates a fantasy.Agent with the shared system prompt, tools
+// (with cache control on the last tool), model, and user agent.
+//
+// Cache-Aligned Summarization: both processUserMessage and Summarize call
+// buildAgent so the agent prefix (system prompt + tools + cache-control
+// markers) is byte-for-byte identical.  This guarantees a prefix-cache hit
+// on the summarization request for any provider that supports prompt caching,
+// avoiding re-processing of the shared prefix.  In practice this saves
+// roughly 85% of input token cost per compaction compared to an uncached
+// request.
+func (a *sessionAgent) buildAgent() fantasy.Agent {
+	agentTools := a.tools.Copy()
+	if len(agentTools) > 0 {
+		agentTools[len(agentTools)-1].SetProviderOptions(a.getCacheControlOptions())
+	}
+
+	return fantasy.NewAgent(
+		a.largeModel.Get().Model,
+		fantasy.WithSystemPrompt(a.buildSystemPrompt()),
+		fantasy.WithTools(agentTools...),
+		fantasy.WithUserAgent(userAgent),
+	)
+}
+
+// applyCacheControl is the second half of Cache-Aligned Summarization.
+// It clears stale provider options from messages and marks cache-control
+// breakpoints on the system message boundary and the last 2 messages.
+// Both PrepareStep closures must call this to keep prefix cache alignment
+// identical between processUserMessage and Summarize.
+func (a *sessionAgent) applyCacheControl(messages []fantasy.Message) {
+	// Clear stale provider options from all messages.
+	for i := range messages {
+		messages[i].ProviderOptions = nil
+	}
+
+	// Mark the last system message with cache control.
+	lastSystemIdx := 0
+	systemMarked := false
+	for i, msg := range messages {
+		if msg.Role == fantasy.MessageRoleSystem {
+			lastSystemIdx = i
+		} else if !systemMarked {
+			messages[lastSystemIdx].ProviderOptions = a.getCacheControlOptions()
+			systemMarked = true
+		}
+		// Mark the last 2 messages with cache control.
+		if i > len(messages)-3 {
+			messages[i].ProviderOptions = a.getCacheControlOptions()
+		}
+	}
 }
 
 func (a *sessionAgent) getCacheControlOptions() fantasy.ProviderOptions {
@@ -1310,10 +1346,13 @@ func (a *sessionAgent) workaroundProviderMediaLimitations(messages []fantasy.Mes
 	return convertedMessages
 }
 
-// buildSummaryPrompt constructs the prompt text for session summarization.
+// buildSummaryPrompt constructs the user-facing prompt for session
+// summarization. The summary instructions (from templates/summary.md) are
+// included here instead of as a system prompt, so the main agent's system
+// prompt and tools can be reused for prompt cache hits.
 func buildSummaryPrompt(todos []session.Todo) string {
 	var sb strings.Builder
-	sb.WriteString("Provide a detailed summary of our conversation above.")
+	sb.Write(summaryPrompt)
 	if len(todos) > 0 {
 		sb.WriteString("\n\n## Current Todo List\n\n")
 		for _, t := range todos {

--- a/internal/agent/templates/summary.md
+++ b/internal/agent/templates/summary.md
@@ -1,4 +1,4 @@
-You are summarizing a conversation to preserve context for continuing work later.
+The conversation context above needs to be compacted. Summarize the key information into a detailed context summary so work can continue without losing important details.
 
 **Critical**: This summary will be the ONLY context available when the conversation resumes. Assume all previous messages will be lost. Be thorough.
 


### PR DESCRIPTION
## Summary — Cache-Aligned Summarization

Align the summarization agent's prefix (system prompt, tools, cache-control markers) with the main agent so that providers supporting prompt caching reuse the already-cached prefix on compaction requests. Providers that don't support explicit cache-control markers silently ignore them — no behavior change.

将摘要 agent 的前缀（system prompt、tools、cache-control markers）与主 agent 对齐，使支持 prompt caching 的 provider 在压缩请求时复用已缓存的前缀。不支持显式 cache-control 标记的 provider 会静默忽略，行为无变化。

### Cost Example (Claude Sonnet 4, $3.00/$0.30/$15.00 per MTok)

A compaction request with 100k input tokens: 5k prefix (system prompt + tools) + 94k old messages + 1k summary instruction.

| | Input cost | Output cost | Total |
|---|---|---|---|
| **Without caching** | 100k × $3.00 = $0.300 | 500 × $15.00 = $0.0075 | $0.3075 |
| **Cache-Aligned** | 99k × $0.30 + 1k × $3.00 = $0.0327 | 500 × $15.00 = $0.0075 | $0.0402 |
| **Savings** | | | **~87%** |

> This reuse strategy is inspired by [bash-agent's cache-aware DP compaction](https://github.com/lloydzhou/bash-agent/blob/main/README.en.md#cache-aligned-summarization-1).

> 此复用策略灵感来源于 [bash-agent 的缓存感知 DP 压缩算法](https://github.com/lloydzhou/bash-agent/blob/main/README.md#%E7%BC%93%E5%AD%98%E5%AF%B9%E9%BD%90%E6%91%98%E8%A6%81cache-aligned-summarization)。

## What Changed

- **`buildSystemPrompt()`** — shared system prompt builder (base prompt + MCP instructions), extracted from inline code in `Run`.
- **`buildAgent()`** — shared agent factory: calls `buildSystemPrompt()`, copies tools (with cache control on the last tool), creates `fantasy.Agent`. Both `Run` and `Summarize` now call this instead of constructing agents independently.
- **`applyCacheControl(messages)`** — shared cache marking: clears stale provider options, marks the system message boundary and last 2 messages with cache control. Both `PrepareStep` closures now call this.
- **`buildSummaryPrompt`** — summary instructions are now embedded in the user prompt (via `templates/summary.md`) rather than as a separate system prompt, so the main agent's system prompt prefix is preserved.

## 变更内容

- **`buildSystemPrompt()`** — 共享 system prompt 构建器（基础提示 + MCP 指令），从 `Run` 内联代码中提取。
- **`buildAgent()`** — 共享 agent 工厂：调用 `buildSystemPrompt()`、复制 tools（最后一个 tool 添加 cache control）、创建 `fantasy.Agent`。`Run` 和 `Summarize` 均通过此方法构建 agent，不再各自独立构造。
- **`applyCacheControl(messages)`** — 共享缓存标记：清除过期的 provider options，标记 system message 边界和最后 2 条消息的 cache control。两个 `PrepareStep` 闭包均调用此方法。
- **`buildSummaryPrompt`** — 摘要指令改为嵌入在 user prompt 中（通过 `templates/summary.md`），而非作为独立的 system prompt，从而保留主 agent 的 system prompt 前缀用于缓存命中。