### PR TITLE
fix(shell): ensure canceling a command stops all child processes

### DIFF
--- a/internal/shell/background.go
+++ b/internal/shell/background.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -17,6 +18,13 @@ const (
 	MaxBackgroundJobs = 50
 	// CompletedJobRetentionMinutes is how long to keep completed jobs before auto-cleanup (8 hours)
 	CompletedJobRetentionMinutes = 8 * 60
+	// KillGracePeriod bounds how long Kill waits for a cancelled shell's
+	// goroutine to exit. With the process-group exec handler in place,
+	// the goroutine should unwind almost immediately on cancellation;
+	// this is a safety net for the pathological cases (children in
+	// uninterruptible sleep, a wedge inside the interpreter) so a tool
+	// call can never block indefinitely on job_kill.
+	KillGracePeriod = 5 * time.Second
 )
 
 // syncBuffer is a thread-safe wrapper around bytes.Buffer.
@@ -143,7 +151,17 @@ func (m *BackgroundShellManager) Remove(id string) error {
 	return nil
 }
 
-// Kill terminates a background shell by ID.
+// Kill terminates a background shell by ID. It cancels the shell's
+// context and waits up to [KillGracePeriod] for the goroutine to unwind.
+// In the steady state — where every external command runs in its own
+// process group via the standard exec handler — cancellation reaches the
+// underlying process(es) immediately and the wait returns in
+// milliseconds. The grace-period fallback exists for the long tail:
+// children stuck in uninterruptible kernel sleeps, a wedge somewhere in
+// mvdan's interpreter, or a misbehaving builtin. In those cases we
+// abandon the tracking entry so callers (job_kill, KillAll) never block
+// indefinitely; the orphan goroutine will exit on its own when its
+// blocking syscall finally returns.
 func (m *BackgroundShellManager) Kill(id string) error {
 	shell, ok := m.shells.Take(id)
 	if !ok {
@@ -151,8 +169,17 @@ func (m *BackgroundShellManager) Kill(id string) error {
 	}
 
 	shell.cancel()
-	<-shell.done
-	return nil
+	select {
+	case <-shell.done:
+		return nil
+	case <-time.After(KillGracePeriod):
+		slog.Warn("Background shell did not exit within grace period; abandoning",
+			"id", id,
+			"command", shell.Command,
+			"grace_period", KillGracePeriod,
+		)
+		return nil
+	}
 }
 
 // BackgroundShellInfo contains information about a background shell.

--- a/internal/shell/background_test.go
+++ b/internal/shell/background_test.go
@@ -116,6 +116,32 @@ func TestBackgroundShellManager_KillNonExistent(t *testing.T) {
 	}
 }
 
+// TestBackgroundShellManager_Kill_Timeout asserts that Kill returns in
+// bounded time. With process-group cancellation in place the normal-case
+// return is well under KillGracePeriod; this test exists as a regression
+// guard against the prior unbounded `<-shell.done` wait, so the upper
+// bound is "KillGracePeriod plus a small wall-clock fudge" rather than
+// the 60s sleep the command would otherwise run for.
+func TestBackgroundShellManager_Kill_Timeout(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	manager := newBackgroundShellManager()
+
+	bgShell, err := manager.Start(t.Context(), workingDir, nil, "trap '' TERM INT; sleep 60", "")
+	require.NoError(t, err)
+
+	// Give the trap builtin time to register before we cancel.
+	time.Sleep(100 * time.Millisecond)
+
+	start := time.Now()
+	err = manager.Kill(bgShell.ID)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.Less(t, elapsed, KillGracePeriod+2*time.Second)
+}
+
 func TestBackgroundShell_IsDone(t *testing.T) {
 	t.Parallel()
 

--- a/internal/shell/dispatch.go
+++ b/internal/shell/dispatch.go
@@ -168,9 +168,11 @@ func isBinary(probe []byte) bool {
 }
 
 // dispatchShebang parses probe's shebang line and execs the resolved
-// interpreter via os/exec, inheriting the parent runner's cwd, env, and
-// stdio. Returns interp.ExitStatus on non-zero interpreter exit so the
-// parent interpreter sees it as a normal non-zero status.
+// interpreter via [runExternal], inheriting the parent runner's cwd,
+// env, and stdio. argv is built per kernel shebang convention: the
+// interpreter's own args, then the script path, then the caller's
+// trailing args. Cancellation handling (process group + SIGINT-then-
+// SIGKILL) is shared with the bare-command path through runExternal.
 func dispatchShebang(ctx context.Context, scriptPath string, probe []byte, args []string) error {
 	sb, err := parseShebang(probe)
 	if err != nil {
@@ -186,30 +188,17 @@ func dispatchShebang(ctx context.Context, scriptPath string, probe []byte, args 
 		return interp.ExitStatus(127)
 	}
 
-	cmdArgs := append([]string{}, sb.args...)
-	cmdArgs = append(cmdArgs, scriptPath)
-	cmdArgs = append(cmdArgs, args[1:]...)
+	// argv[0] is the interpreter so the spawned program sees its own
+	// invocation path the same way the kernel would set it for a real
+	// `#!` exec. Trailing user args follow the script path, mirroring
+	// kernel single-arg semantics already encoded by parseShebang.
+	argv := make([]string, 0, len(sb.args)+1+len(args))
+	argv = append(argv, interpreter)
+	argv = append(argv, sb.args...)
+	argv = append(argv, scriptPath)
+	argv = append(argv, args[1:]...)
 
-	cmd := exec.CommandContext(ctx, interpreter, cmdArgs...)
-	hc := interp.HandlerCtx(ctx)
-	cmd.Dir = hc.Dir
-	cmd.Env = execEnvList(hc.Env)
-	cmd.Stdin = hc.Stdin
-	cmd.Stdout = hc.Stdout
-	cmd.Stderr = hc.Stderr
-
-	if err := cmd.Run(); err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			code := exitErr.ExitCode()
-			if code < 0 {
-				code = 1
-			}
-			return interp.ExitStatus(uint8(code))
-		}
-		return err
-	}
-	return nil
+	return runExternal(ctx, interpreter, argv)
 }
 
 // resolveInterpreter tries the literal shebang path first, then falls back

--- a/internal/shell/exec.go
+++ b/internal/shell/exec.go
@@ -1,0 +1,137 @@
+package shell
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"mvdan.cc/sh/v3/interp"
+)
+
+// processGroupExecHandler is the terminal middleware in the Crush exec
+// handler chain. It owns the final hop into os/exec for every external
+// command — bare or path-prefixed — so that on context cancellation we
+// can signal the entire process tree, not just the direct child.
+//
+// This intentionally replaces mvdan.cc/sh's [interp.DefaultExecHandler],
+// which uses exec.CommandContext + Process.Kill on the direct child only.
+// Without this replacement, commands like `git rebase --continue` that
+// fork an editor leak the editor when the tool call is cancelled. The
+// middleware is the last entry in [standardHandlers] and never invokes
+// next; mvdan's runtime auto-appends DefaultExecHandler after the user
+// chain, and that fallback is exactly what we are trying to displace.
+//
+// PATH resolution mirrors [interp.LookPathDir] (the same primitive
+// DefaultExecHandler uses), so users see identical resolution semantics
+// regardless of which handler runs the binary.
+func processGroupExecHandler() func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
+	return func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
+		return func(ctx context.Context, args []string) error {
+			if len(args) == 0 {
+				return next(ctx, args)
+			}
+			hc := interp.HandlerCtx(ctx)
+			path, err := interp.LookPathDir(hc.Dir, hc.Env, args[0])
+			if err != nil {
+				fmt.Fprintln(hc.Stderr, err)
+				return interp.ExitStatus(127)
+			}
+			return runExternal(ctx, path, args)
+		}
+	}
+}
+
+// runExternal launches path with the given argv under our process-group
+// cancellation regime. argv[0] is preserved as the visible program name
+// (matching how mvdan.cc/sh builds exec.Cmd); path is the already-resolved
+// absolute binary.
+//
+// Cancellation flow on Unix:
+//  1. context.AfterFunc fires when ctx is cancelled.
+//  2. We send SIGINT to the process group (-pid).
+//  3. After [killTimeout], we send SIGKILL to the process group.
+//
+// The two-stage signal lets well-behaved children clean up (close PTYs,
+// flush buffers) before the kernel mows them down. killTimeout is 0 on
+// platforms without SIGINT support; the closure collapses to a single
+// kill in that case.
+//
+// On normal completion, defer stops the AfterFunc so we never signal a
+// reaped pid.
+func runExternal(ctx context.Context, path string, args []string) error {
+	hc := interp.HandlerCtx(ctx)
+	cmd := exec.Cmd{
+		Path:   path,
+		Args:   args,
+		Env:    execEnvList(hc.Env),
+		Dir:    hc.Dir,
+		Stdin:  hc.Stdin,
+		Stdout: hc.Stdout,
+		Stderr: hc.Stderr,
+	}
+	prepareCmd(&cmd)
+
+	if err := cmd.Start(); err != nil {
+		// LookPathDir already validated existence, so a Start failure
+		// here is almost always a permission or fork error. Surface it
+		// the same way mvdan's DefaultExecHandler does — message on
+		// stderr, 127 exit code — to keep UX consistent with the case
+		// where LookPathDir itself fails.
+		fmt.Fprintln(hc.Stderr, err)
+		return interp.ExitStatus(127)
+	}
+
+	stopCancel := context.AfterFunc(ctx, func() {
+		if killTimeout <= 0 {
+			_ = killCmd(&cmd)
+			return
+		}
+		_ = interruptCmd(&cmd)
+		time.Sleep(killTimeout)
+		_ = killCmd(&cmd)
+	})
+	defer stopCancel()
+
+	waitErr := cmd.Wait()
+	return translateExitError(ctx, waitErr)
+}
+
+// translateExitError maps an exec.Cmd.Wait error into the form mvdan's
+// interpreter expects:
+//
+//   - nil           → nil
+//   - cancellation  → ctx.Err() (so callers can errors.Is for Canceled /
+//     DeadlineExceeded; matches IsInterrupt's contract)
+//   - non-zero exit → interp.ExitStatus(code), with signaled exits
+//     reported as 128 since we no longer have signal-specific info on
+//     all platforms
+//   - other errors  → returned verbatim so the runner aborts
+//
+// The ctx.Err() check has to come first: when our AfterFunc kills the
+// process, Wait returns an ExitError whose ExitCode is -1 (signaled). We
+// want callers to see Canceled rather than a synthetic exit code, since
+// the synthetic code can't be distinguished from a genuine SIGINT the
+// user typed.
+func translateExitError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		code := exitErr.ExitCode()
+		if code < 0 {
+			// Signaled but ctx wasn't cancelled — e.g. the user sent
+			// SIGTERM from outside. Report a non-zero status so the
+			// interpreter sees failure, without claiming a specific
+			// signal number we no longer track.
+			code = 128
+		}
+		return interp.ExitStatus(uint8(code))
+	}
+	return err
+}

--- a/internal/shell/exec_unix_test.go
+++ b/internal/shell/exec_unix_test.go
@@ -1,0 +1,143 @@
+//go:build unix
+
+package shell
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestRun_CtxCancel_KillsProcessTree is the regression test for the
+// motivating bug ("cancel leaves orphaned editors / dev servers
+// running"). It exercises the exact shape the bug took:
+//
+//  1. A bare external command (no shebang dispatch, no path prefix) is
+//     run via the standard handler chain.
+//  2. That command forks a grandchild and waits on it.
+//  3. The caller cancels the context.
+//
+// With process-group isolation the grandchild dies along with its
+// parent. Without the fix, the kernel reparents the grandchild to PID 1
+// when the parent is killed and the grandchild keeps running. We probe
+// for liveness with kill(pid, 0) (ESRCH means gone) on a deadline that
+// includes killTimeout plus a small wall-clock fudge for the reaper.
+func TestRun_CtxCancel_KillsProcessTree(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pidfile := filepath.Join(dir, "child.pid")
+	scriptPath := filepath.Join(dir, "run.sh")
+
+	// /bin/sh runs as our external command; the inner `sleep` is its
+	// grandchild relative to the Crush process. Pre-fix, killing sh
+	// would leave that sleep orphaned. Use 600 so a leaked process is
+	// obviously a leak rather than racing the test's deadline.
+	script := fmt.Sprintf("sleep 600 & echo $! > %q\nwait\n", pidfile)
+	require := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	require(os.WriteFile(scriptPath, []byte(script), 0o600))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, RunOptions{
+			Command: "/bin/sh " + strconv.Quote(scriptPath),
+			Cwd:     dir,
+			Env:     os.Environ(),
+		})
+	}()
+
+	pid := waitForPIDFile(t, pidfile, 3*time.Second)
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil && !IsInterrupt(err) {
+			t.Fatalf("Run returned unexpected error: %v", err)
+		}
+	case <-time.After(killTimeout + 5*time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+
+	deadline := time.Now().Add(killTimeout + 3*time.Second)
+	for time.Now().Before(deadline) {
+		if err := unix.Kill(pid, 0); errors.Is(err, unix.ESRCH) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("grandchild pid %d still alive %v after cancel; the process group fix did not reach it", pid, killTimeout+3*time.Second)
+}
+
+// TestRun_CtxCancel_ReturnsContextErr verifies that a cancelled external
+// command surfaces ctx.Err() rather than a synthetic exit code. Callers
+// downstream (the bash tool, the agent loop, IsInterrupt) rely on
+// errors.Is(err, context.Canceled) to tell "user cancelled" apart from
+// "program exited with a signal".
+func TestRun_CtxCancel_ReturnsContextErr(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, RunOptions{
+			Command: "sleep 60",
+			Cwd:     t.TempDir(),
+			Env:     os.Environ(),
+		})
+	}()
+
+	// Give the sleep a chance to start before cancelling.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(killTimeout + 3*time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}
+
+// waitForPIDFile polls path until it contains a positive integer or the
+// timeout expires. The PID-file dance is the simplest way to learn the
+// PID of a grandchild spawned by an external command without plumbing
+// pipes through mvdan's interpreter.
+func waitForPIDFile(t *testing.T, path string, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			s := strings.TrimSpace(string(data))
+			if s != "" {
+				n, err := strconv.Atoi(s)
+				if err == nil && n > 0 {
+					return n
+				}
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("pidfile %s never contained a valid pid", path)
+	return 0
+}

--- a/internal/shell/process_other.go
+++ b/internal/shell/process_other.go
@@ -1,0 +1,37 @@
+//go:build !unix
+
+package shell
+
+import (
+	"os/exec"
+	"time"
+)
+
+// killTimeout is zero on non-Unix platforms because Go's os.Process.Kill
+// is the only portable termination primitive; there is no SIGINT analogue
+// to send first. Kept as a named constant so the call sites read the same
+// on all platforms.
+const killTimeout = 0 * time.Second
+
+// prepareCmd is a no-op outside Unix. True process-tree kill on Windows
+// requires JobObjects; that is out of scope here. The handler still
+// returns control to the caller on cancel, but grandchildren may survive.
+func prepareCmd(cmd *exec.Cmd) {}
+
+// interruptCmd is implemented as a hard kill on non-Unix because
+// os.Process.Signal(os.Interrupt) is not supported on Windows.
+func interruptCmd(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}
+
+// killCmd hard-kills the direct child. See prepareCmd for the
+// grandchild-leak caveat on Windows.
+func killCmd(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}

--- a/internal/shell/process_unix.go
+++ b/internal/shell/process_unix.go
@@ -1,0 +1,48 @@
+//go:build unix
+
+package shell
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// killTimeout is how long to wait after sending SIGINT before sending
+// SIGKILL when cancelling an external command. Matches mvdan.cc/sh's
+// DefaultExecHandler default so users see consistent grace periods
+// regardless of which path executed their command.
+const killTimeout = 2 * time.Second
+
+// prepareCmd configures cmd to run in its own process group so that on
+// cancellation we can signal the entire descendant tree, not just the
+// direct child. Without this, a child that fork+execs an editor (git
+// spawning vim, npm spawning a dev server, etc.) leaves the grandchild
+// reparented to PID 1 when we kill the child.
+func prepareCmd(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// interruptCmd sends SIGINT to the entire process group. The negative
+// PID is the kernel's way of saying "this PGID, not this PID". Safe to
+// call after Start; a no-op if the process is already reaped.
+func interruptCmd(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return unix.Kill(-cmd.Process.Pid, unix.SIGINT)
+}
+
+// killCmd sends SIGKILL to the entire process group. Same negative-PID
+// convention as interruptCmd.
+func killCmd(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return unix.Kill(-cmd.Process.Pid, unix.SIGKILL)
+}

--- a/internal/shell/run.go
+++ b/internal/shell/run.go
@@ -106,7 +106,10 @@ func newRunner(cwd string, env []string, stdin io.Reader, stdout, stderr io.Writ
 //     that deny rules see the already-resolved argv of anything the
 //     script exec's rather than the outer path-prefixed wrapper;
 //  3. block list;
-//  4. optional Go coreutils (only when useGoCoreUtils is on).
+//  4. optional Go coreutils (only when useGoCoreUtils is on);
+//  5. process-group exec (terminal handler). This replaces mvdan's
+//     DefaultExecHandler so every external command gets its own process
+//     group and is killed as a tree on ctx cancellation.
 func standardHandlers(blockFuncs []BlockFunc) []func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
 	handlers := []func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc{
 		builtinHandler(),
@@ -116,6 +119,7 @@ func standardHandlers(blockFuncs []BlockFunc) []func(next interp.ExecHandlerFunc
 	if useGoCoreUtils {
 		handlers = append(handlers, coreutils.ExecHandler)
 	}
+	handlers = append(handlers, processGroupExecHandler())
 	return handlers
 }
 


### PR DESCRIPTION
This revision makes cancelation possible at the shell level via exec-level middleware.

Supersedes #2865