### PR TITLE
fix(server): clean up stale sockets + correct socket location

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -437,7 +437,7 @@ func ensureServer(cmd *cobra.Command, hostURL *url.URL) error {
 			// we detect it with a short DialTimeout and remove the
 			// orphaned file so the normal spawn path can run.
 			if hostURL.Scheme == "unix" {
-				conn, dialErr := net.DialTimeout(
+				conn, dialErr := net.DialTimeout( //nolint:noctx
 					hostURL.Scheme, hostURL.Host, 200*time.Millisecond,
 				)
 				if dialErr == nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -416,6 +416,14 @@ func connectToServer(cmd *cobra.Command) (*client.Client, *proto.Workspace, func
 // version matches the client; on mismatch it shuts down the old server
 // and starts a fresh one.
 func ensureServer(cmd *cobra.Command, hostURL *url.URL) error {
+	// Initialize the persistent log here so stale-socket diagnostics
+	// emitted before connectToServer runs are captured in the per-host
+	// server log file. crushlog.Setup uses sync.Once internally, so the
+	// later call from connectToServer becomes a no-op.
+	debug, _ := cmd.Flags().GetBool("debug")
+	logFile := filepath.Join(config.GlobalCacheDir(), "server-"+safeHostName(hostURL), "crush.log")
+	crushlog.Setup(logFile, debug)
+
 	switch hostURL.Scheme {
 	case "unix", "npipe":
 		needsStart := false

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -430,6 +430,28 @@ func ensureServer(cmd *cobra.Command, hostURL *url.URL) error {
 		_, statErr := os.Stat(hostURL.Host)
 		switch {
 		case statErr == nil:
+			// Probe the socket explicitly before the version-check
+			// path. A stale unix socket file (the previous server
+			// exited without cleaning up) would otherwise make
+			// restartIfStale spin on a non-responsive endpoint; here
+			// we detect it with a short DialTimeout and remove the
+			// orphaned file so the normal spawn path can run.
+			if hostURL.Scheme == "unix" {
+				conn, dialErr := net.DialTimeout(
+					hostURL.Scheme, hostURL.Host, 200*time.Millisecond,
+				)
+				if dialErr == nil {
+					conn.Close()
+				} else if server.IsStaleSocketErr(dialErr) {
+					slog.Warn("Stale socket detected, removing",
+						"path", hostURL.Host, "error", dialErr)
+					if err := os.Remove(hostURL.Host); err != nil && !errors.Is(err, fs.ErrNotExist) {
+						return fmt.Errorf("failed to remove stale server socket %q: %v", hostURL.Host, err)
+					}
+					needsStart = true
+					break
+				}
+			}
 			restarted, err := restartIfStale(cmd, hostURL)
 			if err != nil {
 				slog.Warn("Failed to check server version", "error", err)

--- a/internal/server/net_other.go
+++ b/internal/server/net_other.go
@@ -32,7 +32,7 @@ func listen(network, address string) (net.Listener, bool, error) {
 	var removedStale bool
 	if network == "unix" && address != "" {
 		if _, err := os.Stat(address); err == nil {
-			conn, dialErr := net.DialTimeout(network, address, staleSocketDialTimeout)
+			conn, dialErr := net.DialTimeout(network, address, staleSocketDialTimeout) //nolint:noctx
 			if dialErr == nil {
 				// A live server owns the socket. Fall through to
 				// net.Listen so the caller sees the standard

--- a/internal/server/net_other.go
+++ b/internal/server/net_other.go
@@ -2,9 +2,60 @@
 
 package server
 
-import "net"
+import (
+	"errors"
+	"io/fs"
+	"net"
+	"os"
+	"time"
+)
 
-func listen(network, address string) (net.Listener, error) {
+// staleSocketDialTimeout bounds the probe used to detect whether a Unix
+// socket file on disk is backed by a live listener.
+const staleSocketDialTimeout = 200 * time.Millisecond
+
+// listen binds a net.Listener on the given network and address.
+//
+// For unix sockets it self-heals from stale socket files: if the path
+// already exists on disk, it first probes with a short net.DialTimeout.
+// A successful dial means a live server owns the socket, so we proceed
+// to net.Listen (which surfaces the usual "address already in use"
+// error). A failed dial that isStaleSocketErr classifies as stale
+// triggers an os.Remove of the path (ignoring fs.ErrNotExist) before
+// the bind.
+//
+// The returned removedStale bool reports whether a stale socket file
+// was removed prior to binding so callers can log it. The operation
+// is idempotent: removing an absent file is a no-op, and a live
+// socket is never removed.
+func listen(network, address string) (net.Listener, bool, error) {
+	var removedStale bool
+	if network == "unix" && address != "" {
+		if _, err := os.Stat(address); err == nil {
+			conn, dialErr := net.DialTimeout(network, address, staleSocketDialTimeout)
+			if dialErr == nil {
+				// A live server owns the socket. Fall through to
+				// net.Listen so the caller sees the standard
+				// "address already in use" error.
+				conn.Close()
+			} else if isStaleSocketErr(dialErr) {
+				rmErr := os.Remove(address)
+				switch {
+				case rmErr == nil:
+					removedStale = true
+				case errors.Is(rmErr, fs.ErrNotExist):
+					// Another process removed it between our
+					// stat and remove; treat as a no-op.
+				default:
+					return nil, false, rmErr
+				}
+			}
+		}
+	}
 	//nolint:noctx
-	return net.Listen(network, address)
+	ln, err := net.Listen(network, address)
+	if err != nil {
+		return nil, removedStale, err
+	}
+	return ln, removedStale, nil
 }

--- a/internal/server/net_windows.go
+++ b/internal/server/net_windows.go
@@ -9,7 +9,12 @@ import (
 	"github.com/Microsoft/go-winio"
 )
 
-func listen(network, address string) (net.Listener, error) {
+// listen binds a net.Listener on the given network and address.
+//
+// On Windows there is no Unix-socket stale-file recovery to perform,
+// so removedStale is always false. The signature matches the
+// non-Windows implementation so callers can use a single code path.
+func listen(network, address string) (net.Listener, bool, error) {
 	switch network {
 	case "npipe":
 		cfg := &winio.PipeConfig{
@@ -17,8 +22,16 @@ func listen(network, address string) (net.Listener, error) {
 			InputBufferSize:  65536,
 			OutputBufferSize: 65536,
 		}
-		return winio.ListenPipe(address, cfg)
+		ln, err := winio.ListenPipe(address, cfg)
+		if err != nil {
+			return nil, false, err
+		}
+		return ln, false, nil
 	default:
-		return net.Listen(network, address) //nolint:noctx
+		ln, err := net.Listen(network, address) //nolint:noctx
+		if err != nil {
+			return nil, false, err
+		}
+		return ln, false, nil
 	}
 }

--- a/internal/server/proto.go
+++ b/internal/server/proto.go
@@ -261,16 +261,21 @@ func (c *controllerV1) handleGetWorkspaceEvents(w http.ResponseWriter, r *http.R
 	if !ok {
 		return
 	}
-	if err := c.backend.AttachClient(id, clientID); err != nil {
-		c.handleError(w, r, err)
-		return
-	}
-	defer c.backend.DetachClient(id, clientID)
+	// Subscribe to the event broker BEFORE attaching the client.
+	// AttachClient bumps the stream count that observers use to
+	// detect a live subscriber; subscribing first guarantees that
+	// once a client appears attached, any published event is
+	// delivered rather than dropped on a not-yet-registered stream.
 	events, err := c.backend.SubscribeEvents(r.Context(), id)
 	if err != nil {
 		c.handleError(w, r, err)
 		return
 	}
+	if err := c.backend.AttachClient(id, clientID); err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	defer c.backend.DetachClient(id, clientID)
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,7 +7,9 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -16,6 +18,23 @@ import (
 	_ "github.com/charmbracelet/crush/internal/swagger"
 	httpswagger "github.com/swaggo/http-swagger/v2"
 )
+
+// maxUnixSocketPathLen is the maximum length of a Unix domain socket
+// path. The macOS sun_path field is 104 bytes; Linux allows 108. We
+// use 104 so the resulting path is portable across both platforms.
+const maxUnixSocketPathLen = 104
+
+// socketDir returns the directory used for the Crush Unix socket.
+// It prefers $XDG_RUNTIME_DIR when set (systemd's per-user runtime
+// directory on Linux), and otherwise falls back to [os.TempDir],
+// which resolves to the per-user private $TMPDIR on macOS and to
+// /tmp on Linux.
+func socketDir() string {
+	if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
+		return dir
+	}
+	return os.TempDir()
+}
 
 // ErrServerClosed is returned when the server is closed.
 var ErrServerClosed = http.ErrServerClosed
@@ -44,6 +63,14 @@ func ParseHostURL(host string) (*url.URL, error) {
 }
 
 // DefaultHost returns the default server host.
+//
+// On Windows the address is a named pipe under \\.\pipe\. On Unix
+// platforms the socket lives in the per-user runtime directory
+// returned by [socketDir] and is named crush-<uid>.sock, falling
+// back to crush.sock when the current uid cannot be determined. If
+// the composed path would exceed [maxUnixSocketPathLen] bytes (the
+// macOS sun_path limit), we fall back to /tmp/crush-<uid>.sock so
+// the socket remains bindable.
 func DefaultHost() string {
 	sock := "crush.sock"
 	usr, err := user.Current()
@@ -53,7 +80,11 @@ func DefaultHost() string {
 	if runtime.GOOS == "windows" {
 		return fmt.Sprintf("npipe:////./pipe/%s", sock)
 	}
-	return fmt.Sprintf("unix:///tmp/%s", sock)
+	path := filepath.Join(socketDir(), sock)
+	if len(path) > maxUnixSocketPathLen {
+		path = filepath.Join("/tmp", sock)
+	}
+	return "unix://" + path
 }
 
 // Server represents a Crush server bound to a specific address.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -234,9 +234,12 @@ func (s *Server) ListenAndServe() error {
 	if s.ln != nil {
 		return fmt.Errorf("server already started")
 	}
-	ln, err := listen(s.network, s.Addr)
+	ln, removedStale, err := listen(s.network, s.Addr)
 	if err != nil {
 		return fmt.Errorf("failed to listen on %s: %w", s.Addr, err)
+	}
+	if removedStale && s.logger != nil {
+		s.logger.Warn("Removed stale socket before binding", "address", s.Addr)
 	}
 	return s.Serve(ln)
 }

--- a/internal/server/socket.go
+++ b/internal/server/socket.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package server
+
+import (
+	"errors"
+	"io/fs"
+	"net"
+	"syscall"
+)
+
+// isStaleSocketErr reports whether err indicates a Unix-domain socket file
+// exists on disk but no process is listening on it (a stale or orphaned
+// socket). It returns false for nil and for timeout errors.
+func isStaleSocketErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return false
+	}
+	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, fs.ErrNotExist)
+}

--- a/internal/server/socket.go
+++ b/internal/server/socket.go
@@ -2,23 +2,9 @@
 
 package server
 
-import (
-	"errors"
-	"io/fs"
-	"net"
-	"syscall"
-)
-
-// isStaleSocketErr reports whether err indicates a Unix-domain socket file
-// exists on disk but no process is listening on it (a stale or orphaned
-// socket). It returns false for nil and for timeout errors.
+// isStaleSocketErr is the internal, non-Windows alias for the
+// cross-platform IsStaleSocketErr. It is kept for the existing
+// callers in net_other.go.
 func isStaleSocketErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	var netErr net.Error
-	if errors.As(err, &netErr) && netErr.Timeout() {
-		return false
-	}
-	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, fs.ErrNotExist)
+	return IsStaleSocketErr(err)
 }

--- a/internal/server/socket_classify.go
+++ b/internal/server/socket_classify.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"errors"
+	"io/fs"
+	"net"
+	"syscall"
+)
+
+// IsStaleSocketErr reports whether err indicates that a Unix-domain
+// socket file exists on disk but no process is listening on it (a stale
+// or orphaned socket). It returns false for nil and for timeout errors.
+//
+// The classification is cross-platform: ECONNREFUSED and fs.ErrNotExist
+// are defined on every supported OS, so callers on Windows can use the
+// same helper even though stale-socket recovery only applies to Unix
+// sockets in practice.
+func IsStaleSocketErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return false
+	}
+	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, fs.ErrNotExist)
+}

--- a/internal/server/socket_test.go
+++ b/internal/server/socket_test.go
@@ -1,0 +1,189 @@
+//go:build !windows
+
+package server
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTimeoutErr is a minimal net.Error implementation whose Timeout()
+// returns true. It is used to verify that IsStaleSocketErr never
+// classifies a timeout as stale.
+type fakeTimeoutErr struct{}
+
+func (fakeTimeoutErr) Error() string   { return "fake timeout" }
+func (fakeTimeoutErr) Timeout() bool   { return true }
+func (fakeTimeoutErr) Temporary() bool { return true }
+
+func TestIsStaleSocketErr(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "ECONNREFUSED", err: syscall.ECONNREFUSED, want: true},
+		{
+			name: "wrapped ECONNREFUSED",
+			err:  fmt.Errorf("dial: %w", syscall.ECONNREFUSED),
+			want: true,
+		},
+		{name: "fs.ErrNotExist", err: fs.ErrNotExist, want: true},
+		{
+			name: "wrapped fs.ErrNotExist",
+			err:  fmt.Errorf("stat: %w", fs.ErrNotExist),
+			want: true,
+		},
+		{name: "timeout net.Error", err: fakeTimeoutErr{}, want: false},
+		{name: "generic error", err: errors.New("boom"), want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, IsStaleSocketErr(tc.err))
+		})
+	}
+}
+
+func TestDefaultHost_XDGRuntimeDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", dir)
+
+	host := DefaultHost()
+
+	require.True(t, strings.HasPrefix(host, "unix://"),
+		"DefaultHost should return a unix:// URL, got %q", host)
+	path := strings.TrimPrefix(host, "unix://")
+
+	// The composed path may exceed maxUnixSocketPathLen and fall back
+	// to /tmp; only assert containment when it did not.
+	if len(filepath.Join(dir, "crush.sock")) <= maxUnixSocketPathLen {
+		require.True(t, strings.HasPrefix(path, dir),
+			"socket path %q should live under %q", path, dir)
+	}
+	require.True(t, strings.HasSuffix(path, ".sock"),
+		"socket path %q should end in .sock", path)
+	require.Contains(t, filepath.Base(path), "crush",
+		"socket filename should contain 'crush'")
+}
+
+func TestDefaultHost_FallbackTemp(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", "")
+
+	host := DefaultHost()
+
+	require.True(t, strings.HasPrefix(host, "unix://"),
+		"DefaultHost should return a unix:// URL, got %q", host)
+	path := strings.TrimPrefix(host, "unix://")
+	require.NotEmpty(t, path, "fallback socket path must be non-empty")
+	require.True(t, strings.HasSuffix(path, ".sock"),
+		"socket path %q should end in .sock", path)
+	require.Contains(t, filepath.Base(path), "crush",
+		"socket filename should contain 'crush'")
+}
+
+// staleSocketPath creates a deterministic stale unix socket file on
+// disk: the socket node exists but no goroutine is accepting on it.
+// It does so by binding a listener, disabling unlink-on-close, then
+// closing the listener. The path is returned so the caller can probe
+// it. A leftover file is best-effort removed via t.Cleanup.
+func staleSocketPath(t *testing.T, path string) {
+	t.Helper()
+	ln, err := net.Listen("unix", path)
+	require.NoError(t, err)
+	ul, ok := ln.(*net.UnixListener)
+	require.True(t, ok, "expected *net.UnixListener, got %T", ln)
+	ul.SetUnlinkOnClose(false)
+	require.NoError(t, ul.Close())
+
+	// Verify it is actually stale: dialing should fail.
+	conn, dialErr := net.DialTimeout("unix", path, 200*time.Millisecond)
+	if dialErr == nil {
+		conn.Close()
+		t.Fatalf("expected stale socket at %q to refuse connections", path)
+	}
+	require.True(t, IsStaleSocketErr(dialErr),
+		"expected stale-socket dial error, got %v", dialErr)
+
+	t.Cleanup(func() {
+		_ = os.Remove(path)
+	})
+}
+
+func TestListen_RemovesStaleSocket(t *testing.T) {
+	// t.TempDir() yields a path that may already be near the macOS
+	// sun_path limit; use a short filename to stay well under it.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.sock")
+
+	staleSocketPath(t, path)
+
+	// Confirm the stale node is present before we call listen.
+	_, statErr := os.Stat(path)
+	require.NoError(t, statErr, "stale socket file should exist on disk")
+
+	ln, removedStale, err := listen("unix", path)
+	require.NoError(t, err)
+	require.NotNil(t, ln)
+	require.True(t, removedStale, "listen should report removedStale=true")
+	t.Cleanup(func() {
+		_ = ln.Close()
+	})
+}
+
+func TestListen_LiveSocketNotRemoved(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "s.sock")
+
+	ln1, err := net.Listen("unix", path)
+	require.NoError(t, err)
+
+	// Drain accepts so the listener stays alive and responsive without
+	// blocking the test on a stray connection.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			c, err := ln1.Accept()
+			if err != nil {
+				return
+			}
+			_ = c.Close()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln1.Close()
+		wg.Wait()
+	})
+
+	ln2, removedStale, err := listen("unix", path)
+	if ln2 != nil {
+		_ = ln2.Close()
+	}
+	require.Error(t, err, "listen on a live socket must fail")
+	require.False(t, removedStale,
+		"a live socket must never be removed (got removedStale=true)")
+
+	// The live socket file must still be on disk and dialable.
+	_, statErr := os.Stat(path)
+	require.NoError(t, statErr, "live socket file should still exist")
+	conn, dialErr := net.DialTimeout("unix", path, 200*time.Millisecond)
+	require.NoError(t, dialErr, "live socket should still accept dials")
+	_ = conn.Close()
+}

--- a/internal/server/socket_test.go
+++ b/internal/server/socket_test.go
@@ -71,8 +71,12 @@ func TestDefaultHost_XDGRuntimeDir(t *testing.T) {
 	path := strings.TrimPrefix(host, "unix://")
 
 	// The composed path may exceed maxUnixSocketPathLen and fall back
-	// to /tmp; only assert containment when it did not.
-	if len(filepath.Join(dir, "crush.sock")) <= maxUnixSocketPathLen {
+	// to /tmp; only assert containment when it did not. Recompose the
+	// path under dir (rather than checking the returned path length,
+	// which is short again after a /tmp fallback) to decide whether a
+	// fallback happened. The socket is named crush-<uid>.sock.
+	composed := filepath.Join(dir, filepath.Base(path))
+	if len(composed) <= maxUnixSocketPathLen {
 		require.True(t, strings.HasPrefix(path, dir),
 			"socket path %q should live under %q", path, dir)
 	}
@@ -104,7 +108,7 @@ func TestDefaultHost_FallbackTemp(t *testing.T) {
 // it. A leftover file is best-effort removed via t.Cleanup.
 func staleSocketPath(t *testing.T, path string) {
 	t.Helper()
-	ln, err := net.Listen("unix", path)
+	ln, err := net.Listen("unix", path) //nolint:noctx
 	require.NoError(t, err)
 	ul, ok := ln.(*net.UnixListener)
 	require.True(t, ok, "expected *net.UnixListener, got %T", ln)
@@ -112,7 +116,7 @@ func staleSocketPath(t *testing.T, path string) {
 	require.NoError(t, ul.Close())
 
 	// Verify it is actually stale: dialing should fail.
-	conn, dialErr := net.DialTimeout("unix", path, 200*time.Millisecond)
+	conn, dialErr := net.DialTimeout("unix", path, 200*time.Millisecond) //nolint:noctx
 	if dialErr == nil {
 		conn.Close()
 		t.Fatalf("expected stale socket at %q to refuse connections", path)
@@ -150,7 +154,7 @@ func TestListen_LiveSocketNotRemoved(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "s.sock")
 
-	ln1, err := net.Listen("unix", path)
+	ln1, err := net.Listen("unix", path) //nolint:noctx
 	require.NoError(t, err)
 
 	// Drain accepts so the listener stays alive and responsive without
@@ -183,7 +187,7 @@ func TestListen_LiveSocketNotRemoved(t *testing.T) {
 	// The live socket file must still be on disk and dialable.
 	_, statErr := os.Stat(path)
 	require.NoError(t, statErr, "live socket file should still exist")
-	conn, dialErr := net.DialTimeout("unix", path, 200*time.Millisecond)
+	conn, dialErr := net.DialTimeout("unix", path, 200*time.Millisecond) //nolint:noctx
 	require.NoError(t, dialErr, "live socket should still accept dials")
 	_ = conn.Close()
 }


### PR DESCRIPTION
This fixes a critical bug in client-server mode where leftover sockets would prevent Crush from launching.

It also corrects the socket location from `/tmp` to `$XDG_RUNTIME_DIR` on Linux and `$TMPDIR` on macOS. Named pipes on Windows have not been changed.