### PR TITLE
fix(chat): restore selection when no selectable item found during shift+up/down navigation

### DIFF
--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -477,8 +477,10 @@ func (m *Chat) SetSelected(index int) {
 
 // SelectPrev selects the previous message in the chat list.
 func (m *Chat) SelectPrev() {
+	start := m.list.Selected()
 	for {
 		if !m.list.SelectPrev() {
+			m.list.SetSelected(start)
 			return
 		}
 		if m.isSelectable(m.list.Selected()) {
@@ -489,8 +491,10 @@ func (m *Chat) SelectPrev() {
 
 // SelectNext selects the next message in the chat list.
 func (m *Chat) SelectNext() {
+	start := m.list.Selected()
 	for {
 		if !m.list.SelectNext() {
+			m.list.SetSelected(start)
 			return
 		}
 		if m.isSelectable(m.list.Selected()) {


### PR DESCRIPTION
## Summary

- `SelectPrev` and `SelectNext` on `Chat` walk `selectedIdx` through non-selectable items looking for a focusable one. When none is found before the list boundary, the loop exits with `selectedIdx` stranded on a non-selectable item at the edge — rendering without a highlight, making the selection appear to go *beyond* the first/last message.
- Fix: snapshot the starting index before the loop; restore it via `SetSelected(start)` if the boundary is reached with no selectable item found.

Below is a video showing the bug prior to fixing. Notice how I can `tab` to select the last assistant message then use `shift+down` to make the selection go beyond/below the last assistant message.

https://github.com/user-attachments/assets/b26c2262-3cca-496f-886e-fe865279fc0c

## Test plan

- [ ] Open a session with several messages including tool calls (non-selectable items) at the top
- [ ] Enter chat focus mode and navigate with shift+↑ to the first selectable message
- [ ] Press shift+↑ again — selection should stay on the first message, not disappear
- [ ] Same check in the other direction with shift+↓ at the last message