### PR TITLE
fix(permissions): swallow SPACE in dialog to prevent stray approval

### DIFF
--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -228,6 +228,13 @@ func (*Permissions) ID() string {
 func (p *Permissions) HandleMsg(msg tea.Msg) Action {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
+		// #2799: swallow SPACE so a stray keystroke from the chat editor
+		// can't trigger viewport scroll or any other action when this
+		// dialog opens mid-typing. Approval requires an explicit
+		// Enter / a / s / d / mouse selection.
+		if msg.String() == "space" {
+			return nil
+		}
 		switch {
 		case key.Matches(msg, p.keyMap.Close):
 			// Escape denies the permission request.


### PR DESCRIPTION
## Why

Closes #2799. When a user is typing in the chat editor and a permissions dialog opens, an in-flight SPACE keystroke could be delivered to the dialog. The viewport's default `KeyMap.PageDown` binding includes `space`; the dialog disables that binding via `key.NewBinding(key.WithDisabled())`, so SPACE doesn't currently *approve*, but the experience is still surprising — depending on focus/timing the keystroke can still cause the dialog to react.

## Fix

Add an explicit early return for SPACE in the dialog's `KeyPressMsg` handler, before any other matching. The dialog now requires an explicit `Enter` / `a` / `s` / `d` / mouse click to act — matching what the issue requests.

```go
case tea.KeyPressMsg:
    // #2799: swallow SPACE so a stray keystroke from the chat editor
    // can't trigger viewport scroll or any other action when this
    // dialog opens mid-typing.
    if msg.String() == "space" {
        return nil
    }
    switch {
    ...
```

Pre-existing approve/scroll bindings are unchanged.

## Verification

- `go build ./internal/ui/dialog/...` passes locally.
- All existing keybindings still match (Enter still confirms, `a/A/ctrl+a` still allows, etc.).