### PR TITLE
fix(config): always resolve the data directory to an absolute path

### DIFF
--- a/internal/agent/prompt/prompt.go
+++ b/internal/agent/prompt/prompt.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/filepathext"
 	"github.com/charmbracelet/crush/internal/home"
 	"github.com/charmbracelet/crush/internal/shell"
 	"github.com/charmbracelet/crush/internal/skills"
@@ -107,10 +108,7 @@ func processFile(filePath string) *ContextFile {
 
 func processContextPath(p string, store *config.ConfigStore) []ContextFile {
 	var contexts []ContextFile
-	fullPath := p
-	if !filepath.IsAbs(p) {
-		fullPath = filepath.Join(store.WorkingDir(), p)
-	}
+	fullPath := filepathext.SmartJoin(store.WorkingDir(), p)
 	info, err := os.Stat(fullPath)
 	if err != nil {
 		return contexts

--- a/internal/agent/tools/glob.go
+++ b/internal/agent/tools/glob.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/filepathext"
 	"github.com/charmbracelet/crush/internal/fsext"
 )
 
@@ -96,10 +97,7 @@ func runRipgrep(cmd *exec.Cmd, searchRoot string, limit int) ([]string, error) {
 		if len(p) == 0 {
 			continue
 		}
-		absPath := string(p)
-		if !filepath.IsAbs(absPath) {
-			absPath = filepath.Join(searchRoot, absPath)
-		}
+		absPath := filepathext.SmartJoin(searchRoot, string(p))
 		if fsext.SkipHidden(absPath) {
 			continue
 		}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -429,6 +429,10 @@ func (c *Config) setDefaults(workingDir, dataDir string) {
 			c.Options.DataDirectory = filepath.Join(workingDir, defaultDataDirectory)
 		}
 	}
+	if !filepath.IsAbs(c.Options.DataDirectory) {
+		c.Options.DataDirectory = filepath.Join(workingDir, c.Options.DataDirectory)
+	}
+	c.Options.DataDirectory = filepath.Clean(c.Options.DataDirectory)
 	if c.Providers == nil {
 		c.Providers = csync.NewMap[string, ProviderConfig]()
 	}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -21,6 +21,7 @@ import (
 	"github.com/charmbracelet/crush/internal/agent/hyper"
 	"github.com/charmbracelet/crush/internal/csync"
 	"github.com/charmbracelet/crush/internal/env"
+	"github.com/charmbracelet/crush/internal/filepathext"
 	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/home"
 	powernapConfig "github.com/charmbracelet/x/powernap/pkg/config"
@@ -429,10 +430,7 @@ func (c *Config) setDefaults(workingDir, dataDir string) {
 			c.Options.DataDirectory = filepath.Join(workingDir, defaultDataDirectory)
 		}
 	}
-	if !filepath.IsAbs(c.Options.DataDirectory) {
-		c.Options.DataDirectory = filepath.Join(workingDir, c.Options.DataDirectory)
-	}
-	c.Options.DataDirectory = filepath.Clean(c.Options.DataDirectory)
+	c.Options.DataDirectory = filepath.Clean(filepathext.SmartJoin(workingDir, c.Options.DataDirectory))
 	if c.Providers == nil {
 		c.Providers = csync.NewMap[string, ProviderConfig]()
 	}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -76,8 +76,9 @@ func testStore(cfg *Config) *ConfigStore {
 func TestConfig_setDefaults(t *testing.T) {
 	t.Run("sets default data directory", func(t *testing.T) {
 		cfg := &Config{}
+		workingDir := t.TempDir()
 
-		cfg.setDefaults("/tmp", "")
+		cfg.setDefaults(workingDir, "")
 
 		require.NotNil(t, cfg.Options)
 		require.NotNil(t, cfg.Options.TUI)
@@ -86,7 +87,7 @@ func TestConfig_setDefaults(t *testing.T) {
 		require.NotNil(t, cfg.Models)
 		require.NotNil(t, cfg.LSP)
 		require.NotNil(t, cfg.MCP)
-		require.Equal(t, filepath.Join("/tmp", ".crush"), cfg.Options.DataDirectory)
+		require.Equal(t, filepath.Join(workingDir, ".crush"), cfg.Options.DataDirectory)
 		require.Equal(t, "AGENTS.md", cfg.Options.InitializeAs)
 		for _, path := range defaultContextPaths {
 			require.Contains(t, cfg.Options.ContextPaths, path)
@@ -95,18 +96,20 @@ func TestConfig_setDefaults(t *testing.T) {
 
 	t.Run("resolves relative configured data directory from working directory", func(t *testing.T) {
 		cfg := &Config{Options: &Options{DataDirectory: "."}}
+		workingDir := filepath.Join(t.TempDir(), "worktree")
 
-		cfg.setDefaults("/tmp/worktree", "")
+		cfg.setDefaults(workingDir, "")
 
-		require.Equal(t, "/tmp/worktree", cfg.Options.DataDirectory)
+		require.Equal(t, workingDir, cfg.Options.DataDirectory)
 	})
 
 	t.Run("resolves relative flag data directory from working directory", func(t *testing.T) {
 		cfg := &Config{}
+		workingDir := filepath.Join(t.TempDir(), "worktree")
 
-		cfg.setDefaults("/tmp/worktree", "./state")
+		cfg.setDefaults(workingDir, "./state")
 
-		require.Equal(t, "/tmp/worktree/state", cfg.Options.DataDirectory)
+		require.Equal(t, filepath.Join(workingDir, "state"), cfg.Options.DataDirectory)
 	})
 }
 

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -74,22 +74,40 @@ func testStore(cfg *Config) *ConfigStore {
 }
 
 func TestConfig_setDefaults(t *testing.T) {
-	cfg := &Config{}
+	t.Run("sets default data directory", func(t *testing.T) {
+		cfg := &Config{}
 
-	cfg.setDefaults("/tmp", "")
+		cfg.setDefaults("/tmp", "")
 
-	require.NotNil(t, cfg.Options)
-	require.NotNil(t, cfg.Options.TUI)
-	require.NotNil(t, cfg.Options.ContextPaths)
-	require.NotNil(t, cfg.Providers)
-	require.NotNil(t, cfg.Models)
-	require.NotNil(t, cfg.LSP)
-	require.NotNil(t, cfg.MCP)
-	require.Equal(t, filepath.Join("/tmp", ".crush"), cfg.Options.DataDirectory)
-	require.Equal(t, "AGENTS.md", cfg.Options.InitializeAs)
-	for _, path := range defaultContextPaths {
-		require.Contains(t, cfg.Options.ContextPaths, path)
-	}
+		require.NotNil(t, cfg.Options)
+		require.NotNil(t, cfg.Options.TUI)
+		require.NotNil(t, cfg.Options.ContextPaths)
+		require.NotNil(t, cfg.Providers)
+		require.NotNil(t, cfg.Models)
+		require.NotNil(t, cfg.LSP)
+		require.NotNil(t, cfg.MCP)
+		require.Equal(t, filepath.Join("/tmp", ".crush"), cfg.Options.DataDirectory)
+		require.Equal(t, "AGENTS.md", cfg.Options.InitializeAs)
+		for _, path := range defaultContextPaths {
+			require.Contains(t, cfg.Options.ContextPaths, path)
+		}
+	})
+
+	t.Run("resolves relative configured data directory from working directory", func(t *testing.T) {
+		cfg := &Config{Options: &Options{DataDirectory: "."}}
+
+		cfg.setDefaults("/tmp/worktree", "")
+
+		require.Equal(t, "/tmp/worktree", cfg.Options.DataDirectory)
+	})
+
+	t.Run("resolves relative flag data directory from working directory", func(t *testing.T) {
+		cfg := &Config{}
+
+		cfg.setDefaults("/tmp/worktree", "./state")
+
+		require.Equal(t, "/tmp/worktree/state", cfg.Options.DataDirectory)
+	})
 }
 
 func TestConfig_configureProviders(t *testing.T) {

--- a/internal/shell/dispatch.go
+++ b/internal/shell/dispatch.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/charmbracelet/crush/internal/filepathext"
 	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/interp"
 	"mvdan.cc/sh/v3/syntax"
@@ -51,13 +52,10 @@ func scriptDispatchHandler(blockFuncs []BlockFunc) func(next interp.ExecHandlerF
 				return next(ctx, args)
 			}
 
-			scriptPath := args[0]
 			// Resolve relative paths against the interpreter's cwd, not
 			// the process cwd — hook commands are authored with the hook
 			// Runner's cwd in mind and sub-shells can cd before an exec.
-			if !filepath.IsAbs(scriptPath) {
-				scriptPath = filepath.Join(interp.HandlerCtx(ctx).Dir, scriptPath)
-			}
+			scriptPath := filepathext.SmartJoin(interp.HandlerCtx(ctx).Dir, args[0])
 			probe, err := probeFile(scriptPath)
 			if err != nil {
 				return err


### PR DESCRIPTION
This fixes a bug where Crush would place `crush.db` in the project root and other arbitrary locations due it not fully resolving relative directories. This is especially prevalent when working in Git worktrees.

Following this fix, Crush in worktrees should behave as normal.