### PR TITLE
feat(tools): add allow list for built-in tools

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -270,6 +270,7 @@ type Options struct {
 	// resolved against the working directory; absolute paths are used
 	// verbatim. After defaulting the stored value is always absolute.
 	DataDirectory             string       `json:"data_directory,omitempty" jsonschema:"description=Directory for storing application data. Relative paths are resolved against the working directory; absolute paths are used as-is.,default=.crush,example=.crush"`
+	EnabledTools              []string     `json:"enabled_tools,omitempty" jsonschema:"description=Allow list of built-in tools,example=bash,example=sourcegraph"`
 	DisabledTools             []string     `json:"disabled_tools,omitempty" jsonschema:"description=List of built-in tools to disable and hide from the agent,example=bash,example=sourcegraph"`
 	DisableProviderAutoUpdate bool         `json:"disable_provider_auto_update,omitempty" jsonschema:"description=Disable providers auto-update,default=false"`
 	DisableDefaultProviders   bool         `json:"disable_default_providers,omitempty" jsonschema:"description=Ignore all default/embedded providers. When enabled\\, providers must be fully specified in the config file with base_url\\, models\\, and api_key - no merging with defaults occurs,default=false"`
@@ -680,12 +681,14 @@ func allToolNames() []string {
 	}
 }
 
-func resolveAllowedTools(allTools []string, disabledTools []string) []string {
-	if disabledTools == nil {
-		return allTools
+func resolveAllowedTools(allTools []string, options *Options) []string {
+	filtered := allTools
+	if len(options.EnabledTools) > 0 {
+		// filter to only include tools in EnabledTools
+		filtered = filterSlice(allTools, options.EnabledTools, true)
 	}
 	// filter out disabled tools (exclude mode)
-	return filterSlice(allTools, disabledTools, false)
+	return filterSlice(filtered, options.DisabledTools, false)
 }
 
 func resolveReadOnlyTools(tools []string) []string {
@@ -707,7 +710,7 @@ func filterSlice(data []string, mask []string, include bool) []string {
 }
 
 func (c *Config) SetupAgents() {
-	allowedTools := resolveAllowedTools(allToolNames(), c.Options.DisabledTools)
+	allowedTools := resolveAllowedTools(allToolNames(), c.Options)
 
 	agents := map[string]Agent{
 		AgentCoder: {


### PR DESCRIPTION
Adds the EnabledTools config to allow only specified built in tools. This is also for parity with the EnabledTools field in the MCPConfig.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
