### PR TITLE
feat(mcp): MCP Toggle UI, persisted config

### DIFF
--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -31,6 +31,15 @@ func (b *Backend) SetConfigField(workspaceID string, scope config.Scope, key str
 	return ws.Cfg.SetConfigField(scope, key, value)
 }
 
+// SetConfigFields sets multiple key/value pairs in the config file.
+func (b *Backend) SetConfigFields(workspaceID string, scope config.Scope, kv map[string]any) error {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return err
+	}
+	return ws.Cfg.SetConfigFields(scope, kv)
+}
+
 // RemoveConfigField removes a key from the config file for the given
 // scope.
 func (b *Backend) RemoveConfigField(workspaceID string, scope config.Scope, key string) error {
@@ -211,4 +220,20 @@ func (b *Backend) GetWorkingDir(workspaceID string) (string, error) {
 		return "", err
 	}
 	return ws.Cfg.WorkingDir(), nil
+}
+
+func (b *Backend) MCPInitializeSingle(ctx context.Context, workspaceID string, name string) error {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return err
+	}
+	return mcptools.InitializeSingle(ctx, name, ws.Cfg)
+}
+
+func (b *Backend) MCPDisableSingle(workspaceID string, name string) error {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return err
+	}
+	return mcptools.DisableSingle(ws.Cfg, name)
 }

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/charmbracelet/crush/internal/proto"
 )
 
 // SetConfigField sets a config key/value pair on the server.
@@ -23,6 +24,21 @@ func (c *Client) SetConfigField(ctx context.Context, id string, scope config.Sco
 	defer rsp.Body.Close()
 	if rsp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to set config field: status code %d", rsp.StatusCode)
+	}
+	return nil
+}
+
+func (c *Client) SetConfigFields(ctx context.Context, id string, scope config.Scope, kv map[string]any) error {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/config/set-bulk", id), nil, jsonBody(struct {
+		Scope config.Scope   `json:"scope"`
+		KV    map[string]any `json:"kv"`
+	}{Scope: scope, KV: kv}), http.Header{"Content-Type": []string{"application/json"}})
+	if err != nil {
+		return err
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to set config fields: status %d", rsp.StatusCode)
 	}
 	return nil
 }
@@ -275,4 +291,32 @@ func (c *Client) GetMCPPrompt(ctx context.Context, id, clientID, promptID string
 		return "", fmt.Errorf("failed to decode MCP prompt response: %w", err)
 	}
 	return result.Prompt, nil
+}
+
+func (c *Client) MCPInitializeSingle(ctx context.Context, id string, name string) error {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/mcp/initialize-single", id), nil,
+		jsonBody(proto.MCPNameRequest{Name: name}),
+		http.Header{"Content-Type": []string{"application/json"}})
+	if err != nil {
+		return err
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to initialize MCP: status %d", rsp.StatusCode)
+	}
+	return nil
+}
+
+func (c *Client) MCPDisableSingle(ctx context.Context, id string, name string) error {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/mcp/disable-single", id), nil,
+		jsonBody(proto.MCPNameRequest{Name: name}),
+		http.Header{"Content-Type": []string{"application/json"}})
+	if err != nil {
+		return err
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to disable MCP: status %d", rsp.StatusCode)
+	}
+	return nil
 }

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/proto"
 )
 
@@ -33,6 +34,41 @@ func (c *controllerV1) handlePostWorkspaceConfigSet(w http.ResponseWriter, r *ht
 		c.handleError(w, r, err)
 		return
 	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// handlePostWorkspaceConfigSetBulk sets multiple configuration fields at once.
+//
+//	@Summary		Bulk set config fields
+//	@Tags			config
+//	@Accept			json
+//	@Param			id		path	string	true	"Workspace ID"
+//	@Param			request	body	object	true	"Bulk config set request (expects Scope and KV map)"
+//	@Success		200
+//	@Failure		400	{object}	proto.Error
+//	@Failure		404	{object}	proto.Error
+//	@Failure		500	{object}	proto.Error
+//	@Router			/workspaces/{id}/config/set-bulk [post]
+func (c *controllerV1) handlePostWorkspaceConfigSetBulk(w http.ResponseWriter, r *http.Request) {
+	workspaceID := r.PathValue("id") // Use the ID from the path
+
+	var req struct {
+		Scope config.Scope   `json:"scope"`
+		KV    map[string]any `json:"kv"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		c.server.logError(r, "Failed to decode bulk config request", "error", err)
+		jsonError(w, http.StatusBadRequest, "failed to decode request")
+		return
+	}
+
+	// Call the method we just added to the backend
+	if err := c.backend.SetConfigFields(workspaceID, req.Scope, req.KV); err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -463,5 +499,57 @@ func (c *controllerV1) handlePostWorkspaceMCPRefreshResources(w http.ResponseWri
 	}
 
 	c.backend.MCPRefreshResources(r.Context(), id, req.Name)
+	w.WriteHeader(http.StatusOK)
+}
+
+// handlePostWorkspaceMCPInitializeSingle initializes a single MCP server.
+//
+//	@Summary		Initialize MCP server
+//	@Tags			mcp
+//	@Accept			json
+//	@Param			id		path	string					true	"Workspace ID"
+//	@Param			request	body	proto.MCPNameRequest	true	"MCP name request"
+//	@Success		200
+//	@Failure		400	{object}	proto.Error
+//	@Failure		404	{object}	proto.Error
+//	@Failure		500	{object}	proto.Error
+//	@Router			/workspaces/{id}/mcp/initialize-single [post]
+func (c *controllerV1) handlePostWorkspaceMCPInitializeSingle(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var req proto.MCPNameRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "invalid request")
+		return
+	}
+	if err := c.backend.MCPInitializeSingle(r.Context(), id, req.Name); err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// handlePostWorkspaceMCPDisableSingle disables a single MCP server.
+//
+//	@Summary		Disable MCP server
+//	@Tags			mcp
+//	@Accept			json
+//	@Param			id		path	string					true	"Workspace ID"
+//	@Param			request	body	proto.MCPNameRequest	true	"MCP name request"
+//	@Success		200
+//	@Failure		400	{object}	proto.Error
+//	@Failure		404	{object}	proto.Error
+//	@Failure		500	{object}	proto.Error
+//	@Router			/workspaces/{id}/mcp/disable-single [post]
+func (c *controllerV1) handlePostWorkspaceMCPDisableSingle(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var req proto.MCPNameRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, http.StatusBadRequest, "invalid request")
+		return
+	}
+	if err := c.backend.MCPDisableSingle(id, req.Name); err != nil {
+		c.handleError(w, r, err)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -148,6 +148,7 @@ func NewServer(cfg *config.ConfigStore, network, address string) *Server {
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent/sessions/{sid}/summarize", c.handlePostWorkspaceAgentSessionSummarize)
 	mux.HandleFunc("GET /v1/workspaces/{id}/agent/default-small-model", c.handleGetWorkspaceAgentDefaultSmallModel)
 	mux.HandleFunc("POST /v1/workspaces/{id}/config/set", c.handlePostWorkspaceConfigSet)
+	mux.HandleFunc("POST /v1/workspaces/{id}/config/set-bulk", c.handlePostWorkspaceConfigSetBulk)
 	mux.HandleFunc("POST /v1/workspaces/{id}/config/remove", c.handlePostWorkspaceConfigRemove)
 	mux.HandleFunc("POST /v1/workspaces/{id}/config/model", c.handlePostWorkspaceConfigModel)
 	mux.HandleFunc("POST /v1/workspaces/{id}/config/compact", c.handlePostWorkspaceConfigCompact)
@@ -165,6 +166,8 @@ func NewServer(cfg *config.ConfigStore, network, address string) *Server {
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-resources", c.handlePostWorkspaceMCPRefreshResources)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/docker/enable", c.handlePostWorkspaceMCPEnableDocker)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/docker/disable", c.handlePostWorkspaceMCPDisableDocker)
+	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/initialize-single", c.handlePostWorkspaceMCPInitializeSingle)
+	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/disable-single", c.handlePostWorkspaceMCPDisableSingle)
 	mux.Handle("/v1/docs/", httpswagger.WrapHandler)
 	s.h = &http.Server{
 		Protocols: &p,

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -85,6 +85,16 @@ type (
 	ActionEnableDockerMCP struct{}
 	// ActionDisableDockerMCP is a message to disable Docker MCP.
 	ActionDisableDockerMCP struct{}
+
+	// ActionToggleMCPServer is a message to toggle a specific MCP server.
+	ActionToggleMCPServer struct {
+		Name    string
+		Enabled bool
+	}
+	// ActionToggleAllMCPServers is a message to toggle all MCP servers.
+	ActionToggleAllMCPServers struct {
+		Enable bool
+	}
 )
 
 // Messages for API key input dialog.

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -527,6 +527,11 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		NewCommandItem(c.com.Styles, "quit", "Quit", "ctrl+c", tea.QuitMsg{}).WithAliases("exit"),
 	)
 
+	// Add the MCP Toggle option
+	if len(c.com.Config().MCP) > 0 {
+		commands = append(commands, NewCommandItem(c.com.Styles, "toggle_mcp", "Toggle MCP Servers", "", ActionOpenDialog{DialogID: MCPToggleID}))
+	}
+
 	return commands
 }
 

--- a/internal/ui/dialog/mcp_toggle.go
+++ b/internal/ui/dialog/mcp_toggle.go
@@ -1,0 +1,164 @@
+// internal/ui/dialog/mcp_toggle.go
+package dialog
+
+import (
+	"sort"
+
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/list"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/sahilm/fuzzy"
+)
+
+const MCPToggleID = "mcp_toggle"
+
+type MCPToggle struct {
+	com    *common.Common
+	help   help.Model
+	list   *list.FilterableList
+	keyMap struct {
+		Toggle,
+		ToggleAll,
+		Next,
+		Previous,
+		Close key.Binding
+	}
+}
+
+type MCPItem struct {
+	name    string
+	enabled bool
+	t       *styles.Styles
+	m       fuzzy.Match
+	cache   map[int]string
+	focused bool
+}
+
+func NewMCPToggle(com *common.Common) *MCPToggle {
+	m := &MCPToggle{com: com}
+	m.help = help.New()
+	m.help.Styles = com.Styles.DialogHelpStyles()
+
+	m.list = list.NewFilterableList()
+	m.list.Focus()
+
+	m.keyMap.Toggle = key.NewBinding(
+		key.WithKeys("enter", " ", "ctrl+y"),
+		key.WithHelp("enter/space", "toggle"),
+	)
+	m.keyMap.ToggleAll = key.NewBinding(
+		key.WithKeys("t"),
+		key.WithHelp("t", "toggle all"),
+	)
+	m.keyMap.Next = key.NewBinding(
+		key.WithKeys("down", "j"),
+		key.WithHelp("↓/j", "next"),
+	)
+	m.keyMap.Previous = key.NewBinding(
+		key.WithKeys("up", "k"),
+		key.WithHelp("↑/k", "prev"),
+	)
+	m.keyMap.Close = CloseKey
+
+	m.RefreshItems()
+	return m
+}
+
+func (m *MCPToggle) ID() string { return MCPToggleID }
+
+func (m *MCPToggle) RefreshItems() {
+	cfg := m.com.Config()
+	var items []list.FilterableItem
+
+	// Sort keys for stable display
+	keys := make([]string, 0, len(cfg.MCP))
+	for name := range cfg.MCP {
+		keys = append(keys, name)
+	}
+	sort.Strings(keys)
+
+	for _, name := range keys {
+		c := cfg.MCP[name]
+		items = append(items, &MCPItem{
+			name:    name,
+			enabled: !c.Disabled,
+			t:       m.com.Styles,
+		})
+	}
+	m.list.SetItems(items...)
+}
+
+func (m *MCPToggle) HandleMsg(msg tea.Msg) Action {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, m.keyMap.Close):
+			return ActionClose{}
+		case key.Matches(msg, m.keyMap.Next):
+			m.list.SelectNext()
+		case key.Matches(msg, m.keyMap.Previous):
+			m.list.SelectPrev()
+		case key.Matches(msg, m.keyMap.Toggle):
+			if item, ok := m.list.SelectedItem().(*MCPItem); ok {
+				return ActionToggleMCPServer{Name: item.name, Enabled: !item.enabled}
+			}
+		case key.Matches(msg, m.keyMap.ToggleAll):
+			anyEnabled := false
+			for _, item := range m.list.FilteredItems() {
+				if i, ok := item.(*MCPItem); ok && i.enabled {
+					anyEnabled = true
+					break
+				}
+			}
+			return ActionToggleAllMCPServers{Enable: !anyEnabled}
+		}
+	}
+	return nil
+}
+
+func (m *MCPToggle) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	t := m.com.Styles
+	width := min(60, area.Dx()-4)
+	height := min(15, area.Dy()-4)
+
+	innerWidth := width - t.Dialog.View.GetHorizontalFrameSize()
+	m.list.SetSize(innerWidth, height-6)
+
+	rc := NewRenderContext(t, width)
+	rc.Title = "Toggle MCP Servers"
+	rc.AddPart(t.Dialog.List.Render(m.list.Render()))
+	rc.Help = m.help.View(m)
+
+	DrawCenter(scr, area, rc.Render())
+	return nil
+}
+
+func (m *MCPToggle) ShortHelp() []key.Binding {
+	return []key.Binding{m.keyMap.Toggle, m.keyMap.ToggleAll, m.keyMap.Close}
+}
+
+func (m *MCPToggle) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{m.keyMap.Next, m.keyMap.Previous, m.keyMap.Toggle, m.keyMap.ToggleAll, m.keyMap.Close}}
+}
+
+// MCPItem implementation
+func (i *MCPItem) ID() string             { return i.name }
+func (i *MCPItem) Filter() string         { return i.name }
+func (i *MCPItem) SetFocused(f bool)      { i.focused = f; i.cache = nil }
+func (i *MCPItem) SetMatch(m fuzzy.Match) { i.m = m; i.cache = nil }
+func (i *MCPItem) Render(width int) string {
+	status := i.t.Resource.StatusText.Render("Disabled")
+	if i.enabled {
+		status = i.t.Tool.IconSuccess.Render("Enabled")
+	}
+
+	styles := ListItemStyles{
+		ItemBlurred: i.t.Dialog.NormalItem,
+		ItemFocused: i.t.Dialog.SelectedItem,
+	}
+	return renderItem(styles, i.name, status, i.focused, width, i.cache, &i.m)
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1337,6 +1337,10 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 	// Open dialog message.
 	case dialog.ActionOpenDialog:
 		m.dialog.CloseDialog(dialog.CommandsID)
+		if msg.DialogID == dialog.MCPToggleID {
+			m.dialog.OpenDialog(dialog.NewMCPToggle(m.com))
+			return nil
+		}
 		if cmd := m.openDialog(msg.DialogID); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
@@ -1499,6 +1503,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			return util.NewInfoMsg("Reasoning effort set to " + msg.Effort)
 		})
 		m.dialog.CloseDialog(dialog.ReasoningID)
+
 	case dialog.ActionPermissionResponse:
 		m.dialog.CloseDialog(dialog.PermissionsID)
 		switch msg.Action {
@@ -1557,6 +1562,65 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			break
 		}
 		cmds = append(cmds, m.runMCPPrompt(msg.ClientID, msg.PromptID, msg.Args))
+	case dialog.ActionToggleMCPServer:
+		return func() tea.Msg {
+			ctx := context.Background()
+
+			// Update persistent config
+			key := fmt.Sprintf("mcp.%s.disabled", msg.Name)
+			if err := m.com.Workspace.SetConfigField(config.ScopeGlobal, key, !msg.Enabled); err != nil {
+				return util.ReportError(err)()
+			}
+
+			// Update runtime process state
+			if msg.Enabled {
+				_ = m.com.Workspace.MCPInitializeSingle(ctx, msg.Name)
+			} else {
+				_ = m.com.Workspace.MCPDisableSingle(msg.Name)
+			}
+
+			// Re-init agent to pick up/remove tools
+			_ = m.com.Workspace.UpdateAgentModel(ctx)
+
+			// Refresh the dialog list
+			if d, ok := m.dialog.Dialog(dialog.MCPToggleID).(*dialog.MCPToggle); ok {
+				d.RefreshItems()
+			}
+
+			// Manually trigger the state refresh for the sidebar/landing view
+			// handleStateChanged returns mcpStateChangedMsg which UI.Update uses to update m.mcpStates
+			return m.handleStateChanged()()
+		}
+
+	case dialog.ActionToggleAllMCPServers:
+		return func() tea.Msg {
+			ctx := context.Background()
+			cfg := m.com.Config()
+			kv := make(map[string]any)
+
+			for name := range cfg.MCP {
+				kv[fmt.Sprintf("mcp.%s.disabled", name)] = !msg.Enable
+				if msg.Enable {
+					_ = m.com.Workspace.MCPInitializeSingle(ctx, name)
+				} else {
+					_ = m.com.Workspace.MCPDisableSingle(name)
+				}
+			}
+
+			if err := m.com.Workspace.SetConfigFields(config.ScopeGlobal, kv); err != nil {
+				return util.ReportError(err)()
+			}
+
+			_ = m.com.Workspace.UpdateAgentModel(ctx)
+
+			if d, ok := m.dialog.Dialog(dialog.MCPToggleID).(*dialog.MCPToggle); ok {
+				d.RefreshItems()
+			}
+
+			// Manually trigger the state refresh for the sidebar
+			return m.handleStateChanged()()
+		}
+
 	default:
 		cmds = append(cmds, util.CmdHandler(msg))
 	}

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -272,6 +272,10 @@ func (w *AppWorkspace) SetConfigField(scope config.Scope, key string, value any)
 	return w.store.SetConfigField(scope, key, value)
 }
 
+func (w *AppWorkspace) SetConfigFields(scope config.Scope, kv map[string]any) error {
+	return w.store.SetConfigFields(scope, kv)
+}
+
 func (w *AppWorkspace) RemoveConfigField(scope config.Scope, key string) error {
 	return w.store.RemoveConfigField(scope, key)
 }
@@ -363,6 +367,14 @@ func (w *AppWorkspace) DisableDockerMCP() error {
 		return fmt.Errorf("failed to disable docker MCP: %w", err)
 	}
 	return w.store.DisableDockerMCP()
+}
+
+func (w *AppWorkspace) MCPInitializeSingle(ctx context.Context, name string) error {
+	return mcptools.InitializeSingle(ctx, name, w.store)
+}
+
+func (w *AppWorkspace) MCPDisableSingle(name string) error {
+	return mcptools.DisableSingle(w.store, name)
 }
 
 // -- Lifecycle --

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -424,7 +424,15 @@ func (w *ClientWorkspace) SetProviderAPIKey(scope config.Scope, providerID strin
 }
 
 func (w *ClientWorkspace) SetConfigField(scope config.Scope, key string, value any) error {
-	err := w.client.SetConfigField(context.Background(), w.workspaceID(), scope, key, value)
+	err := w.client.SetConfigField(context.Background(), w.ws.ID, scope, key, value)
+	if err == nil {
+		w.refreshWorkspace()
+	}
+	return err
+}
+
+func (w *ClientWorkspace) SetConfigFields(scope config.Scope, kv map[string]any) error {
+	err := w.client.SetConfigFields(context.Background(), w.ws.ID, scope, kv)
 	if err == nil {
 		w.refreshWorkspace()
 	}
@@ -432,7 +440,7 @@ func (w *ClientWorkspace) SetConfigField(scope config.Scope, key string, value a
 }
 
 func (w *ClientWorkspace) RemoveConfigField(scope config.Scope, key string) error {
-	err := w.client.RemoveConfigField(context.Background(), w.workspaceID(), scope, key)
+	err := w.client.RemoveConfigField(context.Background(), w.ws.ID, scope, key)
 	if err == nil {
 		w.refreshWorkspace()
 	}
@@ -535,6 +543,15 @@ func (w *ClientWorkspace) EnableDockerMCP(ctx context.Context) error {
 
 func (w *ClientWorkspace) DisableDockerMCP() error {
 	return w.client.DisableDockerMCP(context.Background(), w.workspaceID())
+}
+
+func (w *ClientWorkspace) MCPInitializeSingle(ctx context.Context, name string) error {
+	return w.client.MCPInitializeSingle(ctx, w.workspaceID(), name)
+}
+
+func (w *ClientWorkspace) MCPDisableSingle(name string) error {
+	// Use background context for disable to ensure it completes during shutdown/toggles
+	return w.client.MCPDisableSingle(context.Background(), w.workspaceID(), name)
 }
 
 // -- Lifecycle --

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -119,6 +119,7 @@ type Workspace interface {
 	SetCompactMode(scope config.Scope, enabled bool) error
 	SetProviderAPIKey(scope config.Scope, providerID string, apiKey any) error
 	SetConfigField(scope config.Scope, key string, value any) error
+	SetConfigFields(scope config.Scope, kv map[string]any) error
 	RemoveConfigField(scope config.Scope, key string) error
 	ImportCopilot() (*oauth.Token, bool)
 	RefreshOAuthToken(ctx context.Context, scope config.Scope, providerID string) error
@@ -137,6 +138,10 @@ type Workspace interface {
 	GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error)
 	EnableDockerMCP(ctx context.Context) error
 	DisableDockerMCP() error
+
+	// MCP operations
+	MCPInitializeSingle(ctx context.Context, name string) error
+	MCPDisableSingle(name string) error
 
 	// Events
 	Subscribe(program *tea.Program)


### PR DESCRIPTION

<img width="1305" height="561" alt="Screenshot_20260513_221437" src="https://github.com/user-attachments/assets/d1ecbc1b-8d71-48fc-b84d-c6fe3a2747d8" />


A discussion exists here https://github.com/charmbracelet/crush/discussions/1603

This PR would be lighter without the persistent but I find it useful?

It is also refreshing the MCP status in the sidebar or landing page.

Mostly AI generated (Gemini)