### PR TITLE
feat: add aws_auth_refresh and top-level env config for Bedrock SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,26 @@ shell, and any `$(...)` in `crush.json` runs at load time. Don't launch Crush
 in a directory whose config you haven't reviewed, and don't randomly `source`
 files from the internet into your config.
 
+### Environment Variables
+
+The top-level `env` field sets environment variables at startup, before
+providers are configured. This is useful for variables that affect provider
+authentication (e.g. the AWS SDK credential chain) without wrapping the
+`crush` command in a shell script or exporting them in your shell profile:
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "env": {
+    "AWS_PROFILE": "my-sso-profile"
+  }
+}
+```
+
+Values support the same `$VAR` and `$(command)` expansion as other config
+fields, so you can reference existing environment variables or shell out for
+a value.
+
 ### LSPs
 
 Crush can use LSPs for additional context to help inform its decisions, just
@@ -707,10 +727,42 @@ model add custom-anthropic/claude-sonnet-4-20250514 \
 
 Crush currently supports running Anthropic models through Bedrock, with caching disabled.
 
-- A Bedrock provider will appear once you have AWS configured, i.e. `aws configure`
-- Crush also expects the `AWS_REGION` or `AWS_DEFAULT_REGION` to be set
-- To use a specific AWS profile set `AWS_PROFILE` in your environment, i.e. `AWS_PROFILE=myprofile crush`
-- Alternatively to `aws configure`, you can also just set `AWS_BEARER_TOKEN_BEDROCK`
+A Bedrock provider appears once Crush can find AWS credentials. You can
+authenticate in one of two ways:
+
+**API key.** Set `AWS_BEARER_TOKEN_BEDROCK` to a Bedrock API key. This is the
+simplest option and never expires mid-session.
+
+**AWS credential chain (SSO, profiles, access keys).** Configure AWS the usual
+way with `aws configure` or `aws configure sso`. Crush picks up whatever the
+AWS SDK credential chain resolves, including `AWS_PROFILE`, `AWS_ACCESS_KEY_ID`
+/ `AWS_SECRET_ACCESS_KEY`, or an SSO session. To select a specific profile,
+set `AWS_PROFILE` in your shell (`AWS_PROFILE=myprofile crush`) or in the
+top-level [`env`](#environment-variables) config.
+
+If you authenticate via AWS SSO, your session expires periodically. Set
+`aws_auth_refresh` to a command that refreshes it. When Bedrock returns a
+credential error, Crush runs the command, then retries the request in place
+(no duplicate messages, no manual restart):
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "env": {
+    "AWS_PROFILE": "my-sso-profile"
+  },
+  "providers": {
+    "bedrock": {
+      "aws_auth_refresh": "aws sso login --profile my-sso-profile"
+    },
+    "bedrock-europe": {
+      "aws_auth_refresh": "aws sso login --profile my-eu-sso-profile"
+    }
+  }
+}
+```
+
+- `aws_auth_refresh` — shell command run when AWS credentials expire (e.g. `aws sso login`)
 
 ### Vertex AI Platform
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -145,7 +145,7 @@ type SessionAgent interface {
 	QueuedPrompts(sessionID string) int
 	QueuedPromptsList(sessionID string) []string
 	ClearQueue(sessionID string)
-	Summarize(context.Context, string, fantasy.ProviderOptions) error
+	Summarize(context.Context, string, fantasy.ProviderOptions, func(context.Context, *fantasy.ProviderError) error) error
 	Model() Model
 	GenerateTitle(ctx context.Context, sessionID, userPrompt string)
 }
@@ -1194,7 +1194,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 
 	if shouldSummarize {
 		a.activeRequests.Del(call.SessionID)
-		if summarizeErr := a.Summarize(genCtx, call.SessionID, call.ProviderOptions); summarizeErr != nil {
+		if summarizeErr := a.Summarize(genCtx, call.SessionID, call.ProviderOptions, call.OnAuthRefresh); summarizeErr != nil {
 			return nil, summarizeErr
 		}
 		// If the agent wasn't done...
@@ -1329,7 +1329,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	return a.Run(ctx, firstQueuedMessage)
 }
 
-func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fantasy.ProviderOptions) error {
+func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fantasy.ProviderOptions, onAuthRefresh func(context.Context, *fantasy.ProviderError) error) error {
 	if a.IsSessionBusy(sessionID) {
 		return ErrSessionBusy
 	}
@@ -1386,6 +1386,10 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		Messages:        aiMsgs,
 		Headers:         sessionHeaders(sessionID),
 		ProviderOptions: opts,
+		OnAuthRefresh:   onAuthRefresh,
+		ModelProvider: func() fantasy.LanguageModel {
+			return a.largeModel.Get().Model
+		},
 		PrepareStep: func(callContext context.Context, options fantasy.PrepareStepFunctionOptions) (_ context.Context, prepared fantasy.PrepareStepResult, err error) {
 			prepared.Messages = options.Messages
 			if systemPromptPrefix != "" {

--- a/internal/agent/aws_sso_refresh.go
+++ b/internal/agent/aws_sso_refresh.go
@@ -1,0 +1,158 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/agent/notify"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/pubsub"
+)
+
+// awsSSORefreshTimeout bounds how long the AWS SSO refresh command may run.
+// Browser-based SSO needs time, so it is generous, and it runs on a context
+// detached from the agent turn so a cancelled turn doesn't abort the login.
+const awsSSORefreshTimeout = 5 * time.Minute
+
+// awsSSOURLRe matches the https verification URL that `aws sso login` and
+// related commands print to stdout or stderr.
+var awsSSOURLRe = regexp.MustCompile(`https://[^\s]+`)
+
+// extractAWSSSOURL returns the first HTTPS URL in the given command output
+// line, or empty if none is present.
+func extractAWSSSOURL(line string) string {
+	return awsSSOURLRe.FindString(line)
+}
+
+// refreshAWSCredentials runs the provider's configured AWS SSO refresh
+// command (e.g. "aws sso login") on the machine that makes the Bedrock
+// calls, streaming the verification URL to the UI for display, then rebuilds
+// models so the AWS SDK re-reads the refreshed credentials. It returns nil to
+// signal that the failed request should be retried.
+//
+// The command runs here, in the coordinator, rather than in the UI dialog so
+// the refreshed credentials land where the model calls are made. This is
+// correct in both single-process and client/server deployments.
+func (c *coordinator) refreshAWSCredentials(ctx context.Context, providerCfg config.ProviderConfig) error {
+	if c.notify == nil {
+		return errNoInteractiveAuth
+	}
+	slog.Info("AWS credentials expired, running refresh command",
+		"provider", providerCfg.ID, "command", providerCfg.AWSAuthRefresh)
+
+	// Open the dialog immediately so the user sees progress even before the
+	// command prints its verification URL.
+	c.notify.Publish(pubsub.CreatedEvent, notify.Notification{
+		Type:         notify.TypeAWSSSOAuth,
+		ProviderID:   providerCfg.ID,
+		AWSSOCommand: providerCfg.AWSAuthRefresh,
+	})
+
+	// Detach from the turn's context (with a generous timeout) so cancelling
+	// the turn doesn't kill an in-progress browser login.
+	runCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), awsSSORefreshTimeout)
+	defer cancel()
+
+	runErr := c.runAWSAuthRefresh(runCtx, providerCfg)
+
+	result := notify.Notification{Type: notify.TypeAWSSSOAuthResult, ProviderID: providerCfg.ID}
+	if runErr != nil {
+		result.Message = runErr.Error()
+	}
+	c.notify.Publish(pubsub.CreatedEvent, result)
+
+	if runErr != nil {
+		slog.Error("AWS SSO refresh command failed", "provider", providerCfg.ID, "error", runErr)
+		return runErr
+	}
+	// If the turn's context was cancelled while the command ran, fantasy's
+	// retry would fail immediately, so surface the cancellation instead.
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	// Rebuild models so the AWS SDK credential chain re-reads the refreshed
+	// SSO cache on the next attempt.
+	if err := c.UpdateModels(runCtx); err != nil {
+		slog.Error("Failed to update models after AWS SSO refresh", "provider", providerCfg.ID, "error", err)
+		return err
+	}
+	slog.Info("AWS SSO refresh complete, retrying request", "provider", providerCfg.ID)
+	return nil
+}
+
+// runAWSAuthRefresh executes the refresh command, publishing the SSO
+// verification URL to the UI as soon as it appears in the output and
+// returning any failure with captured stderr for context.
+func (c *coordinator) runAWSAuthRefresh(ctx context.Context, providerCfg config.ProviderConfig) error {
+	cmd := exec.CommandContext(ctx, "sh", "-c", providerCfg.AWSAuthRefresh)
+	cmd.Dir = c.cfg.WorkingDir()
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	// Drain stdout and stderr concurrently so a command that fills one pipe
+	// buffer before closing the other can't deadlock. Both are scanned for
+	// the verification URL; stderr is also captured for error detail.
+	var (
+		stderrBuf bytes.Buffer
+		mu        sync.Mutex // Guards the single-shot URL publish across goroutines.
+		urlSent   bool
+	)
+	publishURL := func(line string) {
+		mu.Lock()
+		defer mu.Unlock()
+		if urlSent {
+			return
+		}
+		if url := extractAWSSSOURL(line); url != "" {
+			urlSent = true
+			// Second phase of the two-part publish: the dialog is already
+			// open from refreshAWSCredentials; this fills in the URL on it.
+			c.notify.Publish(pubsub.CreatedEvent, notify.Notification{
+				Type:         notify.TypeAWSSSOAuth,
+				ProviderID:   providerCfg.ID,
+				AWSSOCommand: providerCfg.AWSAuthRefresh,
+				AWSSOURL:     url,
+			})
+		}
+	}
+
+	var wg sync.WaitGroup
+	scan := func(r io.Reader) {
+		defer wg.Done()
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			publishURL(scanner.Text())
+		}
+	}
+	wg.Add(2)
+	go scan(stdout)
+	go scan(io.TeeReader(stderrPipe, &stderrBuf))
+	wg.Wait()
+
+	if err := cmd.Wait(); err != nil {
+		if stderr := strings.TrimSpace(stderrBuf.String()); stderr != "" {
+			return fmt.Errorf("%w: %s", err, stderr)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/agent/aws_sso_refresh_test.go
+++ b/internal/agent/aws_sso_refresh_test.go
@@ -1,0 +1,44 @@
+package agent
+
+import "testing"
+
+func TestExtractAWSSSOURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name: "standard aws sso login output",
+			output: `If the browser does not open or you wish to use a different device to authorize this request, open the following URL:
+https://device.sso.us-east-1.amazonaws.com/?user_code=ABCD-EFGH`,
+			want: "https://device.sso.us-east-1.amazonaws.com/?user_code=ABCD-EFGH",
+		},
+		{
+			name:   "url only",
+			output: "https://device.sso.eu-west-1.amazonaws.com/?user_code=XXXX-YYYY",
+			want:   "https://device.sso.eu-west-1.amazonaws.com/?user_code=XXXX-YYYY",
+		},
+		{
+			name:   "no url",
+			output: "SSO session expired. Please run aws sso login.",
+			want:   "",
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := extractAWSSSOURL(tt.output); got != tt.want {
+				t.Errorf("extractAWSSSOURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -305,8 +305,10 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 	logTurnSkillUsage(sessionID, prompt, c.activeSkills, c.skillTracker, beforeLoaded)
 
 	// Notify only if still unauthorized after retry — a successful
-	// retry means the user doesn't need to re-authenticate.
-	if originalErr != nil && c.isUnauthorized(originalErr) && c.notify != nil && model.ModelCfg.Provider == hyper.Name {
+	// retry means the user doesn't need to re-authenticate. AWS SSO is
+	// handled transparently inside OnAuthRefresh, so it needs no post-run
+	// notification here.
+	if originalErr != nil && isUnauthorized(originalErr) && c.notify != nil && model.ModelCfg.Provider == hyper.Name {
 		c.notify.Publish(pubsub.CreatedEvent, notify.Notification{
 			Type:       notify.TypeReAuthenticate,
 			ProviderID: model.ModelCfg.Provider,
@@ -1244,11 +1246,9 @@ func (c *coordinator) Summarize(ctx context.Context, sessionID string) error {
 		slog.Error("Failed to refresh OAuth2 token before summarize. Proceeding with existing token.", "error", err)
 	}
 
-	summarize := func() error {
-		return c.currentAgent.Summarize(ctx, sessionID, getProviderOptions(c.currentAgent.Model(), providerCfg))
-	}
-
-	return c.runWithUnauthorizedRetry(ctx, providerCfg, summarize)
+	// Auth failures during summarize flow through fantasy's OnAuthRefresh,
+	// the same path used by regular turns.
+	return c.currentAgent.Summarize(ctx, sessionID, getProviderOptions(c.currentAgent.Model(), providerCfg), c.makeAuthRefreshCallback(providerCfg))
 }
 
 // GenerateTitle generates a session title using the current agent.
@@ -1268,25 +1268,11 @@ func (c *coordinator) refreshTokenIfExpired(ctx context.Context, providerCfg con
 	return c.refreshOAuth2Token(ctx, providerCfg)
 }
 
-// runWithUnauthorizedRetry executes fn. If fn returns a 401 error, it
-// attempts to refresh credentials and re-runs fn once. Returns the
-// final error: from the retry if a retry was attempted, otherwise from
-// the original run. Callers that need to notify the user on persistent
-// failure should check isUnauthorized on the returned error.
-func (c *coordinator) runWithUnauthorizedRetry(ctx context.Context, providerCfg config.ProviderConfig, fn func() error) error {
-	err := fn()
-	if err != nil && c.isUnauthorized(err) {
-		if retryErr := c.retryAfterUnauthorized(ctx, providerCfg); retryErr == nil {
-			return fn()
-		}
-	}
-	return err
-}
-
-// retryAfterUnauthorized attempts to refresh credentials after receiving a 401
-// and returns nil if retry should be attempted. When the refresh token is
-// revoked, it triggers interactive re-authentication and blocks until the user
-// completes it (or the context is cancelled).
+// retryAfterUnauthorized attempts to refresh credentials after an auth error
+// and returns nil if the request should be retried. For OAuth providers whose
+// refresh token is revoked, and for Bedrock providers whose AWS SSO session
+// has expired, it triggers interactive re-authentication and blocks until the
+// user completes it (or the context is cancelled).
 func (c *coordinator) retryAfterUnauthorized(ctx context.Context, providerCfg config.ProviderConfig) error {
 	switch {
 	case providerCfg.OAuthToken != nil:
@@ -1301,35 +1287,13 @@ func (c *coordinator) retryAfterUnauthorized(ctx context.Context, providerCfg co
 					Type:       notify.TypeReAuthenticate,
 					ProviderID: providerCfg.ID,
 				})
-				// Use a detached context with a generous timeout so the
-				// wait survives agent run cancellation. The user needs
-				// time to complete browser-based authentication.
-				waitCtx, waitCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Minute)
-				defer waitCancel()
-				slog.Info("Blocking on WaitForTokenChange", "provider", providerCfg.ID)
-				if waitErr := c.cfg.WaitForTokenChange(waitCtx, providerCfg.ID); waitErr != nil {
-					slog.Info("WaitForTokenChange returned error", "provider", providerCfg.ID, "error", waitErr)
-					return waitErr
-				}
-				slog.Info("WaitForTokenChange unblocked, updating models", "provider", providerCfg.ID)
-				// Check if the original context is still alive. If it was
-				// cancelled during the wait, fantasy's retry will fail immediately.
-				if ctx.Err() != nil {
-					slog.Warn("Original context cancelled during auth wait, cannot retry",
-						"provider", providerCfg.ID, "ctx_err", ctx.Err())
-					return ctx.Err()
-				}
-				// Rebuild models so ModelProvider picks up the fresh credentials.
-				if updateErr := c.UpdateModels(waitCtx); updateErr != nil {
-					slog.Error("Failed to update models after re-authentication", "error", updateErr)
-					return updateErr
-				}
-				slog.Info("Models updated, returning nil to retry", "provider", providerCfg.ID)
-				return nil
+				return c.waitForInteractiveReauth(ctx, providerCfg.ID)
 			}
 			return err
 		}
 		return nil
+	case providerCfg.AWSAuthRefresh != "":
+		return c.refreshAWSCredentials(ctx, providerCfg)
 	case strings.Contains(providerCfg.APIKeyTemplate, "$"):
 		slog.Debug("Received 401. Refreshing API Key template and retrying", "provider", providerCfg.ID)
 		return c.refreshApiKeyTemplate(ctx, providerCfg)
@@ -1338,7 +1302,45 @@ func (c *coordinator) retryAfterUnauthorized(ctx context.Context, providerCfg co
 	}
 }
 
-func (c *coordinator) isUnauthorized(err error) bool {
+// errNoInteractiveAuth is returned by an OnAuthRefresh callback when a
+// provider needs interactive re-authentication but no notifier is available
+// to drive it (e.g. headless runs). Returning it surfaces the original auth
+// error rather than retrying.
+var errNoInteractiveAuth = errors.New("interactive authentication unavailable")
+
+// waitForInteractiveReauth blocks until interactive re-authentication for the
+// provider completes (signalled via SignalAuthComplete) or the context is
+// cancelled, then rebuilds models so the next attempt picks up fresh
+// credentials. Returns nil when the caller should retry.
+func (c *coordinator) waitForInteractiveReauth(ctx context.Context, providerID string) error {
+	// Use a detached context with a generous timeout so the wait survives
+	// agent run cancellation. The user needs time to complete browser-based
+	// authentication.
+	waitCtx, waitCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Minute)
+	defer waitCancel()
+	slog.Info("Blocking on WaitForTokenChange", "provider", providerID)
+	if waitErr := c.cfg.WaitForTokenChange(waitCtx, providerID); waitErr != nil {
+		slog.Info("WaitForTokenChange returned error", "provider", providerID, "error", waitErr)
+		return waitErr
+	}
+	// If the original context was cancelled during the wait, fantasy's retry
+	// would fail immediately, so surface the cancellation instead.
+	if ctx.Err() != nil {
+		slog.Warn("Original context cancelled during auth wait, cannot retry",
+			"provider", providerID, "ctx_err", ctx.Err())
+		return ctx.Err()
+	}
+	// Rebuild models so ModelProvider picks up the fresh credentials.
+	if updateErr := c.UpdateModels(waitCtx); updateErr != nil {
+		slog.Error("Failed to update models after re-authentication", "error", updateErr)
+		return updateErr
+	}
+	slog.Info("Models updated, returning nil to retry", "provider", providerID)
+	return nil
+}
+
+// isUnauthorized reports whether err is an HTTP 401 from a provider.
+func isUnauthorized(err error) bool {
 	var providerErr *fantasy.ProviderError
 	return errors.As(err, &providerErr) && providerErr.StatusCode == http.StatusUnauthorized
 }
@@ -1347,7 +1349,9 @@ func (c *coordinator) isUnauthorized(err error) bool {
 // delegates to the coordinator's existing credential refresh logic. Returns
 // nil if no refresh mechanism is configured for the provider.
 func (c *coordinator) makeAuthRefreshCallback(providerCfg config.ProviderConfig) func(context.Context, *fantasy.ProviderError) error {
-	if providerCfg.OAuthToken == nil && !strings.Contains(providerCfg.APIKeyTemplate, "$") {
+	if providerCfg.OAuthToken == nil &&
+		!strings.Contains(providerCfg.APIKeyTemplate, "$") &&
+		providerCfg.AWSAuthRefresh == "" {
 		return nil
 	}
 	return func(ctx context.Context, _ *fantasy.ProviderError) error {
@@ -1440,8 +1444,9 @@ func (c *coordinator) runSubAgent(ctx context.Context, params subAgentParams) (f
 		})
 	}
 	result, err := run()
-	// Notify only if still unauthorized after retry.
-	if err != nil && c.isUnauthorized(err) && c.notify != nil && model.ModelCfg.Provider == hyper.Name {
+	// Notify only if still unauthorized after retry. AWS SSO is handled
+	// transparently inside OnAuthRefresh, so it needs no post-run notice.
+	if err != nil && isUnauthorized(err) && c.notify != nil && model.ModelCfg.Provider == hyper.Name {
 		c.notify.Publish(pubsub.CreatedEvent, notify.Notification{
 			Type:       notify.TypeReAuthenticate,
 			ProviderID: model.ModelCfg.Provider,

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"charm.land/catwalk/pkg/catwalk"
@@ -43,7 +45,7 @@ func (m *mockSessionAgent) IsBusy() bool                                { return
 func (m *mockSessionAgent) QueuedPrompts(sessionID string) int          { return 0 }
 func (m *mockSessionAgent) QueuedPromptsList(sessionID string) []string { return nil }
 func (m *mockSessionAgent) ClearQueue(sessionID string)                 {}
-func (m *mockSessionAgent) Summarize(context.Context, string, fantasy.ProviderOptions) error {
+func (m *mockSessionAgent) Summarize(context.Context, string, fantasy.ProviderOptions, func(context.Context, *fantasy.ProviderError) error) error {
 	return nil
 }
 func (m *mockSessionAgent) GenerateTitle(context.Context, string, string) {}
@@ -521,6 +523,32 @@ func TestGetProviderOptionsReasoningEffort(t *testing.T) {
 			assert.Equal(t, anthropic.Effort("max"), *parsed.Effort)
 		})
 	}
+}
+
+func TestIsUnauthorized(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		assert.False(t, isUnauthorized(nil))
+	})
+
+	t.Run("non-provider error", func(t *testing.T) {
+		assert.False(t, isUnauthorized(errors.New("something broke")))
+	})
+
+	t.Run("provider error with 401", func(t *testing.T) {
+		err := &fantasy.ProviderError{StatusCode: http.StatusUnauthorized, Message: "unauthorized"}
+		assert.True(t, isUnauthorized(err))
+	})
+
+	t.Run("provider error with non-401", func(t *testing.T) {
+		err := &fantasy.ProviderError{StatusCode: http.StatusForbidden, Message: "forbidden"}
+		assert.False(t, isUnauthorized(err))
+	})
+
+	t.Run("wrapped provider error with 401", func(t *testing.T) {
+		inner := &fantasy.ProviderError{StatusCode: http.StatusUnauthorized, Message: "expired"}
+		err := fmt.Errorf("request failed: %w", inner)
+		assert.True(t, isUnauthorized(err))
+	})
 }
 
 func TestGetProviderOptionsReasoningEffortFallback(t *testing.T) {

--- a/internal/agent/notify/notify.go
+++ b/internal/agent/notify/notify.go
@@ -15,6 +15,16 @@ const (
 	// TypeAgentError indicates the agent's turn terminated with an
 	// error. The error text is carried in Notification.Message.
 	TypeAgentError Type = "error"
+	// TypeAWSSSOAuth indicates AWS SSO credentials have expired and the
+	// coordinator is running the configured refresh command. It opens the
+	// AWS SSO dialog; a follow-up with the same type carries the SSO URL
+	// once it appears in the command output. AWSSOCommand carries the
+	// command being run; AWSSOURL carries the verification URL when known.
+	TypeAWSSSOAuth Type = "aws_sso_auth"
+	// TypeAWSSSOAuthResult indicates the AWS SSO refresh command has
+	// finished. Message carries the error text when it failed, empty on
+	// success.
+	TypeAWSSSOAuthResult Type = "aws_sso_auth_result"
 )
 
 // Notification represents a domain event published by the agent.
@@ -32,6 +42,11 @@ type Notification struct {
 	// Message carries the error text for TypeAgentError. Other
 	// notification types ignore it.
 	Message string
+	// AWSSOCommand carries the shell command for TypeAWSSSOAuth.
+	AWSSOCommand string
+	// AWSSOURL carries the SSO verification URL for TypeAWSSSOAuth once it
+	// appears in the refresh command's output.
+	AWSSOURL string
 }
 
 // RunComplete is the authoritative end-of-run signal for a session.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,10 @@ type ProviderConfig struct {
 	// Used to pass extra parameters to the provider.
 	ExtraParams map[string]string `json:"-"`
 
+	// AWSAuthRefresh is a shell command run when Bedrock returns a
+	// credential error. Output is discarded to avoid corrupting the TUI.
+	AWSAuthRefresh string `json:"aws_auth_refresh,omitempty" jsonschema:"description=Shell command to run when AWS credentials expire (Bedrock only)."`
+
 	// Skip cost accumulation for this provider when using subscription or flat rate billing.
 	FlatRate bool `json:"flat_rate,omitempty" jsonschema:"description=Flat-rate mode for this provider"`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -657,6 +657,9 @@ type Config struct {
 
 	Hooks map[string][]HookConfig `json:"hooks,omitempty" jsonschema:"description=User-defined shell commands that fire on hook events (e.g. PreToolUse)"`
 
+	// Env is a map of environment variables set on startup.
+	Env map[string]string `json:"env,omitempty" jsonschema:"description=Environment variables to set on startup"`
+
 	Agents map[string]Agent `json:"-"`
 }
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -117,6 +117,10 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 	store.writeMu.Lock()
 	defer store.writeMu.Unlock()
 
+	// Apply top-level env vars before configuring providers so variables
+	// like AWS_PROFILE are visible to the AWS SDK credential chain.
+	cfg.applyEnv(valueResolver)
+
 	if err := cfg.configureProviders(context.Background(), store, env, valueResolver, store.knownProviders); err != nil {
 		return nil, fmt.Errorf("failed to configure providers: %w", err)
 	}
@@ -502,6 +506,25 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 	}
 
 	return nil
+}
+
+// applyEnv sets top-level env vars from the config. Keys are sorted for
+// deterministic ordering so that vars referencing other vars via the
+// value resolver produce consistent results.
+func (c *Config) applyEnv(resolver VariableResolver) {
+	keys := make([]string, 0, len(c.Env))
+	for k := range c.Env {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	for _, k := range keys {
+		resolved, err := resolver.ResolveValue(c.Env[k])
+		if err != nil {
+			slog.Warn("Skipping env var due to resolution failure.", "key", k, "value", c.Env[k], "error", err)
+			continue
+		}
+		os.Setenv(k, resolved)
+	}
 }
 
 func (c *Config) setDefaults(workingDir, dataDir string) {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -277,20 +277,20 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 			}
 			headers[k] = resolved
 		}
-		prepared := ProviderConfig{
-			ID:                 string(p.ID),
-			Name:               p.Name,
-			BaseURL:            p.APIEndpoint,
-			APIKey:             p.APIKey,
-			APIKeyTemplate:     p.APIKey, // Store original template for re-resolution
-			OAuthToken:         config.OAuthToken,
-			Type:               p.Type,
-			Disable:            config.Disable,
-			SystemPromptPrefix: config.SystemPromptPrefix,
-			ExtraHeaders:       headers,
-			ExtraBody:          config.ExtraBody,
-			ExtraParams:        make(map[string]string),
-			Models:             p.Models,
+		// Start from user config so all user fields survive without
+		// explicit copying. Overlay catwalk identity/endpoint fields
+		// (already merged with user overrides above).
+		prepared := config
+		prepared.ID = string(p.ID)
+		prepared.Name = p.Name
+		prepared.BaseURL = p.APIEndpoint
+		prepared.APIKey = p.APIKey
+		prepared.APIKeyTemplate = p.APIKey // Store original template for re-resolution
+		prepared.Type = p.Type
+		prepared.Models = p.Models
+		prepared.ExtraHeaders = headers
+		if prepared.ExtraParams == nil {
+			prepared.ExtraParams = make(map[string]string)
 		}
 
 		switch {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -2391,3 +2391,26 @@ func TestConfig_configureProviders_UnsetAzureEndpointSkipsProvider(t *testing.T)
 	_, exists := cfg.Providers.Get("azure")
 	require.False(t, exists)
 }
+
+func TestConfig_LoadFromBytes_Env(t *testing.T) {
+	data := []byte(`{"env": {"AWS_PROFILE": "my-profile", "AWS_REGION": "us-west-2"}}`)
+
+	loadedConfig, err := loadFromBytes([][]byte{data})
+
+	require.NoError(t, err)
+	require.NotNil(t, loadedConfig.Env)
+	require.Equal(t, "my-profile", loadedConfig.Env["AWS_PROFILE"])
+	require.Equal(t, "us-west-2", loadedConfig.Env["AWS_REGION"])
+}
+
+func TestConfig_LoadFromBytes_EnvMerge(t *testing.T) {
+	data1 := []byte(`{"env": {"AWS_PROFILE": "first", "AWS_REGION": "us-east-1"}}`)
+	data2 := []byte(`{"env": {"AWS_PROFILE": "second"}}`)
+
+	loadedConfig, err := loadFromBytes([][]byte{data1, data2})
+
+	require.NoError(t, err)
+	require.NotNil(t, loadedConfig.Env)
+	require.Equal(t, "second", loadedConfig.Env["AWS_PROFILE"])
+	require.Equal(t, "us-east-1", loadedConfig.Env["AWS_REGION"])
+}

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -1167,6 +1167,11 @@ func (s *ConfigStore) reloadFromDiskLocked(ctx context.Context) error {
 	// Reconfigure providers
 	env := env.New()
 	resolver := NewShellVariableResolver(env)
+
+	// Apply top-level env vars before configuring providers so variables
+	// like AWS_PROFILE are visible to the AWS SDK credential chain.
+	cfg.applyEnv(resolver)
+
 	providers, err := Providers(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to load providers during reload: %w", err)

--- a/internal/proto/agent.go
+++ b/internal/proto/agent.go
@@ -43,6 +43,15 @@ type AgentEvent struct {
 	SessionTitle string `json:"session_title,omitempty"`
 	Progress     string `json:"progress,omitempty"`
 	Done         bool   `json:"done,omitempty"`
+
+	// AWS SSO progress fields, carried for TypeAWSSSOAuth and
+	// TypeAWSSSOAuthResult so the refresh dialog works in client/server
+	// mode. The command runs on the server; these ferry its progress to
+	// the client. AWSSOCommand is the refresh command being run; AWSSOURL
+	// is the verification URL once it appears in the command output. The
+	// result's failure text travels through Error, like TypeAgentError.
+	AWSSOCommand string `json:"aws_sso_command,omitempty"`
+	AWSSOURL     string `json:"aws_sso_url,omitempty"`
 }
 
 // MarshalJSON implements the [json.Marshaler] interface.

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -120,10 +120,16 @@ func wrapEvent(ev any) *pubsub.Payload {
 			SessionTitle: e.Payload.SessionTitle,
 			RunID:        e.Payload.RunID,
 			Type:         proto.AgentEventType(e.Payload.Type),
+			AWSSOCommand: e.Payload.AWSSOCommand,
+			AWSSOURL:     e.Payload.AWSSOURL,
+		}
+		// Carry any human-readable message across the wire; the client
+		// maps Error back into Notification.Message.
+		if e.Payload.Message != "" {
+			payload.Error = errors.New(e.Payload.Message)
 		}
 		if e.Payload.Type == notify.TypeAgentError {
 			payload.Type = proto.AgentEventTypeError
-			payload.Error = errors.New(e.Payload.Message)
 		}
 		return envelope(pubsub.PayloadTypeAgentEvent, pubsub.Event[proto.AgentEvent]{
 			Type:    e.Type,

--- a/internal/swagger/docs.go
+++ b/internal/swagger/docs.go
@@ -303,8 +303,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK"
+                    "202": {
+                        "description": "Accepted"
                     },
                     "400": {
                         "description": "Bad Request",
@@ -314,6 +314,12 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/proto.Error"
                         }
@@ -616,6 +622,71 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "type": "object"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/agent/sessions/{sid}/shell": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agent"
+                ],
+                "summary": "Run shell command",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "sid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Shell command",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.ShellCommandRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.ShellCommandResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
                         }
                     },
                     "404": {
@@ -1100,6 +1171,62 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaces/{id}/current-session": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Set current session for a client",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Client ID (UUID)",
+                        "name": "client_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "Current session selection",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.CurrentSession"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/events": {
             "get": {
                 "produces": [
@@ -1544,6 +1671,49 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaces/{id}/mcp/prompts": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Get MCP prompts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/proto.MCPPrompt"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/mcp/read-resource": {
             "post": {
                 "consumes": [
@@ -1873,7 +2043,10 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.PermissionGrantResponse"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -2123,6 +2296,104 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "type": "object"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/questions/answer": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "questions"
+                ],
+                "summary": "Answer question batch",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Question batch answer",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.QuestionAnswer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.QuestionAnswerResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/questions/cancel": {
+            "post": {
+                "tags": [
+                    "questions"
+                ],
+                "summary": "Cancel question batch",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.QuestionAnswerResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
                         }
                     },
                     "404": {
@@ -2587,6 +2858,107 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/workspaces/{id}/skills": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "List visible skills",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/proto.SkillInfo"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/skills/read": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Read skill content",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Read skill request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.ReadSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.ReadSkillResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -2697,6 +3069,10 @@ const docTemplate = `{
                     "description": "Regex pattern tested against the tool name. Empty means match all.",
                     "type": "string"
                 },
+                "name": {
+                    "description": "Friendly display name shown in the TUI. Falls back to Command when empty.",
+                    "type": "string"
+                },
                 "timeout": {
                     "description": "Timeout in seconds. Default 30.",
                     "type": "integer"
@@ -2795,6 +3171,30 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "oauth": {
+                    "description": "OAuth enables the MCP OAuth 2.1 authorization flow for HTTP\ntransport servers. When true, the client uses dynamic client\nregistration and opens a browser for the user to authorize.\nTokens are persisted automatically. Only supported for type=http.",
+                    "type": "boolean"
+                },
+                "oauth_callback_port": {
+                    "description": "OAuthCallbackPort pins the localhost port used for the OAuth\nredirect listener. Set this when the OAuth provider requires an\nexact-match callback URL (e.g. GitHub OAuth Apps). When omitted,\nCrush picks the first free port from its default range.",
+                    "type": "integer"
+                },
+                "oauth_client_id": {
+                    "description": "OAuthClientID is an optional pre-registered OAuth client ID. Set\nit for servers that do not support dynamic client registration\n(e.g. GitHub, Slack) and instead issue client credentials when you\nregister an OAuth app. Values run through shell expansion, so\n$VAR and $(cmd) work.",
+                    "type": "string"
+                },
+                "oauth_client_secret": {
+                    "description": "OAuthClientSecret is the optional secret paired with\nOAuthClientID for confidential clients. Values run through shell\nexpansion, so $VAR and $(cmd) work.",
+                    "type": "string"
+                },
+                "oauth_token": {
+                    "description": "OAuthToken is the persisted OAuth token for this server. It is\nmanaged internally and stored in the global data config.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/oauth.Token"
+                        }
+                    ]
+                },
                 "timeout": {
                     "type": "integer"
                 },
@@ -2835,17 +3235,6 @@ const docTemplate = `{
                     }
                 }
             }
-        },
-        "config.Scope": {
-            "type": "integer",
-            "enum": [
-                0,
-                1
-            ],
-            "x-enum-varnames": [
-                "ScopeGlobal",
-                "ScopeWorkspace"
-            ]
         },
         "config.SelectedModel": {
             "type": "object",
@@ -2915,8 +3304,19 @@ const docTemplate = `{
                 "diff_mode": {
                     "type": "string"
                 },
+                "scrollbar": {
+                    "type": "string"
+                },
                 "transparent": {
                     "type": "boolean"
+                }
+            }
+        },
+        "config.ToolGlob": {
+            "type": "object",
+            "properties": {
+                "timeout": {
+                    "$ref": "#/definitions/time.Duration"
                 }
             }
         },
@@ -2942,6 +3342,9 @@ const docTemplate = `{
         "config.Tools": {
             "type": "object",
             "properties": {
+                "glob": {
+                    "$ref": "#/definitions/config.ToolGlob"
+                },
                 "grep": {
                     "$ref": "#/definitions/config.ToolGrep"
                 },
@@ -2971,6 +3374,13 @@ const docTemplate = `{
             "properties": {
                 "$schema": {
                     "type": "string"
+                },
+                "env": {
+                    "description": "Env is a map of environment variables set on startup.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "hooks": {
                     "type": "object",
@@ -3072,6 +3482,12 @@ const docTemplate = `{
                         "type": "string"
                     }
                 },
+                "global_context_paths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "initialize_as": {
                     "type": "string"
                 },
@@ -3091,6 +3507,17 @@ const docTemplate = `{
                     "$ref": "#/definitions/config.TUIOptions"
                 }
             }
+        },
+        "github_com_charmbracelet_crush_internal_config.Scope": {
+            "type": "integer",
+            "enum": [
+                0,
+                1
+            ],
+            "x-enum-varnames": [
+                "ScopeGlobal",
+                "ScopeWorkspace"
+            ]
         },
         "github_com_charmbracelet_crush_internal_proto.Message": {
             "type": "object",
@@ -3141,6 +3568,46 @@ const docTemplate = `{
                 "StateDisabled"
             ]
         },
+        "oauth.OAuthClient": {
+            "type": "object",
+            "properties": {
+                "auth_style": {
+                    "type": "integer"
+                },
+                "auth_url": {
+                    "type": "string"
+                },
+                "client_id": {
+                    "type": "string"
+                },
+                "client_secret": {
+                    "type": "string"
+                },
+                "token_url": {
+                    "type": "string"
+                }
+            }
+        },
+        "oauth.Token": {
+            "type": "object",
+            "properties": {
+                "access_token": {
+                    "type": "string"
+                },
+                "client": {
+                    "$ref": "#/definitions/oauth.OAuthClient"
+                },
+                "expires_at": {
+                    "type": "integer"
+                },
+                "expires_in": {
+                    "type": "integer"
+                },
+                "refresh_token": {
+                    "type": "string"
+                }
+            }
+        },
         "proto.APIKeyKind": {
             "type": "string",
             "enum": [
@@ -3181,6 +3648,9 @@ const docTemplate = `{
                 "prompt": {
                     "type": "string"
                 },
+                "run_id": {
+                    "type": "string"
+                },
                 "session_id": {
                     "type": "string"
                 }
@@ -3189,6 +3659,9 @@ const docTemplate = `{
         "proto.AgentSession": {
             "type": "object",
             "properties": {
+                "attached_clients": {
+                    "type": "integer"
+                },
                 "completion_tokens": {
                     "type": "integer"
                 },
@@ -3218,6 +3691,12 @@ const docTemplate = `{
                 },
                 "title": {
                     "type": "string"
+                },
+                "todos": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.Todo"
+                    }
                 },
                 "updated_at": {
                     "type": "integer"
@@ -3251,7 +3730,7 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3265,7 +3744,7 @@ const docTemplate = `{
                     "$ref": "#/definitions/config.SelectedModelType"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3285,7 +3764,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3296,7 +3775,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3307,7 +3786,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3318,9 +3797,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 },
                 "value": {}
+            }
+        },
+        "proto.CurrentSession": {
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string"
+                }
             }
         },
         "proto.Error": {
@@ -3460,6 +3947,49 @@ const docTemplate = `{
                 }
             }
         },
+        "proto.MCPPrompt": {
+            "type": "object",
+            "properties": {
+                "arguments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.MCPPromptArgument"
+                    }
+                },
+                "client_id": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "prompt_id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.MCPPromptArgument": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
         "proto.MCPReadResourceRequest": {
             "type": "object",
             "properties": {
@@ -3477,13 +4007,15 @@ const docTemplate = `{
                 0,
                 1,
                 2,
-                3
+                3,
+                4
             ],
             "x-enum-varnames": [
                 "MCPStateDisabled",
                 "MCPStateStarting",
                 "MCPStateConnected",
-                "MCPStateError"
+                "MCPStateError",
+                "MCPStateNeedsAuth"
             ]
         },
         "proto.MessageRole": {
@@ -3522,6 +4054,14 @@ const docTemplate = `{
                 },
                 "permission": {
                     "$ref": "#/definitions/proto.PermissionRequest"
+                }
+            }
+        },
+        "proto.PermissionGrantResponse": {
+            "type": "object",
+            "properties": {
+                "resolved": {
+                    "type": "boolean"
                 }
             }
         },
@@ -3576,6 +4116,76 @@ const docTemplate = `{
                 }
             }
         },
+        "proto.QuestionAnswer": {
+            "type": "object",
+            "properties": {
+                "batch_request_id": {
+                    "type": "string"
+                },
+                "responses": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.QuestionResponse"
+                    }
+                }
+            }
+        },
+        "proto.QuestionAnswerResponse": {
+            "type": "object",
+            "properties": {
+                "resolved": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "proto.QuestionResponse": {
+            "type": "object",
+            "properties": {
+                "fill_in_text": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "selected_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "yes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "proto.ReadSkillRequest": {
+            "type": "object",
+            "properties": {
+                "skill_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.ReadSkillResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "result": {
+                    "$ref": "#/definitions/proto.SkillReadResult"
+                }
+            }
+        },
         "proto.ServerControl": {
             "type": "object",
             "properties": {
@@ -3587,6 +4197,9 @@ const docTemplate = `{
         "proto.Session": {
             "type": "object",
             "properties": {
+                "attached_clients": {
+                    "type": "integer"
+                },
                 "completion_tokens": {
                     "type": "integer"
                 },
@@ -3598,6 +4211,9 @@ const docTemplate = `{
                 },
                 "id": {
                     "type": "string"
+                },
+                "is_busy": {
+                    "type": "boolean"
                 },
                 "message_count": {
                     "type": "integer"
@@ -3614,8 +4230,121 @@ const docTemplate = `{
                 "title": {
                     "type": "string"
                 },
+                "todos": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.Todo"
+                    }
+                },
                 "updated_at": {
                     "type": "integer"
+                }
+            }
+        },
+        "proto.ShellCommandRequest": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "term_width": {
+                    "type": "integer"
+                }
+            }
+        },
+        "proto.ShellCommandResponse": {
+            "type": "object",
+            "properties": {
+                "exit_code": {
+                    "type": "integer"
+                },
+                "output": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.SkillDiscoveryState": {
+            "type": "integer",
+            "enum": [
+                0,
+                1
+            ],
+            "x-enum-varnames": [
+                "SkillStateNormal",
+                "SkillStateError"
+            ]
+        },
+        "proto.SkillInfo": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "user_invocable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "proto.SkillReadResult": {
+            "type": "object",
+            "properties": {
+                "builtin": {
+                    "type": "boolean"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.SkillState": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "state": {
+                    "$ref": "#/definitions/proto.SkillDiscoveryState"
+                }
+            }
+        },
+        "proto.Todo": {
+            "type": "object",
+            "properties": {
+                "active_form": {
+                    "type": "string"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
                 }
             }
         },
@@ -3642,6 +4371,16 @@ const docTemplate = `{
         "proto.Workspace": {
             "type": "object",
             "properties": {
+                "channels": {
+                    "description": "Channels lists the MCP servers opted in as channels for this workspace\n(from the --channels flag).",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "client_id": {
+                    "type": "string"
+                },
                 "config": {
                     "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Config"
                 },
@@ -3662,6 +4401,13 @@ const docTemplate = `{
                 },
                 "path": {
                     "type": "string"
+                },
+                "skills": {
+                    "description": "Skills carries the snapshot of skill discovery state at workspace\ncreation time. Subsequent updates flow through the SSE event\nstream.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.SkillState"
+                    }
                 },
                 "version": {
                     "type": "string"

--- a/internal/swagger/swagger.json
+++ b/internal/swagger/swagger.json
@@ -296,8 +296,8 @@
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK"
+                    "202": {
+                        "description": "Accepted"
                     },
                     "400": {
                         "description": "Bad Request",
@@ -307,6 +307,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "$ref": "#/definitions/proto.Error"
                         }
@@ -609,6 +615,71 @@
                         "description": "OK",
                         "schema": {
                             "type": "object"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/agent/sessions/{sid}/shell": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agent"
+                ],
+                "summary": "Run shell command",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "sid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Shell command",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.ShellCommandRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.ShellCommandResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
                         }
                     },
                     "404": {
@@ -1093,6 +1164,62 @@
                 }
             }
         },
+        "/workspaces/{id}/current-session": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "workspaces"
+                ],
+                "summary": "Set current session for a client",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Client ID (UUID)",
+                        "name": "client_id",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "description": "Current session selection",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.CurrentSession"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/events": {
             "get": {
                 "produces": [
@@ -1537,6 +1664,49 @@
                 }
             }
         },
+        "/workspaces/{id}/mcp/prompts": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Get MCP prompts",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/proto.MCPPrompt"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/mcp/read-resource": {
             "post": {
                 "consumes": [
@@ -1866,7 +2036,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.PermissionGrantResponse"
+                        }
                     },
                     "400": {
                         "description": "Bad Request",
@@ -2116,6 +2289,104 @@
                         "description": "OK",
                         "schema": {
                             "type": "object"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/questions/answer": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "questions"
+                ],
+                "summary": "Answer question batch",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Question batch answer",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.QuestionAnswer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.QuestionAnswerResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/questions/cancel": {
+            "post": {
+                "tags": [
+                    "questions"
+                ],
+                "summary": "Cancel question batch",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.QuestionAnswerResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
                         }
                     },
                     "404": {
@@ -2580,6 +2851,107 @@
                     }
                 }
             }
+        },
+        "/workspaces/{id}/skills": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "List visible skills",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/proto.SkillInfo"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/skills/read": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "skills"
+                ],
+                "summary": "Read skill content",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Read skill request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.ReadSkillRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.ReadSkillResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -2690,6 +3062,10 @@
                     "description": "Regex pattern tested against the tool name. Empty means match all.",
                     "type": "string"
                 },
+                "name": {
+                    "description": "Friendly display name shown in the TUI. Falls back to Command when empty.",
+                    "type": "string"
+                },
                 "timeout": {
                     "description": "Timeout in seconds. Default 30.",
                     "type": "integer"
@@ -2788,6 +3164,30 @@
                         "type": "string"
                     }
                 },
+                "oauth": {
+                    "description": "OAuth enables the MCP OAuth 2.1 authorization flow for HTTP\ntransport servers. When true, the client uses dynamic client\nregistration and opens a browser for the user to authorize.\nTokens are persisted automatically. Only supported for type=http.",
+                    "type": "boolean"
+                },
+                "oauth_callback_port": {
+                    "description": "OAuthCallbackPort pins the localhost port used for the OAuth\nredirect listener. Set this when the OAuth provider requires an\nexact-match callback URL (e.g. GitHub OAuth Apps). When omitted,\nCrush picks the first free port from its default range.",
+                    "type": "integer"
+                },
+                "oauth_client_id": {
+                    "description": "OAuthClientID is an optional pre-registered OAuth client ID. Set\nit for servers that do not support dynamic client registration\n(e.g. GitHub, Slack) and instead issue client credentials when you\nregister an OAuth app. Values run through shell expansion, so\n$VAR and $(cmd) work.",
+                    "type": "string"
+                },
+                "oauth_client_secret": {
+                    "description": "OAuthClientSecret is the optional secret paired with\nOAuthClientID for confidential clients. Values run through shell\nexpansion, so $VAR and $(cmd) work.",
+                    "type": "string"
+                },
+                "oauth_token": {
+                    "description": "OAuthToken is the persisted OAuth token for this server. It is\nmanaged internally and stored in the global data config.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/oauth.Token"
+                        }
+                    ]
+                },
                 "timeout": {
                     "type": "integer"
                 },
@@ -2828,17 +3228,6 @@
                     }
                 }
             }
-        },
-        "config.Scope": {
-            "type": "integer",
-            "enum": [
-                0,
-                1
-            ],
-            "x-enum-varnames": [
-                "ScopeGlobal",
-                "ScopeWorkspace"
-            ]
         },
         "config.SelectedModel": {
             "type": "object",
@@ -2908,8 +3297,19 @@
                 "diff_mode": {
                     "type": "string"
                 },
+                "scrollbar": {
+                    "type": "string"
+                },
                 "transparent": {
                     "type": "boolean"
+                }
+            }
+        },
+        "config.ToolGlob": {
+            "type": "object",
+            "properties": {
+                "timeout": {
+                    "$ref": "#/definitions/time.Duration"
                 }
             }
         },
@@ -2935,6 +3335,9 @@
         "config.Tools": {
             "type": "object",
             "properties": {
+                "glob": {
+                    "$ref": "#/definitions/config.ToolGlob"
+                },
                 "grep": {
                     "$ref": "#/definitions/config.ToolGrep"
                 },
@@ -2964,6 +3367,13 @@
             "properties": {
                 "$schema": {
                     "type": "string"
+                },
+                "env": {
+                    "description": "Env is a map of environment variables set on startup.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 },
                 "hooks": {
                     "type": "object",
@@ -3065,6 +3475,12 @@
                         "type": "string"
                     }
                 },
+                "global_context_paths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "initialize_as": {
                     "type": "string"
                 },
@@ -3084,6 +3500,17 @@
                     "$ref": "#/definitions/config.TUIOptions"
                 }
             }
+        },
+        "github_com_charmbracelet_crush_internal_config.Scope": {
+            "type": "integer",
+            "enum": [
+                0,
+                1
+            ],
+            "x-enum-varnames": [
+                "ScopeGlobal",
+                "ScopeWorkspace"
+            ]
         },
         "github_com_charmbracelet_crush_internal_proto.Message": {
             "type": "object",
@@ -3134,6 +3561,46 @@
                 "StateDisabled"
             ]
         },
+        "oauth.OAuthClient": {
+            "type": "object",
+            "properties": {
+                "auth_style": {
+                    "type": "integer"
+                },
+                "auth_url": {
+                    "type": "string"
+                },
+                "client_id": {
+                    "type": "string"
+                },
+                "client_secret": {
+                    "type": "string"
+                },
+                "token_url": {
+                    "type": "string"
+                }
+            }
+        },
+        "oauth.Token": {
+            "type": "object",
+            "properties": {
+                "access_token": {
+                    "type": "string"
+                },
+                "client": {
+                    "$ref": "#/definitions/oauth.OAuthClient"
+                },
+                "expires_at": {
+                    "type": "integer"
+                },
+                "expires_in": {
+                    "type": "integer"
+                },
+                "refresh_token": {
+                    "type": "string"
+                }
+            }
+        },
         "proto.APIKeyKind": {
             "type": "string",
             "enum": [
@@ -3174,6 +3641,9 @@
                 "prompt": {
                     "type": "string"
                 },
+                "run_id": {
+                    "type": "string"
+                },
                 "session_id": {
                     "type": "string"
                 }
@@ -3182,6 +3652,9 @@
         "proto.AgentSession": {
             "type": "object",
             "properties": {
+                "attached_clients": {
+                    "type": "integer"
+                },
                 "completion_tokens": {
                     "type": "integer"
                 },
@@ -3211,6 +3684,12 @@
                 },
                 "title": {
                     "type": "string"
+                },
+                "todos": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.Todo"
+                    }
                 },
                 "updated_at": {
                     "type": "integer"
@@ -3244,7 +3723,7 @@
                     "type": "boolean"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3258,7 +3737,7 @@
                     "$ref": "#/definitions/config.SelectedModelType"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3278,7 +3757,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3289,7 +3768,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3300,7 +3779,7 @@
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 }
             }
         },
@@ -3311,9 +3790,17 @@
                     "type": "string"
                 },
                 "scope": {
-                    "$ref": "#/definitions/config.Scope"
+                    "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Scope"
                 },
                 "value": {}
+            }
+        },
+        "proto.CurrentSession": {
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string"
+                }
             }
         },
         "proto.Error": {
@@ -3453,6 +3940,49 @@
                 }
             }
         },
+        "proto.MCPPrompt": {
+            "type": "object",
+            "properties": {
+                "arguments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.MCPPromptArgument"
+                    }
+                },
+                "client_id": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "prompt_id": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.MCPPromptArgument": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "required": {
+                    "type": "boolean"
+                },
+                "title": {
+                    "type": "string"
+                }
+            }
+        },
         "proto.MCPReadResourceRequest": {
             "type": "object",
             "properties": {
@@ -3470,13 +4000,15 @@
                 0,
                 1,
                 2,
-                3
+                3,
+                4
             ],
             "x-enum-varnames": [
                 "MCPStateDisabled",
                 "MCPStateStarting",
                 "MCPStateConnected",
-                "MCPStateError"
+                "MCPStateError",
+                "MCPStateNeedsAuth"
             ]
         },
         "proto.MessageRole": {
@@ -3515,6 +4047,14 @@
                 },
                 "permission": {
                     "$ref": "#/definitions/proto.PermissionRequest"
+                }
+            }
+        },
+        "proto.PermissionGrantResponse": {
+            "type": "object",
+            "properties": {
+                "resolved": {
+                    "type": "boolean"
                 }
             }
         },
@@ -3569,6 +4109,76 @@
                 }
             }
         },
+        "proto.QuestionAnswer": {
+            "type": "object",
+            "properties": {
+                "batch_request_id": {
+                    "type": "string"
+                },
+                "responses": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.QuestionResponse"
+                    }
+                }
+            }
+        },
+        "proto.QuestionAnswerResponse": {
+            "type": "object",
+            "properties": {
+                "resolved": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "proto.QuestionResponse": {
+            "type": "object",
+            "properties": {
+                "fill_in_text": {
+                    "type": "string"
+                },
+                "notes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "request_id": {
+                    "type": "string"
+                },
+                "selected_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "yes": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "proto.ReadSkillRequest": {
+            "type": "object",
+            "properties": {
+                "skill_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.ReadSkillResponse": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "result": {
+                    "$ref": "#/definitions/proto.SkillReadResult"
+                }
+            }
+        },
         "proto.ServerControl": {
             "type": "object",
             "properties": {
@@ -3580,6 +4190,9 @@
         "proto.Session": {
             "type": "object",
             "properties": {
+                "attached_clients": {
+                    "type": "integer"
+                },
                 "completion_tokens": {
                     "type": "integer"
                 },
@@ -3591,6 +4204,9 @@
                 },
                 "id": {
                     "type": "string"
+                },
+                "is_busy": {
+                    "type": "boolean"
                 },
                 "message_count": {
                     "type": "integer"
@@ -3607,8 +4223,121 @@
                 "title": {
                     "type": "string"
                 },
+                "todos": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.Todo"
+                    }
+                },
                 "updated_at": {
                     "type": "integer"
+                }
+            }
+        },
+        "proto.ShellCommandRequest": {
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string"
+                },
+                "session_id": {
+                    "type": "string"
+                },
+                "term_width": {
+                    "type": "integer"
+                }
+            }
+        },
+        "proto.ShellCommandResponse": {
+            "type": "object",
+            "properties": {
+                "exit_code": {
+                    "type": "integer"
+                },
+                "output": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.SkillDiscoveryState": {
+            "type": "integer",
+            "enum": [
+                0,
+                1
+            ],
+            "x-enum-varnames": [
+                "SkillStateNormal",
+                "SkillStateError"
+            ]
+        },
+        "proto.SkillInfo": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "user_invocable": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "proto.SkillReadResult": {
+            "type": "object",
+            "properties": {
+                "builtin": {
+                    "type": "boolean"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.SkillState": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "state": {
+                    "$ref": "#/definitions/proto.SkillDiscoveryState"
+                }
+            }
+        },
+        "proto.Todo": {
+            "type": "object",
+            "properties": {
+                "active_form": {
+                    "type": "string"
+                },
+                "content": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
                 }
             }
         },
@@ -3635,6 +4364,16 @@
         "proto.Workspace": {
             "type": "object",
             "properties": {
+                "channels": {
+                    "description": "Channels lists the MCP servers opted in as channels for this workspace\n(from the --channels flag).",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "client_id": {
+                    "type": "string"
+                },
                 "config": {
                     "$ref": "#/definitions/github_com_charmbracelet_crush_internal_config.Config"
                 },
@@ -3655,6 +4394,13 @@
                 },
                 "path": {
                     "type": "string"
+                },
+                "skills": {
+                    "description": "Skills carries the snapshot of skill discovery state at workspace\ncreation time. Subsequent updates flow through the SSE event\nstream.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.SkillState"
+                    }
                 },
                 "version": {
                     "type": "string"

--- a/internal/swagger/swagger.yaml
+++ b/internal/swagger/swagger.yaml
@@ -72,6 +72,10 @@ definitions:
         description: Regex pattern tested against the tool name. Empty means match
           all.
         type: string
+      name:
+        description: Friendly display name shown in the TUI. Falls back to Command
+          when empty.
+        type: string
       timeout:
         description: Timeout in seconds. Default 30.
         type: integer
@@ -144,6 +148,40 @@ definitions:
           omitted from the outgoing request rather than sent as
           "Header:".
         type: object
+      oauth:
+        description: |-
+          OAuth enables the MCP OAuth 2.1 authorization flow for HTTP
+          transport servers. When true, the client uses dynamic client
+          registration and opens a browser for the user to authorize.
+          Tokens are persisted automatically. Only supported for type=http.
+        type: boolean
+      oauth_callback_port:
+        description: |-
+          OAuthCallbackPort pins the localhost port used for the OAuth
+          redirect listener. Set this when the OAuth provider requires an
+          exact-match callback URL (e.g. GitHub OAuth Apps). When omitted,
+          Crush picks the first free port from its default range.
+        type: integer
+      oauth_client_id:
+        description: |-
+          OAuthClientID is an optional pre-registered OAuth client ID. Set
+          it for servers that do not support dynamic client registration
+          (e.g. GitHub, Slack) and instead issue client credentials when you
+          register an OAuth app. Values run through shell expansion, so
+          $VAR and $(cmd) work.
+        type: string
+      oauth_client_secret:
+        description: |-
+          OAuthClientSecret is the optional secret paired with
+          OAuthClientID for confidential clients. Values run through shell
+          expansion, so $VAR and $(cmd) work.
+        type: string
+      oauth_token:
+        allOf:
+        - $ref: '#/definitions/oauth.Token'
+        description: |-
+          OAuthToken is the persisted OAuth token for this server. It is
+          managed internally and stored in the global data config.
       timeout:
         type: integer
       type:
@@ -172,14 +210,6 @@ definitions:
           type: string
         type: array
     type: object
-  config.Scope:
-    enum:
-    - 0
-    - 1
-    type: integer
-    x-enum-varnames:
-    - ScopeGlobal
-    - ScopeWorkspace
   config.SelectedModel:
     properties:
       frequency_penalty:
@@ -234,8 +264,15 @@ definitions:
         $ref: '#/definitions/config.Completions'
       diff_mode:
         type: string
+      scrollbar:
+        type: string
       transparent:
         type: boolean
+    type: object
+  config.ToolGlob:
+    properties:
+      timeout:
+        $ref: '#/definitions/time.Duration'
     type: object
   config.ToolGrep:
     properties:
@@ -251,6 +288,8 @@ definitions:
     type: object
   config.Tools:
     properties:
+      glob:
+        $ref: '#/definitions/config.ToolGlob'
       grep:
         $ref: '#/definitions/config.ToolGrep'
       ls:
@@ -272,6 +311,11 @@ definitions:
     properties:
       $schema:
         type: string
+      env:
+        additionalProperties:
+          type: string
+        description: Env is a map of environment variables set on startup.
+        type: object
       hooks:
         additionalProperties:
           items:
@@ -342,6 +386,10 @@ definitions:
         items:
           type: string
         type: array
+      global_context_paths:
+        items:
+          type: string
+        type: array
       initialize_as:
         type: string
       notifications:
@@ -355,6 +403,14 @@ definitions:
       tui:
         $ref: '#/definitions/config.TUIOptions'
     type: object
+  github_com_charmbracelet_crush_internal_config.Scope:
+    enum:
+    - 0
+    - 1
+    type: integer
+    x-enum-varnames:
+    - ScopeGlobal
+    - ScopeWorkspace
   github_com_charmbracelet_crush_internal_proto.Message:
     properties:
       created_at:
@@ -391,6 +447,32 @@ definitions:
     - StateError
     - StateStopped
     - StateDisabled
+  oauth.OAuthClient:
+    properties:
+      auth_style:
+        type: integer
+      auth_url:
+        type: string
+      client_id:
+        type: string
+      client_secret:
+        type: string
+      token_url:
+        type: string
+    type: object
+  oauth.Token:
+    properties:
+      access_token:
+        type: string
+      client:
+        $ref: '#/definitions/oauth.OAuthClient'
+      expires_at:
+        type: integer
+      expires_in:
+        type: integer
+      refresh_token:
+        type: string
+    type: object
   proto.APIKeyKind:
     enum:
     - string
@@ -418,11 +500,15 @@ definitions:
         type: array
       prompt:
         type: string
+      run_id:
+        type: string
       session_id:
         type: string
     type: object
   proto.AgentSession:
     properties:
+      attached_clients:
+        type: integer
       completion_tokens:
         type: integer
       cost:
@@ -443,6 +529,10 @@ definitions:
         type: string
       title:
         type: string
+      todos:
+        items:
+          $ref: '#/definitions/proto.Todo'
+        type: array
       updated_at:
         type: integer
     type: object
@@ -464,7 +554,7 @@ definitions:
       enabled:
         type: boolean
       scope:
-        $ref: '#/definitions/config.Scope'
+        $ref: '#/definitions/github_com_charmbracelet_crush_internal_config.Scope'
     type: object
   proto.ConfigModelRequest:
     properties:
@@ -473,7 +563,7 @@ definitions:
       model_type:
         $ref: '#/definitions/config.SelectedModelType'
       scope:
-        $ref: '#/definitions/config.Scope'
+        $ref: '#/definitions/github_com_charmbracelet_crush_internal_config.Scope'
     type: object
   proto.ConfigProviderKeyRequest:
     properties:
@@ -486,29 +576,34 @@ definitions:
       provider_id:
         type: string
       scope:
-        $ref: '#/definitions/config.Scope'
+        $ref: '#/definitions/github_com_charmbracelet_crush_internal_config.Scope'
     type: object
   proto.ConfigRefreshOAuthRequest:
     properties:
       provider_id:
         type: string
       scope:
-        $ref: '#/definitions/config.Scope'
+        $ref: '#/definitions/github_com_charmbracelet_crush_internal_config.Scope'
     type: object
   proto.ConfigRemoveRequest:
     properties:
       key:
         type: string
       scope:
-        $ref: '#/definitions/config.Scope'
+        $ref: '#/definitions/github_com_charmbracelet_crush_internal_config.Scope'
     type: object
   proto.ConfigSetRequest:
     properties:
       key:
         type: string
       scope:
-        $ref: '#/definitions/config.Scope'
+        $ref: '#/definitions/github_com_charmbracelet_crush_internal_config.Scope'
       value: {}
+    type: object
+  proto.CurrentSession:
+    properties:
+      session_id:
+        type: string
     type: object
   proto.Error:
     properties:
@@ -599,6 +694,34 @@ definitions:
       name:
         type: string
     type: object
+  proto.MCPPrompt:
+    properties:
+      arguments:
+        items:
+          $ref: '#/definitions/proto.MCPPromptArgument'
+        type: array
+      client_id:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      prompt_id:
+        type: string
+      title:
+        type: string
+    type: object
+  proto.MCPPromptArgument:
+    properties:
+      description:
+        type: string
+      id:
+        type: string
+      required:
+        type: boolean
+      title:
+        type: string
+    type: object
   proto.MCPReadResourceRequest:
     properties:
       name:
@@ -612,12 +735,14 @@ definitions:
     - 1
     - 2
     - 3
+    - 4
     type: integer
     x-enum-varnames:
     - MCPStateDisabled
     - MCPStateStarting
     - MCPStateConnected
     - MCPStateError
+    - MCPStateNeedsAuth
   proto.MessageRole:
     enum:
     - assistant
@@ -646,6 +771,11 @@ definitions:
         $ref: '#/definitions/proto.PermissionAction'
       permission:
         $ref: '#/definitions/proto.PermissionRequest'
+    type: object
+  proto.PermissionGrantResponse:
+    properties:
+      resolved:
+        type: boolean
     type: object
   proto.PermissionRequest:
     properties:
@@ -680,6 +810,51 @@ definitions:
       needs_init:
         type: boolean
     type: object
+  proto.QuestionAnswer:
+    properties:
+      batch_request_id:
+        type: string
+      responses:
+        items:
+          $ref: '#/definitions/proto.QuestionResponse'
+        type: array
+    type: object
+  proto.QuestionAnswerResponse:
+    properties:
+      resolved:
+        type: boolean
+    type: object
+  proto.QuestionResponse:
+    properties:
+      fill_in_text:
+        type: string
+      notes:
+        additionalProperties:
+          type: string
+        type: object
+      request_id:
+        type: string
+      selected_ids:
+        items:
+          type: string
+        type: array
+      "yes":
+        type: boolean
+    type: object
+  proto.ReadSkillRequest:
+    properties:
+      skill_id:
+        type: string
+    type: object
+  proto.ReadSkillResponse:
+    properties:
+      content:
+        items:
+          type: integer
+        type: array
+      result:
+        $ref: '#/definitions/proto.SkillReadResult'
+    type: object
   proto.ServerControl:
     properties:
       command:
@@ -687,6 +862,8 @@ definitions:
     type: object
   proto.Session:
     properties:
+      attached_clients:
+        type: integer
       completion_tokens:
         type: integer
       cost:
@@ -695,6 +872,8 @@ definitions:
         type: integer
       id:
         type: string
+      is_busy:
+        type: boolean
       message_count:
         type: integer
       parent_session_id:
@@ -705,8 +884,82 @@ definitions:
         type: string
       title:
         type: string
+      todos:
+        items:
+          $ref: '#/definitions/proto.Todo'
+        type: array
       updated_at:
         type: integer
+    type: object
+  proto.ShellCommandRequest:
+    properties:
+      command:
+        type: string
+      session_id:
+        type: string
+      term_width:
+        type: integer
+    type: object
+  proto.ShellCommandResponse:
+    properties:
+      exit_code:
+        type: integer
+      output:
+        type: string
+    type: object
+  proto.SkillDiscoveryState:
+    enum:
+    - 0
+    - 1
+    type: integer
+    x-enum-varnames:
+    - SkillStateNormal
+    - SkillStateError
+  proto.SkillInfo:
+    properties:
+      description:
+        type: string
+      id:
+        type: string
+      label:
+        type: string
+      name:
+        type: string
+      source:
+        type: string
+      user_invocable:
+        type: boolean
+    type: object
+  proto.SkillReadResult:
+    properties:
+      builtin:
+        type: boolean
+      description:
+        type: string
+      name:
+        type: string
+      source:
+        type: string
+    type: object
+  proto.SkillState:
+    properties:
+      error:
+        type: string
+      name:
+        type: string
+      path:
+        type: string
+      state:
+        $ref: '#/definitions/proto.SkillDiscoveryState'
+    type: object
+  proto.Todo:
+    properties:
+      active_form:
+        type: string
+      content:
+        type: string
+      status:
+        type: string
     type: object
   proto.VersionInfo:
     properties:
@@ -723,6 +976,15 @@ definitions:
     type: object
   proto.Workspace:
     properties:
+      channels:
+        description: |-
+          Channels lists the MCP servers opted in as channels for this workspace
+          (from the --channels flag).
+        items:
+          type: string
+        type: array
+      client_id:
+        type: string
       config:
         $ref: '#/definitions/github_com_charmbracelet_crush_internal_config.Config'
       data_dir:
@@ -737,6 +999,14 @@ definitions:
         type: string
       path:
         type: string
+      skills:
+        description: |-
+          Skills carries the snapshot of skill discovery state at workspace
+          creation time. Subsequent updates flow through the SSE event
+          stream.
+        items:
+          $ref: '#/definitions/proto.SkillState'
+        type: array
       version:
         type: string
       yolo:
@@ -956,14 +1226,18 @@ paths:
         schema:
           $ref: '#/definitions/proto.AgentMessage'
       responses:
-        "200":
-          description: OK
+        "202":
+          description: Accepted
         "400":
           description: Bad Request
           schema:
             $ref: '#/definitions/proto.Error'
         "404":
           description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "409":
+          description: Conflict
           schema:
             $ref: '#/definitions/proto.Error'
         "500":
@@ -1172,6 +1446,49 @@ paths:
           schema:
             $ref: '#/definitions/proto.Error'
       summary: Get queued prompt status
+      tags:
+      - agent
+  /workspaces/{id}/agent/sessions/{sid}/shell:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Session ID
+        in: path
+        name: sid
+        required: true
+        type: string
+      - description: Shell command
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/proto.ShellCommandRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/proto.ShellCommandResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Run shell command
       tags:
       - agent
   /workspaces/{id}/agent/sessions/{sid}/summarize:
@@ -1479,6 +1796,43 @@ paths:
       summary: Set a config field
       tags:
       - config
+  /workspaces/{id}/current-session:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Client ID (UUID)
+        in: query
+        name: client_id
+        required: true
+        type: string
+      - description: Current session selection
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/proto.CurrentSession'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Set current session for a client
+      tags:
+      - workspaces
   /workspaces/{id}/events:
     get:
       parameters:
@@ -1769,6 +2123,34 @@ paths:
       summary: Get MCP prompt
       tags:
       - mcp
+  /workspaces/{id}/mcp/prompts:
+    get:
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/proto.MCPPrompt'
+            type: array
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Get MCP prompts
+      tags:
+      - mcp
   /workspaces/{id}/mcp/read-resource:
     post:
       consumes:
@@ -1984,6 +2366,8 @@ paths:
       responses:
         "200":
           description: OK
+          schema:
+            $ref: '#/definitions/proto.PermissionGrantResponse'
         "400":
           description: Bad Request
           schema:
@@ -2158,6 +2542,70 @@ paths:
       summary: Get workspace providers
       tags:
       - workspaces
+  /workspaces/{id}/questions/answer:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Question batch answer
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/proto.QuestionAnswer'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/proto.QuestionAnswerResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Answer question batch
+      tags:
+      - questions
+  /workspaces/{id}/questions/cancel:
+    post:
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/proto.QuestionAnswerResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Cancel question batch
+      tags:
+      - questions
   /workspaces/{id}/sessions:
     get:
       parameters:
@@ -2454,4 +2902,70 @@ paths:
       summary: Get user messages for session
       tags:
       - sessions
+  /workspaces/{id}/skills:
+    get:
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/proto.SkillInfo'
+            type: array
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: List visible skills
+      tags:
+      - skills
+  /workspaces/{id}/skills/read:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Read skill request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/proto.ReadSkillRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/proto.ReadSkillResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Read skill content
+      tags:
+      - skills
 swagger: "2.0"

--- a/internal/ui/AGENTS.md
+++ b/internal/ui/AGENTS.md
@@ -162,6 +162,34 @@ tool names to specific types:
 - Use `RenderContext` from `dialog/common.go` for consistent layout (title
   gradients, width, gap, cursor offset helpers).
 
+#### Dialog rendering rules
+
+These prevent the wrapping/overflow bugs that recur whenever a new dialog
+is copy-pasted from an old one. In lipgloss v2 `Width(n)` is the **total**
+box width — border and padding live *inside* it.
+
+- Size content to the dialog's **content area**, not the outer width:
+  `innerWidth := m.width - t.Dialog.View.GetHorizontalFrameSize()`. Sizing a
+  block to the full `m.width` makes it 1–2 cols too wide, so the dialog
+  frame re-wraps it (the classic "last few chars wrap" bug).
+- Inset text with **`Padding`, never `Margin`**. Margin sits outside the
+  width and pushes the block past the frame; padding is inside the width
+  and applies to every wrapped line.
+- Render styled text segments **individually** and concatenate the results
+  (`styleA.Render(x) + styleB.Render(y)`), rather than concatenating raw
+  strings and wrapping the whole thing in one style. An inner segment's
+  reset code drops the outer color for everything after it.
+- Use the shared helpers instead of re-deriving widths:
+  - keybind hints → `renderDialogHelp(t, &m.help, m, innerWidth)` (sizes,
+    pads, truncates — never `helpStyle.Render(m.help.View(m))` raw);
+  - text inputs → `dialogInputTextWidth(t, input, innerWidth)` (accounts
+    for the `"> "` prompt);
+  - titles → `common.DialogTitle` (truncates instead of wrapping);
+  - list + scrollbar → `joinScrollbar`;
+  - hiding a crowded info column → `applyInfoColumnVisibility`.
+- Clamp width/height to the drawable `area` (`max(0, min(maxW, area.Dx()-frame))`)
+  so dialogs stay inside small terminals.
+
 ### Shared Context
 
 The `common.Common` struct holds `*app.App` and `*styles.Styles`. Thread it
@@ -195,6 +223,17 @@ through all components that need access to app state or styles.
 - The `list.List` only renders visible items (lazy). No render cache exists
   at the list level — items should cache internally if rendering is
   expensive.
+- Rendering is the chat's hot path; a few invariants keep resize/scroll fast
+  on large conversations:
+  - Syntax highlighting and diff formatting build the chroma style from the
+    theme, which is expensive — it is memoized in `common.ChromaStyle`, and
+    lexer lookups in `xchroma.MatchLexer`. Don't call
+    `chroma.MustNewStyle` / `lexers.Match` directly on a render path.
+  - `list.TotalHeight` renders **every** item; it's only for exact scrollbar
+    geometry. For "does it overflow?" use the bounded `list.Overflows`. Never
+    call `TotalHeight` per frame during a resize — the chat suppresses the
+    scrollbar mid-drag and warms the cache incrementally (`list.Prewarm`)
+    on settle instead.
 - Dialog messages are intercepted first in `Update` before other routing.
 - Focus state determines key event routing: `uiFocusEditor` sends keys to
   the textarea, `uiFocusMain` sends them to the chat list.

--- a/internal/ui/dialog/aws_sso.go
+++ b/internal/ui/dialog/aws_sso.go
@@ -1,0 +1,306 @@
+package dialog
+
+import (
+	"strings"
+
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/pkg/browser"
+)
+
+// AWSSSOID is the identifier for the AWS SSO auth dialog.
+const AWSSSOID = "aws_sso"
+
+// awsSSOState represents the current state of the AWS SSO flow.
+type awsSSOState int
+
+const (
+	awsSSOStateWaiting awsSSOState = iota
+	awsSSOStateSuccess
+	awsSSOStateError
+)
+
+// AWSSSO displays the progress of an AWS SSO refresh. The command itself runs
+// in the coordinator (so the refreshed credentials land where the model calls
+// are made); this dialog is a pure view driven by agent notifications: it
+// shows a spinner while the command runs, the verification URL once it
+// appears, and the final success or error. The only local action it performs
+// is opening the URL in the user's browser.
+type AWSSSO struct {
+	com *common.Common
+
+	state   awsSSOState
+	command string
+
+	spinner spinner.Model
+	help    help.Model
+	keyMap  struct {
+		Open  key.Binding
+		Close key.Binding
+	}
+
+	width  int
+	url    string
+	errMsg string
+}
+
+var _ Dialog = (*AWSSSO)(nil)
+
+// NewAWSSSO creates a new AWS SSO authentication dialog for the given refresh
+// command. The dialog starts in the waiting state; SetURL and Finish drive it
+// as the coordinator reports progress.
+func NewAWSSSO(com *common.Common, command string) (*AWSSSO, tea.Cmd) {
+	t := com.Styles
+
+	m := &AWSSSO{
+		com:     com,
+		command: command,
+		width:   0, // Set dynamically in Draw().
+		state:   awsSSOStateWaiting,
+	}
+
+	m.spinner = spinner.New(
+		spinner.WithSpinner(spinner.Dot),
+		spinner.WithStyle(t.Dialog.OAuth.Spinner),
+	)
+
+	m.help = help.New()
+	m.help.Styles = t.DialogHelpStyles()
+
+	m.keyMap.Open = key.NewBinding(
+		key.WithKeys("enter", "ctrl+y"),
+		key.WithHelp("enter", "open in browser"),
+	)
+	m.keyMap.Close = CloseKey
+
+	return m, m.spinner.Tick
+}
+
+// SetURL records the SSO verification URL so the dialog can display it and
+// offer to open it in the browser.
+func (m *AWSSSO) SetURL(url string) {
+	if m.state == awsSSOStateWaiting {
+		m.url = url
+	}
+}
+
+// Finish transitions the dialog to its terminal state. A nil error means the
+// refresh succeeded; a non-empty message means it failed.
+func (m *AWSSSO) Finish(errMsg string) {
+	if errMsg != "" {
+		m.state = awsSSOStateError
+		m.errMsg = errMsg
+		return
+	}
+	m.state = awsSSOStateSuccess
+}
+
+// ID implements Dialog.
+func (m *AWSSSO) ID() string {
+	return AWSSSOID
+}
+
+// HandleMsg handles messages and state transitions.
+func (m *AWSSSO) HandleMsg(msg tea.Msg) Action {
+	switch msg := msg.(type) {
+	case spinner.TickMsg:
+		if m.state == awsSSOStateWaiting {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			if cmd != nil {
+				return ActionCmd{cmd}
+			}
+		}
+
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, m.keyMap.Open):
+			if m.state == awsSSOStateWaiting && m.url != "" {
+				return ActionCmd{m.openURLCmd()}
+			}
+			if m.state == awsSSOStateSuccess {
+				return ActionClose{}
+			}
+
+		case key.Matches(msg, m.keyMap.Close):
+			return ActionClose{}
+		}
+	}
+
+	return nil
+}
+
+// Draw renders the AWS SSO auth dialog.
+func (m *AWSSSO) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	var (
+		t           = m.com.Styles
+		dialogWidth = max(0, min(60, area.Dx()-t.Dialog.View.GetHorizontalBorderSize()))
+		dialogStyle = t.Dialog.View.Width(dialogWidth)
+	)
+	m.width = dialogWidth
+	view := dialogStyle.Render(m.dialogContent())
+	DrawCenter(scr, area, view)
+	return nil
+}
+
+func (m *AWSSSO) dialogContent() string {
+	t := m.com.Styles
+	innerWidth := m.width - t.Dialog.View.GetHorizontalFrameSize()
+
+	elements := []string{
+		m.headerContent(),
+		m.innerDialogContent(),
+		renderDialogHelp(t, &m.help, m, innerWidth),
+	}
+	return strings.Join(elements, "\n")
+}
+
+func (m *AWSSSO) headerContent() string {
+	var (
+		t            = m.com.Styles
+		titleStyle   = t.Dialog.Title
+		dialogStyle  = t.Dialog.View.Width(m.width)
+		headerOffset = titleStyle.GetHorizontalFrameSize() + dialogStyle.GetHorizontalFrameSize()
+		dialogTitle  = "AWS SSO Authentication"
+	)
+	return common.DialogTitle(t, titleStyle.Render(dialogTitle), m.width-headerOffset, t.Dialog.TitleGradFromColor, t.Dialog.TitleGradToColor)
+}
+
+func (m *AWSSSO) innerDialogContent() string {
+	var (
+		t                = m.com.Styles
+		instructionStyle = t.Dialog.OAuth.Instructions
+		enterKeyStyle    = t.Dialog.OAuth.Enter
+		successStyle     = t.Dialog.OAuth.Success
+		linkStyle        = t.Dialog.OAuth.Link
+		errorStyle       = t.Dialog.OAuth.ErrorText
+		statusTextStyle  = t.Dialog.OAuth.StatusText
+	)
+
+	// innerWidth is the dialog's content area (total minus the View
+	// border). Every block sizes to this and uses padding for the inset, so
+	// nothing is re-wrapped when the dialog frame renders it.
+	innerWidth := m.width - t.Dialog.View.GetHorizontalFrameSize()
+
+	switch m.state {
+	case awsSSOStateWaiting:
+		if m.url != "" {
+			// URL found; show it and wait for auth to complete. Render each
+			// text segment with its own style: wrapping the whole string in
+			// one style would drop the text color after enterKeyStyle's
+			// reset code.
+			instructionText := instructionStyle.Render("Press ") +
+				enterKeyStyle.Render("enter") +
+				instructionStyle.Render(" to open the authorization page.")
+			instructions := lipgloss.NewStyle().
+				Width(innerWidth).
+				Padding(0, 1).
+				Render(instructionText)
+
+			displayURL := ansi.Truncate(m.url, max(0, innerWidth-2), "…") // -2 for padding
+			link := linkStyle.Hyperlink(m.url, "id=aws-sso-verify").Render(displayURL)
+			urlBox := lipgloss.NewStyle().
+				Width(innerWidth).
+				Padding(0, 1).
+				Align(lipgloss.Center).
+				Render(link)
+
+			waiting := statusTextStyle.
+				Width(innerWidth).
+				Padding(0, 1).
+				Render(
+					successStyle.Render(m.spinner.View()) +
+						statusTextStyle.Render("Waiting for authentication..."),
+				)
+
+			return lipgloss.JoinVertical(
+				lipgloss.Left,
+				"",
+				instructions,
+				"",
+				urlBox,
+				"",
+				waiting,
+				"",
+			)
+		}
+
+		// No URL yet; still waiting for command output.
+		spinnerLine := statusTextStyle.
+			Width(innerWidth).
+			Padding(0, 1).
+			Render(
+				successStyle.Render(m.spinner.View()) +
+					statusTextStyle.Render("Starting "+m.command+"..."),
+			)
+		return lipgloss.JoinVertical(lipgloss.Left, "", spinnerLine, "")
+
+	case awsSSOStateSuccess:
+		return successStyle.
+			Width(innerWidth).
+			Align(lipgloss.Center).
+			Render("✓ Authentication successful!")
+
+	case awsSSOStateError:
+		header := errorStyle.
+			Width(innerWidth).
+			Padding(0, 1).
+			Render("Authentication failed.")
+
+		if m.errMsg == "" {
+			return header
+		}
+
+		flattened := strings.Join(strings.Fields(strings.TrimSpace(m.errMsg)), " ")
+		detail := statusTextStyle.
+			Width(innerWidth).
+			Padding(0, 1).
+			Render(flattened)
+
+		return lipgloss.JoinVertical(lipgloss.Left, "", header, "", detail, "")
+
+	default:
+		return ""
+	}
+}
+
+// FullHelp returns the full help view.
+func (m *AWSSSO) FullHelp() [][]key.Binding {
+	return [][]key.Binding{m.ShortHelp()}
+}
+
+// ShortHelp returns the short help view.
+func (m *AWSSSO) ShortHelp() []key.Binding {
+	switch m.state {
+	case awsSSOStateError:
+		return []key.Binding{m.keyMap.Close}
+	case awsSSOStateSuccess:
+		return []key.Binding{
+			key.NewBinding(
+				key.WithKeys("enter", "ctrl+y", "esc"),
+				key.WithHelp("enter", "close"),
+			),
+		}
+	default:
+		if m.url != "" {
+			return []key.Binding{m.keyMap.Open, m.keyMap.Close}
+		}
+		return []key.Binding{m.keyMap.Close}
+	}
+}
+
+func (m *AWSSSO) openURLCmd() tea.Cmd {
+	return func() tea.Msg {
+		if m.url == "" {
+			return nil
+		}
+		_ = browser.OpenURL(m.url)
+		return nil
+	}
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4402,6 +4402,10 @@ func (m *UI) handleAgentNotification(n notify.Notification) tea.Cmd {
 		// busy/queue refresh below.
 	case notify.TypeReAuthenticate:
 		return m.handleReAuthenticate(n.ProviderID)
+	case notify.TypeAWSSSOAuth:
+		return m.handleAWSSSOAuth(n.AWSSOCommand, n.AWSSOURL)
+	case notify.TypeAWSSSOAuthResult:
+		return m.handleAWSSSOAuthResult(n.Message)
 	default:
 		return nil
 	}
@@ -4434,6 +4438,49 @@ func (m *UI) handleReAuthenticate(providerID string) tea.Cmd {
 		return nil
 	}
 	return m.openAuthenticationDialog(providerCfg.ToProvider(), cfg.Models[agentCfg.Model], agentCfg.Model)
+}
+
+// handleAWSSSOAuth opens the AWS SSO progress dialog (or updates the SSO URL
+// on an already-open one). The refresh command runs in the coordinator; this
+// dialog is a display surface driven by agent notifications.
+func (m *UI) handleAWSSSOAuth(command, url string) tea.Cmd {
+	// Update the URL on an already-open dialog.
+	if existing := m.dialog.Dialog(dialog.AWSSSOID); existing != nil {
+		if awsDlg, ok := existing.(*dialog.AWSSSO); ok && url != "" {
+			awsDlg.SetURL(url)
+		}
+		m.dialog.BringToFront(dialog.AWSSSOID)
+		return nil
+	}
+	if command == "" {
+		return nil
+	}
+	dlg, cmd := dialog.NewAWSSSO(m.com, command)
+	if url != "" {
+		dlg.SetURL(url)
+	}
+	m.dialog.OpenDialogWithGrace(dlg)
+	return cmd
+}
+
+// handleAWSSSOAuthResult finishes the AWS SSO dialog once the refresh command
+// exits: it closes on success or shows the error so the user can dismiss it.
+func (m *UI) handleAWSSSOAuthResult(errMsg string) tea.Cmd {
+	existing := m.dialog.Dialog(dialog.AWSSSOID)
+	if existing == nil {
+		return nil
+	}
+	awsDlg, ok := existing.(*dialog.AWSSSO)
+	if !ok {
+		return nil
+	}
+	if errMsg == "" {
+		// Success: the turn retries transparently, so no need to linger.
+		m.dialog.CloseDialog(dialog.AWSSSOID)
+		return nil
+	}
+	awsDlg.Finish(errMsg)
+	return nil
 }
 
 // newSession clears the current session state and prepares for a new session.

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -915,6 +915,8 @@ func (w *ClientWorkspace) translateEvent(ev any) tea.Msg {
 			SessionTitle: e.Payload.SessionTitle,
 			RunID:        e.Payload.RunID,
 			Type:         notify.Type(e.Payload.Type),
+			AWSSOCommand: e.Payload.AWSSOCommand,
+			AWSSOURL:     e.Payload.AWSSOURL,
 		}
 		if e.Payload.Error != nil {
 			n.Message = e.Payload.Error.Error()


### PR DESCRIPTION
## Summary

Adds automatic AWS SSO credential refresh for Bedrock users whose sessions expire mid-session.

### New config fields

**`providers.bedrock.aws_auth_refresh`** — a shell command run automatically when Bedrock returns a credential error (expired SSO token, missing SSO cache file, or HTTP 401). After the command completes, the provider is rebuilt with a fresh AWS SDK credential chain and the request is retried.

Example `crush.json`:
```json
{
  "env": {
    "AWS_PROFILE": "my-bedrock-profile"
  },
  "providers": {
    "bedrock": {
      "aws_auth_refresh": "aws sso login --profile my-bedrock-profile > /dev/null 2>&1"
    }
  }
}
```

The `> /dev/null 2>&1` redirect prevents terminal output from corrupting the TUI. The browser still opens normally since that is handled by the OS.

**`env`** (top-level) — key/value pairs applied via `os.Setenv` at startup before provider configuration, so vars like `AWS_PROFILE` are visible to the AWS SDK credential chain.

### Implementation

- `ProviderConfig.AWSAuthRefresh` — new field, now correctly carried through the known-provider config merge (was previously dropped)
- `retryAfterUnauthorized` — new case alongside existing OAuth and API key template refresh
- `isUnauthorized` — extended to match AWS SDK credential errors that surface before any Bedrock HTTP request (`GetRoleCredentials`, `ForbiddenException`, missing SSO cache file)
- `runAWSAuthRefresh` — runs the command via the embedded shell, then calls `UpdateModels` to rebuild the provider with a fresh credential chain
- `Config.Env` — top-level env map applied before `configureProviders`

## Test plan

- [ ] Configure `aws_auth_refresh` with an expired SSO session and verify the browser opens and the request retries successfully
- [ ] Verify that without `aws_auth_refresh` set, behaviour is unchanged
- [ ] Verify top-level `env` vars are visible to the AWS SDK at startup