### PR TITLE
feat: add --all and --crawl-dir modes to stats subcommand

### DIFF
--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -11,12 +11,15 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/db"
 	"github.com/charmbracelet/crush/internal/event"
+	"github.com/charmbracelet/crush/internal/projects"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
@@ -44,6 +47,11 @@ var statsCmd = &cobra.Command{
 	Short: "Show usage statistics",
 	Long:  "Generate and display usage statistics including token usage, costs, and activity patterns",
 	RunE:  runStats,
+}
+
+func init() {
+	statsCmd.Flags().String("crawl-dir", "", "Crawl a directory recursively for all crush projects and aggregate stats")
+	statsCmd.Flags().Bool("all", false, "Aggregate stats from all known projects (from projects.json)")
 }
 
 // Day names for day of week statistics.
@@ -120,35 +128,68 @@ type HourDayHeatmapPt struct {
 	SessionCount int64 `json:"session_count"`
 }
 
+// ProjectStats associates stats with a project path.
+type ProjectStats struct {
+	ProjectPath string `json:"project_path"`
+	Stats       *Stats `json:"stats"`
+}
+
 func runStats(cmd *cobra.Command, _ []string) error {
-	dataDir, _ := cmd.Flags().GetString("data-dir")
 	ctx := cmd.Context()
+	dataDir, _ := cmd.Flags().GetString("data-dir")
+	crawlDir, _ := cmd.Flags().GetString("crawl-dir")
+	useAll, _ := cmd.Flags().GetBool("all")
 
-	cfg, err := config.Init("", dataDir, false)
-	if err != nil {
-		return fmt.Errorf("failed to initialize config: %w", err)
-	}
-	if dataDir == "" {
-		dataDir = cfg.Config().Options.DataDirectory
-	}
-	if shouldEnableMetrics(cfg.Config()) {
-		event.Init()
+	var projectStats []ProjectStats
+	var err error
+
+	switch {
+	case crawlDir != "":
+		projectStats, err = crawlForStats(ctx, crawlDir)
+		if err != nil {
+			return fmt.Errorf("failed to crawl for stats: %w", err)
+		}
+	case useAll:
+		projectStats, err = gatherStatsFromProjects(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to gather stats from projects: %w", err)
+		}
+	default:
+		cfg, err := config.Init("", dataDir, false)
+		if err != nil {
+			return fmt.Errorf("failed to initialize config: %w", err)
+		}
+		if dataDir == "" {
+			dataDir = cfg.Config().Options.DataDirectory
+		}
+		if shouldEnableMetrics(cfg.Config()) {
+			event.Init()
+		}
+
+		event.StatsViewed()
+
+		conn, err := db.Connect(ctx, dataDir)
+		if err != nil {
+			return fmt.Errorf("failed to connect to database: %w", err)
+		}
+		defer conn.Close()
+
+		stats, err := gatherStats(ctx, conn)
+		if err != nil {
+			return fmt.Errorf("failed to gather stats: %w", err)
+		}
+
+		projectStats = []ProjectStats{{ProjectPath: "", Stats: stats}}
 	}
 
-	event.StatsViewed()
-
-	conn, err := db.Connect(ctx, dataDir)
-	if err != nil {
-		return fmt.Errorf("failed to connect to database: %w", err)
-	}
-	defer conn.Close()
-
-	stats, err := gatherStats(ctx, conn)
-	if err != nil {
-		return fmt.Errorf("failed to gather stats: %w", err)
+	if len(projectStats) == 0 {
+		return fmt.Errorf("no data available: no projects found")
 	}
 
-	if stats.Total.TotalSessions == 0 {
+	// Merge stats from all projects.
+	mergedStats := mergeStats(projectStats)
+
+	if mergedStats.Total.TotalSessions == 0 {
 		return fmt.Errorf("no data available: no sessions found in database")
 	}
 
@@ -157,14 +198,34 @@ func runStats(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to get current user: %w", err)
 	}
 	username := currentUser.Username
-	project, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get current directory: %w", err)
-	}
-	project = strings.Replace(project, currentUser.HomeDir, "~", 1)
 
-	htmlPath := filepath.Join(dataDir, "stats/index.html")
-	if err := generateHTML(stats, project, username, htmlPath); err != nil {
+	var projName string
+	switch {
+	case crawlDir != "":
+		projName = crawlDir
+	case useAll:
+		projName = "all projects"
+	default:
+		project, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current directory: %w", err)
+		}
+		projName = strings.Replace(project, currentUser.HomeDir, "~", 1)
+	}
+
+	outputDataDir := dataDir
+	if outputDataDir == "" {
+		cfg, err := config.Init("", "", false)
+		if err == nil {
+			outputDataDir = cfg.Config().Options.DataDirectory
+		}
+	}
+	if outputDataDir == "" {
+		outputDataDir = ".crush"
+	}
+
+	htmlPath := filepath.Join(outputDataDir, "stats/index.html")
+	if err := generateHTML(mergedStats, projectStats, projName, username, htmlPath); err != nil {
 		return fmt.Errorf("failed to generate HTML: %w", err)
 	}
 
@@ -178,11 +239,305 @@ func runStats(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
+// crawlForStats crawls a directory recursively looking for .crush/crush.db files.
+func crawlForStats(ctx context.Context, rootDir string) ([]ProjectStats, error) {
+	var dbPaths []struct {
+		dbPath     string
+		projectDir string
+	}
+
+	err := filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // Skip errors (permission denied, etc.)
+		}
+
+		// Skip common ignored directories early
+		if d.IsDir() && shouldSkipDir(d.Name()) {
+			return filepath.SkipDir
+		}
+
+		// Look for .crush/crush.db pattern
+		if !d.IsDir() && d.Name() == "crush.db" {
+			dir := filepath.Dir(path)
+			if filepath.Base(dir) == ".crush" {
+				projectDir := filepath.Dir(dir)
+				dbPaths = append(dbPaths, struct {
+					dbPath     string
+					projectDir string
+				}{dbPath: path, projectDir: projectDir})
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return gatherStatsFromDBPaths(ctx, dbPaths)
+}
+
+// shouldSkipDir returns true for directories that should be skipped during crawling.
+func shouldSkipDir(name string) bool {
+	skipDirs := map[string]bool{
+		".git":             true,
+		".svn":             true,
+		".hg":              true,
+		"node_modules":     true,
+		"vendor":           true,
+		"dist":             true,
+		"build":            true,
+		"target":           true,
+		".idea":            true,
+		".vscode":          true,
+		"__pycache__":      true,
+		"bin":              true,
+		"obj":              true,
+		"out":              true,
+		"coverage":         true,
+		"logs":             true,
+		"generated":        true,
+		"bower_components": true,
+		"jspm_packages":    true,
+		".cache":           true,
+		".npm":             true,
+		".cargo":           true,
+		"Library":          true,
+		"Applications":     true,
+		"System":           true,
+	}
+	return skipDirs[name]
+}
+
+// gatherStatsFromProjects gathers stats from all known projects in projects.json.
+func gatherStatsFromProjects(ctx context.Context) ([]ProjectStats, error) {
+	projectList, err := projects.Load()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load projects: %w", err)
+	}
+
+	var dbPaths []struct {
+		dbPath     string
+		projectDir string
+	}
+
+	for _, p := range projectList.Projects {
+		dbPath := filepath.Join(p.DataDir, "crush.db")
+		if _, err := os.Stat(dbPath); err == nil {
+			dbPaths = append(dbPaths, struct {
+				dbPath     string
+				projectDir string
+			}{dbPath: dbPath, projectDir: p.Path})
+		}
+	}
+
+	return gatherStatsFromDBPaths(ctx, dbPaths)
+}
+
+// gatherStatsFromDBPaths gathers stats from a list of database paths in parallel.
+func gatherStatsFromDBPaths(ctx context.Context, dbPaths []struct {
+	dbPath     string
+	projectDir string
+},
+) ([]ProjectStats, error) {
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		results []ProjectStats
+	)
+
+	sem := make(chan struct{}, 10) // Limit concurrent DB connections
+
+	for _, item := range dbPaths {
+		wg.Add(1)
+		go func(dbPath, projectDir string) {
+			defer wg.Done()
+
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			conn, err := db.ConnectReadOnly(ctx, dbPath)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warn: skipping %s: %v\n", dbPath, err)
+				return
+			}
+			defer conn.Close()
+
+			stats, err := gatherStats(ctx, conn)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warn: failed to gather stats from %s: %v\n", dbPath, err)
+				return
+			}
+
+			mu.Lock()
+			results = append(results, ProjectStats{
+				ProjectPath: projectDir,
+				Stats:       stats,
+			})
+			mu.Unlock()
+		}(item.dbPath, item.projectDir)
+	}
+
+	wg.Wait()
+
+	return results, nil
+}
+
+// mergeStats combines stats from multiple projects into a single Stats struct.
+func mergeStats(projectStats []ProjectStats) *Stats {
+	merged := &Stats{
+		GeneratedAt: time.Now().UTC(),
+	}
+
+	// Maps for aggregating unique entries.
+	dailyUsageMap := make(map[string]DailyUsage)
+	modelUsageMap := make(map[string]ModelUsage)
+	hourlyUsageMap := make(map[int]HourlyUsage)
+	dayOfWeekMap := make(map[int]DayOfWeekUsage)
+	recentActivityMap := make(map[string]DailyActivity)
+	toolUsageMap := make(map[string]ToolUsage)
+	heatmapMap := make(map[string]HourDayHeatmapPt) // key: "day-hour"
+
+	var totalResponseTimeMs float64
+	var responseTimeCount int64
+
+	for _, ps := range projectStats {
+		s := ps.Stats
+
+		// Aggregate total stats.
+		merged.Total.TotalSessions += s.Total.TotalSessions
+		merged.Total.TotalPromptTokens += s.Total.TotalPromptTokens
+		merged.Total.TotalCompletionTokens += s.Total.TotalCompletionTokens
+		merged.Total.TotalTokens += s.Total.TotalTokens
+		merged.Total.TotalCost += s.Total.TotalCost
+		merged.Total.TotalMessages += s.Total.TotalMessages
+
+		// Aggregate daily usage.
+		for _, d := range s.UsageByDay {
+			existing := dailyUsageMap[d.Day]
+			existing.Day = d.Day
+			existing.PromptTokens += d.PromptTokens
+			existing.CompletionTokens += d.CompletionTokens
+			existing.TotalTokens += d.TotalTokens
+			existing.Cost += d.Cost
+			existing.SessionCount += d.SessionCount
+			dailyUsageMap[d.Day] = existing
+		}
+
+		// Aggregate model usage.
+		for _, m := range s.UsageByModel {
+			key := m.Model + "|" + m.Provider
+			existing := modelUsageMap[key]
+			existing.Model = m.Model
+			existing.Provider = m.Provider
+			existing.MessageCount += m.MessageCount
+			modelUsageMap[key] = existing
+		}
+
+		// Aggregate hourly usage.
+		for _, h := range s.UsageByHour {
+			existing := hourlyUsageMap[h.Hour]
+			existing.Hour = h.Hour
+			existing.SessionCount += h.SessionCount
+			hourlyUsageMap[h.Hour] = existing
+		}
+
+		// Aggregate day of week usage.
+		for _, d := range s.UsageByDayOfWeek {
+			existing := dayOfWeekMap[d.DayOfWeek]
+			existing.DayOfWeek = d.DayOfWeek
+			existing.DayName = d.DayName
+			existing.SessionCount += d.SessionCount
+			existing.PromptTokens += d.PromptTokens
+			existing.CompletionTokens += d.CompletionTokens
+			dayOfWeekMap[d.DayOfWeek] = existing
+		}
+
+		// Aggregate recent activity.
+		for _, r := range s.RecentActivity {
+			existing := recentActivityMap[r.Day]
+			existing.Day = r.Day
+			existing.SessionCount += r.SessionCount
+			existing.TotalTokens += r.TotalTokens
+			existing.Cost += r.Cost
+			recentActivityMap[r.Day] = existing
+		}
+
+		// Aggregate tool usage (normalize to lowercase for consistency).
+		for _, t := range s.ToolUsage {
+			toolName := strings.ToLower(t.ToolName)
+			existing := toolUsageMap[toolName]
+			existing.ToolName = toolName
+			existing.CallCount += t.CallCount
+			toolUsageMap[toolName] = existing
+		}
+
+		// Aggregate heatmap.
+		for _, h := range s.HourDayHeatmap {
+			key := fmt.Sprintf("%d-%d", h.DayOfWeek, h.Hour)
+			existing := heatmapMap[key]
+			existing.DayOfWeek = h.DayOfWeek
+			existing.Hour = h.Hour
+			existing.SessionCount += h.SessionCount
+			heatmapMap[key] = existing
+		}
+
+		// Accumulate response time for averaging.
+		if s.AvgResponseTimeMs > 0 {
+			totalResponseTimeMs += s.AvgResponseTimeMs * float64(s.Total.TotalMessages)
+			responseTimeCount += s.Total.TotalMessages
+		}
+	}
+
+	// Calculate averages.
+	if merged.Total.TotalSessions > 0 {
+		merged.Total.AvgTokensPerSession = float64(merged.Total.TotalTokens) / float64(merged.Total.TotalSessions)
+		merged.Total.AvgMessagesPerSession = float64(merged.Total.TotalMessages) / float64(merged.Total.TotalSessions)
+	}
+
+	if responseTimeCount > 0 {
+		merged.AvgResponseTimeMs = totalResponseTimeMs / float64(responseTimeCount)
+	}
+
+	// Convert maps back to slices.
+	for _, d := range dailyUsageMap {
+		merged.UsageByDay = append(merged.UsageByDay, d)
+	}
+	for _, m := range modelUsageMap {
+		merged.UsageByModel = append(merged.UsageByModel, m)
+	}
+	for _, h := range hourlyUsageMap {
+		merged.UsageByHour = append(merged.UsageByHour, h)
+	}
+	for _, d := range dayOfWeekMap {
+		merged.UsageByDayOfWeek = append(merged.UsageByDayOfWeek, d)
+	}
+	for _, r := range recentActivityMap {
+		merged.RecentActivity = append(merged.RecentActivity, r)
+	}
+	for _, t := range toolUsageMap {
+		merged.ToolUsage = append(merged.ToolUsage, t)
+	}
+	for _, h := range heatmapMap {
+		merged.HourDayHeatmap = append(merged.HourDayHeatmap, h)
+	}
+
+	// Sort slices by count (descending).
+	sort.Slice(merged.UsageByModel, func(i, j int) bool {
+		return merged.UsageByModel[i].MessageCount > merged.UsageByModel[j].MessageCount
+	})
+	sort.Slice(merged.ToolUsage, func(i, j int) bool {
+		return merged.ToolUsage[i].CallCount > merged.ToolUsage[j].CallCount
+	})
+
+	return merged
+}
+
 func gatherStats(ctx context.Context, conn *sql.DB) (*Stats, error) {
 	queries := db.New(conn)
 
 	stats := &Stats{
-		GeneratedAt: time.Now(),
+		GeneratedAt: time.Now().UTC(),
 	}
 
 	// Total stats.
@@ -343,8 +698,13 @@ func nullFloat64ToInt64(n sql.NullFloat64) int64 {
 	return 0
 }
 
-func generateHTML(stats *Stats, projName, username, path string) error {
+func generateHTML(stats *Stats, projectStats []ProjectStats, projName, username, path string) error {
 	statsJSON, err := json.Marshal(stats)
+	if err != nil {
+		return err
+	}
+
+	projectStatsJSON, err := json.Marshal(projectStats)
 	if err != nil {
 		return err
 	}
@@ -355,25 +715,27 @@ func generateHTML(stats *Stats, projName, username, path string) error {
 	}
 
 	data := struct {
-		StatsJSON   template.JS
-		CSS         template.CSS
-		JS          template.JS
-		Header      template.HTML
-		Heartbit    template.HTML
-		Footer      template.HTML
-		GeneratedAt string
-		ProjectName string
-		Username    string
+		StatsJSON        template.JS
+		ProjectStatsJSON template.JS
+		CSS              template.CSS
+		JS               template.JS
+		Header           template.HTML
+		Heartbit         template.HTML
+		Footer           template.HTML
+		GeneratedAt      string
+		ProjectName      string
+		Username         string
 	}{
-		StatsJSON:   template.JS(statsJSON),
-		CSS:         template.CSS(statsCSS),
-		JS:          template.JS(statsJS),
-		Header:      template.HTML(headerSVG),
-		Heartbit:    template.HTML(heartbitSVG),
-		Footer:      template.HTML(footerSVG),
-		GeneratedAt: stats.GeneratedAt.Format("2006-01-02"),
-		ProjectName: projName,
-		Username:    username,
+		StatsJSON:        template.JS(statsJSON),
+		ProjectStatsJSON: template.JS(projectStatsJSON),
+		CSS:              template.CSS(statsCSS),
+		JS:               template.JS(statsJS),
+		Header:           template.HTML(headerSVG),
+		Heartbit:         template.HTML(heartbitSVG),
+		Footer:           template.HTML(footerSVG),
+		GeneratedAt:      stats.GeneratedAt.Format("2006-01-02"),
+		ProjectName:      projName,
+		Username:         username,
 	}
 
 	var buf bytes.Buffer

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	_ "embed"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -722,6 +723,7 @@ func generateHTML(stats *Stats, projectStats []ProjectStats, projName, username,
 		Header           template.HTML
 		Heartbit         template.HTML
 		Footer           template.HTML
+		Favicon          template.URL
 		GeneratedAt      string
 		ProjectName      string
 		Username         string
@@ -733,6 +735,7 @@ func generateHTML(stats *Stats, projectStats []ProjectStats, projName, username,
 		Header:           template.HTML(headerSVG),
 		Heartbit:         template.HTML(heartbitSVG),
 		Footer:           template.HTML(footerSVG),
+		Favicon:          template.URL("data:image/svg+xml;base64," + base64.StdEncoding.EncodeToString([]byte(heartbitSVG))),
 		GeneratedAt:      stats.GeneratedAt.Format("2006-01-02"),
 		ProjectName:      projName,
 		Username:         username,

--- a/internal/cmd/stats/index.css
+++ b/internal/cmd/stats/index.css
@@ -154,6 +154,8 @@ body {
   font-weight: 700;
   color: var(--butter);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 @media (prefers-color-scheme: light) {
@@ -236,6 +238,20 @@ th {
 
 td {
   font-family: "JetBrains Mono", "SF Mono", Consolas, monospace;
+}
+
+.project-name {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.project-path {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .model-tag {

--- a/internal/cmd/stats/index.html
+++ b/internal/cmd/stats/index.html
@@ -130,6 +130,7 @@
 
     <script>
       const stats = {{.StatsJSON}};
+      const projectStats = {{.ProjectStatsJSON}};
       {{.JS}}
     </script>
   </body>

--- a/internal/cmd/stats/index.html
+++ b/internal/cmd/stats/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Crush Usage Statistics</title>
+    <link rel="icon" type="image/svg+xml" href='{{.Favicon}}' />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/internal/cmd/stats/index.js
+++ b/internal/cmd/stats/index.js
@@ -30,7 +30,20 @@ function formatCompact(n) {
 }
 
 function formatCost(n) {
+  if (n >= 1000) {
+    return "$" + Math.round(n).toLocaleString();
+  }
   return "$" + n.toFixed(2);
+}
+
+function formatDate(dateStr) {
+  // SQL returns UTC dates (YYYY-MM-DD); convert to local date.
+  const utc = new Date(dateStr + "T00:00:00Z");
+  return utc.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
 }
 
 function formatTime(ms) {
@@ -90,7 +103,7 @@ if (stats.recent_activity?.length > 0) {
   new Chart(document.getElementById("recentActivityChart"), {
     type: "bar",
     data: {
-      labels: stats.recent_activity.map((d) => d.day),
+      labels: stats.recent_activity.map((d) => formatDate(d.day)),
       datasets: [
         {
           label: "Sessions",
@@ -128,6 +141,9 @@ if (stats.recent_activity?.length > 0) {
 // Heatmap (Hour × Day of Week) - Bubble Chart
 const dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
+// Convert UTC hour/day to local hour/day using a reference date.
+const utcOffsetHours = new Date().getTimezoneOffset() / -60;
+
 let maxCount =
   stats.hour_day_heatmap?.length > 0
     ? Math.max(...stats.hour_day_heatmap.map((h) => h.session_count))
@@ -144,12 +160,21 @@ if (stats.hour_day_heatmap?.length > 0) {
           label: "Sessions",
           data: stats.hour_day_heatmap
             .filter((h) => h.session_count > 0)
-            .map((h) => ({
-              x: h.hour,
-              y: h.day_of_week,
-              r: Math.sqrt(h.session_count) * scaleFactor,
-              count: h.session_count,
-            })),
+            .map((h) => {
+              const localHour = (h.hour + utcOffsetHours + 24) % 24;
+              const localDay =
+                h.hour + utcOffsetHours < 0
+                  ? (h.day_of_week + 6) % 7
+                  : h.hour + utcOffsetHours >= 24
+                    ? (h.day_of_week + 1) % 7
+                    : h.day_of_week;
+              return {
+                x: localHour,
+                y: localDay,
+                r: Math.sqrt(h.session_count) * scaleFactor,
+                count: h.session_count,
+              };
+            }),
           backgroundColor: (ctx) => {
             const count =
               ctx.raw?.count || ctx.dataset.data[ctx.dataIndex]?.count || 0;
@@ -343,7 +368,7 @@ if (stats.usage_by_day?.length > 0) {
   const fragment = document.createDocumentFragment();
   stats.usage_by_day.slice(0, 30).forEach((d) => {
     const row = document.createElement("tr");
-    row.innerHTML = `<td>${d.day}</td><td>${d.session_count}</td><td>${formatNumber(
+    row.innerHTML = `<td>${formatDate(d.day)}</td><td>${d.session_count}</td><td>${formatNumber(
       d.prompt_tokens,
     )}</td><td>${formatNumber(
       d.completion_tokens,
@@ -353,4 +378,60 @@ if (stats.usage_by_day?.length > 0) {
     fragment.appendChild(row);
   });
   tableBody.appendChild(fragment);
+}
+
+// Per-Project Breakdown (only shown when aggregating multiple projects)
+if (projectStats && projectStats.length > 1) {
+  const projectSection = document.createElement("div");
+  projectSection.className = "chart-card full-width";
+  projectSection.innerHTML = `
+    <h2>Per-Project Breakdown</h2>
+    <div style="overflow-x: auto">
+      <table id="project-table">
+        <thead>
+          <tr>
+            <th>Project</th>
+            <th>Sessions</th>
+            <th>Messages</th>
+            <th>Tokens</th>
+            <th>Cost</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  `;
+
+  const container = document.querySelector(".charts-grid");
+  if (container) {
+    container.appendChild(projectSection);
+
+    const projectTableBody = document.querySelector("#project-table tbody");
+    const fragment = document.createDocumentFragment();
+
+    // Sort by total cost descending
+    const sortedProjects = [...projectStats].sort(
+      (a, b) => b.stats.total.total_cost - a.stats.total.total_cost,
+    );
+
+    sortedProjects.forEach((p) => {
+      const row = document.createElement("tr");
+      const displayPath = p.project_path || "unknown";
+      const projectName = displayPath.split("/").pop() || displayPath;
+      const dirPath = displayPath.substring(0, displayPath.length - projectName.length) || "/";
+      row.innerHTML = `
+        <td>
+          <div class="project-name">${projectName}</div>
+          <div class="project-path" title="${displayPath}">${dirPath}</div>
+        </td>
+        <td>${formatNumber(p.stats.total.total_sessions)}</td>
+        <td>${formatNumber(p.stats.total.total_messages)}</td>
+        <td>${formatNumber(p.stats.total.total_tokens)}</td>
+        <td>${formatCost(p.stats.total.total_cost)}</td>
+      `;
+      fragment.appendChild(row);
+    });
+
+    projectTableBody.appendChild(fragment);
+  }
 }

--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -75,6 +75,28 @@ func Connect(ctx context.Context, dataDir string) (*sql.DB, error) {
 	return db, nil
 }
 
+// ConnectReadOnly opens a read-only SQLite database connection without running
+// migrations. Used for aggregating stats across multiple project databases.
+func ConnectReadOnly(ctx context.Context, dbPath string) (*sql.DB, error) {
+	if dbPath == "" {
+		return nil, fmt.Errorf("database path is empty")
+	}
+
+	db, err := openDBReadOnly(dbPath)
+	if err != nil {
+		return nil, err
+	}
+
+	db.SetMaxOpenConns(1)
+
+	if err = db.PingContext(ctx); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to connect to database: %w", err)
+	}
+
+	return db, nil
+}
+
 func initGoose() error {
 	gooseInitOnce.Do(func() {
 		goose.SetBaseFS(FS)

--- a/internal/db/connect_modernc.go
+++ b/internal/db/connect_modernc.go
@@ -10,6 +10,21 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+func openDBReadOnly(dbPath string) (*sql.DB, error) {
+	params := url.Values{}
+	// Only set safe pragmas for read-only mode - most pragmas require write access
+	params.Set("_txlock", "immediate")
+	params.Set("mode", "ro")
+
+	dsn := fmt.Sprintf("file:%s?%s", dbPath, params.Encode())
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+
+	return db, nil
+}
+
 func openDB(dbPath string) (*sql.DB, error) {
 	// Set pragmas for better performance via _pragma query params.
 	// Format: _pragma=name(value)

--- a/internal/db/connect_ncruces.go
+++ b/internal/db/connect_ncruces.go
@@ -10,6 +10,16 @@ import (
 	"github.com/ncruces/go-sqlite3/driver"
 )
 
+func openDBReadOnly(dbPath string) (*sql.DB, error) {
+	dsn := fmt.Sprintf("file:%s?mode=ro&_txlock=immediate", dbPath)
+	db, err := driver.Open(dsn, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+
+	return db, nil
+}
+
 func openDB(dbPath string) (*sql.DB, error) {
 	// Use BEGIN IMMEDIATE so writers acquire the reserved lock up front,
 	// preventing deferred-to-writer upgrade deadlocks. The "file:" prefix


### PR DESCRIPTION
Also made some improvements to the money display card (rounding) and made all of the graphs render in local time rather than UTC. `--all` uses the project json file to get all projects and `--crawl-dir` manually crawls the directories for older projects that aren't tracked

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/6084a388-715b-4f86-b815-6f473b5f6547" />
