### PR TITLE
fix(message): AppendContent/AppendReasoningContent only extend first match

### DIFF
--- a/internal/message/content.go
+++ b/internal/message/content.go
@@ -234,20 +234,25 @@ func (m *Message) IsThinking() bool {
 }
 
 func (m *Message) AppendContent(delta string) {
-	found := false
+	// Append to the first existing TextContent part only. The sibling
+	// helpers (AddToolCall, AppendThoughtSignature, FinishThinking) all
+	// `return` after finding the first match; without that here, a
+	// message that ever ends up with multiple TextContent parts would
+	// see `delta` appended to every one of them — multiplying the
+	// visible response. There is no current code path that creates two
+	// TextContent parts on the same message, but the defensive
+	// single-match behavior matches the rest of this file.
 	for i, part := range m.Parts {
 		if c, ok := part.(TextContent); ok {
 			m.Parts[i] = TextContent{Text: c.Text + delta}
-			found = true
+			return
 		}
 	}
-	if !found {
-		m.Parts = append(m.Parts, TextContent{Text: delta})
-	}
+	m.Parts = append(m.Parts, TextContent{Text: delta})
 }
 
 func (m *Message) AppendReasoningContent(delta string) {
-	found := false
+	// See AppendContent above — append to the first match only.
 	for i, part := range m.Parts {
 		if c, ok := part.(ReasoningContent); ok {
 			m.Parts[i] = ReasoningContent{
@@ -256,15 +261,13 @@ func (m *Message) AppendReasoningContent(delta string) {
 				StartedAt:  c.StartedAt,
 				FinishedAt: c.FinishedAt,
 			}
-			found = true
+			return
 		}
 	}
-	if !found {
-		m.Parts = append(m.Parts, ReasoningContent{
-			Thinking:  delta,
-			StartedAt: time.Now().Unix(),
-		})
-	}
+	m.Parts = append(m.Parts, ReasoningContent{
+		Thinking:  delta,
+		StartedAt: time.Now().Unix(),
+	})
 }
 
 func (m *Message) AppendThoughtSignature(signature string, toolCallID string) {

--- a/internal/message/content_test.go
+++ b/internal/message/content_test.go
@@ -140,3 +140,60 @@ func BenchmarkPromptWithTextAttachments(b *testing.B) {
 		})
 	}
 }
+
+// TestAppendContent_OnlyAppendsToFirstMatch pins the defensive
+// single-match behavior of AppendContent: a delta must extend exactly
+// one TextContent part, even when Parts contains more than one. Without
+// the `return` after a match, the loop continues and appends `delta`
+// to every TextContent in Parts — quietly multiplying the visible
+// response. The sibling helpers in this file (AppendThoughtSignature,
+// SetReasoningResponsesData, FinishThinking) all single-match; this
+// test guards that AppendContent and AppendReasoningContent stay in
+// the same family.
+func TestAppendContent_OnlyAppendsToFirstMatch(t *testing.T) {
+	t.Parallel()
+
+	m := &Message{
+		Parts: []ContentPart{
+			TextContent{Text: "first"},
+			TextContent{Text: "second"},
+		},
+	}
+
+	m.AppendContent(" delta")
+
+	require.Len(t, m.Parts, 2)
+	require.Equal(t, "first delta", m.Parts[0].(TextContent).Text)
+	require.Equal(t, "second", m.Parts[1].(TextContent).Text,
+		"second TextContent part must be untouched; AppendContent multi-matched")
+}
+
+func TestAppendContent_CreatesPartWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	m := &Message{Parts: []ContentPart{ToolCall{ID: "tc1"}}}
+	m.AppendContent("hello")
+
+	require.Len(t, m.Parts, 2)
+	tc, ok := m.Parts[1].(TextContent)
+	require.True(t, ok, "expected TextContent appended after ToolCall")
+	require.Equal(t, "hello", tc.Text)
+}
+
+func TestAppendReasoningContent_OnlyAppendsToFirstMatch(t *testing.T) {
+	t.Parallel()
+
+	m := &Message{
+		Parts: []ContentPart{
+			ReasoningContent{Thinking: "a", StartedAt: 1},
+			ReasoningContent{Thinking: "b", StartedAt: 2},
+		},
+	}
+
+	m.AppendReasoningContent(" delta")
+
+	require.Len(t, m.Parts, 2)
+	require.Equal(t, "a delta", m.Parts[0].(ReasoningContent).Thinking)
+	require.Equal(t, "b", m.Parts[1].(ReasoningContent).Thinking,
+		"second ReasoningContent part must be untouched")
+}


### PR DESCRIPTION
## Description

`AppendContent` and `AppendReasoningContent` in `internal/message/content.go` walk `m.Parts` looking for an existing `TextContent` / `ReasoningContent` to extend, but **do not return after finding one** — they set a `found = true` flag and keep iterating:

```go
func (m *Message) AppendContent(delta string) {
    found := false
    for i, part := range m.Parts {
        if c, ok := part.(TextContent); ok {
            m.Parts[i] = TextContent{Text: c.Text + delta}
            found = true   // ← but loop continues
        }
    }
    ...
}
```

If `m.Parts` ever ends up with two parts of the matching type, every streamed delta gets appended to *every* matching part — so the visible response is multiplied. The sibling helpers in the same file (`AppendThoughtSignature` at line 270, `SetReasoningResponsesData`, `FinishThinking`) all `return` after their first match. These two were the outliers.

No current code path in the repo constructs a message with multiple `TextContent` or `ReasoningContent` parts (the streaming agent's `OnTextDelta` and `OnReasoningDelta` callbacks rely on this single-part assumption), so this is a **latent / defensive fix** rather than a user-visible regression today. But the inconsistency makes the file an easy place for a future bug to amplify, especially as providers add multi-modal content blocks.

## Fix

Replace the `found = true; ... loop continues` pattern with an early `return` after the first match, matching the rest of the file. Same change in both functions. Net: −10 / +12 lines (the new `return`-style is shorter than the find-then-decide pattern).

## Test plan

- [x] Added `TestAppendContent_OnlyAppendsToFirstMatch` and `TestAppendReasoningContent_OnlyAppendsToFirstMatch` that pin the single-match contract — both fail on the old `found = true` loop and pass with the `return`.
- [x] Added `TestAppendContent_CreatesPartWhenAbsent` to cover the "no existing part, append a new one" path that the old code reached via the `if !found` branch.
- [x] Full `go test ./internal/message/...` passes.
- [x] `go vet ./internal/message/...` clean.
