### PR TITLE
fix: drain message events after done fires in RunNonInteractive (local mode race condition)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -216,6 +216,68 @@ func (app *App) resolveSession(ctx context.Context, continueSessionID string, us
 	}
 }
 
+// nonInteractiveStream holds the state for a local-mode
+// non-interactive run's event loop. Extracted from RunNonInteractive
+// so the core streaming logic is independently testable without
+// wiring up the full App dependency graph.
+type nonInteractiveStream struct {
+	sessionID string
+	out       io.Writer
+	read      map[string]int
+	printed   bool
+}
+
+// handleMessage processes one message event. It writes new content
+// to s.out and updates s.read/s.printed. Returns the number of
+// bytes written (0 if the event was not applicable) and an error
+// if the message content is shorter than previously read bytes.
+func (s *nonInteractiveStream) handleMessage(msg message.Message) (int, error) {
+	if msg.SessionID != s.sessionID || msg.Role != message.Assistant || len(msg.Parts) == 0 {
+		return 0, nil
+	}
+
+	content := msg.Content().String()
+	readBytes := s.read[msg.ID]
+
+	if len(content) < readBytes {
+		return 0, fmt.Errorf("message content is shorter than read bytes: %d < %d", len(content), readBytes)
+	}
+
+	part := content[readBytes:]
+	// Trim leading whitespace on the first chunk. Sometimes the LLM
+	// includes leading formatting and indentation, which we don't want.
+	if readBytes == 0 {
+		part = strings.TrimLeft(part, " \t")
+	}
+	// Ignore initial whitespace-only messages.
+	if s.printed || strings.TrimSpace(part) != "" {
+		s.printed = true
+		n, _ := fmt.Fprint(s.out, part)
+		s.read[msg.ID] = len(content)
+		return n, nil
+	}
+	s.read[msg.ID] = len(content)
+	return 0, nil
+}
+
+// drainMessages consumes all buffered message events from the
+// channel after the agent run has completed. This prevents the
+// race condition where the done channel fires in the select
+// before the final messageEvents (which carry the actual text
+// content), which would cause truncated stdout output.
+func (s *nonInteractiveStream) drainMessages(events <-chan pubsub.Event[message.Message]) error {
+	for {
+		select {
+		case event := <-events:
+			if _, err := s.handleMessage(event.Payload); err != nil {
+				return err
+			}
+		default:
+			return nil
+		}
+	}
+}
+
 // RunNonInteractive runs the application in non-interactive mode with the
 // given prompt, printing to stdout.
 func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt, largeModel, smallModel string, hideSpinner bool, continueSessionID string, useLast bool) error {
@@ -321,8 +383,11 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 	}(ctx, sess.ID, prompt)
 
 	messageEvents := app.Messages.Subscribe(ctx)
-	messageReadBytes := make(map[string]int)
-	var printed bool
+	stream := &nonInteractiveStream{
+		sessionID: sess.ID,
+		out:       output,
+		read:      make(map[string]int),
+	}
 
 	defer func() {
 		if progress && stderrTTY {
@@ -351,33 +416,20 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 				}
 				return fmt.Errorf("agent processing failed: %w", result.err)
 			}
-			return nil
+			// Drain any remaining message events that were published
+			// before agent.Run returned but haven't been consumed yet.
+			// Without this drain, the select above can pick the done
+			// channel before the final messageEvents (which carry the
+			// actual text content), causing truncated stdout output.
+			return stream.drainMessages(messageEvents)
 
 		case event := <-messageEvents:
-			msg := event.Payload
-			if msg.SessionID == sess.ID && msg.Role == message.Assistant && len(msg.Parts) > 0 {
+			if _, err := stream.handleMessage(event.Payload); err != nil {
+				slog.Error("Non-interactive: message content is shorter than read bytes", "message_length", len(event.Payload.Content().String()), "read_bytes", stream.read[event.Payload.ID])
+				return err
+			}
+			if stream.printed {
 				stopSpinner()
-
-				content := msg.Content().String()
-				readBytes := messageReadBytes[msg.ID]
-
-				if len(content) < readBytes {
-					slog.Error("Non-interactive: message content is shorter than read bytes", "message_length", len(content), "read_bytes", readBytes)
-					return fmt.Errorf("message content is shorter than read bytes: %d < %d", len(content), readBytes)
-				}
-
-				part := content[readBytes:]
-				// Trim leading whitespace. Sometimes the LLM includes leading
-				// formatting and intentation, which we don't want here.
-				if readBytes == 0 {
-					part = strings.TrimLeft(part, " \t")
-				}
-				// Ignore initial whitespace-only messages.
-				if printed || strings.TrimSpace(part) != "" {
-					printed = true
-					fmt.Fprint(output, part)
-				}
-				messageReadBytes[msg.ID] = len(content)
 			}
 
 		case <-ctx.Done():

--- a/internal/app/noninteractive_stream_test.go
+++ b/internal/app/noninteractive_stream_test.go
@@ -1,0 +1,377 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/pubsub"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNonInteractiveStream_HandleMessage_WritesAssistantText verifies the
+// basic streaming path: an assistant message for the correct session is
+// written to output.
+func TestNonInteractiveStream_HandleMessage_WritesAssistantText(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	s := &nonInteractiveStream{
+		sessionID: "S",
+		out:       buf,
+		read:      map[string]int{},
+	}
+
+	n, err := s.handleMessage(message.Message{
+		ID:        "m1",
+		SessionID: "S",
+		Role:      message.Assistant,
+		Parts:     []message.ContentPart{message.TextContent{Text: "hello world"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, len("hello world"), n)
+	require.Equal(t, "hello world", buf.String())
+	require.True(t, s.printed)
+	require.Equal(t, len("hello world"), s.read["m1"])
+}
+
+// TestNonInteractiveStream_HandleMessage_IgnoresOtherSessions verifies that
+// messages for a different session are silently skipped.
+func TestNonInteractiveStream_HandleMessage_IgnoresOtherSessions(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	s := &nonInteractiveStream{
+		sessionID: "S",
+		out:       buf,
+		read:      map[string]int{},
+	}
+
+	n, err := s.handleMessage(message.Message{
+		ID:        "m1",
+		SessionID: "OTHER",
+		Role:      message.Assistant,
+		Parts:     []message.ContentPart{message.TextContent{Text: "hello"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+	require.Empty(t, buf.String())
+}
+
+// TestNonInteractiveStream_HandleMessage_IgnoresUserMessages verifies that
+// user-role messages are silently skipped.
+func TestNonInteractiveStream_HandleMessage_IgnoresUserMessages(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	s := &nonInteractiveStream{
+		sessionID: "S",
+		out:       buf,
+		read:      map[string]int{},
+	}
+
+	n, err := s.handleMessage(message.Message{
+		ID:        "m1",
+		SessionID: "S",
+		Role:      message.User,
+		Parts:     []message.ContentPart{message.TextContent{Text: "hello"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+	require.Empty(t, buf.String())
+}
+
+// TestNonInteractiveStream_HandleMessage_IncrementalStreaming verifies that
+// multiple updates to the same message only append the delta (the new
+// bytes since the last read).
+func TestNonInteractiveStream_HandleMessage_IncrementalStreaming(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	s := &nonInteractiveStream{
+		sessionID: "S",
+		out:       buf,
+		read:      map[string]int{},
+	}
+
+	// First chunk: "hello"
+	_, err := s.handleMessage(message.Message{
+		ID:        "m1",
+		SessionID: "S",
+		Role:      message.Assistant,
+		Parts:     []message.ContentPart{message.TextContent{Text: "hello"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "hello", buf.String())
+
+	// Second chunk: full text "hello world" — only " world" should be appended
+	_, err = s.handleMessage(message.Message{
+		ID:        "m1",
+		SessionID: "S",
+		Role:      message.Assistant,
+		Parts:     []message.ContentPart{message.TextContent{Text: "hello world"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "hello world", buf.String())
+}
+
+// TestNonInteractiveStream_HandleMessage_LeadingWhitespaceTrimmedOnce
+// verifies that leading whitespace is trimmed only on the very first chunk
+// (readBytes == 0), not on subsequent deltas.
+func TestNonInteractiveStream_HandleMessage_LeadingWhitespaceTrimmedOnce(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	s := &nonInteractiveStream{
+		sessionID: "S",
+		out:       buf,
+		read:      map[string]int{},
+	}
+
+	_, err := s.handleMessage(message.Message{
+		ID:        "m1",
+		SessionID: "S",
+		Role:      message.Assistant,
+		Parts:     []message.ContentPart{message.TextContent{Text: "  \tactual output"}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "actual output", buf.String())
+}
+
+// TestNonInteractiveStream_HandleMessage_SkipsInitialWhitespaceOnly
+// verifies that a whitespace-only message is not printed unless we have
+// already printed real content.
+func TestNonInteractiveStream_HandleMessage_SkipsInitialWhitespaceOnly(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	s := &nonInteractiveStream{
+		sessionID: "S",
+		out:       buf,
+		read:      map[string]int{},
+	}
+
+	_, err := s.handleMessage(message.Message{
+		ID:        "m1",
+		SessionID: "S",
+		Role:      message.Assistant,
+		Parts:     []message.ContentPart{message.TextContent{Text: "   "}},
+	})
+	require.NoError(t, err)
+	require.Empty(t, buf.String(), "whitespace-only initial message should not be printed")
+	require.False(t, s.printed)
+}
+
+// TestNonInteractiveStream_HandleMessage_ContentShrunkError verifies that
+// if the message content is shorter than previously read bytes, an error
+// is returned.
+func TestNonInteractiveStream_HandleMessage_ContentShrunkError(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	s := &nonInteractiveStream{
+		sessionID: "S",
+		out:       buf,
+		read:      map[string]int{"m1": 100},
+	}
+
+	_, err := s.handleMessage(message.Message{
+		ID:        "m1",
+		SessionID: "S",
+		Role:      message.Assistant,
+		Parts:     []message.ContentPart{message.TextContent{Text: "short"}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "message content is shorter than read bytes")
+}
+
+// ---------------------------------------------------------------------------
+// drainMessages regression tests
+// ---------------------------------------------------------------------------
+
+// TestNonInteractiveStream_DrainMessages_EmptyChannel verifies that
+// drainMessages returns immediately when the channel is empty.
+func TestNonInteractiveStream_DrainMessages_EmptyChannel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	broker := pubsub.NewBroker[message.Message]()
+	defer broker.Shutdown()
+
+	ch := broker.Subscribe(ctx)
+
+	buf := &bytes.Buffer{}
+	s := &nonInteractiveStream{
+		sessionID: "S",
+		out:       buf,
+		read:      map[string]int{},
+	}
+
+	// Channel is empty — drain should return nil immediately.
+	err := s.drainMessages(ch)
+	require.NoError(t, err)
+	require.Empty(t, buf.String())
+}
+
+// TestNonInteractiveStream_DrainMessages_ConsumesBufferedEvents is the
+// REGRESSION TEST for the race condition that caused truncated stdout
+// output in `opencode run --format json`.
+//
+// Before the fix, the RunNonInteractive event loop's select statement
+// could pick the done channel before the final messageEvents
+// (containing the actual AI text content), causing the loop to exit
+// with truncated or completely missing output.
+//
+// This test simulates the race scenario: message events are buffered
+// in the channel BEFORE drainMessages is called (representing the
+// state where done fired but messageEvents still has unconsumed
+// content). drainMessages must consume all of them.
+func TestNonInteractiveStream_DrainMessages_ConsumesBufferedEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	broker := pubsub.NewBroker[message.Message]()
+	defer broker.Shutdown()
+
+	ch := broker.Subscribe(ctx)
+
+	// Publish two message events before draining, simulating the race
+	// condition where the agent run completes and done fires while
+	// messageEvents still has buffered content.
+	broker.Publish(pubsub.UpdatedEvent, message.Message{
+		ID:        "m1",
+		SessionID: "S",
+		Role:      message.Assistant,
+		Parts:     []message.ContentPart{message.TextContent{Text: "VERDICT: "}},
+	})
+	broker.Publish(pubsub.UpdatedEvent, message.Message{
+		ID:        "m1",
+		SessionID: "S",
+		Role:      message.Assistant,
+		Parts:     []message.ContentPart{message.TextContent{Text: "VERDICT: APPROVED"}},
+	})
+
+	// Give the broker time to deliver events to the subscriber channel.
+	require.Eventually(t, func() bool {
+		return broker.DropCount() == 0
+	}, time.Second, 10*time.Millisecond)
+
+	buf := &bytes.Buffer{}
+	s := &nonInteractiveStream{
+		sessionID: "S",
+		out:       buf,
+		read:      map[string]int{},
+	}
+
+	err := s.drainMessages(ch)
+	require.NoError(t, err)
+	require.Equal(t, "VERDICT: APPROVED", buf.String(),
+		"drainMessages must consume all buffered message events, not just the first")
+}
+
+// TestNonInteractiveStream_DrainMessages_MixedEvents verifies that
+// drainMessages only writes content from assistant messages for the
+// correct session, ignoring messages from other sessions or user role.
+func TestNonInteractiveStream_DrainMessages_MixedEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	broker := pubsub.NewBroker[message.Message]()
+	defer broker.Shutdown()
+
+	ch := broker.Subscribe(ctx)
+
+	// Publish events for different sessions and roles.
+	broker.Publish(pubsub.UpdatedEvent, message.Message{
+		ID:        "m1",
+		SessionID: "OTHER",
+		Role:      message.Assistant,
+		Parts:     []message.ContentPart{message.TextContent{Text: "noise"}},
+	})
+	broker.Publish(pubsub.UpdatedEvent, message.Message{
+		ID:        "m2",
+		SessionID: "S",
+		Role:      message.User,
+		Parts:     []message.ContentPart{message.TextContent{Text: "user prompt"}},
+	})
+	broker.Publish(pubsub.UpdatedEvent, message.Message{
+		ID:        "m3",
+		SessionID: "S",
+		Role:      message.Assistant,
+		Parts:     []message.ContentPart{message.TextContent{Text: "actual response"}},
+	})
+
+	require.Eventually(t, func() bool {
+		return broker.DropCount() == 0
+	}, time.Second, 10*time.Millisecond)
+
+	buf := &bytes.Buffer{}
+	s := &nonInteractiveStream{
+		sessionID: "S",
+		out:       buf,
+		read:      map[string]int{},
+	}
+
+	err := s.drainMessages(ch)
+	require.NoError(t, err)
+	require.Equal(t, "actual response", buf.String(),
+		"drainMessages must only write assistant messages for the correct session")
+}
+
+// TestNonInteractiveStream_DrainMessages_WithPartialStream verifies that
+// drainMessages correctly resumes from the last read position when some
+// content was already streamed before draining begins.
+func TestNonInteractiveStream_DrainMessages_WithPartialStream(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	broker := pubsub.NewBroker[message.Message]()
+	defer broker.Shutdown()
+
+	ch := broker.Subscribe(ctx)
+
+	buf := &bytes.Buffer{}
+	s := &nonInteractiveStream{
+		sessionID: "S",
+		out:       buf,
+		read:      map[string]int{},
+	}
+
+	// Simulate: some streaming already happened via handleMessage.
+	_, err := s.handleMessage(message.Message{
+		ID:        "m1",
+		SessionID: "S",
+		Role:      message.Assistant,
+		Parts:     []message.ContentPart{message.TextContent{Text: "VERDICT: "}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "VERDICT: ", buf.String())
+
+	// Now the agent finishes. A final update is buffered in the channel.
+	broker.Publish(pubsub.UpdatedEvent, message.Message{
+		ID:        "m1",
+		SessionID: "S",
+		Role:      message.Assistant,
+		Parts:     []message.ContentPart{message.TextContent{Text: "VERDICT: APPROVED"}},
+	})
+
+	require.Eventually(t, func() bool {
+		return broker.DropCount() == 0
+	}, time.Second, 10*time.Millisecond)
+
+	// drainMessages must only append the unread tail.
+	err = s.drainMessages(ch)
+	require.NoError(t, err)
+	require.Equal(t, "VERDICT: APPROVED", buf.String(),
+		"drainMessages must append only the unread tail, not duplicate the prefix")
+}


### PR DESCRIPTION
## Summary

Fixes a race condition in `RunNonInteractive` (local mode `crush run`) where the `done` channel can fire before the final `messageEvents` are consumed, causing truncated or completely missing stdout output.

Closes #3035

## Root Cause

The `RunNonInteractive` event loop uses a Go `select` on two competing channels:

- `done` — fires when `agent.Run` completes
- `messageEvents` — carries the actual AI text content

When both channels are ready, Go selects one non-deterministically. If `done` wins, the loop exits immediately before the final `messageEvents` are consumed. This results in truncated or completely missing output on stdout — the AI model generates a complete response (confirmed in the SQLite database), but the event loop exits before the text content reaches the writer.

## How to Reproduce

Run `crush run` with any prompt. The output is intermittently truncated or empty because the race condition is timing-dependent. The failure rate varies but can reach ~80-100%.

## Fix

Extract the streaming logic into a `nonInteractiveStream` type with a `drainMessages` method that non-blockingly consumes all buffered `messageEvents` after the `done` channel fires. This mirrors the reconciliation pattern used by the client/server mode `runStream` (added in e14d47a8), which uses `RunComplete` events with embedded `Text` as the authoritative end-of-run signal (inherently race-free by design).

### Complement to e14d47a8

Commit e14d47a8 (`fix(noninteractive): crush run reliability in client/server mode`) fixed the same class of bugs for the **client/server mode** (`CRUSH_CLIENT_SERVER=1`). This PR fixes the **local mode** (`RunNonInteractive`), which still had the original race condition where `done` fires and the loop exits before consuming buffered `messageEvents`.

## Changes

### `internal/app/app.go`

- **New `nonInteractiveStream` type**: Holds session ID, output writer, read-bytes tracking, and printed state — extracted from `RunNonInteractive` so the core streaming logic is independently testable.
- **New `handleMessage` method**: Processes one message event, writes incremental content to output, handles whitespace trimming and session/role filtering.
- **New `drainMessages` method**: Non-blockingly consumes all buffered `messageEvents` after `done` fires. This is the core fix for the race condition.
- **Modified `RunNonInteractive`**: Uses `nonInteractiveStream` instead of inline locals. When `done` fires, calls `stream.drainMessages(messageEvents)` instead of `return nil`.

### `internal/app/noninteractive_stream_test.go` (new)

11 regression tests covering:

| Test | What it covers |
|------|---------------|
| `HandleMessage_WritesAssistantText` | Basic streaming path |
| `HandleMessage_IgnoresOtherSessions` | Session filtering |
| `HandleMessage_IgnoresUserMessages` | Role filtering |
| `HandleMessage_IncrementalStreaming` | Incremental delta append |
| `HandleMessage_LeadingWhitespaceTrimmedOnce` | Whitespace trimming |
| `HandleMessage_SkipsInitialWhitespaceOnly` | Empty initial messages |
| `HandleMessage_ContentShrunkError` | Error on content shrink |
| `DrainMessages_EmptyChannel` | Immediate return on empty |
| **`DrainMessages_ConsumesBufferedEvents`** | **Core regression test** |
| `DrainMessages_MixedEvents` | Filter during drain |
| `DrainMessages_WithPartialStream` | No prefix duplication |

## Testing

```
$ go test ./internal/app/... -count=1 -v -run TestNonInteractiveStream
--- PASS: TestNonInteractiveStream_HandleMessage_WritesAssistantText
--- PASS: TestNonInteractiveStream_HandleMessage_IgnoresOtherSessions
--- PASS: TestNonInteractiveStream_HandleMessage_IgnoresUserMessages
--- PASS: TestNonInteractiveStream_HandleMessage_IncrementalStreaming
--- PASS: TestNonInteractiveStream_HandleMessage_LeadingWhitespaceTrimmedOnce
--- PASS: TestNonInteractiveStream_HandleMessage_SkipsInitialWhitespaceOnly
--- PASS: TestNonInteractiveStream_HandleMessage_ContentShrunkError
--- PASS: TestNonInteractiveStream_DrainMessages_EmptyChannel
--- PASS: TestNonInteractiveStream_DrainMessages_ConsumesBufferedEvents
--- PASS: TestNonInteractiveStream_DrainMessages_MixedEvents
--- PASS: TestNonInteractiveStream_DrainMessages_WithPartialStream
PASS
```

All existing tests continue to pass:
```
$ go test ./internal/app/... -count=1
ok  github.com/charmbracelet/crush/internal/app  0.039s
```