### PR TITLE
fix: group header hidden on wrap-to-first after scrolling to bottom in model selector

### DIFF
--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -179,6 +179,7 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 			m.list.Focus()
 			if m.list.IsSelectedLast() {
 				m.list.SelectFirst()
+				m.list.ScrollToTop()
 			} else {
 				m.list.SelectNext()
 			}


### PR DESCRIPTION
# Issue: When pressing ↓ on the last model in the model selector, the list wraps to the beginning but the first group header (provider title) disappears from view.

Root Cause:

  items = [GroupHeader@0, ModelA@1, ModelB@2, Spacer@3, GroupHeader@4, ModelC@5, Spacer@6]
                                                          ↑ selected (last model)

The wrap call chain:

1.  ModelsList.SelectFirst()  →  List.SelectFirst()  sets  selectedIdx=0  (GroupHeader),
then loops skipping non- *ModelItem , ending at  selectedIdx=1  (first model)
2.  ScrollToSelected()  → finds  selectedIdx(1) < offsetIdx  (offset was still near the
bottom from prior scroll), sets  offsetIdx = 1
3. Rendering starts from  items[1]  → items[0] (GroupHeader) is clipped out of the
viewport

Fix: Add  ScrollToTop()  after  SelectFirst()  to reset  offsetIdx  to 0, bringing the
group header back into view.  ScrollToSelected()  then finds the selected index already
visible and makes no further adjustments.
