### PR TITLE
fix(tools): report every matching line per file in internal grep

### DIFF
--- a/internal/agent/tools/grep.go
+++ b/internal/agent/tools/grep.go
@@ -199,7 +199,10 @@ func searchFiles(ctx context.Context, pattern, rootPath, include string, limit i
 		}
 	}
 
-	sort.Slice(matches, func(i, j int) bool {
+	// Use a stable sort so that the multiple matches a single file can
+	// contribute (all sharing the same modTime) keep their original
+	// line order and stay grouped together in the rendered output.
+	sort.SliceStable(matches, func(i, j int) bool {
 		return matches[i].modTime.After(matches[j].modTime)
 	})
 
@@ -329,20 +332,19 @@ func searchFilesWithRegex(pattern, rootPath, include string) ([]grepMatch, error
 			return nil
 		}
 
-		match, lineNum, charNum, lineText, err := fileContainsPattern(path, regex)
+		lineMatches, err := fileMatches(path, regex)
 		if err != nil {
 			return nil // Skip files we can't read
 		}
 
-		if match {
+		for _, lm := range lineMatches {
 			matches = append(matches, grepMatch{
 				path:     path,
 				modTime:  info.ModTime(),
-				lineNum:  lineNum,
-				charNum:  charNum,
-				lineText: lineText,
+				lineNum:  lm.lineNum,
+				charNum:  lm.charNum,
+				lineText: lm.lineText,
 			})
-
 			if len(matches) >= 200 {
 				return filepath.SkipAll
 			}
@@ -357,21 +359,35 @@ func searchFilesWithRegex(pattern, rootPath, include string) ([]grepMatch, error
 	return matches, nil
 }
 
-func fileContainsPattern(filePath string, pattern *regexp.Regexp) (bool, int, int, string, error) {
+// lineMatch is a single matching line within a file: its 1-based line
+// number, the 1-based column of the first match on that line, and the
+// line text (with the trailing newline stripped).
+type lineMatch struct {
+	lineNum  int
+	charNum  int
+	lineText string
+}
+
+// fileMatches returns every line in filePath that matches pattern. Like
+// ripgrep, it reports one entry per matching line (using the first match
+// on the line for the column) instead of stopping at the first match in
+// the file.
+func fileMatches(filePath string, pattern *regexp.Regexp) ([]lineMatch, error) {
 	if pattern == nil {
-		return false, 0, 0, "", nil
+		return nil, nil
 	}
 	// Only search text files.
 	if !isTextFile(filePath) {
-		return false, 0, 0, "", nil
+		return nil, nil
 	}
 
 	file, err := os.Open(filePath)
 	if err != nil {
-		return false, 0, 0, "", err
+		return nil, err
 	}
 	defer file.Close()
 
+	var matches []lineMatch
 	reader := bufio.NewReader(file)
 	lineNum := 0
 	for {
@@ -380,18 +396,21 @@ func fileContainsPattern(filePath string, pattern *regexp.Regexp) (bool, int, in
 		line = strings.TrimSuffix(line, "\n")
 		line = strings.TrimSuffix(line, "\r")
 		if loc := pattern.FindStringIndex(line); loc != nil {
-			charNum := loc[0] + 1
-			return true, lineNum, charNum, line, nil
+			matches = append(matches, lineMatch{
+				lineNum:  lineNum,
+				charNum:  loc[0] + 1,
+				lineText: line,
+			})
 		}
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			return false, 0, 0, "", err
+			return nil, err
 		}
 	}
 
-	return false, 0, 0, "", nil
+	return matches, nil
 }
 
 // isTextFile checks if a file is a text file by examining its MIME type.

--- a/internal/agent/tools/grep_test.go
+++ b/internal/agent/tools/grep_test.go
@@ -391,6 +391,43 @@ func TestIsTextFile(t *testing.T) {
 	}
 }
 
+func TestMultipleMatchesPerFile(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+
+	// "world" appears on lines 1 and 3, but not line 2. Both grep
+	// implementations must report every matching line, not just the first.
+	content := "Hello world.\nHello.\nHello world.\n"
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "file.txt"), []byte(content), 0o644))
+
+	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
+		"regex": searchFilesWithRegex,
+		"rg": func(pattern, path, include string) ([]grepMatch, error) {
+			return searchWithRipgrep(t.Context(), pattern, path, include)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if name == "rg" && getRg() == "" {
+				t.Skip("rg is not in $PATH")
+			}
+
+			matches, err := fn("world", tempDir, "")
+			require.NoError(t, err)
+			require.Len(t, matches, 2, "should report both matching lines")
+
+			lines := make([]int, len(matches))
+			for i, match := range matches {
+				lines[i] = match.lineNum
+				require.Equal(t, 7, match.charNum)
+				require.Equal(t, "Hello world.", match.lineText)
+			}
+			require.ElementsMatch(t, []int{1, 3}, lines)
+		})
+	}
+}
+
 func TestColumnMatch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The grep tool has two backends: ripgrep when it is available and a pure-Go regex fallback otherwise. ripgrep reports one result per matching line, but the fallback returned only the **first** match in each file, so the two disagree depending on whether `rg` is installed.

For a file containing:

```
Hello world.
Hello.
Hello world.
```

searching for `world` returns 2 matches with ripgrep but only 1 without it (e.g. Linux with `rg` vs. NetBSD without it, as reported in the issue).

### Changes

* The regex fallback (`fileMatches`) now collects **every** matching line, one entry per line, using the first match on the line for the column, exactly matching ripgrep's behavior.
* The result sort is switched to a stable sort so the multiple matches a single file contributes (all sharing the same modtime) keep their line order and stay grouped together in the rendered output. This also makes the existing ripgrep path's multi-match output deterministic.

### Tests

Added `TestMultipleMatchesPerFile`, which runs both backends against the same file and asserts they return the same set of matching lines. The existing `searchFilesWithRegex`/`searchWithRipgrep` parity tests continue to pass.

Closes charmbracelet/crush#2846