### PR TITLE
feat(hooks): add more lifecycle hooks

### DIFF
--- a/docs/hooks/FUTURE.md
+++ b/docs/hooks/FUTURE.md
@@ -152,16 +152,18 @@ unaffected.
 
 ## `UserPromptSubmit` event
 
-**Status:** not implemented.
+**Status:** partially implemented as `TurnStart`. The current `TurnStart` event
+fires when the agent begins processing a prompt but does not yet support
+`decision` (blocking prompts) or `updated_prompt` (rewriting prompts). Those
+control features are still planned.
 
 ### Motivation
 
-Today Crush supports exactly one hook event, `PreToolUse`. That's enough to gate
-and rewrite tool calls but nothing else. The next-most-useful event is
-`UserPromptSubmit`: fires after the user hits Enter but before the turn hits the
-LLM. Lets hooks inject context, rewrite prompts, or gate on content without the
-mutation complexity of `PostToolUse` (output scrubbing, error coercion, size
-limits — all rabbit holes).
+Crush now supports 12 hook events including `TurnStart`, which covers the basic
+observability use case. The remaining gap is **control**: letting hooks block
+prompts matching a policy or rewrite them before they reach the LLM. This would
+enable secret redaction from prompts, policy enforcement ("don't mention
+production credentials"), and shorthand expansion.
 
 ### Use cases
 

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -199,6 +199,10 @@ regex tested against the tool name (e.g. `^bash$`, `^(edit|write)$`,
 `^mcp_`). Omit to match all tools. Lifecycle events run all configured hooks
 unconditionally.
 
+> **Note:** `TurnEnd` carries the assistant's rendered text content in its
+> stdin payload (`text` field). See [Stdin payload — TurnEnd](#stdin-payload--turnend)
+> below. All other lifecycle events use only the common fields.
+
 **Scope**: tool events only fire on the **top-level agent's** tool calls.
 Sub-agents run without hook interception. The outer sub-agent tool call itself
 _is_ hooked.
@@ -747,10 +751,25 @@ Extends the common payload with tool-specific fields:
 
 ### Stdin payload — Lifecycle Events
 
-All other events (SessionStart, SessionEnd, TurnStart, TurnEnd, StopFailure,
+All other events (SessionStart, SessionEnd, TurnStart, StopFailure,
 Interrupt, PermissionRequest, PermissionResult, PreCompact, PostCompact) use
 only the common payload fields (`event`, `session_id`, `cwd`). No tool-specific
 fields are included.
+
+### Stdin payload — TurnEnd
+
+`TurnEnd` extends the common payload with the assistant's rendered text
+content for the completed turn. The hook remains observe-only; output is
+ignored.
+
+```jsonc
+{
+  // ...common fields...
+
+  // string. The assistant's rendered text output for this turn.
+  "text": "Here's what I found..."
+}
+```
 
 ### Output envelope (common)
 

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -762,6 +762,10 @@ fields are included.
 content for the completed turn. The hook remains observe-only; output is
 ignored.
 
+`TurnEnd` fires only for top-level turns. Sub-agents (`agentic_fetch`, the
+task tool, etc.) run non-interactively and do not fire it, so a hook runs
+once per user-facing turn rather than once per delegated sub-agent turn.
+
 ```jsonc
 {
   // ...common fields...

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -17,8 +17,8 @@ forward.
 - Hooks are Claude Code-compatible
 - Crush ships with a builtin `crush-hook` skill write, edit, and configure
   hooks; just tell Crush how to configure Crush
-- Crush currently supports just one hook, `PreToolUse`, with plans to support
-  the full gamut; please let us know which hooks you'd like to see next
+- Crush supports 12 hook events covering the full agent lifecycle: tool use,
+  session management, turn control, permissions, compaction, and error handling
 - Hooks run in parallel for speed, but their results compose in config order
   for determinism
 
@@ -162,12 +162,12 @@ and project-level, with project level hooks taking precedence.
 >   "hooks": {
 >     "PreToolUse": [
 >       {
->         "command": "/home/you/.config/crush/hooks/no-haskell.sh"
+>         "command": "/home/you/.config/crush/hooks/no-haskell.sh",
 >         // or use an inline command:
 >         // "command": "echo '{\"decision\":\"allow\"}'"
->       }
->     ]
->   }
+>       },
+>     ],
+>   },
 > }
 > ```
 
@@ -176,29 +176,123 @@ wins when rewriting input, but first deny wins when blocking.
 
 ## Events
 
-Here are the events you can hook into (spoiler: there's currently just one):
+Crush supports 12 hook events. Event names are case-insensitive and accept
+snake_case (`PreToolUse`, `pre_tool_use`, `PRETOOLUSE` all work).
 
-### PreToolUse
+| Event               | Fires When                          | Control                                  | Matcher   |
+| ------------------- | ----------------------------------- | ---------------------------------------- | --------- |
+| `PreToolUse`        | Before tool execution               | allow/deny, halt, rewrite input, context | tool name |
+| `PostToolUse`       | After tool execution                | halt, replace output, context            | tool name |
+| `SessionStart`      | Session created                     | observe                                  | —         |
+| `SessionEnd`        | App shutdown (2s timeout)           | observe                                  | —         |
+| `TurnStart`         | Agent begins processing prompt      | observe                                  | —         |
+| `TurnEnd`           | Agent finishes turn (idle)          | observe                                  | —         |
+| `StopFailure`       | Turn ends due to API error          | observe                                  | —         |
+| `Interrupt`         | User cancels (ctrl-c, escape)       | observe                                  | —         |
+| `PermissionRequest` | Permission prompt shown (blocked)   | observe                                  | —         |
+| `PermissionResult`  | Permission decided (granted/denied) | observe                                  | —         |
+| `PreCompact`        | Before context compaction           | halt to prevent                          | —         |
+| `PostCompact`       | After context compaction            | observe                                  | —         |
 
-This hook fires before every tool call. Use it to block dangerous commands,
-enforce policies, rewrite tool input, inject context the model should see, log
-stuff, and so on.
+**Matcher** only applies to tool events (`PreToolUse`, `PostToolUse`). It's a
+regex tested against the tool name (e.g. `^bash$`, `^(edit|write)$`,
+`^mcp_`). Omit to match all tools. Lifecycle events run all configured hooks
+unconditionally.
 
-**Matched against**: the tool name (e.g. `bash`, `edit`, `write`,
-`mcp_github_create_pull_request`).
+**Scope**: tool events only fire on the **top-level agent's** tool calls.
+Sub-agents run without hook interception. The outer sub-agent tool call itself
+_is_ hooked.
 
-> [!NOTE]
-> Event names are case insensitive and snake-caseable, so `PreToolUse`,
-> `pretooluse`, `PRETOOLUSE`, `pre_tool_use`, and `PRE_TOOL_USE` all work.
+### What each control field does
 
-**Scope**: `PreToolUse` only fires on the **top-level agent's** tool calls.
-Sub-agents (the `agent` task tool, `agentic_fetch`, etc.) run without hook
-interception so a single delegated turn doesn't trigger your hook N times. The
-outer sub-agent tool call itself _is_ hooked, so policy like "never let the
-agent spawn sub-agents" still works.
+- **`decision: "allow"`** — pre-approves the tool call, skips the permission
+  prompt. `"deny"` blocks it; the model sees the error and may retry.
+- **`halt: true`** — ends the entire turn. For `PreCompact`, prevents
+  compaction instead.
+- **`updated_input`** — for `PreToolUse`: shallow-merge patch against tool
+  input. For `PostToolUse`: replaces what the model sees as the tool's response.
+- **`context`** — string or array appended to what the model sees. Works on
+  both tool events.
 
-Hooks are keyed by event name. Only `command` is required, and you can omit
-`matcher` to match all tools.
+Events marked "observe" ignore all control fields. They exist for logging,
+monitoring, and external integrations (e.g. herdr, dashboards). To auto-approve
+tools, use `PreToolUse` with `decision: "allow"` rather than
+`PermissionRequest`.
+
+### Control field examples
+
+**PreToolUse — rewrite input:**
+
+```bash
+#!/usr/bin/env bash
+# Replace npm with bun in every bash call.
+read -r input
+cmd=$(echo "$input" | jq -r '.tool_input.command')
+if echo "$cmd" | grep -q '^npm '; then
+  new_cmd=$(echo "$cmd" | sed 's/^npm /bun /')
+  echo "{\"updated_input\":{\"command\":\"$new_cmd\"}}"
+fi
+```
+
+**PostToolUse — redact secrets from output:**
+
+```bash
+#!/usr/bin/env bash
+# Replace anything that looks like an API key in tool output.
+read -r input
+output=$(echo "$input" | jq -r '.tool_input // empty')
+redacted=$(echo "$output" | sed -E 's/(sk-|ghp_|AKIA)[A-Za-z0-9]{20,}/[REDACTED]/g')
+echo "{\"updated_input\":\"$redacted\"}"
+```
+
+**PostToolUse — halt on unexpected output:**
+
+```bash
+#!/usr/bin/env bash
+# Stop the turn if bash output contains a credential leak warning.
+read -r input
+if echo "$input" | jq -r '.tool_input // ""' | grep -qi 'credential.*leak'; then
+  echo '{"halt":true,"reason":"Possible credential leak detected in tool output"}'
+  exit 0
+fi
+```
+
+**PreCompact — skip compaction during critical work:**
+
+```bash
+#!/usr/bin/env bash
+# Don't compact if we're in the middle of a migration.
+if [ -f .migration-in-progress ]; then
+  echo '{"halt":true}'
+fi
+```
+
+**PreToolUse — inject context:**
+
+```bash
+#!/usr/bin/env bash
+# Remind the model about formatting rules when editing Go files.
+read -r input
+path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+if [[ "$path" == *.go ]]; then
+  echo '{"context":"Remember: run gofumpt -w after editing Go files."}'
+fi
+```
+
+### Configuration
+
+Hooks are keyed by event name. Only `command` is required:
+
+```jsonc
+{
+  "hooks": {
+    "PreToolUse": [{ "matcher": "^bash$", "command": "./hooks/check.sh" }],
+    "PostToolUse": [{ "matcher": "^bash$", "command": "./hooks/redact.sh" }],
+    "TurnEnd": [{ "command": "./hooks/notify-idle.sh" }],
+    "PreCompact": [{ "command": "./hooks/maybe-skip-compact.sh" }],
+  },
+}
+```
 
 ## Building Hooks
 
@@ -633,9 +727,9 @@ Present in every hook event:
 }
 ```
 
-### Stdin payload — PreToolUse
+### Stdin payload — Tool Events (PreToolUse, PostToolUse)
 
-Extends the common payload:
+Extends the common payload with tool-specific fields:
 
 ```jsonc
 {
@@ -650,6 +744,13 @@ Extends the common payload:
   },
 }
 ```
+
+### Stdin payload — Lifecycle Events
+
+All other events (SessionStart, SessionEnd, TurnStart, TurnEnd, StopFailure,
+Interrupt, PermissionRequest, PermissionResult, PreCompact, PostCompact) use
+only the common payload fields (`event`, `session_id`, `cwd`). No tool-specific
+fields are included.
 
 ### Output envelope (common)
 
@@ -697,6 +798,17 @@ Extends the common envelope:
 }
 ```
 
+### Output envelope — PostToolUse
+
+Same as the common envelope plus `updated_input`, which **replaces** (not
+patches) what the model sees as the tool's response. `decision` is not
+supported since the tool has already executed.
+
+### Output envelope — PreCompact
+
+Same as the common envelope. `halt: true` prevents compaction; the agent
+continues with the full context intact.
+
 ### Exit codes
 
 | Code  | Meaning                                                                  |
@@ -731,6 +843,16 @@ PreToolUse-specific rules:
 5. `updated_input` patches shallow-merge sequentially against the original
    `tool_input`. Later patches override earlier ones on colliding keys. Patches
    are **ignored** if the final decision is deny or halt.
+
+PostToolUse-specific rules:
+
+6. `updated_input` **replaces** the tool output (not a shallow-merge patch like
+   PreToolUse). Later hooks override earlier ones entirely.
+
+PreCompact-specific rules:
+
+7. `halt` prevents context compaction. The agent continues with the full
+   context intact.
 
 ### Environment variables
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -41,6 +41,7 @@ import (
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/hooks"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/session"
@@ -180,6 +181,7 @@ type sessionAgent struct {
 	isYolo               bool
 	notify               pubsub.Publisher[notify.Notification]
 	runComplete          pubsub.Publisher[notify.RunComplete]
+	hookRunner           *hooks.Runner
 
 	messageQueue   *csync.Map[string, []SessionAgentCall]
 	activeRequests *csync.Map[string, *activeCancel]
@@ -222,6 +224,33 @@ type sessionAgent struct {
 	acceptSeqGen uint64
 }
 
+// fireLifecycleHook runs a lifecycle hook event that can control
+// agent behavior (e.g. PreCompact halt). Returns the aggregated
+// result so callers can inspect halt/decision. Errors are logged but
+// do not interrupt the agent.
+func (a *sessionAgent) fireLifecycleHook(ctx context.Context, eventName, sessionID string) hooks.AggregateResult {
+	if a.hookRunner == nil {
+		return hooks.AggregateResult{}
+	}
+	result, err := a.hookRunner.Run(ctx, eventName, sessionID, "", "")
+	if err != nil {
+		slog.Warn("Lifecycle hook failed", "event", eventName, "error", err)
+		return hooks.AggregateResult{}
+	}
+	return result
+}
+
+// fireObservabilityHook runs a lifecycle hook event for observation
+// only (e.g. TurnStart, TurnEnd). Errors are logged and discarded.
+func (a *sessionAgent) fireObservabilityHook(ctx context.Context, eventName, sessionID string) {
+	if a.hookRunner == nil {
+		return
+	}
+	if _, err := a.hookRunner.Run(ctx, eventName, sessionID, "", ""); err != nil {
+		slog.Warn("Lifecycle hook failed", "event", eventName, "error", err)
+	}
+}
+
 type SessionAgentOptions struct {
 	LargeModel           Model
 	SmallModel           Model
@@ -235,6 +264,7 @@ type SessionAgentOptions struct {
 	Tools                []fantasy.AgentTool
 	Notify               pubsub.Publisher[notify.Notification]
 	RunComplete          pubsub.Publisher[notify.RunComplete]
+	LifecycleHooks       *hooks.Runner
 }
 
 func NewSessionAgent(
@@ -253,6 +283,7 @@ func NewSessionAgent(
 		isYolo:               opts.IsYolo,
 		notify:               opts.Notify,
 		runComplete:          opts.RunComplete,
+		hookRunner:           opts.LifecycleHooks,
 		messageQueue:         csync.NewMap[string, []SessionAgentCall](),
 		activeRequests:       csync.NewMap[string, *activeCancel](),
 		dispatchMu:           csync.NewMap[string, *sync.Mutex](),
@@ -784,6 +815,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 
 	startTime := time.Now()
 	a.eventPromptSent(call.SessionID)
+	a.fireObservabilityHook(ctx, hooks.EventTurnStart, call.SessionID)
 
 	var stepMessages []fantasy.Message
 	var shouldSummarize bool
@@ -1071,6 +1103,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			"error_type", fmt.Sprintf("%T", err),
 			"is_hyper", isHyper,
 			"is_cancel", isCancelErr)
+		if isCancelErr {
+			a.fireObservabilityHook(ctx, hooks.EventInterrupt, call.SessionID)
+		}
 		if currentAssistant == nil {
 			// Cancel-before-assistant-creation window: the run was
 			// canceled after activeRequests.Set but before PrepareStep
@@ -1189,7 +1224,16 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		if updateErr != nil {
 			return nil, updateErr
 		}
+		a.fireObservabilityHook(ctx, hooks.EventStopFailure, call.SessionID)
 		return nil, err
+	}
+
+	if shouldSummarize {
+		preCompact := a.fireLifecycleHook(ctx, hooks.EventPreCompact, call.SessionID)
+		if preCompact.Halt {
+			slog.Info("PreCompact hook halted compaction", "session_id", call.SessionID)
+			shouldSummarize = false
+		}
 	}
 
 	if shouldSummarize {
@@ -1197,6 +1241,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		if summarizeErr := a.Summarize(genCtx, call.SessionID, call.ProviderOptions, call.OnAuthRefresh); summarizeErr != nil {
 			return nil, summarizeErr
 		}
+		a.fireObservabilityHook(ctx, hooks.EventPostCompact, call.SessionID)
 		// If the agent wasn't done...
 		if len(currentAssistant.ToolCalls()) > 0 {
 			existing, ok := a.messageQueue.Get(call.SessionID)
@@ -1215,6 +1260,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	// subscribers see stale busy state at the moment of receipt.
 	a.activeRequests.Del(call.SessionID)
 	cancel()
+	a.fireObservabilityHook(ctx, hooks.EventTurnEnd, call.SessionID)
 
 	// Send notification that agent has finished its turn (skip for
 	// nested/non-interactive sessions).

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -241,7 +241,7 @@ func (a *sessionAgent) fireLifecycleHook(ctx context.Context, eventName, session
 }
 
 // fireObservabilityHook runs a lifecycle hook event for observation
-// only (e.g. TurnStart, TurnEnd). Errors are logged and discarded.
+// only (e.g. TurnStart). Errors are logged and discarded.
 func (a *sessionAgent) fireObservabilityHook(ctx context.Context, eventName, sessionID string) {
 	if a.hookRunner == nil {
 		return
@@ -249,6 +249,20 @@ func (a *sessionAgent) fireObservabilityHook(ctx context.Context, eventName, ses
 	if _, err := a.hookRunner.Run(ctx, eventName, sessionID, "", ""); err != nil {
 		slog.Warn("Lifecycle hook failed", "event", eventName, "error", err)
 	}
+}
+
+// fireTurnEndHook runs the TurnEnd lifecycle hook with the
+// assistant's rendered text content. Observe-only; errors are
+// logged and discarded.
+func (a *sessionAgent) fireTurnEndHook(ctx context.Context, sessionID string, msg *message.Message) {
+	if a.hookRunner == nil {
+		return
+	}
+	var text string
+	if msg != nil {
+		text = msg.Content().String()
+	}
+	a.hookRunner.RunTurnEnd(ctx, sessionID, text)
 }
 
 type SessionAgentOptions struct {
@@ -1260,7 +1274,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	// subscribers see stale busy state at the moment of receipt.
 	a.activeRequests.Del(call.SessionID)
 	cancel()
-	a.fireObservabilityHook(ctx, hooks.EventTurnEnd, call.SessionID)
+	a.fireTurnEndHook(ctx, call.SessionID, currentAssistant)
 
 	// Send notification that agent has finished its turn (skip for
 	// nested/non-interactive sessions).

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1274,7 +1274,14 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	// subscribers see stale busy state at the moment of receipt.
 	a.activeRequests.Del(call.SessionID)
 	cancel()
-	a.fireTurnEndHook(ctx, call.SessionID, currentAssistant)
+
+	// Fire the TurnEnd hook only for top-level turns. Sub-agents
+	// (agentic_fetch, the task tool, etc.) run non-interactively and
+	// would otherwise fire the user's hook N times per delegated turn,
+	// matching the sub-agent exclusion applied to tool hooks.
+	if !call.NonInteractive {
+		a.fireTurnEndHook(ctx, call.SessionID, currentAssistant)
+	}
 
 	// Send notification that agent has finished its turn (skip for
 	// nested/non-interactive sessions).

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -709,7 +709,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 	// Build hook runner if PreToolUse hooks are configured.
 	var hookRunner *hooks.Runner
 	if preToolHooks := c.cfg.Config().Hooks[hooks.EventPreToolUse]; len(preToolHooks) > 0 {
-		hookRunner = hooks.NewRunner(preToolHooks, c.cfg.WorkingDir(), c.cfg.WorkingDir())
+		hookRunner = hooks.NewRunner(map[string][]config.HookConfig{hooks.EventPreToolUse: preToolHooks}, c.cfg.WorkingDir(), c.cfg.WorkingDir())
 	}
 
 	allTools = append(

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -126,6 +126,7 @@ type coordinator struct {
 
 	currentAgent SessionAgent
 	agents       map[string]SessionAgent
+	hookRunner   *hooks.Runner
 
 	// Skills discovery results (session-start snapshot).
 	allSkills    []*skills.Skill // Pre-filter: all discovered after dedup.
@@ -150,6 +151,7 @@ type CoordinatorOptions struct {
 	Notify      pubsub.Publisher[notify.Notification]
 	RunComplete pubsub.Publisher[notify.RunComplete]
 	Skills      *skills.Manager
+	HookRunner  *hooks.Runner
 	Interactive bool
 }
 
@@ -183,6 +185,16 @@ func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, 
 		activeSkills: activeSkills,
 		skillTracker: skillTracker,
 		interactive:  opts.Interactive,
+	}
+
+	// Wire the shared hook runner into the agent and permission
+	// service.
+	c.hookRunner = opts.HookRunner
+	if c.hookRunner != nil {
+		c.permissions.SetLifecycleHooks(permission.LifecycleHookRunnerFunc(func(ctx context.Context, eventName, sessionID string) error {
+			_, err := c.hookRunner.Run(ctx, eventName, sessionID, "", "")
+			return err
+		}))
 	}
 
 	agentCfg, ok := opts.Config.Config().Agents[config.AgentCoder]
@@ -630,6 +642,7 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		Tools:                nil,
 		Notify:               c.notify,
 		RunComplete:          c.runComplete,
+		LifecycleHooks:       c.hookRunner,
 	})
 
 	// The readiness goroutines below perform one-time setup — building the

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -799,12 +799,17 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 	// without hook interception to avoid firing the user's hook N times
 	// per delegated turn. The top-level invocation of the sub-agent tool
 	// itself is still wrapped from the coder's side.
-	filteredTools = wrapToolsWithHooks(filteredTools, hookRunner, isSubAgent)
+	// Build PostToolUse runner if configured.
+	var postToolRunner *hooks.Runner
+	if postHooks := c.cfg.Config().Hooks[hooks.EventPostToolUse]; len(postHooks) > 0 {
+		postToolRunner = hooks.NewRunner(map[string][]config.HookConfig{hooks.EventPostToolUse: postHooks}, c.cfg.WorkingDir(), c.cfg.WorkingDir())
+	}
+
+	filteredTools = wrapToolsWithHooks(filteredTools, hookRunner, postToolRunner, isSubAgent)
 
 	return filteredTools, nil
 }
 
-// TODO: when we support multiple agents we need to change this so that we pass in the agent specific model config
 func (c *coordinator) buildAgentModels(ctx context.Context, isSubAgent bool) (Model, Model, error) {
 	largeModelCfg, ok := c.cfg.Config().Models[config.SelectedModelTypeLarge]
 	if !ok {

--- a/internal/agent/hooked_tool.go
+++ b/internal/agent/hooked_tool.go
@@ -13,28 +13,29 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-// hookedTool wraps a fantasy.AgentTool to run PreToolUse hooks before
-// delegating to the inner tool.
+// hookedTool wraps a fantasy.AgentTool to run PreToolUse and PostToolUse
+// hooks around the inner tool's execution.
 type hookedTool struct {
-	inner  fantasy.AgentTool
-	runner *hooks.Runner
+	inner          fantasy.AgentTool
+	preToolRunner  *hooks.Runner
+	postToolRunner *hooks.Runner
 }
 
-func newHookedTool(inner fantasy.AgentTool, runner *hooks.Runner) *hookedTool {
-	return &hookedTool{inner: inner, runner: runner}
+func newHookedTool(inner fantasy.AgentTool, preToolRunner, postToolRunner *hooks.Runner) *hookedTool {
+	return &hookedTool{inner: inner, preToolRunner: preToolRunner, postToolRunner: postToolRunner}
 }
 
 // wrapToolsWithHooks returns a tool slice with each entry wrapped in a
 // hookedTool. Returns the original slice unchanged when runner is nil or
 // when isSubAgent is true — sub-agents never fire hooks, the top-level
 // invocation of the sub-agent tool itself is wrapped on the caller's side.
-func wrapToolsWithHooks(tools []fantasy.AgentTool, runner *hooks.Runner, isSubAgent bool) []fantasy.AgentTool {
-	if runner == nil || isSubAgent {
+func wrapToolsWithHooks(tools []fantasy.AgentTool, preToolRunner, postToolRunner *hooks.Runner, isSubAgent bool) []fantasy.AgentTool {
+	if (preToolRunner == nil && postToolRunner == nil) || isSubAgent {
 		return tools
 	}
 	out := make([]fantasy.AgentTool, len(tools))
 	for i, tool := range tools {
-		out[i] = newHookedTool(tool, runner)
+		out[i] = newHookedTool(tool, preToolRunner, postToolRunner)
 	}
 	return out
 }
@@ -53,46 +54,76 @@ func (h *hookedTool) SetProviderOptions(opts fantasy.ProviderOptions) {
 
 func (h *hookedTool) Run(ctx context.Context, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
 	sessionID := tools.GetSessionFromContext(ctx)
-	result, err := h.runner.Run(ctx, hooks.EventPreToolUse, sessionID, call.Name, call.Input)
-	if err != nil {
-		slog.Warn("Hook execution error, proceeding with tool call",
-			"tool", call.Name, "error", err)
-	}
 
-	if result.Decision == hooks.DecisionDeny || result.Halt {
-		reason := fmt.Sprintf("Tool call blocked by hook. Reason: %s", result.Reason)
-		if result.Halt {
-			reason = fmt.Sprintf("Turn halted by hook. Reason: %s", result.Reason)
+	// Run PreToolUse hooks.
+	var result hooks.AggregateResult
+	if h.preToolRunner != nil {
+		var err error
+		result, err = h.preToolRunner.Run(ctx, hooks.EventPreToolUse, sessionID, call.Name, call.Input)
+		if err != nil {
+			slog.Warn("Hook execution error, proceeding with tool call",
+				"tool", call.Name, "error", err)
 		}
-		resp := fantasy.NewTextErrorResponse(reason)
-		// Halt ends the whole turn; a plain deny only blocks this tool
-		// call so the model can see the error and try something else.
-		resp.StopTurn = result.Halt
-		resp.Metadata = hookMetadataJSON(result)
-		return resp, nil
-	}
 
-	if result.UpdatedInput != "" {
-		call.Input = result.UpdatedInput
-	}
+		if result.Decision == hooks.DecisionDeny || result.Halt {
+			reason := fmt.Sprintf("Tool call blocked by hook. Reason: %s", result.Reason)
+			if result.Halt {
+				reason = fmt.Sprintf("Turn halted by hook. Reason: %s", result.Reason)
+			}
+			resp := fantasy.NewTextErrorResponse(reason)
+			resp.StopTurn = result.Halt
+			resp.Metadata = hookMetadataJSON(result)
+			return resp, nil
+		}
 
-	// An explicit allow from a hook pre-approves the permission prompt for
-	// this tool call. Deny is already handled above; silence falls through
-	// to the normal permission flow.
-	if result.Decision == hooks.DecisionAllow {
-		ctx = permission.WithHookApproval(ctx, call.ID)
+		if result.UpdatedInput != "" {
+			call.Input = result.UpdatedInput
+		}
+
+		if result.Decision == hooks.DecisionAllow {
+			ctx = permission.WithHookApproval(ctx, call.ID)
+		}
 	}
 
 	resp, err := h.inner.Run(ctx, call)
+
+	// Fire PostToolUse hooks with tool output so hooks can inspect/redact.
+	var postResult hooks.AggregateResult
+	if h.postToolRunner != nil {
+		var hookErr error
+		postResult, hookErr = h.postToolRunner.RunPostToolUse(ctx, sessionID, call.Name, call.Input, resp.Content, resp.IsError)
+		if hookErr != nil {
+			slog.Warn("PostToolUse hook failed", "tool", call.Name, "error", hookErr)
+		}
+	}
+
 	if err != nil {
 		return resp, err
 	}
 
+	// Apply PreToolUse context injection.
 	if result.Context != "" {
 		if resp.Content != "" {
 			resp.Content += "\n"
 		}
 		resp.Content += result.Context
+	}
+
+	// Apply PostToolUse results: replace tool output, inject context,
+	// or halt the turn. Note: PostToolUse does not support decision
+	// (allow/deny); the tool has already executed. Only updated_input
+	// (replacement), context, and halt are honored.
+	if postResult.UpdatedInput != "" {
+		resp.Content = postResult.UpdatedInput
+	}
+	if postResult.Context != "" {
+		if resp.Content != "" {
+			resp.Content += "\n"
+		}
+		resp.Content += postResult.Context
+	}
+	if postResult.Halt {
+		resp.StopTurn = true
 	}
 
 	resp.Metadata = mergeHookMetadata(resp.Metadata, result)

--- a/internal/agent/hooked_tool_test.go
+++ b/internal/agent/hooked_tool_test.go
@@ -43,7 +43,7 @@ func newRunner(t *testing.T, cmd string) *hooks.Runner {
 		},
 	}
 	require.NoError(t, cfg.ValidateHooks())
-	return hooks.NewRunner(cfg.Hooks[hooks.EventPreToolUse], t.TempDir(), t.TempDir())
+	return hooks.NewRunner(cfg.Hooks, t.TempDir(), t.TempDir())
 }
 
 func TestHookedTool_AllowStampsHookApproval(t *testing.T) {
@@ -51,7 +51,7 @@ func TestHookedTool_AllowStampsHookApproval(t *testing.T) {
 
 	inner := &fakeTool{name: "view", resp: fantasy.NewTextResponse("ok")}
 	runner := newRunner(t, `echo '{"decision":"allow"}'`)
-	tool := newHookedTool(inner, runner)
+	tool := newHookedTool(inner, runner, nil)
 
 	_, err := tool.Run(t.Context(), fantasy.ToolCall{ID: "call-1", Name: "view"})
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestHookedTool_SilentDoesNotStampApproval(t *testing.T) {
 
 	inner := &fakeTool{name: "view", resp: fantasy.NewTextResponse("ok")}
 	runner := newRunner(t, `exit 0`) // no stdout, no decision
-	tool := newHookedTool(inner, runner)
+	tool := newHookedTool(inner, runner, nil)
 
 	_, err := tool.Run(t.Context(), fantasy.ToolCall{ID: "call-2", Name: "view"})
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestHookedTool_DenySkipsInnerTool(t *testing.T) {
 
 	inner := &fakeTool{name: "bash"}
 	runner := newRunner(t, `echo "blocked" >&2; exit 2`)
-	tool := newHookedTool(inner, runner)
+	tool := newHookedTool(inner, runner, nil)
 
 	resp, err := tool.Run(t.Context(), fantasy.ToolCall{ID: "call-3", Name: "bash"})
 	require.NoError(t, err)
@@ -121,7 +121,7 @@ func TestWrapToolsWithHooks(t *testing.T) {
 
 	t.Run("top-level agent wraps every tool", func(t *testing.T) {
 		t.Parallel()
-		out := wrapToolsWithHooks(inputs, runner, false)
+		out := wrapToolsWithHooks(inputs, runner, nil, false)
 		require.Len(t, out, len(inputs))
 		for i, tool := range out {
 			_, ok := tool.(*hookedTool)
@@ -131,7 +131,7 @@ func TestWrapToolsWithHooks(t *testing.T) {
 
 	t.Run("sub-agent skips the wrap", func(t *testing.T) {
 		t.Parallel()
-		out := wrapToolsWithHooks(inputs, runner, true)
+		out := wrapToolsWithHooks(inputs, runner, nil, true)
 		require.Equal(t, inputs, out, "sub-agent tools should be returned unwrapped")
 		for _, tool := range out {
 			_, isHooked := tool.(*hookedTool)
@@ -141,7 +141,7 @@ func TestWrapToolsWithHooks(t *testing.T) {
 
 	t.Run("nil runner skips the wrap for both agent kinds", func(t *testing.T) {
 		t.Parallel()
-		require.Equal(t, inputs, wrapToolsWithHooks(inputs, nil, false))
-		require.Equal(t, inputs, wrapToolsWithHooks(inputs, nil, true))
+		require.Equal(t, inputs, wrapToolsWithHooks(inputs, nil, nil, false))
+		require.Equal(t, inputs, wrapToolsWithHooks(inputs, nil, nil, true))
 	})
 }

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -43,6 +43,9 @@ func (m *mockBashPermissionService) SubscribeNotifications(ctx context.Context) 
 	return make(<-chan pubsub.Event[permission.PermissionNotification])
 }
 
+func (m *mockBashPermissionService) SetLifecycleHooks(_ permission.LifecycleHookRunner) {
+}
+
 func TestBashTool_DefaultAutoBackgroundThreshold(t *testing.T) {
 	workingDir := t.TempDir()
 	tool := newBashToolForTest(workingDir)
@@ -112,6 +115,9 @@ func (m *recordingPermissionService) SkipRequests() bool {
 
 func (m *recordingPermissionService) SubscribeNotifications(ctx context.Context) <-chan pubsub.Event[permission.PermissionNotification] {
 	return make(<-chan pubsub.Event[permission.PermissionNotification])
+}
+
+func (m *recordingPermissionService) SetLifecycleHooks(_ permission.LifecycleHookRunner) {
 }
 
 func newBashToolForTest(workingDir string) fantasy.AgentTool {

--- a/internal/agent/tools/multiedit_test.go
+++ b/internal/agent/tools/multiedit_test.go
@@ -43,6 +43,9 @@ func (m *mockPermissionService) SubscribeNotifications(ctx context.Context) <-ch
 	return make(<-chan pubsub.Event[permission.PermissionNotification])
 }
 
+func (m *mockPermissionService) SetLifecycleHooks(_ permission.LifecycleHookRunner) {
+}
+
 type mockHistoryService struct {
 	*pubsub.Broker[history.File]
 }

--- a/internal/agent/tools/view_test.go
+++ b/internal/agent/tools/view_test.go
@@ -236,6 +236,9 @@ func (m *mockViewPermissionService) SubscribeNotifications(ctx context.Context) 
 	return make(<-chan pubsub.Event[permission.PermissionNotification])
 }
 
+func (m *mockViewPermissionService) SetLifecycleHooks(_ permission.LifecycleHookRunner) {
+}
+
 type mockFileTracker struct{}
 
 func (m mockFileTracker) RecordRead(ctx context.Context, sessionID, path string) {}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -28,6 +28,7 @@ import (
 	"github.com/charmbracelet/crush/internal/format"
 	"github.com/charmbracelet/crush/internal/herdr"
 	"github.com/charmbracelet/crush/internal/history"
+	"github.com/charmbracelet/crush/internal/hooks"
 	"github.com/charmbracelet/crush/internal/log"
 	"github.com/charmbracelet/crush/internal/lsp"
 	"github.com/charmbracelet/crush/internal/message"
@@ -88,6 +89,10 @@ type App struct {
 	// herdrClient reports agent state to herdr when running inside
 	// a herdr-managed pane. Nil when not in a herdr environment.
 	herdrClient *herdr.Client
+
+	// hookRunner is shared across all hook events. Nil when no hooks
+	// are configured.
+	hookRunner *hooks.Runner
 }
 
 // New initializes a new application instance. skillsMgr carries the
@@ -133,6 +138,11 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 	// (e.g., headless environment), clipboard operations will return nil.
 	if err := clipboard.Init(); err != nil {
 		slog.Warn("Clipboard initialization failed", "error", err)
+	}
+
+	// Create hook runner if any hooks are configured.
+	if len(app.config.Config().Hooks) > 0 {
+		app.hookRunner = hooks.NewRunner(app.config.Config().Hooks, store.WorkingDir(), store.WorkingDir())
 	}
 
 	// Check for updates in the background.
@@ -258,7 +268,30 @@ func (app *App) resolveSession(ctx context.Context, continueSessionID string, us
 		return sess, nil
 
 	default:
-		return app.Sessions.Create(ctx, agent.DefaultSessionName)
+		return app.CreateSession(ctx, agent.DefaultSessionName)
+	}
+}
+
+// CreateSession creates a new session and fires the SessionStart
+// lifecycle hook. All session creation paths should use this method
+// to ensure the hook fires consistently.
+func (app *App) CreateSession(ctx context.Context, title string) (session.Session, error) {
+	sess, err := app.Sessions.Create(ctx, title)
+	if err != nil {
+		return session.Session{}, err
+	}
+	app.fireSessionStartHook(ctx, sess.ID)
+	return sess, nil
+}
+
+// fireSessionStartHook fires the SessionStart lifecycle hook if a
+// runner is configured.
+func (app *App) fireSessionStartHook(ctx context.Context, sessionID string) {
+	if app.hookRunner == nil {
+		return
+	}
+	if _, err := app.hookRunner.Run(ctx, hooks.EventSessionStart, sessionID, "", ""); err != nil {
+		slog.Warn("SessionStart hook failed", "error", err)
 	}
 }
 
@@ -633,6 +666,7 @@ func (app *App) initCoderAgent(ctx context.Context, interactive bool) error {
 		Notify:      app.agentNotifications,
 		RunComplete: app.runCompletions,
 		Skills:      app.Skills,
+		HookRunner:  app.hookRunner,
 		Interactive: interactive,
 	})
 	if err != nil {
@@ -679,6 +713,15 @@ func (app *App) Subscribe(program *tea.Program) {
 func (app *App) Shutdown() {
 	start := time.Now()
 	defer func() { slog.Debug("Shutdown took " + time.Since(start).String()) }()
+
+	// Fire SessionEnd lifecycle hooks before tearing down agents.
+	if app.hookRunner != nil {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		if _, err := app.hookRunner.Run(shutdownCtx, hooks.EventSessionEnd, "", "", ""); err != nil {
+			slog.Warn("SessionEnd hook failed", "error", err)
+		}
+		shutdownCancel()
+	}
 
 	// First, cancel all agents and wait for them to finish. This must complete
 	// before closing the DB so agents can finish writing their state.

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1387,16 +1387,32 @@ func ProjectSkillsDir(workingDir string) []string {
 
 func isAppleTerminal() bool { return os.Getenv("TERM_PROGRAM") == "Apple_Terminal" }
 
+// hookEventNormMap maps lowercased-no-underscores event names to their
+// canonical form. Must stay in sync with hooks.AllEvents; this
+// duplication is forced by the config→hooks import cycle (hooks
+// imports config.HookConfig).
+var hookEventNormMap = map[string]string{
+	"pretooluse":        "PreToolUse",
+	"posttooluse":       "PostToolUse",
+	"sessionstart":      "SessionStart",
+	"sessionend":        "SessionEnd",
+	"turnstart":         "TurnStart",
+	"turnend":           "TurnEnd",
+	"stopfailure":       "StopFailure",
+	"interrupt":         "Interrupt",
+	"permissionrequest": "PermissionRequest",
+	"permissionresult":  "PermissionResult",
+	"precompact":        "PreCompact",
+	"postcompact":       "PostCompact",
+}
+
 // normalizeHookEvent maps user-provided event names to their canonical
-// form. Matching is case-insensitive and accepts snake_case variants
-// (e.g. "pre_tool_use" → "PreToolUse").
+// form. Matching is case-insensitive and accepts snake_case variants.
 func normalizeHookEvent(name string) string {
-	switch strings.ToLower(strings.ReplaceAll(name, "_", "")) {
-	case "pretooluse":
-		return "PreToolUse"
-	default:
-		return name
+	if canonical, ok := hookEventNormMap[strings.ToLower(strings.ReplaceAll(name, "_", ""))]; ok {
+		return canonical
 	}
+	return name
 }
 
 // ValidateHooks normalizes event names and checks that every configured

--- a/internal/config/reload_hooks_test.go
+++ b/internal/config/reload_hooks_test.go
@@ -60,7 +60,7 @@ func assertHookFilters(t *testing.T, store *config.ConfigStore) {
 	preHooks := store.Config().Hooks[hooks.EventPreToolUse]
 	require.Len(t, preHooks, 1)
 
-	runner := hooks.NewRunner(preHooks, t.TempDir(), t.TempDir())
+	runner := hooks.NewRunner(store.Config().Hooks, t.TempDir(), t.TempDir())
 
 	nonMatch, err := runner.Run(context.Background(), hooks.EventPreToolUse, "sess", "view", `{}`)
 	require.NoError(t, err)

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -12,8 +12,99 @@ import (
 
 // Hook event name constants.
 const (
+	// EventPreToolUse fires before each tool execution. Hooks can
+	// allow, deny, halt, or rewrite the tool input.
 	EventPreToolUse = "PreToolUse"
+
+	// EventSessionStart fires when a new session is created.
+	// Carries the session ID for restore/resume support.
+	EventSessionStart = "SessionStart"
+
+	// EventTurnStart fires when the agent begins processing a user
+	// prompt. Marks the transition to working state.
+	EventTurnStart = "TurnStart"
+
+	// EventPermissionRequest fires when a permission prompt is shown
+	// to the user. Marks the transition to blocked state.
+	EventPermissionRequest = "PermissionRequest"
+
+	// EventPermissionResult fires after a permission decision is made
+	// (granted, denied, or cancelled). Marks the transition out of
+	// blocked state.
+	EventPermissionResult = "PermissionResult"
+
+	// EventTurnEnd fires when the agent finishes a turn and returns
+	// to idle state.
+	EventTurnEnd = "TurnEnd"
+
+	// EventInterrupt fires when the user cancels or interrupts an
+	// active turn (e.g. ctrl-c, escape).
+	EventInterrupt = "Interrupt"
+
+	// EventPostToolUse fires after a tool call succeeds. Carries
+	// tool name and input for observability. Cannot block.
+	EventPostToolUse = "PostToolUse"
+
+	// EventSessionEnd fires when a session ends (app shutdown or
+	// explicit session teardown). Carries session ID.
+	EventSessionEnd = "SessionEnd"
+
+	// EventStopFailure fires when a turn ends due to an API or
+	// provider error (not user cancellation). Carries session ID.
+	EventStopFailure = "StopFailure"
+
+	// EventPreCompact fires before context compaction begins.
+	// Can halt to prevent compaction.
+	EventPreCompact = "PreCompact"
+
+	// EventPostCompact fires after context compaction completes.
+	EventPostCompact = "PostCompact"
 )
+
+// AllEvents lists every supported hook event name. Used for config
+// validation and documentation.
+var AllEvents = []string{
+	EventPreToolUse,
+	EventPostToolUse,
+	EventSessionStart,
+	EventSessionEnd,
+	EventTurnStart,
+	EventPermissionRequest,
+	EventPermissionResult,
+	EventTurnEnd,
+	EventInterrupt,
+	EventStopFailure,
+	EventPreCompact,
+	EventPostCompact,
+}
+
+// eventNormMap maps lowercased-no-underscores event names to their
+// canonical form. Derived from AllEvents so adding a new event only
+// requires updating one list.
+var eventNormMap = func() map[string]string {
+	m := make(map[string]string, len(AllEvents))
+	for _, e := range AllEvents {
+		m[strings.ToLower(strings.ReplaceAll(e, "_", ""))] = e
+	}
+	return m
+}()
+
+// NormalizeEventName maps user-provided event names to their canonical
+// form. Matching is case-insensitive and accepts snake_case variants.
+// Returns the input unchanged if no match is found.
+func NormalizeEventName(name string) string {
+	if canonical, ok := eventNormMap[strings.ToLower(strings.ReplaceAll(name, "_", ""))]; ok {
+		return canonical
+	}
+	return name
+}
+
+// IsToolEvent reports whether the event is handled via the tool
+// execution path (Runner.Run with matcher filtering). Lifecycle events
+// return false.
+func IsToolEvent(event string) bool {
+	return event == EventPreToolUse || event == EventPostToolUse
+}
 
 // HaltExitCode is the exit code that halts the whole turn. 2 blocks the
 // current tool call; 49 sits in the no-man's-land between the
@@ -88,10 +179,13 @@ type AggregateResult struct {
 // aggregate merges multiple HookResults into a single AggregateResult.
 // Results are processed in config order (the order of the slice). Deny
 // wins over allow, allow wins over none. Halt is sticky. Reasons and
-// context concatenate in order. updated_input patches shallow-merge in
-// order against the original tool input; later patches override earlier
-// ones on colliding keys.
-func aggregate(results []HookResult, origToolInput string) AggregateResult {
+// context concatenate in order.
+//
+// When replace is true, updated_input uses last-writer-wins replacement
+// semantics (for PostToolUse output replacement). When false,
+// updated_input patches shallow-merge against origToolInput (for
+// PreToolUse input rewriting).
+func aggregate(results []HookResult, origToolInput string, replace bool) AggregateResult {
 	var (
 		decision Decision
 		halt     bool
@@ -126,16 +220,21 @@ func aggregate(results []HookResult, origToolInput string) AggregateResult {
 			contexts = append(contexts, r.Context)
 		}
 		if r.UpdatedInput != "" {
-			next, err := shallowMerge(merged, r.UpdatedInput)
-			if err != nil {
-				slog.Warn(
-					"Hook updated_input patch rejected; ignoring",
-					"error", err,
-					"patch", r.UpdatedInput,
-				)
-				continue
+			if replace {
+				// Last-writer-wins: no merge against base.
+				merged = r.UpdatedInput
+			} else {
+				next, err := shallowMerge(merged, r.UpdatedInput)
+				if err != nil {
+					slog.Warn(
+						"Hook updated_input patch rejected; ignoring",
+						"error", err,
+						"patch", r.UpdatedInput,
+					)
+					continue
+				}
+				merged = next
 			}
-			merged = next
 			anyPatch = true
 		}
 	}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -13,12 +13,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// newTestRunner creates a Runner from a slice of HookConfigs for the
+// PreToolUse event. Convenience wrapper for tests that don't care
+// about event routing.
+func newTestRunner(t *testing.T, cfgs []config.HookConfig) *Runner {
+	t.Helper()
+	return NewRunner(map[string][]config.HookConfig{EventPreToolUse: cfgs}, t.TempDir(), t.TempDir())
+}
+
 func TestAggregation(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty results", func(t *testing.T) {
 		t.Parallel()
-		agg := aggregate(nil, "{}")
+		agg := aggregate(nil, "{}", false)
 		require.Equal(t, DecisionNone, agg.Decision)
 		require.Empty(t, agg.Reason)
 		require.Empty(t, agg.Context)
@@ -29,7 +37,7 @@ func TestAggregation(t *testing.T) {
 		t.Parallel()
 		agg := aggregate([]HookResult{
 			{Decision: DecisionAllow},
-		}, "{}")
+		}, "{}", false)
 		require.Equal(t, DecisionAllow, agg.Decision)
 	})
 
@@ -38,7 +46,7 @@ func TestAggregation(t *testing.T) {
 		agg := aggregate([]HookResult{
 			{Decision: DecisionAllow, Context: "ctx1"},
 			{Decision: DecisionDeny, Reason: "blocked"},
-		}, "{}")
+		}, "{}", false)
 		require.Equal(t, DecisionDeny, agg.Decision)
 		require.Equal(t, "blocked", agg.Reason)
 		require.Equal(t, "ctx1", agg.Context)
@@ -49,7 +57,7 @@ func TestAggregation(t *testing.T) {
 		agg := aggregate([]HookResult{
 			{Decision: DecisionDeny, Reason: "reason1"},
 			{Decision: DecisionDeny, Reason: "reason2"},
-		}, "{}")
+		}, "{}", false)
 		require.Equal(t, DecisionDeny, agg.Decision)
 		require.Equal(t, "reason1\nreason2", agg.Reason)
 	})
@@ -59,7 +67,7 @@ func TestAggregation(t *testing.T) {
 		agg := aggregate([]HookResult{
 			{Decision: DecisionAllow, Context: "ctx-a"},
 			{Decision: DecisionNone, Context: "ctx-b"},
-		}, "{}")
+		}, "{}", false)
 		require.Equal(t, DecisionAllow, agg.Decision)
 		require.Equal(t, "ctx-a\nctx-b", agg.Context)
 	})
@@ -69,7 +77,7 @@ func TestAggregation(t *testing.T) {
 		agg := aggregate([]HookResult{
 			{Decision: DecisionNone},
 			{Decision: DecisionAllow},
-		}, "{}")
+		}, "{}", false)
 		require.Equal(t, DecisionAllow, agg.Decision)
 	})
 
@@ -78,7 +86,7 @@ func TestAggregation(t *testing.T) {
 		agg := aggregate([]HookResult{
 			{Decision: DecisionAllow},
 			{Halt: true, Reason: "stop now"},
-		}, "{}")
+		}, "{}", false)
 		require.True(t, agg.Halt)
 		require.Contains(t, agg.Reason, "stop now")
 	})
@@ -87,7 +95,7 @@ func TestAggregation(t *testing.T) {
 		t.Parallel()
 		agg := aggregate([]HookResult{
 			{Decision: DecisionDeny, Halt: true, Reason: "stop"},
-		}, "{}")
+		}, "{}", false)
 		require.True(t, agg.Halt)
 		require.Equal(t, DecisionDeny, agg.Decision)
 		require.Equal(t, "stop", agg.Reason)
@@ -227,7 +235,7 @@ func TestRunnerExitCode0Allow(t *testing.T) {
 	hookCfg := config.HookConfig{
 		Command: `echo '{"decision":"allow","context":"ok"}'`,
 	}
-	r := NewRunner([]config.HookConfig{hookCfg}, t.TempDir(), t.TempDir())
+	r := newTestRunner(t, []config.HookConfig{hookCfg})
 	result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 	require.NoError(t, err)
 	require.Equal(t, DecisionAllow, result.Decision)
@@ -239,7 +247,7 @@ func TestRunnerExitCode2Deny(t *testing.T) {
 	hookCfg := config.HookConfig{
 		Command: `echo "forbidden" >&2; exit 2`,
 	}
-	r := NewRunner([]config.HookConfig{hookCfg}, t.TempDir(), t.TempDir())
+	r := newTestRunner(t, []config.HookConfig{hookCfg})
 	result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 	require.NoError(t, err)
 	require.Equal(t, DecisionDeny, result.Decision)
@@ -252,7 +260,7 @@ func TestRunnerExitCode49Halt(t *testing.T) {
 	hookCfg := config.HookConfig{
 		Command: `echo "stop the turn" >&2; exit 49`,
 	}
-	r := NewRunner([]config.HookConfig{hookCfg}, t.TempDir(), t.TempDir())
+	r := newTestRunner(t, []config.HookConfig{hookCfg})
 	result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 	require.NoError(t, err)
 	require.True(t, result.Halt)
@@ -265,7 +273,7 @@ func TestRunnerHaltViaJSON(t *testing.T) {
 	hookCfg := config.HookConfig{
 		Command: `echo '{"halt":true,"reason":"via json"}'`,
 	}
-	r := NewRunner([]config.HookConfig{hookCfg}, t.TempDir(), t.TempDir())
+	r := newTestRunner(t, []config.HookConfig{hookCfg})
 	result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 	require.NoError(t, err)
 	require.True(t, result.Halt)
@@ -277,7 +285,7 @@ func TestRunnerExitCodeOtherNonBlocking(t *testing.T) {
 	hookCfg := config.HookConfig{
 		Command: `exit 1`,
 	}
-	r := NewRunner([]config.HookConfig{hookCfg}, t.TempDir(), t.TempDir())
+	r := newTestRunner(t, []config.HookConfig{hookCfg})
 	result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 	require.NoError(t, err)
 	require.Equal(t, DecisionNone, result.Decision)
@@ -289,7 +297,7 @@ func TestRunnerTimeout(t *testing.T) {
 		Command: `sleep 10`,
 		Timeout: 1,
 	}
-	r := NewRunner([]config.HookConfig{hookCfg}, t.TempDir(), t.TempDir())
+	r := newTestRunner(t, []config.HookConfig{hookCfg})
 	start := time.Now()
 	result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 	elapsed := time.Since(start)
@@ -304,7 +312,7 @@ func TestRunnerDeduplication(t *testing.T) {
 	hookCfg := config.HookConfig{
 		Command: `echo '{"decision":"allow"}'`,
 	}
-	r := NewRunner([]config.HookConfig{hookCfg, hookCfg}, t.TempDir(), t.TempDir())
+	r := newTestRunner(t, []config.HookConfig{hookCfg, hookCfg})
 	result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 	require.NoError(t, err)
 	require.Equal(t, DecisionAllow, result.Decision)
@@ -313,7 +321,7 @@ func TestRunnerDeduplication(t *testing.T) {
 func TestRunnerNoMatchingHooks(t *testing.T) {
 	t.Parallel()
 	// Hooks are empty.
-	r := NewRunner(nil, t.TempDir(), t.TempDir())
+	r := newTestRunner(t, nil)
 	result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 	require.NoError(t, err)
 	require.Equal(t, DecisionNone, result.Decision)
@@ -340,7 +348,7 @@ func TestRunnerMatcherFiltering(t *testing.T) {
 		hooks := validatedHooks(t, []config.HookConfig{
 			{Command: `echo '{"decision":"deny","reason":"blocked"}'`, Matcher: "^bash$"},
 		})
-		r := NewRunner(hooks, t.TempDir(), t.TempDir())
+		r := newTestRunner(t, hooks)
 		result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 		require.NoError(t, err)
 		require.Equal(t, DecisionDeny, result.Decision)
@@ -351,7 +359,7 @@ func TestRunnerMatcherFiltering(t *testing.T) {
 		hooks := validatedHooks(t, []config.HookConfig{
 			{Command: `echo '{"decision":"deny","reason":"blocked"}'`, Matcher: "^edit$"},
 		})
-		r := NewRunner(hooks, t.TempDir(), t.TempDir())
+		r := newTestRunner(t, hooks)
 		result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 		require.NoError(t, err)
 		require.Equal(t, DecisionNone, result.Decision)
@@ -362,7 +370,7 @@ func TestRunnerMatcherFiltering(t *testing.T) {
 		hooks := validatedHooks(t, []config.HookConfig{
 			{Command: `echo '{"decision":"allow"}'`},
 		})
-		r := NewRunner(hooks, t.TempDir(), t.TempDir())
+		r := newTestRunner(t, hooks)
 		result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 		require.NoError(t, err)
 		require.Equal(t, DecisionAllow, result.Decision)
@@ -373,7 +381,7 @@ func TestRunnerMatcherFiltering(t *testing.T) {
 		hooks := validatedHooks(t, []config.HookConfig{
 			{Command: `echo '{"decision":"deny","reason":"mcp blocked"}'`, Matcher: "^mcp_"},
 		})
-		r := NewRunner(hooks, t.TempDir(), t.TempDir())
+		r := newTestRunner(t, hooks)
 
 		result, err := r.Run(context.Background(), EventPreToolUse, "sess", "mcp_github_get_me", `{}`)
 		require.NoError(t, err)
@@ -392,7 +400,7 @@ func TestRunnerMatcherFiltering(t *testing.T) {
 		raw := []config.HookConfig{
 			{Command: `echo '{"decision":"deny","reason":"blocked"}'`, Matcher: "^bash$"},
 		}
-		r := NewRunner(raw, t.TempDir(), t.TempDir())
+		r := newTestRunner(t, raw)
 
 		deny, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 		require.NoError(t, err)
@@ -410,12 +418,12 @@ func TestRunnerMatcherFiltering(t *testing.T) {
 		raw := []config.HookConfig{
 			{Command: `echo '{"decision":"deny","reason":"should not fire"}'`, Matcher: "[invalid"},
 		}
-		r := NewRunner(raw, t.TempDir(), t.TempDir())
+		r := newTestRunner(t, raw)
 
 		result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 		require.NoError(t, err)
 		require.Equal(t, DecisionNone, result.Decision)
-		require.Empty(t, r.Hooks())
+		require.False(t, r.HasEvent(EventPreToolUse))
 	})
 }
 
@@ -485,7 +493,7 @@ func TestRunnerHookNameUsesDisplayName(t *testing.T) {
 			Name:    "my-hook",
 			Command: `echo '{"decision":"allow"}'`,
 		}
-		r := NewRunner([]config.HookConfig{hookCfg}, t.TempDir(), t.TempDir())
+		r := newTestRunner(t, []config.HookConfig{hookCfg})
 		result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 		require.NoError(t, err)
 		require.Equal(t, DecisionAllow, result.Decision)
@@ -498,7 +506,7 @@ func TestRunnerHookNameUsesDisplayName(t *testing.T) {
 		hookCfg := config.HookConfig{
 			Command: `echo '{"decision":"allow"}'`,
 		}
-		r := NewRunner([]config.HookConfig{hookCfg}, t.TempDir(), t.TempDir())
+		r := newTestRunner(t, []config.HookConfig{hookCfg})
 		result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 		require.NoError(t, err)
 		require.Equal(t, DecisionAllow, result.Decision)
@@ -514,7 +522,7 @@ func TestRunnerParallelExecution(t *testing.T) {
 		{Command: `echo '{"decision":"allow","context":"hook1"}'`},
 		{Command: `echo '{"decision":"deny","reason":"nope"}' ; exit 0`},
 	}
-	r := NewRunner(hooks, t.TempDir(), t.TempDir())
+	r := newTestRunner(t, hooks)
 	result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 	require.NoError(t, err)
 	require.Equal(t, DecisionDeny, result.Decision)
@@ -526,7 +534,7 @@ func TestRunnerEnvVarsPropagated(t *testing.T) {
 	hookCfg := config.HookConfig{
 		Command: `printf '{"decision":"allow","context":"%s"}' "$CRUSH_TOOL_NAME"`,
 	}
-	r := NewRunner([]config.HookConfig{hookCfg}, t.TempDir(), t.TempDir())
+	r := newTestRunner(t, []config.HookConfig{hookCfg})
 	result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
 	require.NoError(t, err)
 	require.Equal(t, DecisionAllow, result.Decision)
@@ -565,7 +573,7 @@ func TestAggregationUpdatedInput(t *testing.T) {
 		agg := aggregate([]HookResult{
 			{Decision: DecisionAllow, UpdatedInput: `{"command":"first","keep":"me"}`},
 			{Decision: DecisionAllow, UpdatedInput: `{"command":"second"}`},
-		}, `{"command":"orig","timeout":60}`)
+		}, `{"command":"orig","timeout":60}`, false)
 		require.Equal(t, DecisionAllow, agg.Decision)
 		// command overridden by second patch; keep preserved from first
 		// patch; timeout preserved from original input.
@@ -580,7 +588,7 @@ func TestAggregationUpdatedInput(t *testing.T) {
 		t.Parallel()
 		agg := aggregate([]HookResult{
 			{Decision: DecisionAllow, UpdatedInput: `{"env":{"FOO":"bar"}}`},
-		}, `{"env":{"BAZ":"qux"},"command":"ls"}`)
+		}, `{"env":{"BAZ":"qux"},"command":"ls"}`, false)
 		// "env" is replaced entirely; "command" preserved.
 		require.JSONEq(
 			t,
@@ -594,7 +602,7 @@ func TestAggregationUpdatedInput(t *testing.T) {
 		agg := aggregate([]HookResult{
 			{Decision: DecisionAllow, UpdatedInput: `{"command":"rewritten"}`},
 			{Decision: DecisionDeny, Reason: "blocked"},
-		}, `{"command":"orig"}`)
+		}, `{"command":"orig"}`, false)
 		require.Equal(t, DecisionDeny, agg.Decision)
 	})
 
@@ -603,7 +611,7 @@ func TestAggregationUpdatedInput(t *testing.T) {
 		agg := aggregate([]HookResult{
 			{Decision: DecisionAllow},
 			{Decision: DecisionNone},
-		}, `{"command":"orig"}`)
+		}, `{"command":"orig"}`, false)
 		require.Empty(t, agg.UpdatedInput)
 	})
 
@@ -612,7 +620,7 @@ func TestAggregationUpdatedInput(t *testing.T) {
 		agg := aggregate([]HookResult{
 			{Decision: DecisionAllow, UpdatedInput: `"not-an-object"`},
 			{Decision: DecisionAllow, UpdatedInput: `{"command":"good"}`},
-		}, `{"command":"orig"}`)
+		}, `{"command":"orig"}`, false)
 		require.JSONEq(t, `{"command":"good"}`, agg.UpdatedInput)
 	})
 
@@ -621,7 +629,7 @@ func TestAggregationUpdatedInput(t *testing.T) {
 		agg := aggregate([]HookResult{
 			{Decision: DecisionAllow, UpdatedInput: `{broken json`},
 			{Decision: DecisionAllow, UpdatedInput: `{"command":"good"}`},
-		}, `{"command":"orig"}`)
+		}, `{"command":"orig"}`, false)
 		require.JSONEq(t, `{"command":"good"}`, agg.UpdatedInput)
 	})
 
@@ -629,7 +637,7 @@ func TestAggregationUpdatedInput(t *testing.T) {
 		t.Parallel()
 		agg := aggregate([]HookResult{
 			{Decision: DecisionAllow, UpdatedInput: `{"command":"rewrite"}`},
-		}, `"just-a-string"`)
+		}, `"just-a-string"`, false)
 		require.Empty(t, agg.UpdatedInput)
 	})
 
@@ -640,7 +648,7 @@ func TestAggregationUpdatedInput(t *testing.T) {
 		// original tool_input is used unchanged.
 		r := parseStdout(`{"decision":"allow","updated_input":null}`)
 		require.Empty(t, r.UpdatedInput)
-		agg := aggregate([]HookResult{r}, `{"command":"orig"}`)
+		agg := aggregate([]HookResult{r}, `{"command":"orig"}`, false)
 		require.Empty(t, agg.UpdatedInput)
 	})
 }
@@ -688,7 +696,7 @@ func TestRunnerAbandonRaceSafety(t *testing.T) {
 		Command: "# irrelevant; runShell is stubbed",
 		Timeout: 1,
 	}
-	r := NewRunner([]config.HookConfig{hookCfg}, t.TempDir(), t.TempDir())
+	r := newTestRunner(t, []config.HookConfig{hookCfg})
 
 	start := time.Now()
 	result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{}`)
@@ -707,7 +715,7 @@ func TestRunnerUpdatedInput(t *testing.T) {
 	hookCfg := config.HookConfig{
 		Command: `echo '{"decision":"allow","updated_input":{"command":"echo rewritten"}}'`,
 	}
-	r := NewRunner([]config.HookConfig{hookCfg}, t.TempDir(), t.TempDir())
+	r := newTestRunner(t, []config.HookConfig{hookCfg})
 	result, err := r.Run(context.Background(), EventPreToolUse, "sess", "bash", `{"command":"echo original","timeout":60}`)
 	require.NoError(t, err)
 	require.Equal(t, DecisionAllow, result.Decision)

--- a/internal/hooks/input.go
+++ b/internal/hooks/input.go
@@ -48,6 +48,79 @@ func BuildPayload(eventName, sessionID, cwd, toolName, toolInputJSON string) []b
 	return data
 }
 
+// PostToolUsePayload extends Payload with the tool's output so hooks
+// can inspect or redact what the model sees.
+type PostToolUsePayload struct {
+	Payload
+	ToolOutput string `json:"tool_output"`
+	IsError    bool   `json:"is_error,omitempty"`
+}
+
+// BuildPostToolUsePayload constructs the JSON stdin payload for a
+// PostToolUse hook, including the tool's response content.
+func BuildPostToolUsePayload(sessionID, cwd, toolName, toolInputJSON, toolOutput string, isError bool) []byte {
+	toolInput := json.RawMessage(toolInputJSON)
+	if !json.Valid(toolInput) {
+		toolInput = json.RawMessage("{}")
+	}
+	p := PostToolUsePayload{
+		Payload: Payload{
+			Event:     EventPostToolUse,
+			SessionID: sessionID,
+			CWD:       cwd,
+			ToolName:  toolName,
+			ToolInput: toolInput,
+		},
+		ToolOutput: toolOutput,
+		IsError:    isError,
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return []byte("{}")
+	}
+	return data
+}
+
+// LifecyclePayload is the JSON structure piped to hook commands via
+// stdin for non-tool lifecycle events (SessionStart, TurnStart, etc.).
+// ToolName and ToolInput are omitted since they don't apply.
+type LifecyclePayload struct {
+	Event     string `json:"event"`
+	SessionID string `json:"session_id"`
+	CWD       string `json:"cwd"`
+}
+
+// BuildLifecyclePayload constructs the JSON stdin payload for a
+// lifecycle hook command (non-tool events).
+func BuildLifecyclePayload(eventName, sessionID, cwd string) []byte {
+	p := LifecyclePayload{
+		Event:     eventName,
+		SessionID: sessionID,
+		CWD:       cwd,
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return []byte("{}")
+	}
+	return data
+}
+
+// BuildLifecycleEnv constructs the environment variable slice for a
+// lifecycle hook command. Includes core env vars but omits
+// tool-specific ones (CRUSH_TOOL_NAME, CRUSH_TOOL_INPUT_*).
+func BuildLifecycleEnv(eventName, sessionID, cwd, projectDir string) []string {
+	env := os.Environ()
+	env = append(env, shell.CrushEnvMarkers()...)
+	env = append(
+		env,
+		fmt.Sprintf("CRUSH_EVENT=%s", eventName),
+		fmt.Sprintf("CRUSH_SESSION_ID=%s", sessionID),
+		fmt.Sprintf("CRUSH_CWD=%s", cwd),
+		fmt.Sprintf("CRUSH_PROJECT_DIR=%s", projectDir),
+	)
+	return env
+}
+
 // BuildEnv constructs the environment variable slice for a hook command.
 // It includes all current process env vars plus hook-specific ones.
 func BuildEnv(eventName, toolName, sessionID, cwd, projectDir, toolInputJSON string) []string {

--- a/internal/hooks/input.go
+++ b/internal/hooks/input.go
@@ -90,6 +90,14 @@ type LifecyclePayload struct {
 	CWD       string `json:"cwd"`
 }
 
+// TurnEndPayload extends LifecyclePayload with the assistant's
+// rendered text content for the completed turn. Observe-only;
+// hooks cannot modify or block based on this data.
+type TurnEndPayload struct {
+	LifecyclePayload
+	Text string `json:"text"`
+}
+
 // BuildLifecyclePayload constructs the JSON stdin payload for a
 // lifecycle hook command (non-tool events).
 func BuildLifecyclePayload(eventName, sessionID, cwd string) []byte {
@@ -97,6 +105,24 @@ func BuildLifecyclePayload(eventName, sessionID, cwd string) []byte {
 		Event:     eventName,
 		SessionID: sessionID,
 		CWD:       cwd,
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return []byte("{}")
+	}
+	return data
+}
+
+// BuildTurnEndPayload constructs the JSON stdin payload for a
+// TurnEnd hook, including the assistant's rendered text content.
+func BuildTurnEndPayload(sessionID, cwd, text string) []byte {
+	p := TurnEndPayload{
+		LifecyclePayload: LifecyclePayload{
+			Event:     EventTurnEnd,
+			SessionID: sessionID,
+			CWD:       cwd,
+		},
+		Text: text,
 	}
 	data, err := json.Marshal(p)
 	if err != nil {

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -142,6 +142,22 @@ func (r *Runner) RunPostToolUse(ctx context.Context, sessionID, toolName, toolIn
 	return agg, nil
 }
 
+// RunTurnEnd executes TurnEnd hooks with the assistant's rendered
+// text content included in the payload. Observe-only; results are
+// logged but not acted upon.
+func (r *Runner) RunTurnEnd(ctx context.Context, sessionID, text string) {
+	hooks := r.matchingHooks(EventTurnEnd, "")
+	if len(hooks) == 0 {
+		return
+	}
+
+	envVars := BuildLifecycleEnv(EventTurnEnd, sessionID, r.cwd, r.projectDir)
+	payload := BuildTurnEndPayload(sessionID, r.cwd, text)
+
+	agg := r.executeHooks(ctx, hooks, envVars, payload, "", false)
+	slog.Info("Hook completed", "event", EventTurnEnd, "hooks", agg.HookCount)
+}
+
 // executeHooks is the shared orchestration. It deduplicates hooks by
 // command, runs them in parallel, waits for completion, and aggregates
 // results in config order.

--- a/internal/hooks/runner.go
+++ b/internal/hooks/runner.go
@@ -32,14 +32,17 @@ type compiledHook struct {
 	matcher *regexp.Regexp
 }
 
-// Runner executes hook commands and aggregates their results.
+// Runner executes hook commands and aggregates their results. It holds
+// all hook configs keyed by event name and dispatches internally, so
+// callers create a single Runner for the entire application.
 type Runner struct {
-	hooks      []compiledHook
+	// hooks maps canonical event names to their compiled hooks.
+	hooks      map[string][]compiledHook
 	cwd        string
 	projectDir string
 }
 
-// NewRunner creates a Runner from the given hook configs. Each hook's
+// NewRunner creates a Runner from the given hooks map. Each hook's
 // Matcher is compiled here so the Runner is self-sufficient; callers do
 // not have to pre-compile matchers on the config, and reloads or merges
 // that rebuild HookConfig values can't silently strip compiled state.
@@ -47,24 +50,26 @@ type Runner struct {
 // Hooks whose matcher fails to compile are skipped with a warning rather
 // than treated as match-everything. ValidateHooks is expected to have
 // caught syntax errors earlier, so this is defense in depth.
-func NewRunner(hooks []config.HookConfig, cwd, projectDir string) *Runner {
-	compiled := make([]compiledHook, 0, len(hooks))
-	for _, h := range hooks {
-		ch := compiledHook{cfg: h}
-		if h.Matcher != "" {
-			re, err := regexp.Compile(h.Matcher)
-			if err != nil {
-				slog.Warn(
-					"Hook matcher failed to compile; skipping hook",
-					"matcher", h.Matcher,
-					"command", h.Command,
-					"error", err,
-				)
-				continue
+func NewRunner(hooksMap map[string][]config.HookConfig, cwd, projectDir string) *Runner {
+	compiled := make(map[string][]compiledHook, len(hooksMap))
+	for event, cfgs := range hooksMap {
+		for _, h := range cfgs {
+			ch := compiledHook{cfg: h}
+			if h.Matcher != "" {
+				re, err := regexp.Compile(h.Matcher)
+				if err != nil {
+					slog.Warn(
+						"Hook matcher failed to compile; skipping hook",
+						"matcher", h.Matcher,
+						"command", h.Command,
+						"error", err,
+					)
+					continue
+				}
+				ch.matcher = re
 			}
-			ch.matcher = re
+			compiled[event] = append(compiled[event], ch)
 		}
-		compiled = append(compiled, ch)
 	}
 	return &Runner{
 		hooks:      compiled,
@@ -73,39 +78,84 @@ func NewRunner(hooks []config.HookConfig, cwd, projectDir string) *Runner {
 	}
 }
 
-// Hooks returns the hook configs the runner was created with, in config
-// order. Hooks whose matcher failed to compile at construction are
-// omitted. Intended for diagnostics; callers should not rely on ordering
-// or identity beyond that.
-func (r *Runner) Hooks() []config.HookConfig {
-	out := make([]config.HookConfig, len(r.hooks))
-	for i, h := range r.hooks {
-		out[i] = h.cfg
-	}
-	return out
+// HasEvent reports whether any hooks are configured for the given event.
+func (r *Runner) HasEvent(event string) bool {
+	return len(r.hooks[event]) > 0
 }
 
-// Run executes all matching hooks for the given event and tool, returning
-// an aggregated result.
+// Run executes all matching hooks for the given event, returning an
+// aggregated result. For tool events (PreToolUse, PostToolUse), hooks
+// are filtered by matcher against toolName. For lifecycle events, all
+// configured hooks run unconditionally.
+//
+// For PostToolUse, updated_input uses replacement semantics
+// (last-writer-wins). For PreToolUse, updated_input uses shallow-merge
+// patch semantics against toolInputJSON. For lifecycle events,
+// toolName and toolInputJSON are ignored.
 func (r *Runner) Run(ctx context.Context, eventName, sessionID, toolName, toolInputJSON string) (AggregateResult, error) {
-	matching := r.matchingHooks(toolName)
-	if len(matching) == 0 {
+	hooks := r.matchingHooks(eventName, toolName)
+	if len(hooks) == 0 {
 		return AggregateResult{Decision: DecisionNone}, nil
 	}
 
+	isTool := IsToolEvent(eventName)
+	var envVars []string
+	var payload []byte
+	if isTool {
+		envVars = BuildEnv(eventName, toolName, sessionID, r.cwd, r.projectDir, toolInputJSON)
+		payload = BuildPayload(eventName, sessionID, r.cwd, toolName, toolInputJSON)
+	} else {
+		envVars = BuildLifecycleEnv(eventName, sessionID, r.cwd, r.projectDir)
+		payload = BuildLifecyclePayload(eventName, sessionID, r.cwd)
+	}
+
+	// PostToolUse uses replacement semantics for updated_input.
+	replace := eventName == EventPostToolUse
+	agg := r.executeHooks(ctx, hooks, envVars, payload, toolInputJSON, replace)
+
+	logArgs := []any{
+		"event", eventName,
+		"hooks", agg.HookCount,
+		"decision", agg.Decision.String(),
+	}
+	if isTool {
+		logArgs = append(logArgs, "tool", toolName)
+	}
+	slog.Info("Hook completed", logArgs...)
+	return agg, nil
+}
+
+// RunPostToolUse executes PostToolUse hooks with the tool's response
+// content included in the payload. Unlike Run, this passes tool_output
+// so hooks can inspect or redact what the model sees.
+func (r *Runner) RunPostToolUse(ctx context.Context, sessionID, toolName, toolInputJSON, toolOutput string, isError bool) (AggregateResult, error) {
+	hooks := r.matchingHooks(EventPostToolUse, toolName)
+	if len(hooks) == 0 {
+		return AggregateResult{Decision: DecisionNone}, nil
+	}
+
+	envVars := BuildEnv(EventPostToolUse, toolName, sessionID, r.cwd, r.projectDir, toolInputJSON)
+	payload := BuildPostToolUsePayload(sessionID, r.cwd, toolName, toolInputJSON, toolOutput, isError)
+
+	agg := r.executeHooks(ctx, hooks, envVars, payload, toolInputJSON, true)
+	slog.Info("Hook completed", "event", EventPostToolUse, "tool", toolName, "hooks", agg.HookCount, "decision", agg.Decision.String())
+	return agg, nil
+}
+
+// executeHooks is the shared orchestration. It deduplicates hooks by
+// command, runs them in parallel, waits for completion, and aggregates
+// results in config order.
+func (r *Runner) executeHooks(ctx context.Context, hooks []config.HookConfig, envVars []string, payload []byte, origToolInput string, replace bool) AggregateResult {
 	// Deduplicate by command string.
-	seen := make(map[string]bool, len(matching))
+	seen := make(map[string]bool, len(hooks))
 	var deduped []config.HookConfig
-	for _, h := range matching {
+	for _, h := range hooks {
 		if seen[h.Command] {
 			continue
 		}
 		seen[h.Command] = true
 		deduped = append(deduped, h)
 	}
-
-	envVars := BuildEnv(eventName, toolName, sessionID, r.cwd, r.projectDir, toolInputJSON)
-	payload := BuildPayload(eventName, sessionID, r.cwd, toolName, toolInputJSON)
 
 	results := make([]HookResult, len(deduped))
 	var wg sync.WaitGroup
@@ -119,7 +169,7 @@ func (r *Runner) Run(ctx context.Context, eventName, sessionID, toolName, toolIn
 	}
 	wg.Wait()
 
-	agg := aggregate(results, toolInputJSON)
+	agg := aggregate(results, origToolInput, replace)
 	agg.Hooks = make([]HookInfo, len(deduped))
 	for i, h := range deduped {
 		agg.Hooks[i] = HookInfo{
@@ -131,21 +181,28 @@ func (r *Runner) Run(ctx context.Context, eventName, sessionID, toolName, toolIn
 			InputRewrite: results[i].UpdatedInput != "",
 		}
 	}
-	slog.Info(
-		"Hook completed",
-		"event", eventName,
-		"tool", toolName,
-		"hooks", len(deduped),
-		"decision", agg.Decision.String(),
-	)
-	return agg, nil
+	return agg
 }
 
-// matchingHooks returns hooks whose matcher matches the tool name (or has
-// no matcher, which matches everything).
-func (r *Runner) matchingHooks(toolName string) []config.HookConfig {
+// matchingHooks returns hooks for the given event. For tool events,
+// filters by matcher against toolName. For lifecycle events, returns
+// all configured hooks for the event.
+func (r *Runner) matchingHooks(eventName, toolName string) []config.HookConfig {
+	compiled := r.hooks[eventName]
+	if len(compiled) == 0 {
+		return nil
+	}
+	if !IsToolEvent(eventName) {
+		// Lifecycle events: return all hooks, no matcher filtering.
+		out := make([]config.HookConfig, len(compiled))
+		for i, h := range compiled {
+			out[i] = h.cfg
+		}
+		return out
+	}
+	// Tool events: filter by matcher.
 	var matched []config.HookConfig
-	for _, h := range r.hooks {
+	for _, h := range compiled {
 		if h.matcher == nil || h.matcher.MatchString(toolName) {
 			matched = append(matched, h.cfg)
 		}

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -2,6 +2,7 @@ package permission
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"slices"
@@ -33,6 +34,27 @@ func hookApproved(ctx context.Context, toolCallID string) bool {
 	}
 	v, _ := ctx.Value(hookApprovalKey{}).(string)
 	return v == toolCallID
+}
+
+// Lifecycle hook event names. Mirrors hooks.EventPermissionRequest and
+// hooks.EventPermissionResult without importing the hooks package.
+const (
+	EventPermissionRequest = "PermissionRequest"
+	EventPermissionResult  = "PermissionResult"
+)
+
+// LifecycleHookRunner is the narrow interface for running lifecycle
+// hooks. Defined here so callers can provide any compatible
+// implementation without coupling to *hooks.Runner directly.
+type LifecycleHookRunner interface {
+	RunLifecycle(ctx context.Context, eventName, sessionID string) error
+}
+
+// LifecycleHookRunnerFunc is a function adapter for LifecycleHookRunner.
+type LifecycleHookRunnerFunc func(ctx context.Context, eventName, sessionID string) error
+
+func (f LifecycleHookRunnerFunc) RunLifecycle(ctx context.Context, eventName, sessionID string) error {
+	return f(ctx, eventName, sessionID)
 }
 
 type CreatePermissionRequest struct {
@@ -82,6 +104,9 @@ type Service interface {
 	SetSkipRequests(skip bool)
 	SkipRequests() bool
 	SubscribeNotifications(ctx context.Context) <-chan pubsub.Event[PermissionNotification]
+	// SetLifecycleHooks sets the hook runner for PermissionRequest and
+	// PermissionResult lifecycle events.
+	SetLifecycleHooks(runner LifecycleHookRunner)
 }
 
 // PermissionKey is a composite key for session permission lookups.
@@ -108,6 +133,10 @@ type permissionService struct {
 	requestMu       sync.Mutex
 	activeRequest   *PermissionRequest
 	activeRequestMu sync.Mutex
+
+	// lifecycleHooks fires PermissionRequest/PermissionResult hooks.
+	// Set via SetLifecycleHooks after construction; nil means no hooks.
+	lifecycleHooks LifecycleHookRunner
 }
 
 // resolve atomically removes the pending request entry for the given
@@ -269,6 +298,27 @@ func (s *permissionService) Request(ctx context.Context, opts CreatePermissionRe
 	// Publish the request
 	s.Publish(pubsub.CreatedEvent, permission)
 
+	// Fire PermissionRequest lifecycle hook.
+	if s.lifecycleHooks != nil {
+		if err := s.lifecycleHooks.RunLifecycle(ctx, EventPermissionRequest, permission.SessionID); err != nil {
+			slog.Warn("PermissionRequest hook failed", "error", err)
+		}
+	}
+
+	// Fire PermissionResult on every exit path (grant, deny, or cancel)
+	// so external state machines always see the paired transition.
+	defer func() {
+		if s.lifecycleHooks == nil {
+			return
+		}
+		// Use a fresh context so the hook can run even if the
+		// original context was cancelled.
+		hookCtx := context.WithoutCancel(ctx)
+		if err := s.lifecycleHooks.RunLifecycle(hookCtx, EventPermissionResult, permission.SessionID); err != nil {
+			slog.Warn("PermissionResult hook failed", "error", err)
+		}
+	}()
+
 	select {
 	case <-ctx.Done():
 		return false, ctx.Err()
@@ -293,6 +343,10 @@ func (s *permissionService) SetSkipRequests(skip bool) {
 
 func (s *permissionService) SkipRequests() bool {
 	return s.skip.Load()
+}
+
+func (s *permissionService) SetLifecycleHooks(runner LifecycleHookRunner) {
+	s.lifecycleHooks = runner
 }
 
 func NewPermissionService(workingDir string, skip bool, allowedTools []string) Service {

--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -207,9 +207,11 @@ option ui diff unified
 
 ## Hooks runtime
 
-Hooks are user-defined shell commands that fire on agent events. Currently only
-`PreToolUse` is supported, which runs before a tool executes. This behavior is
-the same however the hook is defined (`hook add` or JSON).
+Hooks are user-defined shell commands that fire on agent events. Crush supports
+12 events: `PreToolUse`, `PostToolUse`, `SessionStart`, `SessionEnd`,
+`TurnStart`, `TurnEnd`, `StopFailure`, `Interrupt`, `PermissionRequest`,
+`PermissionResult`, `PreCompact`, and `PostCompact`. This behavior is the same
+however the hook is defined (`hook add` or JSON).
 
 ### How hooks work
 

--- a/internal/skills/builtin/crush-hooks/SKILL.md
+++ b/internal/skills/builtin/crush-hooks/SKILL.md
@@ -23,6 +23,10 @@ names are case-insensitive and accept snake_case (`PreToolUse`, `pretooluse`,
 `pre_tool_use` all work). Tool events (`PreToolUse`, `PostToolUse`) support
 `matcher` to filter by tool name; lifecycle events run all configured hooks.
 
+`TurnEnd` is special among lifecycle events: its stdin payload includes a
+`text` field containing the assistant's rendered text output for the turn.
+The hook remains observe-only.
+
 ## Configuration
 
 ```jsonc

--- a/internal/skills/builtin/crush-hooks/SKILL.md
+++ b/internal/skills/builtin/crush-hooks/SKILL.md
@@ -25,7 +25,9 @@ names are case-insensitive and accept snake_case (`PreToolUse`, `pretooluse`,
 
 `TurnEnd` is special among lifecycle events: its stdin payload includes a
 `text` field containing the assistant's rendered text output for the turn.
-The hook remains observe-only.
+The hook remains observe-only. It fires only for top-level turns, not for
+sub-agents (`agentic_fetch`, the task tool), so it runs once per user-facing
+turn rather than once per delegated sub-agent turn.
 
 ## Configuration
 

--- a/internal/skills/builtin/crush-hooks/SKILL.md
+++ b/internal/skills/builtin/crush-hooks/SKILL.md
@@ -16,8 +16,12 @@ need to author correct hooks.
 
 ## Supported Events
 
-Only `PreToolUse` is currently supported. Event names are case-insensitive and
-accept snake_case (`PreToolUse`, `pretooluse`, `pre_tool_use` all work).
+Crush supports 12 hook events: `PreToolUse`, `PostToolUse`, `SessionStart`,
+`SessionEnd`, `TurnStart`, `TurnEnd`, `StopFailure`, `Interrupt`,
+`PermissionRequest`, `PermissionResult`, `PreCompact`, `PostCompact`. Event
+names are case-insensitive and accept snake_case (`PreToolUse`, `pretooluse`,
+`pre_tool_use` all work). Tool events (`PreToolUse`, `PostToolUse`) support
+`matcher` to filter by tool name; lifecycle events run all configured hooks.
 
 ## Configuration
 

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -45,7 +45,7 @@ func NewAppWorkspace(a *app.App, store *config.ConfigStore) *AppWorkspace {
 // -- Sessions --
 
 func (w *AppWorkspace) CreateSession(ctx context.Context, title string) (session.Session, error) {
-	return w.app.Sessions.Create(ctx, title)
+	return w.app.CreateSession(ctx, title)
 }
 
 func (w *AppWorkspace) GetSession(ctx context.Context, sessionID string) (session.Session, error) {


### PR DESCRIPTION
Adds 11 new lifecycle hooks beyond the existing `PreToolUse`. Events span the full agent lifecycle: tool execution, sessions, turns, permissions, compaction, and errors.

Already implemented:
- **PreToolUse** — Gate/rewrite tool input before execution; allow/deny/halt/inject context

New:
- **PostToolUse** — Inspect/redact/replace tool output after execution
- **SessionStart** — Observe session created
- **SessionEnd** — Observe app shutdown (2s timeout)
- **TurnStart** — Observe agent begins processing a prompt
- **TurnEnd** — Observe agent finishes a turn (carries `text` field with assistant output)
- **StopFailure** — Observe turn ends due to API error
- **Interrupt** — Observe user cancels (ctrl-c, escape)
- **PermissionRequest** — Observe permission prompt shown
- **PermissionResult** — Observe permission decided (granted/denied)
- **PreCompact** — Halt to prevent context compaction
- **PostCompact** — Observe compaction completed