### PR TITLE
RFC: browser-based xAI OAuth login (PoC)

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/charmbracelet/crush/internal/oauth/copilot"
 	"github.com/charmbracelet/crush/internal/oauth/hyper"
+	"github.com/charmbracelet/crush/internal/oauth/xai"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -25,13 +26,16 @@ var loginCmd = &cobra.Command{
 	Short:   "Login Crush to a platform",
 	Long: `Login Crush to a specified platform.
 The platform should be provided as an argument.
-Available platforms are: hyper, copilot.`,
+Available platforms are: hyper, copilot, xai.`,
 	Example: `
 # Authenticate with Charm Hyper
 crush login
 
 # Authenticate with GitHub Copilot
 crush login copilot
+
+# Authenticate with xAI (Grok)
+crush login xai
 
 # Force re-authentication even if already logged in
 crush login -f copilot
@@ -41,6 +45,8 @@ crush login -f copilot
 		"copilot",
 		"github",
 		"github-copilot",
+		"xai",
+		"grok",
 	},
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -66,6 +72,8 @@ crush login -f copilot
 			return loginHyper(c, ws.ID, force)
 		case "copilot", "github", "github-copilot":
 			return loginCopilot(c, ws.ID, force)
+		case "xai", "grok":
+			return loginXAI(c, ws.ID, force)
 		default:
 			return fmt.Errorf("unknown platform: %s", args[0])
 		}
@@ -214,6 +222,55 @@ func loginCopilot(c *client.Client, wsID string, force bool) error {
 
 	fmt.Println()
 	fmt.Println("You're now authenticated with GitHub Copilot!")
+	return nil
+}
+
+func loginXAI(c *client.Client, wsID string, force bool) error {
+	ctx := getLoginContext()
+
+	if !force {
+		cfg, err := c.GetConfig(ctx, wsID)
+		if err == nil && cfg != nil {
+			if pc, ok := cfg.Providers.Get("xai"); ok && pc.OAuthToken != nil {
+				fmt.Println("You are already logged in to xAI.")
+				fmt.Println("Use --force to re-authenticate.")
+				return nil
+			}
+		}
+	}
+
+	fmt.Println("Starting xAI OAuth...")
+	auth, err := xai.NewAuthorizer(ctx)
+	if err != nil {
+		return err
+	}
+	defer auth.Close()
+
+	fmt.Println()
+	fmt.Println("Press enter to open this URL in your browser and sign in to xAI:")
+	fmt.Println()
+	fmt.Println(lipgloss.NewStyle().Hyperlink(auth.AuthURL, "id=xai").Render(auth.AuthURL))
+	fmt.Println()
+	waitEnter()
+	if err := browser.OpenURL(auth.AuthURL); err != nil {
+		fmt.Println("Could not open the URL. You'll need to manually open the URL in your browser.")
+	}
+
+	fmt.Println("Waiting for authorization...")
+	token, err := auth.Wait(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := cmp.Or(
+		c.SetConfigField(ctx, wsID, config.ScopeGlobal, "providers.xai.api_key", token.AccessToken),
+		c.SetConfigField(ctx, wsID, config.ScopeGlobal, "providers.xai.oauth", token),
+	); err != nil {
+		return err
+	}
+
+	fmt.Println()
+	fmt.Println("You're now authenticated with xAI!")
 	return nil
 }
 

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -27,19 +27,24 @@ var logoutCmd = &cobra.Command{
 	Long: `Logout Crush from a specified platform, removing stored credentials.
 The platform should be provided as an argument.
 If no argument is given, a list of logged-in platforms will be shown.
-Available platforms are: hyper, copilot.`,
+Available platforms are: hyper, copilot, xai.`,
 	Example: `
 # Sign out from Charm Hyper
 crush logout hyper
 
 # Sign out from GitHub Copilot
 crush logout copilot
+
+# Sign out from xAI (Grok)
+crush logout xai
   `,
 	ValidArgs: []cobra.Completion{
 		"hyper",
 		"copilot",
 		"github",
 		"github-copilot",
+		"xai",
+		"grok",
 	},
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -84,6 +89,8 @@ crush logout copilot
 			return logoutHyper(c, ws.ID)
 		case "copilot", "github", "github-copilot":
 			return logoutCopilot(c, ws.ID)
+		case "xai", "grok":
+			return logoutXAI(c, ws.ID)
 		default:
 			return fmt.Errorf("unknown platform: %s", provider)
 		}
@@ -115,6 +122,20 @@ func logoutCopilot(c *client.Client, wsID string) error {
 	}
 
 	fmt.Println(logoutHeaderStyle.Render("Successfully logged out of GitHub Copilot."))
+	return nil
+}
+
+func logoutXAI(c *client.Client, wsID string) error {
+	ctx := getLogoutContext()
+
+	if err := cmp.Or(
+		c.RemoveConfigField(ctx, wsID, config.ScopeGlobal, "providers.xai.api_key"),
+		c.RemoveConfigField(ctx, wsID, config.ScopeGlobal, "providers.xai.oauth"),
+	); err != nil {
+		return err
+	}
+
+	fmt.Println(logoutHeaderStyle.Render("Successfully logged out of xAI."))
 	return nil
 }
 

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/charmbracelet/crush/internal/oauth/copilot"
 	"github.com/charmbracelet/crush/internal/oauth/hyper"
+	"github.com/charmbracelet/crush/internal/oauth/xai"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -333,6 +334,8 @@ func (s *ConfigStore) RefreshOAuthToken(ctx context.Context, scope Scope, provid
 		refreshedToken, refreshErr = copilot.RefreshToken(ctx, providerConfig.OAuthToken.RefreshToken)
 	case hyperp.Name:
 		refreshedToken, refreshErr = hyper.ExchangeToken(ctx, providerConfig.OAuthToken.RefreshToken)
+	case string(catwalk.InferenceProviderXAI):
+		refreshedToken, refreshErr = xai.RefreshToken(ctx, providerConfig.OAuthToken.RefreshToken)
 	default:
 		return fmt.Errorf("OAuth refresh not supported for provider %s", providerID)
 	}

--- a/internal/oauth/xai/xai.go
+++ b/internal/oauth/xai/xai.go
@@ -1,0 +1,556 @@
+// Package xai implements the browser-based OAuth2 flow (authorization code
+// with PKCE) for "Sign in with Grok" against xAI's auth server. It mirrors
+// the flow used by goose and OpenClaw.
+package xai
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/oauth"
+)
+
+const (
+	// defaultClientID is xAI's shared public OAuth client for CLI "Sign in
+	// with Grok" tooling — the same client embedded by goose and OpenClaw.
+	// A client ID is a public, non-secret identifier; xAI labels the
+	// consent screen "Grok Build".
+	//
+	// TODO(PoC): before shipping beyond a proof of concept, Crush should
+	// register its own xAI OAuth client rather than reusing the shared one.
+	// See https://github.com/aaif-goose/goose/pull/9339 (comment 4508201758).
+	defaultClientID = "b1a00492-073a-47ea-816f-4c329264a828"
+
+	// clientIDEnv overrides defaultClientID for anyone who registers their
+	// own xAI OAuth client.
+	clientIDEnv = "XAI_OAUTH_CLIENT_ID"
+
+	oauthScope  = "openid profile email offline_access grok-cli:access api:access"
+	oauthIssuer = "https://auth.x.ai"
+
+	// callbackHost and callbackPort form the loopback redirect URI. The
+	// port is fixed because it is part of the shared client's registered
+	// redirect URI; it must not be swapped for an ephemeral port.
+	callbackHost = "127.0.0.1"
+	callbackPort = "56121"
+	callbackPath = "/callback"
+
+	// referrer is a free-text attribution field accepted by xAI's authorize
+	// endpoint; it does not affect the consent screen.
+	referrer = "crush"
+
+	// oauthTimeout bounds how long we wait for the user to finish the
+	// browser flow.
+	oauthTimeout = 5 * time.Minute
+
+	// defaultTokenLifetimeSecs is used when the token response carries no
+	// expiry information.
+	defaultTokenLifetimeSecs = 3600
+
+	userAgent = "crush"
+)
+
+// discoveryURL is xAI's OIDC discovery endpoint. It is a package variable so
+// tests can point it at a local server.
+var discoveryURL = oauthIssuer + "/.well-known/openid-configuration"
+
+// clientID returns the OAuth client ID, honouring the XAI_OAUTH_CLIENT_ID
+// override.
+func clientID() string {
+	if v := strings.TrimSpace(os.Getenv(clientIDEnv)); v != "" {
+		return v
+	}
+	return defaultClientID
+}
+
+// redirectURI is the loopback URL xAI redirects back to after consent.
+func redirectURI() string {
+	return "http://" + net.JoinHostPort(callbackHost, callbackPort) + callbackPath
+}
+
+// discoveryDoc holds the subset of xAI's OIDC discovery document we use.
+type discoveryDoc struct {
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+}
+
+// fetchDiscovery loads and validates xAI's OIDC discovery document.
+func fetchDiscovery(ctx context.Context) (*discoveryDoc, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, discoveryURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create discovery request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", userAgent)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("xAI OAuth discovery request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read discovery response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("xAI OAuth discovery failed with status %d", resp.StatusCode)
+	}
+
+	var doc discoveryDoc
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("decode discovery document: %w", err)
+	}
+
+	authEndpoint, err := trustedEndpoint(doc.AuthorizationEndpoint, "authorization endpoint")
+	if err != nil {
+		return nil, err
+	}
+	tokenEndpoint, err := trustedEndpoint(doc.TokenEndpoint, "token endpoint")
+	if err != nil {
+		return nil, err
+	}
+	return &discoveryDoc{
+		AuthorizationEndpoint: authEndpoint,
+		TokenEndpoint:         tokenEndpoint,
+	}, nil
+}
+
+// trustedEndpoint validates that an OAuth endpoint returned by discovery is an
+// HTTPS URL on an x.ai host, guarding against a hijacked discovery document.
+func trustedEndpoint(endpoint, label string) (string, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("xAI OAuth %s is not a valid URL: %w", label, err)
+	}
+	if u.Scheme != "https" {
+		return "", fmt.Errorf("xAI OAuth %s is not served over HTTPS", label)
+	}
+	host := u.Hostname()
+	if host != "x.ai" && !strings.HasSuffix(host, ".x.ai") {
+		return "", fmt.Errorf("xAI OAuth %s has untrusted host %q", label, host)
+	}
+	return endpoint, nil
+}
+
+// pkceChallenge is a PKCE verifier/challenge pair (RFC 7636).
+type pkceChallenge struct {
+	verifier  string
+	challenge string
+}
+
+// generatePKCE produces a PKCE verifier and its S256 challenge.
+func generatePKCE() (pkceChallenge, error) {
+	verifier, err := randomHex(32)
+	if err != nil {
+		return pkceChallenge{}, err
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	return pkceChallenge{
+		verifier:  verifier,
+		challenge: base64.RawURLEncoding.EncodeToString(sum[:]),
+	}, nil
+}
+
+// randomHex returns n cryptographically random bytes, hex-encoded.
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate random bytes: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// buildAuthorizeURL builds the xAI authorization URL for the browser flow.
+func buildAuthorizeURL(authorizationEndpoint string, p pkceChallenge, state, nonce string) (string, error) {
+	u, err := url.Parse(authorizationEndpoint)
+	if err != nil {
+		return "", fmt.Errorf("parse authorization endpoint: %w", err)
+	}
+	q := u.Query()
+	q.Set("response_type", "code")
+	q.Set("client_id", clientID())
+	q.Set("redirect_uri", redirectURI())
+	q.Set("scope", oauthScope)
+	q.Set("state", state)
+	q.Set("nonce", nonce)
+	q.Set("code_challenge", p.challenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("plan", "generic")
+	q.Set("referrer", referrer)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// callbackResult is the outcome of the loopback OAuth callback.
+type callbackResult struct {
+	code string
+	err  error
+}
+
+// callbackServer is the loopback HTTP server that receives the OAuth redirect.
+type callbackServer struct {
+	server        *http.Server
+	expectedState string
+	resultCh      chan callbackResult
+	once          sync.Once
+}
+
+// startCallbackServer binds the fixed loopback redirect URI and serves the
+// OAuth callback. It fails if the port is already in use.
+func startCallbackServer(expectedState string) (*callbackServer, error) {
+	addr := net.JoinHostPort(callbackHost, callbackPort)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("bind xAI OAuth callback listener on %s: %w", addr, err)
+	}
+
+	cs := &callbackServer{
+		expectedState: expectedState,
+		resultCh:      make(chan callbackResult, 1),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(callbackPath, cs.handle)
+	cs.server = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() { _ = cs.server.Serve(listener) }()
+	return cs, nil
+}
+
+// handle processes the OAuth redirect, validating state and extracting the
+// authorization code.
+func (cs *callbackServer) handle(w http.ResponseWriter, r *http.Request) {
+	applyCallbackCORS(w, r)
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	q := r.URL.Query()
+	switch {
+	case q.Get("error") != "":
+		desc := q.Get("error_description")
+		if desc == "" {
+			desc = q.Get("error")
+		}
+		cs.finish(callbackResult{err: fmt.Errorf("xAI OAuth was denied: %s", desc)})
+		writeCallbackPage(w, false)
+	case q.Get("state") != cs.expectedState:
+		cs.finish(callbackResult{err: errors.New("xAI OAuth callback state mismatch")})
+		writeCallbackPage(w, false)
+	case q.Get("code") == "":
+		cs.finish(callbackResult{err: errors.New("xAI OAuth callback is missing the authorization code")})
+		writeCallbackPage(w, false)
+	default:
+		cs.finish(callbackResult{code: q.Get("code")})
+		writeCallbackPage(w, true)
+	}
+}
+
+// finish delivers the callback result exactly once.
+func (cs *callbackServer) finish(res callbackResult) {
+	cs.once.Do(func() { cs.resultCh <- res })
+}
+
+// close shuts down the callback server. It is safe to call multiple times.
+func (cs *callbackServer) close() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = cs.server.Shutdown(ctx)
+}
+
+// callbackCORSAllowlist is the set of xAI hosts whose CORS preflight against
+// the loopback redirect URI is echoed; mirrors OpenClaw/goose behaviour.
+var callbackCORSAllowlist = map[string]bool{
+	"auth.x.ai":     true,
+	"accounts.x.ai": true,
+}
+
+// applyCallbackCORS echoes CORS headers for trusted xAI origins only.
+func applyCallbackCORS(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return
+	}
+	u, err := url.Parse(origin)
+	if err != nil || !callbackCORSAllowlist[u.Hostname()] {
+		return
+	}
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+	w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "*")
+}
+
+// writeCallbackPage renders the page shown in the user's browser tab.
+func writeCallbackPage(w http.ResponseWriter, success bool) {
+	heading := "xAI sign-in complete"
+	body := "Authentication succeeded. You can close this tab and return to Crush."
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if !success {
+		heading = "xAI sign-in failed"
+		body = "Authentication failed. Return to Crush for details."
+		w.WriteHeader(http.StatusBadRequest)
+	}
+	_, _ = fmt.Fprintf(w, callbackPageTemplate, heading, body)
+}
+
+const callbackPageTemplate = `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>%[1]s</title></head>
+<body style="font-family:system-ui,sans-serif;text-align:center;padding-top:4rem">
+<h2>%[1]s</h2>
+<p>%[2]s</p>
+</body>
+</html>
+`
+
+// Authorizer holds the state of an in-progress browser OAuth flow.
+type Authorizer struct {
+	// AuthURL is the xAI authorization URL the user must open in a browser.
+	AuthURL string
+
+	discovery *discoveryDoc
+	pkce      pkceChallenge
+	server    *callbackServer
+}
+
+// NewAuthorizer begins a browser OAuth flow: it fetches xAI's OIDC discovery
+// document, generates PKCE parameters, starts the loopback callback server,
+// and builds the authorization URL. The caller must open AuthURL in a
+// browser, call Wait to obtain the token, and call Close when done.
+func NewAuthorizer(ctx context.Context) (*Authorizer, error) {
+	discovery, err := fetchDiscovery(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	pkce, err := generatePKCE()
+	if err != nil {
+		return nil, err
+	}
+
+	state, err := randomHex(32)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce, err := randomHex(16)
+	if err != nil {
+		return nil, err
+	}
+
+	authURL, err := buildAuthorizeURL(discovery.AuthorizationEndpoint, pkce, state, nonce)
+	if err != nil {
+		return nil, err
+	}
+
+	server, err := startCallbackServer(state)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Authorizer{
+		AuthURL:   authURL,
+		discovery: discovery,
+		pkce:      pkce,
+		server:    server,
+	}, nil
+}
+
+// Wait blocks until the user completes the browser flow, then exchanges the
+// authorization code for an OAuth token. It returns an error if the context
+// is cancelled or the flow times out. The callback server is shut down before
+// Wait returns, so the loopback port is not held past the flow.
+func (a *Authorizer) Wait(ctx context.Context) (*oauth.Token, error) {
+	defer a.server.close()
+
+	ctx, cancel := context.WithTimeout(ctx, oauthTimeout)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		return nil, fmt.Errorf("xAI OAuth did not complete: %w", ctx.Err())
+	case res := <-a.server.resultCh:
+		if res.err != nil {
+			return nil, res.err
+		}
+		return exchangeCode(ctx, a.discovery.TokenEndpoint, res.code, a.pkce)
+	}
+}
+
+// Close shuts down the loopback callback server. It is safe to call multiple
+// times.
+func (a *Authorizer) Close() {
+	a.server.close()
+}
+
+// tokenResponse is the JSON body of an xAI OAuth token endpoint response.
+type tokenResponse struct {
+	AccessToken      string `json:"access_token"`
+	RefreshToken     string `json:"refresh_token"`
+	ExpiresIn        int    `json:"expires_in"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// exchangeCode swaps an authorization code for an OAuth token.
+func exchangeCode(ctx context.Context, tokenEndpoint, code string, p pkceChallenge) (*oauth.Token, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI())
+	form.Set("client_id", clientID())
+	form.Set("code_verifier", p.verifier)
+	// xAI re-validates the PKCE challenge fields at token exchange for the
+	// shared client, so they are resent here alongside the verifier.
+	form.Set("code_challenge", p.challenge)
+	form.Set("code_challenge_method", "S256")
+
+	token, err := postToken(ctx, tokenEndpoint, form, "")
+	if err != nil {
+		return nil, err
+	}
+	if token.RefreshToken == "" {
+		return nil, errors.New("xAI OAuth token response is missing a refresh token")
+	}
+	return token, nil
+}
+
+// RefreshToken exchanges a refresh token for a fresh xAI OAuth token. It is
+// called by the config store to renew expired credentials.
+func RefreshToken(ctx context.Context, refreshToken string) (*oauth.Token, error) {
+	if refreshToken == "" {
+		return nil, errors.New("xAI OAuth credential is missing a refresh token")
+	}
+
+	discovery, err := fetchDiscovery(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("client_id", clientID())
+	form.Set("refresh_token", refreshToken)
+
+	return postToken(ctx, discovery.TokenEndpoint, form, refreshToken)
+}
+
+// postToken posts a token request and parses the response into an oauth.Token.
+// priorRefresh is retained when the response omits a new refresh token.
+func postToken(ctx context.Context, tokenEndpoint string, form url.Values, priorRefresh string) (*oauth.Token, error) {
+	endpoint, err := trustedEndpoint(tokenEndpoint, "token endpoint")
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", userAgent)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("xAI OAuth token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read token response: %w", err)
+	}
+
+	return parseTokenResponse(body, resp.StatusCode, priorRefresh)
+}
+
+// parseTokenResponse decodes and validates an xAI token endpoint response.
+func parseTokenResponse(body []byte, statusCode int, priorRefresh string) (*oauth.Token, error) {
+	var tr tokenResponse
+	if err := json.Unmarshal(body, &tr); err != nil {
+		return nil, fmt.Errorf("decode token response (status %d): %w", statusCode, err)
+	}
+	if tr.Error != "" {
+		desc := tr.ErrorDescription
+		if desc == "" {
+			desc = tr.Error
+		}
+		return nil, fmt.Errorf("xAI OAuth token request failed: %s", desc)
+	}
+	if statusCode < 200 || statusCode >= 300 {
+		return nil, fmt.Errorf("xAI OAuth token request failed with status %d", statusCode)
+	}
+	if tr.AccessToken == "" {
+		return nil, errors.New("xAI OAuth token response is missing an access token")
+	}
+	return newToken(tr, priorRefresh), nil
+}
+
+// newToken converts a token response into an oauth.Token, computing the
+// expiry from expires_in or, failing that, the access token's JWT exp claim.
+func newToken(tr tokenResponse, priorRefresh string) *oauth.Token {
+	token := &oauth.Token{
+		AccessToken:  tr.AccessToken,
+		RefreshToken: tr.RefreshToken,
+	}
+	if token.RefreshToken == "" {
+		token.RefreshToken = priorRefresh
+	}
+
+	switch {
+	case tr.ExpiresIn > 0:
+		token.ExpiresIn = tr.ExpiresIn
+		token.SetExpiresAt()
+	default:
+		if exp := jwtExpiry(tr.AccessToken); exp > 0 {
+			token.ExpiresAt = exp
+			token.SetExpiresIn()
+		} else {
+			token.ExpiresIn = defaultTokenLifetimeSecs
+			token.SetExpiresAt()
+		}
+	}
+	return token
+}
+
+// jwtExpiry returns the exp claim (unix seconds) of a JWT access token, or 0
+// if it cannot be determined.
+func jwtExpiry(token string) int64 {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return 0
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return 0
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return 0
+	}
+	return claims.Exp
+}

--- a/internal/oauth/xai/xai_test.go
+++ b/internal/oauth/xai/xai_test.go
@@ -1,0 +1,278 @@
+package xai
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientID(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		require.Equal(t, defaultClientID, clientID())
+	})
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv(clientIDEnv, "custom-client")
+		require.Equal(t, "custom-client", clientID())
+	})
+}
+
+func TestRedirectURI(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "http://127.0.0.1:56121/callback", redirectURI())
+}
+
+func TestTrustedEndpoint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		endpoint string
+		wantErr  bool
+	}{
+		{"x.ai apex", "https://x.ai/authorize", false},
+		{"x.ai subdomain", "https://auth.x.ai/oauth2/auth", false},
+		{"http rejected", "http://auth.x.ai/authorize", true},
+		{"foreign host rejected", "https://evil.com/authorize", true},
+		{"lookalike host rejected", "https://auth.x.ai.evil.com/a", true},
+		{"empty rejected", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := trustedEndpoint(tt.endpoint, "test endpoint")
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGeneratePKCE(t *testing.T) {
+	t.Parallel()
+	p, err := generatePKCE()
+	require.NoError(t, err)
+	require.Len(t, p.verifier, 64) // 32 random bytes, hex-encoded.
+
+	sum := sha256.Sum256([]byte(p.verifier))
+	require.Equal(t, base64.RawURLEncoding.EncodeToString(sum[:]), p.challenge)
+
+	p2, err := generatePKCE()
+	require.NoError(t, err)
+	require.NotEqual(t, p.verifier, p2.verifier)
+}
+
+func TestBuildAuthorizeURL(t *testing.T) {
+	t.Parallel()
+	p := pkceChallenge{verifier: "verifier", challenge: "the-challenge"}
+	raw, err := buildAuthorizeURL("https://auth.x.ai/oauth2/auth", p, "the-state", "the-nonce")
+	require.NoError(t, err)
+
+	u, err := url.Parse(raw)
+	require.NoError(t, err)
+	require.Equal(t, "auth.x.ai", u.Host)
+	require.Equal(t, "/oauth2/auth", u.Path)
+
+	q := u.Query()
+	require.Equal(t, "code", q.Get("response_type"))
+	require.Equal(t, defaultClientID, q.Get("client_id"))
+	require.Equal(t, "http://127.0.0.1:56121/callback", q.Get("redirect_uri"))
+	require.Equal(t, oauthScope, q.Get("scope"))
+	require.Equal(t, "the-state", q.Get("state"))
+	require.Equal(t, "the-nonce", q.Get("nonce"))
+	require.Equal(t, "the-challenge", q.Get("code_challenge"))
+	require.Equal(t, "S256", q.Get("code_challenge_method"))
+	require.Equal(t, "crush", q.Get("referrer"))
+}
+
+func TestParseTokenResponse(t *testing.T) {
+	t.Parallel()
+
+	t.Run("expires_in", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"access_token":"at","refresh_token":"rt","expires_in":1800}`)
+		tok, err := parseTokenResponse(body, http.StatusOK, "")
+		require.NoError(t, err)
+		require.Equal(t, "at", tok.AccessToken)
+		require.Equal(t, "rt", tok.RefreshToken)
+		require.Equal(t, 1800, tok.ExpiresIn)
+		require.False(t, tok.IsExpired())
+	})
+
+	t.Run("retains prior refresh token", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"access_token":"at","expires_in":1800}`)
+		tok, err := parseTokenResponse(body, http.StatusOK, "prior-rt")
+		require.NoError(t, err)
+		require.Equal(t, "prior-rt", tok.RefreshToken)
+	})
+
+	t.Run("oauth error", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"error":"invalid_grant","error_description":"bad code"}`)
+		_, err := parseTokenResponse(body, http.StatusBadRequest, "")
+		require.ErrorContains(t, err, "bad code")
+	})
+
+	t.Run("missing access token", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`{"refresh_token":"rt"}`)
+		_, err := parseTokenResponse(body, http.StatusOK, "")
+		require.ErrorContains(t, err, "missing an access token")
+	})
+
+	t.Run("jwt expiry fallback", func(t *testing.T) {
+		t.Parallel()
+		exp := time.Now().Add(time.Hour).Unix()
+		body := []byte(`{"access_token":"` + makeJWT(t, exp) + `","refresh_token":"rt"}`)
+		tok, err := parseTokenResponse(body, http.StatusOK, "")
+		require.NoError(t, err)
+		require.Equal(t, exp, tok.ExpiresAt)
+	})
+
+	t.Run("non-2xx without error body", func(t *testing.T) {
+		t.Parallel()
+		_, err := parseTokenResponse([]byte(`{}`), http.StatusServiceUnavailable, "")
+		require.ErrorContains(t, err, "503")
+	})
+}
+
+func TestJWTExpiry(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, int64(0), jwtExpiry(""))
+	require.Equal(t, int64(0), jwtExpiry("not-a-jwt"))
+	require.Equal(t, int64(1234567890), jwtExpiry(makeJWT(t, 1234567890)))
+}
+
+func TestCallbackHandler(t *testing.T) {
+	t.Parallel()
+
+	newServer := func() *callbackServer {
+		return &callbackServer{
+			expectedState: "expected",
+			resultCh:      make(chan callbackResult, 1),
+		}
+	}
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		cs := newServer()
+		req := httptest.NewRequest(http.MethodGet, "/callback?code=the-code&state=expected", nil)
+		rec := httptest.NewRecorder()
+		cs.handle(rec, req)
+
+		res := <-cs.resultCh
+		require.NoError(t, res.err)
+		require.Equal(t, "the-code", res.code)
+		require.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	t.Run("state mismatch", func(t *testing.T) {
+		t.Parallel()
+		cs := newServer()
+		req := httptest.NewRequest(http.MethodGet, "/callback?code=the-code&state=wrong", nil)
+		rec := httptest.NewRecorder()
+		cs.handle(rec, req)
+
+		res := <-cs.resultCh
+		require.ErrorContains(t, res.err, "state mismatch")
+		require.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("oauth error", func(t *testing.T) {
+		t.Parallel()
+		cs := newServer()
+		req := httptest.NewRequest(http.MethodGet, "/callback?error=access_denied&error_description=nope&state=expected", nil)
+		rec := httptest.NewRecorder()
+		cs.handle(rec, req)
+
+		res := <-cs.resultCh
+		require.ErrorContains(t, res.err, "nope")
+	})
+
+	t.Run("missing code", func(t *testing.T) {
+		t.Parallel()
+		cs := newServer()
+		req := httptest.NewRequest(http.MethodGet, "/callback?state=expected", nil)
+		rec := httptest.NewRecorder()
+		cs.handle(rec, req)
+
+		res := <-cs.resultCh
+		require.ErrorContains(t, res.err, "missing")
+	})
+
+	t.Run("cors preflight echoed for trusted origin", func(t *testing.T) {
+		t.Parallel()
+		cs := newServer()
+		req := httptest.NewRequest(http.MethodOptions, "/callback", nil)
+		req.Header.Set("Origin", "https://auth.x.ai")
+		rec := httptest.NewRecorder()
+		cs.handle(rec, req)
+
+		require.Equal(t, http.StatusNoContent, rec.Code)
+		require.Equal(t, "https://auth.x.ai", rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("cors not echoed for untrusted origin", func(t *testing.T) {
+		t.Parallel()
+		cs := newServer()
+		req := httptest.NewRequest(http.MethodOptions, "/callback", nil)
+		req.Header.Set("Origin", "https://evil.com")
+		rec := httptest.NewRecorder()
+		cs.handle(rec, req)
+
+		require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+	})
+}
+
+func TestFetchDiscovery(t *testing.T) {
+	t.Run("valid document", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"authorization_endpoint":"https://auth.x.ai/authorize","token_endpoint":"https://auth.x.ai/token"}`))
+		}))
+		defer srv.Close()
+		swapDiscoveryURL(t, srv.URL)
+
+		doc, err := fetchDiscovery(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "https://auth.x.ai/authorize", doc.AuthorizationEndpoint)
+		require.Equal(t, "https://auth.x.ai/token", doc.TokenEndpoint)
+	})
+
+	t.Run("rejects untrusted endpoint", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{"authorization_endpoint":"https://evil.com/authorize","token_endpoint":"https://auth.x.ai/token"}`))
+		}))
+		defer srv.Close()
+		swapDiscoveryURL(t, srv.URL)
+
+		_, err := fetchDiscovery(context.Background())
+		require.ErrorContains(t, err, "untrusted")
+	})
+}
+
+// swapDiscoveryURL points discoveryURL at a test server for the duration of
+// the test.
+func swapDiscoveryURL(t *testing.T, u string) {
+	t.Helper()
+	orig := discoveryURL
+	discoveryURL = u
+	t.Cleanup(func() { discoveryURL = orig })
+}
+
+// makeJWT builds an unsigned JWT carrying the given exp claim.
+func makeJWT(t *testing.T, exp int64) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+	payload, err := json.Marshal(map[string]int64{"exp": exp})
+	require.NoError(t, err)
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}

--- a/internal/ui/dialog/oauth.go
+++ b/internal/ui/dialog/oauth.go
@@ -253,24 +253,34 @@ func (m *OAuth) innerDialogContent() string {
 			)
 
 	case OAuthStateDisplay:
+		// Browser (authorization-code) providers have no user code to
+		// display; they open a browser and wait for a loopback callback.
+		browserFlow := m.userCode == ""
+
+		instructionSuffix := " to copy the code below and open the browser."
+		if browserFlow {
+			instructionSuffix = " to open the browser and sign in."
+		}
 		instructions := lipgloss.NewStyle().
 			Margin(0, 1).
 			Width(m.width - 2).
 			Render(
 				instructionStyle.Render("Press ") +
 					enterKeyStyle.Render("enter") +
-					instructionStyle.Render(" to copy the code below and open the browser."),
+					instructionStyle.Render(instructionSuffix),
 			)
 
+		codeContent := t.Dialog.OAuth.UserCode.Render(m.userCode)
+		if browserFlow {
+			codeContent = statusTextStyle.Render("Waiting for your browser…")
+		}
 		codeBox := lipgloss.NewStyle().
 			Width(m.width-2).
 			Height(7).
 			Align(lipgloss.Center, lipgloss.Center).
 			Background(t.Dialog.OAuth.UserCodeBg).
 			Margin(0, 1).
-			Render(
-				t.Dialog.OAuth.UserCode.Render(m.userCode),
-			)
+			Render(codeContent)
 
 		link := linkStyle.Hyperlink(m.verificationURL, "id=oauth-verify").Render(m.verificationURL)
 		url := statusTextStyle.
@@ -278,11 +288,15 @@ func (m *OAuth) innerDialogContent() string {
 			Width(m.width - 2).
 			Render("Browser not opening? Pay a visit to:\n" + link)
 
+		waitingText := "Verifying..."
+		if browserFlow {
+			waitingText = "Waiting for authorization..."
+		}
 		waiting := lipgloss.NewStyle().
 			Margin(0, 1).
 			Width(m.width - 2).
 			Render(
-				successStyle.Render(m.spinner.View()) + statusTextStyle.Render("Verifying..."),
+				successStyle.Render(m.spinner.View()) + statusTextStyle.Render(waitingText),
 			)
 
 		return lipgloss.JoinVertical(
@@ -335,6 +349,17 @@ func (m *OAuth) ShortHelp() []key.Binding {
 		}
 
 	default:
+		// Browser flows have no user code: drop the copy binding and
+		// relabel submit.
+		if m.userCode == "" {
+			return []key.Binding{
+				key.NewBinding(
+					key.WithKeys("enter", "ctrl+y"),
+					key.WithHelp("enter", "open browser"),
+				),
+				m.keyMap.Close,
+			}
+		}
 		return []key.Binding{
 			m.keyMap.Copy,
 			m.keyMap.Submit,
@@ -344,25 +369,31 @@ func (m *OAuth) ShortHelp() []key.Binding {
 }
 
 func (d *OAuth) copyCode() tea.Cmd {
-	if d.State != OAuthStateDisplay {
+	if d.State != OAuthStateDisplay || d.userCode == "" {
 		return nil
 	}
 	return common.CopyToClipboard(d.userCode, "Code copied to clipboard")
+}
+
+func (d *OAuth) openURL() tea.Msg {
+	if err := browser.OpenURL(d.verificationURL); err != nil {
+		return ActionOAuthErrored{fmt.Errorf("failed to open browser: %w", err)}
+	}
+	return nil
 }
 
 func (d *OAuth) copyCodeAndOpenURL() tea.Cmd {
 	if d.State != OAuthStateDisplay {
 		return nil
 	}
+	// Browser flows have no code to copy; just open the authorization URL.
+	if d.userCode == "" {
+		return d.openURL
+	}
 	return common.CopyToClipboardWithCallback(
 		d.userCode,
 		"Code copied and URL opened",
-		func() tea.Msg {
-			if err := browser.OpenURL(d.verificationURL); err != nil {
-				return ActionOAuthErrored{fmt.Errorf("failed to open browser: %w", err)}
-			}
-			return nil
-		},
+		d.openURL,
 	)
 }
 

--- a/internal/ui/dialog/oauth_xai.go
+++ b/internal/ui/dialog/oauth_xai.go
@@ -1,0 +1,79 @@
+package dialog
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/oauth/xai"
+	"github.com/charmbracelet/crush/internal/ui/common"
+)
+
+// NewOAuthXAI creates an OAuth dialog for the xAI browser sign-in flow.
+func NewOAuthXAI(
+	com *common.Common,
+	isOnboarding bool,
+	provider catwalk.Provider,
+	model config.SelectedModel,
+	modelType config.SelectedModelType,
+) (*OAuth, tea.Cmd) {
+	return newOAuth(com, isOnboarding, provider, model, modelType, &OAuthXAI{})
+}
+
+// OAuthXAI drives the xAI authorization-code (PKCE) browser flow. Unlike the
+// device-code providers, there is no user code to display: the dialog opens a
+// browser and waits for the loopback OAuth callback.
+type OAuthXAI struct {
+	authorizer *xai.Authorizer
+	cancelFunc func()
+}
+
+var _ OAuthProvider = (*OAuthXAI)(nil)
+
+func (m *OAuthXAI) name() string { return "xAI" }
+
+func (m *OAuthXAI) initiateAuth() tea.Msg {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	authorizer, err := xai.NewAuthorizer(ctx)
+	if err != nil {
+		return ActionOAuthErrored{Error: fmt.Errorf("failed to initiate xAI OAuth: %w", err)}
+	}
+	m.authorizer = authorizer
+
+	// No DeviceCode/UserCode: VerificationURL is the authorization URL.
+	return ActionInitiateOAuth{
+		VerificationURL: authorizer.AuthURL,
+	}
+}
+
+func (m *OAuthXAI) startPolling(_ string, _ int) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithCancel(context.Background())
+		m.cancelFunc = cancel
+
+		token, err := m.authorizer.Wait(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil // cancelled, don't report error.
+			}
+			return ActionOAuthErrored{Error: err}
+		}
+
+		return ActionCompleteOAuth{Token: token}
+	}
+}
+
+func (m *OAuthXAI) stopPolling() tea.Msg {
+	if m.cancelFunc != nil {
+		m.cancelFunc()
+	}
+	if m.authorizer != nil {
+		m.authorizer.Close()
+	}
+	return nil
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1727,6 +1727,8 @@ func (m *UI) openAuthenticationDialog(provider catwalk.Provider, model config.Se
 		dlg, cmd = dialog.NewOAuthHyper(m.com, isOnboarding, provider, model, modelType)
 	case catwalk.InferenceProviderCopilot:
 		dlg, cmd = dialog.NewOAuthCopilot(m.com, isOnboarding, provider, model, modelType)
+	case catwalk.InferenceProviderXAI:
+		dlg, cmd = dialog.NewOAuthXAI(m.com, isOnboarding, provider, model, modelType)
 	default:
 		dlg, cmd = dialog.NewAPIKeyInput(m.com, isOnboarding, provider, model, modelType)
 	}


### PR DESCRIPTION
## Summary

RFC / proof of concept: adds "Sign in with Grok" to Crush via the OAuth2
authorization-code + PKCE browser flow, alongside the existing `XAI_API_KEY`.

- New `internal/oauth/xai` package: OIDC discovery (`auth.x.ai`), PKCE (S256),
  a loopback callback server on `127.0.0.1:56121`, code/token exchange, and
  refresh. Discovery endpoints are validated to be HTTPS on an `x.ai` host
  before use.
- `crush login xai` / `crush logout xai` (aliases: `grok`).
- TUI: xAI routes to an OAuth dialog during onboarding/auth. The shared OAuth
  dialog now renders a "waiting for browser" state for code-less flows
  (device-code providers are unchanged).
- Token refresh plugs into `ConfigStore.RefreshOAuthToken`, so the
  coordinator's existing proactive + 401 refresh handles xAI automatically.
- Unit tests for PKCE, endpoint trust, authorize-URL building, token-response
  parsing, the callback handler (state/CORS/errors), and discovery.

## Open question -- OAuth client registration

This PoC reuses xAI's shared public OAuth client
(`b1a00492-073a-47ea-816f-4c329264a828`) -- the same client embedded by goose
and OpenClaw. A client ID is a public, non-secret identifier, and xAI labels
the consent screen "Grok Build" regardless of the embedding tool. Still,
**before this ships beyond a PoC, Crush should request its own xAI OAuth
client** rather than reuse the shared one. The ID is overridable via
`XAI_OAUTH_CLIENT_ID`.

Ref: aaif-goose/goose#9339

## Test plan

- `go build ./...`, `go vet ./...`, `go test ./...` -- all green.
- Unit tests: `go test ./internal/oauth/xai/...`.
- Not yet verified end-to-end against live `auth.x.ai` -- there is no
  Crush-registered client, and the flow mirrors the goose + OpenClaw
  implementations. Manual verification welcome.

## Notes / follow-ups

- Register a Crush-owned xAI OAuth client (see above).
- Remote/headless hosts need the loopback callback port forwarded; a
  device-code fallback (as goose/OpenClaw both have) would be a reasonable
  follow-up.
- Pre-existing `go vet` warning in `internal/csync/maps.go:137` is unrelated
  to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
