### PR TITLE
fix(ci): force LF for diffview testdata fixtures on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,10 @@
 .github/crush-schema.json linguist-generated=true
 internal/agent/hyper/provider.json linguist-generated=true
 internal/agent/testdata/**/*.yaml -diff linguist-generated=true
+
+# Embedded test fixtures consumed by chroma syntax highlighting. Without
+# this, Windows checkouts with core.autocrlf=true convert these files to
+# CRLF, which makes the Go lexer mis-tokenize trailing braces and breaks
+# diffview golden tests at specific widths.
+internal/ui/diffview/testdata/*.before text eol=lf
+internal/ui/diffview/testdata/*.after  text eol=lf


### PR DESCRIPTION
## Problem

On Windows CI, `TestDiffViewWidth/Split/WidthOf082` fails with a golden
mismatch: the closing `}` renders red (`#d20f39`, the catppuccin-latte
keyword color) instead of grey (`#4c4f69`, the text color). Example:
https://github.com/charmbracelet/crush/actions/runs/25949037144/job/76283113121

## Root cause

The test embeds Go-source fixtures via `go:embed`:

```go
//go:embed testdata/TestMultipleHunks.before
var TestMultipleHunksBefore string
```

These `.before`/`.after` files have no entry in `.gitattributes`, so on
Windows checkouts with the default `core.autocrlf=true` they get
converted to CRLF on disk. Chroma's Go lexer then sees `}\r\n` at EOF
and tokenizes the trailing brace inconsistently — at most widths the
renderer still picks the text color, but at width 82 the layout boundary
exposes a token that's been classified as a keyword.

Linux and macOS check out with LF, so the issue is invisible there. The
golden files are already protected via `*.golden ... -text`, but the
source fixtures that feed chroma are not.

## Fix

Pin the embedded fixtures to LF in `.gitattributes`:

```
internal/ui/diffview/testdata/*.before text eol=lf
internal/ui/diffview/testdata/*.after  text eol=lf
```

This forces git to keep these files LF in the working tree on all
platforms, matching what's stored in the repo and what macOS / Linux
contributors already see.

## Test plan

- [x] `go test ./internal/ui/diffview/...` passes locally on macOS
      (baseline — was already passing).
- [x] `git check-attr eol internal/ui/diffview/testdata/*.before`
      reports `eol: lf` after the change.
- [ ] CI on Windows passes — to be verified by this PR's checks.

No code change, no behavior change on Linux/macOS, no golden
regeneration needed.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).