### PR TITLE
feat: auto-discover models from openai-compat providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,9 +743,9 @@ To add specific models to the configuration, configure as such:
 
 ### Local Models
 
-Local models can also be configured via OpenAI-compatible API. Here are two common examples:
-
-#### Ollama
+Crush can auto-discovers models from local providers. Add a custom provider
+with `type` set to `omlx`, `lmstudio`, `litellm`, or `ollama` and leave out
+the models list. Crush will populate the model list automatically.
 
 ```json
 {
@@ -753,7 +753,27 @@ Local models can also be configured via OpenAI-compatible API. Here are two comm
     "ollama": {
       "name": "Ollama",
       "base_url": "http://localhost:11434/v1/",
-      "type": "openai-compat",
+      "type": "ollama"
+    }
+  }
+}
+```
+
+#### Manual Model Configuration
+
+You can still list models explicitly. User-defined models always take
+precedence over discovered ones, and any fields you set won't be overwritten
+by auto-discovery. Auto discovery will run if the model list is empty for any
+`openai-compat` provider or if you pass `"auto_discovery": true` it will merge
+ the found models with your hand configured ones.
+
+```json
+{
+  "providers": {
+    "ollama": {
+      "name": "Ollama",
+      "base_url": "http://localhost:11434/v1/",
+      "type": "ollama",
       "models": [
         {
           "name": "Qwen 3 30B",
@@ -761,29 +781,8 @@ Local models can also be configured via OpenAI-compatible API. Here are two comm
           "context_window": 256000,
           "default_max_tokens": 20000
         }
-      ]
-    }
-  }
-}
-```
-
-#### LM Studio
-
-```json
-{
-  "providers": {
-    "lmstudio": {
-      "name": "LM Studio",
-      "base_url": "http://localhost:1234/v1/",
-      "type": "openai-compat",
-      "models": [
-        {
-          "name": "Qwen 3 30B",
-          "id": "qwen/qwen3-30b-a3b-2507",
-          "context_window": 256000,
-          "default_max_tokens": 20000
-        }
-      ]
+      ],
+      "auto_discovery": true
     }
   }
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/charmbracelet/crush/internal/agent/prompt"
 	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/discover"
 	"github.com/charmbracelet/crush/internal/event"
 	"github.com/charmbracelet/crush/internal/filetracker"
 	"github.com/charmbracelet/crush/internal/history"
@@ -415,6 +416,15 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 		parsed, err := openaicompat.ParseOptions(mergedOptions)
 		if err == nil {
 			options[openaicompat.Name] = parsed
+		}
+	default:
+		// Known custom providers (litellm, ollama, omlx) are
+		// openai-compat under the hood.
+		if discover.IsKnownCustomProvider(string(providerCfg.Type)) {
+			parsed, err := openaicompat.ParseOptions(mergedOptions)
+			if err == nil {
+				options[openaicompat.Name] = parsed
+			}
 		}
 	}
 
@@ -924,6 +934,11 @@ func (c *coordinator) buildProvider(providerCfg config.ProviderConfig, model con
 		}
 		return c.buildOpenaiCompatProvider(baseURL, apiKey, headers, providerCfg.ExtraBody, providerCfg.ID, isSubAgent)
 	default:
+		// Known custom providers (litellm, ollama, omlx) are
+		// openai-compat under the hood.
+		if discover.IsKnownCustomProvider(string(providerCfg.Type)) {
+			return c.buildOpenaiCompatProvider(baseURL, apiKey, headers, providerCfg.ExtraBody, providerCfg.ID, isSubAgent)
+		}
 		return nil, fmt.Errorf("provider type not supported: %q", providerCfg.Type)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,13 @@ type ProviderConfig struct {
 	// Skip cost accumulation for this provider when using subscription or flat rate billing.
 	FlatRate bool `json:"flat_rate,omitempty" jsonschema:"description=Flat-rate mode for this provider"`
 
+	// AutoDiscoverModels controls model discovery via /v1/models endpoint.
+	// When Models is empty and this is nil or true, Crush auto-discovers
+	// models. When true and Models is non-empty, discovered models are
+	// merged in (user-specified models take precedence). When false,
+	// only explicitly listed models are used.
+	AutoDiscoverModels *bool `json:"discover_models,omitempty" jsonschema:"description=Auto-discover models from /v1/models endpoint. When true with existing models they are merged (yours win),default=true"`
+
 	// The provider models
 	Models []catwalk.Model `json:"models,omitempty" jsonschema:"description=List of models available from this provider"`
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -15,11 +15,14 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"charm.land/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/agent/hyper"
 	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/discover"
 	"github.com/charmbracelet/crush/internal/env"
 	"github.com/charmbracelet/crush/internal/filepathext"
 	"github.com/charmbracelet/crush/internal/fsext"
@@ -113,7 +116,7 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 	store.autoReloadDisabled = true
 	defer func() { store.autoReloadDisabled = false }()
 
-	if err := cfg.configureProviders(store, env, valueResolver, store.knownProviders); err != nil {
+	if err := cfg.configureProviders(context.Background(), store, env, valueResolver, store.knownProviders); err != nil {
 		return nil, fmt.Errorf("failed to configure providers: %w", err)
 	}
 
@@ -171,7 +174,7 @@ func PushPopCrushEnv() func() {
 	return restore
 }
 
-func (c *Config) configureProviders(store *ConfigStore, env env.Env, resolver VariableResolver, knownProviders []catwalk.Provider) error {
+func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env env.Env, resolver VariableResolver, knownProviders []catwalk.Provider) error {
 	knownProviderNames := make(map[string]bool)
 	restore := PushPopCrushEnv()
 	defer restore()
@@ -338,18 +341,69 @@ func (c *Config) configureProviders(store *ConfigStore, env env.Env, resolver Va
 		c.Providers.Set(string(p.ID), prepared)
 	}
 
-	// validate the custom providers
+	// Discover models concurrently for custom providers that need it.
+	// A provider needs discovery when discover_models is explicitly true,
+	// or when the models list is empty (auto-trigger, unless opted out).
+	type discoveryResult struct {
+		models []catwalk.Model
+		err    error
+	}
+
+	discoveryResults := make(map[string]discoveryResult)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	discoverCtx, discoverCancel := context.WithTimeout(ctx, 3*time.Second)
+	for id, pc := range c.Providers.Seq2() {
+		if knownProviderNames[id] {
+			continue
+		}
+		if pc.Disable || pc.BaseURL == "" {
+			continue
+		}
+		wantsDiscovery := pc.AutoDiscoverModels != nil && *pc.AutoDiscoverModels
+		autoTrigger := len(pc.Models) == 0 && (pc.AutoDiscoverModels == nil || *pc.AutoDiscoverModels)
+		if !wantsDiscovery && !autoTrigger {
+			continue
+		}
+		providerID := cmp.Or(pc.ID, id)
+		cfg := discover.Config{
+			ID:             providerID,
+			BaseURL:        pc.BaseURL,
+			APIKey:         pc.APIKey,
+			ExtraHeaders:   pc.ExtraHeaders,
+			ExistingModels: pc.Models,
+		}
+		providerType := cmp.Or(pc.Type, catwalk.TypeOpenAICompat)
+		wg.Go(func() {
+			models, err := discover.DiscoverModels(discoverCtx, cfg, resolver)
+			if err == nil && len(models) > 0 {
+				if enricher := discover.GetEnricher(string(providerType)); enricher != nil {
+					models, _ = enricher.EnrichModels(discoverCtx, cfg, resolver, models)
+				}
+			}
+			mu.Lock()
+			discoveryResults[id] = discoveryResult{models: models, err: err}
+			mu.Unlock()
+		})
+	}
+	wg.Wait()
+	discoverCancel()
+
+	// Validate the custom providers.
 	for id, providerConfig := range c.Providers.Seq2() {
 		if knownProviderNames[id] {
 			continue
 		}
 
-		// Make sure the provider ID is set
+		// Make sure the provider ID is set.
 		providerConfig.ID = id
 		providerConfig.Name = cmp.Or(providerConfig.Name, id) // Use ID as name if not set
-		// default to OpenAI if not set
+		// Default to OpenAI if not set.
 		providerConfig.Type = cmp.Or(providerConfig.Type, catwalk.TypeOpenAICompat)
-		if !slices.Contains(catwalk.KnownProviderTypes(), providerConfig.Type) && providerConfig.Type != hyper.Name {
+		if !slices.Contains(catwalk.KnownProviderTypes(), providerConfig.Type) &&
+			providerConfig.Type != hyper.Name &&
+			!discover.IsKnownCustomProvider(string(providerConfig.Type)) {
 			slog.Warn("Skipping custom provider due to unsupported provider type", "provider", id)
 			c.Providers.Del(id)
 			continue
@@ -368,11 +422,28 @@ func (c *Config) configureProviders(store *ConfigStore, env env.Env, resolver Va
 			c.Providers.Del(id)
 			continue
 		}
+
+		// Apply discovery results if available.
+		if result, ok := discoveryResults[id]; ok {
+			if result.err != nil {
+				slog.Warn("Model discovery failed", "provider", id, "error", result.err)
+				if len(providerConfig.Models) == 0 {
+					slog.Warn("Skipping provider with no models after failed discovery", "provider", id)
+					c.Providers.Del(id)
+					continue
+				}
+			} else if len(result.models) > 0 {
+				providerConfig.Models = result.models
+				slog.Info("Discovered models for provider", "provider", id, "count", len(result.models))
+			}
+		}
+
 		if len(providerConfig.Models) == 0 {
 			slog.Warn("Skipping custom provider because the provider has no models", "provider", id)
 			c.Providers.Del(id)
 			continue
 		}
+
 		apiKey, err := resolver.ResolveValue(providerConfig.APIKey)
 		if apiKey == "" || err != nil {
 			slog.Warn("Provider is missing API key, this might be OK for local providers", "provider", id)

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"context"
 	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -317,7 +320,7 @@ func TestConfig_configureProviders(t *testing.T) {
 		"OPENAI_API_KEY": "test-key",
 	})
 	resolver := NewShellVariableResolver(env)
-	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 	require.NoError(t, err)
 	require.Equal(t, 1, cfg.Providers.Len())
 
@@ -360,7 +363,7 @@ func TestConfig_configureProvidersWithOverride(t *testing.T) {
 		"OPENAI_API_KEY": "test-key",
 	})
 	resolver := NewShellVariableResolver(env)
-	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 	require.NoError(t, err)
 	require.Equal(t, 1, cfg.Providers.Len())
 
@@ -402,7 +405,7 @@ func TestConfig_configureProvidersWithNewProvider(t *testing.T) {
 		"OPENAI_API_KEY": "test-key",
 	})
 	resolver := NewShellVariableResolver(env)
-	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 	require.NoError(t, err)
 	// Should be to because of the env variable
 	require.Equal(t, cfg.Providers.Len(), 2)
@@ -438,7 +441,7 @@ func TestConfig_configureProvidersBedrockWithCredentials(t *testing.T) {
 		"AWS_SECRET_ACCESS_KEY": "test-secret-key",
 	})
 	resolver := NewShellVariableResolver(env)
-	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 	require.NoError(t, err)
 	require.Equal(t, cfg.Providers.Len(), 1)
 
@@ -464,7 +467,7 @@ func TestConfig_configureProvidersBedrockWithoutCredentials(t *testing.T) {
 	cfg.setDefaults("/tmp", "")
 	env := env.NewFromMap(map[string]string{})
 	resolver := NewShellVariableResolver(env)
-	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 	require.NoError(t, err)
 	// Provider should not be configured without credentials
 	require.Equal(t, cfg.Providers.Len(), 0)
@@ -489,7 +492,7 @@ func TestConfig_configureProvidersVertexAIWithCredentials(t *testing.T) {
 		"VERTEXAI_LOCATION": "us-central1",
 	})
 	resolver := NewShellVariableResolver(env)
-	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 	require.NoError(t, err)
 	require.Equal(t, cfg.Providers.Len(), 1)
 
@@ -521,7 +524,7 @@ func TestConfig_configureProvidersVertexAIWithoutCredentials(t *testing.T) {
 		"GOOGLE_CLOUD_LOCATION":     "us-central1",
 	})
 	resolver := NewShellVariableResolver(env)
-	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 	require.NoError(t, err)
 	// Provider should not be configured without proper credentials
 	require.Equal(t, cfg.Providers.Len(), 0)
@@ -546,7 +549,7 @@ func TestConfig_configureProvidersVertexAIMissingProject(t *testing.T) {
 		"GOOGLE_CLOUD_LOCATION":     "us-central1",
 	})
 	resolver := NewShellVariableResolver(env)
-	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 	require.NoError(t, err)
 	// Provider should not be configured without project
 	require.Equal(t, cfg.Providers.Len(), 0)
@@ -570,7 +573,7 @@ func TestConfig_configureProvidersSetProviderID(t *testing.T) {
 		"OPENAI_API_KEY": "test-key",
 	})
 	resolver := NewShellVariableResolver(env)
-	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 	require.NoError(t, err)
 	require.Equal(t, cfg.Providers.Len(), 1)
 
@@ -761,7 +764,7 @@ func TestConfig_configureProvidersWithDisabledProvider(t *testing.T) {
 		"OPENAI_API_KEY": "test-key",
 	})
 	resolver := NewShellVariableResolver(env)
-	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 	require.NoError(t, err)
 
 	require.Equal(t, cfg.Providers.Len(), 1)
@@ -789,7 +792,7 @@ func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {
 
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, []catwalk.Provider{})
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
 		require.NoError(t, err)
 
 		require.Equal(t, cfg.Providers.Len(), 1)
@@ -812,7 +815,7 @@ func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {
 
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, []catwalk.Provider{})
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
 		require.NoError(t, err)
 
 		require.Equal(t, cfg.Providers.Len(), 0)
@@ -820,7 +823,7 @@ func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {
 		require.False(t, exists)
 	})
 
-	t.Run("custom provider with no models is removed", func(t *testing.T) {
+	t.Run("custom provider with no models attempts discovery and is removed on failure", func(t *testing.T) {
 		cfg := &Config{
 			Providers: csync.NewMapFrom(map[string]ProviderConfig{
 				"custom": {
@@ -834,12 +837,140 @@ func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {
 
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, []catwalk.Provider{})
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
 		require.NoError(t, err)
 
-		require.Equal(t, cfg.Providers.Len(), 0)
+		// Discovery fails (unreachable URL) so provider is removed.
+		require.Equal(t, 0, cfg.Providers.Len())
 		_, exists := cfg.Providers.Get("custom")
 		require.False(t, exists)
+	})
+
+	t.Run("custom provider with no models and discover_models:false is removed", func(t *testing.T) {
+		discoverFalse := false
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"custom": {
+					APIKey:             "test-key",
+					BaseURL:            "https://api.custom.com/v1",
+					Models:             []catwalk.Model{},
+					AutoDiscoverModels: &discoverFalse,
+				},
+			}),
+		}
+		cfg.setDefaults("/tmp", "")
+
+		env := env.NewFromMap(map[string]string{})
+		resolver := NewShellVariableResolver(env)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
+		require.NoError(t, err)
+
+		require.Equal(t, 0, cfg.Providers.Len())
+		_, exists := cfg.Providers.Get("custom")
+		require.False(t, exists)
+	})
+
+	t.Run("custom provider with models and discover_models:true merges discovered models", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data": [
+				{"id": "existing-model", "object": "model"},
+				{"id": "discovered-model", "object": "model"}
+			]}`))
+		}))
+		defer server.Close()
+
+		discoverTrue := true
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"custom": {
+					APIKey:  "test-key",
+					BaseURL: server.URL + "/v1",
+					Models: []catwalk.Model{
+						{ID: "existing-model", Name: "My Custom Name", ContextWindow: 200000},
+					},
+					AutoDiscoverModels: &discoverTrue,
+				},
+			}),
+		}
+		cfg.setDefaults("/tmp", "")
+
+		env := env.NewFromMap(map[string]string{})
+		resolver := NewShellVariableResolver(env)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
+		require.NoError(t, err)
+
+		require.Equal(t, 1, cfg.Providers.Len())
+		p, exists := cfg.Providers.Get("custom")
+		require.True(t, exists)
+		require.Len(t, p.Models, 2)
+
+		// User-specified model keeps its custom fields.
+		require.Equal(t, "existing-model", p.Models[0].ID)
+		require.Equal(t, "My Custom Name", p.Models[0].Name)
+		require.Equal(t, int64(200000), p.Models[0].ContextWindow)
+
+		// Discovered model is appended.
+		require.Equal(t, "discovered-model", p.Models[1].ID)
+	})
+
+	t.Run("custom provider with models and no discover_models uses only listed models", func(t *testing.T) {
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"custom": {
+					APIKey:  "test-key",
+					BaseURL: "https://api.custom.com/v1",
+					Models: []catwalk.Model{
+						{ID: "my-model", Name: "My Model"},
+					},
+				},
+			}),
+		}
+		cfg.setDefaults("/tmp", "")
+
+		env := env.NewFromMap(map[string]string{})
+		resolver := NewShellVariableResolver(env)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
+		require.NoError(t, err)
+
+		require.Equal(t, 1, cfg.Providers.Len())
+		p, exists := cfg.Providers.Get("custom")
+		require.True(t, exists)
+		require.Len(t, p.Models, 1)
+		require.Equal(t, "my-model", p.Models[0].ID)
+	})
+
+	t.Run("custom provider with no models auto-discovers successfully", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data": [
+				{"id": "auto-model-a", "object": "model"},
+				{"id": "auto-model-b", "object": "model"}
+			]}`))
+		}))
+		defer server.Close()
+
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"custom": {
+					APIKey:  "test-key",
+					BaseURL: server.URL + "/v1",
+				},
+			}),
+		}
+		cfg.setDefaults("/tmp", "")
+
+		env := env.NewFromMap(map[string]string{})
+		resolver := NewShellVariableResolver(env)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
+		require.NoError(t, err)
+
+		require.Equal(t, 1, cfg.Providers.Len())
+		p, exists := cfg.Providers.Get("custom")
+		require.True(t, exists)
+		require.Len(t, p.Models, 2)
+		require.Equal(t, "auto-model-a", p.Models[0].ID)
+		require.Equal(t, "auto-model-b", p.Models[1].ID)
 	})
 
 	t.Run("custom provider with unsupported type is removed", func(t *testing.T) {
@@ -859,7 +990,7 @@ func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {
 
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, []catwalk.Provider{})
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
 		require.NoError(t, err)
 
 		require.Equal(t, cfg.Providers.Len(), 0)
@@ -884,7 +1015,7 @@ func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {
 
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, []catwalk.Provider{})
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
 		require.NoError(t, err)
 
 		require.Equal(t, cfg.Providers.Len(), 1)
@@ -912,7 +1043,7 @@ func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {
 
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, []catwalk.Provider{})
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
 		require.NoError(t, err)
 
 		require.Equal(t, cfg.Providers.Len(), 1)
@@ -942,7 +1073,7 @@ func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {
 
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, []catwalk.Provider{})
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
 		require.NoError(t, err)
 
 		require.Equal(t, cfg.Providers.Len(), 0)
@@ -977,7 +1108,7 @@ func TestConfig_configureProvidersEnhancedCredentialValidation(t *testing.T) {
 			"GOOGLE_GENAI_USE_VERTEXAI": "false",
 		})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
 		require.Equal(t, cfg.Providers.Len(), 0)
@@ -1008,7 +1139,7 @@ func TestConfig_configureProvidersEnhancedCredentialValidation(t *testing.T) {
 
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
 		require.Equal(t, cfg.Providers.Len(), 0)
@@ -1039,7 +1170,7 @@ func TestConfig_configureProvidersEnhancedCredentialValidation(t *testing.T) {
 
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
 		require.Equal(t, cfg.Providers.Len(), 0)
@@ -1072,7 +1203,7 @@ func TestConfig_configureProvidersEnhancedCredentialValidation(t *testing.T) {
 			"OPENAI_API_KEY": "test-key",
 		})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
 		require.Equal(t, cfg.Providers.Len(), 1)
@@ -1106,7 +1237,7 @@ func TestConfig_defaultModelSelection(t *testing.T) {
 		cfg.setDefaults("/tmp", "")
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
 		large, small, err := cfg.defaultModelSelection(knownProviders)
@@ -1142,7 +1273,7 @@ func TestConfig_defaultModelSelection(t *testing.T) {
 		cfg.setDefaults("/tmp", "")
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
 		_, _, err = cfg.defaultModelSelection(knownProviders)
@@ -1172,7 +1303,7 @@ func TestConfig_defaultModelSelection(t *testing.T) {
 		cfg.setDefaults("/tmp", "")
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 		_, _, err = cfg.defaultModelSelection(knownProviders)
 		require.Error(t, err)
@@ -1215,7 +1346,7 @@ func TestConfig_defaultModelSelection(t *testing.T) {
 		cfg.setDefaults("/tmp", "")
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 		large, small, err := cfg.defaultModelSelection(knownProviders)
 		require.NoError(t, err)
@@ -1259,7 +1390,7 @@ func TestConfig_defaultModelSelection(t *testing.T) {
 		cfg.setDefaults("/tmp", "")
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 		_, _, err = cfg.defaultModelSelection(knownProviders)
 		require.Error(t, err)
@@ -1301,7 +1432,7 @@ func TestConfig_defaultModelSelection(t *testing.T) {
 		cfg.setDefaults("/tmp", "")
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 		large, small, err := cfg.defaultModelSelection(knownProviders)
 		require.NoError(t, err)
@@ -1346,7 +1477,7 @@ func TestConfig_configureProvidersDisableDefaultProviders(t *testing.T) {
 			"OPENAI_API_KEY": "test-key",
 		})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.ErrorContains(t, err, "no custom providers")
 
 		// openai should NOT be present because it lacks base_url and models.
@@ -1389,7 +1520,7 @@ func TestConfig_configureProvidersDisableDefaultProviders(t *testing.T) {
 			"OPENAI_API_KEY": "test-key",
 		})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
 		// Only fully specified provider should be present.
@@ -1443,7 +1574,7 @@ func TestConfig_configureProvidersDisableDefaultProviders(t *testing.T) {
 			"ANTHROPIC_API_KEY": "test-key",
 		})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
 		// Both providers should be present.
@@ -1454,7 +1585,7 @@ func TestConfig_configureProvidersDisableDefaultProviders(t *testing.T) {
 		require.True(t, exists, "anthropic should be present")
 	})
 
-	t.Run("when enabled, provider missing models is rejected", func(t *testing.T) {
+	t.Run("when enabled, provider missing models attempts discovery but still triggers no-custom-providers error", func(t *testing.T) {
 		cfg := &Config{
 			Options: &Options{
 				DisableDefaultProviders: true,
@@ -1471,10 +1602,10 @@ func TestConfig_configureProvidersDisableDefaultProviders(t *testing.T) {
 
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, []catwalk.Provider{})
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
 		require.ErrorContains(t, err, "no custom providers")
 
-		// Provider should be rejected for missing models.
+		// Discovery fails (unreachable URL) so provider is removed.
 		require.Equal(t, 0, cfg.Providers.Len())
 	})
 
@@ -1495,7 +1626,7 @@ func TestConfig_configureProvidersDisableDefaultProviders(t *testing.T) {
 
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, []catwalk.Provider{})
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
 		require.ErrorContains(t, err, "no custom providers")
 
 		// Provider should be rejected for missing base_url.
@@ -1553,7 +1684,7 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 		store := &ConfigStore{config: cfg, globalDataPath: globalPath}
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(store, env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), store, env, resolver, knownProviders)
 		require.NoError(t, err)
 
 		err = configureSelectedModels(store, knownProviders, false)
@@ -1603,7 +1734,7 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 		cfg.setDefaults("/tmp", "")
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
 		err = configureSelectedModels(testStore(cfg), knownProviders, true)
@@ -1665,7 +1796,7 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 		cfg.setDefaults("/tmp", "")
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
 		err = configureSelectedModels(testStore(cfg), knownProviders, true)
@@ -1710,7 +1841,7 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 		cfg.setDefaults("/tmp", "")
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
 		err = configureSelectedModels(testStore(cfg), knownProviders, true)
@@ -1749,7 +1880,7 @@ func TestConfig_configureProviders_HyperAPIKeyFromEnv(t *testing.T) {
 		"HYPER_API_KEY": "env-api-key",
 	})
 	resolver := NewShellVariableResolver(env)
-	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 	require.NoError(t, err)
 	require.Equal(t, 1, cfg.Providers.Len())
 
@@ -1796,7 +1927,7 @@ func TestConfig_configureProviders_HyperAPIKeyFromConfigOverrides(t *testing.T) 
 		"HYPER_API_KEY": "env-api-key",
 	})
 	resolver := NewShellVariableResolver(env)
-	err := cfg.configureProviders(testStore(cfg), env, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 	require.NoError(t, err)
 	require.Equal(t, 1, cfg.Providers.Len())
 
@@ -1839,7 +1970,7 @@ func TestConfig_configureProviders_ProviderHeaderResolveError(t *testing.T) {
 	})
 	resolver := NewShellVariableResolver(testEnv)
 
-	err := cfg.configureProviders(testStore(cfg), testEnv, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), testEnv, resolver, knownProviders)
 	require.Error(t, err, "failing $(cmd) in a header must fail the provider load")
 	require.Contains(t, err.Error(), "X-Broken", "error must name the offending header")
 }
@@ -1871,7 +2002,7 @@ func TestConfig_configureProviders_CatwalkDefaultWithUnsetVarLoads(t *testing.T)
 	})
 	resolver := NewShellVariableResolver(testEnv)
 
-	err := cfg.configureProviders(testStore(cfg), testEnv, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), testEnv, resolver, knownProviders)
 	require.NoError(t, err, "optional env-gated header must not fail the load")
 
 	pc, ok := cfg.Providers.Get("openai")
@@ -1907,7 +2038,7 @@ func TestConfig_configureProviders_LiteralEmptyHeaderDropped(t *testing.T) {
 	})
 	resolver := NewShellVariableResolver(testEnv)
 
-	err := cfg.configureProviders(testStore(cfg), testEnv, resolver, []catwalk.Provider{})
+	err := cfg.configureProviders(context.Background(), testStore(cfg), testEnv, resolver, []catwalk.Provider{})
 	require.NoError(t, err)
 
 	pc, ok := cfg.Providers.Get("my-llm")
@@ -1944,7 +2075,7 @@ func TestConfig_configureProviders_EchoEmptyHeaderDropped(t *testing.T) {
 	})
 	resolver := NewShellVariableResolver(testEnv)
 
-	err := cfg.configureProviders(testStore(cfg), testEnv, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), testEnv, resolver, knownProviders)
 	require.NoError(t, err)
 
 	pc, ok := cfg.Providers.Get("openai")
@@ -1992,7 +2123,7 @@ func TestConfig_configureProviders_UnsetAPIKeySkipsProvider(t *testing.T) {
 	})
 	resolver := NewShellVariableResolver(testEnv)
 
-	err := cfg.configureProviders(testStore(cfg), testEnv, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), testEnv, resolver, knownProviders)
 	require.NoError(t, err, "skip path must not surface as a load error")
 
 	require.Equal(t, 0, cfg.Providers.Len(), "provider with unset API key must be skipped")
@@ -2030,7 +2161,7 @@ func TestConfig_configureProviders_FailingAPIKeyCmdSkipsProvider(t *testing.T) {
 	})
 	resolver := NewShellVariableResolver(testEnv)
 
-	err := cfg.configureProviders(testStore(cfg), testEnv, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), testEnv, resolver, knownProviders)
 	require.NoError(t, err, "failing $(cmd) in API key must skip provider, not fail load")
 
 	require.Equal(t, 0, cfg.Providers.Len(), "provider with failing $(cmd) API key must be skipped")
@@ -2067,7 +2198,7 @@ func TestConfig_configureProviders_UnsetAzureEndpointSkipsProvider(t *testing.T)
 	})
 	resolver := NewShellVariableResolver(testEnv)
 
-	err := cfg.configureProviders(testStore(cfg), testEnv, resolver, knownProviders)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), testEnv, resolver, knownProviders)
 	require.NoError(t, err)
 
 	require.Equal(t, 0, cfg.Providers.Len(), "azure provider with unset endpoint must be skipped")

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -697,7 +697,7 @@ func (s *ConfigStore) ReloadFromDisk(ctx context.Context) error {
 		return fmt.Errorf("failed to load providers during reload: %w", err)
 	}
 
-	if err := cfg.configureProviders(s, env, resolver, providers); err != nil {
+	if err := cfg.configureProviders(ctx, s, env, resolver, providers); err != nil {
 		return fmt.Errorf("failed to configure providers during reload: %w", err)
 	}
 

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -1,0 +1,135 @@
+package discover
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+// httpClient is shared across all discovery and enrichment calls. It
+// has a reasonable timeout so individual requests cannot block forever
+// even if the caller forgets to set a context deadline.
+var httpClient = &http.Client{Timeout: 10 * time.Second}
+
+// doRequest builds and executes an authenticated HTTP request using the
+// shared client. It resolves variable references in the base URL, API
+// key, and extra headers via the provided Resolver. The path is joined
+// to the base URL with proper slash handling.
+func doRequest(ctx context.Context, method, baseURL, path, apiKey string, extraHeaders map[string]string, resolver Resolver, body any) (*http.Response, error) {
+	resolvedBase, _ := resolver.ResolveValue(baseURL)
+	resolvedKey, _ := resolver.ResolveValue(apiKey)
+
+	url := strings.TrimRight(resolvedBase, "/") + "/" + strings.TrimLeft(path, "/")
+
+	var reqBody *bytes.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling request body: %w", err)
+		}
+		reqBody = bytes.NewReader(data)
+	}
+
+	var req *http.Request
+	var err error
+	if reqBody != nil {
+		req, err = http.NewRequestWithContext(ctx, method, url, reqBody)
+	} else {
+		req, err = http.NewRequestWithContext(ctx, method, url, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if reqBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if resolvedKey != "" {
+		req.Header.Set("Authorization", "Bearer "+resolvedKey)
+	}
+	for k, v := range extraHeaders {
+		resolved, err := resolver.ResolveValue(v)
+		if err != nil || resolved == "" {
+			continue
+		}
+		req.Header.Set(k, resolved)
+	}
+
+	return httpClient.Do(req)
+}
+
+// Config holds the provider configuration needed for model discovery.
+type Config struct {
+	ID           string
+	BaseURL      string
+	APIKey       string
+	ExtraHeaders map[string]string
+	// Existing models from config — IDs present in this list are skipped
+	// during discovery (user-specified models win).
+	ExistingModels []catwalk.Model
+}
+
+// Resolver resolves variable references (e.g. $ENV_VAR) in config values.
+type Resolver interface {
+	ResolveValue(val string) (string, error)
+}
+
+type modelsResponse struct {
+	Data []struct {
+		ID      string `json:"id"`
+		Object  string `json:"object"`
+		Created int64  `json:"created"`
+		OwnedBy string `json:"owned_by"`
+	} `json:"data"`
+}
+
+// DiscoverModels fetches available models from the provider's /models endpoint.
+// It uses the provided context for cancellation and timeout; callers should set
+// a deadline (e.g. context.WithTimeout) to avoid blocking indefinitely.
+// Models whose IDs already appear in cfg.ExistingModels are skipped —
+// user-specified models take precedence.
+func DiscoverModels(ctx context.Context, cfg Config, resolver Resolver) ([]catwalk.Model, error) {
+	resp, err := doRequest(ctx, http.MethodGet, cfg.BaseURL, "/models", cfg.APIKey, cfg.ExtraHeaders, resolver, nil)
+	if err != nil {
+		return nil, fmt.Errorf("discover models for provider %s: %w", cfg.ID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("discover models for provider %s: %s", cfg.ID, resp.Status)
+	}
+
+	var modelsResp modelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&modelsResp); err != nil {
+		return nil, fmt.Errorf("discover models for provider %s: %w", cfg.ID, err)
+	}
+
+	// Build set of existing model IDs to skip.
+	existing := make(map[string]struct{}, len(cfg.ExistingModels))
+	for _, m := range cfg.ExistingModels {
+		existing[m.ID] = struct{}{}
+	}
+
+	// Start with user-specified models.
+	result := make([]catwalk.Model, len(cfg.ExistingModels))
+	copy(result, cfg.ExistingModels)
+
+	// Append discovered models not already in the list.
+	for _, e := range modelsResp.Data {
+		if _, ok := existing[e.ID]; ok {
+			continue
+		}
+		result = append(result, catwalk.Model{
+			ID:   e.ID,
+			Name: e.ID,
+		})
+	}
+
+	return result, nil
+}

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -1,0 +1,202 @@
+package discover
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoverModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/models", r.URL.Path)
+		require.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"object": "list",
+			"data": [
+				{"id": "model-a", "object": "model", "owned_by": "org"},
+				{"id": "model-b", "object": "model", "owned_by": "org"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ID:      "test",
+		BaseURL: server.URL + "/v1",
+		APIKey:  "test-key",
+	}
+
+	models, err := DiscoverModels(context.Background(), cfg, &mockResolver{})
+	require.NoError(t, err)
+	require.Len(t, models, 2)
+	require.Equal(t, "model-a", models[0].ID)
+	require.Equal(t, "model-b", models[1].ID)
+}
+
+func TestDiscoverModels_ExistingModelsWin(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{"id": "model-a", "object": "model"},
+				{"id": "model-b", "object": "model"}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ID:      "test",
+		BaseURL: server.URL + "/v1",
+		APIKey:  "test-key",
+		ExistingModels: []catwalk.Model{
+			{ID: "model-a", Name: "My Custom Name", ContextWindow: 200000, CanReason: true},
+		},
+	}
+
+	models, err := DiscoverModels(context.Background(), cfg, &mockResolver{})
+	require.NoError(t, err)
+	require.Len(t, models, 2)
+
+	require.Equal(t, "model-a", models[0].ID)
+	require.Equal(t, "My Custom Name", models[0].Name)
+	require.Equal(t, int64(200000), models[0].ContextWindow)
+	require.True(t, models[0].CanReason)
+
+	require.Equal(t, "model-b", models[1].ID)
+	require.Equal(t, "model-b", models[1].Name)
+}
+
+func TestDiscoverModels_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ID:      "test",
+		BaseURL: server.URL + "/v1",
+		APIKey:  "test-key",
+	}
+
+	models, err := DiscoverModels(context.Background(), cfg, &mockResolver{})
+	require.Error(t, err)
+	require.Nil(t, models)
+}
+
+func TestDiscoverModels_ExtraHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "custom-value", r.Header.Get("X-Custom"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": [{"id": "m1", "object": "model"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ID:      "test",
+		BaseURL: server.URL + "/v1",
+		APIKey:  "test-key",
+		ExtraHeaders: map[string]string{
+			"X-Custom": "custom-value",
+		},
+	}
+
+	models, err := DiscoverModels(context.Background(), cfg, &mockResolver{})
+	require.NoError(t, err)
+	require.Len(t, models, 1)
+}
+
+type mockResolver struct{}
+
+func (m *mockResolver) ResolveValue(val string) (string, error) { return val, nil }
+
+type envResolver struct {
+	env map[string]string
+}
+
+func (e *envResolver) ResolveValue(val string) (string, error) {
+	if v, ok := e.env[val]; ok {
+		return v, nil
+	}
+	return val, nil
+}
+
+func TestDiscoverModels_ResolvesShellVariables(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer resolved-key", r.Header.Get("Authorization"))
+		require.Equal(t, "resolved-header", r.Header.Get("X-Custom"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": [{"id": "m1", "object": "model"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ID:      "test",
+		BaseURL: server.URL + "/v1",
+		APIKey:  "$MY_API_KEY",
+		ExtraHeaders: map[string]string{
+			"X-Custom": "$MY_HEADER",
+		},
+	}
+
+	resolver := &envResolver{env: map[string]string{
+		"$MY_API_KEY": "resolved-key",
+		"$MY_HEADER":  "resolved-header",
+	}}
+
+	models, err := DiscoverModels(context.Background(), cfg, resolver)
+	require.NoError(t, err)
+	require.Len(t, models, 1)
+}
+
+func TestDiscoverModels_SkipsEmptyExtraHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+		require.Empty(t, r.Header.Get("X-Empty"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": [{"id": "m1", "object": "model"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ID:      "test",
+		BaseURL: server.URL + "/v1",
+		APIKey:  "test-key",
+		ExtraHeaders: map[string]string{
+			"X-Empty": "$UNSET_VAR",
+		},
+	}
+
+	resolver := &envResolver{env: map[string]string{
+		"$UNSET_VAR": "",
+	}}
+
+	models, err := DiscoverModels(context.Background(), cfg, resolver)
+	require.NoError(t, err)
+	require.Len(t, models, 1)
+}
+
+func TestDiscoverModels_NoAuthWhenNoAPIKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": [{"id": "m1", "object": "model"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := Config{
+		ID:      "test",
+		BaseURL: server.URL + "/v1",
+		APIKey:  "",
+	}
+
+	models, err := DiscoverModels(context.Background(), cfg, &mockResolver{})
+	require.NoError(t, err)
+	require.Len(t, models, 1)
+}

--- a/internal/discover/enricher.go
+++ b/internal/discover/enricher.go
@@ -1,0 +1,44 @@
+package discover
+
+import (
+	"context"
+
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+// Enricher fills in model metadata (context window, max tokens, pricing,
+// etc.) for discovered models. Providers that expose richer endpoints
+// beyond /v1/models can register an Enricher to populate fields that the
+// standard listing endpoint omits.
+type Enricher interface {
+	// EnrichModels takes a slice of bare discovered models and returns
+	// them with metadata populated. Implementations should preserve
+	// existing non-zero fields (user overrides take precedence).
+	EnrichModels(ctx context.Context, cfg Config, resolver Resolver, models []catwalk.Model) ([]catwalk.Model, error)
+}
+
+// enrichers maps provider type strings to their enrichment
+// implementations. Each enricher self-registers via init() so that
+// adding a new provider requires only a new file — no changes to
+// load.go or any existing enricher.
+var enrichers = map[string]Enricher{}
+
+// RegisterEnricher registers an Enricher for the given provider type.
+// Called from init() in each enricher implementation file.
+func RegisterEnricher(providerType string, e Enricher) {
+	enrichers[providerType] = e
+}
+
+// GetEnricher returns the Enricher for the given provider type, or nil
+// if no enricher is registered.
+func GetEnricher(providerType string) Enricher {
+	return enrichers[providerType]
+}
+
+// IsKnownCustomProvider reports whether the given provider type has a
+// registered enricher. This signals that the provider type is
+// recognized and speaks OpenAI-compat protocol, without exposing the
+// enricher itself to callers that only need the compatibility check.
+func IsKnownCustomProvider(providerType string) bool {
+	return enrichers[providerType] != nil
+}

--- a/internal/discover/litellm.go
+++ b/internal/discover/litellm.go
@@ -1,0 +1,87 @@
+package discover
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+// litellmModelInfoResponse mirrors the response from LiteLLM's
+// /model/info endpoint, which returns rich metadata including context
+// windows, max tokens, and pricing.
+type litellmModelInfoResponse struct {
+	Data []litellmModelInfo `json:"data"`
+}
+
+// litellmModelInfo is a single entry from /model/info.
+type litellmModelInfo struct {
+	ModelName string           `json:"model_name"`
+	ModelInfo litellmModelMeta `json:"model_info"`
+}
+
+// litellmModelMeta holds the metadata fields we care about from
+// LiteLLM's model_info block.
+type litellmModelMeta struct {
+	MaxInputTokens     *int64   `json:"max_input_tokens"`
+	MaxOutputTokens    *int64   `json:"max_output_tokens"`
+	InputCostPerToken  *float64 `json:"input_cost_per_token"`
+	OutputCostPerToken *float64 `json:"output_cost_per_token"`
+	Mode               string   `json:"mode"`
+}
+
+func init() {
+	RegisterEnricher("litellm", &litellmEnricher{})
+}
+
+// litellmEnricher fetches model metadata from LiteLLM's /model/info
+// endpoint and populates context window, max tokens, and pricing on
+// discovered models.
+type litellmEnricher struct{}
+
+func (e *litellmEnricher) EnrichModels(ctx context.Context, cfg Config, resolver Resolver, models []catwalk.Model) ([]catwalk.Model, error) {
+	resp, err := doRequest(ctx, http.MethodGet, cfg.BaseURL, "/model/info", cfg.APIKey, cfg.ExtraHeaders, resolver, nil)
+	if err != nil {
+		return models, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return models, nil
+	}
+
+	var infoResp litellmModelInfoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&infoResp); err != nil {
+		return models, nil
+	}
+
+	// Index metadata by model name for O(1) lookup.
+	metaByID := make(map[string]litellmModelMeta, len(infoResp.Data))
+	for _, entry := range infoResp.Data {
+		metaByID[entry.ModelName] = entry.ModelInfo
+	}
+
+	// Apply metadata to discovered models, preserving existing
+	// non-zero values (user overrides win).
+	for i := range models {
+		meta, ok := metaByID[models[i].ID]
+		if !ok {
+			continue
+		}
+		if models[i].ContextWindow == 0 && meta.MaxInputTokens != nil {
+			models[i].ContextWindow = *meta.MaxInputTokens
+		}
+		if models[i].DefaultMaxTokens == 0 && meta.MaxOutputTokens != nil {
+			models[i].DefaultMaxTokens = *meta.MaxOutputTokens
+		}
+		if models[i].CostPer1MIn == 0 && meta.InputCostPerToken != nil {
+			models[i].CostPer1MIn = *meta.InputCostPerToken * 1_000_000
+		}
+		if models[i].CostPer1MOut == 0 && meta.OutputCostPerToken != nil {
+			models[i].CostPer1MOut = *meta.OutputCostPerToken * 1_000_000
+		}
+	}
+
+	return models, nil
+}

--- a/internal/discover/litellm_test.go
+++ b/internal/discover/litellm_test.go
@@ -1,0 +1,171 @@
+package discover
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLitellmEnricher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("populates metadata from /model/info", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/model/info", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"data": [
+					{
+						"model_name": "gpt-4o",
+						"model_info": {
+							"max_input_tokens": 128000,
+							"max_output_tokens": 16384,
+							"input_cost_per_token": 2.5e-06,
+							"output_cost_per_token": 1e-05
+						}
+					},
+					{
+						"model_name": "claude-3-opus",
+						"model_info": {
+							"max_input_tokens": 200000,
+							"max_output_tokens": 4096
+						}
+					}
+				]
+			}`))
+		}))
+		defer srv.Close()
+
+		cfg := Config{
+			ID:      "test-litellm",
+			BaseURL: srv.URL,
+			APIKey:  "test-key",
+		}
+		models := []catwalk.Model{
+			{ID: "gpt-4o", Name: "gpt-4o"},
+			{ID: "claude-3-opus", Name: "claude-3-opus"},
+			{ID: "unknown-model", Name: "unknown-model"},
+		}
+
+		e := &litellmEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 3)
+
+		// gpt-4o should have all fields populated.
+		require.Equal(t, int64(128000), result[0].ContextWindow)
+		require.Equal(t, int64(16384), result[0].DefaultMaxTokens)
+		require.InDelta(t, 2.5, result[0].CostPer1MIn, 0.01)
+		require.InDelta(t, 10.0, result[0].CostPer1MOut, 0.01)
+
+		// claude-3-opus should have context window and max tokens.
+		require.Equal(t, int64(200000), result[1].ContextWindow)
+		require.Equal(t, int64(4096), result[1].DefaultMaxTokens)
+
+		// unknown-model should be unchanged.
+		require.Equal(t, int64(0), result[2].ContextWindow)
+	})
+
+	t.Run("preserves existing non-zero values", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"data": [{
+					"model_name": "gpt-4o",
+					"model_info": {
+						"max_input_tokens": 128000,
+						"max_output_tokens": 16384
+					}
+				}]
+			}`))
+		}))
+		defer srv.Close()
+
+		cfg := Config{
+			ID:      "test-litellm",
+			BaseURL: srv.URL,
+		}
+		models := []catwalk.Model{
+			{ID: "gpt-4o", Name: "GPT-4o Custom", ContextWindow: 200000, DefaultMaxTokens: 32768},
+		}
+
+		e := &litellmEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+
+		// User overrides should be preserved.
+		require.Equal(t, int64(200000), result[0].ContextWindow)
+		require.Equal(t, int64(32768), result[0].DefaultMaxTokens)
+		require.Equal(t, "GPT-4o Custom", result[0].Name)
+	})
+
+	t.Run("returns models unchanged on HTTP error", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		cfg := Config{
+			ID:      "test-litellm",
+			BaseURL: srv.URL,
+		}
+		models := []catwalk.Model{{ID: "m1"}}
+
+		e := &litellmEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, "m1", result[0].ID)
+	})
+
+	t.Run("sends auth and extra headers", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "Bearer my-key", r.Header.Get("Authorization"))
+			require.Equal(t, "custom-val", r.Header.Get("X-Custom"))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data": []}`))
+		}))
+		defer srv.Close()
+
+		cfg := Config{
+			ID:      "test-litellm",
+			BaseURL: srv.URL,
+			APIKey:  "my-key",
+			ExtraHeaders: map[string]string{
+				"X-Custom": "custom-val",
+			},
+		}
+
+		e := &litellmEnricher{}
+		_, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, nil)
+		require.NoError(t, err)
+	})
+}
+
+func TestGetEnricher(t *testing.T) {
+	t.Parallel()
+
+	require.NotNil(t, GetEnricher("litellm"))
+	require.Nil(t, GetEnricher("openai-compat"))
+	require.Nil(t, GetEnricher(""))
+}
+
+func TestIsKnownCustomProvider(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, IsKnownCustomProvider("litellm"))
+	require.True(t, IsKnownCustomProvider("ollama"))
+	require.True(t, IsKnownCustomProvider("omlx"))
+	require.True(t, IsKnownCustomProvider("lmstudio"))
+	require.False(t, IsKnownCustomProvider("openai-compat"))
+	require.False(t, IsKnownCustomProvider("anthropic"))
+	require.False(t, IsKnownCustomProvider(""))
+}

--- a/internal/discover/lmstudio.go
+++ b/internal/discover/lmstudio.go
@@ -1,0 +1,94 @@
+package discover
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+func init() {
+	RegisterEnricher("lmstudio", &lmstudioEnricher{})
+}
+
+// lmstudioModelsResponse mirrors the response from LM Studio's native
+// GET /api/v1/models endpoint. Only the fields we care about are
+// decoded.
+type lmstudioModelsResponse struct {
+	Data []lmstudioModelEntry `json:"data"`
+}
+
+// lmstudioModelEntry is a single entry from /api/v1/models.
+type lmstudioModelEntry struct {
+	Key              string             `json:"key"`
+	DisplayName      string             `json:"display_name"`
+	MaxContextLength int64              `json:"max_context_length"`
+	LoadedInstances  []lmstudioInstance `json:"loaded_instances"`
+}
+
+// lmstudioInstance is a currently loaded model instance with its
+// runtime config.
+type lmstudioInstance struct {
+	Config lmstudioInstanceConfig `json:"config"`
+}
+
+// lmstudioInstanceConfig holds per-instance runtime settings.
+type lmstudioInstanceConfig struct {
+	ContextLength int64 `json:"context_length"`
+}
+
+// lmstudioEnricher fetches model metadata from LM Studio's native
+// /api/v1/models endpoint and populates context window and display
+// name on discovered models.
+type lmstudioEnricher struct{}
+
+func (e *lmstudioEnricher) EnrichModels(ctx context.Context, cfg Config, resolver Resolver, models []catwalk.Model) ([]catwalk.Model, error) {
+	resp, err := doRequest(ctx, http.MethodGet, cfg.BaseURL, "/api/v1/models", cfg.APIKey, cfg.ExtraHeaders, resolver, nil)
+	if err != nil {
+		return models, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return models, nil
+	}
+
+	var modelsResp lmstudioModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&modelsResp); err != nil {
+		return models, nil
+	}
+
+	// Index by key for O(1) lookup.
+	metaByKey := make(map[string]lmstudioModelEntry, len(modelsResp.Data))
+	for _, m := range modelsResp.Data {
+		metaByKey[m.Key] = m
+	}
+
+	for i := range models {
+		meta, ok := metaByKey[models[i].ID]
+		if !ok {
+			continue
+		}
+
+		// Context window: prefer loaded instance config, fall back
+		// to the model-level max.
+		if models[i].ContextWindow == 0 {
+			if len(meta.LoadedInstances) > 0 && meta.LoadedInstances[0].Config.ContextLength > 0 {
+				models[i].ContextWindow = meta.LoadedInstances[0].Config.ContextLength
+			} else if meta.MaxContextLength > 0 {
+				models[i].ContextWindow = meta.MaxContextLength
+			}
+		}
+
+		// Display name if not already set by user.
+		if models[i].Name == models[i].ID && meta.DisplayName != "" {
+			models[i].Name = meta.DisplayName
+		}
+
+		// TODO: populate vision/tool-use flags when catwalk.Model
+		// gains dedicated fields for them.
+	}
+
+	return models, nil
+}

--- a/internal/discover/lmstudio_test.go
+++ b/internal/discover/lmstudio_test.go
@@ -1,0 +1,150 @@
+package discover
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLmstudioEnricher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("populates context window and name from /api/v1/models", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/api/v1/models", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(lmstudioModelsResponse{
+				Data: []lmstudioModelEntry{
+					{
+						Key:              "qwen2.5-7b-instruct",
+						DisplayName:      "Qwen 2.5 7B Instruct",
+						MaxContextLength: 32768,
+					},
+					{
+						Key:              "llama-3.1-8b",
+						DisplayName:      "Llama 3.1 8B",
+						MaxContextLength: 131072,
+					},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-lmstudio", BaseURL: srv.URL}
+		models := []catwalk.Model{
+			{ID: "qwen2.5-7b-instruct", Name: "qwen2.5-7b-instruct"},
+			{ID: "llama-3.1-8b", Name: "llama-3.1-8b"},
+			{ID: "unknown-model", Name: "unknown-model"},
+		}
+
+		e := &lmstudioEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 3)
+		require.Equal(t, int64(32768), result[0].ContextWindow)
+		require.Equal(t, "Qwen 2.5 7B Instruct", result[0].Name)
+		require.Equal(t, int64(131072), result[1].ContextWindow)
+		require.Equal(t, "Llama 3.1 8B", result[1].Name)
+		require.Equal(t, int64(0), result[2].ContextWindow)
+		require.Equal(t, "unknown-model", result[2].Name)
+	})
+
+	t.Run("prefers loaded instance context length over model max", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(lmstudioModelsResponse{
+				Data: []lmstudioModelEntry{
+					{
+						Key:              "m1",
+						MaxContextLength: 131072,
+						LoadedInstances: []lmstudioInstance{
+							{Config: lmstudioInstanceConfig{ContextLength: 8192}},
+						},
+					},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-lmstudio", BaseURL: srv.URL}
+		models := []catwalk.Model{{ID: "m1", Name: "m1"}}
+
+		e := &lmstudioEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, int64(8192), result[0].ContextWindow)
+	})
+
+	t.Run("preserves existing non-zero values", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(lmstudioModelsResponse{
+				Data: []lmstudioModelEntry{
+					{
+						Key:              "m1",
+						DisplayName:      "Should Not Override",
+						MaxContextLength: 131072,
+					},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-lmstudio", BaseURL: srv.URL}
+		models := []catwalk.Model{
+			{ID: "m1", Name: "My Custom Name", ContextWindow: 65536},
+		}
+
+		e := &lmstudioEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, int64(65536), result[0].ContextWindow)
+		require.Equal(t, "My Custom Name", result[0].Name)
+	})
+
+	t.Run("returns models unchanged on HTTP error", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-lmstudio", BaseURL: srv.URL}
+		models := []catwalk.Model{{ID: "m1"}}
+
+		e := &lmstudioEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, int64(0), result[0].ContextWindow)
+	})
+
+	t.Run("does not override custom name with display name", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(lmstudioModelsResponse{
+				Data: []lmstudioModelEntry{
+					{Key: "m1", DisplayName: "API Name"},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-lmstudio", BaseURL: srv.URL}
+		models := []catwalk.Model{{ID: "m1", Name: "User Name"}}
+
+		e := &lmstudioEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, "User Name", result[0].Name)
+	})
+}

--- a/internal/discover/ollama.go
+++ b/internal/discover/ollama.go
@@ -1,0 +1,105 @@
+package discover
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+func init() {
+	RegisterEnricher("ollama", &ollamaEnricher{})
+}
+
+// ollamaShowResponse mirrors the response from Ollama's POST /api/show
+// endpoint. Only the fields we care about are decoded.
+type ollamaShowResponse struct {
+	ModelInfo map[string]any `json:"model_info"`
+}
+
+// ollamaEnricher fetches model metadata from Ollama's /api/show
+// endpoint and populates context window on discovered models.
+type ollamaEnricher struct{}
+
+func (e *ollamaEnricher) EnrichModels(ctx context.Context, cfg Config, resolver Resolver, models []catwalk.Model) ([]catwalk.Model, error) {
+	// Collect indices that need enrichment.
+	var needEnrichment []int
+	for i := range models {
+		if models[i].ContextWindow == 0 {
+			needEnrichment = append(needEnrichment, i)
+		}
+	}
+	if len(needEnrichment) == 0 {
+		return models, nil
+	}
+
+	// Fetch metadata concurrently with bounded parallelism.
+	type result struct {
+		index         int
+		contextLength int64
+	}
+
+	results := make([]result, len(needEnrichment))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 5) // Max 5 concurrent requests.
+
+	for ri, idx := range needEnrichment {
+		wg.Go(func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			resp, err := doRequest(ctx, http.MethodPost, cfg.BaseURL, "/api/show",
+				cfg.APIKey, cfg.ExtraHeaders, resolver,
+				map[string]string{"model": models[idx].ID})
+			if err != nil {
+				return
+			}
+			defer resp.Body.Close()
+
+			var showResp ollamaShowResponse
+			if err := json.NewDecoder(resp.Body).Decode(&showResp); err != nil {
+				return
+			}
+
+			if cl := extractContextLength(showResp.ModelInfo); cl > 0 {
+				results[ri] = result{index: idx, contextLength: cl}
+			}
+		})
+	}
+	wg.Wait()
+
+	for _, r := range results {
+		if r.contextLength > 0 {
+			models[r.index].ContextWindow = r.contextLength
+		}
+	}
+
+	return models, nil
+}
+
+// extractContextLength finds the context_length value in Ollama's
+// model_info map. The key is architecture-specific (e.g.
+// "llama.context_length", "qwen2.context_length"), so we scan for any
+// key ending in ".context_length".
+func extractContextLength(info map[string]any) int64 {
+	for k, v := range info {
+		if !strings.HasSuffix(k, ".context_length") {
+			continue
+		}
+		switch n := v.(type) {
+		case float64:
+			return int64(n)
+		case int64:
+			return n
+		case json.Number:
+			i, err := n.Int64()
+			if err == nil {
+				return i
+			}
+		}
+	}
+	return 0
+}

--- a/internal/discover/ollama_test.go
+++ b/internal/discover/ollama_test.go
@@ -1,0 +1,129 @@
+package discover
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOllamaEnricher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("populates context window from /api/show", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/api/show", r.URL.Path)
+			require.Equal(t, http.MethodPost, r.Method)
+
+			var req map[string]string
+			json.NewDecoder(r.Body).Decode(&req)
+
+			w.Header().Set("Content-Type", "application/json")
+			switch req["model"] {
+			case "llama3:latest":
+				json.NewEncoder(w).Encode(ollamaShowResponse{
+					ModelInfo: map[string]any{
+						"llama.context_length": float64(8192),
+					},
+				})
+			case "qwen2:latest":
+				json.NewEncoder(w).Encode(ollamaShowResponse{
+					ModelInfo: map[string]any{
+						"qwen2.context_length": float64(32768),
+					},
+				})
+			default:
+				json.NewEncoder(w).Encode(ollamaShowResponse{})
+			}
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-ollama", BaseURL: srv.URL}
+		models := []catwalk.Model{
+			{ID: "llama3:latest", Name: "llama3:latest"},
+			{ID: "qwen2:latest", Name: "qwen2:latest"},
+			{ID: "unknown:latest", Name: "unknown:latest"},
+		}
+
+		e := &ollamaEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 3)
+		require.Equal(t, int64(8192), result[0].ContextWindow)
+		require.Equal(t, int64(32768), result[1].ContextWindow)
+		require.Equal(t, int64(0), result[2].ContextWindow)
+	})
+
+	t.Run("preserves existing context window", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(ollamaShowResponse{
+				ModelInfo: map[string]any{
+					"llama.context_length": float64(8192),
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-ollama", BaseURL: srv.URL}
+		models := []catwalk.Model{
+			{ID: "llama3:latest", ContextWindow: 16384},
+		}
+
+		e := &ollamaEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, int64(16384), result[0].ContextWindow)
+	})
+
+	t.Run("skips /api/show call when context window already set", func(t *testing.T) {
+		t.Parallel()
+		calls := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			calls++
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(ollamaShowResponse{})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-ollama", BaseURL: srv.URL}
+		models := []catwalk.Model{
+			{ID: "m1", ContextWindow: 4096},
+			{ID: "m2", ContextWindow: 8192},
+		}
+
+		e := &ollamaEnricher{}
+		_, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, 0, calls)
+	})
+}
+
+func TestExtractContextLength(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		info     map[string]any
+		expected int64
+	}{
+		{"llama key", map[string]any{"llama.context_length": float64(8192)}, 8192},
+		{"qwen2 key", map[string]any{"qwen2.context_length": float64(32768)}, 32768},
+		{"no context key", map[string]any{"llama.block_count": float64(32)}, 0},
+		{"empty map", map[string]any{}, 0},
+		{"nil map", nil, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, extractContextLength(tt.info))
+		})
+	}
+}

--- a/internal/discover/omlx.go
+++ b/internal/discover/omlx.go
@@ -1,0 +1,70 @@
+package discover
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+func init() {
+	RegisterEnricher("omlx", &omlxEnricher{})
+}
+
+// omlxModelsStatusResponse mirrors the response from oMLX's
+// GET /v1/models/status endpoint, which returns model metadata
+// including max_context_window and max_tokens.
+type omlxModelsStatusResponse struct {
+	Models []omlxModelStatus `json:"models"`
+}
+
+// omlxModelStatus is a single entry from /v1/models/status.
+type omlxModelStatus struct {
+	ID               string `json:"id"`
+	MaxContextWindow *int64 `json:"max_context_window"`
+	MaxTokens        *int64 `json:"max_tokens"`
+}
+
+// omlxEnricher fetches model metadata from oMLX's /v1/models/status
+// endpoint and populates context window and max tokens on discovered
+// models.
+type omlxEnricher struct{}
+
+func (e *omlxEnricher) EnrichModels(ctx context.Context, cfg Config, resolver Resolver, models []catwalk.Model) ([]catwalk.Model, error) {
+	resp, err := doRequest(ctx, http.MethodGet, cfg.BaseURL, "/v1/models/status", cfg.APIKey, cfg.ExtraHeaders, resolver, nil)
+	if err != nil {
+		return models, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return models, nil
+	}
+
+	var statusResp omlxModelsStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&statusResp); err != nil {
+		return models, nil
+	}
+
+	// Index by model ID for O(1) lookup.
+	metaByID := make(map[string]omlxModelStatus, len(statusResp.Models))
+	for _, m := range statusResp.Models {
+		metaByID[m.ID] = m
+	}
+
+	for i := range models {
+		meta, ok := metaByID[models[i].ID]
+		if !ok {
+			continue
+		}
+		if models[i].ContextWindow == 0 && meta.MaxContextWindow != nil {
+			models[i].ContextWindow = *meta.MaxContextWindow
+		}
+		if models[i].DefaultMaxTokens == 0 && meta.MaxTokens != nil {
+			models[i].DefaultMaxTokens = *meta.MaxTokens
+		}
+	}
+
+	return models, nil
+}

--- a/internal/discover/omlx_test.go
+++ b/internal/discover/omlx_test.go
@@ -1,0 +1,90 @@
+package discover
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOmlxEnricher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("populates context window and max tokens from /v1/models/status", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/v1/models/status", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(omlxModelsStatusResponse{
+				Models: []omlxModelStatus{
+					{ID: "qwen3:latest", MaxContextWindow: ptr(int64(32768)), MaxTokens: ptr(int64(16384))},
+					{ID: "llama3:latest", MaxContextWindow: ptr(int64(8192)), MaxTokens: ptr(int64(4096))},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-omlx", BaseURL: srv.URL}
+		models := []catwalk.Model{
+			{ID: "qwen3:latest", Name: "qwen3:latest"},
+			{ID: "llama3:latest", Name: "llama3:latest"},
+			{ID: "unknown:latest", Name: "unknown:latest"},
+		}
+
+		e := &omlxEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 3)
+		require.Equal(t, int64(32768), result[0].ContextWindow)
+		require.Equal(t, int64(16384), result[0].DefaultMaxTokens)
+		require.Equal(t, int64(8192), result[1].ContextWindow)
+		require.Equal(t, int64(4096), result[1].DefaultMaxTokens)
+		require.Equal(t, int64(0), result[2].ContextWindow)
+	})
+
+	t.Run("preserves existing non-zero values", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(omlxModelsStatusResponse{
+				Models: []omlxModelStatus{
+					{ID: "m1", MaxContextWindow: ptr(int64(32768)), MaxTokens: ptr(int64(16384))},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-omlx", BaseURL: srv.URL}
+		models := []catwalk.Model{
+			{ID: "m1", ContextWindow: 65536, DefaultMaxTokens: 8192},
+		}
+
+		e := &omlxEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, int64(65536), result[0].ContextWindow)
+		require.Equal(t, int64(8192), result[0].DefaultMaxTokens)
+	})
+
+	t.Run("returns models unchanged on HTTP error", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-omlx", BaseURL: srv.URL}
+		models := []catwalk.Model{{ID: "m1"}}
+
+		e := &omlxEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+	})
+}
+
+func ptr[T any](v T) *T { return &v }


### PR DESCRIPTION
### Model Auto-Discovery

Custom providers now auto-discover models from the `/v1/models` endpoint. When a provider has no models listed, Crush fetches them automatically. You can control this with `discover_models` in your provider config:

- **omit or `true`**: auto-discovers when models list is empty; merges discovered models with explicit ones (yours win)
- **`false`**: only uses explicitly listed models

```json
{
  "providers": {
    "my-litellm": {
      "base_url": "http://localhost:4000",
      "api_key": "$LITELLM_KEY",
      "type": "litellm",
      "discover_models": true
    }
  }
}
```

### Enrichers

Discovered models are bare (just an ID). Enrichers fill in context windows, max tokens, pricing, and display names by hitting provider-specific metadata endpoints. Four enrichers ship:

| Type | Endpoint | Populates |
|------|----------|-----------|
| `litellm` | `/model/info` | context window, max tokens, pricing |
| `ollama` | `/api/show` (per model, parallel) | context window |
| `omlx` | `/v1/models/status` | context window, max tokens |
| `lmstudio` | `/api/v1/models` | context window, display name |

All enrichers are openai-compat under the hood, so Crush routes them through the OpenAI-compat provider builder automatically. Discovery runs concurrently with a 3-second timeout and fails gracefully — if enrichment fails, you still get the bare model list.

Fixes #2983 
Fixes #3019