### PR TITLE
fix: reorder tool results in preparePrompt for strict adjacency providers

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -786,6 +786,7 @@ If not, please feel free to ignore. Again do not mention this message to the use
 	// without a result).
 	knownToolCallIDs := make(map[string]struct{})
 	knownToolResultIDs := make(map[string]struct{})
+	tcToResultMsgs := make(map[string][]message.Message)
 	for _, m := range msgs {
 		switch m.Role {
 		case message.Assistant:
@@ -795,11 +796,19 @@ If not, please feel free to ignore. Again do not mention this message to the use
 		case message.Tool:
 			for _, tr := range m.ToolResults() {
 				knownToolResultIDs[tr.ToolCallID] = struct{}{}
+				tcToResultMsgs[tr.ToolCallID] = append(tcToResultMsgs[tr.ToolCallID], m)
 			}
 		}
 	}
 
+	// Track which result messages have been proactively placed after their
+	// assistant, so we skip them when they appear later in the stream.
+	placedResults := make(map[string]bool)
+
 	for _, m := range msgs {
+		if placedResults[m.ID] {
+			continue
+		}
 		if len(m.Parts) == 0 {
 			continue
 		}
@@ -810,14 +819,15 @@ If not, please feel free to ignore. Again do not mention this message to the use
 		if m.Role == message.Tool {
 			if msg, ok := filterOrphanedToolResults(m, knownToolCallIDs); ok {
 				history = append(history, msg)
+				placedResults[m.ID] = true
 			}
 			continue
 		}
 		history = append(history, m.ToAIMessage()...)
 
 		if m.Role == message.Assistant {
-			if msg, ok := syntheticToolResultsForOrphanedCalls(m, knownToolResultIDs); ok {
-				history = append(history, msg)
+			if results, ok := buildToolResultsForCalls(m, tcToResultMsgs, placedResults); ok {
+				history = append(history, results...)
 			}
 		}
 	}
@@ -835,6 +845,48 @@ If not, please feel free to ignore. Again do not mention this message to the use
 	}
 
 	return history, files
+}
+
+// buildToolResultsForCalls returns tool result messages for the tool calls
+// in the given assistant message. Real results are taken from tcToResultMsgs
+// and marked as placed. Tool calls with no result at all receive a synthetic
+// error result so strict-adjacency providers (e.g. DeepSeek) don't reject the
+// turn. Returns the messages to append and true if any were produced.
+func buildToolResultsForCalls(m message.Message, tcToResultMsgs map[string][]message.Message, placedResults map[string]bool) ([]fantasy.Message, bool) {
+	toolCalls := m.ToolCalls()
+	if len(toolCalls) == 0 {
+		return nil, false
+	}
+	var results []fantasy.Message
+	var syntheticParts []fantasy.MessagePart
+	for _, tc := range toolCalls {
+		if resultMsgs, hasResults := tcToResultMsgs[tc.ID]; hasResults {
+			for _, rm := range resultMsgs {
+				if !placedResults[rm.ID] {
+					results = append(results, rm.ToAIMessage()...)
+					placedResults[rm.ID] = true
+				}
+			}
+		} else {
+			slog.Warn("Injecting synthetic tool result for orphaned tool call",
+				"tool_call_id", tc.ID,
+				"tool_name", tc.Name,
+			)
+			syntheticParts = append(syntheticParts, fantasy.ToolResultPart{
+				ToolCallID: tc.ID,
+				Output: fantasy.ToolResultOutputContentError{
+					Error: errors.New("tool call was interrupted and did not produce a result, you may retry this call if the result is still needed"),
+				},
+			})
+		}
+	}
+	if len(syntheticParts) > 0 {
+		results = append(results, fantasy.Message{
+			Role:    fantasy.MessageRoleTool,
+			Content: syntheticParts,
+		})
+	}
+	return results, len(results) > 0
 }
 
 // filterOrphanedToolResults converts a tool message to a fantasy.Message,
@@ -868,39 +920,6 @@ func filterOrphanedToolResults(m message.Message, knownToolCallIDs map[string]st
 	msg := aiMsgs[0]
 	msg.Content = validParts
 	return msg, true
-}
-
-// syntheticToolResultsForOrphanedCalls returns a tool message containing
-// synthetic tool results for any tool calls in the assistant message that
-// have no matching result in knownToolResultIDs. LLM APIs require every
-// tool_use to be immediately followed by a tool_result; an interrupted
-// session can leave orphaned tool_use blocks that permanently lock the
-// conversation. Returns the message and true if any synthetic results were
-// produced.
-func syntheticToolResultsForOrphanedCalls(m message.Message, knownToolResultIDs map[string]struct{}) (fantasy.Message, bool) {
-	var syntheticParts []fantasy.MessagePart
-	for _, tc := range m.ToolCalls() {
-		if _, hasResult := knownToolResultIDs[tc.ID]; hasResult {
-			continue
-		}
-		slog.Warn("Injecting synthetic tool result for orphaned tool call",
-			"tool_call_id", tc.ID,
-			"tool_name", tc.Name,
-		)
-		syntheticParts = append(syntheticParts, fantasy.ToolResultPart{
-			ToolCallID: tc.ID,
-			Output: fantasy.ToolResultOutputContentError{
-				Error: errors.New("tool call was interrupted and did not produce a result, you may retry this call if the result is still needed"),
-			},
-		})
-	}
-	if len(syntheticParts) == 0 {
-		return fantasy.Message{}, false
-	}
-	return fantasy.Message{
-		Role:    fantasy.MessageRoleTool,
-		Content: syntheticParts,
-	}, true
 }
 
 func (a *sessionAgent) getSessionMessages(ctx context.Context, session session.Session) ([]message.Message, error) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1549,6 +1549,7 @@ If not, please feel free to ignore. Again do not mention this message to the use
 	// without a result).
 	knownToolCallIDs := make(map[string]struct{})
 	knownToolResultIDs := make(map[string]struct{})
+	tcToResultMsgs := make(map[string][]message.Message)
 	for _, m := range msgs {
 		switch m.Role {
 		case message.Assistant:
@@ -1558,11 +1559,19 @@ If not, please feel free to ignore. Again do not mention this message to the use
 		case message.Tool:
 			for _, tr := range m.ToolResults() {
 				knownToolResultIDs[tr.ToolCallID] = struct{}{}
+				tcToResultMsgs[tr.ToolCallID] = append(tcToResultMsgs[tr.ToolCallID], m)
 			}
 		}
 	}
 
+	// Track which result messages have been proactively placed after their
+	// assistant, so we skip them when they appear later in the stream.
+	placedResults := make(map[string]bool)
+
 	for _, m := range msgs {
+		if placedResults[m.ID] {
+			continue
+		}
 		if len(m.Parts) == 0 {
 			continue
 		}
@@ -1573,6 +1582,7 @@ If not, please feel free to ignore. Again do not mention this message to the use
 		if m.Role == message.Tool {
 			if msg, ok := filterOrphanedToolResults(m, knownToolCallIDs); ok {
 				history = append(history, msg)
+				placedResults[m.ID] = true
 			}
 			continue
 		}
@@ -1587,8 +1597,8 @@ If not, please feel free to ignore. Again do not mention this message to the use
 		history = append(history, aiMsgs...)
 
 		if m.Role == message.Assistant {
-			if msg, ok := syntheticToolResultsForOrphanedCalls(m, knownToolResultIDs); ok {
-				history = append(history, msg)
+			if results, ok := buildToolResultsForCalls(m, tcToResultMsgs, placedResults); ok {
+				history = append(history, results...)
 			}
 		}
 	}
@@ -1625,6 +1635,48 @@ func filterFileParts(parts []fantasy.MessagePart) []fantasy.MessagePart {
 	return filtered
 }
 
+// buildToolResultsForCalls returns tool result messages for the tool calls
+// in the given assistant message. Real results are taken from tcToResultMsgs
+// and marked as placed. Tool calls with no result at all receive a synthetic
+// error result so strict-adjacency providers (e.g. DeepSeek) don't reject the
+// turn. Returns the messages to append and true if any were produced.
+func buildToolResultsForCalls(m message.Message, tcToResultMsgs map[string][]message.Message, placedResults map[string]bool) ([]fantasy.Message, bool) {
+	toolCalls := m.ToolCalls()
+	if len(toolCalls) == 0 {
+		return nil, false
+	}
+	var results []fantasy.Message
+	var syntheticParts []fantasy.MessagePart
+	for _, tc := range toolCalls {
+		if resultMsgs, hasResults := tcToResultMsgs[tc.ID]; hasResults {
+			for _, rm := range resultMsgs {
+				if !placedResults[rm.ID] {
+					results = append(results, rm.ToAIMessage()...)
+					placedResults[rm.ID] = true
+				}
+			}
+		} else {
+			slog.Warn("Injecting synthetic tool result for orphaned tool call",
+				"tool_call_id", tc.ID,
+				"tool_name", tc.Name,
+			)
+			syntheticParts = append(syntheticParts, fantasy.ToolResultPart{
+				ToolCallID: tc.ID,
+				Output: fantasy.ToolResultOutputContentError{
+					Error: errors.New("tool call was interrupted and did not produce a result, you may retry this call if the result is still needed"),
+				},
+			})
+		}
+	}
+	if len(syntheticParts) > 0 {
+		results = append(results, fantasy.Message{
+			Role:    fantasy.MessageRoleTool,
+			Content: syntheticParts,
+		})
+	}
+	return results, len(results) > 0
+}
+
 // filterOrphanedToolResults converts a tool message to a fantasy.Message,
 // dropping any tool result parts whose tool_call_id has no matching tool call
 // in the known set. An orphaned result causes API validation to fail on every
@@ -1657,40 +1709,6 @@ func filterOrphanedToolResults(m message.Message, knownToolCallIDs map[string]st
 	msg := aiMsgs[0]
 	msg.Content = validParts
 	return msg, true
-}
-
-// syntheticToolResultsForOrphanedCalls returns a tool message containing
-// synthetic tool results for any tool calls in the assistant message that
-// have no matching result in knownToolResultIDs. LLM APIs require every
-// tool_use to be immediately followed by a tool_result; an interrupted
-// session can leave orphaned tool_use blocks that permanently lock the
-// conversation. Returns the message and true if any synthetic results were
-// produced.
-func syntheticToolResultsForOrphanedCalls(m message.Message, knownToolResultIDs map[string]struct{}) (fantasy.Message, bool) {
-	var syntheticParts []fantasy.MessagePart
-	for _, tc := range m.ToolCalls() {
-		if _, hasResult := knownToolResultIDs[tc.ID]; hasResult {
-			continue
-		}
-		slog.Warn(
-			"Injecting synthetic tool result for orphaned tool call",
-			"tool_call_id", tc.ID,
-			"tool_name", tc.Name,
-		)
-		syntheticParts = append(syntheticParts, fantasy.ToolResultPart{
-			ToolCallID: tc.ID,
-			Output: fantasy.ToolResultOutputContentError{
-				Error: errors.New("tool call was interrupted and did not produce a result, you may retry this call if the result is still needed"),
-			},
-		})
-	}
-	if len(syntheticParts) == 0 {
-		return fantasy.Message{}, false
-	}
-	return fantasy.Message{
-		Role:    fantasy.MessageRoleTool,
-		Content: syntheticParts,
-	}, true
 }
 
 func (a *sessionAgent) getSessionMessages(ctx context.Context, session session.Session) ([]message.Message, error) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -795,6 +795,186 @@ func TestPreparePrompt_OrphanedToolUseMixed(t *testing.T) {
 	require.Equal(t, 1, syntheticCount, "expected exactly one synthetic result for the orphaned call")
 }
 
+func TestPreparePrompt_NonAdjacentToolResults(t *testing.T) {
+	// Tests that preparePrompt reorders tool results to be immediately
+	// after their assistant message, even when DB ordering has interleaved
+	// messages between the call and its result.
+	env := testEnv(t)
+	sa := testSessionAgent(env, nil, nil, "test prompt")
+	agent := sa.(*sessionAgent)
+
+	ctx := t.Context()
+	sess, err := env.sessions.Create(ctx, "test")
+	require.NoError(t, err)
+
+	// User message
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "run commands"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Assistant with 2 tool calls: call_A and call_B
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.ToolCall{
+				ID:       "call_A",
+				Name:     "bash",
+				Input:    `{"command":"date"}`,
+				Finished: true,
+			},
+			message.ToolCall{
+				ID:       "call_B",
+				Name:     "bash",
+				Input:    `{"command":"uptime"}`,
+				Finished: true,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Simulate interleaving: a user message appears BEFORE tool results.
+	// This can happen when sub-agents or error recovery paths write
+	// messages concurrently with PrepareStep.
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "are we done?"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Results for call_A and call_B arrive LATE — after the interleaved user.
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.Tool,
+		Parts: []message.ContentPart{
+			message.ToolResult{
+				ToolCallID: "call_A",
+				Name:       "bash",
+				Content:    "Fri May 2 21:00:00 UTC 2026",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.Tool,
+		Parts: []message.ContentPart{
+			message.ToolResult{
+				ToolCallID: "call_B",
+				Name:       "bash",
+				Content:    "21:00  up 3 days",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	msgs, err := env.messages.List(ctx, sess.ID)
+	require.NoError(t, err)
+
+	// Verify DB ordering has the interleaving: user at pos 2, results at 3 and 4
+	require.Equal(t, message.User, msgs[2].Role, "interleaved user should be between assistant and results")
+
+	history, _ := agent.preparePrompt(msgs)
+
+	// After preparePrompt, tool results MUST be immediately after their assistant.
+	// Find the assistant with call_A and verify the next message is a tool result.
+	var assistantIdx int
+	for i, msg := range history {
+		if msg.Role != fantasy.MessageRoleAssistant {
+			continue
+		}
+		for _, part := range msg.Content {
+			if tc, ok := fantasy.AsMessagePart[fantasy.ToolCallPart](part); ok && tc.ToolCallID == "call_A" {
+				assistantIdx = i
+				break
+			}
+		}
+		if assistantIdx > 0 {
+			break
+		}
+	}
+	require.Greater(t, assistantIdx, 0, "should find assistant with call_A")
+
+	// The message immediately after the assistant must be a tool result,
+	// NOT the interleaved user message.
+	require.Equal(t, fantasy.MessageRoleTool, history[assistantIdx+1].Role,
+		"after assistant with tool_calls, next message must be tool (not user)")
+
+	// Both call_A and call_B results must be found in tool messages
+	// immediately following the assistant.
+	foundCallA, foundCallB := false, false
+	for i := assistantIdx + 1; i < len(history) && i <= assistantIdx+3; i++ {
+		if history[i].Role != fantasy.MessageRoleTool {
+			break
+		}
+		for _, part := range history[i].Content {
+			if tr, ok := fantasy.AsMessagePart[fantasy.ToolResultPart](part); ok {
+				switch tr.ToolCallID {
+				case "call_A":
+					foundCallA = true
+				case "call_B":
+					foundCallB = true
+				}
+			}
+		}
+	}
+	require.True(t, foundCallA, "result for call_A must be adjacent to its assistant")
+	require.True(t, foundCallB, "result for call_B must be adjacent to its assistant")
+}
+
+func TestPreparePrompt_ResultBeforeAssistant(t *testing.T) {
+	// Tests that when DB ordering has a tool result BEFORE its assistant
+	// (e.g. from concurrent writes), the result is not duplicated.
+	t.Parallel()
+	env := testEnv(t)
+	sa := testSessionAgent(env, nil, nil, "test prompt")
+	agent := sa.(*sessionAgent)
+
+	ctx := t.Context()
+	sess, err := env.sessions.Create(ctx, "test")
+	require.NoError(t, err)
+
+	// Result arrives BEFORE assistant in DB order.
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.Tool,
+		Parts: []message.ContentPart{
+			message.ToolResult{ToolCallID: "call_X", Name: "bash", Content: "result"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.ToolCall{ID: "call_X", Name: "bash", Input: `{}`, Finished: true},
+		},
+	})
+	require.NoError(t, err)
+
+	msgs, err := env.messages.List(ctx, sess.ID)
+	require.NoError(t, err)
+
+	history, _ := agent.preparePrompt(msgs)
+
+	// Count occurrences of call_X result in history.
+	resultCount := 0
+	for _, msg := range history {
+		if msg.Role != fantasy.MessageRoleTool {
+			continue
+		}
+		for _, part := range msg.Content {
+			if tr, ok := fantasy.AsMessagePart[fantasy.ToolResultPart](part); ok && tr.ToolCallID == "call_X" {
+				resultCount++
+			}
+		}
+	}
+	require.Equal(t, 1, resultCount, "result must not be duplicated")
+}
+
 func TestProviderRetryLogFields(t *testing.T) {
 	t.Run("nil provider error", func(t *testing.T) {
 		fields := providerRetryLogFields(nil, 2*time.Second)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -893,6 +893,186 @@ func TestPreparePrompt_OrphanedToolUseMixed(t *testing.T) {
 	require.Equal(t, 1, syntheticCount, "expected exactly one synthetic result for the orphaned call")
 }
 
+func TestPreparePrompt_NonAdjacentToolResults(t *testing.T) {
+	// Tests that preparePrompt reorders tool results to be immediately
+	// after their assistant message, even when DB ordering has interleaved
+	// messages between the call and its result.
+	env := testEnv(t)
+	sa := testSessionAgent(env, nil, nil, "test prompt")
+	agent := sa.(*sessionAgent)
+
+	ctx := t.Context()
+	sess, err := env.sessions.Create(ctx, "test")
+	require.NoError(t, err)
+
+	// User message
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "run commands"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Assistant with 2 tool calls: call_A and call_B
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.ToolCall{
+				ID:       "call_A",
+				Name:     "bash",
+				Input:    `{"command":"date"}`,
+				Finished: true,
+			},
+			message.ToolCall{
+				ID:       "call_B",
+				Name:     "bash",
+				Input:    `{"command":"uptime"}`,
+				Finished: true,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// Simulate interleaving: a user message appears BEFORE tool results.
+	// This can happen when sub-agents or error recovery paths write
+	// messages concurrently with PrepareStep.
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "are we done?"},
+		},
+	})
+	require.NoError(t, err)
+
+	// Results for call_A and call_B arrive LATE — after the interleaved user.
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.Tool,
+		Parts: []message.ContentPart{
+			message.ToolResult{
+				ToolCallID: "call_A",
+				Name:       "bash",
+				Content:    "Fri May 2 21:00:00 UTC 2026",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.Tool,
+		Parts: []message.ContentPart{
+			message.ToolResult{
+				ToolCallID: "call_B",
+				Name:       "bash",
+				Content:    "21:00  up 3 days",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	msgs, err := env.messages.List(ctx, sess.ID)
+	require.NoError(t, err)
+
+	// Verify DB ordering has the interleaving: user at pos 2, results at 3 and 4
+	require.Equal(t, message.User, msgs[2].Role, "interleaved user should be between assistant and results")
+
+	history, _ := agent.preparePrompt(msgs, false)
+
+	// After preparePrompt, tool results MUST be immediately after their assistant.
+	// Find the assistant with call_A and verify the next message is a tool result.
+	var assistantIdx int
+	for i, msg := range history {
+		if msg.Role != fantasy.MessageRoleAssistant {
+			continue
+		}
+		for _, part := range msg.Content {
+			if tc, ok := fantasy.AsMessagePart[fantasy.ToolCallPart](part); ok && tc.ToolCallID == "call_A" {
+				assistantIdx = i
+				break
+			}
+		}
+		if assistantIdx > 0 {
+			break
+		}
+	}
+	require.Greater(t, assistantIdx, 0, "should find assistant with call_A")
+
+	// The message immediately after the assistant must be a tool result,
+	// NOT the interleaved user message.
+	require.Equal(t, fantasy.MessageRoleTool, history[assistantIdx+1].Role,
+		"after assistant with tool_calls, next message must be tool (not user)")
+
+	// Both call_A and call_B results must be found in tool messages
+	// immediately following the assistant.
+	foundCallA, foundCallB := false, false
+	for i := assistantIdx + 1; i < len(history) && i <= assistantIdx+3; i++ {
+		if history[i].Role != fantasy.MessageRoleTool {
+			break
+		}
+		for _, part := range history[i].Content {
+			if tr, ok := fantasy.AsMessagePart[fantasy.ToolResultPart](part); ok {
+				switch tr.ToolCallID {
+				case "call_A":
+					foundCallA = true
+				case "call_B":
+					foundCallB = true
+				}
+			}
+		}
+	}
+	require.True(t, foundCallA, "result for call_A must be adjacent to its assistant")
+	require.True(t, foundCallB, "result for call_B must be adjacent to its assistant")
+}
+
+func TestPreparePrompt_ResultBeforeAssistant(t *testing.T) {
+	// Tests that when DB ordering has a tool result BEFORE its assistant
+	// (e.g. from concurrent writes), the result is not duplicated.
+	t.Parallel()
+	env := testEnv(t)
+	sa := testSessionAgent(env, nil, nil, "test prompt")
+	agent := sa.(*sessionAgent)
+
+	ctx := t.Context()
+	sess, err := env.sessions.Create(ctx, "test")
+	require.NoError(t, err)
+
+	// Result arrives BEFORE assistant in DB order.
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.Tool,
+		Parts: []message.ContentPart{
+			message.ToolResult{ToolCallID: "call_X", Name: "bash", Content: "result"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.ToolCall{ID: "call_X", Name: "bash", Input: `{}`, Finished: true},
+		},
+	})
+	require.NoError(t, err)
+
+	msgs, err := env.messages.List(ctx, sess.ID)
+	require.NoError(t, err)
+
+	history, _ := agent.preparePrompt(msgs, false)
+
+	// Count occurrences of call_X result in history.
+	resultCount := 0
+	for _, msg := range history {
+		if msg.Role != fantasy.MessageRoleTool {
+			continue
+		}
+		for _, part := range msg.Content {
+			if tr, ok := fantasy.AsMessagePart[fantasy.ToolResultPart](part); ok && tr.ToolCallID == "call_X" {
+				resultCount++
+			}
+		}
+	}
+	require.Equal(t, 1, resultCount, "result must not be duplicated")
+}
+
 func TestWorkaroundProviderMediaLimitations_TextOnlyModel(t *testing.T) {
 	env := testEnv(t)
 	sa := testSessionAgent(env, nil, nil, "test prompt")


### PR DESCRIPTION
## Summary

Providers requiring strict `tool_call` → `tool_result` adjacency (DeepSeek) reject prompts when a non-tool message lands between an assistant with `tool_calls` and its tool results in DB order. `preparePrompt` previously emitted messages in DB order, preserving the gap.

This PR introduces a pre-scan + proactive placement pass: when an assistant with tool calls is emitted, its results are immediately placed after it, regardless of where they sit in the DB.

## Problem
Fixes #2780 

## Approaches Considered and Rejected

### Write-time prevention (lock the session)

Block writes to a session while any tool call is in-flight. Queue user messages until all results arrive.

**Rejected**: session resume is legitimate (checking progress). Locking adds complexity to the write path and doesn't fix already-corrupted sessions.

### Prepend assistant before orphaned results

When a result's assistant hasn't been emitted yet, emit the assistant first.

**Rejected**: breaks natural message ordering — the assistant's position in the conversation stream matters for the model.

### Extend `syntheticToolResultsForOrphanedCalls`

The existing function knew whether results *existed* (`map[string]struct{}`), but not *where* they were. In the non-adjacent case both results existed, so it saw no orphans and did nothing. Extending it to emit real results would converge with the chosen approach, but split the logic across two functions sharing mutable state.

**Rejected**: less readable than a single purpose-built function.

## Chosen Approach

Two-pass message processing in `preparePrompt`:

1. **First pass**: build `tcToResultMsgs` — a `tool_call_id → []result_message` map.
2. **Second pass**: emit messages in order. When an assistant with tool calls is encountered, call `buildToolResultsForCalls(m, tcToResultMsgs, placedResults)` — a new function that:
   - Looks up real results in `tcToResultMsgs`, emits them, marks them as placed.
   - For calls with no result, injects a synthetic error result (preserving orphan handling).
3. On subsequent iterations, skip messages whose ID is in `placedResults` (prevents double emission when the DB later contains the same result).

`filterOrphanedToolResults` also sets `placedResults` when it passes through a non-orphaned result, preventing duplication in the result-before-assistant case.

## Test Plan

- [x] `TestPreparePrompt_OrphanedToolUse` — no regression
- [x] `TestPreparePrompt_OrphanedToolUseMixed` — no regression
- [x] `TestPreparePrompt_NonAdjacentToolResults` — new, passes
- [x] `TestPreparePrompt_ResultBeforeAssistant` — new, passes
- [x] `go test ./internal/agent/` — full suite passes
- [x] `go test ./...` — project-wide passes
- [x] `go vet ./internal/agent/` — clean
- [x] Manual: session resume during in-flight bash with DeepSeek (logic covered by unit tests). Checked with fixed build of crush CLI on broken session
