### PR TITLE
fix(mcp): add per-tool-call timeout to prevent indefinite hangs

### DIFF
--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -522,6 +522,10 @@ func mcpTimeout(m config.MCPConfig) time.Duration {
 	return time.Duration(cmp.Or(m.Timeout, 15)) * time.Second
 }
 
+func mcpToolTimeout(m config.MCPConfig) time.Duration {
+	return time.Duration(cmp.Or(m.ToolTimeout, 120)) * time.Second
+}
+
 func stdioCheck(old *exec.Cmd) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -43,7 +43,16 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 	if err != nil {
 		return ToolResult{}, err
 	}
-	result, err := c.CallTool(ctx, &mcp.CallToolParams{
+
+	// Apply per-tool-call timeout to prevent indefinite hangs on large
+	// payloads (e.g. write_file with 15KB+ content over stdio).
+	// Default: 120s, configurable via "tool_timeout" in MCP config.
+	m := cfg.Config().MCP[name]
+	toolTimeout := mcpToolTimeout(m)
+	toolCtx, cancel := context.WithTimeout(ctx, toolTimeout)
+	defer cancel()
+
+	result, err := c.CallTool(toolCtx, &mcp.CallToolParams{
 		Name:      toolName,
 		Arguments: args,
 	})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -189,6 +189,7 @@ type MCPConfig struct {
 	Disabled      bool              `json:"disabled,omitempty" jsonschema:"description=Whether this MCP server is disabled,default=false"`
 	DisabledTools []string          `json:"disabled_tools,omitempty" jsonschema:"description=List of tools from this MCP server to disable,example=get-library-doc"`
 	Timeout       int               `json:"timeout,omitempty" jsonschema:"description=Timeout in seconds for MCP server connections,default=15,example=30,example=60,example=120"`
+	ToolTimeout   int               `json:"tool_timeout,omitempty" jsonschema:"description=Timeout in seconds for individual MCP tool calls,default=120,example=60,example=300"`
 
 	// Headers are HTTP headers for HTTP/SSE MCP servers. Values run
 	// through shell expansion at MCP startup, so $VAR and $(cmd)


### PR DESCRIPTION
## Summary

- Add configurable per-tool-call timeout (default 120s) to prevent Crush from hanging indefinitely when MCP stdio servers block on large payloads
- Introduce `tool_timeout` field in MCP config for per-server customization
- Wrap `c.CallTool()` with `context.WithTimeout` in `RunTool()`

## Problem

When an LLM generates a `write_file` tool call with large content (15KB+), the MCP stdio pipe can block and Crush hangs indefinitely. Session creation and ping have timeouts (default 15s), but `RunTool()` calls `c.CallTool(ctx, ...)` with no timeout — if the stdio pipe blocks, there is no recovery path.

## Changes

| File | Change |
|:---|:---|
| `internal/config/config.go` | Add `ToolTimeout` field to `MCPConfig` |
| `internal/agent/tools/mcp/init.go` | Add `mcpToolTimeout()` helper (default 120s) |
| `internal/agent/tools/mcp/tools.go` | Wrap `c.CallTool()` with `context.WithTimeout` |

## Config Example

```json
{
  "mcp": {
    "filesystem": {
      "type": "stdio",
      "command": "mcp-server-filesystem",
      "args": ["/Users/me"],
      "tool_timeout": 120
    }
  }
}
```

## Test plan

- [ ] Verify normal tool calls still work within timeout
- [ ] Verify large write_file (15KB+) returns timeout error instead of hanging
- [ ] Verify `tool_timeout` config is respected per MCP server
- [ ] Verify default 120s applies when `tool_timeout` is omitted

Fixes #2854

🤖 Generated with [Claude Code](https://claude.com/claude-code)