### PR TITLE
fix: show actual tool error instead of generic Invalid parameters

### DIFF
--- a/internal/agent/tools/write_test.go
+++ b/internal/agent/tools/write_test.go
@@ -47,3 +47,54 @@ func TestWriteToolWritesEmptyNewFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", string(b))
 }
+
+func TestWriteToolEmptyFilePath(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+
+	tool := NewWriteTool(nil, &mockPermissionService{}, &mockHistoryService{}, mockFileTrackerService{}, workingDir)
+
+	t.Run("empty_file_path", func(t *testing.T) {
+		t.Parallel()
+
+		input, err := json.Marshal(WriteParams{FilePath: "", Content: "hello"})
+		require.NoError(t, err)
+
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "test-call",
+			Name:  WriteToolName,
+			Input: string(input),
+		})
+		require.NoError(t, err)
+		require.True(t, resp.IsError)
+		require.Contains(t, resp.Content, "file_path is required")
+	})
+
+	t.Run("missing_file_path_from_empty_json", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "test-call",
+			Name:  WriteToolName,
+			Input: `{}`,
+		})
+		require.NoError(t, err)
+		require.True(t, resp.IsError)
+		require.Contains(t, resp.Content, "file_path is required")
+	})
+
+	t.Run("invalid_json_input", func(t *testing.T) {
+		t.Parallel()
+
+		resp, err := tool.Run(ctx, fantasy.ToolCall{
+			ID:    "test-call",
+			Name:  WriteToolName,
+			Input: `not json`,
+		})
+		require.NoError(t, err)
+		require.True(t, resp.IsError)
+		require.Contains(t, resp.Content, "invalid parameters")
+	})
+}

--- a/internal/ui/chat/bash.go
+++ b/internal/ui/chat/bash.go
@@ -128,7 +128,7 @@ func (j *JobOutputToolRenderContext) RenderTool(sty *styles.Styles, width int, o
 
 	var params tools.JobOutputParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	var description string
@@ -179,7 +179,7 @@ func (j *JobKillToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 
 	var params tools.JobKillParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	var description string

--- a/internal/ui/chat/fetch.go
+++ b/internal/ui/chat/fetch.go
@@ -41,7 +41,7 @@ func (f *FetchToolRenderContext) RenderTool(sty *styles.Styles, width int, opts 
 
 	var params tools.FetchParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	toolParams := []string{params.URL}
@@ -116,7 +116,7 @@ func (w *WebFetchToolRenderContext) RenderTool(sty *styles.Styles, width int, op
 
 	var params tools.WebFetchParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	toolParams := []string{params.URL}
@@ -170,7 +170,7 @@ func (w *WebSearchToolRenderContext) RenderTool(sty *styles.Styles, width int, o
 
 	var params tools.WebSearchParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	toolParams := []string{params.Query}

--- a/internal/ui/chat/file.go
+++ b/internal/ui/chat/file.go
@@ -44,7 +44,7 @@ func (v *ViewToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *
 
 	var params tools.ViewParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	file := fsext.PrettyPath(params.FilePath)
@@ -130,7 +130,7 @@ func (w *WriteToolRenderContext) RenderTool(sty *styles.Styles, width int, opts 
 
 	var params tools.WriteParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	file := fsext.PrettyPath(params.FilePath)
@@ -185,7 +185,7 @@ func (e *EditToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *
 
 	var params tools.EditParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, width)
+		return toolInvalidParamsError(sty, opts, width)
 	}
 
 	file := fsext.PrettyPath(params.FilePath)
@@ -248,7 +248,7 @@ func (m *MultiEditToolRenderContext) RenderTool(sty *styles.Styles, width int, o
 
 	var params tools.MultiEditParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, width)
+		return toolInvalidParamsError(sty, opts, width)
 	}
 
 	file := fsext.PrettyPath(params.FilePath)
@@ -316,7 +316,7 @@ func (d *DownloadToolRenderContext) RenderTool(sty *styles.Styles, width int, op
 
 	var params tools.DownloadParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	toolParams := []string{params.URL}

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -39,7 +39,7 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 
 	var params map[string]any
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	var toolParams []string

--- a/internal/ui/chat/mcp.go
+++ b/internal/ui/chat/mcp.go
@@ -50,7 +50,7 @@ func (b *MCPToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *T
 
 	var params map[string]any
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	var toolParams []string

--- a/internal/ui/chat/search.go
+++ b/internal/ui/chat/search.go
@@ -42,7 +42,7 @@ func (g *GlobToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *
 
 	var params tools.GlobParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	toolParams := []string{params.Pattern}
@@ -101,7 +101,7 @@ func (g *GrepToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *
 
 	var params tools.GrepParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	toolParams := []string{params.Pattern}
@@ -166,7 +166,7 @@ func (l *LSToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *To
 
 	var params tools.LSParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	path := params.Path
@@ -226,7 +226,7 @@ func (s *SourcegraphToolRenderContext) RenderTool(sty *styles.Styles, width int,
 
 	var params tools.SourcegraphParams
 	if err := json.Unmarshal([]byte(opts.ToolCall.Input), &params); err != nil {
-		return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, cappedWidth)
+		return toolInvalidParamsError(sty, opts, cappedWidth)
 	}
 
 	toolParams := []string{params.Query}

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -548,6 +548,16 @@ func toolErrorContent(sty *styles.Styles, result *message.ToolResult, width int)
 	return fmt.Sprintf("%s %s", errTag, sty.Tool.ErrorMessage.Render(errContent))
 }
 
+// toolInvalidParamsError renders an error for invalid tool parameters.
+// When the tool has already returned an error result, it uses that content
+// instead of the generic "Invalid parameters" message.
+func toolInvalidParamsError(sty *styles.Styles, opts *ToolRenderOpts, width int) string {
+	if opts.Result != nil && opts.Result.Content != "" {
+		return toolErrorContent(sty, opts.Result, width)
+	}
+	return toolErrorContent(sty, &message.ToolResult{Content: "Invalid parameters"}, width)
+}
+
 // toolIcon returns the status icon for a tool call.
 // toolIcon returns the status icon for a tool call based on its status.
 func toolIcon(sty *styles.Styles, status ToolStatus) string {


### PR DESCRIPTION
## Summary

- Show actual tool error content (e.g., \"file_path is required\") instead of generic \"Invalid parameters\" when tool parameter validation fails in the UI.
- Add tests for `WriteTool` parameter validation (empty file path, missing file path, invalid JSON).

## Test plan

- [x] Unit tests added in `internal/agent/tools/write_test.go`
- [x] Verify UI tool renderers use new `toolInvalidParamsError` helper
- [x] Run `go test ./...` to ensure no regressions
- [x] Manual smoke test with a tool that returns invalid parameters

💘 Generated with Crush