### PR TITLE
fix(ui): prevent duplicate skills from rendering

### DIFF
--- a/internal/ui/model/skills.go
+++ b/internal/ui/model/skills.go
@@ -79,6 +79,9 @@ func (m *UI) skillStatusItems() []skillStatusItem {
 		if disabledSet[name] {
 			continue
 		}
+		if _, exists := stateNames[name]; exists {
+			continue
+		}
 		stateNames[name] = struct{}{}
 		icon := t.Resource.OnlineIcon.String()
 		if state.State == skills.StateError {


### PR DESCRIPTION
Hey! Found a small visual bug where skills were showing up multiple times in the ui if they were discovered in overlapping paths.

It looks like the `stateNames` map was already set up to deduplicate them, but the check was missing before appending to the UI list. I just added that check in `internal/ui/model/skills.go` so they correctly only render once now. This fixes it in all the places that render skills.

Tested it locally and it cleans up nicely!

**Before/After:**
<img width="175" height="257" alt="{5ED0E1ED-06C7-4C41-BE9E-A5DF533414EE}" src="https://github.com/user-attachments/assets/2d7e1383-ea3a-4140-81b5-0de45b58310e" />
<img width="170" height="215" alt="{45A9119A-E0C8-4A59-BEEF-4BF0F72831A4}" src="https://github.com/user-attachments/assets/6734285b-aa82-4860-986f-972ed3e4cf6b" />

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).