### PR TITLE
fix(ui): include cancelled prompts in arrow-up history

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -157,6 +157,10 @@ type (
 	creditsUpdatedMsg struct {
 		credits int
 	}
+
+	// agentRunCompleteMsg is sent when an agent run finishes (normally or via
+	// cancellation) so that prompt history can be refreshed.
+	agentRunCompleteMsg struct{}
 )
 
 // UI represents the main user interface model.
@@ -585,6 +589,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.promptHistory.messages = msg.messages
 		m.promptHistory.index = -1
 		m.promptHistory.draft = ""
+
+	case agentRunCompleteMsg:
+		cmds = append(cmds, m.loadPromptHistory())
 
 	case closeDialogMsg:
 		m.dialog.CloseFrontDialog()
@@ -3156,14 +3163,14 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 		if err != nil {
 			isCancelErr := errors.Is(err, context.Canceled)
 			if isCancelErr {
-				return nil
+				return agentRunCompleteMsg{}
 			}
 			return util.InfoMsg{
 				Type: util.InfoTypeError,
 				Msg:  fmt.Sprintf("%v", err),
 			}
 		}
-		return nil
+		return agentRunCompleteMsg{}
 	})
 	return tea.Batch(cmds...)
 }


### PR DESCRIPTION
## Description

Fixes #2771.

Submitting a command and cancelling it before the agent yields back causes the command to be absent from arrow-up history.  It appears correctly in the chat view, but pressing up in the input box skips it entirely.
                                                                                             

Cause: When a command is submitted, `loadPromptHistory()` runs concurrently with the agent goroutine and completes before the agent saves the user message to DB via `createUserMessage`. This means the just-submitted command is never in the in-memory arrow-up history. 

For a normal (non-cancelled) completion, users naturally type a follow-up command, which triggers another                 `loadPromptHistory()` call that now picks up the previous one. For a cancelled run, no such reload is triggered, so the
  command stays invisible in arrow-up history for the rest of the session.

Fix:
Three changes in `internal/ui/model/ui.go`:

1. New message type `agentRunCompleteMsg{}` signalling that the agent goroutine has finished (either via successful completion or cancellation).
2. The `sendMessage` goroutine now returns `agentRunCompleteMsg{}` instead of `nil` on both completion paths (`isCancelErr` and normal completion).
3. `Update` handles `agentRunCompleteMsg` by calling `loadPromptHistory()`. By the time this fires, `createUserMessage`  in `internal/agent/agent.go` has already written the message to the DB (it is invoked at line 234, before cancellation wiring at line 243), so the reload reliably includes the just-submitted prompt.

## Before                                                                                           
  1. Type any command and submit
  2. Double-press Esc to cancel before the agent finishes                                                                     
  3. Press up arrow 
  4. **Bug:** the cancelled prompt is missing from arrow-up history.

## After
Same steps; the cancelled prompt now appears as the most recent entry.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
