### PR TITLE
fix(ui): normalize line endings in session file diff stats

### DIFF
--- a/internal/ui/model/session.go
+++ b/internal/ui/model/session.go
@@ -136,7 +136,14 @@ func (m *UI) loadSessionFiles(sessionID string) ([]SessionFile, error) {
 			}
 		}
 
-		_, additions, deletions := diff.GenerateDiff(first.Content, last.Content, first.Path)
+		// Normalize line endings so that a CRLF/LF mismatch between
+		// historical versions does not inflate the diff stats. Files
+		// round-tripped through the write tool may end up with different
+		// line endings than the original (the LLM typically emits LF),
+		// which previously caused every line to be reported as changed.
+		firstContent, _ := fsext.ToUnixLineEndings(first.Content)
+		lastContent, _ := fsext.ToUnixLineEndings(last.Content)
+		_, additions, deletions := diff.GenerateDiff(firstContent, lastContent, first.Path)
 
 		sessionFiles = append(sessionFiles, SessionFile{
 			FirstVersion:  first,

--- a/internal/ui/model/session_test.go
+++ b/internal/ui/model/session_test.go
@@ -1,10 +1,13 @@
 package model
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/diff"
+	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/history"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/stretchr/testify/require"
@@ -108,6 +111,47 @@ func TestFileList(t *testing.T) {
 		}
 		got := fileList(st, "/", files, 20, 0)
 		require.Empty(t, got)
+	})
+}
+
+func TestLoadSessionFilesNormalizesLineEndings(t *testing.T) {
+	t.Parallel()
+
+	makeContent := func(sep string) string {
+		var b strings.Builder
+		for i := 0; i < 1000; i++ {
+			b.WriteString(fmt.Sprintf("line %d", i))
+			b.WriteString(sep)
+		}
+		return b.String()
+	}
+
+	t.Run("CRLF vs LF reports the real delta, not the line ending swap", func(t *testing.T) {
+		t.Parallel()
+
+		first := history.File{Path: "main.go", Content: makeContent("\r\n"), Version: 0}
+		last := history.File{Path: "main.go", Content: makeContent("\n") + "added\n", Version: 1}
+
+		firstContent, _ := fsext.ToUnixLineEndings(first.Content)
+		lastContent, _ := fsext.ToUnixLineEndings(last.Content)
+		_, additions, removals := diff.GenerateDiff(firstContent, lastContent, first.Path)
+
+		require.Equal(t, 1, additions, "expected one addition for the appended line, got %d", additions)
+		require.Equal(t, 0, removals, "expected zero removals, got %d", removals)
+	})
+
+	t.Run("identical content with mismatched line endings reports no changes", func(t *testing.T) {
+		t.Parallel()
+
+		first := history.File{Path: "main.go", Content: makeContent("\r\n"), Version: 0}
+		last := history.File{Path: "main.go", Content: makeContent("\n"), Version: 1}
+
+		firstContent, _ := fsext.ToUnixLineEndings(first.Content)
+		lastContent, _ := fsext.ToUnixLineEndings(last.Content)
+		_, additions, removals := diff.GenerateDiff(firstContent, lastContent, first.Path)
+
+		require.Equal(t, 0, additions)
+		require.Equal(t, 0, removals)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Normalize CRLF/LF on both sides of the session file diff so historical versions with mismatched line endings don't inflate the stats.
- Add a regression test covering the CRLF↔LF mismatch.

## Problem

The sidebar's "Modified Files" list computes additions/deletions by diffing the first and last versions of a file stored in history (`internal/ui/model/session.go:139`). The two versions can carry different line endings:

- Files first written via the `edit` tool preserve the original line endings (CRLF on Windows).
- Files later overwritten via the `write` tool store whatever the LLM emitted, which is almost always LF.

When the diff runs, every line is reported as changed because the trailing `\r` is missing/present. A 1000-line file gaining 1 line shows `+1001 -1000` instead of `+1 -0`.

## Fix

Normalize both sides to LF with `fsext.ToUnixLineEndings` before calling `diff.GenerateDiff`. This is the same helper the `edit`/`multiedit` tools already use internally for diff computation.

## Test plan

- [x] `go test ./internal/ui/model/ -run TestLoadSessionFilesNormalizesLineEndings` passes
- [x] `go test ./internal/ui/model/ -run TestFileList` still passes
- [x] `go build ./...`

💘 Generated with Crush