### PR TITLE
feat(ui): allow editing selected file paths in completions

### DIFF
--- a/internal/ui/attachments/attachments.go
+++ b/internal/ui/attachments/attachments.go
@@ -39,6 +39,18 @@ type Attachments struct {
 func (m *Attachments) List() []message.Attachment { return m.list }
 func (m *Attachments) Reset()                     { m.list = nil }
 
+// RemoveByPath removes the first attachment whose FilePath matches the given
+// path. Returns true if an attachment was removed.
+func (m *Attachments) RemoveByPath(path string) bool {
+	for i, a := range m.list {
+		if a.FilePath == path {
+			m.list = slices.Delete(m.list, i, i+1)
+			return true
+		}
+	}
+	return false
+}
+
 func (m *Attachments) Update(msg tea.Msg) bool {
 	switch msg := msg.(type) {
 	case message.Attachment:

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -219,6 +219,7 @@ type UI struct {
 	completionsStartIndex    int
 	completionsQuery         string
 	completionsPositionStart image.Point // x,y where user typed '@'
+	completionsLastAttachmentPath string // path of last file completion inserted
 
 	// Chat components
 	chat *Chat
@@ -1917,6 +1918,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 
 				attachments := m.attachments.List()
 				m.attachments.Reset()
+				m.completionsLastAttachmentPath = ""
 				if len(value) == 0 && !message.ContainsTextAttachment(attachments) {
 					return nil
 				}
@@ -2029,6 +2031,22 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 						} else if m.completionsOpen {
 							m.closeCompletions()
 						}
+					}
+				}
+
+				// Re-open completions if the cursor landed inside an @word.
+				if !m.completionsOpen {
+					word := m.textareaWord()
+					if strings.HasPrefix(word, "@") {
+						m.completionsOpen = true
+						m.completionsQuery = word[1:]
+						value := m.textarea.Value()
+						if idx := strings.LastIndex(value, word); idx >= 0 {
+							m.completionsStartIndex = idx
+						}
+						m.completionsPositionStart = m.completionsPosition()
+						depth, limit := m.com.Config().Options.TUI.Completions.Limits()
+						cmds = append(cmds, m.completions.Open(depth, limit))
 					}
 				}
 			}
@@ -2945,21 +2963,27 @@ func (m *UI) insertCompletionText(text string) bool {
 
 	word := m.textareaWord()
 	endIdx := min(m.completionsStartIndex+len(word), len(value))
-	newValue := value[:m.completionsStartIndex] + text + value[endIdx:]
+	newValue := value[:m.completionsStartIndex] + "@" + text + value[endIdx:]
 	m.textarea.SetValue(newValue)
 	m.textarea.MoveToEnd()
-	m.textarea.InsertRune(' ')
 	return true
 }
 
 // insertFileCompletion inserts the selected file path into the textarea,
-// replacing the @query, and adds the file as an attachment.
+// replacing the @query, and adds the file as an attachment. If a previous
+// file completion was inserted, its attachment is removed first.
 func (m *UI) insertFileCompletion(path string) tea.Cmd {
 	prevHeight := m.textarea.Height()
 	if !m.insertCompletionText(path) {
 		return nil
 	}
 	heightCmd := m.handleTextareaHeightChange(prevHeight)
+
+	// Remove the previous file-completion attachment, if any.
+	if m.completionsLastAttachmentPath != "" {
+		m.attachments.RemoveByPath(m.completionsLastAttachmentPath)
+	}
+	m.completionsLastAttachmentPath = path
 
 	fileCmd := func() tea.Msg {
 		absPath, _ := filepath.Abs(path)


### PR DESCRIPTION
## Summary

- Preserve the `@` prefix when inserting a file completion so the user can continue editing the path inline.
- When the cursor is moved back into an `@`-prefixed word, the completions popup re-opens automatically, allowing the user to pick a different file.
- Remove previous attachment when selecting a new file, preventing stale attachments from accumulating.

## Changes

- `insertCompletionText()`: preserve `@` prefix, remove trailing space
- `insertFileCompletion()`: remove previous attachment when selecting a new file
- `handleKeyPressMsg()`: detect when cursor enters an `@word` and re-open completions with the current query
- Add `RemoveByPath()` to `Attachments` component for cleanup
- Reset `completionsLastAttachmentPath` on message send

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (1742 tests)

## Why

This makes the `@` mention workflow feel more like an inline text token that can be edited rather than a one-shot insertion.