### PR TITLE
feat(tui): display git branch in sidebar and landing page

### DIFF
--- a/internal/ui/model/git_test.go
+++ b/internal/ui/model/git_test.go
@@ -1,0 +1,99 @@
+package model
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadGitBranch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns empty for non git dir", func(t *testing.T) {
+		t.Parallel()
+
+		ui := &UI{
+			com: &common.Common{
+				Workspace: &testWorkspace{workingDir: t.TempDir()},
+			},
+		}
+
+		msg := ui.loadGitBranch()()
+		result, ok := msg.(gitBranchLoadedMsg)
+		require.True(t, ok)
+		require.Empty(t, result.branch)
+		require.Nil(t, ui.gitWatcher)
+	})
+
+	t.Run("returns branch for git repo and starts watcher", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		runGit(t, dir, "init")
+		runGit(t, dir, "checkout", "-b", "feature-branch")
+
+		ui := &UI{
+			com: &common.Common{
+				Workspace: &testWorkspace{workingDir: dir},
+			},
+		}
+
+		msg := ui.loadGitBranch()()
+		result, ok := msg.(gitBranchLoadedMsg)
+		require.True(t, ok)
+		require.Equal(t, "feature-branch", result.branch)
+		require.NotNil(t, ui.gitWatcher)
+		ui.gitWatcher.Close()
+	})
+
+	t.Run("returns empty for detached head", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		runGit(t, dir, "init")
+		runGit(t, dir, "commit", "--allow-empty", "-m", "init")
+		hash := runGit(t, dir, "rev-parse", "--short", "HEAD")
+		runGit(t, dir, "checkout", hash)
+
+		ui := &UI{
+			com: &common.Common{
+				Workspace: &testWorkspace{workingDir: dir},
+			},
+		}
+
+		msg := ui.loadGitBranch()()
+		result, ok := msg.(gitBranchLoadedMsg)
+		require.True(t, ok)
+		require.Empty(t, result.branch)
+		require.NotNil(t, ui.gitWatcher)
+		ui.gitWatcher.Close()
+	})
+
+	t.Run("watchGitBranch returns nil when no watcher", func(t *testing.T) {
+		t.Parallel()
+
+		ui := &UI{
+			com: &common.Common{},
+		}
+		cmd := ui.watchGitBranch()
+		require.Nil(t, cmd)
+	})
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = []string{
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@test.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@test.com",
+	}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %s: %s", args, string(out))
+	return strings.TrimSpace(string(out))
+}

--- a/internal/ui/model/landing.go
+++ b/internal/ui/model/landing.go
@@ -5,6 +5,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/crush/internal/workspace"
 	"github.com/charmbracelet/ultraviolet/layout"
 )
@@ -28,6 +29,14 @@ func (m *UI) landingView() string {
 
 	parts := []string{
 		cwd,
+	}
+
+	if m.gitBranch != "" {
+		parts = append(parts,
+			t.Sidebar.GitBranch.Width(width).MaxHeight(1).Render(
+				styles.GitBranchIcon+" "+m.gitBranch,
+			),
+		)
 	}
 
 	parts = append(parts, "", m.modelInfo(width))

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -8,6 +8,7 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/logo"
+	"github.com/charmbracelet/crush/internal/ui/styles"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/ultraviolet/layout"
 )
@@ -141,6 +142,12 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 
 	title := t.Sidebar.SessionTitle.Width(width).MaxHeight(2).Render(m.session.Title)
 	cwd := common.PrettyPath(t, m.com.Workspace.WorkingDir(), width)
+	var branch string
+	if m.gitBranch != "" {
+		branch = t.Sidebar.GitBranch.Width(width).MaxHeight(1).Render(
+			styles.GitBranchIcon + " " + m.gitBranch,
+		)
+	}
 	sidebarLogo := m.sidebarLogo
 	if height < logoHeightBreakpoint {
 		sidebarLogo = logo.SmallRender(m.com.Styles, width, logo.Opts{
@@ -152,10 +159,15 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 		title,
 		"",
 		cwd,
+	}
+	if branch != "" {
+		blocks = append(blocks, branch)
+	}
+	blocks = append(blocks,
 		"",
 		m.modelInfo(width),
 		"",
-	}
+	)
 
 	sidebarHeader := lipgloss.JoinVertical(
 		lipgloss.Left,

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -40,6 +40,7 @@ import (
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/shell"
 	"github.com/charmbracelet/crush/internal/skills"
 	"github.com/charmbracelet/crush/internal/stringext"
 	"github.com/charmbracelet/crush/internal/ui/anim"
@@ -60,6 +61,7 @@ import (
 	"github.com/charmbracelet/ultraviolet/screen"
 	"github.com/charmbracelet/x/editor"
 	xstrings "github.com/charmbracelet/x/exp/strings"
+	"github.com/fsnotify/fsnotify"
 )
 
 // MouseScrollThreshold defines how many lines to scroll the chat when a mouse
@@ -159,6 +161,10 @@ type (
 	creditsUpdatedMsg struct {
 		credits int
 	}
+	// gitBranchLoadedMsg is sent when the git branch has been fetched.
+	gitBranchLoadedMsg struct {
+		branch string
+	}
 )
 
 // UI represents the main user interface model.
@@ -241,6 +247,11 @@ type UI struct {
 
 	// sidebarLogo keeps a cached version of the sidebar sidebarLogo.
 	sidebarLogo string
+
+	// gitBranch is the current git branch name, kept live via fsnotify on
+	// .git/HEAD.
+	gitBranch  string
+	gitWatcher *fsnotify.Watcher
 
 	// Notification state
 	notifyBackend       notification.Backend
@@ -403,6 +414,7 @@ func (m *UI) Init() tea.Cmd {
 	if m.com.IsHyper() {
 		cmds = append(cmds, m.fetchHyperCredits())
 	}
+	cmds = append(cmds, m.loadGitBranch())
 	return tea.Batch(cmds...)
 }
 
@@ -938,6 +950,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case creditsUpdatedMsg:
 		m.hyperCredits = &msg.credits
+	case gitBranchLoadedMsg:
+		m.gitBranch = msg.branch
+		cmds = append(cmds, m.watchGitBranch())
 	case util.InfoMsg:
 		if msg.Type == util.InfoTypeError {
 			slog.Error("Error reported", "error", msg.Msg)
@@ -3907,6 +3922,75 @@ func (m *UI) handleStateChanged() tea.Cmd {
 		m.com.Workspace.UpdateAgentModel(context.Background())
 		return mcpStateChangedMsg{
 			states: m.com.Workspace.MCPGetStates(),
+		}
+	}
+}
+
+func (m *UI) loadGitBranch() tea.Cmd {
+	return func() tea.Msg {
+		dir := m.com.Workspace.WorkingDir()
+		gitDir := filepath.Join(dir, ".git")
+		info, err := os.Stat(gitDir)
+		if err != nil {
+			return gitBranchLoadedMsg{}
+		}
+
+		// Resolve .git file (worktrees) to the actual git dir.
+		resolvedGitDir := gitDir
+		if !info.IsDir() {
+			data, err := os.ReadFile(gitDir)
+			if err != nil {
+				return gitBranchLoadedMsg{}
+			}
+			// Format: "gitdir: /path/to/.git"
+			line := strings.TrimSpace(strings.TrimPrefix(string(data), "gitdir:"))
+			if !filepath.IsAbs(line) {
+				line = filepath.Join(dir, line)
+			}
+			resolvedGitDir = line
+		}
+
+		// Start or restart the watcher on .git/HEAD.
+		if m.gitWatcher != nil {
+			m.gitWatcher.Close()
+		}
+		if w, err := fsnotify.NewWatcher(); err == nil {
+			headFile := filepath.Join(resolvedGitDir, "HEAD")
+			_ = w.Add(headFile)
+			// Also watch the refs/heads dir for branch creation/deletion.
+			_ = w.Add(filepath.Join(resolvedGitDir, "refs", "heads"))
+			m.gitWatcher = w
+		}
+
+		sh := shell.NewShell(&shell.Options{WorkingDir: dir})
+		out, _, err := sh.Exec(context.Background(), "git branch --show-current 2>/dev/null")
+		if err != nil {
+			return gitBranchLoadedMsg{}
+		}
+		return gitBranchLoadedMsg{branch: strings.TrimSpace(out)}
+	}
+}
+
+func (m *UI) watchGitBranch() tea.Cmd {
+	if m.gitWatcher == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		select {
+		case _, ok := <-m.gitWatcher.Events:
+			if !ok {
+				return nil
+			}
+			// Re-fetch the branch.
+			dir := m.com.Workspace.WorkingDir()
+			sh := shell.NewShell(&shell.Options{WorkingDir: dir})
+			out, _, err := sh.Exec(context.Background(), "git branch --show-current 2>/dev/null")
+			if err != nil {
+				return gitBranchLoadedMsg{}
+			}
+			return gitBranchLoadedMsg{branch: strings.TrimSpace(out)}
+		case <-m.gitWatcher.Errors:
+			return nil
 		}
 	}
 }

--- a/internal/ui/model/ui_test.go
+++ b/internal/ui/model/ui_test.go
@@ -87,9 +87,17 @@ func newTestUIWithConfig(t *testing.T, cfg *config.Config) *UI {
 // testWorkspace is a minimal [workspace.Workspace] stub for unit tests.
 type testWorkspace struct {
 	workspace.Workspace
-	cfg *config.Config
+	cfg        *config.Config
+	workingDir string
 }
 
 func (w *testWorkspace) Config() *config.Config {
 	return w.cfg
+}
+
+func (w *testWorkspace) WorkingDir() string {
+	if w.workingDir != "" {
+		return w.workingDir
+	}
+	return ""
 }

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -758,6 +758,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	// Sidebar
 	s.Sidebar.SessionTitle = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)
 	s.Sidebar.WorkingDir = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)
+	s.Sidebar.GitBranch = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)
 
 	// ModelInfo
 	s.ModelInfo.Icon = lipgloss.NewStyle().Foreground(o.fgMostSubtle)

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -22,6 +22,7 @@ const (
 	LoadingIcon     string = "⟳"
 	ModelIcon       string = "◇"
 	HypercreditIcon string = "◆"
+	GitBranchIcon   string = ""
 
 	ArrowRightIcon string = "→"
 
@@ -180,6 +181,7 @@ type Styles struct {
 	Sidebar struct {
 		SessionTitle lipgloss.Style // Current session title at top of sidebar
 		WorkingDir   lipgloss.Style // Working directory path (PrettyPath)
+		GitBranch    lipgloss.Style // Git branch name
 	}
 
 	// ModelInfo (model name, provider, reasoning, token/cost summary)


### PR DESCRIPTION
## Summary

- Display the current git branch name in the sidebar (below working directory) and on the landing page
- Live refresh via `fsnotify` watcher on `.git/HEAD` and `refs/heads/` — branch updates instantly on `git checkout`, `git switch`, rebase, merge, etc.
- Supports worktrees by resolving `.git` file to the actual git directory
- Gracefully hides when not in a git repo or in detached HEAD state

## Implementation details

- Async `tea.Cmd` pattern — never blocks render
- Cached in `UI.gitBranch`, only re-runs `git branch --show-current` when `.git/HEAD` or `refs/heads/` changes on disk
- New `GitBranchIcon` constant and `Sidebar.GitBranch` style following existing conventions
- `MaxHeight(1)` prevents long branch names from wrapping in the narrow sidebar

## Test plan

- [x] `TestLoadGitBranch/returns_empty_for_non_git_dir` — no crash, empty result, no watcher
- [x] `TestLoadGitBranch/returns_branch_for_git_repo_and_starts_watcher` — correct branch, watcher started
- [x] `TestLoadGitBranch/returns_empty_for_detached_head` — graceful fallback
- [x] `TestLoadGitBranch/watchGitBranch_returns_nil_when_no_watcher` — nil safety
- [x] Full model test suite passes
- [ ] Manual: run `go run .` in a git repo, verify branch shows in sidebar
- [ ] Manual: run `git checkout -b test-branch` in another terminal, verify sidebar updates live
- [ ] Manual: verify no branch shown in a non-git directory


💘 Generated with Crush