### PR TITLE
fix(hooks): honor Claude Code additionalContext in parseClaudeCodeOutput

### DIFF
--- a/internal/hooks/input.go
+++ b/internal/hooks/input.go
@@ -161,6 +161,7 @@ func parseClaudeCodeOutput(data json.RawMessage) HookResult {
 		PermissionDecision       string          `json:"permissionDecision"`
 		PermissionDecisionReason string          `json:"permissionDecisionReason"`
 		UpdatedInput             json.RawMessage `json:"updatedInput"`
+		AdditionalContext        string          `json:"additionalContext"`
 	}
 	if err := json.Unmarshal(data, &hso); err != nil {
 		return HookResult{Decision: DecisionNone}
@@ -169,6 +170,7 @@ func parseClaudeCodeOutput(data json.RawMessage) HookResult {
 	result := HookResult{
 		Decision: parseDecision(hso.PermissionDecision),
 		Reason:   hso.PermissionDecisionReason,
+		Context:  hso.AdditionalContext,
 	}
 
 	// Marshal updatedInput back to a string for our opaque format.


### PR DESCRIPTION
Fixes #3156.

`parseClaudeCodeOutput` reads `permissionDecision` / `permissionDecisionReason` / `updatedInput` from `hookSpecificOutput`, but not `additionalContext` — so a Claude Code PreToolUse/SessionStart hook that injects context silently no-ops under Crush, even though the docs advertise Claude Code hook compatibility.

The capability already exists: the native envelope's `context` field flows to the model via `HookResult.Context`. This just bridges the Claude-format field onto the same field — one struct field + one assignment. Claude's `additionalContext` is always a string, so no array handling is needed (unlike the native `context`, which `parseContext` normalizes from `string | []string`).
