### PR TITLE
fix(config): honor configured api_key for the Vertex AI provider

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -999,7 +999,7 @@ func (c *coordinator) buildGoogleProvider(baseURL, apiKey string, headers map[st
 	return google.New(opts...)
 }
 
-func (c *coordinator) buildGoogleVertexProvider(headers map[string]string, options map[string]string) (fantasy.Provider, error) {
+func (c *coordinator) buildGoogleVertexProvider(baseURL, apiKey string, headers map[string]string, options map[string]string) (fantasy.Provider, error) {
 	opts := []google.Option{}
 	if c.cfg.Config().Options.Debug {
 		httpClient := log.NewHTTPClient()
@@ -1012,7 +1012,19 @@ func (c *coordinator) buildGoogleVertexProvider(headers map[string]string, optio
 	project := options["project"]
 	location := options["location"]
 
-	opts = append(opts, google.WithVertex(project, location))
+	switch {
+	case project != "" && location != "":
+		opts = append(opts, google.WithVertex(project, location))
+	case apiKey != "":
+		// Without native GCP credentials, authenticate with the configured
+		// API key (e.g. against a Gemini-API-compatible proxy).
+		opts = append(opts, google.WithGeminiAPIKey(apiKey))
+	default:
+		return nil, errors.New("vertex ai provider requires either VERTEXAI_PROJECT and VERTEXAI_LOCATION or an api_key")
+	}
+	if baseURL != "" {
+		opts = append(opts, google.WithBaseURL(baseURL))
+	}
 
 	return google.New(opts...)
 }
@@ -1067,7 +1079,7 @@ func (c *coordinator) buildProvider(providerCfg config.ProviderConfig, model con
 	case google.Name:
 		return c.buildGoogleProvider(baseURL, apiKey, headers)
 	case "google-vertex":
-		return c.buildGoogleVertexProvider(headers, providerCfg.ExtraParams)
+		return c.buildGoogleVertexProvider(baseURL, apiKey, headers, providerCfg.ExtraParams)
 	case openaicompat.Name, hyper.Name:
 		switch providerCfg.ID {
 		case hyper.Name:

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -306,15 +306,19 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 				project  = env.Get("VERTEXAI_PROJECT")
 				location = env.Get("VERTEXAI_LOCATION")
 			)
-			if project == "" || location == "" {
+			if project != "" && location != "" {
+				prepared.ExtraParams["project"] = project
+				prepared.ExtraParams["location"] = location
+			} else if v, err := resolver.ResolveValue(p.APIKey); v == "" || err != nil {
+				// Without native GCP credentials an API key works like any
+				// other provider (e.g. against a Gemini-API-compatible
+				// proxy); only drop the provider when neither is available.
 				if configExists {
-					slog.Warn("Skipping Vertex AI provider due to missing credentials")
+					slog.Warn("Skipping Vertex AI provider: no VERTEXAI_PROJECT/VERTEXAI_LOCATION and no usable api_key", "provider", p.ID, "error", err)
 					c.Providers.Del(string(p.ID))
 				}
 				continue
 			}
-			prepared.ExtraParams["project"] = project
-			prepared.ExtraParams["location"] = location
 		case catwalk.InferenceProviderAzure:
 			endpoint, err := resolver.ResolveValue(p.APIEndpoint)
 			if err != nil || endpoint == "" {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -556,19 +556,16 @@ func TestConfig_configureProvidersVertexAIMissingProject(t *testing.T) {
 	require.Equal(t, cfg.Providers.Len(), 0)
 }
 
-// TestConfig_configureProvidersVertexAIWithAPIKey reproduces issue #3074:
-// a Vertex AI provider configured with an api_key (and a custom base_url
-// pointing at a proxy) is dropped during config load because the vertexai
-// branch only looks at the VERTEXAI_PROJECT / VERTEXAI_LOCATION env vars and
-// ignores the configured api_key entirely. Once the provider is dropped,
-// Crush thinks it is unconfigured and prompts the user for an API key.
+// TestConfig_configureProvidersVertexAIWithAPIKey is a regression test for
+// issue #3074: a Vertex AI provider configured with an api_key (and a custom
+// base_url pointing at a proxy) used to be dropped during config load because
+// the vertexai branch only looked at the VERTEXAI_PROJECT / VERTEXAI_LOCATION
+// env vars and ignored the configured api_key entirely. Once dropped, Crush
+// thought the provider was unconfigured and prompted the user for an API key,
+// even though the same api_key style works for openai/anthropic.
 //
-// The same api_key style works for openai/anthropic because they go through
-// the generic branch that resolves p.APIKey.
-//
-// This test documents the CURRENT (buggy) behavior: the provider is dropped
-// even though a valid api_key is present. After the fix, the provider should
-// be kept (flip the assertion to Len() == 1).
+// With the fix, an api_key keeps the provider alive when the GCP env vars are
+// absent, matching the generic-provider behavior.
 func TestConfig_configureProvidersVertexAIWithAPIKey(t *testing.T) {
 	knownProviders := []catwalk.Provider{
 		{
@@ -582,18 +579,22 @@ func TestConfig_configureProvidersVertexAIWithAPIKey(t *testing.T) {
 	}
 
 	cfg := &Config{}
-	cfg.setDefaults("/tmp", "")
+	cfg.setDefaults(t.TempDir(), "")
 	// No VERTEXAI_PROJECT / VERTEXAI_LOCATION on purpose: the user is
 	// authenticating via api_key + proxy, not native GCP credentials.
 	env := env.NewFromMap(map[string]string{})
 	resolver := NewShellVariableResolver(env)
 	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 	require.NoError(t, err)
+	require.Equal(t, 1, cfg.Providers.Len(),
+		"vertexai provider with an api_key must be kept (issue #3074)")
 
-	// BUG #3074: the provider is dropped despite a configured api_key.
-	// This assertion PASSES today, which is exactly the bug.
-	require.Equal(t, 0, cfg.Providers.Len(),
-		"BUG #3074")
+	vertexProvider, ok := cfg.Providers.Get("vertexai")
+	require.True(t, ok, "VertexAI provider should be present")
+	require.Equal(t, "test-api-key", vertexProvider.APIKey)
+	require.Equal(t, "https://vertex-proxy.example.com", vertexProvider.BaseURL)
+	require.Empty(t, vertexProvider.ExtraParams["project"], "no GCP project expected when authenticating via api_key")
+	require.Empty(t, vertexProvider.ExtraParams["location"])
 }
 
 func TestConfig_configureProvidersSetProviderID(t *testing.T) {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -556,6 +556,46 @@ func TestConfig_configureProvidersVertexAIMissingProject(t *testing.T) {
 	require.Equal(t, cfg.Providers.Len(), 0)
 }
 
+// TestConfig_configureProvidersVertexAIWithAPIKey reproduces issue #3074:
+// a Vertex AI provider configured with an api_key (and a custom base_url
+// pointing at a proxy) is dropped during config load because the vertexai
+// branch only looks at the VERTEXAI_PROJECT / VERTEXAI_LOCATION env vars and
+// ignores the configured api_key entirely. Once the provider is dropped,
+// Crush thinks it is unconfigured and prompts the user for an API key.
+//
+// The same api_key style works for openai/anthropic because they go through
+// the generic branch that resolves p.APIKey.
+//
+// This test documents the CURRENT (buggy) behavior: the provider is dropped
+// even though a valid api_key is present. After the fix, the provider should
+// be kept (flip the assertion to Len() == 1).
+func TestConfig_configureProvidersVertexAIWithAPIKey(t *testing.T) {
+	knownProviders := []catwalk.Provider{
+		{
+			ID:          catwalk.InferenceProviderVertexAI,
+			APIKey:      "test-api-key",                     // user configured an api_key
+			APIEndpoint: "https://vertex-proxy.example.com", // custom proxy base_url
+			Models: []catwalk.Model{{
+				ID: "gemini-pro",
+			}},
+		},
+	}
+
+	cfg := &Config{}
+	cfg.setDefaults("/tmp", "")
+	// No VERTEXAI_PROJECT / VERTEXAI_LOCATION on purpose: the user is
+	// authenticating via api_key + proxy, not native GCP credentials.
+	env := env.NewFromMap(map[string]string{})
+	resolver := NewShellVariableResolver(env)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
+	require.NoError(t, err)
+
+	// BUG #3074: the provider is dropped despite a configured api_key.
+	// This assertion PASSES today, which is exactly the bug.
+	require.Equal(t, 0, cfg.Providers.Len(),
+		"BUG #3074")
+}
+
 func TestConfig_configureProvidersSetProviderID(t *testing.T) {
 	knownProviders := []catwalk.Provider{
 		{


### PR DESCRIPTION
Fixes #3074

## Problem

A Vertex AI provider configured with an `api_key` (and optionally a custom
`base_url` pointing at a proxy) was dropped during config load. The
`vertexai` case in `configureProviders` only checked the `VERTEXAI_PROJECT`
/ `VERTEXAI_LOCATION` env vars and ignored the configured `api_key`
entirely — so Crush treated the provider as unconfigured and prompted for
an API key, even though the identical config style works for the `openai`
and `anthropic` providers.

## Fix

Two changes, both on the Crush side (`fantasy`'s google provider already
exposes everything needed — `WithGeminiAPIKey`, `WithBaseURL`,
`WithVertex` — so no upstream change is required):

1. **`internal/config/load.go`** — when `VERTEXAI_PROJECT`/`VERTEXAI_LOCATION`
   are absent, resolve the configured `api_key` like the generic provider
   branch does (including `$VAR` / `$(cmd)` templates) and keep the
   provider when it resolves. The provider is only dropped when *neither*
   native GCP credentials nor an api_key are available.
2. **`internal/agent/coordinator.go`** — `buildGoogleVertexProvider` now
   receives the resolved `api_key` and `base_url`. When `project`/`location`
   are present the native `WithVertex` path is unchanged (and still takes
   precedence); otherwise the provider is built with
   `WithGeminiAPIKey(apiKey)`. A configured `base_url` is wired through in
   both cases.

### Behavior

| Config | Before | After |
|---|---|---|
| `VERTEXAI_PROJECT` + `VERTEXAI_LOCATION` set | Vertex backend (ADC) | unchanged |
| `api_key` only (no env vars) | provider dropped, key prompt | kept; Gemini-API auth, `base_url` honored |
| neither | provider dropped | unchanged |

### Design note

I interpreted "api_key + custom base_url" as a Gemini-API-compatible
endpoint/proxy (`WithGeminiAPIKey` + `WithBaseURL`), since that matches
what the reporter's proxy expects and how the other providers behave. If
you'd rather keep the Vertex backend and route through the proxy with
skip-auth, happy to adjust.

## Testing

- New regression test `TestConfig_configureProvidersVertexAIWithAPIKey`
  (fails on `main`, passes here): provider with an `api_key` and no GCP
  env vars is kept, with `api_key`/`base_url` intact and no
  `project`/`location` extra params.
- Existing `VertexAIWithCredentials` / `WithoutCredentials` /
  `MissingProject` tests still pass (env-var behavior unchanged).
- `go test ./internal/config ./internal/agent` — 336 passed.
- `golangci-lint run` clean on the touched packages.