### PR TITLE
feat: show Desc in permission dialog for all tool types

### DIFF
--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -463,6 +463,9 @@ func (p *Permissions) renderHeader(contentWidth int) string {
 			lines = append(lines, p.renderKeyValue("URL", params.URL, contentWidth))
 			lines = append(lines, p.renderKeyValue("File", fsext.PrettyPath(params.FilePath), contentWidth))
 		}
+		if p.permission.Description != "" {
+			lines = append(lines, p.renderKeyValue("Desc", p.permission.Description, contentWidth))
+		}
 	case tools.EditToolName, tools.WriteToolName, tools.MultiEditToolName, tools.ViewToolName:
 		var filePath string
 		switch params := p.permission.Params.(type) {
@@ -478,9 +481,15 @@ func (p *Permissions) renderHeader(contentWidth int) string {
 		if filePath != "" {
 			lines = append(lines, p.renderKeyValue("File", fsext.PrettyPath(filePath), contentWidth))
 		}
+		if p.permission.Description != "" {
+			lines = append(lines, p.renderKeyValue("Desc", p.permission.Description, contentWidth))
+		}
 	case tools.LSToolName:
 		if params, ok := p.permission.Params.(tools.LSPermissionsParams); ok {
 			lines = append(lines, p.renderKeyValue("Directory", fsext.PrettyPath(params.Path), contentWidth))
+		}
+		if p.permission.Description != "" {
+			lines = append(lines, p.renderKeyValue("Desc", p.permission.Description, contentWidth))
 		}
 	}
 


### PR DESCRIPTION
# Motivation

The permission popup currently shows `Desc` only for the Bash tool. For Edit, Write, MultiEdit, View, LS, and Download tools the `Description` field was already being populated on `PermissionRequest` but never rendered — leaving users unable to see why the tool is being called without the dialog obscuring the conversation context.

### All Changes

- **Updated:** `internal/ui/dialog/permissions.go` — render `Desc` row in permission dialog for Edit/Write/MultiEdit/View, LS, and Download tool cases, matching existing Bash behaviour