### PR TITLE
fix(db): keep SQLite temp files in memory

### DIFF
--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -18,6 +18,7 @@ var (
 		"foreign_keys":  "ON",
 		"journal_mode":  "WAL",
 		"page_size":     "4096",
+		"temp_store":    "MEMORY",
 		"cache_size":    "-8000",
 		"synchronous":   "NORMAL",
 		"secure_delete": "ON",


### PR DESCRIPTION
This changes the default temp store to memory which was causing problems in sandboxes like landlock. Should be a straightforward fix but it could potentially cause problems if the .crush db gets enormously large and then we try to do a very large index or query

fixes #2903