### PR TITLE
feat(ui): show notification when toggling yolo mode

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1804,6 +1804,11 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			yolo := !m.com.Workspace.PermissionSkipRequests()
 			m.com.Workspace.PermissionSetSkipRequests(yolo)
 			m.setEditorPrompt(yolo)
+			status := "disabled"
+			if yolo {
+				status = "enabled"
+			}
+			cmds = append(cmds, util.ReportInfo("Yolo mode "+status))
 			return true
 		}
 		return false


### PR DESCRIPTION

## Summary

- Display "Yolo mode enabled/disabled" via `ReportInfo` so the user gets immediate visual feedback after pressing ctrl+y.

## Test plan

- Press ctrl+y in a session and verify the notification appears
- Toggle again and verify it shows the opposite state