### PR TITLE
fix(skills): limit discovery to direct child directories

### DIFF
--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/charlievieth/fastwalk"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"gopkg.in/yaml.v3"
 )
@@ -221,68 +220,63 @@ func Discover(paths []string) []*Skill {
 func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
 	var skills []*Skill
 	var states []*SkillState
-	var mu sync.Mutex
 	seen := make(map[string]bool)
 	addState := func(name, path string, state DiscoveryState, err error) {
-		mu.Lock()
 		states = append(states, &SkillState{
 			Name:  name,
 			Path:  path,
 			State: state,
 			Err:   err,
 		})
-		mu.Unlock()
 	}
 
 	for _, base := range paths {
-		// We use fastwalk with Follow: true instead of filepath.WalkDir because
-		// WalkDir doesn't follow symlinked directories at any depth—only entry
-		// points. This ensures skills in symlinked subdirectories are discovered.
-		// fastwalk is concurrent, so we protect shared state (seen, skills) with mu.
-		conf := fastwalk.Config{
-			Follow:  true,
-			ToSlash: fastwalk.DefaultToSlash(),
+		entries, err := os.ReadDir(base)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				slog.Warn("Failed to read skills path", "path", base, "error", err)
+			}
+			continue
 		}
-		err := fastwalk.Walk(&conf, base, func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				slog.Warn("Failed to walk skills path entry", "base", base, "path", path, "error", err)
-				addState("", path, StateError, err)
-				return nil
+		for _, entry := range entries {
+			if !isSkillDirectoryEntry(base, entry) {
+				continue
 			}
-			if d.IsDir() || d.Name() != SkillFileName {
-				return nil
-			}
-			mu.Lock()
+			path := filepath.Join(base, entry.Name(), SkillFileName)
 			if seen[path] {
-				mu.Unlock()
-				return nil
+				continue
 			}
 			seen[path] = true
-			mu.Unlock()
+
+			info, err := os.Stat(path)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					slog.Warn("Failed to stat skill file", "path", path, "error", err)
+					addState("", path, StateError, err)
+				}
+				continue
+			}
+			if info.IsDir() {
+				continue
+			}
+
 			skill, err := Parse(path)
 			if err != nil {
 				slog.Warn("Failed to parse skill file", "path", path, "error", err)
 				addState("", path, StateError, err)
-				return nil
+				continue
 			}
 			if err := skill.Validate(); err != nil {
 				slog.Warn("Skill validation failed", "path", path, "error", err)
 				addState(skill.Name, path, StateError, err)
-				return nil
+				continue
 			}
 			slog.Debug("Successfully loaded skill", "name", skill.Name, "path", path)
-			mu.Lock()
 			skills = append(skills, skill)
-			mu.Unlock()
 			addState(skill.Name, path, StateNormal, nil)
-			return nil
-		})
-		if err != nil && !os.IsNotExist(err) {
-			slog.Warn("Failed to walk skills path", "path", base, "error", err)
 		}
 	}
 
-	// fastwalk traversal order is non-deterministic, so sort for stable output.
 	// Sort by path first, then alphabetically by name within each path.
 	slices.SortStableFunc(skills, func(a, b *Skill) int {
 		if c := strings.Compare(strings.ToLower(a.Path), strings.ToLower(b.Path)); c != 0 {
@@ -292,6 +286,17 @@ func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
 	})
 
 	return skills, states
+}
+
+func isSkillDirectoryEntry(base string, entry os.DirEntry) bool {
+	if entry.IsDir() {
+		return true
+	}
+	if entry.Type()&os.ModeSymlink == 0 {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(base, entry.Name()))
+	return err == nil && info.IsDir()
 }
 
 // ToPromptXML generates XML for injection into the system prompt.

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -208,15 +208,16 @@ func splitFrontmatter(content string) (frontmatter, body string, err error) {
 	return frontmatter, body, nil
 }
 
-// Discover finds all valid skills in the given paths.
+// Discover finds all valid skills in the immediate child directories of the
+// given paths.
 func Discover(paths []string) []*Skill {
 	skills, _ := DiscoverWithStates(paths)
 	return skills
 }
 
-// DiscoverWithStates finds all valid skills in the given paths and also
-// returns a per-file state slice describing parse/validation outcomes. Useful
-// for diagnostics and UI reporting.
+// DiscoverWithStates finds all valid skills in the immediate child directories
+// of the given paths and also returns a per-file state slice describing
+// parse/validation outcomes. Useful for diagnostics and UI reporting.
 func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
 	var skills []*Skill
 	var states []*SkillState
@@ -235,6 +236,7 @@ func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
 		if err != nil {
 			if !os.IsNotExist(err) {
 				slog.Warn("Failed to read skills path", "path", base, "error", err)
+				addState("", base, StateError, err)
 			}
 			continue
 		}

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -232,12 +232,25 @@ func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
 	}
 
 	for _, base := range paths {
-		entries, err := os.ReadDir(base)
+		info, err := os.Stat(base)
 		if err != nil {
 			if !os.IsNotExist(err) {
-				slog.Warn("Failed to read skills path", "path", base, "error", err)
+				slog.Warn("Failed to stat skills path", "path", base, "error", err)
 				addState("", base, StateError, err)
 			}
+			continue
+		}
+		if !info.IsDir() {
+			err := fmt.Errorf("skills path is not a directory: %s", base)
+			slog.Warn("Invalid skills path", "path", base, "error", err)
+			addState("", base, StateError, err)
+			continue
+		}
+
+		entries, err := os.ReadDir(base)
+		if err != nil {
+			slog.Warn("Failed to read skills path", "path", base, "error", err)
+			addState("", base, StateError, err)
 			continue
 		}
 		for _, entry := range entries {

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -320,6 +320,20 @@ func TestDiscoverMissingPath(t *testing.T) {
 	require.Empty(t, skills)
 }
 
+func TestDiscoverUnreadablePathState(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "file")
+	require.NoError(t, os.WriteFile(path, []byte("not a directory"), 0o644))
+
+	skills, states := DiscoverWithStates([]string{path})
+	require.Empty(t, skills)
+	require.Len(t, states, 1)
+	require.Empty(t, states[0].Name)
+	require.Equal(t, StateError, states[0].State)
+	require.Error(t, states[0].Err)
+}
+
 func TestToPromptXML(t *testing.T) {
 	t.Parallel()
 

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -229,14 +229,32 @@ description: First test skill.
 # Skill One
 `), 0o644))
 
-	// Create valid skill 2 in nested directory.
-	skill2Dir := filepath.Join(tmpDir, "nested", "skill-two")
+	// Create valid skill 2.
+	skill2Dir := filepath.Join(tmpDir, "skill-two")
 	require.NoError(t, os.MkdirAll(skill2Dir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(skill2Dir, "SKILL.md"), []byte(`---
 name: skill-two
 description: Second test skill.
 ---
 # Skill Two
+`), 0o644))
+
+	// Create nested skills (won't be discovered).
+	nestedSkillDir := filepath.Join(tmpDir, "nested", "nested-skill")
+	require.NoError(t, os.MkdirAll(nestedSkillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(nestedSkillDir, "SKILL.md"), []byte(`---
+name: nested-skill
+description: Nested test skill.
+---
+# Nested Skill
+`), 0o644))
+	deepSkillDir := filepath.Join(skill1Dir, "deep", "deep-skill")
+	require.NoError(t, os.MkdirAll(deepSkillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(deepSkillDir, "SKILL.md"), []byte(`---
+name: deep-skill
+description: Deep test skill.
+---
+# Deep Skill
 `), 0o644))
 
 	// Create invalid skill (won't be included).
@@ -268,7 +286,7 @@ description: Name doesn't match directory.
 	require.Equal(t, 1, errorCount)
 	require.True(t, hasInvalidDir)
 	require.Len(t, skills, 2)
-	require.Equal(t, []string{"skill-two", "skill-one"}, []string{skills[0].Name, skills[1].Name})
+	require.Equal(t, []string{"skill-one", "skill-two"}, []string{skills[0].Name, skills[1].Name})
 
 	names := make(map[string]bool)
 	for _, s := range skills {
@@ -276,6 +294,12 @@ description: Name doesn't match directory.
 	}
 	require.True(t, names["skill-one"])
 	require.True(t, names["skill-two"])
+	require.False(t, names["nested-skill"])
+	require.False(t, names["deep-skill"])
+	for _, state := range states {
+		require.NotContains(t, state.Path, "nested-skill")
+		require.NotContains(t, state.Path, "deep-skill")
+	}
 }
 
 func TestDiscoverEmptyDir(t *testing.T) {


### PR DESCRIPTION
Closes #2991.

If you can think of a strong argument for keeping this behavior let me know and perhaps a solution for this that would satisfy everyone would be to gate the subdirectory search behind a config option that limits the depth.

### AI Disclosure

GPT-5.5 (xhigh). 1 round of review (Copilot).

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
