### PR TITLE
fix(test): enable CGO to support -race option in `test` task

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -81,6 +81,8 @@ tasks:
 
   test:
     desc: Run tests
+    env:
+      CGO_ENABLED: 1
     cmds:
       - go test -race -failfast ./... {{.CLI_ARGS}}
 


### PR DESCRIPTION
## Summary

The `-race` flag in `go test` requires CGO to be enabled. This change ensures the testing task in `Taskfile.yaml` run correctly with the race detector

## Before
`go-task test` fails with following outputs:

```bash
task: [test] go test -race -failfast ./...
go: -race requires cgo; enable cgo by setting CGO_ENABLED=1
task: Failed to run task "test": exit status 2
```
## After
`go-task test` successfully trigger the test.

> [!NOTE]
Tests requiring specific authorization may still fail in local environments, but the execution block caused by the race detector requirement is resolved.

## Reference

- [go-doc](https://go.dev/doc/articles/race_detector#Requirements)

## Checklist

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
