### PR TITLE
feat(pkg/crush): add public API for programmatic use

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -79,8 +79,7 @@ var opencodeMessagesModels = map[string]bool{
 }
 
 type Coordinator interface {
-	// INFO: (kujtim) this is not used yet we will use this when we have multiple agents
-	// SetMainAgent(string)
+	SetMainAgent(id string)
 	Run(ctx context.Context, sessionID, prompt string, attachments ...message.Attachment) (*fantasy.AgentResult, error)
 	// RunAccepted runs a call that was already accepted via
 	// BeginAccepted on the fire-and-forget dispatch path. The handle is
@@ -168,24 +167,45 @@ func NewCoordinator(
 		skillTracker: skillTracker,
 	}
 
-	agentCfg, ok := cfg.Config().Agents[config.AgentCoder]
-	if !ok {
+	// Build all configured agents.
+	for agentID, agentCfg := range cfg.Config().Agents {
+		if agentCfg.ID == "" {
+			continue
+		}
+		prompt, err := agentPrompt(agentID, prompt.WithWorkingDir(c.cfg.WorkingDir()))
+		if err != nil {
+			return nil, fmt.Errorf("failed to build prompt for agent %q: %w", agentID, err)
+		}
+		agent, err := c.buildAgent(ctx, prompt, agentCfg, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build agent %q: %w", agentID, err)
+		}
+		c.agents[agentID] = agent
+	}
+
+	// Default to the coder agent if available.
+	if defaultAgent, ok := c.agents[config.AgentCoder]; ok {
+		c.currentAgent = defaultAgent
+	} else if len(c.agents) > 0 {
+		// Pick the first agent as default if coder is not configured.
+		for _, a := range c.agents {
+			c.currentAgent = a
+			break
+		}
+	}
+
+	if c.currentAgent == nil {
 		return nil, errCoderAgentNotConfigured
 	}
 
-	// TODO: make this dynamic when we support multiple agents
-	prompt, err := coderPrompt(prompt.WithWorkingDir(c.cfg.WorkingDir()))
-	if err != nil {
-		return nil, err
-	}
-
-	agent, err := c.buildAgent(ctx, prompt, agentCfg, false)
-	if err != nil {
-		return nil, err
-	}
-	c.currentAgent = agent
-	c.agents[config.AgentCoder] = agent
 	return c, nil
+}
+
+// SetMainAgent switches the active agent to the one identified by id.
+func (c *coordinator) SetMainAgent(id string) {
+	if agent, ok := c.agents[id]; ok {
+		c.currentAgent = agent
+	}
 }
 
 // Run implements Coordinator.

--- a/internal/agent/prompts.go
+++ b/internal/agent/prompts.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	_ "embed"
 
 	"github.com/charmbracelet/crush/internal/agent/prompt"
@@ -31,6 +32,19 @@ func taskPrompt(opts ...prompt.Option) (*prompt.Prompt, error) {
 		return nil, err
 	}
 	return systemPrompt, nil
+}
+
+var agentPrompts = map[string]func(...prompt.Option) (*prompt.Prompt, error){
+	config.AgentCoder: coderPrompt,
+	config.AgentTask:  taskPrompt,
+}
+
+func agentPrompt(id string, opts ...prompt.Option) (*prompt.Prompt, error) {
+	fn, ok := agentPrompts[id]
+	if !ok {
+		return nil, fmt.Errorf("unknown agent id: %s", id)
+	}
+	return fn(opts...)
 }
 
 func InitializePrompt(cfg *config.ConfigStore) (string, error) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -148,7 +148,7 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 		slog.Warn("No agent configuration found")
 		return app, nil
 	}
-	if err := app.InitCoderAgent(ctx); err != nil {
+	if err := app.InitAgent(ctx, config.AgentCoder); err != nil {
 		return nil, fmt.Errorf("failed to initialize coder agent: %w", err)
 	}
 
@@ -233,11 +233,15 @@ func (app *App) resolveSession(ctx context.Context, continueSessionID string, us
 
 // RunNonInteractive runs the application in non-interactive mode with the
 // given prompt, printing to stdout.
-func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt, largeModel, smallModel string, hideSpinner bool, continueSessionID string, useLast bool) error {
+func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt, largeModel, smallModel string, hideSpinner bool, continueSessionID string, useLast bool, agentID string) error {
 	slog.Info("Running in non-interactive mode")
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	if agentID != "" && app.AgentCoordinator != nil {
+		app.AgentCoordinator.SetMainAgent(agentID)
+	}
 
 	if largeModel != "" || smallModel != "" {
 		if err := app.overrideModelsForNonInteractive(ctx, largeModel, smallModel); err != nil {
@@ -580,10 +584,10 @@ func setupSubscriberMustDeliver[T any](
 	})
 }
 
-func (app *App) InitCoderAgent(ctx context.Context) error {
-	coderAgentCfg := app.config.Config().Agents[config.AgentCoder]
-	if coderAgentCfg.ID == "" {
-		return fmt.Errorf("coder agent configuration is missing")
+func (app *App) InitAgent(ctx context.Context, agentID string) error {
+	agentCfg := app.config.Config().Agents[agentID]
+	if agentCfg.ID == "" {
+		return fmt.Errorf("%s agent configuration is missing", agentID)
 	}
 	var err error
 	app.AgentCoordinator, err = agent.NewCoordinator(
@@ -600,10 +604,17 @@ func (app *App) InitCoderAgent(ctx context.Context) error {
 		app.Skills,
 	)
 	if err != nil {
-		slog.Error("Failed to create coder agent", "err", err)
+		slog.Error("Failed to create agent", "agent_id", agentID, "err", err)
 		return err
 	}
+	app.AgentCoordinator.SetMainAgent(agentID)
 	return nil
+}
+
+// InitCoderAgent is a convenience wrapper for InitAgent("coder").
+// Deprecated: Use InitAgent with the specific agent ID instead.
+func (app *App) InitCoderAgent(ctx context.Context) error {
+	return app.InitAgent(ctx, config.AgentCoder)
 }
 
 // Subscribe sends events to the TUI as tea.Msgs.

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -141,7 +141,7 @@ crush run --continue "Follow up on your last response"
 		}
 
 		appWs := ws.(*workspace.AppWorkspace)
-		return appWs.App().RunNonInteractive(ctx, os.Stdout, prompt, largeModel, smallModel, quiet || verbose, sessionID, useLast)
+		return appWs.App().RunNonInteractive(ctx, os.Stdout, prompt, largeModel, smallModel, quiet || verbose, sessionID, useLast, "")
 	},
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -507,6 +507,7 @@ type Agent struct {
 	Description string `json:"description,omitempty"`
 	// This is the id of the system prompt used by the agent
 	Disabled bool `json:"disabled,omitempty"`
+	DisableMCP bool `json:"disable_mcp,omitempty"`
 
 	Model SelectedModelType `json:"model" jsonschema:"required,description=The model type to use for this agent,enum=large,enum=small,default=large"`
 

--- a/pkg/crush/README.md
+++ b/pkg/crush/README.md
@@ -1,0 +1,488 @@
+# Crush Public API (`pkg/crush`)
+
+> **Experimental — no stability guarantees**
+>
+> `pkg/crush` is an unstable, experimental API. Types, functions, and method
+> signatures may change or be removed in any release without notice. There is
+> no semantic-versioning or backward-compatibility promise. Pin to a specific
+> Crush version and plan for breakage when upgrading.
+
+This package exposes a public Go API for [Crush](https://github.com/charmbracelet/crush) — a terminal-based AI coding assistant by [Charm](https://charm.sh). Use it to configure, initialize, and interact with Crush from external Go code.
+
+Do not treat this API as production-stable. It exists for early integration and feedback while the surface matures.
+
+## Usage
+
+```go
+import "github.com/charmbracelet/crush/pkg/crush"
+```
+
+## Overview
+
+The public API is organized around these key areas:
+
+| Area | Types | Description |
+|------|-------|-------------|
+| **Configuration** | `Config`, `ConfigStore`, `SelectedModel`, `ProviderConfig`, `MCPConfig`, `LSPConfig`, `Agent`, `Options` | Crush configuration and settings |
+| **Sessions** | `Session`, `Todo`, `SessionService` | Conversation session management |
+| **Messages** | `Message`, `ContentPart`, `TextContent`, `ToolCall`, `ToolResult`, `MessageService` | Message creation and streaming |
+| **Permissions** | `PermissionRequest`, `PermissionService` | Tool execution permission management |
+| **History** | `File`, `HistoryService` | Versioned file history |
+| **Events** | `Event`, `EventType`, `Subscriber`, `Publisher` | Pub/sub event system |
+| **App** | `App`, `NewApp()` | Top-level application orchestrator |
+
+## Quick Start
+
+### One-Shot Execution
+
+The simplest way to run a single prompt and exit:
+
+```go
+ctx := context.Background()
+
+// Initialize the application (loads config, opens DB, sets up agents)
+app, err := crush.NewAppWithConfig(ctx, ".", ".crush", false, nil)
+if err != nil {
+    log.Fatalf("failed to initialize app: %v", err)
+}
+defer app.Shutdown()
+
+// Run a single prompt with sensible defaults
+err = crush.RunPrompt(app, ctx, "Write a hello world program in Go")
+if err != nil {
+    log.Fatal(err)
+}
+```
+
+See [`example/oneshot`](./example/oneshot/main.go) for a complete runnable example.
+
+### Server-Style Execution
+
+For long-running processes that need session management and event streaming:
+
+```go
+ctx := context.Background()
+
+app, err := crush.NewAppWithConfig(ctx, ".", ".crush", false, nil)
+if err != nil {
+    log.Fatalf("failed to initialize app: %v", err)
+}
+defer app.Shutdown()
+
+// 1. Create a session
+sess, err := app.Sessions.Create(ctx, "My coding session")
+if err != nil {
+    log.Fatal(err)
+}
+
+// 2. Subscribe to live message events BEFORE running the prompt
+eventsCh := crush.SubscribeSessionMessages(ctx, app, sess.ID)
+
+// 3. Consume events in a background goroutine
+go func() {
+    for ev := range eventsCh {
+        switch ev.Type {
+        case crush.EventCreated:
+            fmt.Printf("[CREATED] %s role=%s\n", ev.Payload.ID, ev.Payload.Role)
+        case crush.EventUpdated:
+            msg := ev.Payload
+            if rc := msg.ReasoningContent(); rc.Thinking != "" {
+                fmt.Printf("[THINKING] %s\n", rc.Thinking)
+            }
+            if txt := msg.Content(); txt.Text != "" {
+                fmt.Printf("[TEXT] %s\n", txt.Text)
+            }
+            for _, tc := range msg.ToolCalls() {
+                fmt.Printf("[TOOL_CALL] %s %s\n", tc.Name, tc.ID)
+            }
+            for _, tr := range msg.ToolResults() {
+                fmt.Printf("[TOOL_RESULT] %s\n", tr.ToolCallID)
+            }
+            if msg.IsFinished() {
+                fmt.Printf("[FINISHED] reason=%s\n", msg.FinishReason())
+            }
+        }
+    }
+}()
+
+// 4. Run the prompt in the existing session
+var out bytes.Buffer
+err = crush.RunPromptInSession(app, ctx, &out, sess.ID, "Write a hello world program in Go")
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Printf("Final response:\n%s\n", out.String())
+```
+
+See [`example/server`](./example/server/main.go) for a complete runnable example.
+
+### Loading Configuration
+
+```go
+import (
+    "context"
+    "database/sql"
+
+    "github.com/charmbracelet/crush/pkg/crush"
+)
+
+// Load configuration from default paths (crush.json, etc.)
+store, err := crush.Load("/path/to/project", "", false)
+if err != nil {
+    // handle error
+}
+
+cfg := store.Config()
+```
+
+### Defining Configuration Programmatically
+
+Instead of loading `crush.json` from disk, you can build the configuration entirely in code and wrap it in a `ConfigStore` for use with `NewApp`:
+
+```go
+import (
+    "os"
+
+    "github.com/charmbracelet/crush/pkg/crush"
+    "charm.land/catwalk/pkg/catwalk"
+)
+
+// Build the pure-data configuration
+cfg := &crush.Config{
+    Models: map[crush.SelectedModelType]crush.SelectedModel{
+        crush.SelectedModelTypeLarge: {
+            Provider: "openai",
+            Model:    "gpt-5",
+        },
+        crush.SelectedModelTypeSmall: {
+            Provider: "openai",
+            Model:    "gpt-5-mini",
+        },
+    },
+    Providers: crush.NewMapFrom(map[string]crush.ProviderConfig{
+        "openai": {
+            ID:     "openai",
+            Name:   "OpenAI",
+            Type:   catwalk.TypeOpenAI,
+            APIKey: os.Getenv("OPENAI_API_KEY"),
+            Models: []catwalk.Model{
+                {ID: "gpt-5", Name: "GPT-5"},
+                {ID: "gpt-5-mini", Name: "GPT-5 Mini"},
+            },
+        },
+    }),
+    MCP: map[string]crush.MCPConfig{
+        "filesystem": {
+            Command: "npx",
+            Args:    []string{"-y", "@modelcontextprotocol/server-filesystem", "/tmp"},
+            Type:    crush.MCPStdio,
+        },
+    },
+    Options: &crush.Options{
+        DataDirectory: ".crush",
+        Debug:         true,
+    },
+}
+
+// Derive agents from the configuration
+cfg.SetupAgents()
+
+// Wrap in a store so the app can consume it
+store := crush.NewConfigStore(cfg)
+
+// Now pass it to NewApp exactly as if it had been loaded from file
+app, err := crush.NewApp(ctx, conn, store, nil)
+```
+
+`NewTestStore` is the helper exported for this use-case. It takes a `*Config` (and optional loaded-path hints) and returns a `*ConfigStore` that satisfies everything `App` needs without ever touching the filesystem.
+
+```go
+// Open the SQLite database
+conn, err := sql.Open("sqlite", "path/to/db")
+if err != nil {
+    // handle error
+}
+defer conn.Close()
+
+// Create the application instance
+app, err := crush.NewApp(ctx, conn, store, nil)
+if err != nil {
+    // handle error
+}
+defer app.Shutdown()
+```
+
+## Convenience Functions
+
+### `NewAppWithConfig`
+
+Loads configuration from default paths, opens the SQLite database (with migrations), and creates a fully initialized `App`:
+
+```go
+func NewAppWithConfig(ctx context.Context, workingDir, dataDir string, debug bool, skillsMgr *SkillsManager) (*App, error)
+```
+
+- `workingDir`: project working directory (config lookup starts here)
+- `dataDir`: directory for SQLite DB and other runtime data (e.g. `".crush"`)
+- `debug`: enable debug logging
+- `skillsMgr`: optional skills manager (pass `nil` for default behavior)
+
+### `RunPrompt`
+
+Run a single prompt with sensible defaults — output to `os.Stdout`, models from config, spinner enabled, new session:
+
+```go
+func RunPrompt(app *App, ctx context.Context, prompt string) error
+```
+
+### `RunPromptAndCreateSession`
+
+Create a named session, run a prompt, and return the session ID for later retrieval:
+
+```go
+func RunPromptAndCreateSession(app *App, ctx context.Context, output io.Writer, title, prompt string) (string, error)
+```
+
+### `RunPromptInSession`
+
+Run a prompt in an existing session:
+
+```go
+func RunPromptInSession(app *App, ctx context.Context, output io.Writer, sessionID, prompt string) error
+```
+
+### `SubscribeSessionMessages`
+
+Subscribe to live message events for a specific session. Useful for streaming thinking text, tool calls, and results to a server client:
+
+```go
+func SubscribeSessionMessages(ctx context.Context, app *App, sessionID string) <-chan Event[Message]
+```
+
+Returns a channel that emits events with types `EventCreated`, `EventUpdated`, `EventDeleted`. Use the helpers on `Message` to extract content:
+
+| What you want | Method |
+|---------------|--------|
+| Assistant text | `msg.Content().Text` |
+| Thinking/reasoning text | `msg.ReasoningContent().Thinking` |
+| Tool calls | `msg.ToolCalls()` |
+| Tool results | `msg.ToolResults()` |
+| Turn finished? | `msg.IsFinished()` |
+| Finish reason | `msg.FinishReason()` |
+
+## Working with Sessions
+
+```go
+// Create a new session
+sess, err := app.Sessions.Create(ctx, "My coding session")
+
+// List all sessions
+sessions, err := app.Sessions.List(ctx)
+
+// Get a session by ID
+sess, err := app.Sessions.Get(ctx, sessionID)
+
+// Delete a session
+err = app.Sessions.Delete(ctx, sessionID)
+```
+
+## Working with Messages
+
+```go
+// Create a user message
+msg, err := app.Messages.Create(ctx, sessionID, crush.CreateMessageParams{
+    Role:  crush.RoleUser,
+    Parts: []crush.ContentPart{crush.TextContent{Text: "Hello!"}},
+})
+
+// List messages in a session
+messages, err := app.Messages.List(ctx, sessionID)
+```
+
+### Non-Interactive Agent Execution (Low-Level)
+
+For full control over output, model overrides, session continuation, and spinner:
+
+```go
+err = app.RunNonInteractive(
+    ctx,
+    os.Stdout,
+    "Write a hello world program in Go",
+    "",    // large model override (empty = use config)
+    "",    // small model override
+    false, // hide spinner
+    "",    // continue session ID
+    false, // use last session
+)
+```
+
+## Configuration Types
+
+### SelectedModel
+
+Represents a selected LLM model:
+
+```go
+type SelectedModel struct {
+    Model           string
+    Provider        string
+    ReasoningEffort string
+    Think           bool
+    MaxTokens       int64
+    Temperature     *float64
+    TopP            *float64
+    TopK            *int64
+    // ... and more
+}
+```
+
+### ProviderConfig
+
+Configures an LLM provider:
+
+```go
+type ProviderConfig struct {
+    ID       string
+    Name     string
+    BaseURL  string
+    Type     string // openai, anthropic, gemini, etc.
+    APIKey   string
+    Models   []catwalk.Model
+    // ... and more
+}
+```
+
+### MCPConfig
+
+Configures a Model Context Protocol server:
+
+```go
+type MCPConfig struct {
+    Command string
+    Args    []string
+    Env     map[string]string
+    Type    MCPType // stdio, sse, http
+    URL     string
+    // ... and more
+}
+```
+
+## Session Types
+
+### Session
+
+A conversation session:
+
+```go
+type Session struct {
+    ID               string
+    ParentSessionID  string
+    Title            string
+    MessageCount     int64
+    PromptTokens     int64
+    CompletionTokens int64
+    Cost             float64
+    Todos            []Todo
+    CreatedAt        int64
+    UpdatedAt        int64
+}
+```
+
+### Todo
+
+A task item within a session:
+
+```go
+type Todo struct {
+    Content    string
+    Status     TodoStatus // pending, in_progress, completed
+    ActiveForm string
+}
+```
+
+## Message Types
+
+### Message
+
+A single message in a conversation:
+
+```go
+type Message struct {
+    ID               string
+    Role             MessageRole // assistant, user, system, tool
+    SessionID        string
+    Parts            []ContentPart
+    Model            string
+    Provider         string
+    CreatedAt        int64
+    UpdatedAt        int64
+    IsSummaryMessage bool
+}
+```
+
+### Content Parts
+
+Messages are composed of content parts:
+
+- **`TextContent`** — Plain text
+- **`ReasoningContent`** — Model reasoning/thinking
+- **`ImageURLContent`** — Image referenced by URL
+- **`BinaryContent`** — Binary data (e.g. uploaded files)
+- **`ToolCall`** — Tool invocation request
+- **`ToolResult`** — Tool invocation result
+- **`Finish`** — End-of-turn marker
+
+## Event System
+
+Crush uses an internal pub/sub system for decoupled communication. Each service (sessions, messages, permissions, etc.) has its own broker.
+
+### Per-Session Message Events
+
+For real-time streaming of a single session, use the convenience wrapper:
+
+```go
+eventsCh := crush.SubscribeSessionMessages(ctx, app, sessionID)
+for ev := range eventsCh {
+    msg := ev.Payload
+    if rc := msg.ReasoningContent(); rc.Thinking != "" {
+        fmt.Printf("Thinking: %s\n", rc.Thinking)
+    }
+    if txt := msg.Content(); txt.Text != "" {
+        fmt.Printf("Text: %s\n", txt.Text)
+    }
+    for _, tc := range msg.ToolCalls() {
+        fmt.Printf("Tool call: %s\n", tc.Name)
+    }
+}
+```
+
+### General Service Events
+
+```go
+// Subscribe to all session events
+events := app.Sessions.Subscribe(ctx)
+for event := range events {
+    switch event.Type {
+    case crush.EventCreated:
+        // handle new session
+    case crush.EventUpdated:
+        // handle updated session
+    case crush.EventDeleted:
+        // handle deleted session
+    }
+}
+```
+
+## Experimental API
+
+- **Unstable** — breaking changes can land in any release (including patch releases).
+- **No guarantees** — exported symbols are not covered by semantic versioning or a compatibility policy.
+- **Pin versions** — depend on an explicit Crush module version; do not assume `latest` stays compatible.
+- **Internal code** — packages under `internal/` are not importable and may change without notice.
+
+A formal stability policy may be adopted later. Until then, treat every upgrade as a potential breaking change and read the release notes before bumping your dependency.
+
+## See Also
+
+- [Crush GitHub Repository](https://github.com/charmbracelet/crush)
+- [Crush Documentation](https://charm.sh/crush)

--- a/pkg/crush/agent.go
+++ b/pkg/crush/agent.go
@@ -1,0 +1,156 @@
+package crush
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+var (
+	// ErrAgentIDRequired is returned when an agent is missing an ID.
+	ErrAgentIDRequired = errors.New("agent id is required")
+	// ErrAgentModelInvalid is returned when an agent model is not "large" or "small".
+	ErrAgentModelInvalid = errors.New("agent model must be large or small")
+)
+
+// AgentOption configures an Agent during construction.
+type AgentOption func(*Agent)
+
+// NewAgent creates a new Agent with the given ID and options.
+// ID is required and must be non-empty. Model defaults to SelectedModelTypeLarge.
+func NewAgent(id string, opts ...AgentOption) (Agent, error) {
+	if strings.TrimSpace(id) == "" {
+		return Agent{}, fmt.Errorf("%w: id cannot be empty", ErrAgentIDRequired)
+	}
+	a := Agent{
+		ID:    id,
+		Model: SelectedModelTypeLarge,
+	}
+	for _, opt := range opts {
+		opt(&a)
+	}
+	if err := ValidateAgent(a); err != nil {
+		return Agent{}, err
+	}
+	return a, nil
+}
+
+// WithAgentName sets the agent name.
+func WithAgentName(name string) AgentOption {
+	return func(a *Agent) { a.Name = name }
+}
+
+// WithAgentDescription sets the agent description.
+func WithAgentDescription(desc string) AgentOption {
+	return func(a *Agent) { a.Description = desc }
+}
+
+// WithAgentModel sets the model type (large or small).
+func WithAgentModel(model SelectedModelType) AgentOption {
+	return func(a *Agent) { a.Model = model }
+}
+
+// WithAgentAllowedTools sets the exact list of allowed tool names.
+// If not called, all tools are available (nil).
+func WithAgentAllowedTools(tools ...string) AgentOption {
+	return func(a *Agent) { a.AllowedTools = tools }
+}
+
+// WithAgentAllowedMCPs adds or replaces an MCP server entry.
+// If tools is empty (no variadic args), the slice is nil, meaning all tools
+// from that MCP are available. To disable all MCPs, use WithAgentDisabledMCPs.
+func WithAgentAllowedMCPs(mcp string, tools ...string) AgentOption {
+	return func(a *Agent) {
+		if a.DisableMCP {
+			a.DisableMCP = false
+		}
+		if a.AllowedMCP == nil {
+			a.AllowedMCP = make(map[string][]string)
+		}
+		a.AllowedMCP[mcp] = tools
+	}
+}
+
+// WithAgentAllowedMCP is a deprecated alias for WithAgentAllowedMCPs.
+// Deprecated: Use WithAgentAllowedMCPs instead.
+func WithAgentAllowedMCP(mcp string, tools ...string) AgentOption {
+	return WithAgentAllowedMCPs(mcp, tools...)
+}
+
+// WithAgentAllowAllMCPTools explicitly enables all tools from an MCP server.
+// This is the self-documenting equivalent of calling WithAgentAllowedMCPs(mcp)
+// with no tool arguments.
+func WithAgentAllowAllMCPTools(mcp string) AgentOption {
+	return WithAgentAllowedMCPs(mcp)
+}
+
+// WithAgentDisabledMCPs disables all MCPs for the agent.
+func WithAgentDisabledMCPs() AgentOption {
+	return func(a *Agent) {
+		a.DisableMCP = true
+		a.AllowedMCP = make(map[string][]string)
+	}
+}
+
+// WithAgentDisableMCPs is a deprecated alias for WithAgentDisabledMCPs.
+// Deprecated: Use WithAgentDisabledMCPs instead.
+func WithAgentDisableMCPs() AgentOption {
+	return WithAgentDisabledMCPs()
+}
+
+// WithAgentContextPaths overrides the context paths for the agent.
+func WithAgentContextPaths(paths ...string) AgentOption {
+	return func(a *Agent) { a.ContextPaths = paths }
+}
+
+// WithAgentDisabled sets whether the agent is disabled.
+func WithAgentDisabled(disabled bool) AgentOption {
+	return func(a *Agent) { a.Disabled = disabled }
+}
+
+// ValidateAgent checks the agent configuration for errors.
+func ValidateAgent(a Agent) error {
+	if strings.TrimSpace(a.ID) == "" {
+		return ErrAgentIDRequired
+	}
+	if a.Model != SelectedModelTypeLarge && a.Model != SelectedModelTypeSmall {
+		return fmt.Errorf("%w: got %q", ErrAgentModelInvalid, a.Model)
+	}
+	return nil
+}
+
+// IsAgentValid reports whether the agent configuration is valid.
+func IsAgentValid(a Agent) bool {
+	return ValidateAgent(a) == nil
+}
+
+// AgentIsValid is a deprecated alias for IsAgentValid.
+// Deprecated: Use IsAgentValid instead.
+func AgentIsValid(a *Agent) bool {
+	if a == nil {
+		return false
+	}
+	return IsAgentValid(*a)
+}
+
+// CloneAgent returns a deep copy of the agent.
+func CloneAgent(a Agent) Agent {
+	cloned := Agent{
+		ID:           a.ID,
+		Name:         a.Name,
+		Description:  a.Description,
+		Disabled:     a.Disabled,
+		DisableMCP:   a.DisableMCP,
+		Model:        a.Model,
+		AllowedTools: slices.Clone(a.AllowedTools),
+		ContextPaths: slices.Clone(a.ContextPaths),
+	}
+	if a.AllowedMCP != nil {
+		cloned.AllowedMCP = make(map[string][]string, len(a.AllowedMCP))
+		for k, v := range a.AllowedMCP {
+			cloned.AllowedMCP[k] = slices.Clone(v)
+		}
+	}
+	return cloned
+}

--- a/pkg/crush/agent_test.go
+++ b/pkg/crush/agent_test.go
@@ -1,0 +1,223 @@
+package crush
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAgent(t *testing.T) {
+	t.Parallel()
+
+	// Happy path with defaults.
+	a, err := NewAgent("coder")
+	require.NoError(t, err)
+	assert.Equal(t, "coder", a.ID)
+	assert.Equal(t, SelectedModelTypeLarge, a.Model)
+	assert.Nil(t, a.AllowedTools)
+	assert.Nil(t, a.AllowedMCP)
+	assert.False(t, a.Disabled)
+
+	// Full options.
+	a, err = NewAgent("task",
+		WithAgentName("Task Agent"),
+		WithAgentDescription("Searches for context."),
+		WithAgentModel(SelectedModelTypeSmall),
+		WithAgentAllowedTools("grep", "ls"),
+		WithAgentContextPaths("README.md"),
+		WithAgentDisabled(true),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "task", a.ID)
+	assert.Equal(t, "Task Agent", a.Name)
+	assert.Equal(t, "Searches for context.", a.Description)
+	assert.Equal(t, SelectedModelTypeSmall, a.Model)
+	assert.Equal(t, []string{"grep", "ls"}, a.AllowedTools)
+	assert.Equal(t, []string{"README.md"}, a.ContextPaths)
+	assert.True(t, a.Disabled)
+}
+
+func TestNewAgent_EmptyID(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewAgent("")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAgentIDRequired)
+
+	_, err = NewAgent("   ")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAgentIDRequired)
+}
+
+func TestNewAgent_InvalidModel(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewAgent("coder", WithAgentModel("fast"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAgentModelInvalid)
+}
+
+func TestNewAgent_AllowedMCP(t *testing.T) {
+	t.Parallel()
+
+	// With explicit tools.
+	a, err := NewAgent("coder",
+		WithAgentAllowedMCP("server1", "tool1", "tool2"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, map[string][]string{"server1": {"tool1", "tool2"}}, a.AllowedMCP)
+
+	// With no tools (nil slice means all tools for that MCP).
+	a, err = NewAgent("coder",
+		WithAgentAllowedMCP("server1"),
+	)
+	require.NoError(t, err)
+	assert.Nil(t, a.AllowedMCP["server1"])
+
+	// Multiple MCPs.
+	a, err = NewAgent("coder",
+		WithAgentAllowedMCP("a", "t1"),
+		WithAgentAllowedMCP("b"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"t1"}, a.AllowedMCP["a"])
+	assert.Nil(t, a.AllowedMCP["b"])
+}
+
+func TestNewAgent_DisableMCPs(t *testing.T) {
+	t.Parallel()
+
+	a, err := NewAgent("task", WithAgentDisableMCPs())
+	require.NoError(t, err)
+	assert.NotNil(t, a.AllowedMCP)
+	assert.Empty(t, a.AllowedMCP)
+}
+
+func TestNewAgent_AllowedMCP_LastWriteWins(t *testing.T) {
+	t.Parallel()
+
+	a, err := NewAgent("coder",
+		WithAgentAllowedMCP("server1", "t1"),
+		WithAgentAllowedMCP("server1", "t2"),
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"t2"}, a.AllowedMCP["server1"])
+}
+
+func TestWithAgentDisabled(t *testing.T) {
+	t.Parallel()
+
+	a, err := NewAgent("coder", WithAgentDisabled(true))
+	require.NoError(t, err)
+	assert.True(t, a.Disabled)
+}
+
+func TestValidateAgent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		agent   Agent
+		wantErr error
+	}{
+		{
+			name: "valid with large model",
+			agent: Agent{
+				ID:    "coder",
+				Model: SelectedModelTypeLarge,
+			},
+		},
+		{
+			name: "valid with small model",
+			agent: Agent{
+				ID:    "task",
+				Model: SelectedModelTypeSmall,
+			},
+		},
+		{
+			name: "missing id",
+			agent: Agent{
+				ID:    "",
+				Model: SelectedModelTypeLarge,
+			},
+			wantErr: ErrAgentIDRequired,
+		},
+		{
+			name: "whitespace id",
+			agent: Agent{
+				ID:    "   ",
+				Model: SelectedModelTypeLarge,
+			},
+			wantErr: ErrAgentIDRequired,
+		},
+		{
+			name: "invalid model",
+			agent: Agent{
+				ID:    "coder",
+				Model: "medium",
+			},
+			wantErr: ErrAgentModelInvalid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateAgent(tt.agent)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestAgentIsValid(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, IsAgentValid(Agent{ID: "a", Model: SelectedModelTypeLarge}))
+	assert.False(t, IsAgentValid(Agent{ID: ""}))
+	assert.False(t, IsAgentValid(Agent{ID: "a", Model: "unknown"}))
+}
+
+func TestCloneAgent(t *testing.T) {
+	t.Parallel()
+
+	original := &Agent{
+		ID:           "coder",
+		Name:         "Coder",
+		Description:  "A coding agent.",
+		Disabled:     true,
+		Model:        SelectedModelTypeLarge,
+		AllowedTools: []string{"edit", "bash"},
+		AllowedMCP: map[string][]string{
+			"server1": {"tool1", "tool2"},
+			"server2": nil,
+		},
+		ContextPaths: []string{"AGENTS.md"},
+	}
+
+	cloned := CloneAgent(*original)
+	assert.EqualValues(t, *original, cloned)
+
+	// Mutate slices and maps on the clone to verify deep copy.
+	cloned.AllowedTools[0] = "modified"
+	cloned.AllowedMCP["server1"][0] = "modified"
+	cloned.AllowedMCP["new"] = []string{"tool"}
+	cloned.ContextPaths[0] = "modified"
+
+	assert.Equal(t, "edit", original.AllowedTools[0])
+	assert.Equal(t, "tool1", original.AllowedMCP["server1"][0])
+	assert.NotContains(t, original.AllowedMCP, "new")
+	assert.Equal(t, "AGENTS.md", original.ContextPaths[0])
+}
+
+func TestCloneAgent_ZeroValue(t *testing.T) {
+	t.Parallel()
+
+	var a Agent
+	cloned := CloneAgent(a)
+	assert.Equal(t, a, cloned)
+}

--- a/pkg/crush/app.go
+++ b/pkg/crush/app.go
@@ -1,0 +1,182 @@
+package crush
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/charmbracelet/crush/internal/app"
+	"github.com/charmbracelet/crush/internal/db"
+)
+
+// runOptions collects optional parameters for the prompt-running methods.
+type runOptions struct {
+	agentID    string
+	largeModel string
+	smallModel string
+	hideSpinner bool
+}
+
+// RunOption configures how a prompt is executed.
+type RunOption func(*runOptions)
+
+// WithAgentID selects the agent to use for the run.
+// If not set, the default "coder" agent is used.
+func WithAgentID(id string) RunOption {
+	return func(o *runOptions) { o.agentID = id }
+}
+
+// WithLargeModel overrides the large model for this run.
+func WithLargeModel(model string) RunOption {
+	return func(o *runOptions) { o.largeModel = model }
+}
+
+// WithSmallModel overrides the small model for this run.
+func WithSmallModel(model string) RunOption {
+	return func(o *runOptions) { o.smallModel = model }
+}
+
+// WithHideSpinner disables the progress spinner.
+func WithHideSpinner() RunOption {
+	return func(o *runOptions) { o.hideSpinner = true }
+}
+
+func resolveRunOptions(opts []RunOption) runOptions {
+	var o runOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+
+// App is the public, programmatic API surface for Crush.
+// It wraps the internal orchestrator and exposes only stable fields and
+// methods. Unlike the previous type alias, this struct explicitly chooses
+// what is public, preventing internal implementation details from leaking
+// into the external API.
+type App struct {
+	Sessions    SessionService
+	Messages    MessageService
+	History     HistoryService
+	Permissions PermissionService
+	FileTracker FileTrackerService
+
+	internal *app.App
+}
+
+// NewApp initializes a new application instance from a database connection
+// and configuration store.
+func NewApp(ctx context.Context, conn *sql.DB, store *ConfigStore, skillsMgr *SkillsManager) (*App, error) {
+	a, err := app.New(ctx, conn, store, skillsMgr)
+	if err != nil {
+		return nil, err
+	}
+	return wrapApp(a), nil
+}
+
+// NewAppWithConfig loads the configuration from default paths, opens the
+// SQLite database (using the shared connection pool), and creates a new
+// App instance. The returned App owns the database connection; call
+// Shutdown() when finished.
+func NewAppWithConfig(ctx context.Context, workingDir, dataDir string, debug bool, skillsMgr *SkillsManager) (*App, error) {
+	store, err := Load(workingDir, dataDir, debug)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load config: %w", err)
+	}
+
+	// Ensure the data directory exists before opening the database.
+	if err := os.MkdirAll(store.Config().Options.DataDirectory, 0o755); err != nil {
+		return nil, fmt.Errorf("failed to create data directory: %w", err)
+	}
+
+	conn, err := db.Connect(ctx, store.Config().Options.DataDirectory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+
+	a, err := NewApp(ctx, conn, store, skillsMgr)
+	if err != nil {
+		db.Release(store.Config().Options.DataDirectory)
+		return nil, err
+	}
+
+	return a, nil
+}
+
+func wrapApp(a *app.App) *App {
+	return &App{
+		Sessions:    a.Sessions,
+		Messages:    a.Messages,
+		History:     a.History,
+		Permissions: a.Permissions,
+		FileTracker: a.FileTracker,
+		internal:    a,
+	}
+}
+
+// Config returns the pure-data configuration.
+func (a *App) Config() *Config {
+	return a.internal.Config()
+}
+
+// Store returns the config store.
+func (a *App) Store() *ConfigStore {
+	return a.internal.Store()
+}
+
+// Shutdown performs a graceful shutdown of the application.
+func (a *App) Shutdown() {
+	a.internal.Shutdown()
+}
+
+// RunPrompt runs a single prompt in non-interactive mode with sensible
+// defaults, writing output to os.Stdout. For more control, use
+// RunPromptWithOptions or [App.RunPromptInSession].
+func (a *App) RunPrompt(ctx context.Context, prompt string, opts ...RunOption) error {
+	o := resolveRunOptions(opts)
+	return a.internal.RunNonInteractive(ctx, os.Stdout, prompt, o.largeModel, o.smallModel, o.hideSpinner, "", false, o.agentID)
+}
+
+// RunPromptInSession runs a prompt in an existing session (or a new one if
+// sessionID is empty), streaming output to the given writer.
+func (a *App) RunPromptInSession(ctx context.Context, output io.Writer, sessionID, prompt string, opts ...RunOption) error {
+	o := resolveRunOptions(opts)
+	return a.internal.RunNonInteractive(ctx, output, prompt, o.largeModel, o.smallModel, o.hideSpinner, sessionID, false, o.agentID)
+}
+
+// RunPromptAndCreateSession creates a new named session and runs a prompt
+// in it, returning the session ID so callers can retrieve messages later via
+// [App.Sessions] and [App.Messages].
+func (a *App) RunPromptAndCreateSession(ctx context.Context, output io.Writer, title, prompt string, opts ...RunOption) (string, error) {
+	o := resolveRunOptions(opts)
+	sess, err := a.Sessions.Create(ctx, title)
+	if err != nil {
+		return "", fmt.Errorf("failed to create session: %w", err)
+	}
+	return sess.ID, a.internal.RunNonInteractive(ctx, output, prompt, o.largeModel, o.smallModel, o.hideSpinner, sess.ID, false, o.agentID)
+}
+
+// RunPrompt runs a single prompt in non-interactive mode with sensible defaults.
+// Output is written to os.Stdout, models come from config, the spinner is shown,
+// and a new session is created.
+// Deprecated: Use (*App).RunPrompt instead.
+func RunPrompt(app *App, ctx context.Context, prompt string) error {
+	return app.RunPrompt(ctx, prompt)
+}
+
+// RunPromptAndCreateSession creates a new named session and runs a prompt in it,
+// returning the session ID so callers can retrieve messages later via
+// [App.Sessions] and [App.Messages].
+// Deprecated: Use (*App).RunPromptAndCreateSession instead.
+func RunPromptAndCreateSession(app *App, ctx context.Context, output io.Writer, title, prompt string) (string, error) {
+	return app.RunPromptAndCreateSession(ctx, output, title, prompt)
+}
+
+// RunPromptInSession runs a prompt in an existing session (or a new one if
+// sessionID is empty), streaming output to the given writer.
+// Deprecated: Use (*App).RunPromptInSession instead.
+func RunPromptInSession(app *App, ctx context.Context, output io.Writer, sessionID, prompt string) error {
+	return app.RunPromptInSession(ctx, output, sessionID, prompt)
+}

--- a/pkg/crush/config.go
+++ b/pkg/crush/config.go
@@ -1,0 +1,80 @@
+package crush
+
+import (
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/env"
+	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/charmbracelet/crush/internal/skills"
+)
+
+type (
+	Config            = config.Config
+	ConfigStore       = config.ConfigStore
+	SelectedModel     = config.SelectedModel
+	SelectedModelType = config.SelectedModelType
+	ProviderConfig    = config.ProviderConfig
+	MCPConfig         = config.MCPConfig
+	MCPType           = config.MCPType
+	LSPConfig         = config.LSPConfig
+	Agent             = config.Agent
+	Options           = config.Options
+	TUIOptions        = config.TUIOptions
+	Completions       = config.Completions
+	Permissions       = config.Permissions
+	Attribution       = config.Attribution
+	TrailerStyle      = config.TrailerStyle
+	HookConfig        = config.HookConfig
+	Tools             = config.Tools
+	ToolLs            = config.ToolLs
+	ToolGrep          = config.ToolGrep
+	Scope             = config.Scope
+	VariableResolver  = config.VariableResolver
+	RuntimeOverrides  = config.RuntimeOverrides
+	SkillsManager     = skills.Manager
+	OAuthToken        = oauth.Token
+)
+
+const (
+	SelectedModelTypeLarge = config.SelectedModelTypeLarge
+	SelectedModelTypeSmall = config.SelectedModelTypeSmall
+
+	AgentCoder = config.AgentCoder
+	AgentTask  = config.AgentTask
+
+	MCPStdio = config.MCPStdio
+	MCPSSE   = config.MCPSSE
+	MCPHttp  = config.MCPHttp
+
+	TrailerStyleNone         = config.TrailerStyleNone
+	TrailerStyleCoAuthoredBy = config.TrailerStyleCoAuthoredBy
+	TrailerStyleAssistedBy   = config.TrailerStyleAssistedBy
+)
+
+// Load loads the configuration from default paths and returns a ConfigStore.
+func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
+	return config.Load(workingDir, dataDir, debug)
+}
+
+// NewConfigStore creates a ConfigStore from a pre-built Config for
+// programmatic use. It wraps the Config without loading anything from disk.
+func NewConfigStore(cfg *Config, loadedPaths ...string) *ConfigStore {
+	return config.NewTestStore(cfg, loadedPaths...)
+}
+
+// NewTestStore is a deprecated alias for NewConfigStore.
+// Deprecated: Use NewConfigStore instead.
+func NewTestStore(cfg *Config, loadedPaths ...string) *ConfigStore {
+	return NewConfigStore(cfg, loadedPaths...)
+}
+
+// NewVariableResolver returns a VariableResolver that expands shell
+// variables and command substitutions.
+func NewVariableResolver(environment map[string]string) VariableResolver {
+	return config.NewShellVariableResolver(env.NewFromMap(environment))
+}
+
+// NewShellVariableResolver is a deprecated alias for NewVariableResolver.
+// Deprecated: Use NewVariableResolver instead.
+func NewShellVariableResolver(environment map[string]string) VariableResolver {
+	return NewVariableResolver(environment)
+}

--- a/pkg/crush/doc.go
+++ b/pkg/crush/doc.go
@@ -1,0 +1,18 @@
+// Package crush provides a programmatic Go API for Crush, a terminal-based
+// AI coding assistant.
+//
+// # Experimental API
+//
+// This package is experimental and unstable. Exported types, functions, and
+// method signatures may change or be removed in any release without notice.
+// There are no semantic-versioning or backward-compatibility guarantees.
+//
+// Pin to a specific Crush version if you depend on this API, and expect to
+// update your code when upgrading.
+//
+// Internal packages under internal/ are not importable from outside this
+// module and may change at any time.
+//
+// For command-line usage, see the crush binary. For HTTP API access, see the
+// server and client packages.
+package crush

--- a/pkg/crush/events.go
+++ b/pkg/crush/events.go
@@ -1,0 +1,62 @@
+package crush
+
+import (
+	"context"
+
+	"github.com/charmbracelet/crush/internal/pubsub"
+)
+
+type (
+	Event[T any]      = pubsub.Event[T]
+	EventType         = pubsub.EventType
+	Payload           = pubsub.Payload
+	PayloadType       = pubsub.PayloadType
+	Subscriber[T any] = pubsub.Subscriber[T]
+	Publisher[T any]  = pubsub.Publisher[T]
+)
+
+const (
+	EventCreated = pubsub.CreatedEvent
+	EventUpdated = pubsub.UpdatedEvent
+	EventDeleted = pubsub.DeletedEvent
+
+	PayloadTypeLSPEvent               = pubsub.PayloadTypeLSPEvent
+	PayloadTypeMCPEvent               = pubsub.PayloadTypeMCPEvent
+	PayloadTypePermissionRequest      = pubsub.PayloadTypePermissionRequest
+	PayloadTypePermissionNotification = pubsub.PayloadTypePermissionNotification
+	PayloadTypeMessage                = pubsub.PayloadTypeMessage
+	PayloadTypeSession                = pubsub.PayloadTypeSession
+	PayloadTypeFile                   = pubsub.PayloadTypeFile
+	PayloadTypeAgentEvent             = pubsub.PayloadTypeAgentEvent
+	PayloadTypeSkillsEvent            = pubsub.PayloadTypeSkillsEvent
+)
+
+// SubscribeSessionMessages subscribes to message events for a specific
+// session. The returned channel is closed when ctx is done. Events are
+// typed as [Event[Message]]; use the helper methods on [Message] to
+// inspect thinking text, tool calls, tool results, and regular content.
+func SubscribeSessionMessages(ctx context.Context, app *App, sessionID string) <-chan Event[Message] {
+	return app.SubscribeSessionMessages(ctx, sessionID)
+}
+
+// SubscribeSessionMessages subscribes to message events for a specific
+// session. The returned channel is closed when ctx is done. Events are
+// typed as [Event[Message]]; use the helper methods on [Message] to
+// inspect thinking text, tool calls, tool results, and regular content.
+func (a *App) SubscribeSessionMessages(ctx context.Context, sessionID string) <-chan Event[Message] {
+	out := make(chan Event[Message], 8)
+	go func() {
+		defer close(out)
+		ch := a.Messages.Subscribe(ctx)
+		for ev := range ch {
+			if ev.Payload.SessionID == sessionID {
+				select {
+				case out <- ev:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return out
+}

--- a/pkg/crush/example/custom_agent/main.go
+++ b/pkg/crush/example/custom_agent/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/charmbracelet/crush/internal/db"
+	"github.com/charmbracelet/crush/pkg/crush"
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// ── 1. Build configuration programmatically ────────────────────────────
+	// Instead of loading crush.json from disk, we define the entire config in
+	// code. This lets us create a custom agent that is restricted to a subset
+	// of tools (Option B).
+	cfg := &crush.Config{
+		Models: map[crush.SelectedModelType]crush.SelectedModel{
+			crush.SelectedModelTypeLarge: {
+				Provider: "openai",
+				Model:    "gpt-4o",
+			},
+		},
+		Providers: crush.NewMapFrom(map[string]crush.ProviderConfig{
+			"openai": {
+				ID:     "openai",
+				Name:   "OpenAI",
+				Type:   catwalk.TypeOpenAI,
+				APIKey: os.Getenv("OPENAI_API_KEY"),
+				Models: []catwalk.Model{
+					{ID: "gpt-4o", Name: "GPT-4o"},
+				},
+			},
+		}),
+		Options: &crush.Options{
+			DataDirectory: ".crush",
+		},
+	}
+
+	// Create a custom agent limited to only view, edit, and bash tools.
+	agent, err := crush.NewAgent("reviewer",
+		crush.WithAgentName("Reviewer"),
+		crush.WithAgentDescription("Reviews code with read-only access"),
+		crush.WithAgentAllowedTools("view", "grep", "glob", "ls"),
+	)
+	if err != nil {
+		log.Fatalf("failed to create agent: %v", err)
+	}
+	cfg.Agents = map[string]crush.Agent{
+		"reviewer": agent,
+	}
+	cfg.SetupAgents()
+
+	// ── 2. Open database and initialize the application ───────────────────
+	if err := os.MkdirAll(cfg.Options.DataDirectory, 0o755); err != nil {
+		log.Fatalf("failed to create data directory: %v", err)
+	}
+	conn, err := db.Connect(ctx, cfg.Options.DataDirectory)
+	if err != nil {
+		log.Fatalf("failed to open database: %v", err)
+	}
+
+	store := crush.NewConfigStore(cfg)
+	app, err := crush.NewApp(ctx, conn, store, nil)
+	if err != nil {
+		log.Fatalf("failed to initialize app: %v", err)
+	}
+	defer app.Shutdown()
+
+	// ── 3. Run a prompt with the custom agent ─────────────────────────────
+	prompt := "Review the main.go file in this directory for any issues."
+	fmt.Fprintf(os.Stderr, "Prompt: %s\n", prompt)
+
+	err = app.RunPrompt(ctx, prompt, crush.WithAgentID("reviewer"))
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/crush/example/oneshot/main.go
+++ b/pkg/crush/example/oneshot/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/charmbracelet/crush/internal/db"
+	"github.com/charmbracelet/crush/pkg/crush"
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// ── 1. Build configuration programmatically ────────────────────────────
+	// Instead of loading crush.json from disk, we define the entire config in
+	// code. This lets us create a custom agent that is restricted to a subset
+	// of tools (Option B).
+	cfg := &crush.Config{
+		Models: map[crush.SelectedModelType]crush.SelectedModel{
+			crush.SelectedModelTypeLarge: {
+				Provider: "openai",
+				Model:    "gpt-4o",
+			},
+		},
+		Providers: crush.NewMapFrom(map[string]crush.ProviderConfig{
+			"openai": {
+				ID:     "openai",
+				Name:   "OpenAI",
+				Type:   catwalk.TypeOpenAI,
+				APIKey: os.Getenv("OPENAI_API_KEY"),
+				Models: []catwalk.Model{
+					{ID: "gpt-4o", Name: "GPT-4o"},
+				},
+			},
+		}),
+		Options: &crush.Options{
+			DataDirectory: ".crush",
+		},
+	}
+
+	// Create a custom agent limited to only view, edit, and bash tools.
+	agent, err := crush.NewAgent("limited",
+		crush.WithAgentName("Limited Agent"),
+		crush.WithAgentDescription("Only reads, edits, and runs shell commands"),
+		crush.WithAgentAllowedTools("view", "edit", "bash"),
+	)
+	if err != nil {
+		log.Fatalf("failed to create agent: %v", err)
+	}
+	cfg.Agents = map[string]crush.Agent{
+		"limited": agent,
+	}
+	cfg.SetupAgents()
+
+	// ── 2. Open database and initialize the application ───────────────────
+	if err := os.MkdirAll(cfg.Options.DataDirectory, 0o755); err != nil {
+		log.Fatalf("failed to create data directory: %v", err)
+	}
+	conn, err := db.Connect(ctx, cfg.Options.DataDirectory)
+	if err != nil {
+		log.Fatalf("failed to open database: %v", err)
+	}
+
+	store := crush.NewConfigStore(cfg)
+	app, err := crush.NewApp(ctx, conn, store, nil)
+	if err != nil {
+		log.Fatalf("failed to initialize app: %v", err)
+	}
+	defer app.Shutdown()
+
+	// ── 3. Run a one-shot non-interactive prompt with the limited agent ────
+	prompt := "Write a tic tac toe game for desktop in Go in /tmp/hello/"
+	fmt.Fprintf(os.Stderr, "Prompt: %s\n", prompt)
+
+	err = app.RunPrompt(ctx, prompt, crush.WithAgentID("limited"))
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/crush/example/server/hello/main.go
+++ b/pkg/crush/example/server/hello/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}

--- a/pkg/crush/example/server/main.go
+++ b/pkg/crush/example/server/main.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+
+	"github.com/charmbracelet/crush/internal/db"
+	"github.com/charmbracelet/crush/pkg/crush"
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// ── 1. Build configuration programmatically ────────────────────────────
+	// Instead of loading crush.json from disk, we define the entire config in
+	// code. This lets us create a custom agent that is restricted to a subset
+	// of tools (Option B).
+	cfg := &crush.Config{
+		Models: map[crush.SelectedModelType]crush.SelectedModel{
+			crush.SelectedModelTypeLarge: {
+				Provider: "openai",
+				Model:    "gpt-4o",
+			},
+		},
+		Providers: crush.NewMapFrom(map[string]crush.ProviderConfig{
+			"openai": {
+				ID:     "openai",
+				Name:   "OpenAI",
+				Type:   catwalk.TypeOpenAI,
+				APIKey: os.Getenv("OPENAI_API_KEY"),
+				Models: []catwalk.Model{
+					{ID: "gpt-4o", Name: "GPT-4o"},
+				},
+			},
+		}),
+		Options: &crush.Options{
+			DataDirectory: ".crush",
+		},
+	}
+
+	// Create a custom agent limited to only view, edit, and bash tools.
+	agent, err := crush.NewAgent("limited",
+		crush.WithAgentName("Limited Server Agent"),
+		crush.WithAgentDescription("Only reads, edits, and runs shell commands"),
+		crush.WithAgentAllowedTools("view", "edit", "bash"),
+	)
+	if err != nil {
+		log.Fatalf("failed to create agent: %v", err)
+	}
+	cfg.Agents = map[string]crush.Agent{
+		"limited": agent,
+	}
+	cfg.SetupAgents()
+
+	// ── 2. Open database and initialize the application ───────────────────
+	if err := os.MkdirAll(cfg.Options.DataDirectory, 0o755); err != nil {
+		log.Fatalf("failed to create data directory: %v", err)
+	}
+	conn, err := db.Connect(ctx, cfg.Options.DataDirectory)
+	if err != nil {
+		log.Fatalf("failed to open database: %v", err)
+	}
+
+	store := crush.NewConfigStore(cfg)
+	app, err := crush.NewApp(ctx, conn, store, nil)
+	if err != nil {
+		log.Fatalf("failed to initialize app: %v", err)
+	}
+	defer app.Shutdown()
+
+	// ── 3. Create a named session up front ─────────────────────────────────
+	sess, err := app.Sessions.Create(ctx, "Hello World")
+	if err != nil {
+		log.Fatalf("failed to create session: %v", err)
+	}
+	sessionID := sess.ID
+	fmt.Printf("Session created: %s\n", sessionID)
+
+	// ── 4. Start a background goroutine to consume live message events ────
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	evtCtx, evtCancel := context.WithCancel(ctx)
+	defer evtCancel()
+
+	go func() {
+		defer wg.Done()
+		ch := crush.SubscribeSessionMessages(evtCtx, app, sessionID)
+		for ev := range ch {
+			switch ev.Type {
+			case crush.EventCreated:
+				fmt.Fprintf(os.Stderr, "[CREATED] %s role=%s\n", ev.Payload.ID, ev.Payload.Role)
+			case crush.EventUpdated:
+				msg := ev.Payload
+				if rc := msg.ReasoningContent(); rc.Thinking != "" {
+					fmt.Fprintf(os.Stderr, "[THINKING] %s\n", rc.Thinking)
+				}
+				if txt := msg.Content(); txt.Text != "" {
+					fmt.Fprintf(os.Stderr, "[TEXT] %s\n", txt.Text)
+				}
+				for _, tc := range msg.ToolCalls() {
+					fmt.Fprintf(os.Stderr, "[TOOL_CALL] %s %s\n", tc.Name, tc.ID)
+				}
+				for _, tr := range msg.ToolResults() {
+					fmt.Fprintf(os.Stderr, "[TOOL_RESULT] %s\n", tr.ToolCallID)
+				}
+				if msg.IsFinished() {
+					fmt.Fprintf(os.Stderr, "[FINISHED] reason=%s\n", msg.FinishReason())
+				}
+			case crush.EventDeleted:
+				fmt.Fprintf(os.Stderr, "[DELETED] %s\n", ev.Payload.ID)
+			}
+		}
+	}()
+
+	// ── 5. Run a prompt in the existing session with the limited agent ────
+	var out bytes.Buffer
+	prompt := "Write a hello world program in Go"
+
+	err = app.RunPromptInSession(ctx, &out, sessionID, prompt, crush.WithAgentID("limited"))
+	if err != nil {
+		log.Fatalf("failed to run prompt: %v", err)
+	}
+	fmt.Printf("\nFinal response:\n%s\n", out.String())
+
+	// Signal the event consumer to finish.
+	evtCancel()
+
+	// ── 6. List all sessions ───────────────────────────────────────────────
+	sessions, err := app.Sessions.List(ctx)
+	if err != nil {
+		log.Fatalf("failed to list sessions: %v", err)
+	}
+	fmt.Printf("\nAll sessions:\n")
+	for _, s := range sessions {
+		fmt.Printf("  %s: %s (messages: %d)\n", s.ID, s.Title, s.MessageCount)
+	}
+
+	// ── 7. Retrieve messages for the session ─────────────────────────────
+	msgs, err := app.Messages.List(ctx, sessionID)
+	if err != nil {
+		log.Fatalf("failed to list messages: %v", err)
+	}
+	fmt.Printf("\nMessages in session %s:\n", sessionID)
+	for _, msg := range msgs {
+		fmt.Printf("  Role: %s\n", msg.Role)
+		for _, part := range msg.Parts {
+			switch p := part.(type) {
+			case crush.TextContent:
+				fmt.Printf("    Text: %s\n", p.Text)
+			case crush.ToolCall:
+				fmt.Printf("    ToolCall: %s %s\n", p.Name, p.ID)
+			case crush.ToolResult:
+				fmt.Printf("    ToolResult: %s\n", p.ToolCallID)
+			}
+		}
+	}
+
+	// Wait for the event consumer to finish.
+	wg.Wait()
+}

--- a/pkg/crush/history.go
+++ b/pkg/crush/history.go
@@ -1,0 +1,12 @@
+package crush
+
+import (
+	"github.com/charmbracelet/crush/internal/filetracker"
+	"github.com/charmbracelet/crush/internal/history"
+)
+
+type (
+	File             = history.File
+	HistoryService   = history.Service
+	FileTrackerService = filetracker.Service
+)

--- a/pkg/crush/map.go
+++ b/pkg/crush/map.go
@@ -1,0 +1,16 @@
+package crush
+
+import "github.com/charmbracelet/crush/internal/csync"
+
+// Map is a concurrent map implementation that provides thread-safe access.
+type Map[K comparable, V any] = csync.Map[K, V]
+
+// NewMap creates a new thread-safe map with the specified key and value types.
+func NewMap[K comparable, V any]() *Map[K, V] {
+	return csync.NewMap[K, V]()
+}
+
+// NewMapFrom creates a new thread-safe map from an existing map.
+func NewMapFrom[K comparable, V any](m map[K]V) *Map[K, V] {
+	return csync.NewMapFrom(m)
+}

--- a/pkg/crush/message.go
+++ b/pkg/crush/message.go
@@ -1,0 +1,34 @@
+package crush
+
+import "github.com/charmbracelet/crush/internal/message"
+
+type (
+	Message             = message.Message
+	MessageRole         = message.MessageRole
+	ContentPart         = message.ContentPart
+	TextContent         = message.TextContent
+	ReasoningContent    = message.ReasoningContent
+	ImageURLContent     = message.ImageURLContent
+	BinaryContent       = message.BinaryContent
+	ToolCall            = message.ToolCall
+	ToolResult          = message.ToolResult
+	Finish              = message.Finish
+	FinishReason        = message.FinishReason
+	Attachment          = message.Attachment
+	CreateMessageParams = message.CreateMessageParams
+	MessageService      = message.Service
+)
+
+const (
+	RoleAssistant = message.Assistant
+	RoleUser      = message.User
+	RoleSystem    = message.System
+	RoleTool      = message.Tool
+
+	FinishReasonEndTurn   = message.FinishReasonEndTurn
+	FinishReasonMaxTokens = message.FinishReasonMaxTokens
+	FinishReasonToolUse   = message.FinishReasonToolUse
+	FinishReasonCanceled  = message.FinishReasonCanceled
+	FinishReasonError     = message.FinishReasonError
+	FinishReasonUnknown   = message.FinishReasonUnknown
+)

--- a/pkg/crush/permission.go
+++ b/pkg/crush/permission.go
@@ -1,0 +1,10 @@
+package crush
+
+import "github.com/charmbracelet/crush/internal/permission"
+
+type (
+	PermissionRequest       = permission.PermissionRequest
+	CreatePermissionRequest = permission.CreatePermissionRequest
+	PermissionNotification  = permission.PermissionNotification
+	PermissionService       = permission.Service
+)

--- a/pkg/crush/session.go
+++ b/pkg/crush/session.go
@@ -1,0 +1,16 @@
+package crush
+
+import "github.com/charmbracelet/crush/internal/session"
+
+type (
+	Session        = session.Session
+	Todo           = session.Todo
+	TodoStatus     = session.TodoStatus
+	SessionService = session.Service
+)
+
+const (
+	TodoStatusPending    = session.TodoStatusPending
+	TodoStatusInProgress = session.TodoStatusInProgress
+	TodoStatusCompleted  = session.TodoStatusCompleted
+)


### PR DESCRIPTION

## Summary

- Add convenience functions for initializing Crush from Go code without going through the CLI:
  - `NewAppWithConfig` — loads config + opens SQLite DB + creates App in one call
  - `RunPrompt` — simple one-shot with sensible defaults
  - `RunPromptAndCreateSession` — create named session, run prompt, return session ID
  - `RunPromptInSession` — run prompt in an existing session
  - `SubscribeSessionMessages` — subscribe to live message events per session
- Add `example/oneshot` demonstrating basic programmatic usage
- Add `example/server` demonstrating session management + event streaming
- Update `pkg/crush/README.md` with public API docs (marked as experimental)

## Test plan

- [x] `go build ./pkg/crush` passes
- [x] `go build ./pkg/crush/example/oneshot` passes
- [x] `go build ./pkg/crush/example/server` passes
- [x] Server example runs end-to-end and streams thinking text + tool calls

💘 Generated with Crush