### PR TITLE
fix(config): load system-wide config from /etc/crush/crush.json

### DIFF
--- a/internal/config/config_unix.go
+++ b/internal/config/config_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package config
+
+// systemConfigPath is the system-wide configuration file path. It is
+// loaded at the lowest priority so user and project configs override it.
+const systemConfigPath = "/etc/crush/crush.json"

--- a/internal/config/config_windows.go
+++ b/internal/config/config_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package config
+
+// systemConfigPath is empty on Windows: there is no system-wide config.
+// loadFromConfigPaths skips paths that do not exist, so no special-case
+// handling is needed.
+const systemConfigPath = ""

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -866,6 +866,7 @@ func resolveSelectedModels(cfg *Config, knownProviders []catwalk.Provider) (reso
 func lookupConfigs(cwd string) []string {
 	// prepend default config paths
 	configPaths := []string{
+		systemConfigPath,
 		GlobalConfig(),
 		GlobalConfigData(),
 	}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -130,6 +131,18 @@ func TestLookupConfigs_BoundedByProject(t *testing.T) {
 		// even when no project file exists.
 		require.Contains(t, got, GlobalConfig())
 		require.Contains(t, got, GlobalConfigData())
+	})
+
+	t.Run("system config is loaded first", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("system config not supported on Windows")
+		}
+
+		got := lookupConfigs(t.TempDir())
+		require.NotEmpty(t, got)
+		// The system-wide config must be first so it has the lowest
+		// priority when configs are merged.
+		require.Equal(t, "/etc/crush/crush.json", got[0])
 	})
 }
 


### PR DESCRIPTION
## Summary

Add support for loading system-wide configuration from `/etc/crush/crush.json`.

This fixes an issue where configurations provided by system package managers (such as the NixOS module) are not detected by Crush.

### Changes

* Add `SystemConfig()` for resolving the system-wide config path on Unix systems.
* Load the system-wide config with the lowest priority so user and project configs can override it.
* Add tests covering config path resolution and lookup ordering.

Fixes charmbracelet/crush#2953.