### PR TITLE
fix(ui): properly render model name in summarize

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -681,8 +681,8 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	)
 	summaryMessage, err := a.messages.Create(ctx, sessionID, message.CreateMessageParams{
 		Role:             message.Assistant,
-		Model:            largeModel.Model.Model(),
-		Provider:         largeModel.Model.Provider(),
+		Model:            largeModel.ModelCfg.Model,
+		Provider:         largeModel.ModelCfg.Provider,
 		IsSummaryMessage: true,
 	})
 	if err != nil {


### PR DESCRIPTION
previously when summarizing it would look like this as it didn't render custom providers properly

<img width="390" height="69" alt="image" src="https://github.com/user-attachments/assets/c1cad5d5-1c15-462e-a939-1fd8d0ff94e7" />