### PR TITLE
fix(tools): report elapsed time and threshold when a command is auto-backgrounded

### DIFF
--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -367,16 +367,27 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 				return fantasy.WithResponseMetadata(fantasy.NewTextResponse(stdout), metadata), nil
 			}
 
-			// Still running - keep as background job
+			// Still running - keep as background job. Report how long it
+			// ran and the threshold that triggered backgrounding so the
+			// model (and the user, via the UI) can tell whether the command
+			// is simply slow or has stalled.
+			endTime := time.Now()
+			elapsed := endTime.Sub(startTime).Round(time.Second)
 			metadata := BashResponseMetadata{
 				StartTime:        startTime.UnixMilli(),
-				EndTime:          time.Now().UnixMilli(),
+				EndTime:          endTime.UnixMilli(),
 				Description:      params.Description,
 				WorkingDirectory: bgShell.WorkingDir,
 				Background:       true,
 				ShellID:          bgShell.ID,
 			}
-			response := fmt.Sprintf("Command is taking longer than expected and has been moved to background.\n\nBackground shell ID: %s\n\nUse job_output tool to view output or job_kill to terminate.", bgShell.ID)
+			response := fmt.Sprintf(
+				"Command ran for %s without completing and has been moved to background "+
+					"(commands are auto-backgrounded after %s; set auto_background_after to change this).\n\n"+
+					"Background shell ID: %s\n\n"+
+					"Use job_output tool to view output or job_kill to terminate.",
+				elapsed, autoBackgroundThreshold, bgShell.ID,
+			)
 			return fantasy.WithResponseMetadata(fantasy.NewTextResponse(response), metadata), nil
 		},
 	)

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -74,6 +74,10 @@ func TestBashTool_CustomAutoBackgroundThreshold(t *testing.T) {
 	require.True(t, meta.Background)
 	require.NotEmpty(t, meta.ShellID)
 	require.Contains(t, resp.Content, "moved to background")
+	// The message must tell the model how long the command ran and the
+	// threshold that backgrounded it (see issue #2977).
+	require.Contains(t, resp.Content, "Command ran for")
+	require.Contains(t, resp.Content, "auto-backgrounded after 1s")
 
 	bgManager := shell.GetBackgroundShellManager()
 	require.NoError(t, bgManager.Kill(meta.ShellID))


### PR DESCRIPTION
When a synchronous bash command runs past the auto-background threshold it is moved to a background job. The message was:

> Command is taking longer than expected and has been moved to background.

"longer than expected" never said *how long*, so neither the model nor the user could tell whether the command is merely slow or has stalled. Some commands are expected to finish in a second; others legitimately take minutes. Without the threshold there is no way to know which case you are in.

### Changes

The message now reports how long the command actually ran and the threshold that triggered backgrounding, and notes that the threshold is configurable via `auto_background_after`:

> Command ran for 1m0s without completing and has been moved to background (commands are auto-backgrounded after 1m0s; set auto_background_after to change this).

Because the background-job renderer surfaces the tool response content verbatim, the same information now reaches the UI as well, so it helps both the model and the user as requested in the issue.

### Tests

Extended `TestBashTool_CustomAutoBackgroundThreshold` to assert the response reports the elapsed runtime and the threshold.

Closes #2977
