### PR TITLE
fix(bedrock): honor reasoning_effort for Anthropic-on-Bedrock models

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -286,7 +286,7 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 				options[openai.Name] = parsed
 			}
 		}
-	case anthropic.Name:
+	case anthropic.Name, bedrock.Name:
 		var (
 			_, hasEffort = mergedOptions["effort"]
 			_, hasThink  = mergedOptions["thinking"]

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -7,6 +7,8 @@ import (
 
 	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/fantasy"
+	"charm.land/fantasy/providers/anthropic"
+	"charm.land/fantasy/providers/bedrock"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -382,4 +384,37 @@ func TestUpdateParentSessionCost(t *testing.T) {
 		require.NoError(t, err)
 		assert.InDelta(t, 0.0, updated.Cost, 1e-9)
 	})
+}
+
+func TestGetProviderOptionsReasoningEffort(t *testing.T) {
+	// Bedrock is Fantasy's Anthropic under a different provider name; options
+	// must land under anthropic.Name so the Anthropic language model picks them up.
+	tests := []struct {
+		name         string
+		providerType catwalk.Type
+	}{
+		{"anthropic honors reasoning_effort", catwalk.Type(anthropic.Name)},
+		{"bedrock honors reasoning_effort", catwalk.Type(bedrock.Name)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			model := Model{
+				CatwalkCfg: catwalk.Model{ID: "claude-opus-4-7"},
+				ModelCfg: config.SelectedModel{
+					Provider:        "test",
+					ReasoningEffort: "max",
+				},
+			}
+			providerCfg := config.ProviderConfig{ID: "test", Type: tc.providerType}
+
+			opts := getProviderOptions(model, providerCfg)
+
+			raw, ok := opts[anthropic.Name]
+			require.True(t, ok, "options should be keyed under anthropic.Name for type %q", tc.providerType)
+			parsed, ok := raw.(*anthropic.ProviderOptions)
+			require.True(t, ok)
+			require.NotNil(t, parsed.Effort)
+			assert.Equal(t, anthropic.Effort("max"), *parsed.Effort)
+		})
+	}
 }


### PR DESCRIPTION
Bedrock routes through Fantasy's Anthropic implementation with a different display name, so provider options must still be filed under `anthropic.Name` for the language model to pick them up. Previously the bedrock provider type was missing from `getProviderOptions` entirely, so `reasoning_effort` and `think` were silently dropped for users pointing `provider: bedrock` at Anthropic models on AWS.

## Before / after

**Before** — given `~/.config/crush/crush.json` (or equivalent) with:

```json
{
  "models": {
    "large": {
      "model": "anthropic.claude-opus-4-7",
      "provider": "bedrock",
      "reasoning_effort": "max"
    }
  }
}
```

…the switch in `internal/agent/coordinator.go#getProviderOptions` has no `case bedrock.Name:`, so the merged options never become a `*anthropic.ProviderOptions`. The request goes out at Anthropic's default effort — the user's config is silently ignored.

**After** — `bedrock.Name` is added to the existing `anthropic.Name` case. The merged options are parsed via `anthropic.ParseOptions` and filed under `options[anthropic.Name]`, which is what Fantasy's bedrock shim (literally `anthropic.New(WithName("bedrock"), WithBedrock(), ...)`) looks up when building `MessageNewParams`.

Also applies to `think: true`, which picked up the same silent-drop bug.

## Test

Added `TestGetProviderOptionsReasoningEffort` (table test, anthropic + bedrock) asserting that `reasoning_effort: "max"` on the model config round-trips into `*anthropic.ProviderOptions{Effort: "max"}` keyed under `anthropic.Name`. `go test ./...` passes.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

![JJ Bot](https://www.gravatar.com/avatar/3cd1a8b0b916de49df61865fc284236dde7067f75ade4ad27e7de7f4671bbe7c?s=20) Generated with [JJ Bot](mailto:john.jansen+bot@me.com)