### PR TITLE
fix(tools/view): honor limit parameter on files exceeding MaxViewSize

### DIFF
--- a/internal/agent/tools/view.go
+++ b/internal/agent/tools/view.go
@@ -162,7 +162,8 @@ func NewViewTool(
 			}
 
 			// Based on the specifications we should not limit the skills read.
-			if !isSkillFile && fileInfo.Size() > MaxViewSize {
+			// Only block if no limit is set.
+			if !isSkillFile && params.Limit <= 0 && fileInfo.Size() > MaxViewSize {
 				return fantasy.NewTextErrorResponse(fmt.Sprintf("File is too large (%d bytes). Maximum size is %d bytes",
 					fileInfo.Size(), MaxViewSize)), nil
 			}


### PR DESCRIPTION
## Description

Fixes #2756.

The `view` tool refuses to read any file larger than `MaxViewSize` (100 KB), even when the caller passes an explicit `limit` parameter to read only a small portion. As a result, large files are completely unreadable, the agent receives "File is too large" regardless of how small a slice it asked for.

## Cause

In `internal/agent/tools/view.go`, the size check runs before `params.Limit` is consulted:

```go
if !isSkillFile && fileInfo.Size() > MaxViewSize {
    return fantasy.NewTextErrorResponse(...)
}

if params.Limit <= 0 {
    // apply default limit
}
```

There is no path where an explicit `limit` bypasses the size limit.

## Fix

Added `params.Limit <= 0` to the size guard condition so it only blocks when no limit is specified. When a limit is provided, the guard is skipped and `readTextFile` handles the bounded read as normal.

```go                                                                                                                       
  // before       
  if !isSkillFile && fileInfo.Size() > MaxViewSize {

  // after
  if !isSkillFile && params.Limit <= 0 && fileInfo.Size() > MaxViewSize {
```

## Tests
### Before

1. Create a file larger than 100 KB:
```
{ echo "package fake"; for i in $(seq 1 15000); do echo "// line $i"; done; } > /tmp/big.go
```
2. Run `crush` and ask: *"Use the View tool on /tmp/big.go with limit=20."*
3. **Bug:** error `File is too large ( 198907 bytes). Maximum size is 102400 bytes`.

### After

Same steps, first 20 lines are returned.

### Verified Locally
- Large file with explicit `limit`, reads up to `limit` lines.
- Large file with no `limit`, rejects with error (unchanged).
- Small file with `limit`, reads with no error (unchanged).
- Small file with no `limit`, reads with no error (unchanged).
- Skill file , reads regardless of size or limit (unchanged).

> No new test added. Manual reproduction above confirms the fix and the existing test suite in `view_test.go` passes unchanged.

## Checklist
- [x] `go test -race -failfast ./...` passes
- [x] `gofumpt -w .` clean
- [x] `golangci-lint run` clean
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
