### PR TITLE
fix(ui): calculation bug that would cause modified files to wrap

### DIFF
--- a/internal/ui/model/session.go
+++ b/internal/ui/model/session.go
@@ -213,7 +213,12 @@ func fileList(t *styles.Styles, cwd string, filesWithChanges []SessionFile, widt
 			filePath = rel
 		}
 		filePath = fsext.DirTrim(filePath, 2)
-		filePath = ansi.Truncate(filePath, width-(lipgloss.Width(extraContent)-2), "…")
+		suffix := ""
+		if extraContent != "" {
+			suffix = " " + extraContent
+		}
+		maxPathWidth := max(width-lipgloss.Width(suffix), 0)
+		filePath = ansi.Truncate(filePath, maxPathWidth, "…")
 
 		line := t.Files.Path.Render(filePath)
 		if extraContent != "" {


### PR DESCRIPTION
This fixes a small calculation bug when calculating where to truncate modified file info in the sidebar which would cause wrapping.

Before:

<img width="236" height="137" src="https://github.com/user-attachments/assets/abcf96da-c491-4347-9db1-f8290e203981" />

After:

<img width="240" height="128" src="https://github.com/user-attachments/assets/568c7518-bae8-4f16-8547-96cbc8859d56" />
