### PR TITLE
fix(ui): fix session rename rendering

### DIFF
--- a/internal/ui/dialog/sessions_item.go
+++ b/internal/ui/dialog/sessions_item.go
@@ -93,6 +93,9 @@ func (s *SessionItem) InputValue() string {
 func (s *SessionItem) HandleInput(msg tea.Msg) tea.Cmd {
 	var cmd tea.Cmd
 	s.updateTitleInput, cmd = s.updateTitleInput.Update(msg)
+	if s.Versioned != nil {
+		s.Bump()
+	}
 	return cmd
 }
 


### PR DESCRIPTION
<img width="590" height="390" alt="image" src="https://github.com/user-attachments/assets/cf7b8288-abfe-4c9a-b542-3737fd43030d" />

previously it wasn't rendering new text because the cache was stale