### PR TITLE
fix(skill): skip hidden directories during recursive skill scanning

### DIFF
--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -249,8 +249,11 @@ func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
 				addState("", path, StateError, err)
 				return nil
 			}
-			if d.IsDir() && strings.HasPrefix(d.Name(), ".") {
-				return filepath.SkipDir
+			if strings.HasPrefix(d.Name(), ".") {
+				if d.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
 			}
 			if d.IsDir() || d.Name() != SkillFileName {
 				return nil

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -249,6 +249,9 @@ func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
 				addState("", path, StateError, err)
 				return nil
 			}
+			if d.IsDir() && strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
 			if d.IsDir() || d.Name() != SkillFileName {
 				return nil
 			}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -425,6 +425,14 @@ description: Should not be discovered.
 # Dup Skill
 `), 0o644))
 
+	// Create a hidden skill file inside a visible directory — should be skipped.
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, ".SKILL.md"), []byte(`---
+name: hidden-file-skill
+description: Should not be discovered.
+---
+# Hidden File Skill
+`), 0o644))
+
 	skills, states := DiscoverWithStates([]string{tmpDir})
 
 	require.Len(t, skills, 1)
@@ -433,6 +441,8 @@ description: Should not be discovered.
 	for _, s := range states {
 		require.NotContains(t, s.Path, ".hidden-agents",
 			"hidden directory skill should not appear in states")
+		require.NotContains(t, s.Path, ".SKILL.md",
+			"hidden skill file should not appear in states")
 	}
 }
 

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -400,6 +400,42 @@ func TestParseContent_NoFrontmatter(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestDiscoverSkipsHiddenDirectories(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Create a valid skill in a normal directory.
+	skillDir := filepath.Join(tmpDir, "my-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: my-skill
+description: A visible skill.
+---
+# My Skill
+`), 0o644))
+
+	// Create a skill inside a hidden directory — should be skipped.
+	hiddenDir := filepath.Join(tmpDir, ".hidden-agents", "dup-skill")
+	require.NoError(t, os.MkdirAll(hiddenDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(hiddenDir, "SKILL.md"), []byte(`---
+name: dup-skill
+description: Should not be discovered.
+---
+# Dup Skill
+`), 0o644))
+
+	skills, states := DiscoverWithStates([]string{tmpDir})
+
+	require.Len(t, skills, 1)
+	require.Equal(t, "my-skill", skills[0].Name)
+
+	for _, s := range states {
+		require.NotContains(t, s.Path, ".hidden-agents",
+			"hidden directory skill should not appear in states")
+	}
+}
+
 func TestDiscoverBuiltin(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When a directory entry's name starts with `.` we now return `filepath.SkipDir` to prevent descending into hidden directories like .agents/,  .cursor/,  .gbrain/, etc.

This small fix closes issue #2938.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
