### PR TITLE
fix(agent): retry stream on raw connection reset errors

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -267,7 +267,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 	if call.MaxOutputTokens > 0 {
 		maxOutputTokens = &call.MaxOutputTokens
 	}
-	result, err := agent.Stream(genCtx, fantasy.AgentStreamCall{
+	streamCall := fantasy.AgentStreamCall{
 		Prompt:           message.PromptWithTextAttachments(call.Prompt, call.Attachments),
 		Files:            files,
 		Messages:         history,
@@ -478,7 +478,35 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy
 				return hasRepeatedToolCalls(steps, loopDetectionWindowSize, loopDetectionMaxRepeats)
 			},
 		},
-	})
+	}
+
+	// Re-issue the stream call on raw transient network errors (e.g.
+	// "connection reset by peer") that fantasy's provider-level retry does
+	// not catch because they surface unwrapped. We only retry while
+	// currentAssistant is still nil — once PrepareStep runs we have
+	// committed state that re-streaming could duplicate. The loop is hard
+	// capped at transientMaxAttempts and respects ctx cancellation, so it
+	// cannot spin.
+	var result *fantasy.AgentResult
+retryLoop:
+	for attempt := 1; ; attempt++ {
+		result, err = agent.Stream(genCtx, streamCall)
+		if err == nil || attempt >= transientMaxAttempts || currentAssistant != nil || !isTransientNetErr(err) {
+			break
+		}
+		delay := time.Duration(attempt) * time.Second
+		slog.Warn("Transient network error before stream started; retrying",
+			"attempt", attempt,
+			"delay", delay,
+			"error", err,
+		)
+		select {
+		case <-time.After(delay):
+		case <-genCtx.Done():
+			err = genCtx.Err()
+			break retryLoop
+		}
+	}
 
 	a.eventPromptResponded(call.SessionID, time.Since(startTime).Truncate(time.Second))
 

--- a/internal/agent/transient.go
+++ b/internal/agent/transient.go
@@ -1,0 +1,46 @@
+package agent
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"syscall"
+)
+
+// transientMaxAttempts caps how many times a stream may be re-issued after a
+// transient network error. Total attempts = transientMaxAttempts (initial try
+// plus retries). Keep this small: fantasy already retries inside the provider
+// for the errors it understands, so this layer only catches the residual raw
+// network resets that surface unwrapped.
+const transientMaxAttempts = 3
+
+// isTransientNetErr reports whether err is a transient network failure that
+// is safe to retry at the agent layer. It covers the cases fantasy's own
+// retry logic misses: raw syscall-level connection resets and broken pipes
+// that surface unwrapped from the HTTP client when the provider tears down
+// the TCP connection mid-handshake or before any stream bytes arrive.
+//
+// The check is conservative on purpose. We only return true for errors that:
+//   - are not a context cancellation/deadline (those must propagate);
+//   - clearly indicate the peer closed the socket (ECONNRESET, EPIPE), or
+//     the stream ended before a complete response (io.ErrUnexpectedEOF);
+//   - or contain the canonical "connection reset by peer" substring as a
+//     defensive fallback for wrapped errors that lost their sentinel chain.
+func isTransientNetErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+	if errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	// Fallback: some HTTP/TLS stacks wrap the syscall error in a way that
+	// strips the sentinel by the time it reaches us. Match the canonical
+	// text Go uses for ECONNRESET on every supported platform.
+	return strings.Contains(err.Error(), "connection reset by peer")
+}

--- a/internal/agent/transient_test.go
+++ b/internal/agent/transient_test.go
@@ -1,0 +1,59 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsTransientNetErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"context canceled", context.Canceled, false},
+		{"deadline exceeded", context.DeadlineExceeded, false},
+		{"unrelated error", errors.New("something else"), false},
+
+		{"ECONNRESET sentinel", syscall.ECONNRESET, true},
+		{"EPIPE sentinel", syscall.EPIPE, true},
+		{"unexpected EOF", io.ErrUnexpectedEOF, true},
+
+		{
+			name: "wrapped ECONNRESET via net.OpError",
+			err: &net.OpError{
+				Op:  "read",
+				Net: "tcp",
+				Err: syscall.ECONNRESET,
+			},
+			want: true,
+		},
+		{
+			name: "fmt-wrapped ECONNRESET",
+			err:  fmt.Errorf("stream failed: %w", syscall.ECONNRESET),
+			want: true,
+		},
+		{
+			name: "text fallback only",
+			err:  errors.New("read tcp 1.2.3.4:443: connection reset by peer"),
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, isTransientNetErr(tc.err))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When the upstream model provider tears down the TCP connection mid-handshake
or before any stream bytes arrive, the error surfaces unwrapped from the
HTTP client (commonly as `read tcp ...: connection reset by peer`). Fantasy's
own retry layer only fires for errors it can cast to `*fantasy.ProviderError`
with `IsRetryable() == true`. A raw `syscall.ECONNRESET` never gets that
wrapping, so the session bombs out and the user has to re-prompt by hand.

## Before

1. Provider RSTs the TCP connection before the first SSE event.
2. `agent.Stream` returns `&net.OpError{Err: syscall.ECONNRESET}`.
3. Fantasy retry does nothing (not a `ProviderError`).
4. `Run` enters the error branch, writes a finish message, returns.
5. User sees "connection reset by peer" and must resend the prompt.

## After

1. Provider RSTs the TCP connection before the first SSE event.
2. `agent.Stream` returns the same raw error.
3. Agent layer checks `isTransientNetErr(err)` and `currentAssistant == nil`.
4. Both true → wait 1s, retry. Up to 2 retries (3 total attempts), 1s + 2s
   backoff worst case.
5. On success: stream proceeds normally. On exhaustion: surfaces the error
   through the existing error path unchanged.

## Why it's safe

- **No double execution.** Retry is gated on `currentAssistant == nil`.
  `currentAssistant` is set inside `PrepareStep`, which only runs once the
  request reaches the model. If a single byte of response arrived, we don't
  retry — we surface the error.
- **No infinite loop.** Hard cap of `transientMaxAttempts = 3`. Linear
  backoff. `genCtx.Done()` short-circuits the wait.
- **Conservative detector.** Only matches `syscall.ECONNRESET`, `syscall.EPIPE`,
  `io.ErrUnexpectedEOF`, or the canonical "connection reset by peer" text.
  Context cancellation and deadlines are explicitly excluded so user-cancel
  semantics are preserved.
- **No state pollution.** The user message is persisted before the loop;
  retries don't duplicate it. The title-generation goroutine is independent.
- **Complementary to fantasy's retry.** Wrapped `ProviderError`s with HTTP
  status retry continue to flow through fantasy's existing logic; this layer
  only fills the unwrapped-syscall-error gap.

## Test plan

- [x] `go test ./internal/agent/...` passes.
- [x] `go build ./...` clean.
- [x] `gofmt -l` and `goimports -l` clean on changed files.
- [x] New unit tests cover: nil, ctx errors, unrelated errors, raw sentinels
      (ECONNRESET, EPIPE, `io.ErrUnexpectedEOF`), `net.OpError`-wrapped
      sentinel, `fmt.Errorf`-wrapped sentinel, and text-only fallback.

## Files

- `internal/agent/transient.go` — `isTransientNetErr` + cap constant (new).
- `internal/agent/transient_test.go` — detector tests (new).
- `internal/agent/agent.go` — wrap `agent.Stream` in bounded retry loop.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).