### PR TITLE
fix(ui): restore to-dos pill ui in client/server mode

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -668,7 +668,8 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		}
 	}()
 
-	agent := fantasy.NewAgent(largeModel.Model,
+	agent := fantasy.NewAgent(
+		largeModel.Model,
 		fantasy.WithSystemPrompt(string(summaryPrompt)),
 		fantasy.WithUserAgent(userAgent),
 	)
@@ -814,7 +815,8 @@ func (a *sessionAgent) preparePrompt(msgs []message.Message, supportsImages bool
 	var history []fantasy.Message
 	if !a.isSubAgent {
 		history = append(history, fantasy.NewUserMessage(
-			fmt.Sprintf("<system_reminder>%s</system_reminder>",
+			fmt.Sprintf(
+				"<system_reminder>%s</system_reminder>",
 				`This is a reminder that your todo list is currently empty. DO NOT mention this to the user explicitly because they are already aware.
 If you are working on tasks that would benefit from a todo list please use the "todos" tool to create one.
 If not, please feel free to ignore. Again do not mention this message to the user.`,
@@ -920,7 +922,8 @@ func filterOrphanedToolResults(m message.Message, knownToolCallIDs map[string]st
 		if _, known := knownToolCallIDs[tr.ToolCallID]; known {
 			validParts = append(validParts, part)
 		} else {
-			slog.Warn("Dropping orphaned tool result with no matching tool call",
+			slog.Warn(
+				"Dropping orphaned tool result with no matching tool call",
 				"tool_call_id", tr.ToolCallID,
 			)
 		}
@@ -946,7 +949,8 @@ func syntheticToolResultsForOrphanedCalls(m message.Message, knownToolResultIDs 
 		if _, hasResult := knownToolResultIDs[tc.ID]; hasResult {
 			continue
 		}
-		slog.Warn("Injecting synthetic tool result for orphaned tool call",
+		slog.Warn(
+			"Injecting synthetic tool result for orphaned tool call",
 			"tool_call_id", tc.ID,
 			"tool_name", tc.Name,
 		)
@@ -1004,7 +1008,8 @@ func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, user
 	}
 
 	newAgent := func(m fantasy.LanguageModel, p []byte, tok int64) fantasy.Agent {
-		return fantasy.NewAgent(m,
+		return fantasy.NewAgent(
+			m,
 			fantasy.WithSystemPrompt(string(p)+"\n /no_think"),
 			fantasy.WithMaxOutputTokens(tok),
 			fantasy.WithUserAgent(userAgent),
@@ -1273,7 +1278,8 @@ func (a *sessionAgent) convertToToolResult(result fantasy.ToolResultContent) mes
 	case fantasy.ToolResultContentTypeMedia:
 		if r, ok := fantasy.AsToolResultOutputType[fantasy.ToolResultOutputContentMedia](result.Result); ok {
 			if !stringext.IsValidBase64(r.Data) {
-				slog.Warn("Tool returned media with invalid base64 data, discarding image",
+				slog.Warn(
+					"Tool returned media with invalid base64 data, discarding image",
 					"tool", result.ToolName,
 					"tool_call_id", result.ToolCallID,
 				)

--- a/internal/agent/agent_tool.go
+++ b/internal/agent/agent_tool.go
@@ -63,5 +63,6 @@ func (c *coordinator) agentTool(ctx context.Context) (fantasy.AgentTool, error) 
 				Prompt:         params.Prompt,
 				SessionTitle:   "New Agent Session",
 			})
-		}), nil
+		},
+	), nil
 }

--- a/internal/agent/agentic_fetch_tool.go
+++ b/internal/agent/agentic_fetch_tool.go
@@ -80,7 +80,8 @@ func (c *coordinator) agenticFetchTool(_ context.Context, client *http.Client) (
 				description = "Search the web and analyze results"
 			}
 
-			p, err := c.permissions.Request(ctx,
+			p, err := c.permissions.Request(
+				ctx,
 				permission.CreatePermissionRequest{
 					SessionID:   validationResult.SessionID,
 					Path:        c.cfg.WorkingDir(),
@@ -200,5 +201,6 @@ func (c *coordinator) agenticFetchTool(_ context.Context, client *http.Client) (
 					c.permissions.AutoApproveSession(sessionID)
 				},
 			})
-		}), nil
+		},
+	), nil
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -491,7 +491,8 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 		hookRunner = hooks.NewRunner(preToolHooks, c.cfg.WorkingDir(), c.cfg.WorkingDir())
 	}
 
-	allTools = append(allTools,
+	allTools = append(
+		allTools,
 		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Options.Attribution, modelID),
 		tools.NewCrushInfoTool(c.cfg, c.lspManager, c.allSkills, c.activeSkills, c.skillTracker),
 		tools.NewCrushLogsTool(logFile),
@@ -740,7 +741,8 @@ func (c *coordinator) buildOpenaiCompatProvider(baseURL, apiKey string, headers 
 	// Set HTTP client based on provider and debug mode.
 	var httpClient *http.Client
 	if providerID == string(catwalk.InferenceProviderCopilot) {
-		opts = append(opts,
+		opts = append(
+			opts,
 			openaicompat.WithUseResponsesAPI(),
 			openaicompat.WithResponsesAPIFunc(func(modelID string) bool {
 				return copilotResponsesModels[modelID]
@@ -1213,7 +1215,8 @@ func logTurnSkillUsage(
 		}
 	}
 
-	slog.Info("Skill turn summary",
+	slog.Info(
+		"Skill turn summary",
 		"component", "skills",
 		"session_id", sessionID,
 		"prompt_len", len(prompt),
@@ -1257,7 +1260,8 @@ func logDiscoveryStats(
 
 	xml := skills.ToPromptXML(activeSkills)
 
-	slog.Info("Skill discovery complete",
+	slog.Info(
+		"Skill discovery complete",
 		"component", "skills",
 		"builtin_ok", len(builtin),
 		"builtin_errors", countErrors(builtinStates),

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -219,7 +219,8 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 				return fantasy.ToolResponse{}, fmt.Errorf("session ID is required for executing shell command")
 			}
 			if !isSafeReadOnly {
-				p, err := permissions.Request(ctx,
+				p, err := permissions.Request(
+					ctx,
 					permission.CreatePermissionRequest{
 						SessionID:   sessionID,
 						Path:        execWorkingDir,
@@ -375,7 +376,8 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 			}
 			response := fmt.Sprintf("Command is taking longer than expected and has been moved to background.\n\nBackground shell ID: %s\n\nUse job_output tool to view output or job_kill to terminate.", bgShell.ID)
 			return fantasy.WithResponseMetadata(fantasy.NewTextResponse(response), metadata), nil
-		})
+		},
+	)
 }
 
 // formatOutput formats the output of a completed command with error handling

--- a/internal/agent/tools/crush_info.go
+++ b/internal/agent/tools/crush_info.go
@@ -33,7 +33,8 @@ func NewCrushInfoTool(
 		crushInfoDescription,
 		func(ctx context.Context, _ CrushInfoParams, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			return fantasy.NewTextResponse(buildCrushInfo(cfg, lspManager, allSkills, activeSkills, skillTracker)), nil
-		})
+		},
+	)
 }
 
 func buildCrushInfo(cfg *config.ConfigStore, lspManager *lsp.Manager, allSkills []*skills.Skill, activeSkills []*skills.Skill, skillTracker *skills.Tracker) string {

--- a/internal/agent/tools/diagnostics.go
+++ b/internal/agent/tools/diagnostics.go
@@ -35,7 +35,8 @@ func NewDiagnosticsTool(lspManager *lsp.Manager) fantasy.AgentTool {
 			notifyLSPs(ctx, lspManager, params.FilePath)
 			output := getDiagnostics(params.FilePath, lspManager)
 			return fantasy.NewTextResponse(output), nil
-		})
+		},
+	)
 }
 
 // openInLSPs ensures LSP servers are running and aware of the file, but does

--- a/internal/agent/tools/download.go
+++ b/internal/agent/tools/download.go
@@ -87,7 +87,8 @@ func NewDownloadTool(permissions permission.Service, workingDir string, client *
 				return fantasy.ToolResponse{}, fmt.Errorf("session ID is required for downloading files")
 			}
 
-			p, err := permissions.Request(ctx,
+			p, err := permissions.Request(
+				ctx,
 				permission.CreatePermissionRequest{
 					SessionID:   sessionID,
 					Path:        filePath,
@@ -160,5 +161,6 @@ func NewDownloadTool(permissions permission.Service, workingDir string, client *
 			}
 
 			return fantasy.NewTextResponse(responseMsg), nil
-		})
+		},
+	)
 }

--- a/internal/agent/tools/edit.go
+++ b/internal/agent/tools/edit.go
@@ -104,7 +104,8 @@ func NewEditTool(
 			text += getDiagnostics(params.FilePath, lspManager)
 			response.Content = text
 			return response, nil
-		})
+		},
+	)
 }
 
 func createNewFile(edit editContext, filePath, content string, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
@@ -133,7 +134,8 @@ func createNewFile(edit editContext, filePath, content string, call fantasy.Tool
 		content,
 		strings.TrimPrefix(filePath, edit.workingDir),
 	)
-	p, err := edit.permissions.Request(edit.ctx,
+	p, err := edit.permissions.Request(
+		edit.ctx,
 		permission.CreatePermissionRequest{
 			SessionID:   sessionID,
 			Path:        fsext.PathOrPrefix(filePath, edit.workingDir),
@@ -213,9 +215,11 @@ func deleteContent(edit editContext, filePath, oldString string, replaceAll bool
 	modTime := fileInfo.ModTime().Truncate(time.Second)
 	if modTime.After(lastRead) {
 		return fantasy.NewTextErrorResponse(
-			fmt.Sprintf("file %s has been modified since it was last read (mod time: %s, last read: %s)",
+			fmt.Sprintf(
+				"file %s has been modified since it was last read (mod time: %s, last read: %s)",
 				filePath, modTime.Format(time.RFC3339), lastRead.Format(time.RFC3339),
-			)), nil
+			),
+		), nil
 	}
 
 	content, err := os.ReadFile(filePath)
@@ -252,7 +256,8 @@ func deleteContent(edit editContext, filePath, oldString string, replaceAll bool
 		strings.TrimPrefix(filePath, edit.workingDir),
 	)
 
-	p, err := edit.permissions.Request(edit.ctx,
+	p, err := edit.permissions.Request(
+		edit.ctx,
 		permission.CreatePermissionRequest{
 			SessionID:   sessionID,
 			Path:        fsext.PathOrPrefix(filePath, edit.workingDir),
@@ -344,9 +349,11 @@ func replaceContent(edit editContext, filePath, oldString, newString string, rep
 	modTime := fileInfo.ModTime().Truncate(time.Second)
 	if modTime.After(lastRead) {
 		return fantasy.NewTextErrorResponse(
-			fmt.Sprintf("file %s has been modified since it was last read (mod time: %s, last read: %s)",
+			fmt.Sprintf(
+				"file %s has been modified since it was last read (mod time: %s, last read: %s)",
 				filePath, modTime.Format(time.RFC3339), lastRead.Format(time.RFC3339),
-			)), nil
+			),
+		), nil
 	}
 
 	content, err := os.ReadFile(filePath)
@@ -383,7 +390,8 @@ func replaceContent(edit editContext, filePath, oldString, newString string, rep
 		strings.TrimPrefix(filePath, edit.workingDir),
 	)
 
-	p, err := edit.permissions.Request(edit.ctx,
+	p, err := edit.permissions.Request(
+		edit.ctx,
 		permission.CreatePermissionRequest{
 			SessionID:   sessionID,
 			Path:        fsext.PathOrPrefix(filePath, edit.workingDir),
@@ -445,5 +453,6 @@ func replaceContent(edit editContext, filePath, oldString, newString string, rep
 			NewContent: newContent,
 			Additions:  additions,
 			Removals:   removals,
-		}), nil
+		},
+	), nil
 }

--- a/internal/agent/tools/fetch.go
+++ b/internal/agent/tools/fetch.go
@@ -77,7 +77,8 @@ func NewFetchTool(permissions permission.Service, workingDir string, client *htt
 				return fantasy.ToolResponse{}, fmt.Errorf("session ID is required for creating a new file")
 			}
 
-			p, err := permissions.Request(ctx,
+			p, err := permissions.Request(
+				ctx,
 				permission.CreatePermissionRequest{
 					SessionID:   sessionID,
 					Path:        workingDir,
@@ -184,7 +185,8 @@ func NewFetchTool(permissions permission.Service, workingDir string, client *htt
 			}
 
 			return fantasy.NewTextResponse(content), nil
-		})
+		},
+	)
 }
 
 func extractTextFromHTML(html string) (string, error) {

--- a/internal/agent/tools/glob.go
+++ b/internal/agent/tools/glob.go
@@ -82,7 +82,8 @@ func NewGlobTool(workingDir string) fantasy.AgentTool {
 					Truncated:     truncated,
 				},
 			), nil
-		})
+		},
+	)
 }
 
 func globFiles(ctx context.Context, pattern, searchPath string, limit int) ([]string, bool, error) {

--- a/internal/agent/tools/grep.go
+++ b/internal/agent/tools/grep.go
@@ -186,7 +186,8 @@ func NewGrepTool(workingDir string, config config.ToolGrep) fantasy.AgentTool {
 					Truncated:       truncated,
 				},
 			), nil
-		})
+		},
+	)
 }
 
 func searchFiles(ctx context.Context, pattern, rootPath, include string, limit int) ([]grepMatch, bool, error) {

--- a/internal/agent/tools/job_kill.go
+++ b/internal/agent/tools/job_kill.go
@@ -55,5 +55,6 @@ func NewJobKillTool() fantasy.AgentTool {
 
 			result := fmt.Sprintf("Background shell %s terminated successfully", params.ShellID)
 			return fantasy.WithResponseMetadata(fantasy.NewTextResponse(result), metadata), nil
-		})
+		},
+	)
 }

--- a/internal/agent/tools/job_output.go
+++ b/internal/agent/tools/job_output.go
@@ -87,5 +87,6 @@ func NewJobOutputTool() fantasy.AgentTool {
 
 			result := fmt.Sprintf("Status: %s\n\n%s", status, output)
 			return fantasy.WithResponseMetadata(fantasy.NewTextResponse(result), metadata), nil
-		})
+		},
+	)
 }

--- a/internal/agent/tools/list_mcp_resources.go
+++ b/internal/agent/tools/list_mcp_resources.go
@@ -44,7 +44,8 @@ func NewListMCPResourcesTool(cfg *config.ConfigStore, permissions permission.Ser
 			}
 
 			relPath := filepathext.SmartJoin(cfg.WorkingDir(), params.MCPName)
-			p, err := permissions.Request(ctx,
+			p, err := permissions.Request(
+				ctx,
 				permission.CreatePermissionRequest{
 					SessionID:   sessionID,
 					Path:        relPath,

--- a/internal/agent/tools/ls.go
+++ b/internal/agent/tools/ls.go
@@ -102,7 +102,8 @@ func NewLsTool(permissions permission.Service, workingDir string, lsConfig confi
 					return fantasy.ToolResponse{}, fmt.Errorf("session ID is required for accessing directories outside working directory")
 				}
 
-				granted, err := permissions.Request(ctx,
+				granted, err := permissions.Request(
+					ctx,
 					permission.CreatePermissionRequest{
 						SessionID:   sessionID,
 						Path:        absSearchPath,
@@ -130,7 +131,8 @@ func NewLsTool(permissions permission.Service, workingDir string, lsConfig confi
 				fantasy.NewTextResponse(output),
 				metadata,
 			), nil
-		})
+		},
+	)
 }
 
 func ListDirectoryTree(searchPath string, params LSParams, lsConfig config.ToolLs) (string, LSResponseMetadata, error) {

--- a/internal/agent/tools/lsp_restart.go
+++ b/internal/agent/tools/lsp_restart.go
@@ -75,5 +75,6 @@ func NewLSPRestartTool(lspManager *lsp.Manager) fantasy.AgentTool {
 			}
 
 			return fantasy.NewTextResponse(output), nil
-		})
+		},
+	)
 }

--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -105,7 +105,8 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 	// Skip permission for whitelisted Docker MCP tools.
 	if !slices.Contains(whitelistDockerTools, params.Name) {
 		permissionDescription := fmt.Sprintf("execute %s with the following parameters:", m.Info().Name)
-		p, err := m.permissions.Request(ctx,
+		p, err := m.permissions.Request(
+			ctx,
 			permission.CreatePermissionRequest{
 				SessionID:   sessionID,
 				ToolCallID:  params.ID,

--- a/internal/agent/tools/multiedit.go
+++ b/internal/agent/tools/multiedit.go
@@ -110,7 +110,8 @@ func NewMultiEditTool(
 			text += getDiagnostics(params.FilePath, lspManager)
 			response.Content = text
 			return response, nil
-		})
+		},
+	)
 }
 
 func validateEdits(edits []MultiEditOperation) error {
@@ -266,9 +267,11 @@ func processMultiEditExistingFile(edit editContext, params MultiEditParams, call
 	modTime := fileInfo.ModTime().Truncate(time.Second)
 	if modTime.After(lastRead) {
 		return fantasy.NewTextErrorResponse(
-			fmt.Sprintf("file %s has been modified since it was last read (mod time: %s, last read: %s)",
+			fmt.Sprintf(
+				"file %s has been modified since it was last read (mod time: %s, last read: %s)",
 				params.FilePath, modTime.Format(time.RFC3339), lastRead.Format(time.RFC3339),
-			)), nil
+			),
+		), nil
 	}
 
 	// Read current file content

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -50,7 +50,8 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 			}
 
 			relPath := filepathext.SmartJoin(cfg.WorkingDir(), cmp.Or(params.URI, "mcp-resource"))
-			p, err := permissions.Request(ctx,
+			p, err := permissions.Request(
+				ctx,
 				permission.CreatePermissionRequest{
 					SessionID:   sessionID,
 					Path:        relPath,

--- a/internal/agent/tools/references.go
+++ b/internal/agent/tools/references.go
@@ -87,7 +87,8 @@ func NewReferencesTool(lspManager *lsp.Manager) fantasy.AgentTool {
 				return fantasy.NewTextErrorResponse(allErrs.Error()), nil
 			}
 			return fantasy.NewTextResponse(fmt.Sprintf("No references found for symbol '%s'", params.Symbol)), nil
-		})
+		},
+	)
 }
 
 func (r *referencesTool) Name() string {

--- a/internal/agent/tools/sourcegraph.go
+++ b/internal/agent/tools/sourcegraph.go
@@ -150,7 +150,8 @@ func NewSourcegraphTool(client *http.Client) fantasy.AgentTool {
 			}
 
 			return fantasy.NewTextResponse(formattedResults), nil
-		})
+		},
+	)
 }
 
 func formatSourcegraphResults(result map[string]any, contextWindow int) (string, error) {

--- a/internal/agent/tools/todos.go
+++ b/internal/agent/tools/todos.go
@@ -130,5 +130,6 @@ func NewTodosTool(sessions session.Service) fantasy.AgentTool {
 			}
 
 			return fantasy.WithResponseMetadata(fantasy.NewTextResponse(response), metadata), nil
-		})
+		},
+	)
 }

--- a/internal/agent/tools/view.go
+++ b/internal/agent/tools/view.go
@@ -134,7 +134,8 @@ func NewViewTool(
 
 			// Request permission for files outside working directory, unless it's a skill file.
 			if isOutsideWorkDir && !isSkillFile {
-				granted, permReqErr := permissions.Request(ctx,
+				granted, permReqErr := permissions.Request(
+					ctx,
 					permission.CreatePermissionRequest{
 						SessionID:   sessionID,
 						Path:        absFilePath,
@@ -274,7 +275,8 @@ func NewViewTool(
 				fantasy.NewTextResponse(output),
 				meta,
 			), nil
-		})
+		},
+	)
 }
 
 func addLineNumbers(content string, startLine int) string {

--- a/internal/agent/tools/web_fetch.go
+++ b/internal/agent/tools/web_fetch.go
@@ -75,5 +75,6 @@ func NewWebFetchTool(workingDir string, client *http.Client) fantasy.AgentTool {
 			}
 
 			return fantasy.NewTextResponse(result.String()), nil
-		})
+		},
+	)
 }

--- a/internal/agent/tools/web_search.go
+++ b/internal/agent/tools/web_search.go
@@ -57,5 +57,6 @@ func NewWebSearchTool(client *http.Client) fantasy.AgentTool {
 			}
 
 			return fantasy.NewTextResponse(formatSearchResults(results)), nil
-		})
+		},
+	)
 }

--- a/internal/agent/tools/write.go
+++ b/internal/agent/tools/write.go
@@ -105,7 +105,8 @@ func NewWriteTool(
 				strings.TrimPrefix(filePath, workingDir),
 			)
 
-			p, err := permissions.Request(ctx,
+			p, err := permissions.Request(
+				ctx,
 				permission.CreatePermissionRequest{
 					SessionID:   sessionID,
 					Path:        fsext.PathOrPrefix(filePath, workingDir),
@@ -161,12 +162,14 @@ func NewWriteTool(
 			result := fmt.Sprintf("File successfully written: %s", filePath)
 			result = fmt.Sprintf("<result>\n%s\n</result>", result)
 			result += getDiagnostics(filePath, lspManager)
-			return fantasy.WithResponseMetadata(fantasy.NewTextResponse(result),
+			return fantasy.WithResponseMetadata(
+				fantasy.NewTextResponse(result),
 				WriteResponseMetadata{
 					Diff:      diff,
 					Additions: additions,
 					Removals:  removals,
 				},
 			), nil
-		})
+		},
+	)
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -122,7 +122,8 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 	b.workspaces.Set(id, ws)
 
 	if args.Version != "" && args.Version != version.Version {
-		slog.Warn("Client/server version mismatch",
+		slog.Warn(
+			"Client/server version mismatch",
 			"client", args.Version,
 			"server", version.Version,
 		)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -486,7 +486,8 @@ func perHostServerDir(hostURL *url.URL) (string, error) {
 // the --host flag so client and server compute the same key.
 func safeHostName(hostURL *url.URL) string {
 	return safeNameRegexp.ReplaceAllString(
-		hostURL.Scheme+"://"+hostURL.Host+hostURL.Path, "_")
+		hostURL.Scheme+"://"+hostURL.Host+hostURL.Path, "_",
+	)
 }
 
 // serverReadyTimeout returns the total budget for the readiness probe.

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -248,7 +248,8 @@ func TestConfig_setDefaults(t *testing.T) {
 		cfg := &Config{}
 		cfg.setDefaults(child, "")
 
-		require.Equal(t,
+		require.Equal(
+			t,
 			filepath.Clean(filepath.Join(child, defaultDataDirectory)),
 			filepath.Clean(cfg.Options.DataDirectory),
 		)

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -54,7 +54,8 @@ func TestError(t *testing.T) {
 		}()
 
 		client = nil
-		Error("test error",
+		Error(
+			"test error",
 			"type", "test",
 			"severity", "high",
 			"source", "unit-test",

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -128,7 +128,8 @@ func aggregate(results []HookResult, origToolInput string) AggregateResult {
 		if r.UpdatedInput != "" {
 			next, err := shallowMerge(merged, r.UpdatedInput)
 			if err != nil {
-				slog.Warn("Hook updated_input patch rejected; ignoring",
+				slog.Warn(
+					"Hook updated_input patch rejected; ignoring",
 					"error", err,
 					"patch", r.UpdatedInput,
 				)

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -538,7 +538,8 @@ func TestAggregationUpdatedInput(t *testing.T) {
 		require.Equal(t, DecisionAllow, agg.Decision)
 		// command overridden by second patch; keep preserved from first
 		// patch; timeout preserved from original input.
-		require.JSONEq(t,
+		require.JSONEq(
+			t,
 			`{"command":"second","keep":"me","timeout":60}`,
 			agg.UpdatedInput,
 		)
@@ -550,7 +551,8 @@ func TestAggregationUpdatedInput(t *testing.T) {
 			{Decision: DecisionAllow, UpdatedInput: `{"env":{"FOO":"bar"}}`},
 		}, `{"env":{"BAZ":"qux"},"command":"ls"}`)
 		// "env" is replaced entirely; "command" preserved.
-		require.JSONEq(t,
+		require.JSONEq(
+			t,
 			`{"env":{"FOO":"bar"},"command":"ls"}`,
 			agg.UpdatedInput,
 		)
@@ -678,7 +680,8 @@ func TestRunnerUpdatedInput(t *testing.T) {
 	result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{"command":"echo original","timeout":60}`)
 	require.NoError(t, err)
 	require.Equal(t, DecisionAllow, result.Decision)
-	require.JSONEq(t,
+	require.JSONEq(
+		t,
 		`{"command":"echo rewritten","timeout":60}`,
 		result.UpdatedInput,
 	)

--- a/internal/hooks/input.go
+++ b/internal/hooks/input.go
@@ -53,7 +53,8 @@ func BuildPayload(eventName, sessionID, cwd, toolName, toolInputJSON string) []b
 func BuildEnv(eventName, toolName, sessionID, cwd, projectDir, toolInputJSON string) []string {
 	env := os.Environ()
 	env = append(env, shell.CrushEnvMarkers()...)
-	env = append(env,
+	env = append(
+		env,
 		fmt.Sprintf("CRUSH_EVENT=%s", eventName),
 		fmt.Sprintf("CRUSH_TOOL_NAME=%s", toolName),
 		fmt.Sprintf("CRUSH_SESSION_ID=%s", sessionID),
@@ -105,7 +106,8 @@ func parseStdout(stdout string) HookResult {
 	}
 
 	if parsed.Version > SupportedOutputVersion {
-		slog.Debug("Hook output declared a newer envelope version than this build supports",
+		slog.Debug(
+			"Hook output declared a newer envelope version than this build supports",
 			"version", parsed.Version,
 			"supported", SupportedOutputVersion,
 		)

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -54,7 +54,8 @@ func NewRunner(hooks []config.HookConfig, cwd, projectDir string) *Runner {
 		if h.Matcher != "" {
 			re, err := regexp.Compile(h.Matcher)
 			if err != nil {
-				slog.Warn("Hook matcher failed to compile; skipping hook",
+				slog.Warn(
+					"Hook matcher failed to compile; skipping hook",
 					"matcher", h.Matcher,
 					"command", h.Command,
 					"error", err,
@@ -130,7 +131,8 @@ func (r *Runner) Run(ctx context.Context, eventName, sessionID, toolName, toolIn
 			InputRewrite: results[i].UpdatedInput != "",
 		}
 	}
-	slog.Info("Hook completed",
+	slog.Info(
+		"Hook completed",
 		"event", eventName,
 		"tool", toolName,
 		"hooks", len(deduped),
@@ -194,7 +196,8 @@ func (r *Runner) runOne(parentCtx context.Context, hook config.HookConfig, envVa
 		case err = <-done:
 			// Interpreter yielded within the grace period; safe to read.
 		case <-time.After(abandonGrace):
-			slog.Warn("Hook did not yield after cancel; abandoning goroutine",
+			slog.Warn(
+				"Hook did not yield after cancel; abandoning goroutine",
 				"command", hook.Command,
 				"timeout", timeout,
 			)
@@ -240,7 +243,8 @@ func (r *Runner) runOne(parentCtx context.Context, hook config.HookConfig, envVa
 			}
 		default:
 			// Other non-zero exits are non-blocking errors.
-			slog.Warn("Hook failed with non-blocking error",
+			slog.Warn(
+				"Hook failed with non-blocking error",
 				"command", hook.Command,
 				"exit_code", exitCode,
 				"stderr", strings.TrimSpace(stderr.String()),
@@ -252,7 +256,8 @@ func (r *Runner) runOne(parentCtx context.Context, hook config.HookConfig, envVa
 
 	// Exit code 0 — parse stdout JSON.
 	result := parseStdout(stdout.String())
-	slog.Debug("Hook executed",
+	slog.Debug(
+		"Hook executed",
 		"command", hook.Command,
 		"decision", result.Decision.String(),
 	)

--- a/internal/proto/agent.go
+++ b/internal/proto/agent.go
@@ -51,7 +51,7 @@ func (e AgentEvent) MarshalJSON() ([]byte, error) {
 			}
 			return ""
 		}(),
-		Alias: (Alias)(e),
+		Alias: Alias(e),
 	})
 }
 
@@ -62,7 +62,7 @@ func (e *AgentEvent) UnmarshalJSON(data []byte) error {
 		Error string `json:"error,omitempty"`
 		Alias
 	}{
-		Alias: (Alias)(*e),
+		Alias: Alias(*e),
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err

--- a/internal/proto/mcp.go
+++ b/internal/proto/mcp.go
@@ -100,7 +100,7 @@ func (e MCPEvent) MarshalJSON() ([]byte, error) {
 			}
 			return ""
 		}(),
-		Alias: (Alias)(e),
+		Alias: Alias(e),
 	})
 }
 
@@ -111,7 +111,7 @@ func (e *MCPEvent) UnmarshalJSON(data []byte) error {
 		Error string `json:"error,omitempty"`
 		Alias
 	}{
-		Alias: (Alias)(*e),
+		Alias: Alias(*e),
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
@@ -148,7 +148,7 @@ func (i MCPClientInfo) MarshalJSON() ([]byte, error) {
 			}
 			return ""
 		}(),
-		Alias: (Alias)(i),
+		Alias: Alias(i),
 	})
 }
 
@@ -159,7 +159,7 @@ func (i *MCPClientInfo) UnmarshalJSON(data []byte) error {
 		Error string `json:"error,omitempty"`
 		Alias
 	}{
-		Alias: (Alias)(*i),
+		Alias: Alias(*i),
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -56,7 +56,7 @@ type AgentSession struct {
 
 // IsZero checks if the AgentSession is zero-valued.
 func (a AgentSession) IsZero() bool {
-	return a == AgentSession{}
+	return a.ID == "" && !a.IsBusy
 }
 
 // PermissionAction represents an action taken on a permission request.

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -131,7 +131,7 @@ func (e LSPEvent) MarshalJSON() ([]byte, error) {
 			}
 			return ""
 		}(),
-		Alias: (Alias)(e),
+		Alias: Alias(e),
 	})
 }
 
@@ -142,7 +142,7 @@ func (e *LSPEvent) UnmarshalJSON(data []byte) error {
 		Error string `json:"error,omitempty"`
 		Alias
 	}{
-		Alias: (Alias)(*e),
+		Alias: Alias(*e),
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
@@ -176,7 +176,7 @@ func (i LSPClientInfo) MarshalJSON() ([]byte, error) {
 			}
 			return ""
 		}(),
-		Alias: (Alias)(i),
+		Alias: Alias(i),
 	})
 }
 
@@ -187,7 +187,7 @@ func (i *LSPClientInfo) UnmarshalJSON(data []byte) error {
 		Error string `json:"error,omitempty"`
 		Alias
 	}{
-		Alias: (Alias)(*i),
+		Alias: Alias(*i),
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err

--- a/internal/proto/session.go
+++ b/internal/proto/session.go
@@ -10,6 +10,14 @@ type Session struct {
 	CompletionTokens int64   `json:"completion_tokens"`
 	SummaryMessageID string  `json:"summary_message_id"`
 	Cost             float64 `json:"cost"`
+	Todos            []Todo  `json:"todos,omitempty"`
 	CreatedAt        int64   `json:"created_at"`
 	UpdatedAt        int64   `json:"updated_at"`
+}
+
+// Todo represents a single todo entry on a session in the proto layer.
+type Todo struct {
+	Content    string `json:"content"`
+	Status     string `json:"status"`
+	ActiveForm string `json:"active_form"`
 }

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -135,9 +135,25 @@ func sessionToProto(s session.Session) proto.Session {
 		PromptTokens:     s.PromptTokens,
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
+		Todos:            todosToProto(s.Todos),
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}
+}
+
+func todosToProto(todos []session.Todo) []proto.Todo {
+	if len(todos) == 0 {
+		return nil
+	}
+	out := make([]proto.Todo, len(todos))
+	for i, t := range todos {
+		out[i] = proto.Todo{
+			Content:    t.Content,
+			Status:     string(t.Status),
+			ActiveForm: t.ActiveForm,
+		}
+	}
+	return out
 }
 
 func fileToProto(f history.File) proto.File {

--- a/internal/server/logging.go
+++ b/internal/server/logging.go
@@ -15,7 +15,8 @@ func (s *Server) loggingHandler(next http.Handler) http.Handler {
 
 		start := time.Now()
 		lrw := &loggingResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
-		s.logger.Debug("HTTP request",
+		s.logger.Debug(
+			"HTTP request",
 			slog.String("method", r.Method),
 			slog.String("path", r.URL.Path),
 			slog.String("remote_addr", r.RemoteAddr),
@@ -25,7 +26,8 @@ func (s *Server) loggingHandler(next http.Handler) http.Handler {
 		next.ServeHTTP(lrw, r)
 		duration := time.Since(start)
 
-		s.logger.Debug("HTTP response",
+		s.logger.Debug(
+			"HTTP response",
 			slog.String("method", r.Method),
 			slog.String("path", r.URL.Path),
 			slog.Int("status", lrw.statusCode),

--- a/internal/shell/jq_test.go
+++ b/internal/shell/jq_test.go
@@ -185,7 +185,8 @@ func TestJQ_Success(t *testing.T) {
 	t.Parallel()
 
 	var stdout bytes.Buffer
-	err := handleJQ(t.Context(),
+	err := handleJQ(
+		t.Context(),
 		[]string{"jq", "-c", ".a"},
 		strings.NewReader(`{"a":1}`),
 		&stdout, io.Discard,

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -690,9 +690,10 @@ func toolOutputCodeContent(sty *styles.Styles, path, content string, offset, wid
 
 	// Add truncation message if needed.
 	if len(lines) > maxLines && !expanded {
-		out = append(out, sty.Tool.ContentCodeTruncation.
-			Width(width).
-			Render(fmt.Sprintf(assistantMessageTruncateFormat, len(lines)-maxLines)),
+		out = append(
+			out, sty.Tool.ContentCodeTruncation.
+				Width(width).
+				Render(fmt.Sprintf(assistantMessageTruncateFormat, len(lines)-maxLines)),
 		)
 	}
 
@@ -851,7 +852,8 @@ func renderHookLine(sty *styles.Styles, hi hooks.HookInfo, rawName, detail strin
 		arrowStyle = sty.Tool.HookDeniedLabel
 	}
 
-	return fmt.Sprintf("%s %s%s%s %s %s",
+	return fmt.Sprintf(
+		"%s %s%s%s %s %s",
 		labelStyle.Render("Hook"),
 		name,
 		namePad,
@@ -1063,9 +1065,10 @@ func toolOutputMarkdownContent(sty *styles.Styles, content string, width int, ex
 	}
 
 	if len(lines) > maxLines && !expanded {
-		out = append(out, sty.Tool.ContentTruncation.
-			Width(width).
-			Render(fmt.Sprintf(assistantMessageTruncateFormat, len(lines)-maxLines)),
+		out = append(
+			out, sty.Tool.ContentTruncation.
+				Width(width).
+				Render(fmt.Sprintf(assistantMessageTruncateFormat, len(lines)-maxLines)),
 		)
 	}
 

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -510,7 +510,8 @@ func (c *Commands) defaultCommands() []*CommandItem {
 	}
 	commands = append(commands, NewCommandItem(c.com.Styles, "toggle_notifications", notificationLabel, "", ActionToggleNotifications{}))
 
-	commands = append(commands,
+	commands = append(
+		commands,
 		NewCommandItem(c.com.Styles, "toggle_yolo", "Toggle Yolo Mode", "", ActionToggleYoloMode{}),
 		NewCommandItem(c.com.Styles, "toggle_help", "Toggle Help", "ctrl+g", ActionToggleHelp{}),
 		NewCommandItem(c.com.Styles, "init", "Initialize Project", "", ActionInitializeProject{}),
@@ -523,7 +524,8 @@ func (c *Commands) defaultCommands() []*CommandItem {
 	}
 	commands = append(commands, NewCommandItem(c.com.Styles, "toggle_transparent", transparentLabel, "", ActionToggleTransparentBackground{}))
 
-	commands = append(commands,
+	commands = append(
+		commands,
 		NewCommandItem(c.com.Styles, "quit", "Quit", "ctrl+c", tea.QuitMsg{}).WithAliases("exit"),
 	)
 

--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -775,7 +775,8 @@ func (p *Permissions) ShortHelp() []key.Binding {
 	}
 
 	if p.hasDiffView() {
-		bindings = append(bindings,
+		bindings = append(
+			bindings,
 			p.keyMap.ToggleDiffMode,
 			p.keyMap.ToggleFullscreen,
 		)

--- a/internal/ui/dialog/sessions_item.go
+++ b/internal/ui/dialog/sessions_item.go
@@ -184,7 +184,8 @@ func renderItem(t ListItemStyles, title string, info string, focused bool, width
 			// precisely via [ansi.AttrUnderline] and [ansi.AttrNoUnderline]
 			// which only affect the underline attribute without interfering
 			// with other style attributes.
-			parts = append(parts,
+			parts = append(
+				parts,
 				ansi.NewStyle().Underline(true).String(),
 				ansi.Cut(title, start, stop+1),
 				ansi.NewStyle().Underline(false).String(),

--- a/internal/ui/model/header.go
+++ b/internal/ui/model/header.go
@@ -122,7 +122,8 @@ func (h *header) drawHeader(
 	b.WriteString(details)
 
 	view := uv.NewStyledString(
-		t.Header.Wrapper.Padding(0, rightPadding, 0, leftPadding).Render(b.String()))
+		t.Header.Wrapper.Padding(0, rightPadding, 0, leftPadding).Render(b.String()),
+	)
 	view.Draw(scr, area)
 }
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2301,7 +2301,8 @@ func (m *UI) ShortHelp() []key.Binding {
 			tab.SetHelp("tab", "focus editor")
 		}
 
-		binds = append(binds,
+		binds = append(
+			binds,
 			tab,
 			commands,
 			k.Models,
@@ -2309,11 +2310,13 @@ func (m *UI) ShortHelp() []key.Binding {
 
 		switch m.focus {
 		case uiFocusEditor:
-			binds = append(binds,
+			binds = append(
+				binds,
 				k.Editor.Newline,
 			)
 		case uiFocusMain:
-			binds = append(binds,
+			binds = append(
+				binds,
 				k.Chat.UpDown,
 				k.Chat.UpDownOneItem,
 				k.Chat.PageUp,
@@ -2328,14 +2331,16 @@ func (m *UI) ShortHelp() []key.Binding {
 		// TODO: other states
 		// if m.session == nil {
 		// no session selected
-		binds = append(binds,
+		binds = append(
+			binds,
 			commands,
 			k.Models,
 			k.Editor.Newline,
 		)
 	}
 
-	binds = append(binds,
+	binds = append(
+		binds,
 		k.Quit,
 		k.Help,
 	)
@@ -2382,7 +2387,8 @@ func (m *UI) FullHelp() [][]key.Binding {
 			tab.SetHelp("tab", "focus editor")
 		}
 
-		mainBinds = append(mainBinds,
+		mainBinds = append(
+			mainBinds,
 			tab,
 			commands,
 			k.Models,
@@ -2406,7 +2412,8 @@ func (m *UI) FullHelp() [][]key.Binding {
 			}
 			binds = append(binds, editorBinds)
 			if hasAttachments {
-				binds = append(binds,
+				binds = append(
+					binds,
 					[]key.Binding{
 						k.Editor.AttachmentDeleteMode,
 						k.Editor.DeleteAllAttachments,
@@ -2415,7 +2422,8 @@ func (m *UI) FullHelp() [][]key.Binding {
 				)
 			}
 		case uiFocusMain:
-			binds = append(binds,
+			binds = append(
+				binds,
 				[]key.Binding{
 					k.Chat.UpDown,
 					k.Chat.UpDownOneItem,
@@ -2440,7 +2448,8 @@ func (m *UI) FullHelp() [][]key.Binding {
 	default:
 		if m.session == nil {
 			// no session selected
-			binds = append(binds,
+			binds = append(
+				binds,
 				[]key.Binding{
 					commands,
 					k.Models,
@@ -2457,7 +2466,8 @@ func (m *UI) FullHelp() [][]key.Binding {
 			}
 			binds = append(binds, editorBinds)
 			if hasAttachments {
-				binds = append(binds,
+				binds = append(
+					binds,
 					[]key.Binding{
 						k.Editor.AttachmentDeleteMode,
 						k.Editor.DeleteAllAttachments,
@@ -2468,7 +2478,8 @@ func (m *UI) FullHelp() [][]key.Binding {
 		}
 	}
 
-	binds = append(binds,
+	binds = append(
+		binds,
 		[]key.Binding{
 			help,
 			k.Quit,

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -671,9 +671,25 @@ func protoToSession(s proto.Session) session.Session {
 		PromptTokens:     s.PromptTokens,
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
+		Todos:            protoToTodos(s.Todos),
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}
+}
+
+func protoToTodos(todos []proto.Todo) []session.Todo {
+	if len(todos) == 0 {
+		return nil
+	}
+	out := make([]session.Todo, len(todos))
+	for i, t := range todos {
+		out[i] = session.Todo{
+			Content:    t.Content,
+			Status:     session.TodoStatus(t.Status),
+			ActiveForm: t.ActiveForm,
+		}
+	}
+	return out
 }
 
 func protoToFile(f proto.File) history.File {
@@ -770,7 +786,23 @@ func sessionToProto(s session.Session) proto.Session {
 		PromptTokens:     s.PromptTokens,
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
+		Todos:            todosToProto(s.Todos),
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}
+}
+
+func todosToProto(todos []session.Todo) []proto.Todo {
+	if len(todos) == 0 {
+		return nil
+	}
+	out := make([]proto.Todo, len(todos))
+	for i, t := range todos {
+		out[i] = proto.Todo{
+			Content:    t.Content,
+			Status:     string(t.Status),
+			ActiveForm: t.ActiveForm,
+		}
+	}
+	return out
 }


### PR DESCRIPTION
This revision restores the to-dos pill in client-server mode introduced in `v0.55.0`.

It also runs `gofumpt` over all the source code (`task fmt`).