### PR TITLE
fix(shell): ensure canceling a command stops all child processes on Windows

### DIFF
--- a/internal/shell/exec.go
+++ b/internal/shell/exec.go
@@ -82,6 +82,7 @@ func runExternal(ctx context.Context, path string, args []string) error {
 		fmt.Fprintln(hc.Stderr, err)
 		return interp.ExitStatus(127)
 	}
+	startedCmd(&cmd)
 
 	stopCancel := context.AfterFunc(ctx, func() {
 		if killTimeout <= 0 {
@@ -93,6 +94,7 @@ func runExternal(ctx context.Context, path string, args []string) error {
 		_ = killCmd(&cmd)
 	})
 	defer stopCancel()
+	defer cleanupCmd(&cmd)
 
 	waitErr := cmd.Wait()
 	return translateExitError(ctx, waitErr)

--- a/internal/shell/exec_windows_test.go
+++ b/internal/shell/exec_windows_test.go
@@ -1,0 +1,145 @@
+//go:build windows
+
+package shell
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestRun_CtxCancel_KillsProcessTree verifies that cancelling a running
+// command terminates the entire process tree, not just the direct child.
+//
+// Structure:
+//  1. Run() launches powershell.exe via the standard exec handler chain.
+//     startedCmd assigns powershell.exe to a Windows Job Object.
+//  2. powershell.exe forks a grandchild (ping.exe) via Start-Process.
+//     The grandchild inherits the job association automatically.
+//  3. The grandchild writes its PID to a file, then runs for 10 minutes.
+//  4. The test cancels the context.
+//  5. TerminateJobObject kills both powershell.exe and ping.exe.
+//  6. The test confirms ping.exe is gone via OpenProcess.
+//
+// Without the Job Object fix, killing powershell.exe leaves ping.exe
+// orphaned and running until its 10-minute timeout expires.
+func TestRun_CtxCancel_KillsProcessTree(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	pidfile := filepath.Join(dir, "child.pid")
+
+	// PowerShell script: fork a grandchild (ping 600s), write its PID to
+	// pidfile, then wait on it. When we cancel, TerminateJobObject kills
+	// both the PowerShell parent and the ping grandchild.
+	psContent := fmt.Sprintf(`
+$process = Start-Process -NoNewWindow -PassThru powershell -ArgumentList '-Command "ping -n 600 127.0.0.1"'
+$process.Id | Out-File -FilePath '%s' -Encoding ASCII
+Wait-Process -Id $process.Id
+`, pidfile)
+
+	psScript := filepath.Join(dir, "spawn.ps1")
+	if err := os.WriteFile(psScript, []byte(psContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, RunOptions{
+			Command: fmt.Sprintf(`powershell -ExecutionPolicy Bypass -File "%s"`, psScript),
+			Cwd:     dir,
+			Env:     os.Environ(),
+		})
+	}()
+
+	// Wait for the grandchild to write its PID.
+	grandchildPid := waitForPIDFileWindows(t, pidfile, 10*time.Second)
+
+	// Cancel the parent — this should kill everything in the Job Object.
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil && !IsInterrupt(err) {
+			t.Fatalf("Run returned unexpected error: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Run did not return within 30s of ctx cancel")
+	}
+
+	// Verify the grandchild process is dead. On Windows, OpenProcess
+	// against a non-existent PID returns ERROR_INVALID_PARAMETER.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		h, err := windows.OpenProcess(
+			windows.PROCESS_QUERY_INFORMATION, false, uint32(grandchildPid),
+		)
+		if err != nil {
+			return // process is gone — success
+		}
+		windows.CloseHandle(h)
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("grandchild pid %d still alive after cancel; the Job Object fix did not reach it", grandchildPid)
+}
+
+// TestRun_CtxCancel_ReturnsContextErr is identical in intent to the
+// Unix version — it verifies that a cancelled command surfaces
+// ctx.Err() rather than a synthetic exit code.
+func TestRun_CtxCancel_ReturnsContextErr(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- Run(ctx, RunOptions{
+			Command: "ping -n 600 127.0.0.1",
+			Cwd:     t.TempDir(),
+			Env:     os.Environ(),
+		})
+	}()
+
+	// Give the ping a chance to start before cancelling.
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Run did not return within 30s of ctx cancel")
+	}
+}
+
+// waitForPIDFileWindows polls path until it contains a positive integer
+// or the timeout expires. The PID-file dance mirrors exec_unix_test.go's
+// waitForPIDFile, duplicated here to keep each build-tagged file self-
+// contained.
+func waitForPIDFileWindows(t *testing.T, path string, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			var pid int
+			if _, err := fmt.Sscanf(string(data), "%d", &pid); err == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("pidfile %s never contained a valid pid", path)
+	return 0
+}

--- a/internal/shell/process_other.go
+++ b/internal/shell/process_other.go
@@ -1,4 +1,4 @@
-//go:build !unix
+//go:build !unix && !windows
 
 package shell
 

--- a/internal/shell/process_unix.go
+++ b/internal/shell/process_unix.go
@@ -28,6 +28,14 @@ func prepareCmd(cmd *exec.Cmd) {
 	cmd.SysProcAttr.Setpgid = true
 }
 
+// startedCmd is a no-op on Unix — prepareCmd already configured the
+// process group via Setpgid and no post-Start setup is needed.
+func startedCmd(cmd *exec.Cmd) {}
+
+// cleanupCmd is a no-op on Unix — there are no per-process resources
+// to release after Wait returns.
+func cleanupCmd(cmd *exec.Cmd) {}
+
 // interruptCmd sends SIGINT to the entire process group. The negative
 // PID is the kernel's way of saying "this PGID, not this PID". Safe to
 // call after Start; a no-op if the process is already reaped.

--- a/internal/shell/process_windows.go
+++ b/internal/shell/process_windows.go
@@ -1,0 +1,94 @@
+//go:build windows
+
+package shell
+
+import (
+	"os/exec"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// killTimeout is zero on Windows — we send one hard kill via
+// TerminateJobObject rather than a two-stage interrupt-then-kill.
+// The process-group-level equivalent of SIGINT (GenerateConsoleCtrlEvent)
+// is unreliable for non-console processes and job objects make the
+// two-stage dance unnecessary.
+const killTimeout = 0 * time.Second
+
+// jobHandles maps child PID → Windows job object handle. An entry
+// exists from startedCmd (immediately after cmd.Start()) through
+// cleanupCmd (after cmd.Wait()). killCmd uses the handle to terminate
+// the entire job tree on cancellation.
+var jobHandles sync.Map // map[int]windows.Handle
+
+// prepareCmd is a no-op on Windows. We assign the process to a job
+// object in startedCmd (called right after cmd.Start()), accepting a
+// micro-race where the process could fork before assignment. In
+// practice the window is too small for any real command to exploit it.
+func prepareCmd(cmd *exec.Cmd) {}
+
+// startedCmd creates a job object and assigns the newborn process to
+// it so that on cancellation we can terminate the entire process tree
+// via TerminateJobObject. It is called immediately after cmd.Start().
+func startedCmd(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	pid := cmd.Process.Pid
+
+	jh, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return
+	}
+
+	// Open a handle to the child for AssignProcessToJobObject.
+	ph, err := windows.OpenProcess(windows.PROCESS_ALL_ACCESS, false, uint32(pid))
+	if err != nil {
+		windows.CloseHandle(jh)
+		return
+	}
+	defer windows.CloseHandle(ph)
+
+	if err := windows.AssignProcessToJobObject(jh, ph); err != nil {
+		windows.CloseHandle(jh)
+		return
+	}
+
+	jobHandles.Store(pid, jh)
+}
+
+// interruptCmd is a no-op on Windows — killCmd does the hard work
+// via TerminateJobObject, which is equivalent to SIGKILL on the
+// entire job tree.
+func interruptCmd(cmd *exec.Cmd) error {
+	return nil
+}
+
+// killCmd terminates the entire job tree via TerminateJobObject.
+// This is the Windows equivalent of sending SIGKILL to a Unix
+// process group.
+func killCmd(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	if v, ok := jobHandles.Load(cmd.Process.Pid); ok {
+		_ = windows.TerminateJobObject(v.(windows.Handle), 1)
+	}
+	return nil
+}
+
+// cleanupCmd removes the job handle entry after the process exits.
+// On normal exit, the main process is already gone and grandchildren
+// (if any) are intentionally left running. On cancel, killCmd will
+// have already called TerminateJobObject, so the job is empty.
+func cleanupCmd(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	if v, ok := jobHandles.Load(cmd.Process.Pid); ok {
+		windows.CloseHandle(v.(windows.Handle))
+		jobHandles.Delete(cmd.Process.Pid)
+	}
+}


### PR DESCRIPTION


On Unix, the process-group exec handler (f32dcffc) uses Setpgid + negative-PID kill to terminate the entire process tree on context cancellation. Windows lacks process groups, so the same class of bug — cancelled tool calls leaving orphaned editors, dev servers, or build watchers — was unaddressed.

This commit introduces a Windows-specific exec handler layer backed by Job Objects. When a command starts, startedCmd creates a job object and assigns the newborn process to it. On cancellation, killCmd calls TerminateJobObject, which the kernel translates into a tree-wide kill covering every descendant process.

Platform scaffolding:
  - process_windows.go  — Job Object create/assign/kill lifecycle
  - process_unix.go     — no-op startedCmd/cleanupCmd stubs
  - process_other.go    — build constraint narrowed to !unix && !windows;
                          left as a pure fallback for unknown platforms
  - exec.go             — wire startedCmd after cmd.Start() and
                          defer cleanupCmd after cmd.Wait()
  - exec_windows_test.go— regression test mirroring exec_unix_test.go:
                          cancel a command that forked a grandchild,
                          verify the grandchild is dead via OpenProcess
