### PR TITLE
fix(ui): remove markdown rendering from thinking

### DIFF
--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -446,15 +446,7 @@ func (a *AssistantMessageItem) cachedError(width int) string {
 // ThinkingBox style is applied on top of the (already-windowed)
 // lines so the visual box matches what the user sees today.
 func (a *AssistantMessageItem) renderThinking(thinking string, width int) string {
-	renderer := common.QuietMarkdownRenderer(a.sty, width)
-	mu := common.LockMarkdownRenderer(renderer)
-	mu.Lock()
-	rendered, err := renderer.Render(thinking)
-	mu.Unlock()
-	if err != nil {
-		rendered = thinking
-	}
-	rendered = strings.TrimSpace(rendered)
+	rendered := strings.TrimSpace(thinking)
 
 	lines := strings.Split(rendered, "\n")
 	totalLines := len(lines)

--- a/internal/ui/common/markdown.go
+++ b/internal/ui/common/markdown.go
@@ -57,8 +57,8 @@ func MarkdownRenderer(sty *styles.Styles, width int) *glamour.TermRenderer {
 	return r
 }
 
-// QuietMarkdownRenderer returns a glamour [glamour.TermRenderer] with no colors
-// (plain text with structure) and the given width. Renderers are memoized per
+// QuietMarkdownRenderer returns a glamour [glamour.TermRenderer] with muted
+// colors for tool output and the given width. Renderers are memoized per
 // width and shared across callers. Same concurrency contract as
 // [MarkdownRenderer]: serialize via [LockMarkdownRenderer].
 func QuietMarkdownRenderer(sty *styles.Styles, width int) *glamour.TermRenderer {

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -332,7 +332,7 @@ func quickStyle(o quickStyleOpts) Styles {
 		},
 	}
 
-	// QuietMarkdown style - muted colors on subtle background for thinking content.
+	// QuietMarkdown style - muted colors on subtle background for tool output.
 	plainBg := hex(o.bgLeastVisible)
 	plainFg := hex(o.fgMoreSubtle)
 	s.QuietMarkdown = ansi.StyleConfig{
@@ -811,7 +811,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Messages.AssistantCanceled = lipgloss.NewStyle().Foreground(o.fgBase).Italic(true)
 
 	// Thinking section styles
-	s.Messages.ThinkingBox = subtle.Background(o.bgLeastVisible)
+	s.Messages.ThinkingBox = muted.Background(o.bgLeastVisible)
 	s.Messages.ThinkingTruncationHint = muted
 	s.Messages.ThinkingFooterTitle = muted
 	s.Messages.ThinkingFooterDuration = subtle


### PR DESCRIPTION
the markdown rendering isn't super useful at the moment as there is no highlighting but it inserts spaces around inline codeblocks causing weird output

fixes #3026 