### PR TITLE
fix(release): drop broken .termux.deb artifact

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -217,12 +217,18 @@ npms:
     disable: "{{ with .Prerelease }}true{{ end }}"
 
 nfpms:
+  # NOTE: termux.deb is intentionally omitted (issue #2787). The control
+  # file currently ships `Architecture: arm64`, but Termux's dpkg expects
+  # `aarch64` and refuses to install. Termux users can install via the
+  # existing `crush_<ver>_Android_arm64.tar.gz` static binary instead.
+  # The format-conditional `dst` paths below are kept dead-code for now
+  # so re-enabling termux.deb (e.g. when goreleaser-pro applies the
+  # built-in arch replacement) is a single-line change.
   - formats:
       - apk
       - deb
       - rpm
       - archlinux
-      - termux.deb
     file_name_template: "{{ .ConventionalFileName }}"
     contents:
       - src: ./completions/crush.bash

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -217,13 +217,6 @@ npms:
     disable: "{{ with .Prerelease }}true{{ end }}"
 
 nfpms:
-  # NOTE: termux.deb is intentionally omitted (issue #2787). The control
-  # file currently ships `Architecture: arm64`, but Termux's dpkg expects
-  # `aarch64` and refuses to install. Termux users can install via the
-  # existing `crush_<ver>_Android_arm64.tar.gz` static binary instead.
-  # The format-conditional `dst` paths below are kept dead-code for now
-  # so re-enabling termux.deb (e.g. when goreleaser-pro applies the
-  # built-in arch replacement) is a single-line change.
   - formats:
       - apk
       - deb


### PR DESCRIPTION
## Why

Closes #2787. The `.termux.deb` artifact ships `Architecture: arm64` in its control file (verified on v0.66.1), but Termux's dpkg expects `aarch64` and refuses to install:

\`\`\`
$ pkg install ./crush_0.66.1_arm64.deb.termux.deb
dpkg: error processing archive crush_0.66.1_arm64.deb.termux.deb (--unpack):
 package architecture (arm64) does not match system (aarch64)
\`\`\`

I extracted the v0.66.1 artifact to confirm:

\`\`\`
$ ar x crush_0.66.1_arm64.deb.termux.deb && tar -xzf control.tar.gz && cat control
Package: crush
Version: 0.66.1
Architecture: arm64    ← should be aarch64 for Termux
...
\`\`\`

## Background

goreleaser OSS gained a `termuxArchReplacer` in [#4812](https://github.com/goreleaser/goreleaser/pull/4812) (2024-04) that rewrites both the file name and the deb control field for `termux.deb`. crush's release pipeline runs through `charmbracelet/meta`'s goreleaser-pro workflow, and the v0.66.1 artifact still uses the un-replaced arch — so either pro hasn't picked up that fix yet, or something in the meta workflow predates it.

## Fix

Drop the format from `.goreleaser.yml`. Termux users can install from the existing `crush_<ver>_Android_arm64.tar.gz` static binary (just unpack into `~/.local/bin/`), which is the workflow most Termux users already follow.

The `{{ if eq .Format "termux.deb" }}` conditionals in the nfpm contents block are kept as dead code so re-enabling the format is a one-line change once the upstream pipeline ships the fix.

## Alternatives considered

1. **Wait for goreleaser-pro fix.** Out of crush's repo control. No firm timeline.
2. **Post-build script** to re-pack the .deb with `dpkg-deb -R` / `dpkg-deb -b` and rewrite `control`. More invasive, adds CI complexity.
3. **Keep but rename.** Doesn't fix the actual install error.

Removal is reversible in one line; happy to switch to (2) if you'd prefer to keep the artifact.

## Verification

`.goreleaser.yml` parses cleanly; the diff is purely the format-list removal + a clarifying comment block.