### PR TITLE
feat(ui): clear editor text on Ctrl+C before quitting

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1805,7 +1805,14 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 	}
 
 	if key.Matches(msg, m.keyMap.Quit) && !m.dialog.ContainsDialog(dialog.QuitID) {
-		// Always handle quit keys first
+		// If the editor has text, clear it instead of quitting.
+		if m.focus == uiFocusEditor && m.textarea.Value() != "" {
+			prevHeight := m.textarea.Height()
+			m.textarea.Reset()
+			return tea.Batch(append(cmds, m.handleTextareaHeightChange(prevHeight))...)
+		}
+
+		// Otherwise, open the quit confirmation dialog.
 		if cmd := m.openQuitDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}


### PR DESCRIPTION
## Summary

- When the editor has text and the user presses the quit key (Ctrl+C / Esc), clear the editor instead of immediately showing the quit confirmation dialog.
- Only prompt to quit when the editor is already empty.

## Test plan

- [x] Type text in the editor, press Ctrl+C → editor clears instead of showing quit dialog.
- [x] Press Ctrl+C again on empty editor → quit confirmation dialog appears.

💘 Generated with Crush