### PR TITLE
feat(ui): add ctrl-x shortcut to model list dialog to remove from recently used list

### DIFF
--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -43,6 +43,15 @@ func (b *Backend) RemoveConfigField(workspaceID string, scope config.Scope, key 
 	return ws.Cfg.RemoveConfigField(scope, key)
 }
 
+// RemoveRecentModel removes a recently used model from the config file.
+func (b *Backend) RemoveRecentModel(workspaceID string, scope config.Scope, modelType config.SelectedModelType, model config.SelectedModel) error {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return err
+	}
+	return ws.Cfg.RemoveRecentModel(scope, modelType, model)
+}
+
 // UpdatePreferredModel updates the preferred model for the given type
 // and persists it to the config file at the given scope.
 func (b *Backend) UpdatePreferredModel(workspaceID string, scope config.Scope, modelType config.SelectedModelType, model config.SelectedModel) error {

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -44,6 +44,23 @@ func (c *Client) RemoveConfigField(ctx context.Context, id string, scope config.
 	return nil
 }
 
+// RemoveRecentModel updates the preferred model on the server.
+func (c *Client) RemoveRecentModel(ctx context.Context, id string, scope config.Scope, modelType config.SelectedModelType, model config.SelectedModel) error {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/config/remove-recent-model", id), nil, jsonBody(struct {
+		Scope     config.Scope             `json:"scope"`
+		ModelType config.SelectedModelType `json:"model_type"`
+		Model     config.SelectedModel     `json:"model"`
+	}{Scope: scope, ModelType: modelType, Model: model}), http.Header{"Content-Type": []string{"application/json"}})
+	if err != nil {
+		return fmt.Errorf("failed to update preferred model: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to update preferred model: status code %d", rsp.StatusCode)
+	}
+	return nil
+}
+
 // UpdatePreferredModel updates the preferred model on the server.
 func (c *Client) UpdatePreferredModel(ctx context.Context, id string, scope config.Scope, modelType config.SelectedModelType, model config.SelectedModel) error {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/config/model", id), nil, jsonBody(struct {

--- a/internal/config/recent_models_test.go
+++ b/internal/config/recent_models_test.go
@@ -212,6 +212,33 @@ func TestUpdatePreferredModel_UpdatesRecents(t *testing.T) {
 	require.Len(t, small, 1)
 }
 
+func TestUpdatePreferredModel_RemovesRecents(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfg := &Config{}
+	cfg.setDefaults(dir, "")
+	store := testStoreWithPath(cfg, dir)
+
+	notDeleted := SelectedModel{Provider: "openai", Model: "gpt-4o"}
+	require.NoError(t, store.recordRecentModel(ScopeGlobal, SelectedModelTypeSmall, notDeleted))
+
+	toDelete := SelectedModel{Provider: "openai", Model: "gpt-5"}
+	require.NoError(t, store.recordRecentModel(ScopeGlobal, SelectedModelTypeSmall, toDelete))
+
+	// in-memory
+	require.Len(t, cfg.RecentModels[SelectedModelTypeSmall], 2)
+	require.NoError(t, store.RemoveRecentModel(ScopeGlobal, SelectedModelTypeSmall, toDelete))
+	require.Len(t, cfg.RecentModels[SelectedModelTypeSmall], 1)
+	require.Equal(t, cfg.RecentModels[SelectedModelTypeSmall][0], notDeleted)
+
+	// persisted (read via fs.FS)
+	rm := readRecentModels(t, store.globalDataPath)
+	small, ok := rm[string(SelectedModelTypeSmall)].([]any)
+	require.True(t, ok)
+	require.Len(t, small, 1)
+}
+
 func TestRecordRecentModel_TypeIsolation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -218,7 +218,23 @@ func (s *ConfigStore) UpdatePreferredModel(scope Scope, modelType SelectedModelT
 	return nil
 }
 
+// removeModelFromList removes a model from a list of recently used models.
+// It returns the updated list or an error if the model is not found.
+func removeModelFromList(current []SelectedModel, model SelectedModel) ([]SelectedModel, error) {
+	eq := func(a SelectedModel) bool {
+		return a.Provider == model.Provider && a.Model == model.Model
+	}
+
+	if !slices.ContainsFunc(current, eq) {
+		return nil, fmt.Errorf("model %s:%s is not in recently used list", model.Provider, model.Model)
+	}
+
+	return slices.DeleteFunc(slices.Clone(current), eq), nil
+}
+
 // RemoveRecentModel removes a recently used model from the config file.
+// If the model has an empty provider or model ID, this is a no-op (the UI
+// should prevent this case, but we handle it defensively).
 func (s *ConfigStore) RemoveRecentModel(scope Scope, modelType SelectedModelType, model SelectedModel) error {
 	if model.Provider == "" || model.Model == "" {
 		return nil
@@ -228,19 +244,12 @@ func (s *ConfigStore) RemoveRecentModel(scope Scope, modelType SelectedModelType
 		return nil
 	}
 
-	eq := func(a SelectedModel) bool {
-		return a.Provider == model.Provider && a.Model == model.Model
-	}
-
 	current := s.config.RecentModels[modelType]
-
-	// Check if the model exists in the list before attempting deletion
-	found := slices.ContainsFunc(current, eq)
-	if !found {
-		return fmt.Errorf("model %s:%s is not in recently used list", model.Provider, model.Model)
+	updated, err := removeModelFromList(current, model)
+	if err != nil {
+		return err
 	}
 
-	updated := slices.DeleteFunc(slices.Clone(current), eq)
 	s.config.RecentModels[modelType] = updated
 
 	if err := s.SetConfigField(scope, fmt.Sprintf("recent_models.%s", modelType), updated); err != nil {

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -233,13 +233,14 @@ func (s *ConfigStore) RemoveRecentModel(scope Scope, modelType SelectedModelType
 	}
 
 	current := s.config.RecentModels[modelType]
-	updated := slices.DeleteFunc(slices.Clone(current), func(existing SelectedModel) bool {
-		return eq(existing)
-	})
-	if len(updated) == len(current) {
+
+	// Check if the model exists in the list before attempting deletion
+	found := slices.ContainsFunc(current, eq)
+	if !found {
 		return fmt.Errorf("model %s:%s is not in recently used list", model.Provider, model.Model)
 	}
 
+	updated := slices.DeleteFunc(slices.Clone(current), eq)
 	s.config.RecentModels[modelType] = updated
 
 	if err := s.SetConfigField(scope, fmt.Sprintf("recent_models.%s", modelType), updated); err != nil {

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -218,6 +218,37 @@ func (s *ConfigStore) UpdatePreferredModel(scope Scope, modelType SelectedModelT
 	return nil
 }
 
+// RemoveRecentModel removes a recently used model from the config file.
+func (s *ConfigStore) RemoveRecentModel(scope Scope, modelType SelectedModelType, model SelectedModel) error {
+	if model.Provider == "" || model.Model == "" {
+		return nil
+	}
+
+	if s.config.RecentModels == nil {
+		return nil
+	}
+
+	eq := func(a SelectedModel) bool {
+		return a.Provider == model.Provider && a.Model == model.Model
+	}
+
+	current := s.config.RecentModels[modelType]
+	updated := slices.DeleteFunc(slices.Clone(current), func(existing SelectedModel) bool {
+		return eq(existing)
+	})
+	if len(updated) == len(current) {
+		return fmt.Errorf("model %s:%s is not in recently used list", model.Provider, model.Model)
+	}
+
+	s.config.RecentModels[modelType] = updated
+
+	if err := s.SetConfigField(scope, fmt.Sprintf("recent_models.%s", modelType), updated); err != nil {
+		return fmt.Errorf("failed to persist recent models: %w", err)
+	}
+
+	return nil
+}
+
 // SetCompactMode sets the compact mode setting and persists it.
 func (s *ConfigStore) SetCompactMode(scope Scope, enabled bool) error {
 	if s.config.Options == nil {

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -94,6 +94,35 @@ func (c *controllerV1) handlePostWorkspaceConfigModel(w http.ResponseWriter, r *
 	w.WriteHeader(http.StatusOK)
 }
 
+// handleDeleteWorkspaceConfigRecentModel updates the preferred model.
+//
+//	@Summary		Set the preferred model
+//	@Tags			config
+//	@Accept			json
+//	@Param			id		path	string						true	"Workspace ID"
+//	@Param			request	body	proto.ConfigModelRequest	true	"Config model request"
+//	@Success		200
+//	@Failure		400	{object}	proto.Error
+//	@Failure		404	{object}	proto.Error
+//	@Failure		500	{object}	proto.Error
+//	@Router			/workspaces/{id}/config/model [post]
+func (c *controllerV1) handleDeleteWorkspaceConfigRecentModel(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	var req proto.ConfigModelRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		c.server.logError(r, "Failed to decode request", "error", err)
+		jsonError(w, http.StatusBadRequest, "failed to decode request")
+		return
+	}
+
+	if err := c.backend.RemoveRecentModel(id, req.Scope, req.ModelType, req.Model); err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
 // handlePostWorkspaceConfigCompact sets compact mode.
 //
 //	@Summary		Set compact mode

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -94,9 +94,9 @@ func (c *controllerV1) handlePostWorkspaceConfigModel(w http.ResponseWriter, r *
 	w.WriteHeader(http.StatusOK)
 }
 
-// handleDeleteWorkspaceConfigRecentModel updates the preferred model.
+// handleDeleteWorkspaceConfigRecentModel removes a model from the recently used list.
 //
-//	@Summary		Set the preferred model
+//	@Summary		Remove a recent model
 //	@Tags			config
 //	@Accept			json
 //	@Param			id		path	string						true	"Workspace ID"
@@ -105,7 +105,7 @@ func (c *controllerV1) handlePostWorkspaceConfigModel(w http.ResponseWriter, r *
 //	@Failure		400	{object}	proto.Error
 //	@Failure		404	{object}	proto.Error
 //	@Failure		500	{object}	proto.Error
-//	@Router			/workspaces/{id}/config/model [post]
+//	@Router			/workspaces/{id}/config/remove-recent-model [post]
 func (c *controllerV1) handleDeleteWorkspaceConfigRecentModel(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -150,6 +150,7 @@ func NewServer(cfg *config.ConfigStore, network, address string) *Server {
 	mux.HandleFunc("POST /v1/workspaces/{id}/config/set", c.handlePostWorkspaceConfigSet)
 	mux.HandleFunc("POST /v1/workspaces/{id}/config/remove", c.handlePostWorkspaceConfigRemove)
 	mux.HandleFunc("POST /v1/workspaces/{id}/config/model", c.handlePostWorkspaceConfigModel)
+	mux.HandleFunc("POST /v1/workspaces/{id}/config/remove-recent-model", c.handleDeleteWorkspaceConfigRecentModel)
 	mux.HandleFunc("POST /v1/workspaces/{id}/config/compact", c.handlePostWorkspaceConfigCompact)
 	mux.HandleFunc("POST /v1/workspaces/{id}/config/provider-key", c.handlePostWorkspaceConfigProviderKey)
 	mux.HandleFunc("POST /v1/workspaces/{id}/config/import-copilot", c.handlePostWorkspaceConfigImportCopilot)

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -44,12 +44,13 @@ type ActionSelectModel struct {
 }
 
 // ActionRemoveRecentModel is a message indicating a model is to be removed from the recent models list.
-// It optionally stores a command to be executed if the model was successfully removed.
 type ActionRemoveRecentModel struct {
 	Model     config.SelectedModel
 	ModelType config.SelectedModelType
-	Cmd       tea.Cmd
 }
+
+// ActionRefreshModels is a message indicating the models dialog should refresh its list.
+type ActionRefreshModels struct{}
 
 // Messages for commands
 type (

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -43,6 +43,14 @@ type ActionSelectModel struct {
 	ReAuthenticate bool
 }
 
+// ActionRemoveRecentModel is a message indicating a model is to be removed from the recent models list.
+// It optionally stores a command to be executed if the model was successfully removed.
+type ActionRemoveRecentModel struct {
+	Model     config.SelectedModel
+	ModelType config.SelectedModelType
+	Cmd       tea.Cmd
+}
+
 // Messages for commands
 type (
 	ActionNewSession                  struct{}

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -50,7 +50,7 @@ type ActionRemoveRecentModel struct {
 	ModelType config.SelectedModelType
 }
 
-// ActionRefreshModels is a message indicating the models dialog should refresh its list, and optionally select an item.
+// ActionRefreshModels is a message indicating the models dialog should refresh its list, and optionally select an item by index.
 type ActionRefreshModels struct {
 	Selected int
 }

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -45,12 +45,15 @@ type ActionSelectModel struct {
 
 // ActionRemoveRecentModel is a message indicating a model is to be removed from the recent models list.
 type ActionRemoveRecentModel struct {
+	Selected  int
 	Model     config.SelectedModel
 	ModelType config.SelectedModelType
 }
 
-// ActionRefreshModels is a message indicating the models dialog should refresh its list.
-type ActionRefreshModels struct{}
+// ActionRefreshModels is a message indicating the models dialog should refresh its list, and optionally select an item.
+type ActionRefreshModels struct {
+	Selected int
+}
 
 // Messages for commands
 type (

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -173,6 +173,9 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 		if err := m.setProviderItems(); err != nil {
 			return util.ReportError(err)
 		}
+		if msg.Selected >= 0 {
+			m.list.SetSelected(msg.Selected)
+		}
 	case tea.KeyPressMsg:
 		switch {
 		case key.Matches(msg, m.keyMap.Close):
@@ -229,6 +232,7 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 			if selectedItem == nil {
 				break
 			}
+			selected := m.list.Selected()
 
 			modelItem, ok := selectedItem.(*ModelItem)
 			if !ok || !modelItem.IsRecent() {
@@ -236,6 +240,7 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 			}
 
 			return ActionRemoveRecentModel{
+				Selected:  selected,
 				Model:     modelItem.SelectedModel(),
 				ModelType: modelItem.SelectedModelType(),
 			}

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -173,8 +173,15 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 		if err := m.setProviderItems(); err != nil {
 			return util.ReportError(err)
 		}
+		// Select the item at the specified index, clamping to valid range
 		if msg.Selected >= 0 {
-			m.list.SetSelected(msg.Selected)
+			totalItems := m.list.Len()
+			if totalItems > 0 {
+				// Clamp to valid range
+				selected := min(msg.Selected, totalItems-1)
+				m.list.SetSelected(selected)
+				m.list.ScrollToSelected()
+			}
 		}
 	case tea.KeyPressMsg:
 		switch {
@@ -235,7 +242,7 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 			selected := m.list.Selected()
 
 			modelItem, ok := selectedItem.(*ModelItem)
-			if !ok || !modelItem.IsRecent() {
+			if !ok || !modelItem.IsRecent(m.com.Config()) {
 				break
 			}
 
@@ -391,7 +398,7 @@ func (m *Models) isSelectedRecent() bool {
 	if !ok {
 		return false
 	}
-	return modelItem.IsRecent()
+	return modelItem.IsRecent(m.com.Config())
 }
 
 // setProviderItems sets the provider items in the list.
@@ -439,7 +446,7 @@ func (m *Models) setProviderItems() error {
 
 			group := NewModelGroup(t, name, true)
 			for _, model := range p.Models {
-				item := NewModelItem(t, provider, model, m.modelType, false, false)
+				item := NewModelItem(t, provider, model, m.modelType, false)
 				group.AppendItems(item)
 				itemsMap[item.ID()] = item
 				if model.ID == currentModel.Model && string(provider.ID) == currentModel.Provider {
@@ -492,7 +499,7 @@ func (m *Models) setProviderItems() error {
 
 		group := NewModelGroup(t, name, providerConfigured)
 		for _, model := range displayProvider.Models {
-			item := NewModelItem(t, provider, model, m.modelType, false, false)
+			item := NewModelItem(t, provider, model, m.modelType, false)
 			group.AppendItems(item)
 			itemsMap[item.ID()] = item
 			if model.ID == currentModel.Model && string(provider.ID) == currentModel.Provider {
@@ -515,7 +522,7 @@ func (m *Models) setProviderItems() error {
 			}
 
 			// Show provider for recent items
-			item = NewModelItem(t, item.prov, item.model, m.modelType, true, true)
+			item = NewModelItem(t, item.prov, item.model, m.modelType, true)
 			item.showProvider = true
 
 			validRecentItems = append(validRecentItems, recent)

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -120,7 +120,7 @@ func NewModels(com *common.Common, isOnboarding bool) (*Models, error) {
 
 	m.keyMap.Tab = key.NewBinding(
 		key.WithKeys("tab", "shift+tab"),
-		key.WithHelp("tab", "toggle type"),
+		key.WithHelp("tab", "toggle"),
 	)
 	m.keyMap.Select = key.NewBinding(
 		key.WithKeys("enter", "ctrl+y"),
@@ -132,7 +132,7 @@ func NewModels(com *common.Common, isOnboarding bool) (*Models, error) {
 	)
 	m.keyMap.Delete = key.NewBinding(
 		key.WithKeys("ctrl+x"),
-		key.WithHelp("ctrl+x", "delete"),
+		key.WithHelp("ctrl+x", "remove"),
 	)
 	m.keyMap.UpDown = key.NewBinding(
 		key.WithKeys("up", "down"),
@@ -169,6 +169,10 @@ func (m *Models) ID() string {
 // HandleMsg implements Dialog.
 func (m *Models) HandleMsg(msg tea.Msg) Action {
 	switch msg := msg.(type) {
+	case ActionRefreshModels:
+		if err := m.setProviderItems(); err != nil {
+			return util.ReportError(err)
+		}
 	case tea.KeyPressMsg:
 		switch {
 		case key.Matches(msg, m.keyMap.Close):
@@ -225,24 +229,15 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 			if selectedItem == nil {
 				break
 			}
-			selected := m.list.Selected()
 
 			modelItem, ok := selectedItem.(*ModelItem)
-			if !ok {
+			if !ok || !modelItem.IsRecent() {
 				break
 			}
 
 			return ActionRemoveRecentModel{
 				Model:     modelItem.SelectedModel(),
 				ModelType: modelItem.SelectedModelType(),
-				Cmd: func() tea.Msg {
-					if err := m.setProviderItems(); err != nil {
-						return util.ReportError(err)
-					}
-					m.list.SetSelected(selected)
-					m.list.ScrollToSelected()
-					return nil
-				},
 			}
 		default:
 			var cmd tea.Cmd
@@ -356,6 +351,9 @@ func (m *Models) ShortHelp() []key.Binding {
 	if m.isSelectedConfigured() {
 		h = append(h, m.keyMap.Edit)
 	}
+	if m.isSelectedRecent() {
+		h = append(h, m.keyMap.Delete)
+	}
 	h = append(h, m.keyMap.Close)
 	return h
 }
@@ -377,6 +375,18 @@ func (m *Models) isSelectedConfigured() bool {
 	providerID := string(modelItem.prov.ID)
 	_, isConfigured := m.com.Config().Providers.Get(providerID)
 	return isConfigured
+}
+
+func (m *Models) isSelectedRecent() bool {
+	selectedItem := m.list.SelectedItem()
+	if selectedItem == nil {
+		return false
+	}
+	modelItem, ok := selectedItem.(*ModelItem)
+	if !ok {
+		return false
+	}
+	return modelItem.IsRecent()
 }
 
 // setProviderItems sets the provider items in the list.
@@ -424,7 +434,7 @@ func (m *Models) setProviderItems() error {
 
 			group := NewModelGroup(t, name, true)
 			for _, model := range p.Models {
-				item := NewModelItem(t, provider, model, m.modelType, false)
+				item := NewModelItem(t, provider, model, m.modelType, false, false)
 				group.AppendItems(item)
 				itemsMap[item.ID()] = item
 				if model.ID == currentModel.Model && string(provider.ID) == currentModel.Provider {
@@ -477,7 +487,7 @@ func (m *Models) setProviderItems() error {
 
 		group := NewModelGroup(t, name, providerConfigured)
 		for _, model := range displayProvider.Models {
-			item := NewModelItem(t, provider, model, m.modelType, false)
+			item := NewModelItem(t, provider, model, m.modelType, false, false)
 			group.AppendItems(item)
 			itemsMap[item.ID()] = item
 			if model.ID == currentModel.Model && string(provider.ID) == currentModel.Provider {
@@ -500,7 +510,7 @@ func (m *Models) setProviderItems() error {
 			}
 
 			// Show provider for recent items
-			item = NewModelItem(t, item.prov, item.model, m.modelType, true)
+			item = NewModelItem(t, item.prov, item.model, m.modelType, true, true)
 			item.showProvider = true
 
 			validRecentItems = append(validRecentItems, recent)

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -85,6 +85,7 @@ type Models struct {
 		UpDown   key.Binding
 		Select   key.Binding
 		Edit     key.Binding
+		Delete   key.Binding
 		Next     key.Binding
 		Previous key.Binding
 		Close    key.Binding
@@ -128,6 +129,10 @@ func NewModels(com *common.Common, isOnboarding bool) (*Models, error) {
 	m.keyMap.Edit = key.NewBinding(
 		key.WithKeys("ctrl+e"),
 		key.WithHelp("ctrl+e", "edit"),
+	)
+	m.keyMap.Delete = key.NewBinding(
+		key.WithKeys("ctrl+x"),
+		key.WithHelp("ctrl+x", "delete"),
 	)
 	m.keyMap.UpDown = key.NewBinding(
 		key.WithKeys("up", "down"),
@@ -214,6 +219,30 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 			}
 			if err := m.setProviderItems(); err != nil {
 				return util.ReportError(err)
+			}
+		case key.Matches(msg, m.keyMap.Delete):
+			selectedItem := m.list.SelectedItem()
+			if selectedItem == nil {
+				break
+			}
+			selected := m.list.Selected()
+
+			modelItem, ok := selectedItem.(*ModelItem)
+			if !ok {
+				break
+			}
+
+			return ActionRemoveRecentModel{
+				Model:     modelItem.SelectedModel(),
+				ModelType: modelItem.SelectedModelType(),
+				Cmd: func() tea.Msg {
+					if err := m.setProviderItems(); err != nil {
+						return util.ReportError(err)
+					}
+					m.list.SetSelected(selected)
+					m.list.ScrollToSelected()
+					return nil
+				},
 			}
 		default:
 			var cmd tea.Cmd

--- a/internal/ui/dialog/models_item.go
+++ b/internal/ui/dialog/models_item.go
@@ -69,12 +69,18 @@ type ModelItem struct {
 	m            fuzzy.Match
 	focused      bool
 	showProvider bool
+	isRecent     bool
 }
 
 // Finished implements list.Item. Model items are render-stable
 // outside of explicit SetFocused / SetMatch.
 func (m *ModelItem) Finished() bool {
 	return true
+}
+
+// IsRecent returns true if this item is in the recently used list.
+func (m *ModelItem) IsRecent() bool {
+	return m.isRecent
 }
 
 // SelectedModel returns this model item as a [config.SelectedModel] instance.
@@ -95,7 +101,7 @@ func (m *ModelItem) SelectedModelType() config.SelectedModelType {
 var _ ListItem = &ModelItem{}
 
 // NewModelItem creates a new ModelItem.
-func NewModelItem(t *styles.Styles, prov catwalk.Provider, model catwalk.Model, typ ModelType, showProvider bool) *ModelItem {
+func NewModelItem(t *styles.Styles, prov catwalk.Provider, model catwalk.Model, typ ModelType, showProvider bool, isRecent bool) *ModelItem {
 	return &ModelItem{
 		Versioned:    list.NewVersioned(),
 		prov:         prov,
@@ -104,6 +110,7 @@ func NewModelItem(t *styles.Styles, prov catwalk.Provider, model catwalk.Model, 
 		t:            t,
 		cache:        make(map[int]string),
 		showProvider: showProvider,
+		isRecent:     isRecent,
 	}
 }
 

--- a/internal/ui/dialog/models_item.go
+++ b/internal/ui/dialog/models_item.go
@@ -1,6 +1,8 @@
 package dialog
 
 import (
+	"slices"
+
 	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/config"
@@ -69,7 +71,6 @@ type ModelItem struct {
 	m            fuzzy.Match
 	focused      bool
 	showProvider bool
-	isRecent     bool
 }
 
 // Finished implements list.Item. Model items are render-stable
@@ -79,8 +80,11 @@ func (m *ModelItem) Finished() bool {
 }
 
 // IsRecent returns true if this item is in the recently used list.
-func (m *ModelItem) IsRecent() bool {
-	return m.isRecent
+func (m *ModelItem) IsRecent(cfg *config.Config) bool {
+	recentModels := cfg.RecentModels[m.SelectedModelType()]
+	return slices.ContainsFunc(recentModels, func(sm config.SelectedModel) bool {
+		return sm.Provider == m.SelectedModel().Provider && sm.Model == m.SelectedModel().Model
+	})
 }
 
 // SelectedModel returns this model item as a [config.SelectedModel] instance.
@@ -101,7 +105,7 @@ func (m *ModelItem) SelectedModelType() config.SelectedModelType {
 var _ ListItem = &ModelItem{}
 
 // NewModelItem creates a new ModelItem.
-func NewModelItem(t *styles.Styles, prov catwalk.Provider, model catwalk.Model, typ ModelType, showProvider bool, isRecent bool) *ModelItem {
+func NewModelItem(t *styles.Styles, prov catwalk.Provider, model catwalk.Model, typ ModelType, showProvider bool) *ModelItem {
 	return &ModelItem{
 		Versioned:    list.NewVersioned(),
 		prov:         prov,
@@ -110,7 +114,6 @@ func NewModelItem(t *styles.Styles, prov catwalk.Provider, model catwalk.Model, 
 		t:            t,
 		cache:        make(map[int]string),
 		showProvider: showProvider,
-		isRecent:     isRecent,
 	}
 }
 

--- a/internal/ui/dialog/version_bump_test.go
+++ b/internal/ui/dialog/version_bump_test.go
@@ -104,7 +104,7 @@ func TestModelItem_MutatorsBumpVersion(t *testing.T) {
 	sty := styles.CharmtonePantera()
 	prov := catwalk.Provider{ID: "openai", Name: "OpenAI"}
 	model := catwalk.Model{ID: "gpt-4", Name: "GPT-4"}
-	item := NewModelItem(&sty, prov, model, ModelTypeLarge, true)
+	item := NewModelItem(&sty, prov, model, ModelTypeLarge, true, false)
 
 	requireBump(t, "SetFocused[true]", item, func() {
 		item.SetFocused(true)

--- a/internal/ui/dialog/version_bump_test.go
+++ b/internal/ui/dialog/version_bump_test.go
@@ -104,7 +104,7 @@ func TestModelItem_MutatorsBumpVersion(t *testing.T) {
 	sty := styles.CharmtonePantera()
 	prov := catwalk.Provider{ID: "openai", Name: "OpenAI"}
 	model := catwalk.Model{ID: "gpt-4", Name: "GPT-4"}
-	item := NewModelItem(&sty, prov, model, ModelTypeLarge, true, false)
+	item := NewModelItem(&sty, prov, model, ModelTypeLarge, true)
 
 	requireBump(t, "SetFocused[true]", item, func() {
 		item.SetFocused(true)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1475,6 +1475,10 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		}
 		cmds = append(cmds, m.initializeProject())
 		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionRemoveRecentModel:
+		if cmd := m.handleRemoveRecentModel(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 
 	case dialog.ActionSelectModel:
 		if cmd := m.handleSelectModel(msg); cmd != nil {
@@ -1577,6 +1581,25 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		cmds = append(cmds, m.runMCPPrompt(msg.ClientID, msg.PromptID, msg.Args))
 	default:
 		cmds = append(cmds, util.CmdHandler(msg))
+	}
+
+	return tea.Batch(cmds...)
+}
+
+func (m *UI) handleRemoveRecentModel(msg dialog.ActionRemoveRecentModel) tea.Cmd {
+	var cmds []tea.Cmd
+
+	if err := m.com.Workspace.RemoveRecentModel(config.ScopeGlobal, msg.ModelType, msg.Model); err != nil {
+		cmds = append(cmds, util.ReportError(err))
+	} else {
+		if msg.Cmd != nil {
+			cmds = append(cmds, msg.Cmd)
+		}
+		cmds = append(cmds, func() tea.Msg {
+			modelMsg := fmt.Sprintf("removed %s from %s provider", msg.Model.Model, msg.ModelType)
+
+			return util.NewInfoMsg(modelMsg)
+		})
 	}
 
 	return tea.Batch(cmds...)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1592,13 +1592,12 @@ func (m *UI) handleRemoveRecentModel(msg dialog.ActionRemoveRecentModel) tea.Cmd
 	if err := m.com.Workspace.RemoveRecentModel(config.ScopeGlobal, msg.ModelType, msg.Model); err != nil {
 		cmds = append(cmds, util.ReportError(err))
 	} else {
-		if msg.Cmd != nil {
-			cmds = append(cmds, msg.Cmd)
+		// Send a refresh message to the models dialog
+		if modelsDialog, ok := m.dialog.Dialog(dialog.ModelsID).(*dialog.Models); ok {
+			modelsDialog.HandleMsg(dialog.ActionRefreshModels{})
 		}
 		cmds = append(cmds, func() tea.Msg {
-			modelMsg := fmt.Sprintf("removed %s from %s provider", msg.Model.Model, msg.ModelType)
-
-			return util.NewInfoMsg(modelMsg)
+			return util.NewInfoMsg(fmt.Sprintf("Removed %s from recent models", msg.Model.Model))
 		})
 	}
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1594,7 +1594,9 @@ func (m *UI) handleRemoveRecentModel(msg dialog.ActionRemoveRecentModel) tea.Cmd
 	} else {
 		// Send a refresh message to the models dialog
 		if modelsDialog, ok := m.dialog.Dialog(dialog.ModelsID).(*dialog.Models); ok {
-			modelsDialog.HandleMsg(dialog.ActionRefreshModels{})
+			modelsDialog.HandleMsg(dialog.ActionRefreshModels{
+				Selected: msg.Selected,
+			})
 		}
 		cmds = append(cmds, func() tea.Msg {
 			return util.NewInfoMsg(fmt.Sprintf("Removed %s from recent models", msg.Model.Model))

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1587,23 +1587,20 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 }
 
 func (m *UI) handleRemoveRecentModel(msg dialog.ActionRemoveRecentModel) tea.Cmd {
-	var cmds []tea.Cmd
-
 	if err := m.com.Workspace.RemoveRecentModel(config.ScopeGlobal, msg.ModelType, msg.Model); err != nil {
-		cmds = append(cmds, util.ReportError(err))
-	} else {
-		// Send a refresh message to the models dialog
-		if modelsDialog, ok := m.dialog.Dialog(dialog.ModelsID).(*dialog.Models); ok {
-			modelsDialog.HandleMsg(dialog.ActionRefreshModels{
-				Selected: msg.Selected,
-			})
-		}
-		cmds = append(cmds, func() tea.Msg {
-			return util.NewInfoMsg(fmt.Sprintf("Removed %s from recent models", msg.Model.Model))
-		})
+		return util.ReportError(err)
 	}
 
-	return tea.Batch(cmds...)
+	return tea.Batch(
+		func() tea.Msg {
+			return dialog.ActionRefreshModels{
+				Selected: msg.Selected,
+			}
+		},
+		func() tea.Msg {
+			return util.NewInfoMsg(fmt.Sprintf("Removed %s from recent models", msg.Model.Model))
+		},
+	)
 }
 
 // substituteArgs replaces $ARG_NAME placeholders in content with actual values.

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -267,6 +267,10 @@ func (w *AppWorkspace) UpdatePreferredModel(scope config.Scope, modelType config
 	return w.store.UpdatePreferredModel(scope, modelType, model)
 }
 
+func (w *AppWorkspace) RemoveRecentModel(scope config.Scope, modelType config.SelectedModelType, model config.SelectedModel) error {
+	return w.store.RemoveRecentModel(scope, modelType, model)
+}
+
 func (w *AppWorkspace) SetCompactMode(scope config.Scope, enabled bool) error {
 	return w.store.SetCompactMode(scope, enabled)
 }

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -418,6 +418,15 @@ func (w *ClientWorkspace) UpdatePreferredModel(scope config.Scope, modelType con
 	return err
 }
 
+func (w *ClientWorkspace) RemoveRecentModel(scope config.Scope, modelType config.SelectedModelType, model config.SelectedModel) error {
+	err := w.client.RemoveRecentModel(context.Background(), w.workspaceID(), scope, modelType, model)
+	if err == nil {
+		w.refreshWorkspace()
+	}
+	return err
+
+}
+
 func (w *ClientWorkspace) SetCompactMode(scope config.Scope, enabled bool) error {
 	err := w.client.SetCompactMode(context.Background(), w.workspaceID(), scope, enabled)
 	if err == nil {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -424,7 +424,6 @@ func (w *ClientWorkspace) RemoveRecentModel(scope config.Scope, modelType config
 		w.refreshWorkspace()
 	}
 	return err
-
 }
 
 func (w *ClientWorkspace) SetCompactMode(scope config.Scope, enabled bool) error {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -117,6 +117,7 @@ type Workspace interface {
 
 	// Config mutations (proxied to server in client mode)
 	UpdatePreferredModel(scope config.Scope, modelType config.SelectedModelType, model config.SelectedModel) error
+	RemoveRecentModel(scope config.Scope, modelType config.SelectedModelType, model config.SelectedModel) error
 	SetCompactMode(scope config.Scope, enabled bool) error
 	SetProviderAPIKey(scope config.Scope, providerID string, apiKey any) error
 	SetConfigField(scope config.Scope, key string, value any) error


### PR DESCRIPTION
This patch adds the ctrl-x shortcut handler to the model selection dialog to remove the model from the recently used model list. The shortcut works on any selected model item. An error message is shown if removing any model that is not in the recently used list.

For consistency I also added a new endpoint to the server and a handler method to the client code.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
