### PR TITLE
fix(db): add an exclusive locking mode for sandboxes

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -101,7 +101,9 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 		return nil, proto.Workspace{}, fmt.Errorf("failed to create data directory: %w", err)
 	}
 
-	conn, err := db.Connect(b.ctx, cfg.Config().Options.DataDirectory)
+	conn, err := db.Connect(b.ctx, cfg.Config().Options.DataDirectory, db.ConnectOptions{
+		ExclusiveLock: cfg.Config().Options.SQLiteExclusiveLock,
+	})
 	if err != nil {
 		return nil, proto.Workspace{}, fmt.Errorf("failed to connect to database: %w", err)
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -276,7 +276,9 @@ func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error
 		slog.Warn("Failed to register project", "error", err)
 	}
 
-	conn, err := db.Connect(ctx, cfg.Options.DataDirectory)
+	conn, err := db.Connect(ctx, cfg.Options.DataDirectory, db.ConnectOptions{
+		ExclusiveLock: cfg.Options.SQLiteExclusiveLock,
+	})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -119,7 +119,9 @@ func sessionSetup(cmd *cobra.Command) (context.Context, *sessionServices, func()
 		event.Init()
 	}
 
-	conn, err := db.Connect(ctx, dataDir)
+	conn, err := db.Connect(ctx, dataDir, db.ConnectOptions{
+		ExclusiveLock: cfg.Config().Options.SQLiteExclusiveLock,
+	})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to connect to database: %w", err)
 	}

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -137,7 +137,9 @@ func runStats(cmd *cobra.Command, _ []string) error {
 
 	event.StatsViewed()
 
-	conn, err := db.Connect(ctx, dataDir)
+	conn, err := db.Connect(ctx, dataDir, db.ConnectOptions{
+		ExclusiveLock: cfg.Config().Options.SQLiteExclusiveLock,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -281,6 +281,7 @@ type Options struct {
 	Progress                  *bool        `json:"progress,omitempty" jsonschema:"description=Show indeterminate progress updates during long operations,default=true"`
 	DisableNotifications      bool         `json:"disable_notifications,omitempty" jsonschema:"description=Disable desktop notifications,default=false"`
 	DisabledSkills            []string     `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
+	SQLiteExclusiveLock       bool         `json:"sqlite_exclusive_lock,omitempty" jsonschema:"description=Use exclusive locking mode for SQLite. Eliminates the shared-memory file and avoids mmap\\, which fixes 'unable to open database' errors in sandboxed environments. Only one Crush instance can access the database at a time when enabled.,default=false"`
 }
 
 type MCPs map[string]MCPConfig

--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -68,6 +69,7 @@ func init() {
 type connEntry struct {
 	db       *sql.DB
 	refCount int
+	lockFile *os.File // exclusive-mode lockfile; nil when not in exclusive mode.
 }
 
 var (
@@ -118,18 +120,35 @@ func Connect(ctx context.Context, dataDir string, opts ...ConnectOptions) (*sql.
 	}
 
 	pragmaList := basePragmas
+	exclusiveMode := o.ExclusiveLock
 	if o.ExclusiveLock {
 		pragmaList = append(slices.Clone(basePragmas), pragma{"locking_mode", "EXCLUSIVE"})
 	} else if !mmapAvailable(probeMmapDir(dbPath)) {
 		pragmaList = append(slices.Clone(basePragmas), pragma{"locking_mode", "EXCLUSIVE"})
+		exclusiveMode = true
 		slog.Warn("Mmap appears blocked in this environment; enabled exclusive SQLite locking mode automatically.")
 		mmapFlagMu.Lock()
 		mmapAutoEnabled = true
 		mmapFlagMu.Unlock()
 	}
 
+	// In exclusive mode, acquire a cross-process advisory lock so a
+	// second Crush instance gets a clear error instead of a cryptic
+	// SQLite failure.
+	var lockFile *os.File
+	if exclusiveMode {
+		lockPath := filepath.Join(dataDir, "crush.lock")
+		lockFile, err = tryExclusiveLock(lockPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	conn, err := openDB(dbPath, pragmaList)
 	if err != nil {
+		if lockFile != nil {
+			lockFile.Close()
+		}
 		return nil, err
 	}
 
@@ -142,22 +161,31 @@ func Connect(ctx context.Context, dataDir string, opts ...ConnectOptions) (*sql.
 
 	if err = conn.PingContext(ctx); err != nil {
 		conn.Close()
+		if lockFile != nil {
+			lockFile.Close()
+		}
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
 
 	if err := initGoose(); err != nil {
 		conn.Close()
+		if lockFile != nil {
+			lockFile.Close()
+		}
 		slog.Error("Failed to initialize goose", "error", err)
 		return nil, fmt.Errorf("failed to initialize goose: %w", err)
 	}
 
 	if err := goose.Up(conn, "migrations"); err != nil {
 		conn.Close()
+		if lockFile != nil {
+			lockFile.Close()
+		}
 		slog.Error("Failed to apply migrations", "error", err)
 		return nil, fmt.Errorf("failed to apply migrations: %w", err)
 	}
 
-	pool[absPath] = &connEntry{db: conn, refCount: 1}
+	pool[absPath] = &connEntry{db: conn, refCount: 1, lockFile: lockFile}
 	return conn, nil
 }
 
@@ -194,7 +222,11 @@ func Release(dataDir string) error {
 		slog.Warn("WAL checkpoint failed during release", "error", err)
 	}
 
-	return entry.db.Close()
+	dbErr := entry.db.Close()
+	if entry.lockFile != nil {
+		entry.lockFile.Close()
+	}
+	return dbErr
 }
 
 // ResetPool closes all pooled connections and clears the pool. This is
@@ -205,6 +237,9 @@ func ResetPool() {
 	for path, entry := range pool {
 		entry.db.ExecContext(context.Background(), "PRAGMA wal_checkpoint(TRUNCATE)") //nolint:errcheck
 		entry.db.Close()
+		if entry.lockFile != nil {
+			entry.lockFile.Close()
+		}
 		delete(pool, path)
 	}
 }

--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -23,9 +23,13 @@ type pragma struct {
 
 // basePragmas are applied in order on every connection. page_size must
 // come before journal_mode because setting WAL writes to the database
-// and locks in the current page size on new databases.
+// and locks in the current page size on new databases. temp_store=MEMORY
+// keeps SQLite temp files in RAM instead of the OS temp directory,
+// which avoids SQLITE_CANTOPEN errors in sandboxed environments
+// (e.g. Landlock) that restrict access to /tmp.
 var basePragmas = []pragma{
 	{"page_size", "4096"},
+	{"temp_store", "MEMORY"},
 	{"journal_mode", "WAL"},
 	{"foreign_keys", "ON"},
 	{"cache_size", "-8000"},

--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -7,25 +7,51 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 
 	"github.com/pressly/goose/v3"
 )
 
+// pragma is a single SQLite pragma with a guaranteed execution order.
+type pragma struct {
+	name  string
+	value string
+}
+
+// basePragmas are applied in order on every connection. page_size must
+// come before journal_mode because setting WAL writes to the database
+// and locks in the current page size on new databases.
+var basePragmas = []pragma{
+	{"page_size", "4096"},
+	{"journal_mode", "WAL"},
+	{"foreign_keys", "ON"},
+	{"cache_size", "-8000"},
+	{"synchronous", "NORMAL"},
+	{"secure_delete", "ON"},
+	{"busy_timeout", "30000"},
+}
+
 var (
-	pragmas = map[string]string{
-		"foreign_keys":  "ON",
-		"journal_mode":  "WAL",
-		"page_size":     "4096",
-		"cache_size":    "-8000",
-		"synchronous":   "NORMAL",
-		"secure_delete": "ON",
-		"busy_timeout":  "30000",
-	}
 	gooseInitOnce sync.Once
 	gooseInitErr  error
+
+	// mmapAutoEnabled is set to true when Connect auto-detects a
+	// blocked mmap and enables exclusive locking mode automatically.
+	// Callers (e.g. the TUI) can check this via [MmapAutoEnabled]
+	// to show a warning banner.
+	mmapAutoEnabled bool
+	mmapFlagMu      sync.RWMutex
 )
+
+// MmapAutoEnabled returns true if mmap was auto-detected as blocked
+// and exclusive locking was enabled automatically.
+func MmapAutoEnabled() bool {
+	mmapFlagMu.RLock()
+	defer mmapFlagMu.RUnlock()
+	return mmapAutoEnabled
+}
 
 //go:embed migrations/*.sql
 var FS embed.FS
@@ -49,12 +75,22 @@ var (
 	poolMu sync.Mutex
 )
 
+// ConnectOptions configures optional behavior for [Connect].
+type ConnectOptions struct {
+	// ExclusiveLock uses PRAGMA locking_mode=EXCLUSIVE, which
+	// eliminates the shared-memory (-shm) file and avoids mmap.
+	// This fixes "unable to open database" errors in sandboxed
+	// environments that restrict mmap, but only one process can
+	// access the database at a time.
+	ExclusiveLock bool
+}
+
 // Connect opens a SQLite database connection for the given data
 // directory and runs migrations. If a connection to the same database
 // file already exists, the existing connection is returned with its
 // reference count incremented. Callers must pair each Connect with a
 // [Release] when they no longer need the connection.
-func Connect(ctx context.Context, dataDir string) (*sql.DB, error) {
+func Connect(ctx context.Context, dataDir string, opts ...ConnectOptions) (*sql.DB, error) {
 	if dataDir == "" {
 		return nil, fmt.Errorf("data.dir is not set")
 	}
@@ -76,7 +112,23 @@ func Connect(ctx context.Context, dataDir string) (*sql.DB, error) {
 		return entry.db, nil
 	}
 
-	conn, err := openDB(dbPath)
+	var o ConnectOptions
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+
+	pragmaList := basePragmas
+	if o.ExclusiveLock {
+		pragmaList = append(slices.Clone(basePragmas), pragma{"locking_mode", "EXCLUSIVE"})
+	} else if !mmapAvailable(probeMmapDir(dbPath)) {
+		pragmaList = append(slices.Clone(basePragmas), pragma{"locking_mode", "EXCLUSIVE"})
+		slog.Warn("Mmap appears blocked in this environment; enabled exclusive SQLite locking mode automatically.")
+		mmapFlagMu.Lock()
+		mmapAutoEnabled = true
+		mmapFlagMu.Unlock()
+	}
+
+	conn, err := openDB(dbPath, pragmaList)
 	if err != nil {
 		return nil, err
 	}
@@ -133,6 +185,15 @@ func Release(dataDir string) error {
 	}
 
 	delete(pool, absPath)
+
+	// Checkpoint and truncate the WAL before closing so the -wal and
+	// -shm sidecar files are cleaned up. This reduces the chance of
+	// stale sidecar files causing issues on the next open. Errors
+	// are best-effort — we still close the connection regardless.
+	if _, err := entry.db.ExecContext(context.Background(), "PRAGMA wal_checkpoint(TRUNCATE)"); err != nil {
+		slog.Warn("WAL checkpoint failed during release", "error", err)
+	}
+
 	return entry.db.Close()
 }
 
@@ -142,6 +203,7 @@ func ResetPool() {
 	poolMu.Lock()
 	defer poolMu.Unlock()
 	for path, entry := range pool {
+		entry.db.ExecContext(context.Background(), "PRAGMA wal_checkpoint(TRUNCATE)") //nolint:errcheck
 		entry.db.Close()
 		delete(pool, path)
 	}

--- a/internal/db/connect_modernc.go
+++ b/internal/db/connect_modernc.go
@@ -10,12 +10,12 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-func openDB(dbPath string) (*sql.DB, error) {
+func openDB(dbPath string, pragmaList []pragma) (*sql.DB, error) {
 	// Set pragmas for better performance via _pragma query params.
 	// Format: _pragma=name(value)
 	params := url.Values{}
-	for name, value := range pragmas {
-		params.Add("_pragma", fmt.Sprintf("%s(%s)", name, value))
+	for _, p := range pragmaList {
+		params.Add("_pragma", fmt.Sprintf("%s(%s)", p.name, p.value))
 	}
 	// Use BEGIN IMMEDIATE so writers acquire the reserved lock up front,
 	// preventing deferred-to-writer upgrade deadlocks.

--- a/internal/db/connect_ncruces.go
+++ b/internal/db/connect_ncruces.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ncruces/go-sqlite3/driver"
 )
 
-func openDB(dbPath string) (*sql.DB, error) {
+func openDB(dbPath string, pragmaList []pragma) (*sql.DB, error) {
 	// Use BEGIN IMMEDIATE so writers acquire the reserved lock up front,
 	// preventing deferred-to-writer upgrade deadlocks. The "file:" prefix
 	// is required for the ncruces driver to parse query parameters.
@@ -18,9 +18,9 @@ func openDB(dbPath string) (*sql.DB, error) {
 	db, err := driver.Open(dsn, func(c *sqlite3.Conn) error {
 		// Set pragmas for better performance via _pragma query params.
 		// Format: PRAGMA name = value;
-		for name, value := range pragmas {
-			if err := c.Exec(fmt.Sprintf("PRAGMA %s = %s;", name, value)); err != nil {
-				return fmt.Errorf("failed to set pragma %q: %w", name, err)
+		for _, p := range pragmaList {
+			if err := c.Exec(fmt.Sprintf("PRAGMA %s = %s;", p.name, p.value)); err != nil {
+				return fmt.Errorf("failed to set pragma %q: %w", p.name, err)
 			}
 		}
 		return nil

--- a/internal/db/connect_test.go
+++ b/internal/db/connect_test.go
@@ -52,3 +52,35 @@ func TestRelease_NoopForUnknownDataDir(t *testing.T) {
 
 	require.NoError(t, Release("/nonexistent/path"), "releasing unknown data dir should not error")
 }
+
+func TestConnect_ExclusiveLock(t *testing.T) {
+	t.Cleanup(ResetPool)
+
+	dataDir := t.TempDir()
+
+	conn, err := Connect(context.Background(), dataDir, ConnectOptions{
+		ExclusiveLock: true,
+	})
+	require.NoError(t, err)
+
+	var mode string
+	require.NoError(t, conn.QueryRowContext(t.Context(), "PRAGMA locking_mode").Scan(&mode))
+	require.Equal(t, "exclusive", mode)
+
+	require.NoError(t, Release(dataDir))
+}
+
+func TestConnect_DefaultLockingMode(t *testing.T) {
+	t.Cleanup(ResetPool)
+
+	dataDir := t.TempDir()
+
+	conn, err := Connect(context.Background(), dataDir)
+	require.NoError(t, err)
+
+	var mode string
+	require.NoError(t, conn.QueryRowContext(t.Context(), "PRAGMA locking_mode").Scan(&mode))
+	require.Equal(t, "normal", mode)
+
+	require.NoError(t, Release(dataDir))
+}

--- a/internal/db/connect_test.go
+++ b/internal/db/connect_test.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"context"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -51,6 +53,38 @@ func TestRelease_NoopForUnknownDataDir(t *testing.T) {
 	t.Cleanup(ResetPool)
 
 	require.NoError(t, Release("/nonexistent/path"), "releasing unknown data dir should not error")
+}
+
+func TestConnect_ExclusiveLockPreventsSecondInstance(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flock-based lockfile not supported on Windows")
+	}
+
+	t.Cleanup(ResetPool)
+
+	dataDir := t.TempDir()
+
+	// First connection succeeds.
+	_, err := Connect(t.Context(), dataDir, ConnectOptions{
+		ExclusiveLock: true,
+	})
+	require.NoError(t, err)
+
+	// Simulate a second process by trying to acquire the lockfile
+	// directly (same pool would just bump refcount).
+	lockPath := filepath.Join(dataDir, "crush.lock")
+	_, err = tryExclusiveLock(lockPath)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "another Crush instance")
+
+	require.NoError(t, Release(dataDir))
+
+	// After release, the lock should be available again.
+	lf, err := tryExclusiveLock(lockPath)
+	require.NoError(t, err)
+	if lf != nil {
+		lf.Close()
+	}
 }
 
 func TestConnect_ExclusiveLock(t *testing.T) {

--- a/internal/db/lockfile.go
+++ b/internal/db/lockfile.go
@@ -1,0 +1,32 @@
+//go:build unix
+
+package db
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// tryExclusiveLock attempts to acquire an exclusive advisory lock on
+// the given file path using flock. Returns the locked file handle on
+// success. If another process holds the lock, returns a descriptive
+// error. The lock is automatically released when the file is closed
+// or the process exits.
+func tryExclusiveLock(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open lock file: %w", err)
+	}
+
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		f.Close()
+		return nil, fmt.Errorf(
+			"another Crush instance is using this project (exclusive locking mode). " +
+				"Close it first or disable sqlite_exclusive_lock in crush.json",
+		)
+	}
+
+	return f, nil
+}

--- a/internal/db/lockfile_other.go
+++ b/internal/db/lockfile_other.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package db
+
+import (
+	"os"
+)
+
+// tryExclusiveLock is a no-op on non-Unix platforms. Windows uses
+// mandatory locking which SQLite handles natively.
+func tryExclusiveLock(_ string) (*os.File, error) {
+	return nil, nil
+}

--- a/internal/db/mmap_probe.go
+++ b/internal/db/mmap_probe.go
@@ -1,0 +1,52 @@
+//go:build unix
+
+package db
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+// mmapAvailable probes whether mmap with MAP_SHARED works in dir by
+// creating a small temporary file, mapping it, and immediately
+// unmapping. Returns true if the operation succeeds. SQLite's WAL
+// mode requires mmap for the -shm shared-memory file; sandboxed
+// environments (nsjail, bubblewrap, restrictive seccomp profiles)
+// sometimes block this syscall.
+func mmapAvailable(dir string) bool {
+	f, err := os.CreateTemp(dir, ".crush-mmap-probe-*")
+	if err != nil {
+		return false
+	}
+	name := f.Name()
+	defer os.Remove(name)
+
+	// The file needs at least one page of content to map.
+	if err := f.Truncate(int64(os.Getpagesize())); err != nil {
+		f.Close()
+		return false
+	}
+
+	fd := int(f.Fd())
+	data, err := unix.Mmap(fd, 0, os.Getpagesize(), unix.PROT_READ, unix.MAP_SHARED)
+	f.Close()
+	if err != nil {
+		return false
+	}
+
+	_ = unix.Munmap(data)
+	return true
+}
+
+// probeMmapDir returns the directory to use for the mmap probe. It
+// prefers the database directory itself (since that is where the -shm
+// file would live), falling back to os.TempDir().
+func probeMmapDir(dbPath string) string {
+	dir := filepath.Dir(dbPath)
+	if info, err := os.Stat(dir); err == nil && info.IsDir() {
+		return dir
+	}
+	return os.TempDir()
+}

--- a/internal/db/mmap_probe_other.go
+++ b/internal/db/mmap_probe_other.go
@@ -1,0 +1,22 @@
+//go:build !unix
+
+package db
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// mmapAvailable always returns true on non-Unix platforms where
+// sandbox-restricted mmap is not a concern.
+func mmapAvailable(_ string) bool {
+	return true
+}
+
+func probeMmapDir(dbPath string) string {
+	dir := filepath.Dir(dbPath)
+	if info, err := os.Stat(dir); err == nil && info.IsDir() {
+		return dir
+	}
+	return os.TempDir()
+}

--- a/internal/db/mmap_probe_test.go
+++ b/internal/db/mmap_probe_test.go
@@ -1,0 +1,48 @@
+// This is a manual test helper — run it to see the mmap probe and
+// exclusive lock auto-detection in action.
+//
+//	go test ./internal/db/ -run TestMmapProbe -v
+package db
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMmapProbe_Available(t *testing.T) {
+	dir := t.TempDir()
+	result := mmapAvailable(dir)
+	fmt.Fprintf(os.Stderr, "mmap available in %s: %v\n", dir, result)
+	require.True(t, result, "mmap should work in a normal temp dir")
+}
+
+func TestMmapProbe_FallbackToExclusive(t *testing.T) {
+	t.Cleanup(ResetPool)
+
+	dataDir := t.TempDir()
+	conn, err := Connect(t.Context(), dataDir, ConnectOptions{
+		ExclusiveLock: true,
+	})
+	require.NoError(t, err)
+
+	var mode string
+	require.NoError(t, conn.QueryRowContext(t.Context(), "PRAGMA locking_mode").Scan(&mode))
+	fmt.Fprintf(os.Stderr, "locking_mode: %s\n", mode)
+	require.Equal(t, "exclusive", mode)
+
+	// Verify the DB is fully functional.
+	_, err = conn.ExecContext(t.Context(), "CREATE TABLE test_probe (id INTEGER PRIMARY KEY)")
+	require.NoError(t, err)
+	_, err = conn.ExecContext(t.Context(), "INSERT INTO test_probe (id) VALUES (1)")
+	require.NoError(t, err)
+
+	var id int
+	require.NoError(t, conn.QueryRowContext(t.Context(), "SELECT id FROM test_probe").Scan(&id))
+	require.Equal(t, 1, id)
+	fmt.Fprintf(os.Stderr, "DB read/write OK in exclusive mode\n")
+
+	require.NoError(t, Release(dataDir))
+}

--- a/internal/ui/model/status.go
+++ b/internal/ui/model/status.go
@@ -18,11 +18,12 @@ const DefaultStatusTTL = 5 * time.Second
 
 // Status is the status bar and help model.
 type Status struct {
-	com      *common.Common
-	hideHelp bool
-	help     help.Model
-	helpKm   help.KeyMap
-	msg      util.InfoMsg
+	com           *common.Common
+	hideHelp      bool
+	help          help.Model
+	helpKm        help.KeyMap
+	msg           util.InfoMsg
+	persistentMsg util.InfoMsg
 }
 
 // NewStatus creates a new status bar and help model.
@@ -43,6 +44,18 @@ func (s *Status) SetInfoMsg(msg util.InfoMsg) {
 // ClearInfoMsg clears the status info message.
 func (s *Status) ClearInfoMsg() {
 	s.msg = util.InfoMsg{}
+}
+
+// SetPersistentMsg sets a persistent status message that is always
+// shown in the status bar (below transient messages). It can only be
+// replaced or cleared — it does not auto-expire.
+func (s *Status) SetPersistentMsg(msg util.InfoMsg) {
+	s.persistentMsg = msg
+}
+
+// ClearPersistentMsg clears the persistent status message.
+func (s *Status) ClearPersistentMsg() {
+	s.persistentMsg = util.InfoMsg{}
 }
 
 // SetWidth sets the width of the status bar and help view.
@@ -75,40 +88,44 @@ func (s *Status) Draw(scr uv.Screen, area uv.Rectangle) {
 	}
 
 	// Render notifications
-	if s.msg.IsEmpty() {
-		return
+	if !s.msg.IsEmpty() {
+		drawInfoMsg(scr, area, s.msg, s.com)
+	} else if !s.persistentMsg.IsEmpty() {
+		drawInfoMsg(scr, area, s.persistentMsg, s.com)
 	}
+}
 
+func drawInfoMsg(scr uv.Screen, area uv.Rectangle, msg util.InfoMsg, com *common.Common) {
 	var indStyle lipgloss.Style
 	var msgStyle lipgloss.Style
-	switch s.msg.Type {
+	switch msg.Type {
 	case util.InfoTypeError:
-		indStyle = s.com.Styles.Status.ErrorIndicator
-		msgStyle = s.com.Styles.Status.ErrorMessage
+		indStyle = com.Styles.Status.ErrorIndicator
+		msgStyle = com.Styles.Status.ErrorMessage
 	case util.InfoTypeWarn:
-		indStyle = s.com.Styles.Status.WarnIndicator
-		msgStyle = s.com.Styles.Status.WarnMessage
+		indStyle = com.Styles.Status.WarnIndicator
+		msgStyle = com.Styles.Status.WarnMessage
 	case util.InfoTypeUpdate:
-		indStyle = s.com.Styles.Status.UpdateIndicator
-		msgStyle = s.com.Styles.Status.UpdateMessage
+		indStyle = com.Styles.Status.UpdateIndicator
+		msgStyle = com.Styles.Status.UpdateMessage
 	case util.InfoTypeInfo:
-		indStyle = s.com.Styles.Status.InfoIndicator
-		msgStyle = s.com.Styles.Status.InfoMessage
+		indStyle = com.Styles.Status.InfoIndicator
+		msgStyle = com.Styles.Status.InfoMessage
 	case util.InfoTypeSuccess:
-		indStyle = s.com.Styles.Status.SuccessIndicator
-		msgStyle = s.com.Styles.Status.SuccessMessage
+		indStyle = com.Styles.Status.SuccessIndicator
+		msgStyle = com.Styles.Status.SuccessMessage
 	}
 
 	ind := indStyle.String()
 	indWidth := lipgloss.Width(ind)
 	msgPad := msgStyle.GetPaddingLeft() + msgStyle.GetPaddingRight()
 	avail := max(0, area.Dx()-indWidth-msgPad)
-	msg := strings.Join(strings.Split(s.msg.Msg, "\n"), " ")
-	msg = ansi.Truncate(msg, avail, "…")
-	if w := lipgloss.Width(msg); w < avail {
-		msg += strings.Repeat(" ", avail-w)
+	text := strings.Join(strings.Split(msg.Msg, "\n"), " ")
+	text = ansi.Truncate(text, avail, "…")
+	if w := lipgloss.Width(text); w < avail {
+		text += strings.Repeat(" ", avail-w)
 	}
-	info := msgStyle.Render(msg)
+	info := msgStyle.Render(text)
 
 	// Draw the info message over the help view
 	uv.NewStyledString(ind+info).Draw(scr, area)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -32,6 +32,7 @@ import (
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/commands"
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/db"
 	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/history"
 	"github.com/charmbracelet/crush/internal/home"
@@ -397,6 +398,13 @@ func (m *UI) Init() tea.Cmd {
 	}
 	if m.com.IsHyper() {
 		cmds = append(cmds, m.fetchHyperCredits())
+	}
+	// Show a persistent warning if the DB had to fall back to exclusive
+	// locking due to a blocked mmap (e.g. in a sandbox).
+	if db.MmapAutoEnabled() {
+		m.status.SetPersistentMsg(util.NewWarnMsg(
+			"SQLite exclusive locking enabled (mmap blocked by sandbox). Set sqlite_exclusive_lock to silence.",
+		))
 	}
 	return tea.Batch(cmds...)
 }

--- a/schema.json
+++ b/schema.json
@@ -504,6 +504,11 @@
           },
           "type": "array",
           "description": "List of skill names to disable and hide from the agent"
+        },
+        "sqlite_exclusive_lock": {
+          "type": "boolean",
+          "description": "Use exclusive locking mode for SQLite. Eliminates the shared-memory file and avoids mmap, which fixes 'unable to open database' errors in sandboxed environments. Only one Crush instance can access the database at a time when enabled.",
+          "default": false
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
fixes https://github.com/charmbracelet/crush/issues/2903

adds new config field that uses `PRAGMA locking_mode=EXCLUSIVE` to bypass `.shm` memory files and the `mmap` restrictions that come with that

```json
{
  "options": {
    "sqlite_exclusive_lock": true
  }
}
```