### PR TITLE
fix(backend): deduplicate workspaces by data directory to prevent SQLite contention

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -38,6 +38,7 @@ type ShutdownFunc func()
 // server. It manages workspaces and delegates to [app.App] services.
 type Backend struct {
 	workspaces *csync.Map[string, *Workspace]
+	clients    *clientTracker
 	cfg        *config.ConfigStore
 	ctx        context.Context
 	shutdownFn ShutdownFunc
@@ -57,19 +58,29 @@ type Workspace struct {
 func New(ctx context.Context, cfg *config.ConfigStore, shutdownFn ShutdownFunc) *Backend {
 	return &Backend{
 		workspaces: csync.NewMap[string, *Workspace](),
+		clients:    newClientTracker(),
 		cfg:        cfg,
 		ctx:        ctx,
 		shutdownFn: shutdownFn,
 	}
 }
 
-// GetWorkspace retrieves a workspace by ID.
+// GetWorkspace retrieves a workspace by ID. The ID can be either a workspace ID
+// or a client ID that maps to a shared workspace.
 func (b *Backend) GetWorkspace(id string) (*Workspace, error) {
-	ws, ok := b.workspaces.Get(id)
-	if !ok {
-		return nil, ErrWorkspaceNotFound
+	// Try direct workspace lookup first.
+	if ws, ok := b.workspaces.Get(id); ok {
+		return ws, nil
 	}
-	return ws, nil
+
+	// Try as a client ID.
+	if workspaceID, ok := b.clients.workspaceForClient(id); ok {
+		if ws, ok := b.workspaces.Get(workspaceID); ok {
+			return ws, nil
+		}
+	}
+
+	return nil, ErrWorkspaceNotFound
 }
 
 // ListWorkspaces returns all running workspaces.
@@ -81,27 +92,48 @@ func (b *Backend) ListWorkspaces() []proto.Workspace {
 	return workspaces
 }
 
-// CreateWorkspace initializes a new workspace from the given
-// parameters. It creates the config, database connection, and
-// [app.App] instance.
+// CreateWorkspace initializes a new workspace from the given parameters.
+// If a workspace already exists for the same data directory, the existing
+// workspace is returned with a new client ID to avoid opening multiple
+// DB connections to the same file.
 func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Workspace, error) {
 	if args.Path == "" {
 		return nil, proto.Workspace{}, ErrPathRequired
 	}
 
-	id := uuid.New().String()
+	clientID := uuid.New().String()
+
 	cfg, err := config.Init(args.Path, args.DataDir, args.Debug)
 	if err != nil {
 		return nil, proto.Workspace{}, fmt.Errorf("failed to initialize config: %w", err)
 	}
 
+	dataDir := cfg.Config().Options.DataDirectory
+
+	// Check for existing workspace.
+	if existingID, ok := b.clients.workspaceForDataDir(dataDir); ok {
+		if ws, ok := b.workspaces.Get(existingID); ok {
+			count, _ := b.clients.addClient(clientID, existingID, dataDir)
+			slog.Info("Reusing existing workspace for data directory",
+				"client_id", clientID,
+				"workspace_id", existingID,
+				"data_dir", dataDir,
+				"client_count", count,
+			)
+			return ws, b.makeProtoWorkspace(clientID, args.Path, dataDir, args.Env, ws.Cfg), nil
+		}
+		// Stale entry - clean up.
+		b.clients.cleanupStaleWorkspace(existingID, dataDir)
+	}
+
+	// Create new workspace.
 	cfg.Overrides().SkipPermissionRequests = args.YOLO
 
-	if err := createDotCrushDir(cfg.Config().Options.DataDirectory); err != nil {
+	if err := createDotCrushDir(dataDir); err != nil {
 		return nil, proto.Workspace{}, fmt.Errorf("failed to create data directory: %w", err)
 	}
 
-	conn, err := db.Connect(b.ctx, cfg.Config().Options.DataDirectory)
+	conn, err := db.Connect(b.ctx, dataDir)
 	if err != nil {
 		return nil, proto.Workspace{}, fmt.Errorf("failed to connect to database: %w", err)
 	}
@@ -113,13 +145,14 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 
 	ws := &Workspace{
 		App:  appWorkspace,
-		ID:   id,
+		ID:   clientID,
 		Path: args.Path,
 		Cfg:  cfg,
 		Env:  args.Env,
 	}
 
-	b.workspaces.Set(id, ws)
+	b.workspaces.Set(clientID, ws)
+	b.clients.addClient(clientID, clientID, dataDir)
 
 	if args.Version != "" && args.Version != version.Version {
 		slog.Warn("Client/server version mismatch",
@@ -132,31 +165,57 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 		)))
 	}
 
-	result := proto.Workspace{
-		ID:      id,
-		Path:    args.Path,
-		DataDir: cfg.Config().Options.DataDirectory,
-		Debug:   cfg.Config().Options.Debug,
-		YOLO:    cfg.Overrides().SkipPermissionRequests,
-		Config:  cfg.Config(),
-		Env:     args.Env,
-	}
-
-	return ws, result, nil
+	return ws, b.makeProtoWorkspace(clientID, args.Path, dataDir, args.Env, cfg), nil
 }
 
-// DeleteWorkspace shuts down and removes a workspace. If it was the
-// last workspace, the shutdown callback is invoked.
-func (b *Backend) DeleteWorkspace(id string) {
-	ws, ok := b.workspaces.Get(id)
-	if ok {
+// DeleteWorkspace removes a client from its workspace. The workspace is only
+// shut down when the last client disconnects.
+func (b *Backend) DeleteWorkspace(clientID string) {
+	workspaceID, _, lastClient, ok := b.clients.removeClient(clientID)
+	if !ok {
+		// Unknown client - try legacy direct lookup.
+		if ws, ok := b.workspaces.Get(clientID); ok {
+			ws.Shutdown()
+			b.workspaces.Del(clientID)
+		}
+		b.maybeShutdown()
+		return
+	}
+
+	slog.Info("Client disconnected from workspace",
+		"client_id", clientID,
+		"workspace_id", workspaceID,
+		"last_client", lastClient,
+	)
+
+	if !lastClient {
+		return
+	}
+
+	if ws, ok := b.workspaces.Get(workspaceID); ok {
 		ws.Shutdown()
 	}
-	b.workspaces.Del(id)
+	b.workspaces.Del(workspaceID)
+	b.maybeShutdown()
+}
 
+func (b *Backend) maybeShutdown() {
 	if b.workspaces.Len() == 0 && b.shutdownFn != nil {
 		slog.Info("Last workspace removed, shutting down server...")
 		b.shutdownFn()
+	}
+}
+
+func (b *Backend) makeProtoWorkspace(clientID, path, dataDir string, env []string, cfg *config.ConfigStore) proto.Workspace {
+	c := cfg.Config()
+	return proto.Workspace{
+		ID:      clientID,
+		Path:    path,
+		DataDir: dataDir,
+		Debug:   c.Options.Debug,
+		YOLO:    cfg.Overrides().SkipPermissionRequests,
+		Config:  c,
+		Env:     env,
 	}
 }
 

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -1,0 +1,117 @@
+package backend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateWorkspace_DeduplicatesByDataDir(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfg, err := config.Init(tempDir, "", false)
+	require.NoError(t, err)
+
+	b := New(context.Background(), cfg, nil)
+
+	// Create first workspace.
+	ws1, result1, err := b.CreateWorkspace(proto.Workspace{
+		Path: tempDir,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result1.ID)
+
+	// Create second workspace for the same directory.
+	ws2, result2, err := b.CreateWorkspace(proto.Workspace{
+		Path: tempDir,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result2.ID)
+
+	// Should get different client IDs.
+	require.NotEqual(t, result1.ID, result2.ID, "clients should have different IDs")
+
+	// But should share the same workspace.
+	require.Same(t, ws1, ws2, "should return the same workspace instance")
+
+	// Both client IDs should resolve to the same workspace.
+	got1, err := b.GetWorkspace(result1.ID)
+	require.NoError(t, err)
+	got2, err := b.GetWorkspace(result2.ID)
+	require.NoError(t, err)
+	require.Same(t, got1, got2, "both client IDs should resolve to same workspace")
+
+	// Verify client tracking via the tracker's client count.
+	wsID, ok := b.clients.workspaceForClient(result1.ID)
+	require.True(t, ok)
+	require.Equal(t, 2, b.clients.clientCount(wsID), "should have 2 clients tracked")
+}
+
+func TestDeleteWorkspace_OnlyDeletesWhenLastClientDisconnects(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfg, err := config.Init(tempDir, "", false)
+	require.NoError(t, err)
+
+	shutdownCalled := false
+	b := New(context.Background(), cfg, func() {
+		shutdownCalled = true
+	})
+
+	// Create two clients for the same directory.
+	_, result1, err := b.CreateWorkspace(proto.Workspace{Path: tempDir})
+	require.NoError(t, err)
+
+	_, result2, err := b.CreateWorkspace(proto.Workspace{Path: tempDir})
+	require.NoError(t, err)
+
+	// Delete first client.
+	b.DeleteWorkspace(result1.ID)
+
+	// Workspace should still exist.
+	_, err = b.GetWorkspace(result2.ID)
+	require.NoError(t, err, "workspace should still exist after first client disconnects")
+	require.False(t, shutdownCalled, "shutdown should not be called yet")
+
+	// Delete second client.
+	b.DeleteWorkspace(result2.ID)
+
+	// Now workspace should be gone.
+	_, err = b.GetWorkspace(result2.ID)
+	require.Error(t, err, "workspace should be deleted after last client disconnects")
+	require.True(t, shutdownCalled, "shutdown should be called when last workspace removed")
+}
+
+func TestDeleteWorkspace_CleansUpDataDirMapping(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfg, err := config.Init(tempDir, "", false)
+	require.NoError(t, err)
+
+	b := New(context.Background(), cfg, nil)
+
+	// Create workspace.
+	_, result1, err := b.CreateWorkspace(proto.Workspace{Path: tempDir})
+	require.NoError(t, err)
+
+	dataDir := result1.DataDir
+
+	// Verify mapping exists.
+	_, exists := b.clients.workspaceForDataDir(dataDir)
+	require.True(t, exists, "data dir mapping should exist")
+
+	// Delete workspace.
+	b.DeleteWorkspace(result1.ID)
+
+	// Verify mapping is cleaned up.
+	_, exists = b.clients.workspaceForDataDir(dataDir)
+	require.False(t, exists, "data dir mapping should be cleaned up")
+
+	// Creating a new workspace should work.
+	_, result2, err := b.CreateWorkspace(proto.Workspace{Path: tempDir})
+	require.NoError(t, err)
+	require.NotEqual(t, result1.ID, result2.ID, "new workspace should have new ID")
+}

--- a/internal/backend/client_tracker.go
+++ b/internal/backend/client_tracker.go
@@ -1,0 +1,109 @@
+package backend
+
+import "sync"
+
+// clientTracker manages the mapping between clients, workspaces, and data
+// directories. It ensures that multiple clients connecting to the same data
+// directory share a single workspace to prevent SQLite contention.
+type clientTracker struct {
+	mu sync.Mutex
+	// byDataDir maps data directory paths to workspace IDs.
+	byDataDir map[string]string
+	// byWorkspace maps workspace IDs to their connected client IDs.
+	byWorkspace map[string]map[string]struct{}
+	// byClient maps client IDs to their workspace ID.
+	byClient map[string]string
+}
+
+func newClientTracker() *clientTracker {
+	return &clientTracker{
+		byDataDir:   make(map[string]string),
+		byWorkspace: make(map[string]map[string]struct{}),
+		byClient:    make(map[string]string),
+	}
+}
+
+// workspaceForDataDir returns the workspace ID for a data directory, if one exists.
+func (t *clientTracker) workspaceForDataDir(dataDir string) (workspaceID string, ok bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	workspaceID, ok = t.byDataDir[dataDir]
+	return
+}
+
+// workspaceForClient returns the workspace ID for a client ID.
+func (t *clientTracker) workspaceForClient(clientID string) (workspaceID string, ok bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	workspaceID, ok = t.byClient[clientID]
+	return
+}
+
+// addClient registers a new client for a workspace and data directory.
+// If this is the first client for the data directory, isNew is true.
+func (t *clientTracker) addClient(clientID, workspaceID, dataDir string) (clientCount int, isNew bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	_, existed := t.byDataDir[dataDir]
+	isNew = !existed
+
+	t.byDataDir[dataDir] = workspaceID
+	t.byClient[clientID] = workspaceID
+
+	if t.byWorkspace[workspaceID] == nil {
+		t.byWorkspace[workspaceID] = make(map[string]struct{})
+	}
+	t.byWorkspace[workspaceID][clientID] = struct{}{}
+
+	return len(t.byWorkspace[workspaceID]), isNew
+}
+
+// removeClient unregisters a client and returns the workspace ID it belonged to.
+// If this was the last client for the workspace, lastClient is true and dataDir
+// is returned for cleanup.
+func (t *clientTracker) removeClient(clientID string) (workspaceID, dataDir string, lastClient bool, ok bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	workspaceID, ok = t.byClient[clientID]
+	if !ok {
+		return "", "", false, false
+	}
+
+	delete(t.byClient, clientID)
+
+	clients := t.byWorkspace[workspaceID]
+	delete(clients, clientID)
+
+	if len(clients) > 0 {
+		return workspaceID, "", false, true
+	}
+
+	// Last client - find and clean up data directory mapping.
+	for dir, wsID := range t.byDataDir {
+		if wsID == workspaceID {
+			dataDir = dir
+			delete(t.byDataDir, dir)
+			break
+		}
+	}
+	delete(t.byWorkspace, workspaceID)
+
+	return workspaceID, dataDir, true, true
+}
+
+// clientCount returns the number of clients connected to a workspace.
+func (t *clientTracker) clientCount(workspaceID string) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.byWorkspace[workspaceID])
+}
+
+// cleanupStaleWorkspace removes tracking for a workspace that no longer exists.
+func (t *clientTracker) cleanupStaleWorkspace(workspaceID, dataDir string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.byDataDir, dataDir)
+	delete(t.byWorkspace, workspaceID)
+}


### PR DESCRIPTION
## Summary

Fixes a race condition where multiple crush clients connecting from the same directory would each open separate database connections to the same `.crush/crush.db` file, causing SQLite WAL checkpoint conflicts and potential database corruption.

## Problem

When the crush server receives workspace creation requests from multiple clients in the same directory:

1. Each client creates a new workspace with a unique UUID
2. Each workspace opens its own `*sql.DB` connection to the same `crush.db` file
3. SQLite WAL mode allows concurrent readers but multiple writers from different processes can cause:
   - WAL/header desync resulting in `SQLITE_NOTADB` (error 26) on subsequent opens
   - Logical race conditions where concurrent writes overwrite each other's changes
   - The comment in `internal/db/connect.go:53-57` already warns about this issue within a single process

This was discovered by observing that `GET /v1/workspaces` could return multiple workspace entries for the same data directory, each with different IDs but pointing to the same database file.

## Solution

Track workspaces by their data directory path and share the workspace instance when multiple clients connect to the same directory:

- **`dataDirToID`** - maps data directory paths → workspace IDs to detect duplicates
- **`workspaceClients`** - maps workspace ID → set of client IDs to track usage
- **`clientToWorkspace`** - maps client ID → workspace ID for reverse lookup during disconnect

### Behavior Changes

- `CreateWorkspace`: Returns existing workspace (with new client ID) when data directory already has a workspace
- `DeleteWorkspace`: Only shuts down workspace when the **last** client disconnects
- `GetWorkspace`: Supports lookup by either workspace ID or client ID

## Test Plan

- [x] Added `TestCreateWorkspace_DeduplicatesByDataDir` - verifies workspace sharing
- [x] Added `TestDeleteWorkspace_OnlyDeletesWhenLastClientDisconnects` - verifies cleanup logic  
- [x] Added `TestDeleteWorkspace_CleansUpDataDirMapping` - verifies mapping cleanup after full disconnect
- [x] All existing tests pass


💜 Generated with Crush