### PR TITLE
fix(bedrock): accept cross-region inference profile model IDs

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -298,7 +298,15 @@ func (c *Config) configureProviders(store *ConfigStore, env env.Env, resolver Va
 				prepared.ExtraParams["region"] = env.Get("AWS_DEFAULT_REGION")
 			}
 			for _, model := range p.Models {
-				if !strings.HasPrefix(model.ID, "anthropic.") {
+				// Strip optional cross-region inference profile prefix (e.g.
+				// "us.", "eu.", "apac.", "us-gov.") before checking the model
+				// family. Claude 4.x on Bedrock is only available through these
+				// inference profiles.
+				id := model.ID
+				for _, prefix := range []string{"us.", "eu.", "apac.", "us-gov."} {
+					id = strings.TrimPrefix(id, prefix)
+				}
+				if !strings.HasPrefix(id, "anthropic.") {
 					return fmt.Errorf("bedrock provider only supports anthropic models for now, found: %s", model.ID)
 				}
 			}


### PR DESCRIPTION
## Summary

The Bedrock provider loader in `internal/config/load.go` rejects any model ID that does not start with `anthropic.`. Cross-region inference profile IDs (`us.anthropic.*`, `eu.anthropic.*`, `apac.anthropic.*`, `us-gov.anthropic.*`) fail that check, which makes crush unusable with Claude 4.x on Bedrock: those models are only available via cross-region inference profiles — on-demand throughput is not offered.

Observed error with a custom Bedrock provider using `us.anthropic.claude-opus-4-7`:

```
Failed to configure providers: bedrock provider only supports anthropic models for now, found: us.anthropic.claude-opus-4-7
```

This PR strips the optional regional inference-profile prefix before checking the model family, so both plain `anthropic.*` IDs and inference-profile IDs are accepted.

Relevant AWS docs:
- Cross-region inference: https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
- Supported inference profiles: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html

## Test plan

- [x] `go build ./...` passes
- [x] Configured custom Bedrock provider with `id: "us.anthropic.claude-opus-4-7"`
- [x] crush starts with no provider-configuration error
- [x] `crush run "Reply with exactly: PONG"` completes a full round-trip against Bedrock (`AWS_PROFILE=...` / `AWS_REGION=us-east-1`)
- [x] Existing `anthropic.*` IDs still validate (prefix strip is a no-op when no regional prefix is present)