### PR TITLE
feat(schema): fix the reflection on provider options

### DIFF
--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -4,7 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/agent/hyper"
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/discover"
 	"github.com/invopop/jsonschema"
 	"github.com/spf13/cobra"
 )
@@ -16,11 +19,42 @@ var schemaCmd = &cobra.Command{
 	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		reflector := new(jsonschema.Reflector)
-		bts, err := json.MarshalIndent(reflector.Reflect(&config.Config{}), "", "  ")
+		schema := reflector.Reflect(&config.Config{})
+		setProviderTypeEnum(schema)
+		bts, err := json.MarshalIndent(schema, "", "  ")
 		if err != nil {
 			return fmt.Errorf("failed to marshal schema: %w", err)
 		}
 		fmt.Println(string(bts))
 		return nil
 	},
+}
+
+// setProviderTypeEnum overwrites the provider `type` enum with the live set
+// of accepted values rather than a hand-maintained struct tag. The values
+// must match exactly what load.go validates against: the catwalk provider
+// types, the Charm Hyper type, and any locally-discovered providers that
+// self-register an enricher (e.g. ollama, omlx). Sourcing the enum here keeps
+// the published schema from drifting as provider types are added or renamed.
+func setProviderTypeEnum(schema *jsonschema.Schema) {
+	def, ok := schema.Definitions["ProviderConfig"]
+	if !ok || def.Properties == nil {
+		return
+	}
+	typeProp, ok := def.Properties.Get("type")
+	if !ok {
+		return
+	}
+
+	var types []string
+	for _, t := range catwalk.KnownProviderTypes() {
+		types = append(types, string(t))
+	}
+	types = append(types, string(hyper.Name))
+	types = append(types, discover.RegisteredProviderTypes()...)
+
+	typeProp.Enum = make([]any, len(types))
+	for i, t := range types {
+		typeProp.Enum[i] = t
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,7 +95,7 @@ type ProviderConfig struct {
 	// The provider's API endpoint.
 	BaseURL string `json:"base_url,omitempty" jsonschema:"description=Base URL for the provider's API,format=uri,example=https://api.openai.com/v1"`
 	// The provider type, e.g. "openai", "anthropic", etc. if empty it defaults to openai.
-	Type catwalk.Type `json:"type,omitempty" jsonschema:"description=Provider type that determines the API format,enum=openai,enum=openai-compat,enum=anthropic,enum=gemini,enum=azure,enum=vertexai,default=openai"`
+	Type catwalk.Type `json:"type,omitempty" jsonschema:"description=Provider type that determines the API format,default=openai"`
 	// The provider's API key.
 	APIKey string `json:"api_key,omitempty" jsonschema:"description=API key for authentication with the provider,example=$OPENAI_API_KEY"`
 	// The original API key template before resolution (for re-resolution on auth errors).

--- a/internal/discover/enricher.go
+++ b/internal/discover/enricher.go
@@ -2,6 +2,7 @@ package discover
 
 import (
 	"context"
+	"sort"
 
 	"charm.land/catwalk/pkg/catwalk"
 )
@@ -41,4 +42,19 @@ func GetEnricher(providerType string) Enricher {
 // enricher itself to callers that only need the compatibility check.
 func IsKnownCustomProvider(providerType string) bool {
 	return enrichers[providerType] != nil
+}
+
+// RegisteredProviderTypes returns the provider type strings that have a
+// registered enricher, sorted for stable output. These are the custom,
+// locally-discovered providers (e.g. ollama, omlx) that Crush accepts as
+// a `type` value even though they are not catwalk provider types. The
+// schema generator uses this so the published enum stays in sync with the
+// registry instead of drifting from a hand-maintained list.
+func RegisteredProviderTypes() []string {
+	types := make([]string, 0, len(enrichers))
+	for providerType := range enrichers {
+		types = append(types, providerType)
+	}
+	sort.Strings(types)
+	return types
 }


### PR DESCRIPTION
the schema was manually generated before and was drifting out of date so this changes it to generate it via reflection properly also handling the custom providers as well