### PR TITLE
perf: remove hot-path slog.Info from SSE event delivery

### DIFF
--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -179,7 +179,6 @@ func (c *Client) SubscribeEvents(ctx context.Context, id string) (<-chan any, er
 }
 
 func sendEvent(ctx context.Context, evc chan any, ev any) {
-	slog.Info("Event received", "event", fmt.Sprintf("%T %+v", ev, ev))
 	select {
 	case evc <- ev:
 	case <-ctx.Done():

--- a/internal/server/proto.go
+++ b/internal/server/proto.go
@@ -218,7 +218,6 @@ func (c *controllerV1) handleGetWorkspaceEvents(w http.ResponseWriter, r *http.R
 			if !ok {
 				return
 			}
-			c.server.logDebug(r, "Sending event", "event", fmt.Sprintf("%T %+v", ev.Payload, ev.Payload))
 			wrapped := wrapEvent(ev.Payload)
 			if wrapped == nil {
 				continue


### PR DESCRIPTION

## Summary

- Removes `slog.Info` + eager `fmt.Sprintf("%+v")` in `sendEvent` (client/proto.go) that fired for every SSE event, serializing full payloads at Info level
- Removes `logDebug` with eager `fmt.Sprintf("%+v")` in the SSE handler (server/proto.go) that allocated even when debug logging was disabled

During LLM streaming this caused hundreds of allocations/sec per connected client, resulting in multi-second input lag when multiple clients were connected to the same server.

## Test plan

- [x] Verified build passes
- [x] Verified all tests pass
- [x] Tested with 2 concurrent client instances — second instance is now responsive