### PR TITLE
feat(tui): reduce animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,6 +651,40 @@ it creates. You can customize this behavior with the `attribution` option:
 - `generated_with`: When true (default), adds `💘 Generated with Crush` line to
   commit messages and PR descriptions
 
+### TUI Options
+
+Crush provides several options to customize the terminal UI:
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "options": {
+    "tui": {
+      "compact_mode": true,
+      "diff_mode": "split",
+      "transparent": true,
+      "reduce_animations": true,
+      "ssh_animation_mode": "reduce"
+    }
+  }
+}
+```
+
+- `compact_mode`: Enable compact TUI layout (default: `false`)
+- `diff_mode`: Diff view style - `"unified"` or `"split"` (default: `"unified"`)
+- `transparent`: Enable transparent background (default: `false`)
+- `reduce_animations`: When true, animated spinners are replaced with a static
+  "Working..." label. Can also be enabled via the `CRUSH_REDUCE_ANIMATIONS`
+  environment variable.
+- `ssh_animation_mode`: Controls animation behavior over SSH connections:
+  - `"ask"`: Prompt the user on first SSH session (default)
+  - `"reduce"`: Automatically reduce animations over SSH
+  - `"never"`: Keep animations enabled over SSH
+
+When Crush detects it is running over SSH and `ssh_animation_mode` is `"ask"`
+(the default), it will display a dialog asking whether to switch to simpler
+animations.
+
 ### Custom Providers
 
 Crush supports custom provider configurations for both OpenAI-compatible and

--- a/README.md
+++ b/README.md
@@ -704,9 +704,9 @@ Crush provides several options to customize the terminal UI:
 - `compact_mode`: Enable compact TUI layout (default: `false`)
 - `diff_mode`: Diff view style - `"unified"` or `"split"` (default: `"unified"`)
 - `transparent`: Enable transparent background (default: `false`)
-- `reduce_animations`: When true, animated spinners are replaced with a static
-  "Working..." label. Can also be enabled via the `CRUSH_REDUCE_ANIMATIONS`
-  environment variable.
+- `reduce_animations`: When true, animated spinners are replaced with a simpler
+  "Working..." ellipsis animation. Can also be enabled via the
+  `CRUSH_REDUCE_ANIMATIONS` environment variable.
 - `ssh_animation_mode`: Controls animation behavior over SSH connections:
   - `"ask"`: Prompt the user on first SSH session (default)
   - `"reduce"`: Automatically reduce animations over SSH

--- a/README.md
+++ b/README.md
@@ -682,6 +682,40 @@ option attribution-generated-with true
 - `generated_with`: When true (default), adds `💘 Generated with Crush` line to
   commit messages and PR descriptions
 
+### TUI Options
+
+Crush provides several options to customize the terminal UI:
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "options": {
+    "tui": {
+      "compact_mode": true,
+      "diff_mode": "split",
+      "transparent": true,
+      "reduce_animations": true,
+      "ssh_animation_mode": "reduce"
+    }
+  }
+}
+```
+
+- `compact_mode`: Enable compact TUI layout (default: `false`)
+- `diff_mode`: Diff view style - `"unified"` or `"split"` (default: `"unified"`)
+- `transparent`: Enable transparent background (default: `false`)
+- `reduce_animations`: When true, animated spinners are replaced with a static
+  "Working..." label. Can also be enabled via the `CRUSH_REDUCE_ANIMATIONS`
+  environment variable.
+- `ssh_animation_mode`: Controls animation behavior over SSH connections:
+  - `"ask"`: Prompt the user on first SSH session (default)
+  - `"reduce"`: Automatically reduce animations over SSH
+  - `"never"`: Keep animations enabled over SSH
+
+When Crush detects it is running over SSH and `ssh_animation_mode` is `"ask"`
+(the default), it will display a dialog asking whether to switch to simpler
+animations.
+
 ### Custom Providers
 
 Crush supports custom provider configurations for both OpenAI-compatible and

--- a/README.md
+++ b/README.md
@@ -714,7 +714,8 @@ Crush provides several options to customize the terminal UI:
 
 When Crush detects it is running over SSH and `ssh_animation_mode` is `"ask"`
 (the default), it will display a dialog asking whether to switch to simpler
-animations.
+animations. The choice you make in that dialog is saved to the global `crush.json`
+under `options.tui.ssh_animation_mode` and applies to future SSH sessions.
 
 ### Custom Providers
 

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -483,9 +483,10 @@ func outputSessionHuman(ctx context.Context, cfg *config.ConfigStore, sess sessi
 	}
 	fmt.Fprintln(&buf)
 
+	reduceAnimations := cfg.Config().ShouldReduceAnimations()
 	first := true
 	for _, msg := range msgs {
-		items := chat.ExtractMessageItems(&styles, msg, toolResults)
+		items := chat.ExtractMessageItems(&styles, msg, toolResults, reduceAnimations)
 		for _, item := range items {
 			if !first {
 				fmt.Fprintln(&buf)

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -483,9 +483,10 @@ func outputSessionHuman(ctx context.Context, cfg *config.ConfigStore, sess sessi
 	}
 	fmt.Fprintln(&buf)
 
+	reduceAnimations := cfg.Config().ShouldReduceAnimations()
 	first := true
 	for _, msg := range msgs {
-		items := chat.ExtractMessageItems(&styles, msg, toolResults, "")
+		items := chat.ExtractMessageItems(&styles, msg, toolResults, "", reduceAnimations)
 		for _, item := range items {
 			if !first {
 				fmt.Fprintln(&buf)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -222,6 +222,7 @@ type TUIOptions struct {
 	CompactMode      bool   `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
 	DiffMode         string `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
 	ReduceAnimations *bool  `json:"reduce_animations,omitempty" jsonschema:"description=Reduce animations in the TUI,default=false"`
+	SSHAnimationMode string `json:"ssh_animation_mode,omitempty" jsonschema:"description=SSH animation behavior,enum=ask,enum=reduce,enum=never"`
 	// Here we can add themes later or any TUI related options
 	//
 
@@ -728,6 +729,17 @@ func (c *Config) SmallModel() *catwalk.Model {
 	return c.GetModel(model.Provider, model.Model)
 }
 
+func (c *Config) SetSSHAnimationMode(mode string) error {
+	if c.Options == nil {
+		c.Options = &Options{}
+	}
+	if c.Options.TUI == nil {
+		c.Options.TUI = &TUIOptions{}
+	}
+	c.Options.TUI.SSHAnimationMode = mode
+	return nil
+}
+
 const maxRecentModelsPerType = 5
 
 func allToolNames() []string {
@@ -944,4 +956,8 @@ func ptrValOr[T any](t *T, el T) T {
 		return el
 	}
 	return *t
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -219,8 +219,9 @@ type LSPConfig struct {
 }
 
 type TUIOptions struct {
-	CompactMode bool   `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
-	DiffMode    string `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
+	CompactMode      bool   `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
+	DiffMode         string `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
+	ReduceAnimations *bool  `json:"reduce_animations,omitempty" jsonschema:"description=Reduce animations in the TUI,default=false"`
 	// Here we can add themes later or any TUI related options
 	//
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -270,8 +270,10 @@ type LSPConfig struct {
 }
 
 type TUIOptions struct {
-	CompactMode bool   `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
-	DiffMode    string `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
+	CompactMode      bool   `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
+	DiffMode         string `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
+	ReduceAnimations *bool  `json:"reduce_animations,omitempty" jsonschema:"description=Reduce animations in the TUI,default=false"`
+	SSHAnimationMode string `json:"ssh_animation_mode,omitempty" jsonschema:"description=SSH animation behavior,enum=ask,enum=reduce,enum=never"`
 	// Here we can add themes later or any TUI related options
 	//
 
@@ -877,6 +879,17 @@ func (c *Config) SmallModel() *catwalk.Model {
 	return c.GetModel(model.Provider, model.Model)
 }
 
+func (c *Config) SetSSHAnimationMode(mode string) error {
+	if c.Options == nil {
+		c.Options = &Options{}
+	}
+	if c.Options.TUI == nil {
+		c.Options.TUI = &TUIOptions{}
+	}
+	c.Options.TUI.SSHAnimationMode = mode
+	return nil
+}
+
 const maxRecentModelsPerType = 5
 
 func allToolNames() []string {
@@ -1099,4 +1112,8 @@ func ptrValOr[T any](t *T, el T) T {
 		return el
 	}
 	return *t
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -99,6 +99,17 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 		assignIfNil(&cfg.Options.TUI.Transparent, true)
 	}
 
+	if isSSH() {
+		slog.Warn("Running over SSH, will enable reduce animations")
+		assignIfNil(&cfg.Options.TUI.ReduceAnimations, true)
+	}
+
+	if str, ok := os.LookupEnv("CRUSH_REDUCE_ANIMATIONS"); ok {
+		if val, err := strconv.ParseBool(str); err == nil {
+			assignIfNil(&cfg.Options.TUI.ReduceAnimations, val)
+		}
+	}
+
 	// Load known providers, this loads the config from catwalk
 	providers, err := Providers(cfg)
 	if err != nil {
@@ -1279,3 +1290,14 @@ func (c *Config) ValidateHooks() error {
 	}
 	return nil
 }
+
+func isSSH() bool {
+	return os.Getenv("SSH_TTY") != ""
+}
+
+// ShouldReduceAnimations returns whether animations should be reduced based on config.
+func (c *Config) ShouldReduceAnimations() bool {
+	return c.Options != nil && c.Options.TUI != nil && c.Options.TUI.ReduceAnimations != nil && *c.Options.TUI.ReduceAnimations
+}
+
+

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -99,11 +99,6 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 		assignIfNil(&cfg.Options.TUI.Transparent, true)
 	}
 
-	if isSSH() {
-		slog.Warn("Running over SSH, will enable reduce animations")
-		assignIfNil(&cfg.Options.TUI.ReduceAnimations, true)
-	}
-
 	if str, ok := os.LookupEnv("CRUSH_REDUCE_ANIMATIONS"); ok {
 		if val, err := strconv.ParseBool(str); err == nil {
 			assignIfNil(&cfg.Options.TUI.ReduceAnimations, val)
@@ -1297,7 +1292,28 @@ func isSSH() bool {
 
 // ShouldReduceAnimations returns whether animations should be reduced based on config.
 func (c *Config) ShouldReduceAnimations() bool {
-	return c.Options != nil && c.Options.TUI != nil && c.Options.TUI.ReduceAnimations != nil && *c.Options.TUI.ReduceAnimations
+	if c.Options == nil || c.Options.TUI == nil {
+		return false
+	}
+	// Explicit reduce_animations setting takes precedence.
+	if c.Options.TUI.ReduceAnimations != nil && *c.Options.TUI.ReduceAnimations {
+		return true
+	}
+	// Auto-reduce when SSH and ssh_animation_mode is "reduce".
+	if isSSH() && c.Options.TUI.SSHAnimationMode == "reduce" {
+		return true
+	}
+	return false
 }
 
-
+// ShouldPromptForSSHAnimations returns whether we should prompt the user about
+// reducing animations over SSH. This is true when:
+// - Running over SSH
+// - ssh_animation_mode is "ask" (default)
+// - reduce_animations is not explicitly set
+func (c *Config) ShouldPromptForSSHAnimations() bool {
+	if c.Options == nil || c.Options.TUI == nil {
+		return false
+	}
+	return isSSH() && (c.Options.TUI.SSHAnimationMode == "" || c.Options.TUI.SSHAnimationMode == "ask") && c.Options.TUI.ReduceAnimations == nil
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1454,7 +1454,9 @@ func (c *Config) ValidateHooks() error {
 }
 
 func isSSH() bool {
-	return os.Getenv("SSH_TTY") != ""
+	return os.Getenv("SSH_TTY") != "" ||
+		os.Getenv("SSH_CONNECTION") != "" ||
+		os.Getenv("SSH_CLIENT") != ""
 }
 
 // ShouldReduceAnimations returns whether animations should be reduced based on config.

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -100,6 +100,12 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 		assignIfNil(&cfg.Options.TUI.Transparent, true)
 	}
 
+	if str, ok := os.LookupEnv("CRUSH_REDUCE_ANIMATIONS"); ok {
+		if val, err := strconv.ParseBool(str); err == nil {
+			assignIfNil(&cfg.Options.TUI.ReduceAnimations, val)
+		}
+	}
+
 	// Load known providers, this loads the config from catwalk. A failed
 	// refresh still yields the cached or embedded catalog, so only an empty
 	// list is fatal: starting up without providers is worse than starting
@@ -1445,4 +1451,36 @@ func (c *Config) ValidateHooks() error {
 		}
 	}
 	return nil
+}
+
+func isSSH() bool {
+	return os.Getenv("SSH_TTY") != ""
+}
+
+// ShouldReduceAnimations returns whether animations should be reduced based on config.
+func (c *Config) ShouldReduceAnimations() bool {
+	if c.Options == nil || c.Options.TUI == nil {
+		return false
+	}
+	// Explicit reduce_animations setting takes precedence.
+	if c.Options.TUI.ReduceAnimations != nil && *c.Options.TUI.ReduceAnimations {
+		return true
+	}
+	// Auto-reduce when SSH and ssh_animation_mode is "reduce".
+	if isSSH() && c.Options.TUI.SSHAnimationMode == "reduce" {
+		return true
+	}
+	return false
+}
+
+// ShouldPromptForSSHAnimations returns whether we should prompt the user about
+// reducing animations over SSH. This is true when:
+// - Running over SSH
+// - ssh_animation_mode is "ask" (default)
+// - reduce_animations is not explicitly set
+func (c *Config) ShouldPromptForSSHAnimations() bool {
+	if c.Options == nil || c.Options.TUI == nil {
+		return false
+	}
+	return isSSH() && (c.Options.TUI.SSHAnimationMode == "" || c.Options.TUI.SSHAnimationMode == "ask") && c.Options.TUI.ReduceAnimations == nil
 }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -2290,6 +2290,8 @@ func TestConfig_configureProviders_UnsetAzureEndpointSkipsProvider(t *testing.T)
 	require.Equal(t, 0, cfg.Providers.Len(), "azure provider with unset endpoint must be skipped")
 	_, exists := cfg.Providers.Get("azure")
 	require.False(t, exists)
+}
+
 // TestShouldReduceAnimations tests the ShouldReduceAnimations logic.
 func TestShouldReduceAnimations(t *testing.T) {
 	// Test explicit reduce_animations: true

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -2418,5 +2418,4 @@ func TestConfig_load(t *testing.T) {
 	assert.NotNil(t, cfg2.config.Options)
 	assert.NotNil(t, cfg2.config.Options.TUI)
 	assert.Nil(t, cfg2.config.Options.TUI.ReduceAnimations) // Should be nil, not auto-set to true
-
 }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -2290,4 +2290,131 @@ func TestConfig_configureProviders_UnsetAzureEndpointSkipsProvider(t *testing.T)
 	require.Equal(t, 0, cfg.Providers.Len(), "azure provider with unset endpoint must be skipped")
 	_, exists := cfg.Providers.Get("azure")
 	require.False(t, exists)
+// TestShouldReduceAnimations tests the ShouldReduceAnimations logic.
+func TestShouldReduceAnimations(t *testing.T) {
+	// Test explicit reduce_animations: true
+	cfg := &Config{
+		Options: &Options{
+			TUI: &TUIOptions{
+				ReduceAnimations: ptr(true),
+			},
+		},
+	}
+	assert.True(t, cfg.ShouldReduceAnimations())
+
+	// Test explicit reduce_animations: false
+	cfg.Options.TUI.ReduceAnimations = ptr(false)
+	assert.False(t, cfg.ShouldReduceAnimations())
+
+	// Test SSH with reduce mode
+	cfg.Options.TUI.ReduceAnimations = nil
+	cfg.Options.TUI.SSHAnimationMode = "reduce"
+	os.Setenv("SSH_TTY", "some_value")
+	assert.True(t, cfg.ShouldReduceAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test SSH with never mode (should not reduce)
+	cfg.Options.TUI.SSHAnimationMode = "never"
+	os.Setenv("SSH_TTY", "some_value")
+	assert.False(t, cfg.ShouldReduceAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test SSH with ask mode (should not reduce unless explicitly set)
+	cfg.Options.TUI.SSHAnimationMode = "ask"
+	os.Setenv("SSH_TTY", "some_value")
+	assert.False(t, cfg.ShouldReduceAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test no SSH, no explicit setting
+	cfg.Options.TUI.SSHAnimationMode = ""
+	assert.False(t, cfg.ShouldReduceAnimations())
+}
+
+// TestShouldPromptForSSHAnimations tests when we should prompt for SSH animations.
+func TestShouldPromptForSSHAnimations(t *testing.T) {
+	// Test SSH + ask mode + no explicit setting = prompt
+	cfg := &Config{
+		Options: &Options{
+			TUI: &TUIOptions{
+				SSHAnimationMode: "ask",
+			},
+		},
+	}
+	os.Setenv("SSH_TTY", "some_value")
+	assert.True(t, cfg.ShouldPromptForSSHAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test default (empty) ssh_animation_mode = prompt (same as "ask")
+	cfg.Options.TUI.SSHAnimationMode = ""
+	os.Setenv("SSH_TTY", "some_value")
+	assert.True(t, cfg.ShouldPromptForSSHAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test SSH + ask mode + explicit setting = no prompt
+	cfg.Options.TUI.ReduceAnimations = ptr(true)
+	assert.False(t, cfg.ShouldPromptForSSHAnimations())
+
+	// Test SSH + reduce mode = no prompt (auto-enabled)
+	cfg.Options.TUI.ReduceAnimations = nil
+	cfg.Options.TUI.SSHAnimationMode = "reduce"
+	os.Setenv("SSH_TTY", "some_value")
+	assert.False(t, cfg.ShouldPromptForSSHAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test SSH + never mode = no prompt (never enable)
+	cfg.Options.TUI.SSHAnimationMode = "never"
+	os.Setenv("SSH_TTY", "some_value")
+	assert.False(t, cfg.ShouldPromptForSSHAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test non-SSH = no prompt
+	os.Unsetenv("SSH_TTY")
+	assert.False(t, cfg.ShouldPromptForSSHAnimations())
+}
+
+// TestSetSSHAnimationMode tests persisting SSH animation mode.
+func TestSetSSHAnimationMode(t *testing.T) {
+	cfg := &Config{
+		Options: &Options{
+			TUI: &TUIOptions{},
+		},
+	}
+
+	// Test setting to reduce
+	assert.NoError(t, cfg.SetSSHAnimationMode("reduce"))
+	assert.Equal(t, "reduce", cfg.Options.TUI.SSHAnimationMode)
+
+	// Test setting to never
+	assert.NoError(t, cfg.SetSSHAnimationMode("never"))
+	assert.Equal(t, "never", cfg.Options.TUI.SSHAnimationMode)
+
+	// Test setting to ask (empty string)
+	assert.NoError(t, cfg.SetSSHAnimationMode(""))
+	assert.Equal(t, "", cfg.Options.TUI.SSHAnimationMode)
+}
+
+// TestConfig_load applies environment variable and SSH detection.
+func TestConfig_load(t *testing.T) {
+	// Test CRUSH_REDUCE_ANIMATIONS env var
+	t.Setenv("CRUSH_REDUCE_ANIMATIONS", "true")
+
+	cfg, err := Load("", "", false)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.NotNil(t, cfg.config.Options)
+	assert.NotNil(t, cfg.config.Options.TUI)
+	assert.True(t, *cfg.config.Options.TUI.ReduceAnimations)
+
+	// Test SSH auto-enable is removed (should not auto-enable)
+	// When SSH_TTY is set but CRUSH_REDUCE_ANIMATIONS is NOT set,
+	// ReduceAnimations should remain nil.
+	os.Unsetenv("CRUSH_REDUCE_ANIMATIONS")
+	t.Setenv("SSH_TTY", "some_value")
+	cfg2, err := Load("", "", false)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg2)
+	assert.NotNil(t, cfg2.config.Options)
+	assert.NotNil(t, cfg2.config.Options.TUI)
+	assert.Nil(t, cfg2.config.Options.TUI.ReduceAnimations) // Should be nil, not auto-set to true
+
 }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -2534,3 +2534,131 @@ func TestConfig_LoadFromBytes_EnvMerge(t *testing.T) {
 	require.Equal(t, "second", loadedConfig.Env["AWS_PROFILE"])
 	require.Equal(t, "us-east-1", loadedConfig.Env["AWS_REGION"])
 }
+
+// TestShouldReduceAnimations tests the ShouldReduceAnimations logic.
+func TestShouldReduceAnimations(t *testing.T) {
+	// Test explicit reduce_animations: true
+	cfg := &Config{
+		Options: &Options{
+			TUI: &TUIOptions{
+				ReduceAnimations: ptr(true),
+			},
+		},
+	}
+	assert.True(t, cfg.ShouldReduceAnimations())
+
+	// Test explicit reduce_animations: false
+	cfg.Options.TUI.ReduceAnimations = ptr(false)
+	assert.False(t, cfg.ShouldReduceAnimations())
+
+	// Test SSH with reduce mode
+	cfg.Options.TUI.ReduceAnimations = nil
+	cfg.Options.TUI.SSHAnimationMode = "reduce"
+	os.Setenv("SSH_TTY", "some_value")
+	assert.True(t, cfg.ShouldReduceAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test SSH with never mode (should not reduce)
+	cfg.Options.TUI.SSHAnimationMode = "never"
+	os.Setenv("SSH_TTY", "some_value")
+	assert.False(t, cfg.ShouldReduceAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test SSH with ask mode (should not reduce unless explicitly set)
+	cfg.Options.TUI.SSHAnimationMode = "ask"
+	os.Setenv("SSH_TTY", "some_value")
+	assert.False(t, cfg.ShouldReduceAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test no SSH, no explicit setting
+	cfg.Options.TUI.SSHAnimationMode = ""
+	assert.False(t, cfg.ShouldReduceAnimations())
+}
+
+// TestShouldPromptForSSHAnimations tests when we should prompt for SSH animations.
+func TestShouldPromptForSSHAnimations(t *testing.T) {
+	// Test SSH + ask mode + no explicit setting = prompt
+	cfg := &Config{
+		Options: &Options{
+			TUI: &TUIOptions{
+				SSHAnimationMode: "ask",
+			},
+		},
+	}
+	os.Setenv("SSH_TTY", "some_value")
+	assert.True(t, cfg.ShouldPromptForSSHAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test default (empty) ssh_animation_mode = prompt (same as "ask")
+	cfg.Options.TUI.SSHAnimationMode = ""
+	os.Setenv("SSH_TTY", "some_value")
+	assert.True(t, cfg.ShouldPromptForSSHAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test SSH + ask mode + explicit setting = no prompt
+	cfg.Options.TUI.ReduceAnimations = ptr(true)
+	assert.False(t, cfg.ShouldPromptForSSHAnimations())
+
+	// Test SSH + reduce mode = no prompt (auto-enabled)
+	cfg.Options.TUI.ReduceAnimations = nil
+	cfg.Options.TUI.SSHAnimationMode = "reduce"
+	os.Setenv("SSH_TTY", "some_value")
+	assert.False(t, cfg.ShouldPromptForSSHAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test SSH + never mode = no prompt (never enable)
+	cfg.Options.TUI.SSHAnimationMode = "never"
+	os.Setenv("SSH_TTY", "some_value")
+	assert.False(t, cfg.ShouldPromptForSSHAnimations())
+	os.Unsetenv("SSH_TTY")
+
+	// Test non-SSH = no prompt
+	os.Unsetenv("SSH_TTY")
+	assert.False(t, cfg.ShouldPromptForSSHAnimations())
+}
+
+// TestSetSSHAnimationMode tests persisting SSH animation mode.
+func TestSetSSHAnimationMode(t *testing.T) {
+	cfg := &Config{
+		Options: &Options{
+			TUI: &TUIOptions{},
+		},
+	}
+
+	// Test setting to reduce
+	assert.NoError(t, cfg.SetSSHAnimationMode("reduce"))
+	assert.Equal(t, "reduce", cfg.Options.TUI.SSHAnimationMode)
+
+	// Test setting to never
+	assert.NoError(t, cfg.SetSSHAnimationMode("never"))
+	assert.Equal(t, "never", cfg.Options.TUI.SSHAnimationMode)
+
+	// Test setting to ask (empty string)
+	assert.NoError(t, cfg.SetSSHAnimationMode(""))
+	assert.Equal(t, "", cfg.Options.TUI.SSHAnimationMode)
+}
+
+// TestConfig_load applies environment variable and SSH detection.
+func TestConfig_load(t *testing.T) {
+	// Test CRUSH_REDUCE_ANIMATIONS env var
+	t.Setenv("CRUSH_REDUCE_ANIMATIONS", "true")
+
+	cfg, err := Load("", "", false)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.NotNil(t, cfg.config.Options)
+	assert.NotNil(t, cfg.config.Options.TUI)
+	assert.True(t, *cfg.config.Options.TUI.ReduceAnimations)
+
+	// Test SSH auto-enable is removed (should not auto-enable)
+	// When SSH_TTY is set but CRUSH_REDUCE_ANIMATIONS is NOT set,
+	// ReduceAnimations should remain nil.
+	os.Unsetenv("CRUSH_REDUCE_ANIMATIONS")
+	t.Setenv("SSH_TTY", "some_value")
+	cfg2, err := Load("", "", false)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg2)
+	assert.NotNil(t, cfg2.config.Options)
+	assert.NotNil(t, cfg2.config.Options.TUI)
+	assert.Nil(t, cfg2.config.Options.TUI.ReduceAnimations) // Should be nil, not auto-set to true
+}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -2535,6 +2535,50 @@ func TestConfig_LoadFromBytes_EnvMerge(t *testing.T) {
 	require.Equal(t, "us-east-1", loadedConfig.Env["AWS_REGION"])
 }
 
+func TestIsSSH(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{
+			name: "SSH_TTY set",
+			env:  map[string]string{"SSH_TTY": "/dev/pts/0"},
+			want: true,
+		},
+		{
+			name: "SSH_CONNECTION set",
+			env:  map[string]string{"SSH_CONNECTION": "10.0.0.1 12345 10.0.0.2 22"},
+			want: true,
+		},
+		{
+			name: "SSH_CLIENT set",
+			env:  map[string]string{"SSH_CLIENT": "10.0.0.1 12345 22"},
+			want: true,
+		},
+		{
+			name: "no SSH env",
+			env:  map[string]string{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			// Ensure other SSH variables are unset.
+			for _, k := range []string{"SSH_TTY", "SSH_CONNECTION", "SSH_CLIENT"} {
+				if _, ok := tt.env[k]; !ok {
+					t.Setenv(k, "")
+				}
+			}
+			assert.Equal(t, tt.want, isSSH())
+		})
+	}
+}
+
 // TestShouldReduceAnimations tests the ShouldReduceAnimations logic.
 func TestShouldReduceAnimations(t *testing.T) {
 	// Test explicit reduce_animations: true

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -447,6 +447,18 @@ func (s *ConfigStore) SetTransparentBackground(scope Scope, enabled bool) error 
 	})
 }
 
+// SetSSHAnimationMode sets the SSH animation mode and persists it.
+func (s *ConfigStore) SetSSHAnimationMode(scope Scope, mode string) error {
+	if s.config.Options == nil {
+		s.config.Options = &Options{}
+	}
+	if s.config.Options.TUI == nil {
+		s.config.Options.TUI = &TUIOptions{}
+	}
+	s.config.Options.TUI.SSHAnimationMode = mode
+	return s.SetConfigField(scope, "options.tui.ssh_animation_mode", mode)
+}
+
 // SetProviderAPIKey sets the API key for a provider and persists it.
 func (s *ConfigStore) SetProviderAPIKey(scope Scope, providerID string, apiKey any) error {
 	var providerConfig ProviderConfig

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -560,6 +560,18 @@ func (s *ConfigStore) SetTransparentBackground(scope Scope, enabled bool) error 
 	})
 }
 
+// SetSSHAnimationMode sets the SSH animation mode and persists it.
+func (s *ConfigStore) SetSSHAnimationMode(scope Scope, mode string) error {
+	if s.config.Options == nil {
+		s.config.Options = &Options{}
+	}
+	if s.config.Options.TUI == nil {
+		s.config.Options.TUI = &TUIOptions{}
+	}
+	s.config.Options.TUI.SSHAnimationMode = mode
+	return s.SetConfigField(scope, "options.tui.ssh_animation_mode", mode)
+}
+
 // SetProviderAPIKey sets the API key for a provider and persists it.
 func (s *ConfigStore) SetProviderAPIKey(scope Scope, providerID string, apiKey any) error {
 	var providerConfig ProviderConfig

--- a/internal/ui/anim/anim.go
+++ b/internal/ui/anim/anim.go
@@ -47,8 +47,16 @@ const (
 	// Default number of cycling chars.
 	defaultNumCyclingChars = 10
 
-	// Number of steps per color cycle for the static dot animation (500ms at 20fps).
+	// Number of steps per color cycle for the static dot animation.
 	dotColorCycleSteps = 10
+
+	// Tick interval for static (reduced) animation mode. Slower tick means
+	// fewer re-renders and less bandwidth over SSH.
+	staticTickInterval = 2 * time.Second
+
+	// Phase offset between consecutive dots in the static animation. Each dot
+	// is offset by this many steps, creating a left-to-right color wave.
+	staticDotPhase = 3
 )
 
 // Default colors for gradient.
@@ -131,8 +139,9 @@ type Anim struct {
 	ellipsisStep     atomic.Int64         // current ellipsis frame step
 	ellipsisFrames   *csync.Slice[string] // ellipsis animation frames
 	id               string
-	static           bool // when true, don't animate
+	static           bool     // when true, don't animate
 	staticRendered   string
+	dotColors        []string // pre-rendered dot characters for static mode
 	gradColorA       color.Color
 	gradColorB       color.Color
 }
@@ -381,8 +390,9 @@ func (a *Anim) Width() (w int) {
 
 // Start starts the animation.
 func (a *Anim) Start() tea.Cmd {
-	// Always start the tick so Animate can advance the step, even in static
-	// mode (for color cycling dots).
+	if a.static {
+		return a.staticTick()
+	}
 	return a.Step()
 }
 
@@ -397,7 +407,7 @@ func (a *Anim) Animate(msg StepMsg) tea.Cmd {
 		if int(step) >= dotColorCycleSteps {
 			a.step.Store(0)
 		}
-		return a.Step()
+		return a.staticTick()
 	}
 
 	step := a.step.Add(1)
@@ -418,19 +428,48 @@ func (a *Anim) Animate(msg StepMsg) tea.Cmd {
 	return a.Step()
 }
 
-// renderStatic renders the static "Working" label (without dots, which are colored dynamically).
+// renderStatic renders the static "Working" label and pre-renders dot colors.
 func (a *Anim) renderStatic() {
 	a.staticRendered = lipgloss.NewStyle().
 		Foreground(a.labelColor).
 		Render("Working")
+
+	// Pre-render all dot colors to avoid MakeColor + lipgloss on every Render().
+	c1, ok1 := colorful.MakeColor(a.gradColorA)
+	c2, ok2 := colorful.MakeColor(a.gradColorB)
+	if ok1 && ok2 {
+		a.dotColors = make([]string, dotColorCycleSteps)
+		for step := range dotColorCycleSteps {
+			pos := float64(step) / float64(dotColorCycleSteps)
+			var c color.Color
+			if pos < 0.5 {
+				c = c1.BlendHcl(c2, pos*2)
+			} else {
+				c = c2.BlendHcl(c1, (pos-0.5)*2)
+			}
+			a.dotColors[step] = lipgloss.NewStyle().Foreground(c).Render(".")
+		}
+	}
 }
 
 // Render renders the current state of the animation.
 func (a *Anim) Render() string {
 	if a.static {
 		step := int(a.step.Load())
-		dots := lipgloss.NewStyle().Foreground(a.dotColor(step)).Render("...")
-		return a.staticRendered + dots
+		var b strings.Builder
+		b.WriteString(a.staticRendered)
+		if a.dotColors != nil {
+			for i := range 3 {
+				dotStep := (step + i*staticDotPhase) % dotColorCycleSteps
+				b.WriteString(a.dotColors[dotStep])
+			}
+		} else {
+			// Fallback: plain dots if MakeColor failed during init.
+			for range 3 {
+				b.WriteByte('.')
+			}
+		}
+		return b.String()
 	}
 
 	var b strings.Builder
@@ -470,27 +509,19 @@ func (a *Anim) Render() string {
 	return b.String()
 }
 
-// dotColor returns a color blended between GradColorA and GradColorB based on
-// the current step, cycling every 500ms (dotColorCycleSteps frames at fps).
-func (a *Anim) dotColor(step int) color.Color {
-	pos := float64(step%dotColorCycleSteps) / float64(dotColorCycleSteps)
 
-	c1, ok1 := colorful.MakeColor(a.gradColorA)
-	c2, ok2 := colorful.MakeColor(a.gradColorB)
-	if !ok1 || !ok2 {
-		return a.labelColor
-	}
-
-	// Oscillate between A and B.
-	if pos < 0.5 {
-		return c1.BlendHcl(c2, pos*2)
-	}
-	return c2.BlendHcl(c1, (pos-0.5)*2)
-}
 
 // Step is a command that triggers the next step in the animation.
 func (a *Anim) Step() tea.Cmd {
 	return tea.Tick(time.Second/time.Duration(fps), func(t time.Time) tea.Msg {
+		return StepMsg{ID: a.id}
+	})
+}
+
+// staticTick returns a slower tick for static/reduced animation mode to
+// minimize bandwidth and re-renders.
+func (a *Anim) staticTick() tea.Cmd {
+	return tea.Tick(staticTickInterval, func(t time.Time) tea.Msg {
 		return StepMsg{ID: a.id}
 	})
 }

--- a/internal/ui/anim/anim.go
+++ b/internal/ui/anim/anim.go
@@ -339,6 +339,11 @@ func (a *Anim) SetLabel(newLabel string) {
 		a.width += a.labelWidth
 	}
 
+	if a.static {
+		a.staticRendered = lipgloss.NewStyle().Foreground(a.labelColor).Render(newLabel)
+		return
+	}
+
 	// Re-render the label
 	a.renderLabel(newLabel)
 }

--- a/internal/ui/anim/anim.go
+++ b/internal/ui/anim/anim.go
@@ -47,17 +47,12 @@ const (
 	// Default number of cycling chars.
 	defaultNumCyclingChars = 10
 
-	// Number of steps per color cycle for the static dot animation.
-	dotColorCycleSteps = 10
-
-	// Tick interval for static (reduced) animation mode. Slower tick means
-	// fewer re-renders and less bandwidth over SSH.
-	staticTickInterval = 2 * time.Second
-
-	// Phase offset between consecutive dots in the static animation. Each dot
-	// is offset by this many steps, creating a left-to-right color wave.
-	staticDotPhase = 3
+	// Tick interval for static (reduced) animation mode.
+	staticTickInterval = 500 * time.Millisecond
 )
+
+// Ellipsis frames for the static animation.
+var staticEllipsisFrames = []string{"", ".", "..", "..."}
 
 // Default colors for gradient.
 var (
@@ -94,8 +89,8 @@ var animCacheMap = csync.NewMap[string, *animCache]()
 // settingsHash creates a hash key for the settings to use for caching
 func settingsHash(opts Settings) string {
 	h := xxh3.New()
-	fmt.Fprintf(h, "%d-%s-%v-%v-%v-%t",
-		opts.Size, opts.Label, opts.LabelColor, opts.GradColorA, opts.GradColorB, opts.CycleColors)
+	fmt.Fprintf(h, "%d-%s-%v-%v-%v-%v-%t",
+		opts.Size, opts.Label, opts.LabelColor, opts.EllipsisColor, opts.GradColorA, opts.GradColorB, opts.CycleColors)
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
@@ -104,14 +99,15 @@ type StepMsg struct{ ID string }
 
 // Settings defines settings for the animation.
 type Settings struct {
-	ID          string
-	Static      bool
-	Size        int
-	Label       string
-	LabelColor  color.Color
-	GradColorA  color.Color
-	GradColorB  color.Color
-	CycleColors bool
+	ID            string
+	Static        bool
+	Size          int
+	Label         string
+	LabelColor    color.Color
+	EllipsisColor color.Color // Color for ellipsis dots; defaults to LabelColor if unset
+	GradColorA    color.Color
+	GradColorB    color.Color
+	CycleColors   bool
 
 	// NoScramble disables the scrambled rune animation. The cycling
 	// character region is removed entirely so only the label and its
@@ -125,25 +121,24 @@ const ()
 
 // Anim is a Bubble for an animated spinner.
 type Anim struct {
-	width            int
-	cyclingCharWidth int
-	label            *csync.Slice[string]
-	labelWidth       int
-	labelColor       color.Color
-	birthSteps       []int
-	initialFrames    [][]string // frames for the initial characters
-	initialized      atomic.Bool
-	cyclingFrames    [][]string           // frames for the cycling characters
-	step             atomic.Int64         // current main frame step (wraps)
-	framesSinceStart atomic.Int64         // total Animate ticks (does not wrap)
-	ellipsisStep     atomic.Int64         // current ellipsis frame step
-	ellipsisFrames   *csync.Slice[string] // ellipsis animation frames
-	id               string
-	static           bool // when true, don't animate
-	staticRendered   string
-	dotColors        []string // pre-rendered dot characters for static mode
-	gradColorA       color.Color
-	gradColorB       color.Color
+	width                int
+	cyclingCharWidth     int
+	label                *csync.Slice[string]
+	labelWidth           int
+	labelColor           color.Color
+	ellipsisColor        color.Color
+	birthSteps           []int
+	initialFrames        [][]string // frames for the initial characters
+	initialized          atomic.Bool
+	cyclingFrames        [][]string           // frames for the cycling characters
+	step                 atomic.Int64         // current main frame step (wraps)
+	framesSinceStart     atomic.Int64         // total Animate ticks (does not wrap)
+	ellipsisStep         atomic.Int64         // current ellipsis frame step
+	ellipsisFrames       *csync.Slice[string] // ellipsis animation frames
+	id                   string
+	static               bool // when true, don't animate
+	staticRendered       string
+	staticEllipsisFrames []string // pre-rendered ellipsis frames for static mode
 }
 
 // New creates a new Anim instance with the specified width and label.
@@ -174,10 +169,12 @@ func New(opts Settings) *Anim {
 		a.cyclingCharWidth = opts.Size
 	}
 	a.labelColor = opts.LabelColor
+	if colorIsUnset(opts.EllipsisColor) {
+		a.ellipsisColor = opts.LabelColor
+	} else {
+		a.ellipsisColor = opts.EllipsisColor
+	}
 	a.static = opts.Static
-
-	a.gradColorA = opts.GradColorA
-	a.gradColorB = opts.GradColorB
 
 	// For static mode, render a static "Working..." label and return early.
 	if opts.Static {
@@ -340,7 +337,7 @@ func (a *Anim) SetLabel(newLabel string) {
 	}
 
 	if a.static {
-		a.staticRendered = lipgloss.NewStyle().Foreground(a.labelColor).Render(newLabel)
+		a.renderStatic()
 		return
 	}
 
@@ -409,7 +406,7 @@ func (a *Anim) Animate(msg StepMsg) tea.Cmd {
 
 	if a.static {
 		step := a.step.Add(1)
-		if int(step) >= dotColorCycleSteps {
+		if int(step) >= len(staticEllipsisFrames) {
 			a.step.Store(0)
 		}
 		return a.staticTick()
@@ -433,27 +430,14 @@ func (a *Anim) Animate(msg StepMsg) tea.Cmd {
 	return a.Step()
 }
 
-// renderStatic renders the static "Working" label and pre-renders dot colors.
+// renderStatic renders the static label and pre-renders ellipsis frames.
 func (a *Anim) renderStatic() {
-	a.staticRendered = lipgloss.NewStyle().
-		Foreground(a.labelColor).
-		Render("Working")
-
-	// Pre-render all dot colors to avoid MakeColor + lipgloss on every Render().
-	c1, ok1 := colorful.MakeColor(a.gradColorA)
-	c2, ok2 := colorful.MakeColor(a.gradColorB)
-	if ok1 && ok2 {
-		a.dotColors = make([]string, dotColorCycleSteps)
-		for step := range dotColorCycleSteps {
-			pos := float64(step) / float64(dotColorCycleSteps)
-			var c color.Color
-			if pos < 0.5 {
-				c = c1.BlendHcl(c2, pos*2)
-			} else {
-				c = c2.BlendHcl(c1, (pos-0.5)*2)
-			}
-			a.dotColors[step] = lipgloss.NewStyle().Foreground(c).Render(".")
-		}
+	labelStyle := lipgloss.NewStyle().Foreground(a.labelColor)
+	dotStyle := lipgloss.NewStyle().Foreground(a.ellipsisColor)
+	a.staticRendered = labelStyle.Render("Working")
+	a.staticEllipsisFrames = make([]string, len(staticEllipsisFrames))
+	for i, frame := range staticEllipsisFrames {
+		a.staticEllipsisFrames[i] = dotStyle.Render(frame)
 	}
 }
 
@@ -463,16 +447,8 @@ func (a *Anim) Render() string {
 		step := int(a.step.Load())
 		var b strings.Builder
 		b.WriteString(a.staticRendered)
-		if a.dotColors != nil {
-			for i := range 3 {
-				dotStep := (step + i*staticDotPhase) % dotColorCycleSteps
-				b.WriteString(a.dotColors[dotStep])
-			}
-		} else {
-			// Fallback: plain dots if MakeColor failed during init.
-			for range 3 {
-				b.WriteByte('.')
-			}
+		if step < len(a.staticEllipsisFrames) {
+			b.WriteString(a.staticEllipsisFrames[step])
 		}
 		return b.String()
 	}

--- a/internal/ui/anim/anim.go
+++ b/internal/ui/anim/anim.go
@@ -94,6 +94,7 @@ type StepMsg struct{ ID string }
 // Settings defines settings for the animation.
 type Settings struct {
 	ID          string
+	Static      bool
 	Size        int
 	Label       string
 	LabelColor  color.Color
@@ -127,6 +128,8 @@ type Anim struct {
 	ellipsisStep     atomic.Int64         // current ellipsis frame step
 	ellipsisFrames   *csync.Slice[string] // ellipsis animation frames
 	id               string
+	static           bool // when true, don't animate
+	staticRendered   string
 }
 
 // New creates a new Anim instance with the specified width and label.
@@ -157,6 +160,14 @@ func New(opts Settings) *Anim {
 		a.cyclingCharWidth = opts.Size
 	}
 	a.labelColor = opts.LabelColor
+	a.static = opts.Static
+
+	// For static mode, render a static "Working..." label and return early.
+	if opts.Static {
+		a.initialized.Store(true)
+		a.renderStatic()
+		return a
+	}
 
 	// NoScramble means no cycling chars and no birth animation. Mark as
 	// initialized immediately so the label renders without a fade-in.
@@ -362,12 +373,15 @@ func (a *Anim) Width() (w int) {
 
 // Start starts the animation.
 func (a *Anim) Start() tea.Cmd {
+	if a.static {
+		return nil
+	}
 	return a.Step()
 }
 
 // Animate advances the animation to the next step.
 func (a *Anim) Animate(msg StepMsg) tea.Cmd {
-	if msg.ID != a.id {
+	if a.static || msg.ID != a.id {
 		return nil
 	}
 
@@ -389,8 +403,19 @@ func (a *Anim) Animate(msg StepMsg) tea.Cmd {
 	return a.Step()
 }
 
+// renderStatic renders the static version of the spinner (label with "..." ellipsis).
+func (a *Anim) renderStatic() {
+	a.staticRendered = lipgloss.NewStyle().
+		Foreground(a.labelColor).
+		Render("Working...")
+}
+
 // Render renders the current state of the animation.
 func (a *Anim) Render() string {
+	if a.static {
+		return a.staticRendered
+	}
+
 	var b strings.Builder
 	step := int(a.step.Load())
 	frames := int(a.framesSinceStart.Load())

--- a/internal/ui/anim/anim.go
+++ b/internal/ui/anim/anim.go
@@ -381,9 +381,8 @@ func (a *Anim) Width() (w int) {
 
 // Start starts the animation.
 func (a *Anim) Start() tea.Cmd {
-	if a.static {
-		return nil
-	}
+	// Always start the tick so Animate can advance the step, even in static
+	// mode (for color cycling dots).
 	return a.Step()
 }
 

--- a/internal/ui/anim/anim.go
+++ b/internal/ui/anim/anim.go
@@ -46,6 +46,9 @@ const (
 
 	// Default number of cycling chars.
 	defaultNumCyclingChars = 10
+
+	// Number of steps per color cycle for the static dot animation (500ms at 20fps).
+	dotColorCycleSteps = 10
 )
 
 // Default colors for gradient.
@@ -130,6 +133,8 @@ type Anim struct {
 	id               string
 	static           bool // when true, don't animate
 	staticRendered   string
+	gradColorA       color.Color
+	gradColorB       color.Color
 }
 
 // New creates a new Anim instance with the specified width and label.
@@ -161,6 +166,9 @@ func New(opts Settings) *Anim {
 	}
 	a.labelColor = opts.LabelColor
 	a.static = opts.Static
+
+	a.gradColorA = opts.GradColorA
+	a.gradColorB = opts.GradColorB
 
 	// For static mode, render a static "Working..." label and return early.
 	if opts.Static {
@@ -381,8 +389,16 @@ func (a *Anim) Start() tea.Cmd {
 
 // Animate advances the animation to the next step.
 func (a *Anim) Animate(msg StepMsg) tea.Cmd {
-	if a.static || msg.ID != a.id {
+	if msg.ID != a.id {
 		return nil
+	}
+
+	if a.static {
+		step := a.step.Add(1)
+		if int(step) >= dotColorCycleSteps {
+			a.step.Store(0)
+		}
+		return a.Step()
 	}
 
 	step := a.step.Add(1)
@@ -403,17 +419,19 @@ func (a *Anim) Animate(msg StepMsg) tea.Cmd {
 	return a.Step()
 }
 
-// renderStatic renders the static version of the spinner (label with "..." ellipsis).
+// renderStatic renders the static "Working" label (without dots, which are colored dynamically).
 func (a *Anim) renderStatic() {
 	a.staticRendered = lipgloss.NewStyle().
 		Foreground(a.labelColor).
-		Render("Working...")
+		Render("Working")
 }
 
 // Render renders the current state of the animation.
 func (a *Anim) Render() string {
 	if a.static {
-		return a.staticRendered
+		step := int(a.step.Load())
+		dots := lipgloss.NewStyle().Foreground(a.dotColor(step)).Render("...")
+		return a.staticRendered + dots
 	}
 
 	var b strings.Builder
@@ -451,6 +469,24 @@ func (a *Anim) Render() string {
 	}
 
 	return b.String()
+}
+
+// dotColor returns a color blended between GradColorA and GradColorB based on
+// the current step, cycling every 500ms (dotColorCycleSteps frames at fps).
+func (a *Anim) dotColor(step int) color.Color {
+	pos := float64(step%dotColorCycleSteps) / float64(dotColorCycleSteps)
+
+	c1, ok1 := colorful.MakeColor(a.gradColorA)
+	c2, ok2 := colorful.MakeColor(a.gradColorB)
+	if !ok1 || !ok2 {
+		return a.labelColor
+	}
+
+	// Oscillate between A and B.
+	if pos < 0.5 {
+		return c1.BlendHcl(c2, pos*2)
+	}
+	return c2.BlendHcl(c1, (pos-0.5)*2)
 }
 
 // Step is a command that triggers the next step in the animation.

--- a/internal/ui/anim/anim.go
+++ b/internal/ui/anim/anim.go
@@ -139,7 +139,7 @@ type Anim struct {
 	ellipsisStep     atomic.Int64         // current ellipsis frame step
 	ellipsisFrames   *csync.Slice[string] // ellipsis animation frames
 	id               string
-	static           bool     // when true, don't animate
+	static           bool // when true, don't animate
 	staticRendered   string
 	dotColors        []string // pre-rendered dot characters for static mode
 	gradColorA       color.Color
@@ -508,8 +508,6 @@ func (a *Anim) Render() string {
 
 	return b.String()
 }
-
-
 
 // Step is a command that triggers the next step in the animation.
 func (a *Anim) Step() tea.Cmd {

--- a/internal/ui/anim/anim.go
+++ b/internal/ui/anim/anim.go
@@ -46,7 +46,13 @@ const (
 
 	// Default number of cycling chars.
 	defaultNumCyclingChars = 10
+
+	// Tick interval for static (reduced) animation mode.
+	staticTickInterval = 500 * time.Millisecond
 )
+
+// Ellipsis frames for the static animation.
+var staticEllipsisFrames = []string{"", ".", "..", "..."}
 
 // Default colors for gradient.
 var (
@@ -82,8 +88,8 @@ var animCacheMap = csync.NewMap[string, *animCache]()
 // settingsHash creates a hash key for the settings to use for caching
 func settingsHash(opts Settings) string {
 	h := xxh3.New()
-	fmt.Fprintf(h, "%d-%s-%v-%v-%v-%t-%v",
-		opts.Size, opts.Label, opts.LabelColor, opts.GradColorA, opts.GradColorB, opts.CycleColors, opts.SuffixColor)
+	fmt.Fprintf(h, "%d-%s-%v-%v-%v-%v-%v-%t-%v",
+		opts.Size, opts.Label, opts.LabelColor, opts.EllipsisColor, opts.GradColorA, opts.GradColorB, opts.CycleColors, opts.Static, opts.SuffixColor)
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
@@ -100,13 +106,15 @@ type StepMsg struct {
 
 // Settings defines settings for the animation.
 type Settings struct {
-	ID          string
-	Size        int
-	Label       string
-	LabelColor  color.Color
-	GradColorA  color.Color
-	GradColorB  color.Color
-	CycleColors bool
+	ID            string
+	Static        bool
+	Size          int
+	Label         string
+	LabelColor    color.Color
+	EllipsisColor color.Color // Color for ellipsis dots; defaults to LabelColor if unset
+	GradColorA    color.Color
+	GradColorB    color.Color
+	CycleColors   bool
 
 	// NoScramble disables the scrambled rune animation. The cycling
 	// character region is removed entirely so only the label and its
@@ -128,22 +136,26 @@ const ()
 
 // Anim is a Bubble for an animated spinner.
 type Anim struct {
-	width            int
-	cyclingCharWidth int
-	label            *csync.Slice[string]
-	labelWidth       int
-	labelColor       color.Color
-	birthSteps       []int
-	initialFrames    [][]string // frames for the initial characters
-	initialized      atomic.Bool
-	cyclingFrames    [][]string           // frames for the cycling characters
-	step             atomic.Int64         // current main frame step (wraps)
-	framesSinceStart atomic.Int64         // total Animate ticks (does not wrap)
-	ellipsisStep     atomic.Int64         // current ellipsis frame step
-	ellipsisFrames   *csync.Slice[string] // ellipsis animation frames
-	id               string
-	suffix           func() string
-	suffixColor      color.Color
+	width                int
+	cyclingCharWidth     int
+	label                *csync.Slice[string]
+	labelWidth           int
+	labelColor           color.Color
+	ellipsisColor        color.Color
+	birthSteps           []int
+	initialFrames        [][]string // frames for the initial characters
+	initialized          atomic.Bool
+	cyclingFrames        [][]string           // frames for the cycling characters
+	step                 atomic.Int64         // current main frame step (wraps)
+	framesSinceStart     atomic.Int64         // total Animate ticks (does not wrap)
+	ellipsisStep         atomic.Int64         // current ellipsis frame step
+	ellipsisFrames       *csync.Slice[string] // ellipsis animation frames
+	id                   string
+	suffix               func() string
+	suffixColor          color.Color
+	static               bool // when true, don't animate
+	staticRendered       string
+	staticEllipsisFrames []string // pre-rendered ellipsis frames for static mode
 
 	// gen identifies the currently armed tick chain. Start() bumps it and
 	// stamps every emitted StepMsg with the new value; Animate() drops ticks
@@ -181,6 +193,19 @@ func New(opts Settings) *Anim {
 		a.cyclingCharWidth = opts.Size
 	}
 	a.labelColor = opts.LabelColor
+	if colorIsUnset(opts.EllipsisColor) {
+		a.ellipsisColor = opts.LabelColor
+	} else {
+		a.ellipsisColor = opts.EllipsisColor
+	}
+	a.static = opts.Static
+
+	// For static mode, render a static "Working..." label and return early.
+	if opts.Static {
+		a.initialized.Store(true)
+		a.renderStatic()
+		return a
+	}
 
 	// Store the suffix function if provided.
 	if opts.Suffix != nil {
@@ -345,6 +370,11 @@ func (a *Anim) SetLabel(newLabel string) {
 		a.width += a.labelWidth
 	}
 
+	if a.static {
+		a.renderStatic()
+		return
+	}
+
 	// Re-render the label
 	a.renderLabel(newLabel)
 }
@@ -402,6 +432,9 @@ func (a *Anim) Width() (w int) {
 // part) would run two chains concurrently and render a doubled animation.
 func (a *Anim) Start() tea.Cmd {
 	a.gen.Add(1)
+	if a.static {
+		return a.staticTick()
+	}
 	return a.Step()
 }
 
@@ -422,6 +455,14 @@ func (a *Anim) Animate(msg StepMsg) tea.Cmd {
 		return nil
 	}
 
+	if a.static {
+		step := a.step.Add(1)
+		if int(step) >= len(staticEllipsisFrames) {
+			a.step.Store(0)
+		}
+		return a.staticTick()
+	}
+
 	step := a.step.Add(1)
 	if int(step) >= len(a.cyclingFrames) {
 		a.step.Store(0)
@@ -440,8 +481,29 @@ func (a *Anim) Animate(msg StepMsg) tea.Cmd {
 	return a.Step()
 }
 
+// renderStatic renders the static label and pre-renders ellipsis frames.
+func (a *Anim) renderStatic() {
+	labelStyle := lipgloss.NewStyle().Foreground(a.labelColor)
+	dotStyle := lipgloss.NewStyle().Foreground(a.ellipsisColor)
+	a.staticRendered = labelStyle.Render("Working")
+	a.staticEllipsisFrames = make([]string, len(staticEllipsisFrames))
+	for i, frame := range staticEllipsisFrames {
+		a.staticEllipsisFrames[i] = dotStyle.Render(frame)
+	}
+}
+
 // Render renders the current state of the animation.
 func (a *Anim) Render() string {
+	if a.static {
+		step := int(a.step.Load())
+		var b strings.Builder
+		b.WriteString(a.staticRendered)
+		if step < len(a.staticEllipsisFrames) {
+			b.WriteString(a.staticEllipsisFrames[step])
+		}
+		return b.String()
+	}
+
 	var b strings.Builder
 	step := int(a.step.Load())
 	frames := int(a.framesSinceStart.Load())
@@ -504,6 +566,14 @@ func (a *Anim) Step() tea.Cmd {
 	gen := a.gen.Load()
 	return tea.Tick(time.Second/time.Duration(fps), func(t time.Time) tea.Msg {
 		return StepMsg{ID: a.id, Gen: gen}
+	})
+}
+
+// staticTick returns a slower tick for static/reduced animation mode to
+// minimize bandwidth and re-renders.
+func (a *Anim) staticTick() tea.Cmd {
+	return tea.Tick(staticTickInterval, func(t time.Time) tea.Msg {
+		return StepMsg{ID: a.id}
 	})
 }
 

--- a/internal/ui/anim/anim.go
+++ b/internal/ui/anim/anim.go
@@ -570,10 +570,13 @@ func (a *Anim) Step() tea.Cmd {
 }
 
 // staticTick returns a slower tick for static/reduced animation mode to
-// minimize bandwidth and re-renders.
+// minimize bandwidth and re-renders. Like Step(), it stamps the current
+// generation into the StepMsg so the tick chain survives the generation
+// gate in Animate().
 func (a *Anim) staticTick() tea.Cmd {
+	gen := a.gen.Load()
 	return tea.Tick(staticTickInterval, func(t time.Time) tea.Msg {
-		return StepMsg{ID: a.id}
+		return StepMsg{ID: a.id, Gen: gen}
 	})
 }
 

--- a/internal/ui/anim/anim.go
+++ b/internal/ui/anim/anim.go
@@ -151,6 +151,7 @@ type Anim struct {
 	ellipsisStep         atomic.Int64         // current ellipsis frame step
 	ellipsisFrames       *csync.Slice[string] // ellipsis animation frames
 	id                   string
+	labelText            string // current label text; used by the static renderer
 	suffix               func() string
 	suffixColor          color.Color
 	static               bool // when true, don't animate
@@ -199,8 +200,12 @@ func New(opts Settings) *Anim {
 		a.ellipsisColor = opts.EllipsisColor
 	}
 	a.static = opts.Static
+	a.labelText = opts.Label
+	if a.static && a.labelText == "" {
+		a.labelText = "Working"
+	}
 
-	// For static mode, render a static "Working..." label and return early.
+	// For static mode, render the static label and return early.
 	if opts.Static {
 		a.initialized.Store(true)
 		a.renderStatic()
@@ -359,6 +364,7 @@ func New(opts Settings) *Anim {
 
 // SetLabel updates the label text and re-renders it.
 func (a *Anim) SetLabel(newLabel string) {
+	a.labelText = newLabel
 	a.labelWidth = lipgloss.Width(newLabel)
 
 	// Update total width. Skip the label gap when there are no cycling chars.
@@ -485,7 +491,7 @@ func (a *Anim) Animate(msg StepMsg) tea.Cmd {
 func (a *Anim) renderStatic() {
 	labelStyle := lipgloss.NewStyle().Foreground(a.labelColor)
 	dotStyle := lipgloss.NewStyle().Foreground(a.ellipsisColor)
-	a.staticRendered = labelStyle.Render("Working")
+	a.staticRendered = labelStyle.Render(a.labelText)
 	a.staticEllipsisFrames = make([]string, len(staticEllipsisFrames))
 	for i, frame := range staticEllipsisFrames {
 		a.staticEllipsisFrames[i] = dotStyle.Render(frame)

--- a/internal/ui/anim/anim_test.go
+++ b/internal/ui/anim/anim_test.go
@@ -2,10 +2,11 @@ package anim
 
 import (
 	"image/color"
+	"strings"
 	"testing"
 )
 
-func TestStaticColorCycling(t *testing.T) {
+func TestStaticEllipsisCycling(t *testing.T) {
 	a := New(Settings{
 		Static:      true,
 		Size:        15,
@@ -15,49 +16,78 @@ func TestStaticColorCycling(t *testing.T) {
 		CycleColors: true,
 	})
 
-	// Capture initial render
-	previous := a.Render()
+	// Capture renders for each step
+	renders := make([]string, len(staticEllipsisFrames))
+	for i := range staticEllipsisFrames {
+		a.step.Store(int64(i))
+		renders[i] = a.Render()
+	}
 
-	distinctRenders := 0
-
-	// Simulate 3 full cycles (30 steps) and track distinct renders
-	for i := 0; i < 30; i++ {
-		a.step.Add(1)
-		current := a.Render()
-		if current != previous {
-			distinctRenders++
-			previous = current
+	// Each render should contain "Working" and the appropriate dots
+	for i, r := range renders {
+		if !strings.Contains(r, "Working") {
+			t.Errorf("expected render to contain 'Working', got %q", r)
+		}
+		expectedDots := staticEllipsisFrames[i]
+		if expectedDots != "" && !strings.Contains(r, expectedDots) {
+			t.Errorf("step %d: expected render to contain %q, got %q", i, expectedDots, r)
 		}
 	}
 
-	// With 10 distinct colors in a cycle, we should see at least 5 changes
-	// across 30 steps (3 cycles × 10 colors = 30, but step 0 repeats at wrap)
-	if distinctRenders < 5 {
-		t.Errorf("expected at least 5 distinct renders across 3 cycles, got %d", distinctRenders)
+	// Verify cycle wraps correctly
+	a.step.Store(int64(len(staticEllipsisFrames)))
+	a.Animate(StepMsg{ID: a.id})
+	if int(a.step.Load()) != 0 {
+		t.Errorf("expected step to wrap to 0, got %d", a.step.Load())
 	}
 }
 
-func TestStaticStartsWithGradColorA(t *testing.T) {
-	red := color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff}
-	blue := color.RGBA{R: 0, G: 0, B: 0xff, A: 0xff}
+func TestStaticStartsWithWorking(t *testing.T) {
 	label := color.RGBA{R: 0xcc, G: 0xcc, B: 0xcc, A: 0xff}
 
 	a := New(Settings{
 		Static:      true,
 		Size:        15,
-		GradColorA:  red,
-		GradColorB:  blue,
+		GradColorA:  color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff},
+		GradColorB:  color.RGBA{R: 0, G: 0, B: 0xff, A: 0xff},
 		LabelColor:  label,
 		CycleColors: true,
 	})
 
-	// At step 0, dotColor should be GradColorA (red)
+	// At step 0, should show "Working" (no dots yet).
 	r := a.Render()
-	if len(r) == 0 {
-		t.Fatal("expected non-empty render")
+	if !strings.Contains(r, "Working") {
+		t.Fatalf("expected render to contain 'Working', got %q", r)
 	}
-	// Verify it contains "Working" in the label color
 	if a.staticRendered == "" {
 		t.Fatal("expected staticRendered to be set")
+	}
+}
+
+func TestStaticEllipsisColor(t *testing.T) {
+	label := color.RGBA{R: 0xcc, G: 0xcc, B: 0xcc, A: 0xff}
+	ellipsis := color.RGBA{R: 0x66, G: 0x66, B: 0x66, A: 0xff}
+
+	a := New(Settings{
+		Static:        true,
+		Size:          15,
+		LabelColor:    label,
+		EllipsisColor: ellipsis,
+		CycleColors:   true,
+	})
+
+	if a.ellipsisColor != ellipsis {
+		t.Errorf("expected ellipsisColor to be set, got %v", a.ellipsisColor)
+	}
+
+	// When EllipsisColor is unset, it should default to LabelColor
+	b := New(Settings{
+		Static:      true,
+		Size:        15,
+		LabelColor:  label,
+		CycleColors: true,
+	})
+	if b.ellipsisColor != label {
+		t.Errorf("expected ellipsisColor to default to LabelColor, got %v", b.ellipsisColor)
 	}
 }

--- a/internal/ui/anim/anim_test.go
+++ b/internal/ui/anim/anim_test.go
@@ -1,0 +1,63 @@
+package anim
+
+import (
+	"image/color"
+	"testing"
+)
+
+func TestStaticColorCycling(t *testing.T) {
+	a := New(Settings{
+		Static:      true,
+		Size:        15,
+		GradColorA:  color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff},
+		GradColorB:  color.RGBA{R: 0, G: 0, B: 0xff, A: 0xff},
+		LabelColor:  color.RGBA{R: 0xcc, G: 0xcc, B: 0xcc, A: 0xff},
+		CycleColors: true,
+	})
+
+	// Capture initial render
+	previous := a.Render()
+
+	distinctRenders := 0
+
+	// Simulate 3 full cycles (30 steps) and track distinct renders
+	for i := 0; i < 30; i++ {
+		a.step.Add(1)
+		current := a.Render()
+		if current != previous {
+			distinctRenders++
+			previous = current
+		}
+	}
+
+	// With 10 distinct colors in a cycle, we should see at least 5 changes
+	// across 30 steps (3 cycles × 10 colors = 30, but step 0 repeats at wrap)
+	if distinctRenders < 5 {
+		t.Errorf("expected at least 5 distinct renders across 3 cycles, got %d", distinctRenders)
+	}
+}
+
+func TestStaticStartsWithGradColorA(t *testing.T) {
+	red := color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff}
+	blue := color.RGBA{R: 0, G: 0, B: 0xff, A: 0xff}
+	label := color.RGBA{R: 0xcc, G: 0xcc, B: 0xcc, A: 0xff}
+
+	a := New(Settings{
+		Static:      true,
+		Size:        15,
+		GradColorA:  red,
+		GradColorB:  blue,
+		LabelColor:  label,
+		CycleColors: true,
+	})
+
+	// At step 0, dotColor should be GradColorA (red)
+	r := a.Render()
+	if len(r) == 0 {
+		t.Fatal("expected non-empty render")
+	}
+	// Verify it contains "Working" in the label color
+	if a.staticRendered == "" {
+		t.Fatal("expected staticRendered to be set")
+	}
+}

--- a/internal/ui/anim/anim_test.go
+++ b/internal/ui/anim/anim_test.go
@@ -314,6 +314,46 @@ func TestStopThenStart(t *testing.T) {
 	require.NotNil(t, a.Animate(msg2))
 }
 
+// TestStaticTickCarriesGeneration verifies that the reduced/static
+// animation mode uses the generation gate correctly. Without this, the
+// first tick after Start() is dropped and the "Working" ellipsis never
+// animates.
+func TestStaticTickCarriesGeneration(t *testing.T) {
+	t.Parallel()
+
+	label := color.RGBA{R: 0xcc, G: 0xcc, B: 0xcc, A: 0xff}
+	a := New(Settings{
+		ID:          "static",
+		Static:      true,
+		Size:        5,
+		LabelColor:  label,
+		CycleColors: true,
+	})
+
+	cmd := a.Start()
+	msg := cmd().(StepMsg)
+
+	// The tick must carry the current generation so Animate() accepts it.
+	require.Equal(t, a.id, msg.ID)
+	require.Equal(t, a.gen.Load(), msg.Gen, "static tick must carry the current generation")
+	require.NotEqual(t, int64(0), msg.Gen, "generation must have been bumped by Start()")
+
+	// The first animation step should advance the ellipsis frame and
+	// schedule the next tick.
+	next := a.Animate(msg)
+	require.NotNil(t, next, "matching static tick must schedule the next step")
+	require.Equal(t, int64(1), a.step.Load(), "first Animate must advance the ellipsis step")
+
+	// After one step the rendered output should show the first dot.
+	rendered := a.Render()
+	require.Contains(t, rendered, "Working")
+	require.Contains(t, rendered, ".")
+
+	// The next scheduled tick must carry the same generation.
+	nextMsg := next().(StepMsg)
+	require.Equal(t, msg.Gen, nextMsg.Gen, "chained static tick must carry the same generation")
+}
+
 // TestAnimateWithoutStart verifies that Animate works on a fresh Anim
 // whose generation is still zero, matching a zero-gen StepMsg.
 func TestAnimateWithoutStart(t *testing.T) {

--- a/internal/ui/anim/anim_test.go
+++ b/internal/ui/anim/anim_test.go
@@ -314,6 +314,39 @@ func TestStopThenStart(t *testing.T) {
 	require.NotNil(t, a.Animate(msg2))
 }
 
+// TestStaticLabel verifies that the reduced mode uses the configured
+// label and that SetLabel updates it.
+func TestStaticLabel(t *testing.T) {
+	t.Parallel()
+
+	label := color.RGBA{R: 0xcc, G: 0xcc, B: 0xcc, A: 0xff}
+	a := New(Settings{
+		Static:     true,
+		Label:      "Thinking",
+		LabelColor: label,
+	})
+	require.Contains(t, a.Render(), "Thinking")
+
+	a.SetLabel("Summarizing")
+	require.Contains(t, a.Render(), "Summarizing")
+
+	// Empty labels are rendered as empty.
+	a.SetLabel("")
+	rendered := a.Render()
+	require.NotContains(t, rendered, "Working")
+	require.NotContains(t, rendered, "Thinking")
+}
+
+// TestStaticDefaultsToWorking verifies that the reduced mode falls back
+// to a "Working" label when none is supplied.
+func TestStaticDefaultsToWorking(t *testing.T) {
+	t.Parallel()
+
+	label := color.RGBA{R: 0xcc, G: 0xcc, B: 0xcc, A: 0xff}
+	a := New(Settings{Static: true, LabelColor: label})
+	require.Contains(t, a.Render(), "Working")
+}
+
 // TestStaticTickCarriesGeneration verifies that the reduced/static
 // animation mode uses the generation gate correctly. Without this, the
 // first tick after Start() is dropped and the "Working" ellipsis never

--- a/internal/ui/anim/anim_test.go
+++ b/internal/ui/anim/anim_test.go
@@ -1,10 +1,98 @@
 package anim
 
 import (
+	"image/color"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestStaticEllipsisCycling(t *testing.T) {
+	a := New(Settings{
+		Static:      true,
+		Size:        15,
+		GradColorA:  color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff},
+		GradColorB:  color.RGBA{R: 0, G: 0, B: 0xff, A: 0xff},
+		LabelColor:  color.RGBA{R: 0xcc, G: 0xcc, B: 0xcc, A: 0xff},
+		CycleColors: true,
+	})
+
+	// Capture renders for each step
+	renders := make([]string, len(staticEllipsisFrames))
+	for i := range staticEllipsisFrames {
+		a.step.Store(int64(i))
+		renders[i] = a.Render()
+	}
+
+	// Each render should contain "Working" and the appropriate dots
+	for i, r := range renders {
+		if !strings.Contains(r, "Working") {
+			t.Errorf("expected render to contain 'Working', got %q", r)
+		}
+		expectedDots := staticEllipsisFrames[i]
+		if expectedDots != "" && !strings.Contains(r, expectedDots) {
+			t.Errorf("step %d: expected render to contain %q, got %q", i, expectedDots, r)
+		}
+	}
+
+	// Verify cycle wraps correctly
+	a.step.Store(int64(len(staticEllipsisFrames)))
+	a.Animate(StepMsg{ID: a.id})
+	if int(a.step.Load()) != 0 {
+		t.Errorf("expected step to wrap to 0, got %d", a.step.Load())
+	}
+}
+
+func TestStaticStartsWithWorking(t *testing.T) {
+	label := color.RGBA{R: 0xcc, G: 0xcc, B: 0xcc, A: 0xff}
+
+	a := New(Settings{
+		Static:      true,
+		Size:        15,
+		GradColorA:  color.RGBA{R: 0xff, G: 0, B: 0, A: 0xff},
+		GradColorB:  color.RGBA{R: 0, G: 0, B: 0xff, A: 0xff},
+		LabelColor:  label,
+		CycleColors: true,
+	})
+
+	// At step 0, should show "Working" (no dots yet).
+	r := a.Render()
+	if !strings.Contains(r, "Working") {
+		t.Fatalf("expected render to contain 'Working', got %q", r)
+	}
+	if a.staticRendered == "" {
+		t.Fatal("expected staticRendered to be set")
+	}
+}
+
+func TestStaticEllipsisColor(t *testing.T) {
+	label := color.RGBA{R: 0xcc, G: 0xcc, B: 0xcc, A: 0xff}
+	ellipsis := color.RGBA{R: 0x66, G: 0x66, B: 0x66, A: 0xff}
+
+	a := New(Settings{
+		Static:        true,
+		Size:          15,
+		LabelColor:    label,
+		EllipsisColor: ellipsis,
+		CycleColors:   true,
+	})
+
+	if a.ellipsisColor != ellipsis {
+		t.Errorf("expected ellipsisColor to be set, got %v", a.ellipsisColor)
+	}
+
+	// When EllipsisColor is unset, it should default to LabelColor
+	b := New(Settings{
+		Static:      true,
+		Size:        15,
+		LabelColor:  label,
+		CycleColors: true,
+	})
+	if b.ellipsisColor != label {
+		t.Errorf("expected ellipsisColor to default to LabelColor, got %v", b.ellipsisColor)
+	}
+}
 
 // TestStartSupersedesPreviousChain verifies that calling Start() twice
 // does not result in two concurrent tick chains advancing the same Anim.

--- a/internal/ui/chat/agent.go
+++ b/internal/ui/chat/agent.go
@@ -42,9 +42,10 @@ func NewAgentToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) *AgentToolMessageItem {
 	t := &AgentToolMessageItem{}
-	t.baseToolMessageItem = newBaseToolMessageItem(sty, toolCall, result, &AgentToolRenderContext{agent: t}, canceled)
+	t.baseToolMessageItem = newBaseToolMessageItem(sty, toolCall, result, &AgentToolRenderContext{agent: t}, canceled, reduceAnimations)
 	// For the agent tool we keep spinning until the tool call is finished.
 	t.spinningFunc = func(state SpinningState) bool {
 		return !state.HasResult() && !state.IsCanceled()
@@ -214,9 +215,10 @@ func NewAgenticFetchToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) *AgenticFetchToolMessageItem {
 	t := &AgenticFetchToolMessageItem{}
-	t.baseToolMessageItem = newBaseToolMessageItem(sty, toolCall, result, &AgenticFetchToolRenderContext{fetch: t}, canceled)
+	t.baseToolMessageItem = newBaseToolMessageItem(sty, toolCall, result, &AgenticFetchToolRenderContext{fetch: t}, canceled, reduceAnimations)
 	// For the agentic fetch tool we keep spinning until the tool call is finished.
 	t.spinningFunc = func(state SpinningState) bool {
 		return !state.HasResult() && !state.IsCanceled()

--- a/internal/ui/chat/applyhighlight_callback_test.go
+++ b/internal/ui/chat/applyhighlight_callback_test.go
@@ -102,7 +102,7 @@ func TestList_CallbackDrivenHighlightUnfreezeAndReFreeze(t *testing.T) {
 				message.Finish{Reason: message.FinishReasonEndTurn, Time: testFinishTime},
 			},
 		}
-		inner := NewAssistantMessageItem(&sty, msg)
+		inner := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 		require.True(t, inner.Finished(), "test fixture must be Finished()")
 		return newRenderCountingItem(inner)
 	}

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -168,13 +168,14 @@ func NewAssistantMessageItem(sty *styles.Styles, message *message.Message, reduc
 	}
 
 	a.anim = anim.New(anim.Settings{
-		ID:          a.ID(),
-		Static:      reduceAnimations,
-		Size:        15,
-		GradColorA:  sty.WorkingGradFromColor,
-		GradColorB:  sty.WorkingGradToColor,
-		LabelColor:  sty.WorkingLabelColor,
-		CycleColors: true,
+		ID:            a.ID(),
+		Static:        reduceAnimations,
+		Size:          15,
+		GradColorA:    sty.WorkingGradFromColor,
+		GradColorB:    sty.WorkingGradToColor,
+		LabelColor:    sty.WorkingLabelColor,
+		EllipsisColor: sty.WorkingEllipsisColor,
+		CycleColors:   true,
 	})
 	return a
 }

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -156,7 +156,7 @@ type AssistantMessageItem struct {
 var _ Expandable = (*AssistantMessageItem)(nil)
 
 // NewAssistantMessageItem creates a new AssistantMessageItem.
-func NewAssistantMessageItem(sty *styles.Styles, message *message.Message) MessageItem {
+func NewAssistantMessageItem(sty *styles.Styles, message *message.Message, reduceAnimations bool) MessageItem {
 	v := list.NewVersioned()
 	a := &AssistantMessageItem{
 		Versioned:                v,
@@ -169,6 +169,7 @@ func NewAssistantMessageItem(sty *styles.Styles, message *message.Message) Messa
 
 	a.anim = anim.New(anim.Settings{
 		ID:          a.ID(),
+		Static:      reduceAnimations,
 		Size:        15,
 		GradColorA:  sty.WorkingGradFromColor,
 		GradColorB:  sty.WorkingGradToColor,

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -219,7 +219,8 @@ type AssistantMessageItem struct {
 var _ Expandable = (*AssistantMessageItem)(nil)
 
 // NewAssistantMessageItem creates a new AssistantMessageItem.
-func NewAssistantMessageItem(sty *styles.Styles, message *message.Message) MessageItem {
+func NewAssistantMessageItem(sty *styles.Styles, message *message.Message, reduceAnimations ...bool) MessageItem {
+	static := len(reduceAnimations) > 0 && reduceAnimations[0]
 	v := list.NewVersioned()
 	a := &AssistantMessageItem{
 		Versioned:                v,
@@ -231,12 +232,14 @@ func NewAssistantMessageItem(sty *styles.Styles, message *message.Message) Messa
 	}
 
 	a.anim = anim.New(anim.Settings{
-		ID:          a.ID(),
-		Size:        15,
-		GradColorA:  sty.WorkingGradFromColor,
-		GradColorB:  sty.WorkingGradToColor,
-		LabelColor:  sty.WorkingLabelColor,
-		CycleColors: true,
+		ID:            a.ID(),
+		Static:        static,
+		Size:          15,
+		GradColorA:    sty.WorkingGradFromColor,
+		GradColorB:    sty.WorkingGradToColor,
+		LabelColor:    sty.WorkingLabelColor,
+		EllipsisColor: sty.WorkingEllipsisColor,
+		CycleColors:   true,
 		Suffix: func() string {
 			return common.Elapsed()
 		},

--- a/internal/ui/chat/assistant_section_cache_test.go
+++ b/internal/ui/chat/assistant_section_cache_test.go
@@ -91,7 +91,7 @@ func TestAssistantSectionCache_ContentChangeDoesNotInvalidateThinking(t *testing
 	sty := styles.CharmtonePantera()
 	thinking := "Step 1\nStep 2\nStep 3"
 	msg := thinkingMessage("a1", thinking, "Initial answer.")
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 
 	const width = 71
 
@@ -119,7 +119,7 @@ func TestAssistantSectionCache_ThinkingChangeDoesNotInvalidateContent(t *testing
 	sty := styles.CharmtonePantera()
 	content := "Final answer goes here."
 	msg := thinkingMessage("a2", "Step 1", content)
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 
 	const width = 73
 
@@ -146,8 +146,8 @@ func TestAssistantSectionCache_HashKeyDiscrimination(t *testing.T) {
 	msgA := thinkingMessage("a3", "thinking A", "content A")
 	msgB := thinkingMessage("a3", "thinking B", "content B")
 
-	itemA := NewAssistantMessageItem(&sty, msgA).(*AssistantMessageItem)
-	itemB := NewAssistantMessageItem(&sty, msgB).(*AssistantMessageItem)
+	itemA := NewAssistantMessageItem(&sty, msgA, false).(*AssistantMessageItem)
+	itemB := NewAssistantMessageItem(&sty, msgB, false).(*AssistantMessageItem)
 
 	thinkSrcA, _ := itemA.thinkingKey()
 	thinkSrcB, _ := itemB.thinkingKey()
@@ -161,7 +161,7 @@ func TestAssistantSectionCache_HashKeyDiscrimination(t *testing.T) {
 
 	// Identical source text on a fresh item must produce the same
 	// hashes — keying invariant for cache hits.
-	itemAClone := NewAssistantMessageItem(&sty, thinkingMessage("a3", "thinking A", "content A")).(*AssistantMessageItem)
+	itemAClone := NewAssistantMessageItem(&sty, thinkingMessage("a3", "thinking A", "content A"), false).(*AssistantMessageItem)
 	thinkSrcAClone, _ := itemAClone.thinkingKey()
 	contentSrcAClone, _ := itemAClone.contentKey()
 	require.Equal(t, thinkSrcA, thinkSrcAClone)
@@ -175,7 +175,7 @@ func TestAssistantSectionCache_HashKeyDiscrimination(t *testing.T) {
 func TestAssistantSectionCache_CloneRoundTrip(t *testing.T) {
 	sty := styles.CharmtonePantera()
 	orig := thinkingMessage("a4", "Reasoning step.", "Answer text.")
-	item := NewAssistantMessageItem(&sty, orig).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, orig, false).(*AssistantMessageItem)
 
 	const width = 75
 	_ = item.RawRender(width)
@@ -204,7 +204,7 @@ func TestAssistantSectionCache_ResizeInvalidatesAll(t *testing.T) {
 			FinishedAt: testFinishedAt,
 		},
 	}, msg.Parts...)
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 
 	_ = item.RawRender(77)
 	first := snapshot(item)
@@ -247,7 +247,7 @@ func TestAssistantSectionCache_ErrorIndependentOfThinkingAndContent(t *testing.T
 		}
 	}
 
-	item := NewAssistantMessageItem(&sty, build("think", "content", "boom", "details")).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, build("think", "content", "boom", "details"), false).(*AssistantMessageItem)
 	_ = item.RawRender(79)
 	first := snapshot(item)
 
@@ -288,7 +288,7 @@ func TestAssistantSectionCache_PrefixCacheRespectsSectionChanges(t *testing.T) {
 		}
 	}
 
-	item := NewAssistantMessageItem(&sty, build("first content")).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, build("first content"), false).(*AssistantMessageItem)
 	item.SetFocused(true)
 
 	const width = 81
@@ -366,11 +366,11 @@ func TestAssistantSectionCache_ByteIdenticalToFreshRender(t *testing.T) {
 	}
 
 	first := steps[0].msg.Clone()
-	cached := NewAssistantMessageItem(&sty, &first).(*AssistantMessageItem)
+	cached := NewAssistantMessageItem(&sty, &first, false).(*AssistantMessageItem)
 	for _, s := range steps {
 		cached.SetMessage(s.msg)
 		freshMsg := s.msg.Clone()
-		fresh := NewAssistantMessageItem(&sty, &freshMsg).(*AssistantMessageItem)
+		fresh := NewAssistantMessageItem(&sty, &freshMsg, false).(*AssistantMessageItem)
 		require.Equal(t, fresh.RawRender(width), cached.RawRender(width),
 			"step %q: cached path must match fresh render byte-for-byte", s.name)
 	}
@@ -401,7 +401,7 @@ func TestAssistantSectionCache_PrefixCacheInvalidatesOnCompositionOnlyChange(t *
 		}
 	}
 
-	item := NewAssistantMessageItem(&sty, build(message.FinishReasonEndTurn)).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, build(message.FinishReasonEndTurn), false).(*AssistantMessageItem)
 	endTurnOut := item.Render(width)
 
 	// Flip only the finish reason. Thinking is empty and content
@@ -415,7 +415,7 @@ func TestAssistantSectionCache_PrefixCacheInvalidatesOnCompositionOnlyChange(t *
 	// A fresh item built with the same final state must match the
 	// cached item byte-for-byte — caching is invisible from the
 	// outside and never serves stale output.
-	fresh := NewAssistantMessageItem(&sty, build(message.FinishReasonCanceled)).(*AssistantMessageItem)
+	fresh := NewAssistantMessageItem(&sty, build(message.FinishReasonCanceled), false).(*AssistantMessageItem)
 	require.Equal(t, fresh.Render(width), canceledOut,
 		"cached output must equal a fresh render of the same final state")
 }
@@ -440,7 +440,7 @@ func TestAssistantSectionCache_ThinkingBoxHeightSurvivesCacheHit(t *testing.T) {
 		"Verifying constraints.",
 	}, "\n")
 	msg := thinkingMessage("hbox", thinking, "initial answer")
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 	item.thinkingViewMode = thinkingFullExpanded
 
 	_ = item.RawRender(width)

--- a/internal/ui/chat/assistant_test.go
+++ b/internal/ui/chat/assistant_test.go
@@ -27,7 +27,7 @@ func TestAssistantMessageItemExpandable(t *testing.T) {
 	// Short thinking: under the tail-window cap, so the cycle is
 	// collapsed -> full -> collapsed (tail-window is skipped).
 	msg := thinkingMessage("m1", "step one\nstep two\nstep three", "")
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 
 	exp, ok := any(item).(Expandable)
 	require.True(t, ok, "AssistantMessageItem must satisfy Expandable")
@@ -54,7 +54,7 @@ func TestAssistantMessageItemExpandableEmptyThinkingNoOp(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	msg := &message.Message{ID: "m1-empty", Role: message.Assistant}
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 
 	exp, ok := any(item).(Expandable)
 	require.True(t, ok, "AssistantMessageItem must satisfy Expandable")
@@ -87,11 +87,11 @@ func TestAssistantMessageItemTailWindowBoundary(t *testing.T) {
 	atCap := buildLines(maxExpandedThinkingTailLines)
 	overCap := buildLines(maxExpandedThinkingTailLines + 1)
 
-	atItem := NewAssistantMessageItem(&sty, thinkingMessage("at-cap", atCap, "")).(*AssistantMessageItem)
+	atItem := NewAssistantMessageItem(&sty, thinkingMessage("at-cap", atCap, ""), false).(*AssistantMessageItem)
 	require.False(t, atItem.tailWindowWouldTruncate(),
 		"a source with exactly N logical lines must not trip the tail-window step")
 
-	overItem := NewAssistantMessageItem(&sty, thinkingMessage("over-cap", overCap, "")).(*AssistantMessageItem)
+	overItem := NewAssistantMessageItem(&sty, thinkingMessage("over-cap", overCap, ""), false).(*AssistantMessageItem)
 	require.True(t, overItem.tailWindowWouldTruncate(),
 		"a source with N+1 logical lines must trip the tail-window step")
 }
@@ -123,7 +123,7 @@ func TestAssistantMessageItemHandleMouseClick(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	msg := &message.Message{ID: "m2", Role: message.Assistant}
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 	item.thinkingBoxHeight = 5
 
 	// Click inside the thinking box signals handled but must not mutate

--- a/internal/ui/chat/assistant_test.go
+++ b/internal/ui/chat/assistant_test.go
@@ -140,3 +140,29 @@ func TestAssistantMessageItemHandleMouseClick(t *testing.T) {
 	require.False(t, item.HandleMouseClick(ansi.MouseRight, 0, 2))
 	require.Equal(t, thinkingCollapsed, item.thinkingViewMode)
 }
+
+// TestAssistantMessageItemReducedAnimationsStreamsContent verifies that
+// enabling reduce_animations does not disable the live rendering of
+// streamed LLM output. The spinner should reduce to a simpler "Working..."
+// ellipsis, but the assistant content must still appear as it arrives.
+func TestAssistantMessageItemReducedAnimationsStreamsContent(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{ID: "m1", Role: message.Assistant}
+	item := NewAssistantMessageItem(&sty, msg, true).(*AssistantMessageItem)
+
+	require.True(t, item.isSpinning(),
+		"message with no content must spin regardless of reduce_animations")
+
+	// Simulate a streaming content delta.
+	msg.AppendContent("hello world")
+	item.SetMessage(msg)
+
+	require.False(t, item.isSpinning(),
+		"message with streamed content must stop spinning")
+
+	rendered := ansi.Strip(item.RawRender(80))
+	require.Contains(t, rendered, "hello world",
+		"reduced-animations item must still render streamed content")
+}

--- a/internal/ui/chat/assistant_thinking_window_test.go
+++ b/internal/ui/chat/assistant_thinking_window_test.go
@@ -91,7 +91,7 @@ func TestThinkingWindow_CollapsedCapPreserved(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	msg := thinkingMessageWithLines("collapsed", 5000)
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 
 	// Default state must be collapsed.
 	require.Equal(t, thinkingCollapsed, item.thinkingViewMode)
@@ -126,7 +126,7 @@ func TestThinkingWindow_ExpandedShortSkipsTailWindow(t *testing.T) {
 	require.Less(t, lines, maxExpandedThinkingTailLines,
 		"this test relies on the source being well under the tail cap")
 	msg := thinkingMessageWithLines("short", lines)
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 
 	require.True(t, item.ToggleExpanded(),
 		"first toggle should report expanded")
@@ -174,7 +174,7 @@ func TestThinkingWindow_TailWindowed(t *testing.T) {
 
 	// Tail-windowed render.
 	tailMsg := thinkingMessageWithLines("tail", total)
-	tailItem := NewAssistantMessageItem(&sty, tailMsg).(*AssistantMessageItem)
+	tailItem := NewAssistantMessageItem(&sty, tailMsg, false).(*AssistantMessageItem)
 	require.True(t, tailItem.ToggleExpanded(), "first toggle should report expanded")
 	require.Equal(t, thinkingTailWindow, tailItem.thinkingViewMode,
 		"a long block must enter tail-window after the first toggle")
@@ -205,7 +205,7 @@ func TestThinkingWindow_TailWindowed(t *testing.T) {
 	// expansion (no tail slice). The tail-windowed output's last K
 	// lines must byte-equal the unwindowed output's last K lines.
 	fullMsg := thinkingMessageWithLines("tail-full-ref", total)
-	fullItem := NewAssistantMessageItem(&sty, fullMsg).(*AssistantMessageItem)
+	fullItem := NewAssistantMessageItem(&sty, fullMsg, false).(*AssistantMessageItem)
 	fullItem.thinkingViewMode = thinkingFullExpanded
 	_ = fullItem.RawRender(width)
 	fullPlain := ansi.Strip(fullItem.thinkingSec.out)
@@ -243,7 +243,7 @@ func TestThinkingWindow_PromoteToFull(t *testing.T) {
 	sty := styles.CharmtonePantera()
 	const total = 1500
 	msg := thinkingMessageWithLines("promote", total)
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 
 	const width = 97
 
@@ -269,7 +269,7 @@ func TestThinkingWindow_PromoteToFull(t *testing.T) {
 	// Independent reference: a fresh item, rendered straight into
 	// the full-expanded state, must produce byte-equal output.
 	freshMsg := thinkingMessageWithLines("promote-fresh", total)
-	fresh := NewAssistantMessageItem(&sty, freshMsg).(*AssistantMessageItem)
+	fresh := NewAssistantMessageItem(&sty, freshMsg, false).(*AssistantMessageItem)
 	fresh.thinkingViewMode = thinkingFullExpanded
 	_ = fresh.RawRender(width)
 	require.Equal(t, fresh.thinkingSec.out, fullOut,
@@ -339,7 +339,7 @@ func TestThinkingWindow_ContentChangeKeepsThinkingCacheInTailWindow(t *testing.T
 		return &message.Message{ID: "tail-stream", Role: message.Assistant, Parts: parts}
 	}
 
-	item := NewAssistantMessageItem(&sty, build("first answer")).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, build("first answer"), false).(*AssistantMessageItem)
 	item.thinkingViewMode = thinkingTailWindow
 
 	const width = 99
@@ -410,7 +410,7 @@ func TestThinkingWindow_ToggleInvalidatesOnlyThinking(t *testing.T) {
 		}
 	}
 
-	item := NewAssistantMessageItem(&sty, build()).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, build(), false).(*AssistantMessageItem)
 
 	const width = 101
 	_ = item.RawRender(width)
@@ -477,7 +477,7 @@ func TestThinkingWindow_BoxHeightTracksWindow(t *testing.T) {
 	sty := styles.CharmtonePantera()
 	const total = 5000
 	msg := thinkingMessageWithLines("box-height", total)
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 
 	const width = 103
 

--- a/internal/ui/chat/bash.go
+++ b/internal/ui/chat/bash.go
@@ -30,8 +30,9 @@ func NewBashToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &BashToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &BashToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // BashToolRenderContext renders bash tool messages.
@@ -115,8 +116,9 @@ func NewJobOutputToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &JobOutputToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &JobOutputToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // JobOutputToolRenderContext renders job_output tool messages.
@@ -166,8 +168,9 @@ func NewJobKillToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &JobKillToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &JobKillToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // JobKillToolRenderContext renders job_kill tool messages.

--- a/internal/ui/chat/bash.go
+++ b/internal/ui/chat/bash.go
@@ -32,8 +32,9 @@ func NewBashToolMessageItem(
 	result *message.ToolResult,
 	canceled bool,
 	workingDir string,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &BashToolRenderContext{workingDir: workingDir}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &BashToolRenderContext{workingDir: workingDir}, canceled, reduceAnimations)
 }
 
 // BashToolRenderContext renders bash tool messages.
@@ -123,8 +124,9 @@ func NewJobOutputToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &JobOutputToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &JobOutputToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // JobOutputToolRenderContext renders job_output tool messages.
@@ -174,8 +176,9 @@ func NewJobKillToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &JobKillToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &JobKillToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // JobKillToolRenderContext renders job_kill tool messages.

--- a/internal/ui/chat/call_hierarchy.go
+++ b/internal/ui/chat/call_hierarchy.go
@@ -21,8 +21,9 @@ func NewCallHierarchyToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &CallHierarchyToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &CallHierarchyToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // CallHierarchyToolRenderContext renders call hierarchy tool messages.

--- a/internal/ui/chat/definition.go
+++ b/internal/ui/chat/definition.go
@@ -21,8 +21,9 @@ func NewDefinitionToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &DefinitionToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &DefinitionToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // DefinitionToolRenderContext renders definition tool messages.

--- a/internal/ui/chat/diagnostics.go
+++ b/internal/ui/chat/diagnostics.go
@@ -26,8 +26,9 @@ func NewDiagnosticsToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &DiagnosticsToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &DiagnosticsToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // DiagnosticsToolRenderContext renders diagnostics tool messages.

--- a/internal/ui/chat/docker_mcp.go
+++ b/internal/ui/chat/docker_mcp.go
@@ -27,8 +27,9 @@ func NewDockerMCPToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &DockerMCPToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &DockerMCPToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // DockerMCPToolRenderContext renders Docker MCP tool messages.

--- a/internal/ui/chat/fetch.go
+++ b/internal/ui/chat/fetch.go
@@ -25,8 +25,9 @@ func NewFetchToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &FetchToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &FetchToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // FetchToolRenderContext renders fetch tool messages.
@@ -100,8 +101,9 @@ func NewWebFetchToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &WebFetchToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &WebFetchToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // WebFetchToolRenderContext renders web_fetch tool messages.
@@ -154,8 +156,9 @@ func NewWebSearchToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &WebSearchToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &WebSearchToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // WebSearchToolRenderContext renders web_search tool messages.

--- a/internal/ui/chat/file.go
+++ b/internal/ui/chat/file.go
@@ -28,8 +28,9 @@ func NewViewToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &ViewToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &ViewToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // ViewToolRenderContext renders view tool messages.
@@ -114,8 +115,9 @@ func NewWriteToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &WriteToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &WriteToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // WriteToolRenderContext renders write tool messages.
@@ -183,8 +185,9 @@ func NewEditToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &EditToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &EditToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // EditToolRenderContext renders edit tool messages.
@@ -251,8 +254,9 @@ func NewMultiEditToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &MultiEditToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &MultiEditToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // MultiEditToolRenderContext renders multi-edit tool messages.
@@ -325,8 +329,9 @@ func NewDownloadToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &DownloadToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &DownloadToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // DownloadToolRenderContext renders download tool messages.

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -21,8 +21,9 @@ func NewGenericToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &GenericToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &GenericToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // GenericToolRenderContext renders unknown/generic tool messages.

--- a/internal/ui/chat/incremental_glamour_test.go
+++ b/internal/ui/chat/incremental_glamour_test.go
@@ -833,7 +833,7 @@ func TestAssistantStreamingContent_ResetOnClearCache(t *testing.T) {
 	sty := styles.CharmtonePantera()
 	doc := "Para one.\n\nPara two.\n\nPara three."
 	msg := finishedAssistantMessage("stream-clear", doc)
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 
 	const width = 80
 	_ = item.RawRender(width)

--- a/internal/ui/chat/incremental_glamour_test.go
+++ b/internal/ui/chat/incremental_glamour_test.go
@@ -834,7 +834,7 @@ func TestAssistantStreamingContent_ResetOnClearCache(t *testing.T) {
 	sty := styles.CharmtonePantera()
 	doc := "Para one.\n\nPara two.\n\nPara three."
 	msg := finishedAssistantMessage("stream-clear", doc)
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 
 	const width = 80
 	_ = item.RawRender(width)

--- a/internal/ui/chat/lsp_restart.go
+++ b/internal/ui/chat/lsp_restart.go
@@ -21,8 +21,9 @@ func NewLSPRestartToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &LSPRestartToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &LSPRestartToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // LSPRestartToolRenderContext renders lsprestart tool messages.

--- a/internal/ui/chat/mcp.go
+++ b/internal/ui/chat/mcp.go
@@ -22,8 +22,9 @@ func NewMCPToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &MCPToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &MCPToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // MCPToolRenderContext renders bash tool messages.

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -364,7 +364,7 @@ func cappedMessageWidth(availableWidth int) int {
 //
 // For assistant messages with tool calls, pass a toolResults map to link results.
 // Use BuildToolResultMap to create this map from all messages in a session.
-func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults map[string]message.ToolResult) []MessageItem {
+func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults map[string]message.ToolResult, reduceAnimations bool) []MessageItem {
 	switch msg.Role {
 	case message.User:
 		// Reconstruct shell command items from ShellCommand parts.
@@ -388,7 +388,7 @@ func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults m
 	case message.Assistant:
 		var items []MessageItem
 		if ShouldRenderAssistantMessage(msg) {
-			items = append(items, NewAssistantMessageItem(sty, msg))
+			items = append(items, NewAssistantMessageItem(sty, msg, reduceAnimations))
 		}
 		for _, tc := range msg.ToolCalls() {
 			var result *message.ToolResult

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -401,6 +401,7 @@ func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults m
 				tc,
 				result,
 				msg.FinishReason() == message.FinishReasonCanceled,
+				reduceAnimations,
 			))
 		}
 		return items

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -423,7 +423,7 @@ func formatHypercreditSavings(v float64) string {
 //
 // For assistant messages with tool calls, pass a toolResults map to link results.
 // Use BuildToolResultMap to create this map from all messages in a session.
-func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults map[string]message.ToolResult, workingDir string) []MessageItem {
+func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults map[string]message.ToolResult, workingDir string, reduceAnimations bool) []MessageItem {
 	switch msg.Role {
 	case message.User:
 		// Reconstruct shell command items from ShellCommand parts.
@@ -448,7 +448,7 @@ func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults m
 	case message.Assistant:
 		var items []MessageItem
 		if ShouldRenderAssistantMessage(msg) {
-			items = append(items, NewAssistantMessageItem(sty, msg))
+			items = append(items, NewAssistantMessageItem(sty, msg, reduceAnimations))
 		}
 		for _, tc := range msg.ToolCalls() {
 			var result *message.ToolResult
@@ -462,6 +462,7 @@ func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults m
 				result,
 				msg.FinishReason() == message.FinishReasonCanceled,
 				workingDir,
+				reduceAnimations,
 			))
 		}
 		return items

--- a/internal/ui/chat/prefix_cache_test.go
+++ b/internal/ui/chat/prefix_cache_test.go
@@ -33,7 +33,7 @@ func TestAssistantMessageItemRender_PrefixCacheFocusBlur(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	msg := finishedAssistantMessage("m1", "Hello world from the cache test.")
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 
 	const width = 60
 
@@ -58,7 +58,7 @@ func TestAssistantMessageItemRender_PrefixCacheWidthInvalidates(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	msg := finishedAssistantMessage("m2", "Some content that wraps differently at different widths so the rendered output diverges.")
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 	item.SetFocused(true)
 
 	narrow := item.Render(40)
@@ -78,7 +78,7 @@ func TestAssistantMessageItemRender_PrefixCacheHighlightOnTop(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	msg := finishedAssistantMessage("m3", "Hello world from the highlight test.")
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 	item.SetFocused(true)
 
 	const width = 60
@@ -184,7 +184,7 @@ func TestAssistantMessageItemRender_PrefixCacheNoCacheLeak(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	msg := finishedAssistantMessage("m4", strings.Repeat("word ", 40))
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 	item.SetFocused(true)
 
 	out80 := item.Render(80)

--- a/internal/ui/chat/prefix_cache_test.go
+++ b/internal/ui/chat/prefix_cache_test.go
@@ -33,7 +33,7 @@ func TestAssistantMessageItemRender_PrefixCacheFocusBlur(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	msg := finishedAssistantMessage("m1", "Hello world from the cache test.")
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 
 	const width = 60
 
@@ -58,7 +58,7 @@ func TestAssistantMessageItemRender_PrefixCacheWidthInvalidates(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	msg := finishedAssistantMessage("m2", "Some content that wraps differently at different widths so the rendered output diverges.")
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 	item.SetFocused(true)
 
 	narrow := item.Render(40)
@@ -78,7 +78,7 @@ func TestAssistantMessageItemRender_PrefixCacheHighlightOnTop(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	msg := finishedAssistantMessage("m3", "Hello world from the highlight test.")
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 	item.SetFocused(true)
 
 	const width = 60
@@ -185,7 +185,7 @@ func TestAssistantMessageItemRender_PrefixCacheNoCacheLeak(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	msg := finishedAssistantMessage("m4", strings.Repeat("word ", 40))
-	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, msg, false).(*AssistantMessageItem)
 	item.SetFocused(true)
 
 	out80 := item.Render(80)

--- a/internal/ui/chat/question.go
+++ b/internal/ui/chat/question.go
@@ -24,8 +24,9 @@ func NewQuestionToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &QuestionToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &QuestionToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // QuestionToolRenderContext renders question tool messages.

--- a/internal/ui/chat/references.go
+++ b/internal/ui/chat/references.go
@@ -22,8 +22,9 @@ func NewReferencesToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &ReferencesToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &ReferencesToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // ReferencesToolRenderContext renders references tool messages.

--- a/internal/ui/chat/rename.go
+++ b/internal/ui/chat/rename.go
@@ -22,8 +22,9 @@ func NewRenameToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &RenameToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &RenameToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // RenameToolRenderContext renders rename tool messages.

--- a/internal/ui/chat/replace_symbol.go
+++ b/internal/ui/chat/replace_symbol.go
@@ -22,8 +22,9 @@ func NewReplaceSymbolToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &ReplaceSymbolToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &ReplaceSymbolToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // ReplaceSymbolToolRenderContext renders replace symbol tool messages.

--- a/internal/ui/chat/resize_bench_test.go
+++ b/internal/ui/chat/resize_bench_test.go
@@ -55,7 +55,7 @@ func BenchmarkResizeSession(b *testing.B) {
 	sty := styles.CharmtonePantera()
 	var items []list.Item
 	for _, m := range ptrs {
-		for _, it := range ExtractMessageItems(&sty, m, toolResults, "") {
+		for _, it := range ExtractMessageItems(&sty, m, toolResults, "", false) {
 			items = append(items, it)
 		}
 	}

--- a/internal/ui/chat/search.go
+++ b/internal/ui/chat/search.go
@@ -26,8 +26,9 @@ func NewGlobToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &GlobToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &GlobToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // GlobToolRenderContext renders glob tool messages.
@@ -85,8 +86,9 @@ func NewGrepToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &GrepToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &GrepToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // GrepToolRenderContext renders grep tool messages.
@@ -150,8 +152,9 @@ func NewLSToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &LSToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &LSToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // LSToolRenderContext renders ls tool messages.
@@ -210,8 +213,9 @@ func NewSourcegraphToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &SourcegraphToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &SourcegraphToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // SourcegraphToolRenderContext renders sourcegraph tool messages.

--- a/internal/ui/chat/symbols.go
+++ b/internal/ui/chat/symbols.go
@@ -21,8 +21,9 @@ func NewSymbolsToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &SymbolsToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &SymbolsToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // SymbolsToolRenderContext renders symbols tool messages.

--- a/internal/ui/chat/todos.go
+++ b/internal/ui/chat/todos.go
@@ -30,8 +30,9 @@ func NewTodosToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &TodosToolRenderContext{}, canceled)
+	return newBaseToolMessageItem(sty, toolCall, result, &TodosToolRenderContext{}, canceled, reduceAnimations)
 }
 
 // TodosToolRenderContext renders todos tool messages.

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -193,13 +193,14 @@ func newBaseToolMessageItem(
 		hasCappedWidth:           hasCappedWidth,
 	}
 	t.anim = anim.New(anim.Settings{
-		ID:          toolCall.ID,
-		Size:        15,
-		GradColorA:  sty.WorkingGradFromColor,
-		GradColorB:  sty.WorkingGradToColor,
-		LabelColor:  sty.WorkingLabelColor,
-		CycleColors: true,
-		Static:      reduceAnimations,
+		ID:            toolCall.ID,
+		Size:          15,
+		GradColorA:    sty.WorkingGradFromColor,
+		GradColorB:    sty.WorkingGradToColor,
+		LabelColor:    sty.WorkingLabelColor,
+		EllipsisColor: sty.WorkingEllipsisColor,
+		CycleColors:   true,
+		Static:        reduceAnimations,
 	})
 
 	return t

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -169,6 +169,7 @@ func newBaseToolMessageItem(
 	result *message.ToolResult,
 	toolRenderer ToolRenderer,
 	canceled bool,
+	reduceAnimations bool,
 ) *baseToolMessageItem {
 	// we only do full width for diffs (as far as I know)
 	hasCappedWidth := toolCall.Name != tools.EditToolName && toolCall.Name != tools.MultiEditToolName
@@ -198,6 +199,7 @@ func newBaseToolMessageItem(
 		GradColorB:  sty.WorkingGradToColor,
 		LabelColor:  sty.WorkingLabelColor,
 		CycleColors: true,
+		Static:      reduceAnimations,
 	})
 
 	return t
@@ -214,58 +216,59 @@ func NewToolMessageItem(
 	toolCall message.ToolCall,
 	result *message.ToolResult,
 	canceled bool,
+	reduceAnimations bool,
 ) ToolMessageItem {
 	var item ToolMessageItem
 	switch toolCall.Name {
 	case tools.BashToolName:
-		item = NewBashToolMessageItem(sty, toolCall, result, canceled)
+		item = NewBashToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.JobOutputToolName:
-		item = NewJobOutputToolMessageItem(sty, toolCall, result, canceled)
+		item = NewJobOutputToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.JobKillToolName:
-		item = NewJobKillToolMessageItem(sty, toolCall, result, canceled)
+		item = NewJobKillToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.ViewToolName:
-		item = NewViewToolMessageItem(sty, toolCall, result, canceled)
+		item = NewViewToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.WriteToolName:
-		item = NewWriteToolMessageItem(sty, toolCall, result, canceled)
+		item = NewWriteToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.EditToolName:
-		item = NewEditToolMessageItem(sty, toolCall, result, canceled)
+		item = NewEditToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.MultiEditToolName:
-		item = NewMultiEditToolMessageItem(sty, toolCall, result, canceled)
+		item = NewMultiEditToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.GlobToolName:
-		item = NewGlobToolMessageItem(sty, toolCall, result, canceled)
+		item = NewGlobToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.GrepToolName:
-		item = NewGrepToolMessageItem(sty, toolCall, result, canceled)
+		item = NewGrepToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.LSToolName:
-		item = NewLSToolMessageItem(sty, toolCall, result, canceled)
+		item = NewLSToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.DownloadToolName:
-		item = NewDownloadToolMessageItem(sty, toolCall, result, canceled)
+		item = NewDownloadToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.FetchToolName:
-		item = NewFetchToolMessageItem(sty, toolCall, result, canceled)
+		item = NewFetchToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.SourcegraphToolName:
-		item = NewSourcegraphToolMessageItem(sty, toolCall, result, canceled)
+		item = NewSourcegraphToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.DiagnosticsToolName:
-		item = NewDiagnosticsToolMessageItem(sty, toolCall, result, canceled)
+		item = NewDiagnosticsToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case agent.AgentToolName:
-		item = NewAgentToolMessageItem(sty, toolCall, result, canceled)
+		item = NewAgentToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.AgenticFetchToolName:
-		item = NewAgenticFetchToolMessageItem(sty, toolCall, result, canceled)
+		item = NewAgenticFetchToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.WebFetchToolName:
-		item = NewWebFetchToolMessageItem(sty, toolCall, result, canceled)
+		item = NewWebFetchToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.WebSearchToolName:
-		item = NewWebSearchToolMessageItem(sty, toolCall, result, canceled)
+		item = NewWebSearchToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.TodosToolName:
-		item = NewTodosToolMessageItem(sty, toolCall, result, canceled)
+		item = NewTodosToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.ReferencesToolName:
-		item = NewReferencesToolMessageItem(sty, toolCall, result, canceled)
+		item = NewReferencesToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.LSPRestartToolName:
-		item = NewLSPRestartToolMessageItem(sty, toolCall, result, canceled)
+		item = NewLSPRestartToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	default:
 		if IsDockerMCPTool(toolCall.Name) {
-			item = NewDockerMCPToolMessageItem(sty, toolCall, result, canceled)
+			item = NewDockerMCPToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 		} else if strings.HasPrefix(toolCall.Name, "mcp_") {
-			item = NewMCPToolMessageItem(sty, toolCall, result, canceled)
+			item = NewMCPToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 		} else {
-			item = NewGenericToolMessageItem(sty, toolCall, result, canceled)
+			item = NewGenericToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 		}
 	}
 	item.SetMessageID(messageID)

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -169,6 +169,7 @@ func newBaseToolMessageItem(
 	result *message.ToolResult,
 	toolRenderer ToolRenderer,
 	canceled bool,
+	reduceAnimations bool,
 ) *baseToolMessageItem {
 	// we only do full width for diffs (as far as I know)
 	hasCappedWidth := toolCall.Name != tools.EditToolName && toolCall.Name != tools.MultiEditToolName
@@ -192,12 +193,14 @@ func newBaseToolMessageItem(
 		hasCappedWidth:           hasCappedWidth,
 	}
 	t.anim = anim.New(anim.Settings{
-		ID:          toolCall.ID,
-		Size:        15,
-		GradColorA:  sty.WorkingGradFromColor,
-		GradColorB:  sty.WorkingGradToColor,
-		LabelColor:  sty.WorkingLabelColor,
-		CycleColors: true,
+		ID:            toolCall.ID,
+		Size:          15,
+		GradColorA:    sty.WorkingGradFromColor,
+		GradColorB:    sty.WorkingGradToColor,
+		LabelColor:    sty.WorkingLabelColor,
+		EllipsisColor: sty.WorkingEllipsisColor,
+		CycleColors:   true,
+		Static:        reduceAnimations,
 	})
 
 	return t
@@ -215,70 +218,71 @@ func NewToolMessageItem(
 	result *message.ToolResult,
 	canceled bool,
 	workingDir string,
+	reduceAnimations bool,
 ) ToolMessageItem {
 	var item ToolMessageItem
 	switch toolCall.Name {
 	case tools.BashToolName:
-		item = NewBashToolMessageItem(sty, toolCall, result, canceled, workingDir)
+		item = NewBashToolMessageItem(sty, toolCall, result, canceled, workingDir, reduceAnimations)
 	case tools.JobOutputToolName:
-		item = NewJobOutputToolMessageItem(sty, toolCall, result, canceled)
+		item = NewJobOutputToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.JobKillToolName:
-		item = NewJobKillToolMessageItem(sty, toolCall, result, canceled)
+		item = NewJobKillToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.ViewToolName:
-		item = NewViewToolMessageItem(sty, toolCall, result, canceled)
+		item = NewViewToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.WriteToolName:
-		item = NewWriteToolMessageItem(sty, toolCall, result, canceled)
+		item = NewWriteToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.EditToolName:
-		item = NewEditToolMessageItem(sty, toolCall, result, canceled)
+		item = NewEditToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.MultiEditToolName:
-		item = NewMultiEditToolMessageItem(sty, toolCall, result, canceled)
+		item = NewMultiEditToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.GlobToolName:
-		item = NewGlobToolMessageItem(sty, toolCall, result, canceled)
+		item = NewGlobToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.GrepToolName:
-		item = NewGrepToolMessageItem(sty, toolCall, result, canceled)
+		item = NewGrepToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.LSToolName:
-		item = NewLSToolMessageItem(sty, toolCall, result, canceled)
+		item = NewLSToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.DownloadToolName:
-		item = NewDownloadToolMessageItem(sty, toolCall, result, canceled)
+		item = NewDownloadToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.FetchToolName:
-		item = NewFetchToolMessageItem(sty, toolCall, result, canceled)
+		item = NewFetchToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.SourcegraphToolName:
-		item = NewSourcegraphToolMessageItem(sty, toolCall, result, canceled)
+		item = NewSourcegraphToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.DiagnosticsToolName:
-		item = NewDiagnosticsToolMessageItem(sty, toolCall, result, canceled)
+		item = NewDiagnosticsToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case agent.AgentToolName:
-		item = NewAgentToolMessageItem(sty, toolCall, result, canceled)
+		item = NewAgentToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.AgenticFetchToolName:
-		item = NewAgenticFetchToolMessageItem(sty, toolCall, result, canceled)
+		item = NewAgenticFetchToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.WebFetchToolName:
-		item = NewWebFetchToolMessageItem(sty, toolCall, result, canceled)
+		item = NewWebFetchToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.WebSearchToolName:
-		item = NewWebSearchToolMessageItem(sty, toolCall, result, canceled)
+		item = NewWebSearchToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.TodosToolName:
-		item = NewTodosToolMessageItem(sty, toolCall, result, canceled)
+		item = NewTodosToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.QuestionToolName:
-		item = NewQuestionToolMessageItem(sty, toolCall, result, canceled)
+		item = NewQuestionToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.ReferencesToolName:
-		item = NewReferencesToolMessageItem(sty, toolCall, result, canceled)
+		item = NewReferencesToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.DefinitionToolName:
-		item = NewDefinitionToolMessageItem(sty, toolCall, result, canceled)
+		item = NewDefinitionToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.RenameToolName:
-		item = NewRenameToolMessageItem(sty, toolCall, result, canceled)
+		item = NewRenameToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.ReplaceSymbolToolName:
-		item = NewReplaceSymbolToolMessageItem(sty, toolCall, result, canceled)
+		item = NewReplaceSymbolToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.CallHierarchyToolName:
-		item = NewCallHierarchyToolMessageItem(sty, toolCall, result, canceled)
+		item = NewCallHierarchyToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.SymbolsToolName:
-		item = NewSymbolsToolMessageItem(sty, toolCall, result, canceled)
+		item = NewSymbolsToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	case tools.LSPRestartToolName:
-		item = NewLSPRestartToolMessageItem(sty, toolCall, result, canceled)
+		item = NewLSPRestartToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 	default:
 		if IsDockerMCPTool(toolCall.Name) {
-			item = NewDockerMCPToolMessageItem(sty, toolCall, result, canceled)
+			item = NewDockerMCPToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 		} else if strings.HasPrefix(toolCall.Name, "mcp_") {
-			item = NewMCPToolMessageItem(sty, toolCall, result, canceled)
+			item = NewMCPToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 		} else {
-			item = NewGenericToolMessageItem(sty, toolCall, result, canceled)
+			item = NewGenericToolMessageItem(sty, toolCall, result, canceled, reduceAnimations)
 		}
 	}
 	item.SetMessageID(messageID)

--- a/internal/ui/chat/version_bump_test.go
+++ b/internal/ui/chat/version_bump_test.go
@@ -54,7 +54,7 @@ func TestAssistantMessageItem_MutatorsBumpVersion(t *testing.T) {
 		return &message.Message{ID: "a-mut", Role: message.Assistant, Parts: parts}
 	}
 
-	item := NewAssistantMessageItem(&sty, build("thinking", "content")).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, build("thinking", "content"), false).(*AssistantMessageItem)
 
 	requireBump(t, "SetMessage", item, func() {
 		item.SetMessage(build("thinking", "more content"))
@@ -131,7 +131,7 @@ func TestBaseToolMessageItem_MutatorsBumpVersion(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	tc := message.ToolCall{ID: "tc1", Name: "bash", Input: "{}", Finished: false}
-	item := NewToolMessageItem(&sty, "msg", tc, nil, false)
+	item := NewToolMessageItem(&sty, "msg", tc, nil, false, false)
 
 	v := item.(versionedItem)
 
@@ -185,7 +185,7 @@ func TestAssistantMessageItem_AnimateBumpsVersion(t *testing.T) {
 			message.ReasoningContent{Thinking: "thinking..."},
 		},
 	}
-	item := NewAssistantMessageItem(&sty, streaming).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, streaming, false).(*AssistantMessageItem)
 
 	requireBump(t, "Animate", item, func() {
 		item.Animate(anim.StepMsg{})
@@ -226,7 +226,7 @@ func TestAssistantMessageItem_FinishedTransition(t *testing.T) {
 			message.ReasoningContent{Thinking: "thinking..."},
 		},
 	}
-	item := NewAssistantMessageItem(&sty, streaming).(*AssistantMessageItem)
+	item := NewAssistantMessageItem(&sty, streaming, false).(*AssistantMessageItem)
 	require.False(t, item.Finished(), "streaming assistant message must not be Finished()")
 
 	// Finished with content.
@@ -279,11 +279,11 @@ func TestAgentToolMessageItem_NestedToolMutatorsBumpVersion(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	parent := message.ToolCall{ID: "agent-parent", Name: "agent", Input: `{}`, Finished: false}
-	item := NewAgentToolMessageItem(&sty, parent, nil, false)
+	item := NewAgentToolMessageItem(&sty, parent, nil, false, false)
 
 	mkChild := func(id string) ToolMessageItem {
 		tc := message.ToolCall{ID: id, Name: "bash", Input: `{}`, Finished: false}
-		return NewToolMessageItem(&sty, "msg", tc, nil, false)
+		return NewToolMessageItem(&sty, "msg", tc, nil, false, false)
 	}
 
 	// AddNestedTool always bumps.
@@ -316,11 +316,11 @@ func TestAgenticFetchToolMessageItem_NestedToolMutatorsBumpVersion(t *testing.T)
 
 	sty := styles.CharmtonePantera()
 	parent := message.ToolCall{ID: "fetch-parent", Name: "agentic_fetch", Input: `{}`, Finished: false}
-	item := NewAgenticFetchToolMessageItem(&sty, parent, nil, false)
+	item := NewAgenticFetchToolMessageItem(&sty, parent, nil, false, false)
 
 	mkChild := func(id string) ToolMessageItem {
 		tc := message.ToolCall{ID: id, Name: "fetch", Input: `{}`, Finished: false}
-		return NewToolMessageItem(&sty, "msg", tc, nil, false)
+		return NewToolMessageItem(&sty, "msg", tc, nil, false, false)
 	}
 
 	requireBump(t, "AddNestedTool", item, func() {
@@ -354,10 +354,10 @@ func TestAgentToolMessageItem_NestedChildInPlaceMutationBumpsParent(t *testing.T
 
 	sty := styles.CharmtonePantera()
 	parent := message.ToolCall{ID: "agent-parent", Name: "agent", Input: `{}`, Finished: false}
-	item := NewAgentToolMessageItem(&sty, parent, nil, false)
+	item := NewAgentToolMessageItem(&sty, parent, nil, false, false)
 
 	childTC := message.ToolCall{ID: "c1", Name: "bash", Input: `{}`, Finished: false}
-	child := NewToolMessageItem(&sty, "msg", childTC, nil, false)
+	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, false)
 	item.AddNestedTool(child)
 
 	v0 := item.Version()
@@ -383,10 +383,10 @@ func TestAgenticFetchToolMessageItem_NestedChildInPlaceMutationBumpsParent(t *te
 
 	sty := styles.CharmtonePantera()
 	parent := message.ToolCall{ID: "fetch-parent", Name: "agentic_fetch", Input: `{}`, Finished: false}
-	item := NewAgenticFetchToolMessageItem(&sty, parent, nil, false)
+	item := NewAgenticFetchToolMessageItem(&sty, parent, nil, false, false)
 
 	childTC := message.ToolCall{ID: "c1", Name: "fetch", Input: `{}`, Finished: false}
-	child := NewToolMessageItem(&sty, "msg", childTC, nil, false)
+	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, false)
 	item.AddNestedTool(child)
 
 	v0 := item.Version()
@@ -427,7 +427,7 @@ func TestBaseToolMessageItem_AnimateBumpsVersion(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	tc := message.ToolCall{ID: "tc-spin", Name: "bash", Input: "{}", Finished: false}
-	item := NewToolMessageItem(&sty, "msg", tc, nil, false)
+	item := NewToolMessageItem(&sty, "msg", tc, nil, false, false)
 	v := item.(versionedItem)
 	a, ok := item.(Animatable)
 	require.True(t, ok, "base tool message item must implement Animatable")
@@ -472,10 +472,10 @@ func TestAgentToolMessageItem_AnimateBumpsVersion(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	parentTC := message.ToolCall{ID: "agent-parent", Name: "agent", Input: `{}`, Finished: false}
-	parent := NewAgentToolMessageItem(&sty, parentTC, nil, false)
+	parent := NewAgentToolMessageItem(&sty, parentTC, nil, false, false)
 
 	childTC := message.ToolCall{ID: "agent-child", Name: "bash", Input: `{}`, Finished: false}
-	child := NewToolMessageItem(&sty, "msg", childTC, nil, false)
+	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, false)
 	parent.AddNestedTool(child)
 
 	// Spinning + parent's own ID → parent bumps.
@@ -517,10 +517,10 @@ func TestAgenticFetchToolMessageItem_AnimateBumpsVersion(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	parentTC := message.ToolCall{ID: "fetch-parent", Name: "agentic_fetch", Input: `{}`, Finished: false}
-	parent := NewAgenticFetchToolMessageItem(&sty, parentTC, nil, false)
+	parent := NewAgenticFetchToolMessageItem(&sty, parentTC, nil, false, false)
 
 	childTC := message.ToolCall{ID: "fetch-child", Name: "fetch", Input: `{}`, Finished: false}
-	child := NewToolMessageItem(&sty, "msg", childTC, nil, false)
+	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, false)
 	parent.AddNestedTool(child)
 
 	requireBump(t, "Animate[spinning,parent ID]", parent, func() {
@@ -551,7 +551,7 @@ func TestBaseToolMessageItem_FinishedTransition(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	tc := message.ToolCall{ID: "tc-fin", Name: "bash", Input: "{}", Finished: false}
-	item := NewToolMessageItem(&sty, "msg", tc, nil, false)
+	item := NewToolMessageItem(&sty, "msg", tc, nil, false, false)
 	require.False(t, item.Finished(), "running tool must not be Finished()")
 
 	tcFinished := tc
@@ -562,6 +562,6 @@ func TestBaseToolMessageItem_FinishedTransition(t *testing.T) {
 
 	// Canceled tool with no result is also Finished.
 	tcCanceled := message.ToolCall{ID: "tc-cancel", Name: "bash", Input: "{}", Finished: false}
-	canceled := NewToolMessageItem(&sty, "msg", tcCanceled, nil, true)
+	canceled := NewToolMessageItem(&sty, "msg", tcCanceled, nil, true, false)
 	require.True(t, canceled.Finished(), "canceled tool must be Finished()")
 }

--- a/internal/ui/chat/version_bump_test.go
+++ b/internal/ui/chat/version_bump_test.go
@@ -132,7 +132,7 @@ func TestBaseToolMessageItem_MutatorsBumpVersion(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	tc := message.ToolCall{ID: "tc1", Name: "bash", Input: "{}", Finished: false}
-	item := NewToolMessageItem(&sty, "msg", tc, nil, false, "")
+	item := NewToolMessageItem(&sty, "msg", tc, nil, false, "", false)
 
 	v := item.(versionedItem)
 
@@ -281,11 +281,11 @@ func TestAgentToolMessageItem_NestedToolMutatorsBumpVersion(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	parent := message.ToolCall{ID: "agent-parent", Name: "agent", Input: `{}`, Finished: false}
-	item := NewAgentToolMessageItem(&sty, parent, nil, false)
+	item := NewAgentToolMessageItem(&sty, parent, nil, false, false)
 
 	mkChild := func(id string) ToolMessageItem {
 		tc := message.ToolCall{ID: id, Name: "bash", Input: `{}`, Finished: false}
-		return NewToolMessageItem(&sty, "msg", tc, nil, false, "")
+		return NewToolMessageItem(&sty, "msg", tc, nil, false, "", false)
 	}
 
 	// AddNestedTool always bumps.
@@ -318,11 +318,11 @@ func TestAgenticFetchToolMessageItem_NestedToolMutatorsBumpVersion(t *testing.T)
 
 	sty := styles.CharmtonePantera()
 	parent := message.ToolCall{ID: "fetch-parent", Name: "agentic_fetch", Input: `{}`, Finished: false}
-	item := NewAgenticFetchToolMessageItem(&sty, parent, nil, false)
+	item := NewAgenticFetchToolMessageItem(&sty, parent, nil, false, false)
 
 	mkChild := func(id string) ToolMessageItem {
 		tc := message.ToolCall{ID: id, Name: "fetch", Input: `{}`, Finished: false}
-		return NewToolMessageItem(&sty, "msg", tc, nil, false, "")
+		return NewToolMessageItem(&sty, "msg", tc, nil, false, "", false)
 	}
 
 	requireBump(t, "AddNestedTool", item, func() {
@@ -356,10 +356,10 @@ func TestAgentToolMessageItem_NestedChildInPlaceMutationBumpsParent(t *testing.T
 
 	sty := styles.CharmtonePantera()
 	parent := message.ToolCall{ID: "agent-parent", Name: "agent", Input: `{}`, Finished: false}
-	item := NewAgentToolMessageItem(&sty, parent, nil, false)
+	item := NewAgentToolMessageItem(&sty, parent, nil, false, false)
 
 	childTC := message.ToolCall{ID: "c1", Name: "bash", Input: `{}`, Finished: false}
-	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, "")
+	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, "", false)
 	item.AddNestedTool(child)
 
 	v0 := item.Version()
@@ -385,10 +385,10 @@ func TestAgenticFetchToolMessageItem_NestedChildInPlaceMutationBumpsParent(t *te
 
 	sty := styles.CharmtonePantera()
 	parent := message.ToolCall{ID: "fetch-parent", Name: "agentic_fetch", Input: `{}`, Finished: false}
-	item := NewAgenticFetchToolMessageItem(&sty, parent, nil, false)
+	item := NewAgenticFetchToolMessageItem(&sty, parent, nil, false, false)
 
 	childTC := message.ToolCall{ID: "c1", Name: "fetch", Input: `{}`, Finished: false}
-	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, "")
+	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, "", false)
 	item.AddNestedTool(child)
 
 	v0 := item.Version()
@@ -429,7 +429,7 @@ func TestBaseToolMessageItem_AnimateBumpsVersion(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	tc := message.ToolCall{ID: "tc-spin", Name: "bash", Input: "{}", Finished: false}
-	item := NewToolMessageItem(&sty, "msg", tc, nil, false, "")
+	item := NewToolMessageItem(&sty, "msg", tc, nil, false, "", false)
 	v := item.(versionedItem)
 	a, ok := item.(Animatable)
 	require.True(t, ok, "base tool message item must implement Animatable")
@@ -474,10 +474,10 @@ func TestAgentToolMessageItem_AnimateBumpsVersion(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	parentTC := message.ToolCall{ID: "agent-parent", Name: "agent", Input: `{}`, Finished: false}
-	parent := NewAgentToolMessageItem(&sty, parentTC, nil, false)
+	parent := NewAgentToolMessageItem(&sty, parentTC, nil, false, false)
 
 	childTC := message.ToolCall{ID: "agent-child", Name: "bash", Input: `{}`, Finished: false}
-	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, "")
+	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, "", false)
 	parent.AddNestedTool(child)
 
 	// Spinning + parent's own ID → parent bumps.
@@ -519,10 +519,10 @@ func TestAgenticFetchToolMessageItem_AnimateBumpsVersion(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	parentTC := message.ToolCall{ID: "fetch-parent", Name: "agentic_fetch", Input: `{}`, Finished: false}
-	parent := NewAgenticFetchToolMessageItem(&sty, parentTC, nil, false)
+	parent := NewAgenticFetchToolMessageItem(&sty, parentTC, nil, false, false)
 
 	childTC := message.ToolCall{ID: "fetch-child", Name: "fetch", Input: `{}`, Finished: false}
-	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, "")
+	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, "", false)
 	parent.AddNestedTool(child)
 
 	requireBump(t, "Animate[spinning,parent ID]", parent, func() {
@@ -553,7 +553,7 @@ func TestBaseToolMessageItem_FinishedTransition(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 	tc := message.ToolCall{ID: "tc-fin", Name: "bash", Input: "{}", Finished: false}
-	item := NewToolMessageItem(&sty, "msg", tc, nil, false, "")
+	item := NewToolMessageItem(&sty, "msg", tc, nil, false, "", false)
 	require.False(t, item.Finished(), "running tool must not be Finished()")
 
 	tcFinished := tc
@@ -564,6 +564,6 @@ func TestBaseToolMessageItem_FinishedTransition(t *testing.T) {
 
 	// Canceled tool with no result is also Finished.
 	tcCanceled := message.ToolCall{ID: "tc-cancel", Name: "bash", Input: "{}", Finished: false}
-	canceled := NewToolMessageItem(&sty, "msg", tcCanceled, nil, true, "")
+	canceled := NewToolMessageItem(&sty, "msg", tcCanceled, nil, true, "", false)
 	require.True(t, canceled.Finished(), "canceled tool must be Finished()")
 }

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -140,6 +140,18 @@ type ActionFilePickerSelected struct {
 	Path string
 }
 
+// ActionReduceSSHAAnimations reduces SSH animations for the current session.
+type ActionReduceSSHAAnimations struct{}
+
+// ActionKeepSSHAAnimations keeps animations over SSH for the current session.
+type ActionKeepSSHAAnimations struct{}
+
+// ActionPersistSSHAutoReduce persists the preference to auto-reduce SSH animations.
+type ActionPersistSSHAutoReduce struct{}
+
+// ActionPersistSSHNever persists the preference to never reduce SSH animations.
+type ActionPersistSSHNever struct{}
+
 // Cmd returns a command that reads the file at path and sends a
 // [message.Attachement] to the program.
 func (a ActionFilePickerSelected) Cmd() tea.Cmd {

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -165,6 +165,18 @@ type ActionFilePickerSelected struct {
 	Path string
 }
 
+// ActionReduceSSHAAnimations reduces SSH animations for the current session.
+type ActionReduceSSHAAnimations struct{}
+
+// ActionKeepSSHAAnimations keeps animations over SSH for the current session.
+type ActionKeepSSHAAnimations struct{}
+
+// ActionPersistSSHAutoReduce persists the preference to auto-reduce SSH animations.
+type ActionPersistSSHAutoReduce struct{}
+
+// ActionPersistSSHNever persists the preference to never reduce SSH animations.
+type ActionPersistSSHNever struct{}
+
 // Cmd returns a command that reads the file at path and sends a
 // [message.Attachement] to the program.
 func (a ActionFilePickerSelected) Cmd() tea.Cmd {

--- a/internal/ui/dialog/ssh_animations.go
+++ b/internal/ui/dialog/ssh_animations.go
@@ -1,0 +1,223 @@
+package dialog
+
+import (
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// SSHAnimationsID is the identifier for the SSH animations dialog.
+const SSHAnimationsID = "ssh_animations"
+
+// SSHAAnimationAction represents the user's response to an SSH animation dialog.
+type SSHAAnimationAction string
+
+const (
+	SSHAAnimationReduce       SSHAAnimationAction = "reduce"
+	SSHAAnimationKeep         SSHAAnimationAction = "keep"
+	SSHAAnimationPersistAuto  SSHAAnimationAction = "persist_auto"
+	SSHAAnimationPersistNever SSHAAnimationAction = "persist_never"
+)
+
+// SSHAnimations represents a dialog for prompting about SSH animation preferences.
+type SSHAnimations struct {
+	com            *common.Common
+	selectedOption int // 0: Yes, 1: No, 2: On all SSH, 3: Never
+}
+
+var _ Dialog = (*SSHAnimations)(nil)
+
+// NewSSHAnimations creates a new SSH animations dialog.
+func NewSSHAnimations(com *common.Common) *SSHAnimations {
+	return &SSHAnimations{
+		com:            com,
+		selectedOption: 1, // Default to "No"
+	}
+}
+
+// ID implements [Dialog].
+func (*SSHAnimations) ID() string {
+	return SSHAnimationsID
+}
+
+// HandleMsg implements [Dialog].
+func (s *SSHAnimations) HandleMsg(msg tea.Msg) Action {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, s.keyMap().Right), key.Matches(msg, s.keyMap().Tab):
+			s.selectedOption = (s.selectedOption + 1) % 4
+		case key.Matches(msg, s.keyMap().Left):
+			s.selectedOption = (s.selectedOption + 3) % 4
+		case key.Matches(msg, s.keyMap().Select):
+			return s.selectCurrentOption()
+		case key.Matches(msg, s.keyMap().Yes):
+			return s.respond(SSHAAnimationReduce)
+		case key.Matches(msg, s.keyMap().No):
+			return s.respond(SSHAAnimationKeep)
+		case key.Matches(msg, s.keyMap().PersistAuto):
+			return s.respond(SSHAAnimationPersistAuto)
+		case key.Matches(msg, s.keyMap().PersistNever):
+			return s.respond(SSHAAnimationPersistNever)
+		case key.Matches(msg, s.keyMap().Close):
+			return ActionClose{}
+		}
+	}
+	return nil
+}
+
+func (s *SSHAnimations) selectCurrentOption() Action {
+	switch s.selectedOption {
+	case 0:
+		return s.respond(SSHAAnimationReduce)
+	case 1:
+		return s.respond(SSHAAnimationKeep)
+	case 2:
+		return s.respond(SSHAAnimationPersistAuto)
+	default:
+		return s.respond(SSHAAnimationPersistNever)
+	}
+}
+
+func (s *SSHAnimations) respond(action SSHAAnimationAction) Action {
+	switch action {
+	case SSHAAnimationReduce:
+		return ActionReduceSSHAAnimations{}
+	case SSHAAnimationKeep:
+		return ActionKeepSSHAAnimations{}
+	case SSHAAnimationPersistAuto:
+		return ActionPersistSSHAutoReduce{}
+	case SSHAAnimationPersistNever:
+		return ActionPersistSSHNever{}
+	}
+	return ActionClose{}
+}
+
+// Draw implements [Dialog].
+func (s *SSHAnimations) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	t := s.com.Styles
+
+	// Calculate dialog width.
+	width := min(area.Dx()-4, defaultDialogMaxWidth)
+
+	dialogStyle := t.Dialog.View.Width(width).Padding(0, 1)
+	contentWidth := width - dialogStyle.GetHorizontalFrameSize() - 2
+
+	// Render components to compute needed height.
+	header := s.renderHeader(contentWidth)
+	buttons := s.renderButtons(contentWidth)
+	helpView := s.renderHelp(contentWidth)
+	body := s.renderBody(contentWidth)
+
+	parts := []string{header, "", body, "", buttons, "", helpView}
+	content := lipgloss.JoinVertical(lipgloss.Left, parts...)
+	dialogHeight := lipgloss.Height(content) + dialogStyle.GetVerticalFrameSize()
+	height := min(area.Dy()-4, dialogHeight)
+
+	// Re-render with corrected height style (for vertical centering within the dialog frame).
+	dialogStyle = t.Dialog.View.Width(width).Height(height).Padding(0, 1)
+	DrawCenterCursor(scr, area, dialogStyle.Render(content), nil)
+	return nil
+}
+
+func (s *SSHAnimations) renderHeader(contentWidth int) string {
+	t := s.com.Styles
+	title := common.DialogTitle(t, "Reduce animations over SSH?", contentWidth-t.Dialog.Title.GetHorizontalFrameSize(), t.Dialog.TitleGradFromColor, t.Dialog.TitleGradToColor)
+	return t.Dialog.Title.Render(title)
+}
+
+func (s *SSHAnimations) renderBody(contentWidth int) string {
+	return lipgloss.NewStyle().
+		Width(contentWidth).
+		Align(lipgloss.Center).
+		Render("Crush detected that you are connected over SSH. \nAnimated spinners can look choppy or\nconsume extra bandwidth in some terminal sessions.\n\nWould you like to switch to a simpler animation mode?")
+}
+
+func (s *SSHAnimations) renderButtons(contentWidth int) string {
+	buttons := []common.ButtonOpts{
+		{Text: "Yes", UnderlineIndex: 0, Selected: s.selectedOption == 0},
+		{Text: "No", UnderlineIndex: 0, Selected: s.selectedOption == 1},
+		{Text: "For all SSH connections", UnderlineIndex: 2, Selected: s.selectedOption == 2},
+		{Text: "Never", UnderlineIndex: 0, Selected: s.selectedOption == 3},
+	}
+
+	content := common.ButtonGroup(s.com.Styles, buttons, "  ")
+	if lipgloss.Width(content) > contentWidth {
+		content = common.ButtonGroup(s.com.Styles, buttons, "\n")
+		return lipgloss.NewStyle().
+			Width(contentWidth).
+			Align(lipgloss.Center).
+			Render(content)
+	}
+	return lipgloss.NewStyle().
+		Width(contentWidth).
+		Align(lipgloss.Right).
+		Render(content)
+}
+
+func (s *SSHAnimations) renderHelp(contentWidth int) string {
+	return "←/→ or tab to navigate · enter to confirm · esc to dismiss"
+}
+
+type sshAnimationsKeyMap struct {
+	Left         key.Binding
+	Right        key.Binding
+	Tab          key.Binding
+	Select       key.Binding
+	Yes          key.Binding
+	No           key.Binding
+	PersistAuto  key.Binding
+	PersistNever key.Binding
+	Close        key.Binding
+}
+
+func (s *SSHAnimations) keyMap() sshAnimationsKeyMap {
+	return sshAnimationsKeyMap{
+		Left: key.NewBinding(
+			key.WithKeys("left", "h"),
+			key.WithHelp("←", "previous"),
+		),
+		Right: key.NewBinding(
+			key.WithKeys("right", "l"),
+			key.WithHelp("→", "next"),
+		),
+		Tab: key.NewBinding(
+			key.WithKeys("tab"),
+			key.WithHelp("tab", "next option"),
+		),
+		Select: key.NewBinding(
+			key.WithKeys("enter", "ctrl+y"),
+			key.WithHelp("enter", "confirm"),
+		),
+		Yes: key.NewBinding(
+			key.WithKeys("y", "Y"),
+			key.WithHelp("y", "yes"),
+		),
+		No: key.NewBinding(
+			key.WithKeys("n", "N"),
+			key.WithHelp("n", "no"),
+		),
+		PersistAuto: key.NewBinding(
+			key.WithKeys("a", "A"),
+			key.WithHelp("a", "all SSH"),
+		),
+		PersistNever: key.NewBinding(
+			key.WithKeys("v", "V"),
+			key.WithHelp("v", "never"),
+		),
+		Close: CloseKey,
+	}
+}
+
+// ShortHelp implements [help.KeyMap].
+func (s *SSHAnimations) ShortHelp() []key.Binding {
+	km := s.keyMap()
+	return []key.Binding{km.Left, km.Right, km.Select, km.Close}
+}
+
+// FullHelp implements [help.KeyMap].
+func (s *SSHAnimations) FullHelp() [][]key.Binding {
+	return [][]key.Binding{s.ShortHelp()}
+}

--- a/internal/ui/dialog/ssh_animations.go
+++ b/internal/ui/dialog/ssh_animations.go
@@ -1,0 +1,223 @@
+package dialog
+
+import (
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// SSHAnimationsID is the identifier for the SSH animations dialog.
+const SSHAnimationsID = "ssh_animations"
+
+// SSHAAnimationAction represents the user's response to an SSH animation dialog.
+type SSHAAnimationAction string
+
+const (
+	SSHAAnimationReduce       SSHAAnimationAction = "reduce"
+	SSHAAnimationKeep         SSHAAnimationAction = "keep"
+	SSHAAnimationPersistAuto  SSHAAnimationAction = "persist_auto"
+	SSHAAnimationPersistNever SSHAAnimationAction = "persist_never"
+)
+
+// SSHAnimations represents a dialog for prompting about SSH animation preferences.
+type SSHAnimations struct {
+	com            *common.Common
+	selectedOption int // 0: Yes, 1: No, 2: On all SSH, 3: Never
+}
+
+var _ Dialog = (*SSHAnimations)(nil)
+
+// NewSSHAnimations creates a new SSH animations dialog.
+func NewSSHAnimations(com *common.Common) *SSHAnimations {
+	return &SSHAnimations{
+		com:            com,
+		selectedOption: 1, // Default to "No"
+	}
+}
+
+// ID implements [Dialog].
+func (*SSHAnimations) ID() string {
+	return SSHAnimationsID
+}
+
+// HandleMsg implements [Dialog].
+func (s *SSHAnimations) HandleMsg(msg tea.Msg) Action {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, s.keyMap().Right), key.Matches(msg, s.keyMap().Tab):
+			s.selectedOption = (s.selectedOption + 1) % 4
+		case key.Matches(msg, s.keyMap().Left):
+			s.selectedOption = (s.selectedOption + 3) % 4
+		case key.Matches(msg, s.keyMap().Select):
+			return s.selectCurrentOption()
+		case key.Matches(msg, s.keyMap().Yes):
+			return s.respond(SSHAAnimationReduce)
+		case key.Matches(msg, s.keyMap().No):
+			return s.respond(SSHAAnimationKeep)
+		case key.Matches(msg, s.keyMap().PersistAuto):
+			return s.respond(SSHAAnimationPersistAuto)
+		case key.Matches(msg, s.keyMap().PersistNever):
+			return s.respond(SSHAAnimationPersistNever)
+		case key.Matches(msg, s.keyMap().Close):
+			return ActionClose{}
+		}
+	}
+	return nil
+}
+
+func (s *SSHAnimations) selectCurrentOption() Action {
+	switch s.selectedOption {
+	case 0:
+		return s.respond(SSHAAnimationReduce)
+	case 1:
+		return s.respond(SSHAAnimationKeep)
+	case 2:
+		return s.respond(SSHAAnimationPersistAuto)
+	default:
+		return s.respond(SSHAAnimationPersistNever)
+	}
+}
+
+func (s *SSHAnimations) respond(action SSHAAnimationAction) Action {
+	switch action {
+	case SSHAAnimationReduce:
+		return ActionReduceSSHAAnimations{}
+	case SSHAAnimationKeep:
+		return ActionKeepSSHAAnimations{}
+	case SSHAAnimationPersistAuto:
+		return ActionPersistSSHAutoReduce{}
+	case SSHAAnimationPersistNever:
+		return ActionPersistSSHNever{}
+	}
+	return ActionClose{}
+}
+
+// Draw implements [Dialog].
+func (s *SSHAnimations) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	t := s.com.Styles
+
+	// Calculate dialog width.
+	width := min(area.Dx()-4, defaultDialogMaxWidth)
+
+	dialogStyle := t.Dialog.View.Width(width).Padding(0, 1)
+	contentWidth := width - dialogStyle.GetHorizontalFrameSize() - 2
+
+	// Render components to compute needed height.
+	header := s.renderHeader(contentWidth)
+	buttons := s.renderButtons(contentWidth)
+	helpView := s.renderHelp()
+	body := s.renderBody(contentWidth)
+
+	parts := []string{header, "", body, "", buttons, "", helpView}
+	content := lipgloss.JoinVertical(lipgloss.Left, parts...)
+	dialogHeight := lipgloss.Height(content) + dialogStyle.GetVerticalFrameSize()
+	height := min(area.Dy()-4, dialogHeight)
+
+	// Re-render with corrected height style (for vertical centering within the dialog frame).
+	dialogStyle = t.Dialog.View.Width(width).Height(height).Padding(0, 1)
+	DrawCenterCursor(scr, area, dialogStyle.Render(content), nil)
+	return nil
+}
+
+func (s *SSHAnimations) renderHeader(contentWidth int) string {
+	t := s.com.Styles
+	title := common.DialogTitle(t, "Reduce animations over SSH?", contentWidth-t.Dialog.Title.GetHorizontalFrameSize(), t.Dialog.TitleGradFromColor, t.Dialog.TitleGradToColor)
+	return t.Dialog.Title.Render(title)
+}
+
+func (s *SSHAnimations) renderBody(contentWidth int) string {
+	return lipgloss.NewStyle().
+		Width(contentWidth).
+		Align(lipgloss.Center).
+		Render("Crush detected that you are connected over SSH. \nAnimated spinners can look choppy or\nconsume extra bandwidth in some terminal sessions.\n\nWould you like to switch to a simpler animation mode?")
+}
+
+func (s *SSHAnimations) renderButtons(contentWidth int) string {
+	buttons := []common.ButtonOpts{
+		{Text: "Yes", UnderlineIndex: 0, Selected: s.selectedOption == 0},
+		{Text: "No", UnderlineIndex: 0, Selected: s.selectedOption == 1},
+		{Text: "For all SSH connections", UnderlineIndex: 4, Selected: s.selectedOption == 2},
+		{Text: "Never", UnderlineIndex: 2, Selected: s.selectedOption == 3},
+	}
+
+	content := common.ButtonGroup(s.com.Styles, buttons, "  ")
+	if lipgloss.Width(content) > contentWidth {
+		content = common.ButtonGroup(s.com.Styles, buttons, "\n")
+		return lipgloss.NewStyle().
+			Width(contentWidth).
+			Align(lipgloss.Center).
+			Render(content)
+	}
+	return lipgloss.NewStyle().
+		Width(contentWidth).
+		Align(lipgloss.Right).
+		Render(content)
+}
+
+func (s *SSHAnimations) renderHelp() string {
+	return "←/→ or tab to navigate · enter to confirm · esc to dismiss"
+}
+
+type sshAnimationsKeyMap struct {
+	Left         key.Binding
+	Right        key.Binding
+	Tab          key.Binding
+	Select       key.Binding
+	Yes          key.Binding
+	No           key.Binding
+	PersistAuto  key.Binding
+	PersistNever key.Binding
+	Close        key.Binding
+}
+
+func (s *SSHAnimations) keyMap() sshAnimationsKeyMap {
+	return sshAnimationsKeyMap{
+		Left: key.NewBinding(
+			key.WithKeys("left", "h"),
+			key.WithHelp("←", "previous"),
+		),
+		Right: key.NewBinding(
+			key.WithKeys("right", "l"),
+			key.WithHelp("→", "next"),
+		),
+		Tab: key.NewBinding(
+			key.WithKeys("tab"),
+			key.WithHelp("tab", "next option"),
+		),
+		Select: key.NewBinding(
+			key.WithKeys("enter", "ctrl+y"),
+			key.WithHelp("enter", "confirm"),
+		),
+		Yes: key.NewBinding(
+			key.WithKeys("y", "Y"),
+			key.WithHelp("y", "yes"),
+		),
+		No: key.NewBinding(
+			key.WithKeys("n", "N"),
+			key.WithHelp("n", "no"),
+		),
+		PersistAuto: key.NewBinding(
+			key.WithKeys("a", "A"),
+			key.WithHelp("a", "all SSH"),
+		),
+		PersistNever: key.NewBinding(
+			key.WithKeys("v", "V"),
+			key.WithHelp("v", "never"),
+		),
+		Close: CloseKey,
+	}
+}
+
+// ShortHelp implements [help.KeyMap].
+func (s *SSHAnimations) ShortHelp() []key.Binding {
+	km := s.keyMap()
+	return []key.Binding{km.Left, km.Right, km.Select, km.Close}
+}
+
+// FullHelp implements [help.KeyMap].
+func (s *SSHAnimations) FullHelp() [][]key.Binding {
+	return [][]key.Binding{s.ShortHelp()}
+}

--- a/internal/ui/dialog/ssh_animations.go
+++ b/internal/ui/dialog/ssh_animations.go
@@ -108,7 +108,7 @@ func (s *SSHAnimations) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	// Render components to compute needed height.
 	header := s.renderHeader(contentWidth)
 	buttons := s.renderButtons(contentWidth)
-	helpView := s.renderHelp(contentWidth)
+	helpView := s.renderHelp()
 	body := s.renderBody(contentWidth)
 
 	parts := []string{header, "", body, "", buttons, "", helpView}
@@ -139,8 +139,8 @@ func (s *SSHAnimations) renderButtons(contentWidth int) string {
 	buttons := []common.ButtonOpts{
 		{Text: "Yes", UnderlineIndex: 0, Selected: s.selectedOption == 0},
 		{Text: "No", UnderlineIndex: 0, Selected: s.selectedOption == 1},
-		{Text: "For all SSH connections", UnderlineIndex: 2, Selected: s.selectedOption == 2},
-		{Text: "Never", UnderlineIndex: 0, Selected: s.selectedOption == 3},
+		{Text: "For all SSH connections", UnderlineIndex: 4, Selected: s.selectedOption == 2},
+		{Text: "Never", UnderlineIndex: 2, Selected: s.selectedOption == 3},
 	}
 
 	content := common.ButtonGroup(s.com.Styles, buttons, "  ")
@@ -157,7 +157,7 @@ func (s *SSHAnimations) renderButtons(contentWidth int) string {
 		Render(content)
 }
 
-func (s *SSHAnimations) renderHelp(contentWidth int) string {
+func (s *SSHAnimations) renderHelp() string {
 	return "←/→ or tab to navigate · enter to confirm · esc to dismiss"
 }
 

--- a/internal/ui/dialog/ssh_animations.go
+++ b/internal/ui/dialog/ssh_animations.go
@@ -1,6 +1,7 @@
 package dialog
 
 import (
+	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -25,15 +26,19 @@ const (
 type SSHAnimations struct {
 	com            *common.Common
 	selectedOption int // 0: Yes, 1: No, 2: On all SSH, 3: Never
+	help           help.Model
 }
 
 var _ Dialog = (*SSHAnimations)(nil)
 
 // NewSSHAnimations creates a new SSH animations dialog.
 func NewSSHAnimations(com *common.Common) *SSHAnimations {
+	h := help.New()
+	h.Styles = com.Styles.DialogHelpStyles()
 	return &SSHAnimations{
 		com:            com,
 		selectedOption: 1, // Default to "No"
+		help:           h,
 	}
 }
 
@@ -108,7 +113,7 @@ func (s *SSHAnimations) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	// Render components to compute needed height.
 	header := s.renderHeader(contentWidth)
 	buttons := s.renderButtons(contentWidth)
-	helpView := s.renderHelp()
+	helpView := s.renderHelp(contentWidth)
 	body := s.renderBody(contentWidth)
 
 	parts := []string{header, "", body, "", buttons, "", helpView}
@@ -157,8 +162,8 @@ func (s *SSHAnimations) renderButtons(contentWidth int) string {
 		Render(content)
 }
 
-func (s *SSHAnimations) renderHelp() string {
-	return "←/→ or tab to navigate · enter to confirm · esc to dismiss"
+func (s *SSHAnimations) renderHelp(contentWidth int) string {
+	return shortHelpLine(&s.help, s.ShortHelp(), contentWidth)
 }
 
 type sshAnimationsKeyMap struct {
@@ -214,7 +219,7 @@ func (s *SSHAnimations) keyMap() sshAnimationsKeyMap {
 // ShortHelp implements [help.KeyMap].
 func (s *SSHAnimations) ShortHelp() []key.Binding {
 	km := s.keyMap()
-	return []key.Binding{km.Left, km.Right, km.Select, km.Close}
+	return []key.Binding{km.Left, km.Right, km.Tab, km.Select, km.Close}
 }
 
 // FullHelp implements [help.KeyMap].

--- a/internal/ui/dialog/ssh_animations.go
+++ b/internal/ui/dialog/ssh_animations.go
@@ -137,7 +137,7 @@ func (s *SSHAnimations) renderBody(contentWidth int) string {
 	return lipgloss.NewStyle().
 		Width(contentWidth).
 		Align(lipgloss.Center).
-		Render("Crush detected that you are connected over SSH. \nAnimated spinners can look choppy or\nconsume extra bandwidth in some terminal sessions.\n\nWould you like to switch to a simpler animation mode?")
+		Render("Crush detected that you are connected over SSH.\nAnimated spinners can look choppy or\nconsume extra bandwidth in some terminal sessions.\n\nWould you like to switch to a simpler animation mode?")
 }
 
 func (s *SSHAnimations) renderButtons(contentWidth int) string {

--- a/internal/ui/model/chat_expand_test.go
+++ b/internal/ui/model/chat_expand_test.go
@@ -27,7 +27,7 @@ func TestChatToggleExpandedSelectedItem_AssistantMessage(t *testing.T) {
 			message.ReasoningContent{Thinking: "thinking about it"},
 		},
 	}
-	item := chat.NewAssistantMessageItem(u.com.Styles, msg)
+	item := chat.NewAssistantMessageItem(u.com.Styles, msg, false)
 
 	// The keyboard expand path uses the generic Expandable interface;
 	// verifying satisfaction at runtime guards the contract.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -285,9 +285,17 @@ type UI struct {
 	// forceCompactMode tracks whether compact mode is forced by user toggle
 	forceCompactMode bool
 
+	// forceReduceAnimations tracks whether animations are reduced (either by
+	// user toggle or from SSH dialog preference)
+	forceReduceAnimations bool
+
 	// isCompact tracks whether we're currently in compact layout mode (either
 	// by user toggle or auto-switch based on window size)
 	isCompact bool
+
+	// sshAnimationsDialogShown tracks whether we've shown the SSH animations
+	// dialog in this session to avoid showing it multiple times
+	sshAnimationsDialogShown bool
 
 	// detailsOpen tracks whether the details panel is open (in compact mode)
 	detailsOpen bool
@@ -435,6 +443,14 @@ func (m *UI) Init() tea.Cmd {
 			cmds = append(cmds, cmd)
 		}
 	}
+
+	// Check if we should show SSH animations dialog
+	if m.com.Config().ShouldPromptForSSHAnimations() && !m.sshAnimationsDialogShown {
+		if cmd := m.openSSHAnimationsDialog(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+
 	// load the user commands async
 	cmds = append(cmds, m.loadCustomCommands())
 	// load prompt history async
@@ -447,6 +463,14 @@ func (m *UI) Init() tea.Cmd {
 		cmds = append(cmds, m.fetchHyperCredits())
 	}
 	return tea.Batch(cmds...)
+}
+
+// openSSHAnimationsDialog opens the SSH animations preference dialog.
+func (m *UI) openSSHAnimationsDialog() tea.Cmd {
+	m.sshAnimationsDialogShown = true
+	dialog := dialog.NewSSHAnimations(m.com)
+	m.dialog.OpenDialog(dialog)
+	return nil
 }
 
 // loadInitialSession loads the initial session if one was specified on startup.
@@ -1132,7 +1156,7 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 	}
 
 	// Add messages to chat with linked tool results
-	reduceAnimations := m.com.Config().ShouldReduceAnimations()
+	reduceAnimations := m.shouldReduceAnimations()
 	items := make([]chat.MessageItem, 0, len(msgs)*2)
 	for _, msg := range msgPtrs {
 		switch msg.Role {
@@ -1175,7 +1199,7 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 
 // loadNestedToolCalls recursively loads nested tool calls for agent/agentic_fetch tools.
 func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
-	reduceAnimations := m.com.Config().ShouldReduceAnimations()
+	reduceAnimations := m.shouldReduceAnimations()
 	for _, item := range items {
 		nestedContainer, ok := item.(chat.NestedToolContainer)
 		if !ok {
@@ -1236,7 +1260,7 @@ func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
 // if the message is a tool result it will update the corresponding tool call message
 func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 	var cmds []tea.Cmd
-	reduceAnimations := m.com.Config().ShouldReduceAnimations()
+	reduceAnimations := m.shouldReduceAnimations()
 
 	existing := m.chat.MessageItem(msg.ID)
 	if existing != nil {
@@ -1654,6 +1678,24 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			return util.NewInfoMsg("Transparent background " + status)
 		})
 		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionReduceSSHAAnimations:
+		m.forceReduceAnimations = true
+		m.dialog.CloseDialog(dialog.SSHAnimationsID)
+	case dialog.ActionKeepSSHAAnimations:
+		m.forceReduceAnimations = false
+		m.dialog.CloseDialog(dialog.SSHAnimationsID)
+	case dialog.ActionPersistSSHAutoReduce:
+		m.forceReduceAnimations = true
+		if err := m.com.Workspace.SetSSHAnimationMode(config.ScopeGlobal, "reduce"); err != nil {
+			return util.ReportError(err)
+		}
+		m.dialog.CloseDialog(dialog.SSHAnimationsID)
+	case dialog.ActionPersistSSHNever:
+		m.forceReduceAnimations = false
+		if err := m.com.Workspace.SetSSHAnimationMode(config.ScopeGlobal, "never"); err != nil {
+			return util.ReportError(err)
+		}
+		m.dialog.CloseDialog(dialog.SSHAnimationsID)
 	case dialog.ActionQuit:
 		cmds = append(cmds, tea.Quit)
 	case dialog.ActionEnableDockerMCP:
@@ -2821,6 +2863,15 @@ func (m *UI) toggleCompactMode() tea.Cmd {
 	m.updateLayoutAndSize()
 
 	return nil
+}
+
+// shouldReduceAnimations returns whether animations should be reduced.
+// It considers both the config setting and runtime override from SSH dialog.
+func (m *UI) shouldReduceAnimations() bool {
+	if m.forceReduceAnimations {
+		return true
+	}
+	return m.com.Config().ShouldReduceAnimations()
 }
 
 // updateLayoutAndSize updates the layout and sizes of UI components.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1175,7 +1175,7 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 	}
 
 	// Load nested tool calls for agent/agentic_fetch tools.
-	m.loadNestedToolCalls(items)
+	m.loadNestedToolCalls(items, reduceAnimations)
 
 	// If the user switches between sessions while the agent is working we want
 	// to make sure the animations are shown.
@@ -1198,8 +1198,7 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 }
 
 // loadNestedToolCalls recursively loads nested tool calls for agent/agentic_fetch tools.
-func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
-	reduceAnimations := m.shouldReduceAnimations()
+func (m *UI) loadNestedToolCalls(items []chat.MessageItem, reduceAnimations bool) {
 	for _, item := range items {
 		nestedContainer, ok := item.(chat.NestedToolContainer)
 		if !ok {
@@ -1249,7 +1248,7 @@ func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
 		for i, nt := range nestedTools {
 			nestedMessageItems[i] = nt
 		}
-		m.loadNestedToolCalls(nestedMessageItems)
+		m.loadNestedToolCalls(nestedMessageItems, reduceAnimations)
 
 		// Set nested tools on the parent.
 		nestedContainer.SetNestedTools(nestedTools)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1132,20 +1132,21 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 	}
 
 	// Add messages to chat with linked tool results
+	reduceAnimations := m.com.Config().ShouldReduceAnimations()
 	items := make([]chat.MessageItem, 0, len(msgs)*2)
 	for _, msg := range msgPtrs {
 		switch msg.Role {
 		case message.User:
 			m.lastUserMessageTime = msg.CreatedAt
-			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap)...)
+			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap, reduceAnimations)...)
 		case message.Assistant:
-			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap)...)
+			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap, reduceAnimations)...)
 			if msg.FinishPart() != nil && msg.FinishPart().Reason == message.FinishReasonEndTurn {
 				infoItem := chat.NewAssistantInfoItem(m.com.Styles, msg, m.com.Config(), time.Unix(m.lastUserMessageTime, 0))
 				items = append(items, infoItem)
 			}
 		default:
-			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap)...)
+			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap, reduceAnimations)...)
 		}
 	}
 
@@ -1174,6 +1175,7 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 
 // loadNestedToolCalls recursively loads nested tool calls for agent/agentic_fetch tools.
 func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
+	reduceAnimations := m.com.Config().ShouldReduceAnimations()
 	for _, item := range items {
 		nestedContainer, ok := item.(chat.NestedToolContainer)
 		if !ok {
@@ -1206,7 +1208,7 @@ func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
 		// Extract nested tool items.
 		var nestedTools []chat.ToolMessageItem
 		for _, nestedMsg := range nestedMsgPtrs {
-			nestedItems := chat.ExtractMessageItems(m.com.Styles, nestedMsg, nestedToolResultMap)
+			nestedItems := chat.ExtractMessageItems(m.com.Styles, nestedMsg, nestedToolResultMap, reduceAnimations)
 			for _, nestedItem := range nestedItems {
 				if nestedToolItem, ok := nestedItem.(chat.ToolMessageItem); ok {
 					// Mark nested tools as simple (compact) rendering.
@@ -1234,6 +1236,7 @@ func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
 // if the message is a tool result it will update the corresponding tool call message
 func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 	var cmds []tea.Cmd
+	reduceAnimations := m.com.Config().ShouldReduceAnimations()
 
 	existing := m.chat.MessageItem(msg.ID)
 	if existing != nil {
@@ -1256,7 +1259,7 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 			return nil
 		}
 		m.lastUserMessageTime = msg.CreatedAt
-		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil)
+		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil, reduceAnimations)
 		for _, item := range items {
 			if animatable, ok := item.(chat.Animatable); ok {
 				if cmd := animatable.StartAnimation(); cmd != nil {
@@ -1269,7 +1272,7 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 			cmds = append(cmds, cmd)
 		}
 	case message.Assistant:
-		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil)
+		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil, reduceAnimations)
 		for _, item := range items {
 			if animatable, ok := item.(chat.Animatable); ok {
 				if cmd := animatable.StartAnimation(); cmd != nil {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1405,7 +1405,7 @@ func (m *UI) updateSessionMessage(msg message.Message) tea.Cmd {
 			}
 		}
 		if existingToolItem == nil {
-			items = append(items, chat.NewToolMessageItem(m.com.Styles, msg.ID, tc, nil, false))
+			items = append(items, chat.NewToolMessageItem(m.com.Styles, msg.ID, tc, nil, false, m.shouldReduceAnimations()))
 		}
 	}
 
@@ -1482,7 +1482,7 @@ func (m *UI) handleChildSessionMessage(event pubsub.Event[message.Message]) tea.
 		}
 		if !found {
 			// Create a new nested tool item.
-			nestedItem := chat.NewToolMessageItem(m.com.Styles, event.Payload.ID, tc, nil, false)
+			nestedItem := chat.NewToolMessageItem(m.com.Styles, event.Payload.ID, tc, nil, false, m.shouldReduceAnimations())
 			if simplifiable, ok := nestedItem.(chat.Compactable); ok {
 				simplifiable.SetCompact(true)
 			}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -329,9 +329,17 @@ type UI struct {
 	// forceCompactMode tracks whether compact mode is forced by user toggle
 	forceCompactMode bool
 
+	// forceReduceAnimations tracks whether animations are reduced (either by
+	// user toggle or from SSH dialog preference)
+	forceReduceAnimations bool
+
 	// isCompact tracks whether we're currently in compact layout mode (either
 	// by user toggle or auto-switch based on window size)
 	isCompact bool
+
+	// sshAnimationsDialogShown tracks whether we've shown the SSH animations
+	// dialog in this session to avoid showing it multiple times
+	sshAnimationsDialogShown bool
 
 	// detailsOpen tracks whether the details panel is open (in compact mode)
 	detailsOpen bool
@@ -537,6 +545,14 @@ func (m *UI) Init() tea.Cmd {
 			cmds = append(cmds, cmd)
 		}
 	}
+
+	// Check if we should show SSH animations dialog
+	if m.com.Config().ShouldPromptForSSHAnimations() && !m.sshAnimationsDialogShown {
+		if cmd := m.openSSHAnimationsDialog(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+
 	// load the user commands async
 	cmds = append(cmds, m.loadCustomCommands())
 	// load prompt history async
@@ -558,6 +574,14 @@ func (m *UI) Init() tea.Cmd {
 	}
 	cmds = append(cmds, m.checkPendingMCPAuth())
 	return tea.Batch(cmds...)
+}
+
+// openSSHAnimationsDialog opens the SSH animations preference dialog.
+func (m *UI) openSSHAnimationsDialog() tea.Cmd {
+	m.sshAnimationsDialogShown = true
+	dialog := dialog.NewSSHAnimations(m.com)
+	m.dialog.OpenDialog(dialog)
+	return nil
 }
 
 // loadInitialSession loads the initial session if one was specified on startup.
@@ -1462,25 +1486,26 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 	}
 
 	// Add messages to chat with linked tool results
+	reduceAnimations := m.shouldReduceAnimations()
 	items := make([]chat.MessageItem, 0, len(msgs)*2)
 	for _, msg := range msgPtrs {
 		switch msg.Role {
 		case message.User:
 			m.lastUserMessageTime = msg.CreatedAt
-			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap, m.com.Workspace.WorkingDir())...)
+			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap, m.com.Workspace.WorkingDir(), reduceAnimations)...)
 		case message.Assistant:
-			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap, m.com.Workspace.WorkingDir())...)
+			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap, m.com.Workspace.WorkingDir(), reduceAnimations)...)
 			if chat.ShouldShowAssistantInfo(msg) {
 				infoItem := chat.NewAssistantInfoItem(m.com.Styles, msg, m.com.Config(), time.Unix(m.lastUserMessageTime, 0))
 				items = append(items, infoItem)
 			}
 		default:
-			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap, m.com.Workspace.WorkingDir())...)
+			items = append(items, chat.ExtractMessageItems(m.com.Styles, msg, toolResultMap, m.com.Workspace.WorkingDir(), reduceAnimations)...)
 		}
 	}
 
 	// Load nested tool calls for agent/agentic_fetch tools.
-	m.loadNestedToolCalls(items)
+	m.loadNestedToolCalls(items, reduceAnimations)
 
 	// If the user switches between sessions while the agent is working we
 	// want to make sure the animations are shown. Gate on the agent actually
@@ -1543,7 +1568,7 @@ func (m *UI) handleConnectionEvent(msg workspace.ConnectionEvent) []tea.Cmd {
 }
 
 // loadNestedToolCalls recursively loads nested tool calls for agent/agentic_fetch tools.
-func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
+func (m *UI) loadNestedToolCalls(items []chat.MessageItem, reduceAnimations bool) {
 	for _, item := range items {
 		nestedContainer, ok := item.(chat.NestedToolContainer)
 		if !ok {
@@ -1576,7 +1601,7 @@ func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
 		// Extract nested tool items.
 		var nestedTools []chat.ToolMessageItem
 		for _, nestedMsg := range nestedMsgPtrs {
-			nestedItems := chat.ExtractMessageItems(m.com.Styles, nestedMsg, nestedToolResultMap, m.com.Workspace.WorkingDir())
+			nestedItems := chat.ExtractMessageItems(m.com.Styles, nestedMsg, nestedToolResultMap, m.com.Workspace.WorkingDir(), reduceAnimations)
 			for _, nestedItem := range nestedItems {
 				if nestedToolItem, ok := nestedItem.(chat.ToolMessageItem); ok {
 					// Mark nested tools as simple (compact) rendering.
@@ -1593,7 +1618,7 @@ func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
 		for i, nt := range nestedTools {
 			nestedMessageItems[i] = nt
 		}
-		m.loadNestedToolCalls(nestedMessageItems)
+		m.loadNestedToolCalls(nestedMessageItems, reduceAnimations)
 
 		// Set nested tools on the parent.
 		nestedContainer.SetNestedTools(nestedTools)
@@ -1604,6 +1629,7 @@ func (m *UI) loadNestedToolCalls(items []chat.MessageItem) {
 // if the message is a tool result it will update the corresponding tool call message
 func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 	var cmds []tea.Cmd
+	reduceAnimations := m.shouldReduceAnimations()
 
 	existing := m.chat.MessageItem(msg.ID)
 	if existing != nil {
@@ -1626,7 +1652,7 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 			return nil
 		}
 		m.lastUserMessageTime = msg.CreatedAt
-		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil, m.com.Workspace.WorkingDir())
+		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil, m.com.Workspace.WorkingDir(), reduceAnimations)
 		for _, item := range items {
 			if animatable, ok := item.(chat.Animatable); ok {
 				if cmd := animatable.StartAnimation(); cmd != nil {
@@ -1639,7 +1665,7 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 			cmds = append(cmds, cmd)
 		}
 	case message.Assistant:
-		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil, m.com.Workspace.WorkingDir())
+		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil, m.com.Workspace.WorkingDir(), reduceAnimations)
 		for _, item := range items {
 			if animatable, ok := item.(chat.Animatable); ok {
 				if cmd := animatable.StartAnimation(); cmd != nil {
@@ -1749,6 +1775,7 @@ func (m *UI) updateSessionMessage(msg message.Message) tea.Cmd {
 		m.chat.RemoveMessage(chat.AssistantInfoID(msg.ID))
 	}
 
+	reduceAnimations := m.shouldReduceAnimations()
 	var items []chat.MessageItem
 	for _, tc := range msg.ToolCalls() {
 		existingToolItem := m.chat.MessageItem(tc.ID)
@@ -1761,7 +1788,7 @@ func (m *UI) updateSessionMessage(msg message.Message) tea.Cmd {
 			}
 		}
 		if existingToolItem == nil {
-			items = append(items, chat.NewToolMessageItem(m.com.Styles, msg.ID, tc, nil, false, m.com.Workspace.WorkingDir()))
+			items = append(items, chat.NewToolMessageItem(m.com.Styles, msg.ID, tc, nil, false, m.com.Workspace.WorkingDir(), reduceAnimations))
 		}
 	}
 
@@ -1786,6 +1813,7 @@ func (m *UI) updateSessionMessage(msg message.Message) tea.Cmd {
 // handleChildSessionMessage handles messages from child sessions (agent tools).
 func (m *UI) handleChildSessionMessage(event pubsub.Event[message.Message]) tea.Cmd {
 	var cmds []tea.Cmd
+	reduceAnimations := m.shouldReduceAnimations()
 
 	// Only process messages with tool calls or results.
 	if len(event.Payload.ToolCalls()) == 0 && len(event.Payload.ToolResults()) == 0 {
@@ -1837,7 +1865,7 @@ func (m *UI) handleChildSessionMessage(event pubsub.Event[message.Message]) tea.
 		}
 		if !found {
 			// Create a new nested tool item.
-			nestedItem := chat.NewToolMessageItem(m.com.Styles, event.Payload.ID, tc, nil, false, m.com.Workspace.WorkingDir())
+			nestedItem := chat.NewToolMessageItem(m.com.Styles, event.Payload.ID, tc, nil, false, m.com.Workspace.WorkingDir(), reduceAnimations)
 			if simplifiable, ok := nestedItem.(chat.Compactable); ok {
 				simplifiable.SetCompact(true)
 			}
@@ -2054,6 +2082,24 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			return util.NewInfoMsg("Mouse support " + status)
 		})
 		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionReduceSSHAAnimations:
+		m.forceReduceAnimations = true
+		m.dialog.CloseDialog(dialog.SSHAnimationsID)
+	case dialog.ActionKeepSSHAAnimations:
+		m.forceReduceAnimations = false
+		m.dialog.CloseDialog(dialog.SSHAnimationsID)
+	case dialog.ActionPersistSSHAutoReduce:
+		m.forceReduceAnimations = true
+		if err := m.com.Workspace.SetSSHAnimationMode(config.ScopeGlobal, "reduce"); err != nil {
+			return util.ReportError(err)
+		}
+		m.dialog.CloseDialog(dialog.SSHAnimationsID)
+	case dialog.ActionPersistSSHNever:
+		m.forceReduceAnimations = false
+		if err := m.com.Workspace.SetSSHAnimationMode(config.ScopeGlobal, "never"); err != nil {
+			return util.ReportError(err)
+		}
+		m.dialog.CloseDialog(dialog.SSHAnimationsID)
 	case dialog.ActionQuit:
 		cmds = append(cmds, tea.Quit)
 	case dialog.ActionEnableDockerMCP:
@@ -3486,6 +3532,18 @@ func (m *UI) toggleCompactMode() tea.Cmd {
 	m.updateLayoutAndSize()
 
 	return nil
+}
+
+// shouldReduceAnimations returns whether animations should be reduced.
+// It considers both the config setting and runtime override from SSH dialog.
+func (m *UI) shouldReduceAnimations() bool {
+	if m.forceReduceAnimations {
+		return true
+	}
+	if m.com == nil || m.com.Config() == nil {
+		return false
+	}
+	return m.com.Config().ShouldReduceAnimations()
 }
 
 // updateLayoutAndSize updates the layout and sizes of UI components.

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -97,7 +97,8 @@ func quickStyle(o quickStyleOpts) Styles {
 	// Populate color fields
 	s.WorkingGradFromColor = o.primary
 	s.WorkingGradToColor = o.secondary
-	s.WorkingLabelColor = o.fgMostSubtle
+	s.WorkingLabelColor = o.fgMoreSubtle
+	s.WorkingEllipsisColor = o.fgMostSubtle
 
 	s.TextInput = textinput.Styles{
 		Focused: textinput.StyleState{

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -98,8 +98,9 @@ func quickStyle(o quickStyleOpts) Styles {
 	// Populate color fields
 	s.WorkingGradFromColor = o.primary
 	s.WorkingGradToColor = o.secondary
-	s.WorkingLabelColor = o.fgMostSubtle
+	s.WorkingLabelColor = o.fgMoreSubtle
 	s.WorkingTimerColor = o.fgMostSubtle
+	s.WorkingEllipsisColor = o.fgMostSubtle
 
 	s.TextInput = textinput.Styles{
 		Focused: textinput.StyleState{

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -170,6 +170,7 @@ type Styles struct {
 	WorkingGradFromColor color.Color
 	WorkingGradToColor   color.Color
 	WorkingLabelColor    color.Color // Label text color next to the indicator
+	WorkingEllipsisColor color.Color // Muted color for static ellipsis dots
 
 	// Section Title
 	Section struct {

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -222,6 +222,7 @@ type Styles struct {
 	WorkingGradToColor   color.Color
 	WorkingLabelColor    color.Color // Label text color next to the indicator
 	WorkingTimerColor    color.Color // Elapsed timer suffix color
+	WorkingEllipsisColor color.Color // Muted color for static ellipsis dots
 
 	// Section Title
 	Section struct {

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -341,6 +341,10 @@ func (w *AppWorkspace) RemoveConfigField(scope config.Scope, key string) error {
 	return w.store.RemoveConfigField(scope, key)
 }
 
+func (w *AppWorkspace) SetSSHAnimationMode(scope config.Scope, mode string) error {
+	return w.store.SetSSHAnimationMode(scope, mode)
+}
+
 func (w *AppWorkspace) ImportCopilot() (*oauth.Token, bool) {
 	return w.store.ImportCopilot()
 }

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -367,6 +367,10 @@ func (w *AppWorkspace) RemoveConfigField(scope config.Scope, key string) error {
 	return w.store.RemoveConfigField(scope, key)
 }
 
+func (w *AppWorkspace) SetSSHAnimationMode(scope config.Scope, mode string) error {
+	return w.store.SetSSHAnimationMode(scope, mode)
+}
+
 func (w *AppWorkspace) ImportCopilot() (*oauth.Token, bool) {
 	return w.store.ImportCopilot()
 }

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -476,6 +476,10 @@ func (w *ClientWorkspace) RemoveConfigField(scope config.Scope, key string) erro
 	return err
 }
 
+func (w *ClientWorkspace) SetSSHAnimationMode(scope config.Scope, mode string) error {
+	return w.SetConfigField(scope, "options.tui.ssh_animation_mode", mode)
+}
+
 func (w *ClientWorkspace) ImportCopilot() (*oauth.Token, bool) {
 	token, ok, err := w.client.ImportCopilot(context.Background(), w.workspaceID())
 	if err != nil {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -570,6 +570,10 @@ func (w *ClientWorkspace) RemoveConfigField(scope config.Scope, key string) erro
 	return err
 }
 
+func (w *ClientWorkspace) SetSSHAnimationMode(scope config.Scope, mode string) error {
+	return w.SetConfigField(scope, "options.tui.ssh_animation_mode", mode)
+}
+
 func (w *ClientWorkspace) ImportCopilot() (*oauth.Token, bool) {
 	token, ok, err := w.client.ImportCopilot(context.Background(), w.workspaceID())
 	if err != nil {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -137,6 +137,7 @@ type Workspace interface {
 	SetProviderAPIKey(scope config.Scope, providerID string, apiKey any) error
 	SetConfigField(scope config.Scope, key string, value any) error
 	RemoveConfigField(scope config.Scope, key string) error
+	SetSSHAnimationMode(scope config.Scope, mode string) error
 	ImportCopilot() (*oauth.Token, bool)
 	RefreshOAuthToken(ctx context.Context, scope config.Scope, providerID string) error
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -207,6 +207,7 @@ type Workspace interface {
 	SetProviderAPIKey(scope config.Scope, providerID string, apiKey any) error
 	SetConfigField(scope config.Scope, key string, value any) error
 	RemoveConfigField(scope config.Scope, key string) error
+	SetSSHAnimationMode(scope config.Scope, mode string) error
 	ImportCopilot() (*oauth.Token, bool)
 	RefreshOAuthToken(ctx context.Context, scope config.Scope, providerID string) error
 


### PR DESCRIPTION
## Summary

- Adds `reduce_animations` option to disable TUI spinner animation
- Enabled via `CRUSH_REDUCE_ANIMATIONS=true` env var or configuration setting
- Shows dialog if  `SSH_TTY` is set to ask user if `reduce_animations` should be enabled, always enabled or nerver asked again (`ssh_animation_mode` option)
- Shows static "Working..." instead of animated spinner when enabled
- No CPU wasted on animation ticks in static mode (early exit on Start/Animate)

This is a continuation/revival of #1250 with review feedback incorporated:

> The code looks good and works, but I think we can probably improve the UX a little bit, even if static.
> — @andreynering


closes #908
closes #1147
