### PR TITLE
feat(skills): default user-invocable to true

### DIFF
--- a/internal/skills/catalog.go
+++ b/internal/skills/catalog.go
@@ -54,7 +54,7 @@ func Catalog(active []*Skill, skillPaths []string, workingDir string) []CatalogE
 			Description:   skill.Description,
 			Label:         label,
 			Source:        source,
-			UserInvocable: skill.UserInvocable,
+			UserInvocable: skill.IsUserInvocable(),
 		})
 	}
 	return entries

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -38,7 +38,7 @@ var (
 type Skill struct {
 	Name                   string            `yaml:"name" json:"name"`
 	Description            string            `yaml:"description" json:"description"`
-	UserInvocable          bool              `yaml:"user-invocable" json:"user_invocable"`
+	UserInvocable          *bool             `yaml:"user-invocable,omitempty" json:"user_invocable,omitempty"`
 	DisableModelInvocation bool              `yaml:"disable-model-invocation" json:"disable_model_invocation"`
 	License                string            `yaml:"license,omitempty" json:"license,omitempty"`
 	Compatibility          string            `yaml:"compatibility,omitempty" json:"compatibility,omitempty"`
@@ -47,6 +47,13 @@ type Skill struct {
 	Path                   string            `yaml:"-" json:"path"`
 	SkillFilePath          string            `yaml:"-" json:"skill_file_path"`
 	Builtin                bool              `yaml:"-" json:"builtin"`
+}
+
+// IsUserInvocable reports whether the skill should appear in the command
+// palette. When the user-invocable frontmatter field is absent, skills
+// default to user-invocable to make the feature opt-out.
+func (s *Skill) IsUserInvocable() bool {
+	return s.UserInvocable == nil || *s.UserInvocable
 }
 
 // DiscoveryState represents the outcome of discovering a single skill file.

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -400,6 +400,41 @@ func TestParseContent_NoFrontmatter(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestIsUserInvocable_DefaultTrue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		yaml string
+		want bool
+	}{
+		{
+			name: "absent defaults to true",
+			yaml: "---\nname: a\ndescription: x.\n---\n",
+			want: true,
+		},
+		{
+			name: "explicit true",
+			yaml: "---\nname: a\ndescription: x.\nuser-invocable: true\n---\n",
+			want: true,
+		},
+		{
+			name: "explicit false",
+			yaml: "---\nname: a\ndescription: x.\nuser-invocable: false\n---\n",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			skill, err := ParseContent([]byte(tt.yaml))
+			require.NoError(t, err)
+			require.Equal(t, tt.want, skill.IsUserInvocable())
+		})
+	}
+}
+
 func TestDiscoverBuiltin(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Make `user-invocable` opt-out: when a `SKILL.md` does not declare the field, the skill appears in the command palette by default.
- Skills that should stay hidden from the palette can opt out explicitly with `user-invocable: false`.
- Switches `Skill.UserInvocable` to `*bool` so the catalog layer can tell "absent" from "false" without parsing YAML twice; downstream `CatalogEntry` / `SkillInfo` keep a plain bool filled in from a new `Skill.IsUserInvocable()` helper, so no consumer changes are required.
- Adds table-driven coverage in `internal/skills/skills_test.go` for the absent / true / false cases.

## Motivation

The user-invocable feature (#2834) currently requires every skill author to add `user-invocable: true` to opt in. In practice most custom skills are workflow shortcuts the user *wants* to fire from the command palette, so the friction is mostly on the common case. Flipping the default makes the feature useful out of the box while still allowing explicit opt-out for skills that are meant to be model-only (especially in combination with `disable-model-invocation: true`).

## Related

- #2834 — initial `user-invocable` frontmatter support
- #2970 — description + attachment style in the skill picker
- #2562 / #2467 — earlier command-palette dialogs that this implementation effectively replaces for skill invocation
- #1972 — broader discussion on skill discoverability / forced invocation

## Test plan

- [x] `go test ./internal/skills/...` — new `TestIsUserInvocable_DefaultTrue` covers absent / true / false
- [x] `go test ./internal/commands/...` — `TestFromSkillCatalog_UserInvocableOnly` and symlink test still pass
- [x] `go build ./...` clean

## Note

This change was authored with AI assistance (Crush / MiniMax-M3) and should be reviewed carefully. The semantic change is small (a single default flip) but it affects every skill in the system, so the explicit opt-out path should be documented once the PR is approved.

Supersedes the head ref of the originally opened PR (#3079) which closed automatically when the source branch was renamed.


💘 Generated with Crush



Assisted-by: Crush:MiniMax-M3