### PR TITLE
feat: add bang mode for direct shell command execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,3 +181,43 @@ func TestYourFunction(t *testing.T) {
 
 Anytime you need to work on the TUI, read `internal/ui/AGENTS.md` before
 starting work.
+
+## Styling System
+
+The styling system lives in `internal/ui/styles/` and is organized into
+three layers:
+
+- **`quickstyle.go`**: The stable base theme builder. `quickStyle(opts)`
+  constructs a `Styles` struct from `quickStyleOpts` — a palette of
+  design tokens (primary, secondary, fgBase, bgBase, success, error, etc.).
+  `quickStyle` must be fully token-driven: never hardcode specific
+  `charmtone.*` colors here (except Chroma syntax highlighting, which is
+  pending tokenization). This lets any theme reuse the base without
+  inheriting Charmtone-specific colors.
+- **`themes.go`**: Defines concrete themes. Each theme function (e.g.
+  `CharmtonePantera`) calls `quickStyle` with its palette, then applies
+  theme-specific overrides as needed.
+- **`styles.go`**: Defines the `Styles` struct and its documentation —
+  the shape of what `quickStyle` produces.
+
+**Adding theme-specific overrides**: When a style genuinely needs a
+color that doesn't fit the token model (e.g. the bang prompt uses
+Salt/Hazy/Larple), keep `quickStyle` on the closest semantic token and
+override only the differing colors in the theme function:
+
+```go
+func CharmtonePantera() Styles {
+	s := quickStyle(quickStyleOpts{ /* palette */ })
+
+	// Override only the colors that differ from the token defaults.
+	s.Editor.PromptBangIconFocused = s.Editor.PromptBangIconFocused.
+		Foreground(charmtone.Salt).
+		Background(charmtone.Hazy)
+
+	return s
+}
+```
+
+**Adding a new theme**: Add a function in `themes.go` that returns the
+result of `quickStyle` with a `quickStyleOpts` palette (plus any needed
+overrides), then wire it into `ThemeForProvider`.

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/clipperhouse/displaywidth v0.11.0
 	github.com/clipperhouse/uax29/v2 v2.7.0
+	github.com/creack/pty v1.1.24
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/disintegration/imaging v1.6.2
 	github.com/dustin/go-humanize v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/clipperhouse/displaywidth v0.11.0
 	github.com/clipperhouse/uax29/v2 v2.7.0
-	github.com/creack/pty v1.1.24
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/disintegration/imaging v1.6.2
 	github.com/dustin/go-humanize v1.0.1

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -138,6 +138,7 @@ type SessionAgent interface {
 	ClearQueue(sessionID string)
 	Summarize(context.Context, string, fantasy.ProviderOptions) error
 	Model() Model
+	GenerateTitle(ctx context.Context, sessionID, userPrompt string)
 }
 
 type Model struct {
@@ -681,11 +682,11 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	}
 
 	var wg sync.WaitGroup
-	// Generate title if first message.
-	if len(msgs) == 0 {
+	// Generate title from the first real (non-shell) user prompt.
+	if !hasUserTextMessage(msgs) {
 		titleCtx := ctx // Copy to avoid race with ctx reassignment below.
 		wg.Go(func() {
-			a.generateTitle(titleCtx, call.SessionID, call.Prompt)
+			a.GenerateTitle(titleCtx, call.SessionID, call.Prompt)
 		})
 	}
 	defer wg.Wait()
@@ -1631,8 +1632,24 @@ func (a *sessionAgent) getSessionMessages(ctx context.Context, session session.S
 	return msgs, nil
 }
 
-// generateTitle generates a session titled based on the initial prompt.
-func (a *sessionAgent) generateTitle(ctx context.Context, sessionID string, userPrompt string) {
+// hasUserTextMessage reports whether any user message in msgs contains
+// text content (as opposed to only shell commands or other non-text parts).
+func hasUserTextMessage(msgs []message.Message) bool {
+	for _, msg := range msgs {
+		if msg.Role != message.User {
+			continue
+		}
+		for _, part := range msg.Parts {
+			if tc, ok := part.(message.TextContent); ok && tc.Text != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// GenerateTitle generates a session title based on the initial prompt.
+func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, userPrompt string) {
 	if userPrompt == "" {
 		return
 	}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -101,6 +101,7 @@ type Coordinator interface {
 	Summarize(context.Context, string) error
 	Model() Model
 	UpdateModels(ctx context.Context) error
+	GenerateTitle(ctx context.Context, sessionID, prompt string)
 }
 
 type coordinator struct {
@@ -1137,6 +1138,14 @@ func (c *coordinator) Summarize(ctx context.Context, sessionID string) error {
 	}
 
 	return c.runWithUnauthorizedRetry(ctx, providerCfg, summarize)
+}
+
+// GenerateTitle generates a session title using the current agent.
+func (c *coordinator) GenerateTitle(ctx context.Context, sessionID, prompt string) {
+	if c.currentAgent == nil {
+		return
+	}
+	c.currentAgent.GenerateTitle(ctx, sessionID, prompt)
 }
 
 // refreshTokenIfExpired proactively refreshes the OAuth token if it has expired.

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -45,6 +45,7 @@ func (m *mockSessionAgent) ClearQueue(sessionID string)                 {}
 func (m *mockSessionAgent) Summarize(context.Context, string, fantasy.ProviderOptions) error {
 	return nil
 }
+func (m *mockSessionAgent) GenerateTitle(context.Context, string, string) {}
 
 // newTestCoordinator creates a minimal coordinator for unit testing runSubAgent.
 func newTestCoordinator(t *testing.T, env fakeEnv, providerID string, providerCfg config.ProviderConfig) *coordinator {

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"os"
 
 	"github.com/charmbracelet/crush/internal/agent"
@@ -251,26 +250,29 @@ func (b *Backend) RunShellCommand(ctx context.Context, workspaceID string, req p
 		return proto.ShellCommandResponse{}, err
 	}
 
-	result, err := shell.RunAndCapturePTY(ctx, shell.RunOptions{
-		Command: req.Command,
-		Cwd:     ws.Path,
-		Env:     append(os.Environ(), ws.Env...),
-	})
-	if err != nil {
-		return proto.ShellCommandResponse{}, err
+	var persist shell.PersistFunc
+	if req.SessionID != "" {
+		persist = func(cmd, output string, exitCode int) error {
+			_, err := ws.Messages.Create(ctx, req.SessionID, message.CreateMessageParams{
+				Role: message.User,
+				Parts: []message.ContentPart{message.ShellCommand{
+					Command:  cmd,
+					Output:   output,
+					ExitCode: exitCode,
+				}},
+			})
+			return err
+		}
 	}
 
-	if req.SessionID != "" {
-		if _, err := ws.Messages.Create(ctx, req.SessionID, message.CreateMessageParams{
-			Role: message.User,
-			Parts: []message.ContentPart{message.ShellCommand{
-				Command:  req.Command,
-				Output:   result.Output,
-				ExitCode: result.ExitCode,
-			}},
-		}); err != nil {
-			slog.Error("Failed to persist shell command output", "error", err, "session_id", req.SessionID)
-		}
+	result, err := shell.RunAndPersist(ctx, shell.RunOptions{
+		Command:   req.Command,
+		Cwd:       ws.Path,
+		Env:       append(os.Environ(), ws.Env...),
+		TermWidth: req.TermWidth,
+	}, persist)
+	if err != nil {
+		return proto.ShellCommandResponse{}, err
 	}
 
 	return proto.ShellCommandResponse{

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -1,14 +1,19 @@
 package backend
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"os"
 
 	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/pubsub"
+	"github.com/charmbracelet/crush/internal/shell"
 )
 
 // SendMessage validates and accepts a prompt for the workspace's agent,
@@ -237,4 +242,49 @@ func (b *Backend) GetDefaultSmallModel(workspaceID, providerID string) (config.S
 	}
 
 	return ws.GetDefaultSmallModel(providerID), nil
+}
+
+// RunShellCommand runs a shell command in the workspace directory and
+// persists the command + output as a user message in the session.
+func (b *Backend) RunShellCommand(ctx context.Context, workspaceID string, req proto.ShellCommandRequest) (proto.ShellCommandResponse, error) {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return proto.ShellCommandResponse{}, err
+	}
+
+	var stdout, stderr bytes.Buffer
+	runErr := shell.Run(ctx, shell.RunOptions{
+		Command: req.Command,
+		Cwd:     ws.Path,
+		Env:     append(os.Environ(), ws.Env...),
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	})
+
+	exitCode := 0
+	if runErr != nil {
+		exitCode = shell.ExitCode(runErr)
+	}
+
+	output := stdout.String()
+	if stderr.Len() > 0 {
+		if output != "" {
+			output += "\n"
+		}
+		output += stderr.String()
+	}
+
+	// Persist as a user message so the LLM has context on follow-up.
+	msgContent := fmt.Sprintf("$ %s\n%s", req.Command, output)
+	if req.SessionID != "" {
+		_, _ = ws.Messages.Create(ctx, req.SessionID, message.CreateMessageParams{
+			Role:  message.User,
+			Parts: []message.ContentPart{message.TextContent{Text: msgContent}},
+		})
+	}
+
+	return proto.ShellCommandResponse{
+		Output:   output,
+		ExitCode: exitCode,
+	}, nil
 }

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -1,10 +1,9 @@
 package backend
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/charmbracelet/crush/internal/agent"
@@ -252,39 +251,30 @@ func (b *Backend) RunShellCommand(ctx context.Context, workspaceID string, req p
 		return proto.ShellCommandResponse{}, err
 	}
 
-	var stdout, stderr bytes.Buffer
-	runErr := shell.Run(ctx, shell.RunOptions{
+	result, err := shell.RunAndCapturePTY(ctx, shell.RunOptions{
 		Command: req.Command,
 		Cwd:     ws.Path,
 		Env:     append(os.Environ(), ws.Env...),
-		Stdout:  &stdout,
-		Stderr:  &stderr,
 	})
-
-	exitCode := 0
-	if runErr != nil {
-		exitCode = shell.ExitCode(runErr)
+	if err != nil {
+		return proto.ShellCommandResponse{}, err
 	}
 
-	output := stdout.String()
-	if stderr.Len() > 0 {
-		if output != "" {
-			output += "\n"
-		}
-		output += stderr.String()
-	}
-
-	// Persist as a user message so the LLM has context on follow-up.
-	msgContent := fmt.Sprintf("$ %s\n%s", req.Command, output)
 	if req.SessionID != "" {
-		_, _ = ws.Messages.Create(ctx, req.SessionID, message.CreateMessageParams{
-			Role:  message.User,
-			Parts: []message.ContentPart{message.TextContent{Text: msgContent}},
-		})
+		if _, err := ws.Messages.Create(ctx, req.SessionID, message.CreateMessageParams{
+			Role: message.User,
+			Parts: []message.ContentPart{message.ShellCommand{
+				Command:  req.Command,
+				Output:   result.Output,
+				ExitCode: result.ExitCode,
+			}},
+		}); err != nil {
+			slog.Error("Failed to persist shell command output", "error", err, "session_id", req.SessionID)
+		}
 	}
 
 	return proto.ShellCommandResponse{
-		Output:   output,
-		ExitCode: exitCode,
+		Output:   result.Output,
+		ExitCode: result.ExitCode,
 	}, nil
 }

--- a/internal/backend/agent_runcomplete_test.go
+++ b/internal/backend/agent_runcomplete_test.go
@@ -47,6 +47,7 @@ func (c *errorCoordinator) ClearQueue(string)                                 {}
 func (c *errorCoordinator) Summarize(context.Context, string) error           { return nil }
 func (c *errorCoordinator) Model() agent.Model                                { return agent.Model{} }
 func (c *errorCoordinator) UpdateModels(context.Context) error                { return nil }
+func (c *errorCoordinator) GenerateTitle(context.Context, string, string)     {}
 
 // insertRunCompleteWorkspace installs a workspace backed by a real
 // app.App (so the runCompletions broker exists) with the given

--- a/internal/backend/agent_test.go
+++ b/internal/backend/agent_test.go
@@ -57,6 +57,7 @@ func (c *blockingCoordinator) ClearQueue(string)                                
 func (c *blockingCoordinator) Summarize(context.Context, string) error           { return nil }
 func (c *blockingCoordinator) Model() agent.Model                                { return agent.Model{} }
 func (c *blockingCoordinator) UpdateModels(context.Context) error                { return nil }
+func (c *blockingCoordinator) GenerateTitle(context.Context, string, string)     {}
 
 // insertAgentWorkspace installs a synthetic workspace with the given
 // coordinator (or none) and a workspace run context, mirroring the

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -445,6 +445,25 @@ func decodeErrorMessage(body io.Reader) string {
 	return e.Message
 }
 
+// RunShellCommand runs a shell command in the workspace without triggering the agent.
+func (c *Client) RunShellCommand(ctx context.Context, id, sessionID, command string) (proto.ShellCommandResponse, error) {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/agent/sessions/%s/shell", id, sessionID), nil, jsonBody(proto.ShellCommandRequest{
+		Command: command,
+	}), http.Header{"Content-Type": []string{"application/json"}})
+	if err != nil {
+		return proto.ShellCommandResponse{}, fmt.Errorf("failed to run shell command: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return proto.ShellCommandResponse{}, fmt.Errorf("failed to run shell command: status code %d", rsp.StatusCode)
+	}
+	var resp proto.ShellCommandResponse
+	if err := json.NewDecoder(rsp.Body).Decode(&resp); err != nil {
+		return proto.ShellCommandResponse{}, fmt.Errorf("failed to decode shell command response: %w", err)
+	}
+	return resp, nil
+}
+
 // GetAgentSessionInfo retrieves the agent session info for a workspace.
 func (c *Client) GetAgentSessionInfo(ctx context.Context, id string, sessionID string) (*proto.AgentSession, error) {
 	rsp, err := c.get(ctx, fmt.Sprintf("/workspaces/%s/agent/sessions/%s", id, sessionID), nil, nil)

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -446,9 +446,10 @@ func decodeErrorMessage(body io.Reader) string {
 }
 
 // RunShellCommand runs a shell command in the workspace without triggering the agent.
-func (c *Client) RunShellCommand(ctx context.Context, id, sessionID, command string) (proto.ShellCommandResponse, error) {
+func (c *Client) RunShellCommand(ctx context.Context, id, sessionID, command string, termWidth int) (proto.ShellCommandResponse, error) {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/agent/sessions/%s/shell", id, sessionID), nil, jsonBody(proto.ShellCommandRequest{
-		Command: command,
+		Command:   command,
+		TermWidth: termWidth,
 	}), http.Header{"Content-Type": []string{"application/json"}})
 	if err != nil {
 		return proto.ShellCommandResponse{}, fmt.Errorf("failed to run shell command: %w", err)

--- a/internal/message/content.go
+++ b/internal/message/content.go
@@ -139,6 +139,27 @@ type ShellCommand struct {
 
 func (ShellCommand) isPart() {}
 
+// HasShellCommand reports whether the message contains any ShellCommand parts.
+func (m *Message) HasShellCommand() bool {
+	for _, part := range m.Parts {
+		if _, ok := part.(ShellCommand); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ShellCommands returns all ShellCommand parts from the message.
+func (m *Message) ShellCommands() []ShellCommand {
+	var cmds []ShellCommand
+	for _, part := range m.Parts {
+		if sc, ok := part.(ShellCommand); ok {
+			cmds = append(cmds, sc)
+		}
+	}
+	return cmds
+}
+
 type Message struct {
 	ID               string
 	Role             MessageRole
@@ -492,6 +513,15 @@ func (m *Message) ToAIMessage() []fantasy.Message {
 			})
 		}
 		text = PromptWithTextAttachments(text, textAttachments)
+		// Include bang-mode shell commands as context for the agent.
+		for _, sc := range m.ShellCommands() {
+			shellText := fmt.Sprintf("$ %s\n%s\n(exit code %d)", sc.Command, sc.Output, sc.ExitCode)
+			if text != "" {
+				text += "\n\n" + shellText
+			} else {
+				text = shellText
+			}
+		}
 		if text != "" {
 			parts = append(parts, fantasy.TextPart{Text: text})
 		}

--- a/internal/message/content.go
+++ b/internal/message/content.go
@@ -129,6 +129,16 @@ type Finish struct {
 
 func (Finish) isPart() {}
 
+// ShellCommand stores a bang-mode shell command and its output as a
+// distinct content part so it can be reconstructed on session restore.
+type ShellCommand struct {
+	Command  string `json:"command"`
+	Output   string `json:"output"`
+	ExitCode int    `json:"exit_code"`
+}
+
+func (ShellCommand) isPart() {}
+
 type Message struct {
 	ID               string
 	Role             MessageRole

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -519,13 +519,14 @@ func (s *service) fromDBItem(item db.Message) (Message, error) {
 type partType string
 
 const (
-	reasoningType  partType = "reasoning"
-	textType       partType = "text"
-	imageURLType   partType = "image_url"
-	binaryType     partType = "binary"
-	toolCallType   partType = "tool_call"
-	toolResultType partType = "tool_result"
-	finishType     partType = "finish"
+	reasoningType    partType = "reasoning"
+	textType         partType = "text"
+	imageURLType     partType = "image_url"
+	binaryType       partType = "binary"
+	toolCallType     partType = "tool_call"
+	toolResultType   partType = "tool_result"
+	finishType       partType = "finish"
+	shellCommandType partType = "shell_command"
 )
 
 type partWrapper struct {
@@ -554,6 +555,8 @@ func marshalParts(parts []ContentPart) ([]byte, error) {
 			typ = toolResultType
 		case Finish:
 			typ = finishType
+		case ShellCommand:
+			typ = shellCommandType
 		default:
 			return nil, fmt.Errorf("unknown part type: %T", part)
 		}
@@ -624,6 +627,12 @@ func unmarshalParts(data []byte) ([]ContentPart, error) {
 			parts = append(parts, part)
 		case finishType:
 			part := Finish{}
+			if err := json.Unmarshal(wrapper.Data, &part); err != nil {
+				return nil, err
+			}
+			parts = append(parts, part)
+		case shellCommandType:
+			part := ShellCommand{}
 			if err := json.Unmarshal(wrapper.Data, &part); err != nil {
 				return nil, err
 			}

--- a/internal/proto/message.go
+++ b/internal/proto/message.go
@@ -172,6 +172,15 @@ type Finish struct {
 
 func (Finish) isPart() {}
 
+// ShellCommand stores a bang-mode shell command and its output.
+type ShellCommand struct {
+	Command  string `json:"command"`
+	Output   string `json:"output"`
+	ExitCode int    `json:"exit_code"`
+}
+
+func (ShellCommand) isPart() {}
+
 // MarshalJSON implements the [json.Marshaler] interface.
 func (m Message) MarshalJSON() ([]byte, error) {
 	parts, err := MarshalParts(m.Parts)
@@ -495,13 +504,14 @@ func (m *Message) AddBinary(mimeType string, data []byte) {
 type partType string
 
 const (
-	reasoningType  partType = "reasoning"
-	textType       partType = "text"
-	imageURLType   partType = "image_url"
-	binaryType     partType = "binary"
-	toolCallType   partType = "tool_call"
-	toolResultType partType = "tool_result"
-	finishType     partType = "finish"
+	reasoningType    partType = "reasoning"
+	textType         partType = "text"
+	imageURLType     partType = "image_url"
+	binaryType       partType = "binary"
+	toolCallType     partType = "tool_call"
+	toolResultType   partType = "tool_result"
+	finishType       partType = "finish"
+	shellCommandType partType = "shell_command"
 )
 
 type partWrapper struct {
@@ -531,6 +541,8 @@ func MarshalParts(parts []ContentPart) ([]byte, error) {
 			typ = toolResultType
 		case Finish:
 			typ = finishType
+		case ShellCommand:
+			typ = shellCommandType
 		default:
 			return nil, fmt.Errorf("unknown part type: %T", part)
 		}
@@ -602,6 +614,12 @@ func UnmarshalParts(data []byte) ([]ContentPart, error) {
 			parts = append(parts, part)
 		case finishType:
 			part := Finish{}
+			if err := json.Unmarshal(wrapper.Data, &part); err != nil {
+				return nil, err
+			}
+			parts = append(parts, part)
+		case shellCommandType:
+			part := ShellCommand{}
 			if err := json.Unmarshal(wrapper.Data, &part); err != nil {
 				return nil, err
 			}

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -139,6 +139,7 @@ type AgentMessage struct {
 type ShellCommandRequest struct {
 	SessionID string `json:"session_id"`
 	Command   string `json:"command"`
+	TermWidth int    `json:"term_width,omitempty"`
 }
 
 // ShellCommandResponse represents the result of a direct shell command.

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -135,6 +135,18 @@ type AgentMessage struct {
 	Attachments []Attachment `json:"attachments,omitempty"`
 }
 
+// ShellCommandRequest represents a request to run a shell command directly.
+type ShellCommandRequest struct {
+	SessionID string `json:"session_id"`
+	Command   string `json:"command"`
+}
+
+// ShellCommandResponse represents the result of a direct shell command.
+type ShellCommandResponse struct {
+	Output   string `json:"output"`
+	ExitCode int    `json:"exit_code"`
+}
+
 // AgentSession represents a session with its busy status.
 type AgentSession struct {
 	Session

--- a/internal/server/agent_cancel_test.go
+++ b/internal/server/agent_cancel_test.go
@@ -79,8 +79,9 @@ func (s *runCoordinator) ClearQueue(string)                 {}
 func (s *runCoordinator) Summarize(context.Context, string) error {
 	return nil
 }
-func (s *runCoordinator) Model() agent.Model                 { return agent.Model{} }
-func (s *runCoordinator) UpdateModels(context.Context) error { return nil }
+func (s *runCoordinator) Model() agent.Model                            { return agent.Model{} }
+func (s *runCoordinator) UpdateModels(context.Context) error            { return nil }
+func (s *runCoordinator) GenerateTitle(context.Context, string, string) {}
 
 func (s *runCoordinator) capturedCtx() context.Context {
 	s.mu.Lock()

--- a/internal/server/e2e_agent_test.go
+++ b/internal/server/e2e_agent_test.go
@@ -212,14 +212,15 @@ func (c *scriptedCoordinator) CancelAll() {
 	}
 }
 
-func (c *scriptedCoordinator) IsBusy() bool                            { return false }
-func (c *scriptedCoordinator) IsSessionBusy(string) bool               { return false }
-func (c *scriptedCoordinator) QueuedPrompts(string) int                { return 0 }
-func (c *scriptedCoordinator) QueuedPromptsList(string) []string       { return nil }
-func (c *scriptedCoordinator) ClearQueue(string)                       {}
-func (c *scriptedCoordinator) Summarize(context.Context, string) error { return nil }
-func (c *scriptedCoordinator) Model() agent.Model                      { return agent.Model{} }
-func (c *scriptedCoordinator) UpdateModels(context.Context) error      { return nil }
+func (c *scriptedCoordinator) IsBusy() bool                                  { return false }
+func (c *scriptedCoordinator) IsSessionBusy(string) bool                     { return false }
+func (c *scriptedCoordinator) QueuedPrompts(string) int                      { return 0 }
+func (c *scriptedCoordinator) QueuedPromptsList(string) []string             { return nil }
+func (c *scriptedCoordinator) ClearQueue(string)                             {}
+func (c *scriptedCoordinator) Summarize(context.Context, string) error       { return nil }
+func (c *scriptedCoordinator) Model() agent.Model                            { return agent.Model{} }
+func (c *scriptedCoordinator) UpdateModels(context.Context) error            { return nil }
+func (c *scriptedCoordinator) GenerateTitle(context.Context, string, string) {}
 
 // agentE2EHarness extends the SSE harness with a scripted coordinator
 // wired into the workspace's embedded app.App, so POST /agent drives a

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -269,6 +269,12 @@ func messageToProto(m message.Message) proto.Message {
 			msg.Parts = append(msg.Parts, proto.ImageURLContent{URL: v.URL, Detail: v.Detail})
 		case message.BinaryContent:
 			msg.Parts = append(msg.Parts, proto.BinaryContent{Path: v.Path, MIMEType: v.MIMEType, Data: v.Data})
+		case message.ShellCommand:
+			msg.Parts = append(msg.Parts, proto.ShellCommand{
+				Command:  v.Command,
+				Output:   v.Output,
+				ExitCode: v.ExitCode,
+			})
 		}
 	}
 

--- a/internal/server/proto.go
+++ b/internal/server/proto.go
@@ -915,6 +915,40 @@ func (c *controllerV1) handlePostWorkspaceAgentSessionSummarize(w http.ResponseW
 	w.WriteHeader(http.StatusOK)
 }
 
+// handlePostWorkspaceAgentSessionShell runs a shell command in the workspace.
+//
+//	@Summary		Run shell command
+//	@Tags			agent
+//	@Accept			json
+//	@Produce		json
+//	@Param			id		path		string						true	"Workspace ID"
+//	@Param			sid		path		string						true	"Session ID"
+//	@Param			request	body		proto.ShellCommandRequest	true	"Shell command"
+//	@Success		200		{object}	proto.ShellCommandResponse
+//	@Failure		400		{object}	proto.Error
+//	@Failure		404		{object}	proto.Error
+//	@Failure		500		{object}	proto.Error
+//	@Router			/workspaces/{id}/agent/sessions/{sid}/shell [post]
+func (c *controllerV1) handlePostWorkspaceAgentSessionShell(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	sid := r.PathValue("sid")
+
+	var req proto.ShellCommandRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		c.server.logError(r, "Failed to decode request", "error", err)
+		jsonError(w, http.StatusBadRequest, "failed to decode request")
+		return
+	}
+	req.SessionID = sid
+
+	resp, err := c.backend.RunShellCommand(r.Context(), id, req)
+	if err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	jsonEncode(w, resp)
+}
+
 // handleGetWorkspaceAgentSessionPromptList returns the list of queued prompts.
 //
 //	@Summary		List queued prompts

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -189,6 +189,7 @@ func (s *Server) installHandler() {
 	mux.HandleFunc("GET /v1/workspaces/{id}/agent/sessions/{sid}/prompts/list", c.handleGetWorkspaceAgentSessionPromptList)
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent/sessions/{sid}/prompts/clear", c.handlePostWorkspaceAgentSessionPromptClear)
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent/sessions/{sid}/summarize", c.handlePostWorkspaceAgentSessionSummarize)
+	mux.HandleFunc("POST /v1/workspaces/{id}/agent/sessions/{sid}/shell", c.handlePostWorkspaceAgentSessionShell)
 	mux.HandleFunc("GET /v1/workspaces/{id}/agent/default-small-model", c.handleGetWorkspaceAgentDefaultSmallModel)
 	mux.HandleFunc("POST /v1/workspaces/{id}/config/set", c.handlePostWorkspaceConfigSet)
 	mux.HandleFunc("POST /v1/workspaces/{id}/config/remove", c.handlePostWorkspaceConfigRemove)

--- a/internal/server/sessions_isbusy_test.go
+++ b/internal/server/sessions_isbusy_test.go
@@ -50,8 +50,9 @@ func (s *stubCoordinator) ClearQueue(string)                 {}
 func (s *stubCoordinator) Summarize(context.Context, string) error {
 	return nil
 }
-func (s *stubCoordinator) Model() agent.Model                 { return agent.Model{} }
-func (s *stubCoordinator) UpdateModels(context.Context) error { return nil }
+func (s *stubCoordinator) Model() agent.Model                            { return agent.Model{} }
+func (s *stubCoordinator) UpdateModels(context.Context) error            { return nil }
+func (s *stubCoordinator) GenerateTitle(context.Context, string, string) {}
 
 // stubSessions is a minimal session.Service that returns a fixed list
 // (and supports Get by ID). All other methods return zero values; the

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -223,22 +223,30 @@ func (s *service) Save(ctx context.Context, session Session) (Session, error) {
 // UpdateTitleAndUsage updates only the title and usage fields atomically.
 // This is safer than fetching, modifying, and saving the entire session.
 func (s *service) UpdateTitleAndUsage(ctx context.Context, sessionID, title string, promptTokens, completionTokens int64, cost float64) error {
-	return s.q.UpdateSessionTitleAndUsage(ctx, db.UpdateSessionTitleAndUsageParams{
+	if err := s.q.UpdateSessionTitleAndUsage(ctx, db.UpdateSessionTitleAndUsageParams{
 		ID:               sessionID,
 		Title:            title,
 		PromptTokens:     promptTokens,
 		CompletionTokens: completionTokens,
 		Cost:             cost,
-	})
+	}); err != nil {
+		return err
+	}
+	s.publishSessionUpdate(ctx, sessionID)
+	return nil
 }
 
 // Rename updates only the title of a session without touching updated_at or
 // usage fields.
 func (s *service) Rename(ctx context.Context, id string, title string) error {
-	return s.q.RenameSession(ctx, db.RenameSessionParams{
+	if err := s.q.RenameSession(ctx, db.RenameSessionParams{
 		ID:    id,
 		Title: title,
-	})
+	}); err != nil {
+		return err
+	}
+	s.publishSessionUpdate(ctx, id)
+	return nil
 }
 
 func (s *service) List(ctx context.Context) ([]Session, error) {
@@ -252,6 +260,17 @@ func (s *service) List(ctx context.Context) ([]Session, error) {
 		s.applyEstimatedUsageState(&sessions[i])
 	}
 	return sessions, nil
+}
+
+// publishSessionUpdate re-fetches a session and publishes an UpdatedEvent so
+// that UI subscribers reflect title or usage changes.
+func (s *service) publishSessionUpdate(ctx context.Context, sessionID string) {
+	session, err := s.Get(ctx, sessionID)
+	if err != nil {
+		slog.Error("Failed to re-fetch session for event publish", "error", err, "sessionID", sessionID)
+		return
+	}
+	s.Publish(pubsub.UpdatedEvent, session)
 }
 
 func (s *service) applyEstimatedUsageState(session *Session) {

--- a/internal/shell/run.go
+++ b/internal/shell/run.go
@@ -1,12 +1,16 @@
 package shell
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
 	"slices"
 	"strings"
 
+	"github.com/creack/pty"
 	"mvdan.cc/sh/moreinterp/coreutils"
 	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/interp"
@@ -41,6 +45,9 @@ type RunOptions struct {
 	// BlockFuncs is an optional list of deny-list matchers applied before
 	// each command reaches the exec layer. nil disables blocking entirely.
 	BlockFuncs []BlockFunc
+	// TermWidth is the terminal width in columns for PTY execution.
+	// Zero uses a default of 200.
+	TermWidth int
 }
 
 // Run parses and executes a shell command using the same mvdan.cc/sh
@@ -86,6 +93,98 @@ func Run(ctx context.Context, opts RunOptions) (err error) {
 	return runner.Run(ctx, line)
 }
 
+// CaptureResult holds the combined output and exit code from a
+// captured shell execution.
+type CaptureResult struct {
+	Output   string
+	ExitCode int
+}
+
+// RunAndCapture executes a shell command and returns its combined
+// stdout/stderr output along with the exit code. It inherits the
+// current process environment when opts.Env is nil.
+func RunAndCapture(ctx context.Context, opts RunOptions) (CaptureResult, error) {
+	if opts.Env == nil {
+		opts.Env = os.Environ()
+	}
+
+	var stdout, stderr bytes.Buffer
+	opts.Stdout = &stdout
+	opts.Stderr = &stderr
+
+	runErr := Run(ctx, opts)
+
+	exitCode := 0
+	if runErr != nil {
+		exitCode = ExitCode(runErr)
+	}
+
+	output := stdout.String()
+	if stderr.Len() > 0 {
+		if output != "" {
+			output += "\n"
+		}
+		output += stderr.String()
+	}
+
+	return CaptureResult{
+		Output:   output,
+		ExitCode: exitCode,
+	}, nil
+}
+
+// RunAndCapturePTY executes a shell command through a pseudo-TTY and
+// returns its combined output along with the exit code. Programs that
+// check isatty (eza, ls --color=auto, bat, etc.) will emit ANSI color
+// sequences because they see a real terminal on stdout. The env vars
+// from nonInteractiveEnvVars are still applied. Falls back to
+// RunAndCapture if PTY allocation fails.
+func RunAndCapturePTY(ctx context.Context, opts RunOptions) (CaptureResult, error) {
+	if opts.Env == nil {
+		opts.Env = os.Environ()
+	}
+	env := withNonInteractiveEnv(opts.Env)
+
+	cols := uint16(opts.TermWidth)
+	if cols == 0 {
+		cols = 200
+	}
+
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", opts.Command)
+	cmd.Dir = opts.Cwd
+	cmd.Env = env
+
+	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: 50, Cols: cols})
+	if err != nil {
+		return RunAndCapture(ctx, opts)
+	}
+	defer ptmx.Close()
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		_, copyErr := io.Copy(&buf, ptmx)
+		done <- copyErr
+	}()
+
+	waitErr := cmd.Wait()
+	<-done
+
+	exitCode := 0
+	if waitErr != nil {
+		if exitErr, ok := waitErr.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = 1
+		}
+	}
+
+	return CaptureResult{
+		Output:   buf.String(),
+		ExitCode: exitCode,
+	}, nil
+}
+
 // newRunner constructs an [interp.Runner] configured with the standard
 // Crush handler stack. Shared by the stateless [Run] entrypoint and the
 // stateful [Shell] so the two surfaces cannot drift.
@@ -126,6 +225,9 @@ func execHandlerOption(blockFuncs []BlockFunc) interp.RunnerOption {
 // hangs, not useful behavior.
 var nonInteractiveEnvVars = []string{
 	"TERM=xterm-256color",
+	"COLORTERM=truecolor",
+	"CLICOLOR_FORCE=1",
+	"FORCE_COLOR=1",
 	"GIT_EDITOR=false",
 	"EDITOR=false",
 	"VISUAL=false",

--- a/internal/shell/run.go
+++ b/internal/shell/run.go
@@ -7,11 +7,9 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/exec"
 	"slices"
 	"strings"
 
-	"github.com/creack/pty"
 	"mvdan.cc/sh/moreinterp/coreutils"
 	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/interp"
@@ -165,57 +163,21 @@ var ptyColorEnvVars = []string{
 	"FORCE_COLOR=1",
 }
 
-// RunAndCapturePTY executes a shell command through a pseudo-TTY and
-// returns its combined output along with the exit code. Programs that
-// check isatty (eza, ls --color=auto, bat, etc.) will emit ANSI color
-// sequences because they see a real terminal on stdout. Falls back to
-// RunAndCapture if PTY allocation fails (logged as a warning).
+// RunAndCapturePTY executes a shell command through the mvdan.cc/sh
+// interpreter with color-forcing environment variables set. Programs
+// that respect FORCE_COLOR or CLICOLOR_FORCE (git, cargo, npm, eza,
+// bat, ripgrep, etc.) will emit ANSI color sequences even without a
+// real PTY. This approach is fully cross-platform — no /bin/sh or
+// unix PTY required.
+//
+// The name is preserved for API compatibility; the PTY path has been
+// replaced by the portable interpreter + env-var approach.
 func RunAndCapturePTY(ctx context.Context, opts RunOptions) (CaptureResult, error) {
 	if opts.Env == nil {
 		opts.Env = os.Environ()
 	}
-	env := withNonInteractiveEnv(opts.Env)
-	env = append(env, ptyColorEnvVars...)
-
-	cols := uint16(opts.TermWidth)
-	if cols == 0 {
-		cols = 200
-	}
-
-	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", opts.Command)
-	cmd.Dir = opts.Cwd
-	cmd.Env = env
-
-	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: 50, Cols: cols})
-	if err != nil {
-		slog.Warn("PTY allocation failed, falling back to pipe capture", "error", err, "command", opts.Command)
-		return RunAndCapture(ctx, opts)
-	}
-	defer ptmx.Close()
-
-	var buf bytes.Buffer
-	done := make(chan error, 1)
-	go func() {
-		_, copyErr := io.Copy(&buf, ptmx)
-		done <- copyErr
-	}()
-
-	waitErr := cmd.Wait()
-	<-done
-
-	exitCode := 0
-	if waitErr != nil {
-		if exitErr, ok := waitErr.(*exec.ExitError); ok {
-			exitCode = exitErr.ExitCode()
-		} else {
-			exitCode = 1
-		}
-	}
-
-	return CaptureResult{
-		Output:   buf.String(),
-		ExitCode: exitCode,
-	}, nil
+	opts.Env = append(opts.Env, ptyColorEnvVars...)
+	return RunAndCapture(ctx, opts)
 }
 
 // newRunner constructs an [interp.Runner] configured with the standard

--- a/internal/shell/run.go
+++ b/internal/shell/run.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"slices"
@@ -100,6 +101,28 @@ type CaptureResult struct {
 	ExitCode int
 }
 
+// PersistFunc is a callback that persists a shell command result.
+// Used by RunAndPersist to decouple execution from storage.
+type PersistFunc func(command, output string, exitCode int) error
+
+// RunAndPersist executes a shell command via PTY and optionally
+// persists the result through the provided callback. This unifies
+// the run-and-save pattern used by both AppWorkspace and Backend.
+func RunAndPersist(ctx context.Context, opts RunOptions, persist PersistFunc) (CaptureResult, error) {
+	result, err := RunAndCapturePTY(ctx, opts)
+	if err != nil {
+		return CaptureResult{}, err
+	}
+
+	if persist != nil {
+		if persistErr := persist(opts.Command, result.Output, result.ExitCode); persistErr != nil {
+			slog.Error("Failed to persist shell command output", "error", persistErr, "command", opts.Command)
+		}
+	}
+
+	return result, nil
+}
+
 // RunAndCapture executes a shell command and returns its combined
 // stdout/stderr output along with the exit code. It inherits the
 // current process environment when opts.Env is nil.
@@ -133,17 +156,26 @@ func RunAndCapture(ctx context.Context, opts RunOptions) (CaptureResult, error) 
 	}, nil
 }
 
+// ptyColorEnvVars force color output for programs running inside a
+// PTY. These are only applied in RunAndCapturePTY, not in the plain
+// Run/RunAndCapture paths where ANSI codes would be noise.
+var ptyColorEnvVars = []string{
+	"COLORTERM=truecolor",
+	"CLICOLOR_FORCE=1",
+	"FORCE_COLOR=1",
+}
+
 // RunAndCapturePTY executes a shell command through a pseudo-TTY and
 // returns its combined output along with the exit code. Programs that
 // check isatty (eza, ls --color=auto, bat, etc.) will emit ANSI color
-// sequences because they see a real terminal on stdout. The env vars
-// from nonInteractiveEnvVars are still applied. Falls back to
-// RunAndCapture if PTY allocation fails.
+// sequences because they see a real terminal on stdout. Falls back to
+// RunAndCapture if PTY allocation fails (logged as a warning).
 func RunAndCapturePTY(ctx context.Context, opts RunOptions) (CaptureResult, error) {
 	if opts.Env == nil {
 		opts.Env = os.Environ()
 	}
 	env := withNonInteractiveEnv(opts.Env)
+	env = append(env, ptyColorEnvVars...)
 
 	cols := uint16(opts.TermWidth)
 	if cols == 0 {
@@ -156,6 +188,7 @@ func RunAndCapturePTY(ctx context.Context, opts RunOptions) (CaptureResult, erro
 
 	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: 50, Cols: cols})
 	if err != nil {
+		slog.Warn("PTY allocation failed, falling back to pipe capture", "error", err, "command", opts.Command)
 		return RunAndCapture(ctx, opts)
 	}
 	defer ptmx.Close()
@@ -225,9 +258,6 @@ func execHandlerOption(blockFuncs []BlockFunc) interp.RunnerOption {
 // hangs, not useful behavior.
 var nonInteractiveEnvVars = []string{
 	"TERM=xterm-256color",
-	"COLORTERM=truecolor",
-	"CLICOLOR_FORCE=1",
-	"FORCE_COLOR=1",
 	"GIT_EDITOR=false",
 	"EDITOR=false",
 	"VISUAL=false",

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -367,6 +367,16 @@ func cappedMessageWidth(availableWidth int) int {
 func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults map[string]message.ToolResult) []MessageItem {
 	switch msg.Role {
 	case message.User:
+		// Reconstruct shell command items from ShellCommand parts.
+		var items []MessageItem
+		for _, part := range msg.Parts {
+			if sc, ok := part.(message.ShellCommand); ok {
+				items = append(items, NewShellItem(sty, sc.Command, sc.Output, sc.ExitCode))
+			}
+		}
+		if len(items) > 0 {
+			return items
+		}
 		r := attachments.NewRenderer(
 			sty.Attachments.Normal,
 			sty.Attachments.Deleting,

--- a/internal/ui/chat/shell.go
+++ b/internal/ui/chat/shell.go
@@ -1,0 +1,147 @@
+package chat
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/list"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+)
+
+const shellMaxCollapsedLines = 10
+
+// ShellItem renders a bang-mode shell command result in the chat with a
+// vertical bar on the left and plain-text output.
+type ShellItem struct {
+	*list.Versioned
+	*highlightableMessageItem
+	*cachedMessageItem
+	*focusableMessageItem
+
+	id              string
+	command         string
+	output          string
+	exitCode        int
+	expandedContent bool
+	sty             *styles.Styles
+}
+
+var (
+	_ Expandable         = (*ShellItem)(nil)
+	_ list.Highlightable = (*ShellItem)(nil)
+)
+
+// NewShellItem creates a new ShellItem for displaying bang-mode results.
+func NewShellItem(sty *styles.Styles, command, output string, exitCode int) MessageItem {
+	v := list.NewVersioned()
+	return &ShellItem{
+		Versioned:                v,
+		highlightableMessageItem: defaultHighlighter(sty, v),
+		cachedMessageItem:        &cachedMessageItem{},
+		focusableMessageItem:     newFocusableMessageItem(v),
+		id:                       fmt.Sprintf("shell-%s", command),
+		command:                  command,
+		output:                   output,
+		exitCode:                 exitCode,
+		sty:                      sty,
+	}
+}
+
+func (s *ShellItem) ID() string          { return s.id }
+func (s *ShellItem) FilterValue() string { return s.command }
+func (s *ShellItem) Finished() bool      { return true }
+
+func (s *ShellItem) Render(width int) string {
+	innerWidth := max(0, width-MessageLeftPaddingTotal)
+	content := s.RawRender(innerWidth)
+
+	var prefix string
+	if s.focused {
+		prefix = s.sty.Messages.ShellBarFocused.Render()
+	} else {
+		prefix = s.sty.Messages.ShellBarBlurred.Render()
+	}
+	lines := strings.Split(content, "\n")
+	for i, ln := range lines {
+		lines[i] = prefix + ln
+	}
+	out := strings.Join(lines, "\n")
+
+	return s.renderHighlighted(out, width, lipgloss.Height(out))
+}
+
+// HandleMouseClick implements MouseClickable so clicks select this item.
+func (s *ShellItem) HandleMouseClick(btn ansi.MouseButton, x, y int) bool {
+	return btn == ansi.MouseLeft
+}
+
+// ToggleExpanded toggles the expanded state and invalidates the cache.
+func (s *ShellItem) ToggleExpanded() bool {
+	s.expandedContent = !s.expandedContent
+	s.Bump()
+	return s.expandedContent
+}
+
+func (s *ShellItem) RawRender(width int) string {
+	cappedWidth := cappedMessageWidth(width)
+
+	cmd := strings.ReplaceAll(s.command, "\n", " ")
+	cmd = strings.ReplaceAll(cmd, "\t", "    ")
+
+	var prompt string
+	if s.focused {
+		prompt = s.sty.Messages.ShellPrompt.Render("$")
+	} else {
+		prompt = s.sty.Messages.ShellPromptBlurred.Render("$")
+	}
+
+	highlighted, err := common.SyntaxHighlight(s.sty, cmd, "cmd.sh", s.sty.Background)
+	if err != nil || highlighted == "" {
+		highlighted = s.sty.Messages.ShellCommand.Render(cmd)
+	}
+	header := prompt + " " + highlighted
+
+	if s.exitCode != 0 {
+		header += " " + s.sty.Messages.ShellExitCode.Render(fmt.Sprintf("(exit %d)", s.exitCode))
+	}
+
+	if s.output == "" {
+		return header
+	}
+
+	output := strings.TrimRight(s.output, "\n")
+	lines := strings.Split(output, "\n")
+
+	maxLines := shellMaxCollapsedLines
+	if s.expandedContent {
+		maxLines = len(lines)
+	}
+
+	displayLines := lines
+	if len(lines) > maxLines {
+		displayLines = lines[:maxLines]
+	}
+
+	var body strings.Builder
+	for _, ln := range displayLines {
+		truncated := ansi.Truncate(ln, cappedWidth, "…")
+		body.WriteString(s.sty.Messages.ShellOutput.Render(truncated))
+		body.WriteString("\n")
+	}
+
+	if len(lines) > maxLines && !s.expandedContent {
+		body.WriteString(s.sty.Messages.ShellTruncation.Render(
+			fmt.Sprintf("… %d more lines", len(lines)-maxLines),
+		))
+	} else {
+		// Remove trailing newline from last line.
+		result := body.String()
+		return header + "\n" + strings.TrimRight(result, "\n")
+	}
+
+	return header + "\n" + body.String()
+}

--- a/internal/ui/chat/shell.go
+++ b/internal/ui/chat/shell.go
@@ -3,7 +3,9 @@ package chat
 import (
 	"fmt"
 	"strings"
+	"sync/atomic"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
 	"github.com/charmbracelet/crush/internal/ui/common"
@@ -12,7 +14,14 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-const shellMaxCollapsedLines = 10
+// shellSeq provides unique IDs for ShellItems even when the same
+// command is run multiple times.
+var shellSeq atomic.Int64
+
+const (
+	shellMaxCollapsedLines = 10
+	shellHScrollStep       = 5
+)
 
 // ShellItem renders a bang-mode shell command result in the chat with a
 // vertical bar on the left and plain-text output.
@@ -27,12 +36,15 @@ type ShellItem struct {
 	output          string
 	exitCode        int
 	expandedContent bool
+	xOffset         int
+	maxLineWidth    int // computed during render, used to clamp xOffset
 	sty             *styles.Styles
 }
 
 var (
 	_ Expandable         = (*ShellItem)(nil)
 	_ list.Highlightable = (*ShellItem)(nil)
+	_ KeyEventHandler    = (*ShellItem)(nil)
 )
 
 // NewShellItem creates a new ShellItem for displaying bang-mode results.
@@ -43,7 +55,7 @@ func NewShellItem(sty *styles.Styles, command, output string, exitCode int) Mess
 		highlightableMessageItem: defaultHighlighter(sty, v),
 		cachedMessageItem:        &cachedMessageItem{},
 		focusableMessageItem:     newFocusableMessageItem(v),
-		id:                       fmt.Sprintf("shell-%s", command),
+		id:                       fmt.Sprintf("shell-%d-%s", shellSeq.Add(1), command),
 		command:                  command,
 		output:                   output,
 		exitCode:                 exitCode,
@@ -77,6 +89,32 @@ func (s *ShellItem) Render(width int) string {
 // HandleMouseClick implements MouseClickable so clicks select this item.
 func (s *ShellItem) HandleMouseClick(btn ansi.MouseButton, x, y int) bool {
 	return btn == ansi.MouseLeft
+}
+
+// HandleKeyEvent implements KeyEventHandler for horizontal scrolling.
+func (s *ShellItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
+	switch key.String() {
+	case "shift+left", "H":
+		if s.xOffset > 0 {
+			s.xOffset = max(0, s.xOffset-shellHScrollStep)
+			s.Bump()
+			return true, nil
+		}
+	case "shift+right", "L":
+		s.xOffset = min(s.xOffset+shellHScrollStep, max(s.maxLineWidth, s.xOffset))
+		s.Bump()
+		return true, nil
+	}
+	return false, nil
+}
+
+// ScrollHorizontal adjusts the horizontal scroll offset by delta columns.
+func (s *ShellItem) ScrollHorizontal(delta int) {
+	s.xOffset = max(0, s.xOffset+delta)
+	if s.maxLineWidth > 0 {
+		s.xOffset = min(s.xOffset, s.maxLineWidth)
+	}
+	s.Bump()
 }
 
 // ToggleExpanded toggles the expanded state and invalidates the cache.
@@ -126,9 +164,23 @@ func (s *ShellItem) RawRender(width int) string {
 		displayLines = lines[:maxLines]
 	}
 
+	// Compute max line width for scroll clamping.
+	maxW := 0
+	for _, ln := range displayLines {
+		w := ansi.StringWidth(ln)
+		if w > maxW {
+			maxW = w
+		}
+	}
+	s.maxLineWidth = max(0, maxW-cappedWidth)
+
 	var body strings.Builder
 	for _, ln := range displayLines {
-		truncated := ansi.Truncate(ln, cappedWidth, "…")
+		scrolled := ansi.GraphemeWidth.Cut(ln, s.xOffset, len(ln))
+		truncated := ansi.Truncate(scrolled, cappedWidth, "…")
+		if s.xOffset > 0 && strings.TrimSpace(truncated) != "" {
+			truncated = "…" + truncated
+		}
 		body.WriteString(s.sty.Messages.ShellOutput.Render(truncated))
 		body.WriteString("\n")
 	}
@@ -138,7 +190,6 @@ func (s *ShellItem) RawRender(width int) string {
 			fmt.Sprintf("… %d more lines", len(lines)-maxLines),
 		))
 	} else {
-		// Remove trailing newline from last line.
 		result := body.String()
 		return header + "\n" + strings.TrimRight(result, "\n")
 	}

--- a/internal/ui/chat/shell.go
+++ b/internal/ui/chat/shell.go
@@ -194,5 +194,5 @@ func (s *ShellItem) RawRender(width int) string {
 		return header + "\n" + strings.TrimRight(result, "\n")
 	}
 
-	return header + "\n" + body.String()
+	return header + "\n" + strings.TrimRight(body.String(), "\n")
 }

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -614,6 +614,21 @@ func (m *Chat) ToggleExpandedSelectedItem() {
 	}
 }
 
+// IsSelectedShellItem returns true if the currently selected item is a
+// ShellItem (bang-mode result).
+func (m *Chat) IsSelectedShellItem() bool {
+	_, ok := m.list.SelectedItem().(*chat.ShellItem)
+	return ok
+}
+
+// ScrollSelectedShellHorizontal scrolls the selected ShellItem horizontally
+// by delta columns. No-op if the selected item is not a ShellItem.
+func (m *Chat) ScrollSelectedShellHorizontal(delta int) {
+	if shell, ok := m.list.SelectedItem().(*chat.ShellItem); ok {
+		shell.ScrollHorizontal(delta)
+	}
+}
+
 // HandleKeyMsg handles key events for the chat component.
 func (m *Chat) HandleKeyMsg(key tea.KeyMsg) (bool, tea.Cmd) {
 	if m.list.Focused() {

--- a/internal/ui/model/header.go
+++ b/internal/ui/model/header.go
@@ -157,7 +157,7 @@ func renderHeaderDetails(
 	}
 
 	if com.IsHyper() && hyperCredits != nil {
-		hc := t.Header.Hypercredit.Render(styles.HypercreditIcon) + " " + t.Header.Percentage.Render(common.FormatCredits(*hyperCredits))
+		hc := t.Header.HypercreditIcon.Render(styles.HypercreditIcon) + " " + t.Header.Percentage.Render(common.FormatCredits(*hyperCredits))
 		parts = append(parts, hc)
 	}
 

--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -47,6 +47,8 @@ type KeyMap struct {
 		Copy           key.Binding
 		ClearHighlight key.Binding
 		Expand         key.Binding
+		ScrollLeft     key.Binding
+		ScrollRight    key.Binding
 	}
 
 	Initialize struct {
@@ -249,6 +251,14 @@ func DefaultKeyMap() KeyMap {
 	km.Chat.Expand = key.NewBinding(
 		key.WithKeys("space"),
 		key.WithHelp("space", "expand/collapse"),
+	)
+	km.Chat.ScrollLeft = key.NewBinding(
+		key.WithKeys("shift+left", "H"),
+		key.WithHelp("shift+←/H", "scroll left"),
+	)
+	km.Chat.ScrollRight = key.NewBinding(
+		key.WithKeys("shift+right", "L"),
+		key.WithHelp("shift+→/L", "scroll right"),
 	)
 	km.Initialize.Yes = key.NewBinding(
 		key.WithKeys("y", "Y"),

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2116,7 +2116,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				// Bang mode: enter when "!" typed on empty prompt, exit on
 				// backspace clearing the last character.
 				newVal := m.textarea.Value()
-				if !m.bangMode && newVal == "!" {
+				if !m.bangMode && strings.TrimSpace(newVal) == "!" {
 					m.bangMode = true
 					m.bangWasEmpty = true
 					m.textarea.Reset()

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -998,12 +998,14 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case uiFocusMain:
 	case uiFocusEditor:
 		// Textarea placeholder logic
-		if m.isAgentBusy() {
+		if m.bangMode {
+			m.textarea.Placeholder = "Run a shell command..."
+		} else if m.isAgentBusy() {
 			m.textarea.Placeholder = m.workingPlaceholder
 		} else {
 			m.textarea.Placeholder = m.readyPlaceholder
 		}
-		if m.com.Workspace.PermissionSkipRequests() {
+		if !m.bangMode && m.com.Workspace.PermissionSkipRequests() {
 			m.textarea.Placeholder = "Yolo mode!"
 		}
 	}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -999,7 +999,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case uiFocusEditor:
 		// Textarea placeholder logic
 		if m.bangMode {
-			m.textarea.Placeholder = "Run a shell command..."
+			m.textarea.Placeholder = "Run a shell command"
 		} else if m.isAgentBusy() {
 			m.textarea.Placeholder = m.workingPlaceholder
 		} else {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -876,6 +876,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// others send DeltaY=1.
 		switch m.state {
 		case uiChat:
+			if msg.DeltaX != 0 {
+				m.chat.ScrollSelectedShellHorizontal(int(msg.DeltaX))
+			}
 			lines := int(msg.DeltaY)
 			if lines == 0 {
 				break
@@ -1998,12 +2001,6 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				value = strings.TrimSpace(value)
 				if value == "exit" || value == "quit" {
 					return m.openQuitDialog()
-				}
-
-				if command, ok := strings.CutPrefix(value, "!"); ok && command != "" {
-					m.randomizePlaceholders()
-					m.historyReset()
-					return tea.Batch(m.runShellCommand(command), m.loadPromptHistory())
 				}
 
 				if m.bangMode && value != "" {
@@ -3386,12 +3383,25 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 // runShellCommand executes a shell command server-side without triggering
 // the LLM. The result is displayed as a tool-style item in the chat.
 func (m *UI) runShellCommand(command string) tea.Cmd {
-	return func() tea.Msg {
-		sessionID := ""
-		if m.hasSession() {
-			sessionID = m.session.ID
+	var cmds []tea.Cmd
+	if !m.hasSession() {
+		newSession, err := m.com.Workspace.CreateSession(context.Background(), "New Session")
+		if err != nil {
+			return util.ReportError(err)
 		}
-		contentWidth := min(m.layout.main.Dx()-2, 120)
+		if m.forceCompactMode {
+			m.isCompact = true
+		}
+		if newSession.ID != "" {
+			m.session = &newSession
+			cmds = append(cmds, m.loadSession(newSession.ID))
+		}
+		m.setState(uiChat, m.focus)
+	}
+
+	sessionID := m.session.ID
+	contentWidth := min(m.layout.main.Dx()-2, 120)
+	cmds = append(cmds, func() tea.Msg {
 		resp, err := m.com.Workspace.AgentRunShellCommand(context.Background(), sessionID, command, contentWidth)
 		if err != nil {
 			return util.InfoMsg{
@@ -3404,7 +3414,8 @@ func (m *UI) runShellCommand(command string) tea.Cmd {
 			Output:   resp.Output,
 			ExitCode: resp.ExitCode,
 		}
-	}
+	})
+	return tea.Batch(cmds...)
 }
 
 const cancelTimerDuration = 2 * time.Second

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1972,6 +1972,12 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					return m.openQuitDialog()
 				}
 
+				if command, ok := strings.CutPrefix(value, "!"); ok && command != "" {
+					m.randomizePlaceholders()
+					m.historyReset()
+					return tea.Batch(m.runShellCommand(command), m.loadPromptHistory())
+				}
+
 				attachments := m.attachments.List()
 				m.attachments.Reset()
 				if len(value) == 0 && !message.ContainsTextAttachment(attachments) {
@@ -3293,6 +3299,25 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 		return nil
 	})
 	return tea.Batch(cmds...)
+}
+
+// runShellCommand executes a shell command server-side without triggering
+// the LLM. The command and output are persisted as a user message.
+func (m *UI) runShellCommand(command string) tea.Cmd {
+	if !m.hasSession() {
+		return util.ReportError(fmt.Errorf("no active session"))
+	}
+	sessionID := m.session.ID
+	return func() tea.Msg {
+		_, err := m.com.Workspace.AgentRunShellCommand(context.Background(), sessionID, command)
+		if err != nil {
+			return util.InfoMsg{
+				Type: util.InfoTypeError,
+				Msg:  fmt.Sprintf("shell: %v", err),
+			}
+		}
+		return nil
+	}
 }
 
 const cancelTimerDuration = 2 * time.Second

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -111,6 +111,12 @@ type openEditorMsg struct {
 	Text string
 }
 
+type shellResultMsg struct {
+	Command  string
+	Output   string
+	ExitCode int
+}
+
 type (
 	// cancelTimerExpiredMsg is sent when the cancel timer expires.
 	cancelTimerExpiredMsg struct{}
@@ -191,6 +197,10 @@ type UI struct {
 
 	// isCanceling tracks whether the user has pressed escape once to cancel.
 	isCanceling bool
+
+	// bangMode tracks whether the editor is in bang (!) shell mode.
+	bangMode     bool
+	bangWasEmpty bool // true when bang prompt became empty on last keystroke
 
 	header *header
 
@@ -926,6 +936,12 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.textarea.SetValue(msg.Text)
 		m.textarea.MoveToEnd()
 		cmds = append(cmds, m.updateTextareaWithPrevHeight(msg, prevHeight))
+	case shellResultMsg:
+		item := chat.NewShellItem(m.com.Styles, msg.Command, msg.Output, msg.ExitCode)
+		m.chat.AppendMessages(item)
+		if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case hyperRefreshDoneMsg:
 		if cmd := m.handleSelectModel(msg.action); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -1118,6 +1134,18 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 
 	switch msg.Role {
 	case message.User:
+		// Shell commands are rendered live via shellResultMsg; skip
+		// the persisted duplicate.
+		hasShellCmd := false
+		for _, part := range msg.Parts {
+			if _, ok := part.(message.ShellCommand); ok {
+				hasShellCmd = true
+				break
+			}
+		}
+		if hasShellCmd {
+			return nil
+		}
 		m.lastUserMessageTime = msg.CreatedAt
 		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil)
 		for _, item := range items {
@@ -1978,6 +2006,15 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					return tea.Batch(m.runShellCommand(command), m.loadPromptHistory())
 				}
 
+				if m.bangMode && value != "" {
+					m.bangMode = false
+					yolo := m.com.Workspace.PermissionSkipRequests()
+					m.setEditorPrompt(yolo)
+					m.randomizePlaceholders()
+					m.historyReset()
+					return tea.Batch(m.runShellCommand(value), m.loadPromptHistory())
+				}
+
 				attachments := m.attachments.List()
 				m.attachments.Reset()
 				if len(value) == 0 && !message.ContainsTextAttachment(attachments) {
@@ -2042,6 +2079,15 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					break
 				}
 
+				// Bang mode: backspace on already-empty prompt exits.
+				if m.bangMode && m.bangWasEmpty && msg.Code == tea.KeyBackspace {
+					m.bangMode = false
+					m.bangWasEmpty = false
+					yolo := m.com.Workspace.PermissionSkipRequests()
+					m.setEditorPrompt(yolo)
+					break
+				}
+
 				// Check for @ trigger before passing to textarea.
 				curValue := m.textarea.Value()
 				curIdx := len(curValue)
@@ -2067,6 +2113,22 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 
 				prevHeight := m.textarea.Height()
 				cmds = append(cmds, m.updateTextareaWithPrevHeight(msg, prevHeight))
+
+				// Bang mode: enter when "!" typed on empty prompt, exit on
+				// backspace clearing the last character.
+				newVal := m.textarea.Value()
+				if !m.bangMode && newVal == "!" {
+					m.bangMode = true
+					m.bangWasEmpty = true
+					m.textarea.Reset()
+					yolo := m.com.Workspace.PermissionSkipRequests()
+					m.setEditorPrompt(yolo)
+				} else if m.bangMode && newVal == "" && curValue != "" {
+					// Just cleared last character; mark empty, stay in bang mode.
+					m.bangWasEmpty = true
+				} else if m.bangMode && newVal != "" {
+					m.bangWasEmpty = false
+				}
 
 				// Any text modification becomes the current draft.
 				m.updateHistoryDraft(curValue)
@@ -2948,8 +3010,12 @@ func (m *UI) openEditor(value string) tea.Cmd {
 }
 
 // setEditorPrompt configures the textarea prompt function based on whether
-// yolo mode is enabled.
+// yolo mode or bang mode is enabled.
 func (m *UI) setEditorPrompt(yolo bool) {
+	if m.bangMode {
+		m.textarea.SetPromptFunc(4, m.bangPromptFunc)
+		return
+	}
 	if yolo {
 		m.textarea.SetPromptFunc(4, m.yoloPromptFunc)
 		return
@@ -2988,6 +3054,22 @@ func (m *UI) yoloPromptFunc(info textarea.PromptInfo) string {
 		return t.Editor.PromptYoloDotsFocused.Render()
 	}
 	return t.Editor.PromptYoloDotsBlurred.Render()
+}
+
+// bangPromptFunc returns the bang mode editor prompt style with Turtle-colored
+// icon and dots.
+func (m *UI) bangPromptFunc(info textarea.PromptInfo) string {
+	t := m.com.Styles
+	if info.LineNumber == 0 {
+		if info.Focused {
+			return t.Editor.PromptBangIconFocused.Render()
+		}
+		return t.Editor.PromptBangIconBlurred.Render()
+	}
+	if info.Focused {
+		return t.Editor.PromptBangDotsFocused.Render()
+	}
+	return t.Editor.PromptBangDotsBlurred.Render()
 }
 
 // closeCompletions closes the completions popup and resets state.
@@ -3302,21 +3384,26 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 }
 
 // runShellCommand executes a shell command server-side without triggering
-// the LLM. The command and output are persisted as a user message.
+// the LLM. The result is displayed as a tool-style item in the chat.
 func (m *UI) runShellCommand(command string) tea.Cmd {
-	if !m.hasSession() {
-		return util.ReportError(fmt.Errorf("no active session"))
-	}
-	sessionID := m.session.ID
 	return func() tea.Msg {
-		_, err := m.com.Workspace.AgentRunShellCommand(context.Background(), sessionID, command)
+		sessionID := ""
+		if m.hasSession() {
+			sessionID = m.session.ID
+		}
+		contentWidth := min(m.layout.main.Dx()-2, 120)
+		resp, err := m.com.Workspace.AgentRunShellCommand(context.Background(), sessionID, command, contentWidth)
 		if err != nil {
 			return util.InfoMsg{
 				Type: util.InfoTypeError,
 				Msg:  fmt.Sprintf("shell: %v", err),
 			}
 		}
-		return nil
+		return shellResultMsg{
+			Command:  command,
+			Output:   resp.Output,
+			ExitCode: resp.ExitCode,
+		}
 	}
 }
 

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -699,6 +699,10 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Editor.PromptYoloIconBlurred = s.Editor.PromptYoloIconFocused.Foreground(o.bgBase).Background(o.fgMoreSubtle)
 	s.Editor.PromptYoloDotsFocused = lipgloss.NewStyle().MarginRight(1).Foreground(o.warningSubtle).SetString(":::")
 	s.Editor.PromptYoloDotsBlurred = s.Editor.PromptYoloDotsFocused.Foreground(o.fgMoreSubtle)
+	s.Editor.PromptBangIconFocused = lipgloss.NewStyle().MarginRight(1).Foreground(o.fgMostSubtle).Background(charmtone.Turtle).Bold(true).SetString(" ! ")
+	s.Editor.PromptBangIconBlurred = s.Editor.PromptBangIconFocused.Foreground(o.bgBase).Background(o.fgMoreSubtle)
+	s.Editor.PromptBangDotsFocused = lipgloss.NewStyle().MarginRight(1).Foreground(charmtone.Turtle).SetString(":::")
+	s.Editor.PromptBangDotsBlurred = s.Editor.PromptBangDotsFocused.Foreground(o.fgMoreSubtle)
 
 	s.Radio.On = lipgloss.NewStyle().Foreground(o.fgSubtle).SetString(RadioOn)
 	s.Radio.Off = lipgloss.NewStyle().Foreground(o.fgSubtle).SetString(RadioOff)
@@ -803,6 +807,20 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Messages.ToolCallBlurred = muted.PaddingLeft(2)
 	// No padding or border for compact tool calls within messages
 	s.Messages.ToolCallCompact = muted
+
+	// Shell (bang mode) item styles.
+	s.Messages.ShellBarFocused = lipgloss.NewStyle().PaddingLeft(1).
+		BorderStyle(messageFocussedBorder).BorderLeft(true).
+		BorderForeground(charmtone.Lichen)
+	s.Messages.ShellBarBlurred = lipgloss.NewStyle().PaddingLeft(1).BorderLeft(true).
+		BorderForeground(charmtone.Turtle).BorderStyle(lipgloss.NormalBorder())
+	s.Messages.ShellPrompt = base.Foreground(charmtone.Lichen).Bold(true)
+	s.Messages.ShellPromptBlurred = base.Foreground(charmtone.Turtle)
+	s.Messages.ShellCommand = base.Foreground(o.fgBase)
+	s.Messages.ShellOutput = subtle
+	s.Messages.ShellExitCode = lipgloss.NewStyle().Foreground(o.destructive)
+	s.Messages.ShellTruncation = muted
+
 	s.Messages.SectionHeader = base.PaddingLeft(2)
 	s.Messages.AssistantInfoIcon = subtle
 	s.Messages.AssistantInfoModel = muted

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -695,13 +695,13 @@ func quickStyle(o quickStyleOpts) Styles {
 	// Editor
 	s.Editor.PromptNormalFocused = lipgloss.NewStyle().Foreground(o.successMostSubtle).SetString("::: ")
 	s.Editor.PromptNormalBlurred = s.Editor.PromptNormalFocused.Foreground(o.fgMoreSubtle)
-	s.Editor.PromptYoloIconFocused = lipgloss.NewStyle().MarginRight(1).Foreground(o.fgMostSubtle).Background(o.busy).Bold(true).SetString(" ! ")
+	s.Editor.PromptYoloIconFocused = lipgloss.NewStyle().MarginRight(1).Foreground(o.fgMostSubtle).Background(o.busy).Bold(true).SetString(" Y ")
 	s.Editor.PromptYoloIconBlurred = s.Editor.PromptYoloIconFocused.Foreground(o.bgBase).Background(o.fgMoreSubtle)
 	s.Editor.PromptYoloDotsFocused = lipgloss.NewStyle().MarginRight(1).Foreground(o.warningSubtle).SetString(":::")
 	s.Editor.PromptYoloDotsBlurred = s.Editor.PromptYoloDotsFocused.Foreground(o.fgMoreSubtle)
-	s.Editor.PromptBangIconFocused = lipgloss.NewStyle().MarginRight(1).Foreground(o.fgMostSubtle).Background(charmtone.Turtle).Bold(true).SetString(" ! ")
+	s.Editor.PromptBangIconFocused = lipgloss.NewStyle().MarginRight(1).Foreground(charmtone.Salt).Background(charmtone.Hazy).Bold(true).SetString(" ! ")
 	s.Editor.PromptBangIconBlurred = s.Editor.PromptBangIconFocused.Foreground(o.bgBase).Background(o.fgMoreSubtle)
-	s.Editor.PromptBangDotsFocused = lipgloss.NewStyle().MarginRight(1).Foreground(charmtone.Turtle).SetString(":::")
+	s.Editor.PromptBangDotsFocused = lipgloss.NewStyle().MarginRight(1).Foreground(charmtone.Hazy).SetString(":::")
 	s.Editor.PromptBangDotsBlurred = s.Editor.PromptBangDotsFocused.Foreground(o.fgMoreSubtle)
 
 	s.Radio.On = lipgloss.NewStyle().Foreground(o.fgSubtle).SetString(RadioOn)
@@ -811,11 +811,11 @@ func quickStyle(o quickStyleOpts) Styles {
 	// Shell (bang mode) item styles.
 	s.Messages.ShellBarFocused = lipgloss.NewStyle().PaddingLeft(1).
 		BorderStyle(messageFocussedBorder).BorderLeft(true).
-		BorderForeground(charmtone.Lichen)
+		BorderForeground(charmtone.Char)
 	s.Messages.ShellBarBlurred = lipgloss.NewStyle().PaddingLeft(1).BorderLeft(true).
-		BorderForeground(charmtone.Turtle).BorderStyle(lipgloss.NormalBorder())
-	s.Messages.ShellPrompt = base.Foreground(charmtone.Lichen).Bold(true)
-	s.Messages.ShellPromptBlurred = base.Foreground(charmtone.Turtle)
+		BorderForeground(charmtone.Char).BorderStyle(lipgloss.NormalBorder())
+	s.Messages.ShellPrompt = base.Foreground(charmtone.Hazy).Bold(true)
+	s.Messages.ShellPromptBlurred = base.Foreground(charmtone.Char)
 	s.Messages.ShellCommand = base.Foreground(o.fgBase)
 	s.Messages.ShellOutput = subtle
 	s.Messages.ShellExitCode = lipgloss.NewStyle().Foreground(o.destructive)

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -578,7 +578,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Header.Charm = base.Foreground(o.secondary)
 	s.Header.Diagonals = base.Foreground(o.primary)
 	s.Header.Percentage = muted
-	s.Header.Hypercredit = base.Foreground(charmtone.Dolly)
+	s.Header.HypercreditIcon = base.Foreground(o.secondary)
 	s.Header.Keystroke = muted
 	s.Header.KeystrokeTip = subtle
 	s.Header.WorkingDir = muted
@@ -699,9 +699,9 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Editor.PromptYoloIconBlurred = s.Editor.PromptYoloIconFocused.Foreground(o.bgBase).Background(o.fgMoreSubtle)
 	s.Editor.PromptYoloDotsFocused = lipgloss.NewStyle().MarginRight(1).Foreground(o.warningSubtle).SetString(":::")
 	s.Editor.PromptYoloDotsBlurred = s.Editor.PromptYoloDotsFocused.Foreground(o.fgMoreSubtle)
-	s.Editor.PromptBangIconFocused = lipgloss.NewStyle().MarginRight(1).Foreground(charmtone.Salt).Background(charmtone.Hazy).Bold(true).SetString(" ! ")
+	s.Editor.PromptBangIconFocused = lipgloss.NewStyle().MarginRight(1).Foreground(o.onPrimary).Background(o.primary).Bold(true).SetString(" ! ")
 	s.Editor.PromptBangIconBlurred = s.Editor.PromptBangIconFocused.Foreground(o.bgBase).Background(o.fgMoreSubtle)
-	s.Editor.PromptBangDotsFocused = lipgloss.NewStyle().MarginRight(1).Foreground(charmtone.Hazy).SetString(":::")
+	s.Editor.PromptBangDotsFocused = lipgloss.NewStyle().MarginRight(1).Foreground(o.primary).SetString(":::")
 	s.Editor.PromptBangDotsBlurred = s.Editor.PromptBangDotsFocused.Foreground(o.fgMoreSubtle)
 
 	s.Radio.On = lipgloss.NewStyle().Foreground(o.fgSubtle).SetString(RadioOn)
@@ -773,7 +773,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.ModelInfo.TokenPercentage = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)
 	s.ModelInfo.EstimatedUsagePrefix = s.ModelInfo.TokenPercentage
 	s.ModelInfo.Cost = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)
-	s.ModelInfo.HypercreditIcon = lipgloss.NewStyle().Foreground(charmtone.Dolly)
+	s.ModelInfo.HypercreditIcon = lipgloss.NewStyle().Foreground(o.secondary)
 	s.ModelInfo.HypercreditText = lipgloss.NewStyle().Foreground(o.fgMoreSubtle)
 
 	// ResourceGroup
@@ -811,11 +811,11 @@ func quickStyle(o quickStyleOpts) Styles {
 	// Shell (bang mode) item styles.
 	s.Messages.ShellBarFocused = lipgloss.NewStyle().PaddingLeft(1).
 		BorderStyle(messageFocussedBorder).BorderLeft(true).
-		BorderForeground(charmtone.Char)
+		BorderForeground(o.primary)
 	s.Messages.ShellBarBlurred = lipgloss.NewStyle().PaddingLeft(1).BorderLeft(true).
-		BorderForeground(charmtone.Char).BorderStyle(lipgloss.NormalBorder())
-	s.Messages.ShellPrompt = base.Foreground(charmtone.Hazy).Bold(true)
-	s.Messages.ShellPromptBlurred = base.Foreground(charmtone.Char)
+		BorderForeground(o.bgMostVisible).BorderStyle(lipgloss.NormalBorder())
+	s.Messages.ShellPrompt = base.Foreground(o.primary).Bold(true)
+	s.Messages.ShellPromptBlurred = base.Foreground(o.fgMoreSubtle)
 	s.Messages.ShellCommand = base.Foreground(o.fgBase)
 	s.Messages.ShellOutput = subtle
 	s.Messages.ShellExitCode = lipgloss.NewStyle().Foreground(o.destructive)

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -65,7 +65,7 @@ type Styles struct {
 		Charm             lipgloss.Style // Style for "Charm™" label
 		Diagonals         lipgloss.Style // Style for diagonal separators (╱)
 		Percentage        lipgloss.Style // Style for context percentage
-		Hypercredit       lipgloss.Style // Style for Hypercredit count (◆ N)
+		HypercreditIcon   lipgloss.Style // Style for Hypercredit count (◆ N)
 		Keystroke         lipgloss.Style // Style for keystroke hints (e.g., "ctrl+d")
 		KeystrokeTip      lipgloss.Style // Style for keystroke action text (e.g., "open", "close")
 		WorkingDir        lipgloss.Style // Style for current working directory

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -123,6 +123,12 @@ type Styles struct {
 		PromptYoloIconBlurred lipgloss.Style
 		PromptYoloDotsFocused lipgloss.Style
 		PromptYoloDotsBlurred lipgloss.Style
+
+		// Bang mode prompt (" ! " icon + ":::" dots, Turtle color).
+		PromptBangIconFocused lipgloss.Style
+		PromptBangIconBlurred lipgloss.Style
+		PromptBangDotsFocused lipgloss.Style
+		PromptBangDotsBlurred lipgloss.Style
 	}
 
 	// Radio
@@ -241,7 +247,17 @@ type Styles struct {
 		ToolCallFocused  lipgloss.Style
 		ToolCallCompact  lipgloss.Style
 		ToolCallBlurred  lipgloss.Style
-		SectionHeader    lipgloss.Style
+
+		// Shell (bang mode) item styles.
+		ShellBarFocused    lipgloss.Style // Left vertical bar when focused.
+		ShellBarBlurred    lipgloss.Style // Left vertical bar when blurred.
+		ShellPrompt        lipgloss.Style // "$" prompt symbol (focused).
+		ShellPromptBlurred lipgloss.Style // "$" prompt symbol (blurred).
+		ShellCommand       lipgloss.Style // Command text (syntax-highlighted).
+		ShellOutput        lipgloss.Style // Plain output text.
+		ShellExitCode      lipgloss.Style // Non-zero exit code indicator.
+		ShellTruncation    lipgloss.Style // "N more lines" hint.
+		SectionHeader      lipgloss.Style
 
 		// Thinking section styles
 		ThinkingBox            lipgloss.Style // Background for thinking content

--- a/internal/ui/styles/themes.go
+++ b/internal/ui/styles/themes.go
@@ -1,6 +1,8 @@
 package styles
 
-import "github.com/charmbracelet/x/exp/charmtone"
+import (
+	"github.com/charmbracelet/x/exp/charmtone"
+)
 
 // ThemeForProvider returns the Styles associated with the given provider
 // ID. Unknown or empty provider IDs yield the default Charmtone Pantera
@@ -17,7 +19,7 @@ func ThemeForProvider(providerID string) Styles {
 // CharmtonePantera returns the Charmtone dark theme. It's the default style
 // for the UI.
 func CharmtonePantera() Styles {
-	return quickStyle(quickStyleOpts{
+	s := quickStyle(quickStyleOpts{
 		primary:   charmtone.Charple,
 		secondary: charmtone.Dolly,
 		accent:    charmtone.Bok,
@@ -50,40 +52,30 @@ func CharmtonePantera() Styles {
 		successMoreSubtle: charmtone.Bok,
 		successMostSubtle: charmtone.Guac,
 	})
+
+	// Bang ! prompt overrides - use Salt/Hazy/Larple colors.
+	s.Editor.PromptBangIconFocused = s.Editor.PromptBangIconFocused.
+		Foreground(charmtone.Salt).
+		Background(charmtone.Hazy)
+	s.Editor.PromptBangDotsFocused = s.Editor.PromptBangDotsFocused.
+		Foreground(charmtone.Hazy)
+	s.Editor.PromptBangDotsBlurred = s.Editor.PromptBangDotsBlurred.
+		Foreground(charmtone.Larple)
+
+	// Shell bar/prompt overrides - use Charple/Iron/Hazy colors.
+	s.Messages.ShellBarFocused = s.Messages.ShellBarFocused.
+		BorderForeground(charmtone.Charple)
+	s.Messages.ShellBarBlurred = s.Messages.ShellBarBlurred.
+		BorderForeground(charmtone.Iron)
+	s.Messages.ShellPrompt = s.Messages.ShellPrompt.
+		Foreground(charmtone.Hazy)
+	s.Messages.ShellPromptBlurred = s.Messages.ShellPromptBlurred.
+		Foreground(charmtone.Hazy)
+
+	return s
 }
 
 // HypercrushObsidiana returns the Hypercrush dark theme.
 func HypercrushObsidiana() Styles {
-	return quickStyle(quickStyleOpts{
-		primary:   charmtone.Charple,
-		secondary: charmtone.Dolly,
-		accent:    charmtone.Bok,
-
-		fgBase:       charmtone.Sash,
-		fgMoreSubtle: charmtone.Squid,
-		fgSubtle:     charmtone.Smoke,
-		fgMostSubtle: charmtone.Oyster,
-
-		onPrimary: charmtone.Butter,
-
-		bgBase:         charmtone.Pepper,
-		bgLeastVisible: charmtone.BBQ,
-		bgLessVisible:  charmtone.Char,
-		bgMostVisible:  charmtone.Iron,
-
-		separator: charmtone.Char,
-
-		destructive:       charmtone.Coral,
-		error:             charmtone.Sriracha,
-		warningSubtle:     charmtone.Zest,
-		warning:           charmtone.Mustard,
-		denied:            charmtone.Tang,
-		busy:              charmtone.Citron,
-		info:              charmtone.Malibu,
-		infoMoreSubtle:    charmtone.Sardine,
-		infoMostSubtle:    charmtone.Damson,
-		success:           charmtone.Julep,
-		successMoreSubtle: charmtone.Bok,
-		successMostSubtle: charmtone.Guac,
-	})
+	return CharmtonePantera()
 }

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -17,7 +18,9 @@ import (
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/charmbracelet/crush/internal/permission"
+	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/shell"
 	"github.com/charmbracelet/crush/internal/skills"
 )
 
@@ -103,6 +106,43 @@ func (w *AppWorkspace) AgentRun(ctx context.Context, sessionID, prompt string, a
 	}
 	_, err := w.app.AgentCoordinator.Run(ctx, sessionID, prompt, attachments...)
 	return err
+}
+
+func (w *AppWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string) (proto.ShellCommandResponse, error) {
+	var stdout, stderr bytes.Buffer
+	runErr := shell.Run(ctx, shell.RunOptions{
+		Command: command,
+		Cwd:     w.store.WorkingDir(),
+		Stdout:  &stdout,
+		Stderr:  &stderr,
+	})
+
+	exitCode := 0
+	if runErr != nil {
+		exitCode = shell.ExitCode(runErr)
+	}
+
+	output := stdout.String()
+	if stderr.Len() > 0 {
+		if output != "" {
+			output += "\n"
+		}
+		output += stderr.String()
+	}
+
+	// Persist as a user message so the LLM has context on follow-up.
+	msgContent := fmt.Sprintf("$ %s\n%s", command, output)
+	if sessionID != "" {
+		_, _ = w.app.Messages.Create(ctx, sessionID, message.CreateMessageParams{
+			Role:  message.User,
+			Parts: []message.ContentPart{message.TextContent{Text: msgContent}},
+		})
+	}
+
+	return proto.ShellCommandResponse{
+		Output:   output,
+		ExitCode: exitCode,
+	}, nil
 }
 
 func (w *AppWorkspace) AgentCancel(sessionID string) {

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -109,26 +108,28 @@ func (w *AppWorkspace) AgentRun(ctx context.Context, sessionID, prompt string, a
 }
 
 func (w *AppWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int) (proto.ShellCommandResponse, error) {
-	result, err := shell.RunAndCapturePTY(ctx, shell.RunOptions{
+	var persist shell.PersistFunc
+	if sessionID != "" {
+		persist = func(cmd, output string, exitCode int) error {
+			_, err := w.app.Messages.Create(ctx, sessionID, message.CreateMessageParams{
+				Role: message.User,
+				Parts: []message.ContentPart{message.ShellCommand{
+					Command:  cmd,
+					Output:   output,
+					ExitCode: exitCode,
+				}},
+			})
+			return err
+		}
+	}
+
+	result, err := shell.RunAndPersist(ctx, shell.RunOptions{
 		Command:   command,
 		Cwd:       w.store.WorkingDir(),
 		TermWidth: termWidth,
-	})
+	}, persist)
 	if err != nil {
 		return proto.ShellCommandResponse{}, err
-	}
-
-	if sessionID != "" {
-		if _, err := w.app.Messages.Create(ctx, sessionID, message.CreateMessageParams{
-			Role: message.User,
-			Parts: []message.ContentPart{message.ShellCommand{
-				Command:  command,
-				Output:   result.Output,
-				ExitCode: result.ExitCode,
-			}},
-		}); err != nil {
-			slog.Error("Failed to persist shell command output", "error", err, "session_id", sessionID)
-		}
 	}
 
 	return proto.ShellCommandResponse{

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -1,10 +1,10 @@
 package workspace
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -108,40 +108,32 @@ func (w *AppWorkspace) AgentRun(ctx context.Context, sessionID, prompt string, a
 	return err
 }
 
-func (w *AppWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string) (proto.ShellCommandResponse, error) {
-	var stdout, stderr bytes.Buffer
-	runErr := shell.Run(ctx, shell.RunOptions{
-		Command: command,
-		Cwd:     w.store.WorkingDir(),
-		Stdout:  &stdout,
-		Stderr:  &stderr,
+func (w *AppWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int) (proto.ShellCommandResponse, error) {
+	result, err := shell.RunAndCapturePTY(ctx, shell.RunOptions{
+		Command:   command,
+		Cwd:       w.store.WorkingDir(),
+		TermWidth: termWidth,
 	})
-
-	exitCode := 0
-	if runErr != nil {
-		exitCode = shell.ExitCode(runErr)
+	if err != nil {
+		return proto.ShellCommandResponse{}, err
 	}
 
-	output := stdout.String()
-	if stderr.Len() > 0 {
-		if output != "" {
-			output += "\n"
-		}
-		output += stderr.String()
-	}
-
-	// Persist as a user message so the LLM has context on follow-up.
-	msgContent := fmt.Sprintf("$ %s\n%s", command, output)
 	if sessionID != "" {
-		_, _ = w.app.Messages.Create(ctx, sessionID, message.CreateMessageParams{
-			Role:  message.User,
-			Parts: []message.ContentPart{message.TextContent{Text: msgContent}},
-		})
+		if _, err := w.app.Messages.Create(ctx, sessionID, message.CreateMessageParams{
+			Role: message.User,
+			Parts: []message.ContentPart{message.ShellCommand{
+				Command:  command,
+				Output:   result.Output,
+				ExitCode: result.ExitCode,
+			}},
+		}); err != nil {
+			slog.Error("Failed to persist shell command output", "error", err, "session_id", sessionID)
+		}
 	}
 
 	return proto.ShellCommandResponse{
-		Output:   output,
-		ExitCode: exitCode,
+		Output:   result.Output,
+		ExitCode: result.ExitCode,
 	}, nil
 }
 

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -186,6 +186,10 @@ func (w *ClientWorkspace) AgentRun(ctx context.Context, sessionID, prompt string
 	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", prompt, attachments...)
 }
 
+func (w *ClientWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string) (proto.ShellCommandResponse, error) {
+	return w.client.RunShellCommand(ctx, w.workspaceID(), sessionID, command)
+}
+
 func (w *ClientWorkspace) AgentCancel(sessionID string) {
 	_ = w.client.CancelAgentSession(context.Background(), w.workspaceID(), sessionID)
 }

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -187,7 +187,7 @@ func (w *ClientWorkspace) AgentRun(ctx context.Context, sessionID, prompt string
 }
 
 func (w *ClientWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int) (proto.ShellCommandResponse, error) {
-	return w.client.RunShellCommand(ctx, w.workspaceID(), sessionID, command)
+	return w.client.RunShellCommand(ctx, w.workspaceID(), sessionID, command, termWidth)
 }
 
 func (w *ClientWorkspace) AgentCancel(sessionID string) {
@@ -869,6 +869,12 @@ func protoToMessage(m proto.Message) message.Message {
 			msg.Parts = append(msg.Parts, message.ImageURLContent{URL: v.URL, Detail: v.Detail})
 		case proto.BinaryContent:
 			msg.Parts = append(msg.Parts, message.BinaryContent{Path: v.Path, MIMEType: v.MIMEType, Data: v.Data})
+		case proto.ShellCommand:
+			msg.Parts = append(msg.Parts, message.ShellCommand{
+				Command:  v.Command,
+				Output:   v.Output,
+				ExitCode: v.ExitCode,
+			})
 		}
 	}
 

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -186,7 +186,7 @@ func (w *ClientWorkspace) AgentRun(ctx context.Context, sessionID, prompt string
 	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", prompt, attachments...)
 }
 
-func (w *ClientWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string) (proto.ShellCommandResponse, error) {
+func (w *ClientWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int) (proto.ShellCommandResponse, error) {
 	return w.client.RunShellCommand(ctx, w.workspaceID(), sessionID, command)
 }
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -17,6 +17,7 @@ import (
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/charmbracelet/crush/internal/permission"
+	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/skills"
 )
@@ -82,6 +83,7 @@ type Workspace interface {
 
 	// Agent
 	AgentRun(ctx context.Context, sessionID, prompt string, attachments ...message.Attachment) error
+	AgentRunShellCommand(ctx context.Context, sessionID, command string) (proto.ShellCommandResponse, error)
 	AgentCancel(sessionID string)
 	AgentIsBusy() bool
 	AgentIsSessionBusy(sessionID string) bool

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -83,7 +83,7 @@ type Workspace interface {
 
 	// Agent
 	AgentRun(ctx context.Context, sessionID, prompt string, attachments ...message.Attachment) error
-	AgentRunShellCommand(ctx context.Context, sessionID, command string) (proto.ShellCommandResponse, error)
+	AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int) (proto.ShellCommandResponse, error)
 	AgentCancel(sessionID string)
 	AgentIsBusy() bool
 	AgentIsSessionBusy(sessionID string) bool


### PR DESCRIPTION

## Summary

- Adds `!` prefix support for running shell commands directly without triggering the LLM
- Command + output persisted as a user message so the LLM has context on follow-up prompts
- Full client-server implementation: backend runs the command in the workspace directory, result flows through the existing message pubsub to the UI

## Test plan

- [ ] Type `!ls` in the input — should display directory listing without LLM response
- [ ] Type `!echo hello` — output appears as user message in chat
- [ ] Follow up with a normal prompt — LLM should see the previous shell output as context
- [ ] Test with non-zero exit code (`!false`) — should not error, just show empty output

Closes: https://github.com/charmbracelet/crush/issues/2430