### PR TITLE
Fix markdown locking and divide-by-zero display

### DIFF
--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -74,8 +74,12 @@ func (m *UserMessageItem) RawRender(width int) string {
 	}
 
 	renderer := common.MarkdownRenderer(m.sty, cappedWidth)
+	mu := common.LockMarkdownRenderer(renderer)
 
+	mu.Lock()
 	result, err := renderer.Render(msgContent)
+	mu.Unlock()
+
 	if err != nil {
 		content = msgContent
 	} else {
@@ -102,7 +106,12 @@ func (m *UserMessageItem) renderSkillInvocation(content string, width int) strin
 	if err := xml.Unmarshal([]byte(content), &skill); err != nil {
 		// If parsing fails, just render as markdown
 		renderer := common.MarkdownRenderer(m.sty, width)
+		mu := common.LockMarkdownRenderer(renderer)
+
+		mu.Lock()
 		result, err := renderer.Render(content)
+		mu.Unlock()
+
 		if err != nil {
 			return content
 		}

--- a/internal/ui/common/elements.go
+++ b/internal/ui/common/elements.go
@@ -111,7 +111,10 @@ func formatTokensAndCost(t *styles.Styles, tokens, contextWindow int64, cost flo
 		formattedTokens = strings.Replace(formattedTokens, ".0M", "M", 1)
 	}
 
-	percentage := (float64(tokens) / float64(contextWindow)) * 100
+	var percentage float64
+	if contextWindow > 0 {
+		percentage = (float64(tokens) / float64(contextWindow)) * 100
+	}
 
 	formattedCost := t.ModelInfo.Cost.Render(fmt.Sprintf("$%.2f", cost))
 


### PR DESCRIPTION
I surfaced these two patches while working on Crush.   

Also see these two, which together segfault `crush`:
 * https://github.com/charmbracelet/lipgloss/pull/689
 * https://github.com/charmbracelet/glamour/pull/557

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
