### PR TITLE
fix(shell): properly kill process groups on cancellation

### DIFF
--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -5,6 +5,7 @@ import (
 	"cmp"
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"html/template"
 	"path/filepath"
@@ -336,7 +337,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 					// Incoming context was cancelled before we moved to background
 					// Kill the shell and return error
 					bgManager.Kill(bgShell.ID)
-					return fantasy.ToolResponse{}, ctx.Err()
+					return fantasy.ToolResponse{}, fmt.Errorf("command was interrupted")
 				}
 			}
 
@@ -393,7 +394,7 @@ func formatOutput(stdout, stderr string, execErr error) string {
 	stderr = truncateOutput(stderr)
 
 	errorMessage := stderr
-	if errorMessage == "" && execErr != nil {
+	if errorMessage == "" && execErr != nil && !interrupted {
 		errorMessage = execErr.Error()
 	}
 
@@ -401,7 +402,11 @@ func formatOutput(stdout, stderr string, execErr error) string {
 		if errorMessage != "" {
 			errorMessage += "\n"
 		}
-		errorMessage += "Command was aborted before completion"
+		if errors.Is(execErr, context.DeadlineExceeded) {
+			errorMessage += "Command timed out"
+		} else {
+			errorMessage += "Command was aborted before completion"
+		}
 	} else if exitCode != 0 {
 		if errorMessage != "" {
 			errorMessage += "\n"

--- a/internal/agent/tools/job_output.go
+++ b/internal/agent/tools/job_output.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -63,9 +64,17 @@ func NewJobOutputTool() fantasy.AgentTool {
 			if done {
 				status = "completed"
 				if err != nil {
-					exitCode := shell.ExitCode(err)
-					if exitCode != 0 {
-						outputParts = append(outputParts, fmt.Sprintf("Exit code %d", exitCode))
+					if shell.IsInterrupt(err) {
+						if errors.Is(err, context.DeadlineExceeded) {
+							outputParts = append(outputParts, "Command timed out")
+						} else {
+							outputParts = append(outputParts, "Command was aborted before completion")
+						}
+					} else {
+						exitCode := shell.ExitCode(err)
+						if exitCode != 0 {
+							outputParts = append(outputParts, fmt.Sprintf("Exit code %d", exitCode))
+						}
 					}
 				}
 			}

--- a/internal/shell/background.go
+++ b/internal/shell/background.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -17,6 +18,10 @@ const (
 	MaxBackgroundJobs = 50
 	// CompletedJobRetentionMinutes is how long to keep completed jobs before auto-cleanup (8 hours)
 	CompletedJobRetentionMinutes = 8 * 60
+	// KillGracePeriod is how long to wait for a graceful shutdown before abandoning.
+	// We cannot forcefully kill processes spawned by mvdan.cc/sh since we don't have
+	// direct access to their PIDs, but we avoid blocking the caller forever.
+	KillGracePeriod = 5 * time.Second
 )
 
 // syncBuffer is a thread-safe wrapper around bytes.Buffer.
@@ -143,16 +148,33 @@ func (m *BackgroundShellManager) Remove(id string) error {
 	return nil
 }
 
-// Kill terminates a background shell by ID.
+// Kill terminates a background shell by ID. It first requests graceful
+// shutdown via context cancellation, then waits up to KillGracePeriod for
+// the shell to exit. If the shell doesn't exit within the grace period,
+// the goroutine is abandoned (we can't forcefully kill processes spawned
+// by mvdan.cc/sh since we don't have direct PID access).
 func (m *BackgroundShellManager) Kill(id string) error {
 	shell, ok := m.shells.Take(id)
 	if !ok {
 		return fmt.Errorf("background shell not found: %s", id)
 	}
 
+	// Request graceful shutdown.
 	shell.cancel()
-	<-shell.done
-	return nil
+
+	// Wait with timeout.
+	select {
+	case <-shell.done:
+		// Clean exit.
+		return nil
+	case <-time.After(KillGracePeriod):
+		slog.Warn("Background shell did not exit within grace period; abandoning",
+			"id", id,
+			"command", shell.Command,
+			"grace_period", KillGracePeriod,
+		)
+		return nil
+	}
 }
 
 // BackgroundShellInfo contains information about a background shell.

--- a/internal/shell/background_test.go
+++ b/internal/shell/background_test.go
@@ -116,6 +116,30 @@ func TestBackgroundShellManager_KillNonExistent(t *testing.T) {
 	}
 }
 
+func TestBackgroundShellManager_Kill_Timeout(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	manager := newBackgroundShellManager()
+
+	// Start a shell that traps signals and ignores cancellation.
+	bgShell, err := manager.Start(t.Context(), workingDir, nil, "trap '' TERM INT; sleep 60", "")
+	require.NoError(t, err)
+
+	// Give the trap a moment to be set up.
+	time.Sleep(100 * time.Millisecond)
+
+	start := time.Now()
+	err = manager.Kill(bgShell.ID)
+	elapsed := time.Since(start)
+
+	// Must not return an error (abandonment is not an error).
+	require.NoError(t, err)
+
+	// Must return within a reasonable time after KillGracePeriod, not hang for 60 seconds.
+	require.Less(t, elapsed, KillGracePeriod+2*time.Second)
+}
+
 func TestBackgroundShell_IsDone(t *testing.T) {
 	t.Parallel()
 

--- a/internal/shell/dispatch.go
+++ b/internal/shell/dispatch.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/crush/internal/filepathext"
 	"mvdan.cc/sh/v3/expand"
@@ -171,6 +172,10 @@ func isBinary(probe []byte) bool {
 // interpreter via os/exec, inheriting the parent runner's cwd, env, and
 // stdio. Returns interp.ExitStatus on non-zero interpreter exit so the
 // parent interpreter sees it as a normal non-zero status.
+//
+// On Unix, the command runs in its own process group so that on context
+// cancellation we can kill the entire tree (the interpreter and any
+// children it spawns, e.g. an editor).
 func dispatchShebang(ctx context.Context, scriptPath string, probe []byte, args []string) error {
 	sb, err := parseShebang(probe)
 	if err != nil {
@@ -190,7 +195,9 @@ func dispatchShebang(ctx context.Context, scriptPath string, probe []byte, args 
 	cmdArgs = append(cmdArgs, scriptPath)
 	cmdArgs = append(cmdArgs, args[1:]...)
 
-	cmd := exec.CommandContext(ctx, interpreter, cmdArgs...)
+	// Don't use exec.CommandContext - we handle cancellation ourselves
+	// to properly kill the process group.
+	cmd := exec.Command(interpreter, cmdArgs...) //nolint:noctx // intentional - we handle ctx cancellation manually for process group kill
 	hc := interp.HandlerCtx(ctx)
 	cmd.Dir = hc.Dir
 	cmd.Env = execEnvList(hc.Env)
@@ -198,7 +205,26 @@ func dispatchShebang(ctx context.Context, scriptPath string, probe []byte, args 
 	cmd.Stdout = hc.Stdout
 	cmd.Stderr = hc.Stderr
 
-	if err := cmd.Run(); err != nil {
+	// Set up process group isolation so we can kill child processes.
+	prepareCmd(cmd)
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	// Set up cancellation handler to kill the process group.
+	stopCancel := context.AfterFunc(ctx, func() {
+		if killTimeout <= 0 {
+			_ = killCmd(cmd)
+			return
+		}
+		_ = interruptCmd(cmd)
+		time.Sleep(killTimeout)
+		_ = killCmd(cmd)
+	})
+	defer stopCancel()
+
+	if err := cmd.Wait(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
 			code := exitErr.ExitCode()

--- a/internal/shell/process_other.go
+++ b/internal/shell/process_other.go
@@ -1,0 +1,31 @@
+//go:build !unix
+
+package shell
+
+import (
+	"os/exec"
+	"time"
+)
+
+// killTimeout is how long to wait after sending interrupt before sending kill.
+// On Windows, we send kill immediately since Go doesn't support Interrupt.
+const killTimeout = 0 * time.Second
+
+// prepareCmd is a no-op on non-Unix platforms.
+func prepareCmd(cmd *exec.Cmd) {}
+
+// interruptCmd kills the process on non-Unix platforms (no SIGINT support).
+func interruptCmd(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}
+
+// killCmd kills the process.
+func killCmd(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}

--- a/internal/shell/process_unix.go
+++ b/internal/shell/process_unix.go
@@ -1,0 +1,36 @@
+//go:build unix
+
+package shell
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// killTimeout is how long to wait after sending SIGINT before sending SIGKILL.
+const killTimeout = 2 * time.Second
+
+// prepareCmd sets up process group isolation for the command so we can
+// kill the entire process tree on cancellation.
+func prepareCmd(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// interruptCmd sends SIGINT to the process group.
+func interruptCmd(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return unix.Kill(-cmd.Process.Pid, unix.SIGINT)
+}
+
+// killCmd sends SIGKILL to the process group.
+func killCmd(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return unix.Kill(-cmd.Process.Pid, unix.SIGKILL)
+}


### PR DESCRIPTION
## Summary

Fixes an issue where `job_kill` would hang forever and fail to kill child processes spawned by background commands.

**Problem**: When running commands like `git rebase --continue` that spawn editors, cancelling the background job would:
1. Block indefinitely waiting for the process to exit
2. Only kill the direct child (git), leaving the editor orphaned

**Root causes**:
1. `BackgroundShellManager.Kill()` blocked forever on `<-shell.done` with no timeout
2. `dispatchShebang()` used `exec.CommandContext` without process group isolation, so child processes weren't killed

**Solution**:

1. **Add timeout to Kill()** - Now waits up to 5 seconds for graceful shutdown before abandoning the goroutine. This prevents the caller from blocking forever.

2. **Add process group isolation** - On Unix, commands now run in their own process group (`Setpgid: true`). On cancellation:
   - Send SIGINT to the process group (graceful)
   - Wait 2 seconds
   - Send SIGKILL to the process group (forceful)
   
   Using negative PID (`kill(-pid, signal)`) sends the signal to all processes in the group, killing the entire process tree.

This mirrors the approach used by `mvdan.cc/sh`'s `DefaultExecHandler`.

## Test plan

- [x] Added `TestBackgroundShellManager_Kill_Timeout` to verify Kill returns within grace period
- [x] All existing shell tests pass
- [x] All dispatch tests pass (shebang handling unchanged functionally)

## Notes

- On Windows, SIGKILL is sent immediately (no SIGINT support in Go)
- The 5-second grace period for `Kill()` and 2-second kill timeout for shebang scripts are chosen to match existing patterns in the codebase (`abandonGrace` in hooks, `DefaultExecHandler` timeout)