### PR TITLE
fix: account for section overhead in sidebar height allocation

### DIFF
--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -166,7 +166,11 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 		layout.Len(lipgloss.Height(sidebarHeader)),
 		layout.Fill(1),
 	).Split(m.layout.sidebar).Assign(new(image.Rectangle), &remainingHeightArea)
-	remainingHeight := remainingHeightArea.Dy() - 6
+	// Account for 4 section titles (1 each), 4 blank lines within sections
+	// (1 each from "\n\n"), and 3 separator lines between sections — total 11
+	// lines of overhead that getDynamicHeightLimits doesn't track.
+	const sectionOverhead = 11
+	remainingHeight := max(0, remainingHeightArea.Dy()-sectionOverhead)
 	filesCount := 0
 	for _, f := range m.sessionFiles {
 		if f.Additions == 0 && f.Deletions == 0 {


### PR DESCRIPTION
• Fixes sidebar content overflowing past the available terminal area
• Sections (Files, LSPs, MCPs, Skills) were allocated items as if each consumed 1 line,
but section titles, blank lines, and inter-section separators add 11 lines of unaccounted
overhead
• Changed the magic constant from  -6  to  -11  so  totalItems + 11  fits exactly within
remainingHeightArea

Before:

https://github.com/user-attachments/assets/a5de02c2-2278-49d1-a63e-24647eb90053

After:


https://github.com/user-attachments/assets/f9b56feb-4113-40b5-a7ac-23e50aa98bc8

