### PR TITLE
fix(agent): estimate tokens when provider fails to 

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -252,6 +252,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 	a.eventPromptSent(call.SessionID)
 
 	var currentAssistant *message.Message
+	var stepMessages []fantasy.Message
 	var shouldSummarize bool
 	// Don't send MaxOutputTokens if 0 — some providers (e.g. LM Studio) reject it
 	var maxOutputTokens *int64
@@ -309,6 +310,10 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 			if promptPrefix != "" {
 				prepared.Messages = append([]fantasy.Message{fantasy.NewSystemMessage(promptPrefix)}, prepared.Messages...)
 			}
+
+			sessionLock.Lock()
+			stepMessages = cloneFantasyMessages(prepared.Messages)
+			sessionLock.Unlock()
 
 			var assistantMsg message.Message
 			assistantMsg, err = a.messages.Create(callContext, call.SessionID, message.CreateMessageParams{
@@ -435,7 +440,8 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 			if getSessionErr != nil {
 				return getSessionErr
 			}
-			a.updateSessionUsage(largeModel, &updatedSession, stepResult.Usage, a.openrouterCost(stepResult.ProviderMetadata))
+			usage, estimated := fallbackStepUsage(stepMessages, stepResult)
+			a.updateSessionUsage(largeModel, &updatedSession, usage, a.openrouterCost(stepResult.ProviderMetadata), estimated)
 			_, sessionErr := a.sessions.Save(ctx, updatedSession)
 			if sessionErr != nil {
 				return sessionErr
@@ -734,7 +740,7 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		}
 	}
 
-	a.updateSessionUsage(largeModel, &currentSession, resp.TotalUsage, openrouterCost)
+	a.updateSessionUsage(largeModel, &currentSession, resp.TotalUsage, openrouterCost, false)
 
 	// Just in case, get just the last usage info.
 	usage := resp.Response.Usage
@@ -1113,28 +1119,40 @@ func (a *sessionAgent) openrouterCost(metadata fantasy.ProviderMetadata) *float6
 	return &opts.Usage.Cost
 }
 
-func (a *sessionAgent) updateSessionUsage(model Model, session *session.Session, usage fantasy.Usage, overrideCost *float64) {
+func (a *sessionAgent) updateSessionUsage(model Model, session *session.Session, usage fantasy.Usage, overrideCost *float64, estimated bool) {
 	modelConfig := model.CatwalkCfg
 	cost := modelConfig.CostPer1MInCached/1e6*float64(usage.CacheCreationTokens) +
 		modelConfig.CostPer1MOutCached/1e6*float64(usage.CacheReadTokens) +
 		modelConfig.CostPer1MIn/1e6*float64(usage.InputTokens) +
 		modelConfig.CostPer1MOut/1e6*float64(usage.OutputTokens)
 
-	a.eventTokensUsed(session.ID, model, usage, cost)
-
-	// Use override cost if available (e.g., from OpenRouter).
-	if overrideCost != nil {
-		cost = *overrideCost
+	eventCost := cost
+	if estimated {
+		eventCost = 0
 	}
+	a.eventTokensUsed(session.ID, model, usage, eventCost)
 
-	// Skip cost accumulation
-	if model.FlatRate {
+	if estimated {
 		cost = 0
+	} else {
+		// Use override cost if available (e.g., from OpenRouter).
+		if overrideCost != nil {
+			cost = *overrideCost
+		}
+
+		// Skip cost accumulation
+		if model.FlatRate {
+			cost = 0
+		}
 	}
 
 	session.Cost += cost
-	session.CompletionTokens = usage.OutputTokens
-	session.PromptTokens = usage.InputTokens + usage.CacheReadTokens
+	if usage.OutputTokens != 0 {
+		session.CompletionTokens = usage.OutputTokens
+	}
+	if promptTokens := usage.InputTokens + usage.CacheReadTokens; promptTokens != 0 {
+		session.PromptTokens = promptTokens
+	}
 }
 
 func (a *sessionAgent) Cancel(sessionID string) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -745,7 +745,9 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	// Just in case, get just the last usage info.
 	usage := resp.Response.Usage
 	currentSession.SummaryMessageID = summaryMessage.ID
-	currentSession.CompletionTokens = usage.OutputTokens
+	if completionTokens := summaryCompletionTokens(usage, summaryMessage); completionTokens != 0 {
+		currentSession.CompletionTokens = completionTokens
+	}
 	currentSession.PromptTokens = 0
 	_, err = a.sessions.Save(genCtx, currentSession)
 	if err != nil {
@@ -1126,11 +1128,9 @@ func (a *sessionAgent) updateSessionUsage(model Model, session *session.Session,
 		modelConfig.CostPer1MIn/1e6*float64(usage.InputTokens) +
 		modelConfig.CostPer1MOut/1e6*float64(usage.OutputTokens)
 
-	eventCost := cost
-	if estimated {
-		eventCost = 0
+	if !estimated {
+		a.eventTokensUsed(session.ID, model, usage, cost)
 	}
-	a.eventTokensUsed(session.ID, model, usage, eventCost)
 
 	if estimated {
 		cost = 0
@@ -1147,10 +1147,23 @@ func (a *sessionAgent) updateSessionUsage(model Model, session *session.Session,
 	}
 
 	session.Cost += cost
-	if !usageIsZero(usage) {
+	updateSessionTokenCounters(session, usage)
+}
+
+func updateSessionTokenCounters(session *session.Session, usage fantasy.Usage) {
+	if usage.OutputTokens != 0 {
 		session.CompletionTokens = usage.OutputTokens
-		session.PromptTokens = usage.InputTokens + usage.CacheReadTokens
 	}
+	if promptTokens := usage.InputTokens + usage.CacheReadTokens; promptTokens != 0 {
+		session.PromptTokens = promptTokens
+	}
+}
+
+func summaryCompletionTokens(usage fantasy.Usage, summaryMessage message.Message) int64 {
+	if usage.OutputTokens != 0 {
+		return usage.OutputTokens
+	}
+	return approxTokenCount(summaryMessage.Content().Text) + approxTokenCount(summaryMessage.ReasoningContent().String())
 }
 
 func (a *sessionAgent) Cancel(sessionID string) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -747,6 +747,7 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	currentSession.SummaryMessageID = summaryMessage.ID
 	currentSession.CompletionTokens = summaryCompletionTokens(usage, summaryMessage)
 	currentSession.PromptTokens = 0
+	currentSession.EstimatedUsage = usageIsZero(usage)
 	_, err = a.sessions.Save(genCtx, currentSession)
 	if err != nil {
 		return err
@@ -1120,6 +1121,10 @@ func (a *sessionAgent) openrouterCost(metadata fantasy.ProviderMetadata) *float6
 }
 
 func (a *sessionAgent) updateSessionUsage(model Model, session *session.Session, usage fantasy.Usage, overrideCost *float64, estimated bool) {
+	if !usageIsZero(usage) {
+		session.EstimatedUsage = estimated
+	}
+
 	modelConfig := model.CatwalkCfg
 	cost := modelConfig.CostPer1MInCached/1e6*float64(usage.CacheCreationTokens) +
 		modelConfig.CostPer1MOutCached/1e6*float64(usage.CacheReadTokens) +

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -745,9 +745,7 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	// Just in case, get just the last usage info.
 	usage := resp.Response.Usage
 	currentSession.SummaryMessageID = summaryMessage.ID
-	if completionTokens := summaryCompletionTokens(usage, summaryMessage); completionTokens != 0 {
-		currentSession.CompletionTokens = completionTokens
-	}
+	currentSession.CompletionTokens = summaryCompletionTokens(usage, summaryMessage)
 	currentSession.PromptTokens = 0
 	_, err = a.sessions.Save(genCtx, currentSession)
 	if err != nil {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1147,11 +1147,9 @@ func (a *sessionAgent) updateSessionUsage(model Model, session *session.Session,
 	}
 
 	session.Cost += cost
-	if usage.OutputTokens != 0 {
+	if !usageIsZero(usage) {
 		session.CompletionTokens = usage.OutputTokens
-	}
-	if promptTokens := usage.InputTokens + usage.CacheReadTokens; promptTokens != 0 {
-		session.PromptTokens = promptTokens
+		session.PromptTokens = usage.InputTokens + usage.CacheReadTokens
 	}
 }
 

--- a/internal/agent/usage_fallback.go
+++ b/internal/agent/usage_fallback.go
@@ -1,0 +1,172 @@
+package agent
+
+import (
+	"fmt"
+
+	"charm.land/fantasy"
+)
+
+func usageIsZero(usage fantasy.Usage) bool {
+	return usage.InputTokens == 0 &&
+		usage.OutputTokens == 0 &&
+		usage.TotalTokens == 0 &&
+		usage.ReasoningTokens == 0 &&
+		usage.CacheCreationTokens == 0 &&
+		usage.CacheReadTokens == 0
+}
+
+func fallbackStepUsage(messages []fantasy.Message, step fantasy.StepResult) (fantasy.Usage, bool) {
+	if !usageIsZero(step.Usage) {
+		return step.Usage, false
+	}
+
+	inputTokens := estimateMessageTokens(messages)
+	outputTokens := estimateStepCompletionTokens(step)
+	if inputTokens == 0 && outputTokens == 0 {
+		return fantasy.Usage{}, false
+	}
+
+	return fantasy.Usage{
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+		TotalTokens:  inputTokens + outputTokens,
+	}, true
+}
+
+func cloneFantasyMessages(messages []fantasy.Message) []fantasy.Message {
+	cloned := make([]fantasy.Message, len(messages))
+	for i, msg := range messages {
+		cloned[i] = msg
+		cloned[i].Content = append([]fantasy.MessagePart(nil), msg.Content...)
+	}
+	return cloned
+}
+
+func estimateMessageTokens(messages []fantasy.Message) int64 {
+	var tokens int64
+	for _, msg := range messages {
+		tokens += approxTokenCount(string(msg.Role))
+		for _, part := range msg.Content {
+			tokens += estimateMessagePartTokens(part)
+		}
+	}
+	return tokens
+}
+
+func estimateStepCompletionTokens(step fantasy.StepResult) int64 {
+	var tokens int64
+	for _, content := range step.Content {
+		switch c := content.(type) {
+		case fantasy.TextContent:
+			tokens += approxTokenCount(c.Text)
+		case *fantasy.TextContent:
+			tokens += approxTokenCount(c.Text)
+		case fantasy.ReasoningContent:
+			tokens += approxTokenCount(c.Text)
+		case *fantasy.ReasoningContent:
+			tokens += approxTokenCount(c.Text)
+		case fantasy.FileContent:
+			tokens += estimateGeneratedFileTokens(c)
+		case *fantasy.FileContent:
+			tokens += estimateGeneratedFileTokens(*c)
+		case fantasy.SourceContent:
+			tokens += estimateSourceTokens(c)
+		case *fantasy.SourceContent:
+			tokens += estimateSourceTokens(*c)
+		case fantasy.ToolCallContent:
+			tokens += estimateToolCallTokens(c.ToolName, c.Input)
+		case *fantasy.ToolCallContent:
+			tokens += estimateToolCallTokens(c.ToolName, c.Input)
+		case fantasy.ToolResultContent:
+			tokens += estimateToolResultContentTokens(c.ToolCallID, c.ToolName, c.ClientMetadata, c.Result)
+		case *fantasy.ToolResultContent:
+			tokens += estimateToolResultContentTokens(c.ToolCallID, c.ToolName, c.ClientMetadata, c.Result)
+		}
+	}
+	return tokens
+}
+
+func estimateMessagePartTokens(part fantasy.MessagePart) int64 {
+	switch p := part.(type) {
+	case fantasy.TextPart:
+		return approxTokenCount(p.Text)
+	case *fantasy.TextPart:
+		return approxTokenCount(p.Text)
+	case fantasy.ReasoningPart:
+		return approxTokenCount(p.Text)
+	case *fantasy.ReasoningPart:
+		return approxTokenCount(p.Text)
+	case fantasy.FilePart:
+		return estimateFilePartTokens(p)
+	case *fantasy.FilePart:
+		return estimateFilePartTokens(*p)
+	case fantasy.ToolCallPart:
+		return estimateToolCallTokens(p.ToolName, p.Input)
+	case *fantasy.ToolCallPart:
+		return estimateToolCallTokens(p.ToolName, p.Input)
+	case fantasy.ToolResultPart:
+		return estimateToolResultContentTokens(p.ToolCallID, "", "", p.Output)
+	case *fantasy.ToolResultPart:
+		return estimateToolResultContentTokens(p.ToolCallID, "", "", p.Output)
+	default:
+		return 0
+	}
+}
+
+func estimateToolCallTokens(toolName, input string) int64 {
+	return approxTokenCount(toolName) + approxTokenCount(input)
+}
+
+func estimateToolResultContentTokens(toolCallID, toolName, metadata string, output fantasy.ToolResultOutputContent) int64 {
+	tokens := approxTokenCount(toolCallID) + approxTokenCount(toolName) + approxTokenCount(metadata)
+	switch result := output.(type) {
+	case fantasy.ToolResultOutputContentText:
+		tokens += approxTokenCount(result.Text)
+	case *fantasy.ToolResultOutputContentText:
+		tokens += approxTokenCount(result.Text)
+	case fantasy.ToolResultOutputContentError:
+		if result.Error != nil {
+			tokens += approxTokenCount(result.Error.Error())
+		}
+	case *fantasy.ToolResultOutputContentError:
+		if result.Error != nil {
+			tokens += approxTokenCount(result.Error.Error())
+		}
+	case fantasy.ToolResultOutputContentMedia:
+		tokens += estimateMediaTokens(result.MediaType, result.Text, len(result.Data))
+	case *fantasy.ToolResultOutputContentMedia:
+		tokens += estimateMediaTokens(result.MediaType, result.Text, len(result.Data))
+	}
+	return tokens
+}
+
+func estimateFilePartTokens(file fantasy.FilePart) int64 {
+	return estimateMediaTokens(file.MediaType, file.Filename, len(file.Data))
+}
+
+func estimateGeneratedFileTokens(file fantasy.FileContent) int64 {
+	return estimateMediaTokens(file.MediaType, "", len(file.Data))
+}
+
+func estimateMediaTokens(mediaType, text string, dataBytes int) int64 {
+	if dataBytes == 0 {
+		return approxTokenCount(mediaType) + approxTokenCount(text)
+	}
+	return approxTokenCount(fmt.Sprintf("%s %s %d bytes", mediaType, text, dataBytes))
+}
+
+func estimateSourceTokens(source fantasy.SourceContent) int64 {
+	return approxTokenCount(string(source.SourceType)) +
+		approxTokenCount(source.ID) +
+		approxTokenCount(source.URL) +
+		approxTokenCount(source.Title) +
+		approxTokenCount(source.MediaType) +
+		approxTokenCount(source.Filename)
+}
+
+func approxTokenCount(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	return int64((len(s) + 3) / 4)
+}

--- a/internal/agent/usage_fallback.go
+++ b/internal/agent/usage_fallback.go
@@ -78,9 +78,13 @@ func estimateStepCompletionTokens(step fantasy.StepResult) int64 {
 		case *fantasy.ToolCallContent:
 			tokens += estimateToolCallTokens(c.ToolName, c.Input)
 		case fantasy.ToolResultContent:
-			tokens += estimateToolResultContentTokens(c.ToolCallID, c.ToolName, c.ClientMetadata, c.Result)
+			if c.ProviderExecuted {
+				tokens += estimateToolResultContentTokens(c.ToolCallID, c.ToolName, c.ClientMetadata, c.Result)
+			}
 		case *fantasy.ToolResultContent:
-			tokens += estimateToolResultContentTokens(c.ToolCallID, c.ToolName, c.ClientMetadata, c.Result)
+			if c.ProviderExecuted {
+				tokens += estimateToolResultContentTokens(c.ToolCallID, c.ToolName, c.ClientMetadata, c.Result)
+			}
 		}
 	}
 	return tokens

--- a/internal/agent/usage_fallback_test.go
+++ b/internal/agent/usage_fallback_test.go
@@ -145,6 +145,51 @@ func TestFallbackStepUsageEstimatesToolResults(t *testing.T) {
 	require.Equal(t, usage.InputTokens, usage.TotalTokens)
 }
 
+func TestFallbackStepUsageSkipsClientToolResultsAsOutput(t *testing.T) {
+	t.Parallel()
+
+	step := fantasy.StepResult{
+		Response: fantasy.Response{
+			Content: fantasy.ResponseContent{
+				fantasy.ToolResultContent{
+					ToolCallID: "tool-call-1",
+					ToolName:   "bash",
+					Result: fantasy.ToolResultOutputContentText{
+						Text: "large client-executed payload that should not count as model output tokens",
+					},
+				},
+			},
+		},
+	}
+
+	usage, estimated := fallbackStepUsage(nil, step)
+	require.False(t, estimated)
+	require.Zero(t, usage.OutputTokens)
+}
+
+func TestFallbackStepUsageCountsProviderToolResultsAsOutput(t *testing.T) {
+	t.Parallel()
+
+	step := fantasy.StepResult{
+		Response: fantasy.Response{
+			Content: fantasy.ResponseContent{
+				fantasy.ToolResultContent{
+					ToolCallID:       "tool-call-1",
+					ToolName:         "web_search",
+					ProviderExecuted: true,
+					ClientMetadata:   "provider metadata",
+					Result:           fantasy.ToolResultOutputContentText{Text: "provider-executed result"},
+				},
+			},
+		},
+	}
+
+	usage, estimated := fallbackStepUsage(nil, step)
+	require.True(t, estimated)
+	require.Positive(t, usage.OutputTokens)
+	require.Equal(t, usage.OutputTokens, usage.TotalTokens)
+}
+
 func TestFallbackStepUsageReturnsZeroWithoutContent(t *testing.T) {
 	t.Parallel()
 
@@ -185,6 +230,24 @@ func TestUpdateSessionUsageKeepsCountersForZeroUsage(t *testing.T) {
 	require.Equal(t, 1.25, currentSession.Cost)
 	require.Equal(t, int64(123), currentSession.PromptTokens)
 	require.Equal(t, int64(456), currentSession.CompletionTokens)
+}
+
+func TestUpdateSessionUsageReplacesCountersForPartialUsage(t *testing.T) {
+	t.Parallel()
+
+	agent := &sessionAgent{}
+	currentSession := &session.Session{
+		ID:               "session-id",
+		PromptTokens:     123,
+		CompletionTokens: 456,
+	}
+	model := Model{CatwalkCfg: catwalk.Model{CostPer1MIn: 10, CostPer1MOut: 20}}
+	usage := fantasy.Usage{InputTokens: 789}
+
+	agent.updateSessionUsage(model, currentSession, usage, nil, false)
+
+	require.Equal(t, int64(789), currentSession.PromptTokens)
+	require.Zero(t, currentSession.CompletionTokens)
 }
 
 func TestUpdateSessionUsageAddsProviderCost(t *testing.T) {

--- a/internal/agent/usage_fallback_test.go
+++ b/internal/agent/usage_fallback_test.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/stretchr/testify/require"
 )
@@ -232,7 +233,7 @@ func TestUpdateSessionUsageKeepsCountersForZeroUsage(t *testing.T) {
 	require.Equal(t, int64(456), currentSession.CompletionTokens)
 }
 
-func TestUpdateSessionUsageReplacesCountersForPartialUsage(t *testing.T) {
+func TestUpdateSessionUsagePreservesOmittedCountersForPartialUsage(t *testing.T) {
 	t.Parallel()
 
 	agent := &sessionAgent{}
@@ -247,7 +248,77 @@ func TestUpdateSessionUsageReplacesCountersForPartialUsage(t *testing.T) {
 	agent.updateSessionUsage(model, currentSession, usage, nil, false)
 
 	require.Equal(t, int64(789), currentSession.PromptTokens)
-	require.Zero(t, currentSession.CompletionTokens)
+	require.Equal(t, int64(456), currentSession.CompletionTokens)
+}
+
+func TestUpdateSessionUsagePreservesCountersForTotalOnlyUsage(t *testing.T) {
+	t.Parallel()
+
+	agent := &sessionAgent{}
+	currentSession := &session.Session{
+		ID:               "session-id",
+		PromptTokens:     123,
+		CompletionTokens: 456,
+	}
+	model := Model{CatwalkCfg: catwalk.Model{CostPer1MIn: 10, CostPer1MOut: 20}}
+	usage := fantasy.Usage{TotalTokens: 100}
+
+	agent.updateSessionUsage(model, currentSession, usage, nil, false)
+
+	require.Equal(t, int64(123), currentSession.PromptTokens)
+	require.Equal(t, int64(456), currentSession.CompletionTokens)
+}
+
+func TestUpdateSessionUsagePreservesPromptForOutputOnlyUsage(t *testing.T) {
+	t.Parallel()
+
+	agent := &sessionAgent{}
+	currentSession := &session.Session{
+		ID:               "session-id",
+		PromptTokens:     123,
+		CompletionTokens: 456,
+	}
+	model := Model{CatwalkCfg: catwalk.Model{CostPer1MIn: 10, CostPer1MOut: 20}}
+	usage := fantasy.Usage{OutputTokens: 50}
+
+	agent.updateSessionUsage(model, currentSession, usage, nil, false)
+
+	require.Equal(t, int64(123), currentSession.PromptTokens)
+	require.Equal(t, int64(50), currentSession.CompletionTokens)
+}
+
+func TestUpdateSessionUsageKeepsCountersForEstimatedZeroUsage(t *testing.T) {
+	t.Parallel()
+
+	agent := &sessionAgent{}
+	currentSession := &session.Session{
+		ID:               "session-id",
+		PromptTokens:     123,
+		CompletionTokens: 456,
+		Cost:             1.25,
+	}
+	model := Model{CatwalkCfg: catwalk.Model{CostPer1MIn: 10, CostPer1MOut: 20}}
+
+	agent.updateSessionUsage(model, currentSession, fantasy.Usage{}, nil, true)
+
+	require.Equal(t, 1.25, currentSession.Cost)
+	require.Equal(t, int64(123), currentSession.PromptTokens)
+	require.Equal(t, int64(456), currentSession.CompletionTokens)
+}
+
+func TestSummaryCompletionTokens(t *testing.T) {
+	t.Parallel()
+
+	summaryMessage := message.Message{
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "summary text"},
+			message.ReasoningContent{Thinking: "reasoning text"},
+		},
+	}
+
+	require.Equal(t, int64(42), summaryCompletionTokens(fantasy.Usage{OutputTokens: 42}, summaryMessage))
+	require.Equal(t, approxTokenCount("summary text")+approxTokenCount("reasoning text"), summaryCompletionTokens(fantasy.Usage{}, summaryMessage))
+	require.Zero(t, summaryCompletionTokens(fantasy.Usage{}, message.Message{}))
 }
 
 func TestUpdateSessionUsageAddsProviderCost(t *testing.T) {

--- a/internal/agent/usage_fallback_test.go
+++ b/internal/agent/usage_fallback_test.go
@@ -212,6 +212,7 @@ func TestUpdateSessionUsageSkipsEstimatedCost(t *testing.T) {
 	require.Equal(t, 1.25, currentSession.Cost)
 	require.Equal(t, int64(1000), currentSession.PromptTokens)
 	require.Equal(t, int64(2000), currentSession.CompletionTokens)
+	require.True(t, currentSession.EstimatedUsage)
 }
 
 func TestUpdateSessionUsageKeepsCountersForZeroUsage(t *testing.T) {
@@ -334,4 +335,5 @@ func TestUpdateSessionUsageAddsProviderCost(t *testing.T) {
 	require.Equal(t, 1.3, currentSession.Cost)
 	require.Equal(t, int64(1000), currentSession.PromptTokens)
 	require.Equal(t, int64(2000), currentSession.CompletionTokens)
+	require.False(t, currentSession.EstimatedUsage)
 }

--- a/internal/agent/usage_fallback_test.go
+++ b/internal/agent/usage_fallback_test.go
@@ -1,0 +1,203 @@
+package agent
+
+import (
+	"errors"
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUsageIsZero(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, usageIsZero(fantasy.Usage{}))
+	require.False(t, usageIsZero(fantasy.Usage{InputTokens: 1}))
+	require.False(t, usageIsZero(fantasy.Usage{OutputTokens: 1}))
+	require.False(t, usageIsZero(fantasy.Usage{TotalTokens: 1}))
+	require.False(t, usageIsZero(fantasy.Usage{ReasoningTokens: 1}))
+	require.False(t, usageIsZero(fantasy.Usage{CacheCreationTokens: 1}))
+	require.False(t, usageIsZero(fantasy.Usage{CacheReadTokens: 1}))
+}
+
+func TestFallbackStepUsageKeepsProviderUsage(t *testing.T) {
+	t.Parallel()
+
+	usage := fantasy.Usage{
+		InputTokens:  10,
+		OutputTokens: 5,
+		TotalTokens:  15,
+	}
+	step := fantasy.StepResult{
+		Response: fantasy.Response{Usage: usage},
+	}
+
+	fallbackUsage, estimated := fallbackStepUsage(nil, step)
+	require.False(t, estimated)
+	require.Equal(t, usage, fallbackUsage)
+}
+
+func TestFallbackStepUsageEstimatesPromptAndAssistantText(t *testing.T) {
+	t.Parallel()
+
+	messages := []fantasy.Message{
+		fantasy.NewUserMessage("please explain the implementation details"),
+	}
+	step := fantasy.StepResult{
+		Response: fantasy.Response{
+			Content: fantasy.ResponseContent{
+				fantasy.TextContent{Text: "the implementation stores state safely"},
+			},
+		},
+	}
+
+	usage, estimated := fallbackStepUsage(messages, step)
+	require.True(t, estimated)
+	require.Positive(t, usage.InputTokens)
+	require.Positive(t, usage.OutputTokens)
+	require.Equal(t, usage.InputTokens+usage.OutputTokens, usage.TotalTokens)
+}
+
+func TestFallbackStepUsageEstimatesReasoning(t *testing.T) {
+	t.Parallel()
+
+	messages := []fantasy.Message{
+		{
+			Role: fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{
+				fantasy.ReasoningPart{Text: "first reason about the request"},
+			},
+		},
+	}
+	step := fantasy.StepResult{
+		Response: fantasy.Response{
+			Content: fantasy.ResponseContent{
+				fantasy.ReasoningContent{Text: "second reason about the answer"},
+			},
+		},
+	}
+
+	usage, estimated := fallbackStepUsage(messages, step)
+	require.True(t, estimated)
+	require.Positive(t, usage.InputTokens)
+	require.Positive(t, usage.OutputTokens)
+}
+
+func TestFallbackStepUsageEstimatesToolCalls(t *testing.T) {
+	t.Parallel()
+
+	step := fantasy.StepResult{
+		Response: fantasy.Response{
+			Content: fantasy.ResponseContent{
+				fantasy.ToolCallContent{
+					ToolCallID: "tool-call-1",
+					ToolName:   "view",
+					Input:      `{"file_path":"/tmp/example.go"}`,
+				},
+			},
+		},
+	}
+
+	usage, estimated := fallbackStepUsage(nil, step)
+	require.True(t, estimated)
+	require.Zero(t, usage.InputTokens)
+	require.Positive(t, usage.OutputTokens)
+	require.Equal(t, usage.OutputTokens, usage.TotalTokens)
+}
+
+func TestFallbackStepUsageEstimatesToolResults(t *testing.T) {
+	t.Parallel()
+
+	messages := []fantasy.Message{
+		{
+			Role: fantasy.MessageRoleTool,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolResultPart{
+					ToolCallID: "tool-call-1",
+					Output: fantasy.ToolResultOutputContentText{
+						Text: "file contents returned by the tool",
+					},
+				},
+				fantasy.ToolResultPart{
+					ToolCallID: "tool-call-2",
+					Output: fantasy.ToolResultOutputContentError{
+						Error: errors.New("permission denied"),
+					},
+				},
+				fantasy.ToolResultPart{
+					ToolCallID: "tool-call-3",
+					Output: fantasy.ToolResultOutputContentMedia{
+						MediaType: "image/png",
+						Text:      "screenshot",
+						Data:      "abc123",
+					},
+				},
+			},
+		},
+	}
+
+	usage, estimated := fallbackStepUsage(messages, fantasy.StepResult{})
+	require.True(t, estimated)
+	require.Positive(t, usage.InputTokens)
+	require.Zero(t, usage.OutputTokens)
+	require.Equal(t, usage.InputTokens, usage.TotalTokens)
+}
+
+func TestFallbackStepUsageReturnsZeroWithoutContent(t *testing.T) {
+	t.Parallel()
+
+	usage, estimated := fallbackStepUsage(nil, fantasy.StepResult{})
+	require.False(t, estimated)
+	require.True(t, usageIsZero(usage))
+}
+
+func TestUpdateSessionUsageSkipsEstimatedCost(t *testing.T) {
+	t.Parallel()
+
+	agent := &sessionAgent{}
+	currentSession := &session.Session{ID: "session-id", Cost: 1.25}
+	model := Model{CatwalkCfg: catwalk.Model{CostPer1MIn: 10, CostPer1MOut: 20}}
+	usage := fantasy.Usage{InputTokens: 1000, OutputTokens: 2000}
+
+	agent.updateSessionUsage(model, currentSession, usage, nil, true)
+
+	require.Equal(t, 1.25, currentSession.Cost)
+	require.Equal(t, int64(1000), currentSession.PromptTokens)
+	require.Equal(t, int64(2000), currentSession.CompletionTokens)
+}
+
+func TestUpdateSessionUsageKeepsCountersForZeroUsage(t *testing.T) {
+	t.Parallel()
+
+	agent := &sessionAgent{}
+	currentSession := &session.Session{
+		ID:               "session-id",
+		PromptTokens:     123,
+		CompletionTokens: 456,
+		Cost:             1.25,
+	}
+	model := Model{CatwalkCfg: catwalk.Model{CostPer1MIn: 10, CostPer1MOut: 20}}
+
+	agent.updateSessionUsage(model, currentSession, fantasy.Usage{}, nil, false)
+
+	require.Equal(t, 1.25, currentSession.Cost)
+	require.Equal(t, int64(123), currentSession.PromptTokens)
+	require.Equal(t, int64(456), currentSession.CompletionTokens)
+}
+
+func TestUpdateSessionUsageAddsProviderCost(t *testing.T) {
+	t.Parallel()
+
+	agent := &sessionAgent{}
+	currentSession := &session.Session{ID: "session-id", Cost: 1.25}
+	model := Model{CatwalkCfg: catwalk.Model{CostPer1MIn: 10, CostPer1MOut: 20}}
+	usage := fantasy.Usage{InputTokens: 1000, OutputTokens: 2000}
+
+	agent.updateSessionUsage(model, currentSession, usage, nil, false)
+
+	require.Equal(t, 1.3, currentSession.Cost)
+	require.Equal(t, int64(1000), currentSession.PromptTokens)
+	require.Equal(t, int64(2000), currentSession.CompletionTokens)
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 
 	"github.com/charmbracelet/crush/internal/db"
 	"github.com/charmbracelet/crush/internal/event"
@@ -84,6 +85,12 @@ type service struct {
 	*pubsub.Broker[Session]
 	db *sql.DB
 	q  *db.Queries
+
+	// Estimated usage stays in memory so fetch-modify-save paths (e.g.,
+	// updating todos or parent-session cost) do not rebuild a session from
+	// SQLite and incorrectly clear the UI "~" marker.
+	estimatedUsageMu sync.RWMutex
+	estimatedUsage   map[string]bool
 }
 
 func (s *service) Create(ctx context.Context, title string) (Session, error) {
@@ -155,6 +162,7 @@ func (s *service) Delete(ctx context.Context, id string) error {
 	}
 
 	session := s.fromDBItem(dbSession)
+	s.clearEstimatedUsageState(dbSession.ID)
 	s.Publish(pubsub.DeletedEvent, session)
 	event.SessionDeleted()
 	return nil
@@ -165,7 +173,9 @@ func (s *service) Get(ctx context.Context, id string) (Session, error) {
 	if err != nil {
 		return Session{}, err
 	}
-	return s.fromDBItem(dbSession), nil
+	session := s.fromDBItem(dbSession)
+	s.applyEstimatedUsageState(&session)
+	return session, nil
 }
 
 func (s *service) GetLast(ctx context.Context) (Session, error) {
@@ -173,7 +183,9 @@ func (s *service) GetLast(ctx context.Context) (Session, error) {
 	if err != nil {
 		return Session{}, err
 	}
-	return s.fromDBItem(dbSession), nil
+	session := s.fromDBItem(dbSession)
+	s.applyEstimatedUsageState(&session)
+	return session, nil
 }
 
 func (s *service) Save(ctx context.Context, session Session) (Session, error) {
@@ -201,6 +213,7 @@ func (s *service) Save(ctx context.Context, session Session) (Session, error) {
 		return Session{}, err
 	}
 	estimatedUsage := session.EstimatedUsage
+	s.setEstimatedUsageState(session.ID, estimatedUsage)
 	session = s.fromDBItem(dbSession)
 	session.EstimatedUsage = estimatedUsage
 	s.Publish(pubsub.UpdatedEvent, session)
@@ -236,11 +249,34 @@ func (s *service) List(ctx context.Context) ([]Session, error) {
 	sessions := make([]Session, len(dbSessions))
 	for i, dbSession := range dbSessions {
 		sessions[i] = s.fromDBItem(dbSession)
+		s.applyEstimatedUsageState(&sessions[i])
 	}
 	return sessions, nil
 }
 
-func (s service) fromDBItem(item db.Session) Session {
+func (s *service) applyEstimatedUsageState(session *Session) {
+	s.estimatedUsageMu.RLock()
+	session.EstimatedUsage = s.estimatedUsage[session.ID]
+	s.estimatedUsageMu.RUnlock()
+}
+
+func (s *service) setEstimatedUsageState(sessionID string, estimatedUsage bool) {
+	s.estimatedUsageMu.Lock()
+	defer s.estimatedUsageMu.Unlock()
+	if estimatedUsage {
+		s.estimatedUsage[sessionID] = true
+		return
+	}
+	delete(s.estimatedUsage, sessionID)
+}
+
+func (s *service) clearEstimatedUsageState(sessionID string) {
+	s.estimatedUsageMu.Lock()
+	delete(s.estimatedUsage, sessionID)
+	s.estimatedUsageMu.Unlock()
+}
+
+func (s *service) fromDBItem(item db.Session) Session {
 	todos, err := unmarshalTodos(item.Todos.String)
 	if err != nil {
 		slog.Error("Failed to unmarshal todos", "session_id", item.ID, "error", err)
@@ -285,9 +321,10 @@ func unmarshalTodos(data string) ([]Todo, error) {
 func NewService(q *db.Queries, conn *sql.DB) Service {
 	broker := pubsub.NewBroker[Session]()
 	return &service{
-		Broker: broker,
-		db:     conn,
-		q:      q,
+		Broker:         broker,
+		db:             conn,
+		q:              q,
+		estimatedUsage: make(map[string]bool),
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -53,6 +53,7 @@ type Session struct {
 	MessageCount     int64
 	PromptTokens     int64
 	CompletionTokens int64
+	EstimatedUsage   bool
 	SummaryMessageID string
 	Cost             float64
 	Todos            []Todo
@@ -199,7 +200,9 @@ func (s *service) Save(ctx context.Context, session Session) (Session, error) {
 	if err != nil {
 		return Session{}, err
 	}
+	estimatedUsage := session.EstimatedUsage
 	session = s.fromDBItem(dbSession)
+	session.EstimatedUsage = estimatedUsage
 	s.Publish(pubsub.UpdatedEvent, session)
 	return session, nil
 }

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1,0 +1,81 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/db"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEstimatedUsageStateSurvivesFetchModifySave(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Cleanup(func() {
+		require.NoError(t, db.Release(dataDir))
+		db.ResetPool()
+	})
+
+	conn, err := db.Connect(t.Context(), dataDir)
+	require.NoError(t, err)
+
+	sessions := NewService(db.New(conn), conn)
+
+	created, err := sessions.Create(t.Context(), "test")
+	require.NoError(t, err)
+	created.PromptTokens = 100
+	created.CompletionTokens = 50
+	created.EstimatedUsage = true
+
+	saved, err := sessions.Save(t.Context(), created)
+	require.NoError(t, err)
+	require.True(t, saved.EstimatedUsage)
+
+	fetched, err := sessions.Get(t.Context(), created.ID)
+	require.NoError(t, err)
+	require.True(t, fetched.EstimatedUsage)
+
+	fetched.Todos = []Todo{{
+		Content:    "Check estimate state",
+		Status:     TodoStatusInProgress,
+		ActiveForm: "Checking estimate state",
+	}}
+
+	updated, err := sessions.Save(t.Context(), fetched)
+	require.NoError(t, err)
+	require.True(t, updated.EstimatedUsage)
+
+	refetched, err := sessions.Get(t.Context(), created.ID)
+	require.NoError(t, err)
+	require.True(t, refetched.EstimatedUsage)
+}
+
+func TestEstimatedUsageStateCanBeClearedByExplicitSave(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Cleanup(func() {
+		require.NoError(t, db.Release(dataDir))
+		db.ResetPool()
+	})
+
+	conn, err := db.Connect(t.Context(), dataDir)
+	require.NoError(t, err)
+
+	sessions := NewService(db.New(conn), conn)
+
+	created, err := sessions.Create(t.Context(), "test")
+	require.NoError(t, err)
+	created.PromptTokens = 100
+	created.CompletionTokens = 50
+	created.EstimatedUsage = true
+
+	saved, err := sessions.Save(t.Context(), created)
+	require.NoError(t, err)
+	require.True(t, saved.EstimatedUsage)
+
+	saved.EstimatedUsage = false
+	updated, err := sessions.Save(t.Context(), saved)
+	require.NoError(t, err)
+	require.False(t, updated.EstimatedUsage)
+
+	refetched, err := sessions.Get(t.Context(), created.ID)
+	require.NoError(t, err)
+	require.False(t, refetched.EstimatedUsage)
+}

--- a/internal/ui/common/elements.go
+++ b/internal/ui/common/elements.go
@@ -33,9 +33,10 @@ func FormatReasoningEffort(effort string) string {
 
 // ModelContextInfo contains token usage and cost information for a model.
 type ModelContextInfo struct {
-	ContextUsed  int64
-	ModelContext int64
-	Cost         float64
+	ContextUsed    int64
+	ModelContext   int64
+	Cost           float64
+	EstimatedUsage bool
 }
 
 // ModelInfo renders model information including name, provider, reasoning
@@ -74,7 +75,7 @@ func ModelInfo(t *styles.Styles, modelName, providerName, reasoningInfo string, 
 	}
 
 	if context != nil {
-		formattedInfo := formatTokensAndCost(t, context.ContextUsed, context.ModelContext, context.Cost)
+		formattedInfo := formatTokensAndCost(t, context.ContextUsed, context.ModelContext, context.Cost, context.EstimatedUsage)
 		parts = append(parts, lipgloss.NewStyle().PaddingLeft(2).Render(formattedInfo))
 	}
 
@@ -92,7 +93,7 @@ func ModelInfo(t *styles.Styles, modelName, providerName, reasoningInfo string, 
 
 // formatTokensAndCost formats token usage and cost with appropriate units
 // (K/M) and percentage of context window.
-func formatTokensAndCost(t *styles.Styles, tokens, contextWindow int64, cost float64) string {
+func formatTokensAndCost(t *styles.Styles, tokens, contextWindow int64, cost float64, estimated bool) string {
 	var formattedTokens string
 	switch {
 	case tokens >= 1_000_000:
@@ -115,7 +116,11 @@ func formatTokensAndCost(t *styles.Styles, tokens, contextWindow int64, cost flo
 	formattedCost := t.ModelInfo.Cost.Render(fmt.Sprintf("$%.2f", cost))
 
 	formattedTokens = t.ModelInfo.TokenCount.Render(fmt.Sprintf("(%s)", formattedTokens))
-	formattedPercentage := t.ModelInfo.TokenPercentage.Render(fmt.Sprintf("%d%%", int(percentage)))
+	percentageText := fmt.Sprintf("%d%%", int(percentage))
+	if estimated {
+		percentageText = t.ModelInfo.EstimatedUsagePrefix.Render("~") + percentageText
+	}
+	formattedPercentage := t.ModelInfo.TokenPercentage.Render(percentageText)
 	formattedTokens = fmt.Sprintf("%s %s", formattedPercentage, formattedTokens)
 	if percentage > 80 {
 		formattedTokens = fmt.Sprintf("%s %s", styles.LSPWarningIcon, formattedTokens)

--- a/internal/ui/common/elements.go
+++ b/internal/ui/common/elements.go
@@ -118,7 +118,7 @@ func formatTokensAndCost(t *styles.Styles, tokens, contextWindow int64, cost flo
 	formattedTokens = t.ModelInfo.TokenCount.Render(fmt.Sprintf("(%s)", formattedTokens))
 	percentageText := fmt.Sprintf("%d%%", int(percentage))
 	if estimated {
-		percentageText = t.ModelInfo.EstimatedUsagePrefix.Render("~") + percentageText
+		percentageText = "~" + percentageText
 	}
 	formattedPercentage := t.ModelInfo.TokenPercentage.Render(percentageText)
 	formattedTokens = fmt.Sprintf("%s %s", formattedPercentage, formattedTokens)

--- a/internal/ui/common/elements_test.go
+++ b/internal/ui/common/elements_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/ui/styles"
@@ -13,11 +14,13 @@ func TestFormatTokensAndCostPrefixesEstimatedUsage(t *testing.T) {
 
 	sty := styles.CharmtonePantera()
 
-	actual := ansi.Strip(formatTokensAndCost(&sty, 120, 1000, 0, true))
+	rendered := formatTokensAndCost(&sty, 120, 1000, 0, true)
+	actual := ansi.Strip(rendered)
 
 	require.Contains(t, actual, "~12%")
 	require.Contains(t, actual, "(120)")
 	require.Contains(t, actual, "$0.00")
+	require.True(t, strings.Contains(rendered, sty.ModelInfo.TokenPercentage.Render("~12%")))
 }
 
 func TestFormatTokensAndCostOmitsEstimatedPrefix(t *testing.T) {

--- a/internal/ui/common/elements_test.go
+++ b/internal/ui/common/elements_test.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatTokensAndCostPrefixesEstimatedUsage(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+
+	actual := ansi.Strip(formatTokensAndCost(&sty, 120, 1000, 0, true))
+
+	require.Contains(t, actual, "~12%")
+	require.Contains(t, actual, "(120)")
+	require.Contains(t, actual, "$0.00")
+}
+
+func TestFormatTokensAndCostOmitsEstimatedPrefix(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+
+	actual := ansi.Strip(formatTokensAndCost(&sty, 120, 1000, 0, false))
+
+	require.Contains(t, actual, "12%")
+	require.NotContains(t, actual, "~12%")
+}

--- a/internal/ui/model/header.go
+++ b/internal/ui/model/header.go
@@ -149,7 +149,7 @@ func renderHeaderDetails(
 		percentage := (float64(session.CompletionTokens+session.PromptTokens) / float64(model.ContextWindow)) * 100
 		percentageText := fmt.Sprintf("%d%%", int(percentage))
 		if session.EstimatedUsage {
-			percentageText = t.ModelInfo.EstimatedUsagePrefix.Render("~") + percentageText
+			percentageText = "~" + percentageText
 		}
 		formattedPercentage := t.Header.Percentage.Render(percentageText)
 		parts = append(parts, formattedPercentage)

--- a/internal/ui/model/header.go
+++ b/internal/ui/model/header.go
@@ -147,7 +147,11 @@ func renderHeaderDetails(
 	model := com.Config().GetModelByType(agentCfg.Model)
 	if model != nil && model.ContextWindow > 0 {
 		percentage := (float64(session.CompletionTokens+session.PromptTokens) / float64(model.ContextWindow)) * 100
-		formattedPercentage := t.Header.Percentage.Render(fmt.Sprintf("%d%%", int(percentage)))
+		percentageText := fmt.Sprintf("%d%%", int(percentage))
+		if session.EstimatedUsage {
+			percentageText = t.ModelInfo.EstimatedUsagePrefix.Render("~") + percentageText
+		}
+		formattedPercentage := t.Header.Percentage.Render(percentageText)
 		parts = append(parts, formattedPercentage)
 	}
 

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -44,9 +44,10 @@ func (m *UI) modelInfo(width int) string {
 	var modelContext *common.ModelContextInfo
 	if model != nil && m.session != nil {
 		modelContext = &common.ModelContextInfo{
-			ContextUsed:  m.session.CompletionTokens + m.session.PromptTokens,
-			Cost:         m.session.Cost,
-			ModelContext: model.CatwalkCfg.ContextWindow,
+			ContextUsed:    m.session.CompletionTokens + m.session.PromptTokens,
+			Cost:           m.session.Cost,
+			ModelContext:   model.CatwalkCfg.ContextWindow,
+			EstimatedUsage: m.session.EstimatedUsage,
 		}
 	}
 	var modelName string

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -763,7 +763,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.ModelInfo.Reasoning = lipgloss.NewStyle().Foreground(o.fgMostSubtle).PaddingLeft(2)
 	s.ModelInfo.TokenCount = lipgloss.NewStyle().Foreground(o.fgMostSubtle)
 	s.ModelInfo.TokenPercentage = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)
-	s.ModelInfo.EstimatedUsagePrefix = lipgloss.NewStyle().Foreground(o.fgBase)
+	s.ModelInfo.EstimatedUsagePrefix = s.ModelInfo.TokenPercentage
 	s.ModelInfo.Cost = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)
 	s.ModelInfo.HypercreditIcon = lipgloss.NewStyle().Foreground(charmtone.Dolly)
 	s.ModelInfo.HypercreditText = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -763,6 +763,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.ModelInfo.Reasoning = lipgloss.NewStyle().Foreground(o.fgMostSubtle).PaddingLeft(2)
 	s.ModelInfo.TokenCount = lipgloss.NewStyle().Foreground(o.fgMostSubtle)
 	s.ModelInfo.TokenPercentage = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)
+	s.ModelInfo.EstimatedUsagePrefix = lipgloss.NewStyle().Foreground(o.fgBase)
 	s.ModelInfo.Cost = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)
 	s.ModelInfo.HypercreditIcon = lipgloss.NewStyle().Foreground(charmtone.Dolly)
 	s.ModelInfo.HypercreditText = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -183,16 +183,17 @@ type Styles struct {
 
 	// ModelInfo (model name, provider, reasoning, token/cost summary)
 	ModelInfo struct {
-		Icon             lipgloss.Style // Model icon (◇)
-		Name             lipgloss.Style // Model name text
-		Provider         lipgloss.Style // "via <provider>" text
-		ProviderFallback lipgloss.Style // Provider on its own second line
-		Reasoning        lipgloss.Style // Reasoning effort text
-		TokenCount       lipgloss.Style // "(42K)" token count
-		TokenPercentage  lipgloss.Style // "42%" percent of context window
-		Cost             lipgloss.Style // "$0.42" cost readout
-		HypercreditIcon  lipgloss.Style // Hypercredit icon (◆)
-		HypercreditText  lipgloss.Style // Remaining Hypercredits text
+		Icon                 lipgloss.Style // Model icon (◇)
+		Name                 lipgloss.Style // Model name text
+		Provider             lipgloss.Style // "via <provider>" text
+		ProviderFallback     lipgloss.Style // Provider on its own second line
+		Reasoning            lipgloss.Style // Reasoning effort text
+		TokenCount           lipgloss.Style // "(42K)" token count
+		TokenPercentage      lipgloss.Style // "42%" percent of context window
+		EstimatedUsagePrefix lipgloss.Style // "~" prefix for estimated usage
+		Cost                 lipgloss.Style // "$0.42" cost readout
+		HypercreditIcon      lipgloss.Style // Hypercredit icon (◆)
+		HypercreditText      lipgloss.Style // Remaining Hypercredits text
 	}
 
 	// Resource styles the LSP/MCP/skills sidebar lists: their heading,


### PR DESCRIPTION
This closes #2891 to handle broken openai-compat providers that don't set `usage.total_tokens` in their streaming responses by estimating the number of tokens used. This fixes the issue of sessions having zero idea of how much context they've used by estimating the number of tokens.

This PR also adds a new orange tilde to indicate that the token count is an estimate in such circumstances:

<img width="419" height="144" alt="image" src="https://github.com/user-attachments/assets/c6b58de5-4163-47c4-af3a-eb4299b3b3ec" />

An alternative fix was sent in by @taciturnaxolotl (#2894) at about the same time as I was about to send this one in.

I'm sending this in anyway to offer two options to the maintainers to pick from.

I asked GPT-5.5 to compare the two, this is what it said:

<details>

## Comparison

- **PR #2894** is a minimal fix: it estimates only completion tokens from response text when usage is missing. It is small and easy to review, but incomplete.
- **This branch** is a fuller accounting fix: it estimates prompt tokens from the actual prepared messages, completion tokens from assistant text/reasoning/tool calls, avoids fake cost/telemetry, preserves counters when usage is absent/partial, and adds targeted tests.

## Better approach

**This branch is better technically** because issue #2891 is about context usage, and context usage needs both prompt and completion accounting. PR #2894 only increments completion tokens, so long sessions with large prompts/tool results can still badly underreport context and delay summarization.

## Main tradeoff

PR #2894 is simpler and lower-risk for merge conflicts, but it imports `internal/skills` into `internal/agent`, has no tests, can still add estimated usage into cost/telemetry paths, and misses tool/reasoning/prompt content. This branch is larger, but it solves the root problem more correctly and defensively.

</details>

## AI Disclosure

This PR used a mixture of GPT-5.5, Opus 4.7, and Kimi K2.6 with 2 rounds of reviews.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
