### PR TITLE
fix(cmd/session): close pager stdin pipe when Start fails

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -556,6 +556,10 @@ func sessionWriter(ctx context.Context, contentHeight int) (io.Writer, func(), b
 	}
 
 	if err := cmd.Start(); err != nil {
+		// `pipe` is the read end of an OS pipe owned by `cmd`; once Start fails,
+		// the cleanup func we return is a no-op, so close it here or the FD leaks
+		// every time the pager binary is missing/unexecutable.
+		pipe.Close()
 		return colorprofile.NewWriter(os.Stdout, os.Environ()), func() {}, false
 	}
 


### PR DESCRIPTION
## Description

`maybeStartPager` in `internal/cmd/session.go` opens an OS pipe to the pager's stdin via `cmd.StdinPipe()`, then calls `cmd.Start()`. On the happy path the returned cleanup func closes the pipe and waits for the pager:

```go
return ..., func() {
    pipe.Close()
    _ = cmd.Wait()
}, true
```

On the `cmd.Start()` failure path (e.g., `PAGER=foo` where `foo` isn't on `$PATH`, or isn't executable), the cleanup is replaced with a no-op `func() {}` and `pipe` is never closed:

```go
if err := cmd.Start(); err != nil {
    return colorprofile.NewWriter(os.Stdout, os.Environ()), func() {}, false
}
```

The read-end of that OS pipe leaks every time the function is invoked. For one-shot CLI invocations this is benign, but `session show` / `session list` / `session diff` paths run in long-lived shells when crush is being used as a server (e.g., the MCP integration), and the FDs accumulate.

## Fix

Close `pipe` explicitly in the Start-failed branch so the FD lifecycle matches the happy path. 4-line change inside the existing `if` block.

## Reproduction

```bash
PAGER=/does/not/exist crush session show <id>
# Each invocation leaks one pipe FD; visible with `lsof -p $(pgrep crush)` under repeated calls.
```

## Test plan
- [x] `go build ./...` passes
- N/A for unit tests — this is a cleanup-on-error path with no behavior change on the happy path; an integration test would require mocking the `exec` package
