### PR TITLE
fix(bangmode): cover various ux edge cases

### DIFF
--- a/internal/ui/model/history.go
+++ b/internal/ui/model/history.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"log/slog"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -35,6 +36,9 @@ func (m *UI) loadPromptHistory() tea.Cmd {
 		for _, msg := range messages {
 			if text := msg.Content().Text; text != "" {
 				texts = append(texts, text)
+			}
+			for _, sc := range msg.ShellCommands() {
+				texts = append(texts, "!"+sc.Command)
 			}
 		}
 		return promptHistoryLoadedMsg{messages: texts}
@@ -93,6 +97,7 @@ func (m *UI) handleHistoryEscape(msg tea.Msg) tea.Cmd {
 		m.promptHistory.index = -1
 		m.textarea.Reset()
 		m.textarea.InsertString(m.promptHistory.draft)
+		m.syncBangModeFromTextarea()
 		return m.updateTextareaWithPrevHeight(nil, prevHeight)
 	}
 
@@ -106,6 +111,26 @@ func (m *UI) updateHistoryDraft(oldValue string) {
 		m.promptHistory.draft = m.textarea.Value()
 		m.promptHistory.index = -1
 	}
+}
+
+// syncBangModeFromTextarea engages or disengages bang mode based on
+// whether the current textarea value starts with "!". The "!" prefix
+// is stripped when entering bang mode and re-added when leaving it so
+// the visible text always reflects the correct state.
+func (m *UI) syncBangModeFromTextarea() {
+	val := m.textarea.Value()
+	hasBang := strings.HasPrefix(val, "!")
+	if hasBang && !m.bangMode {
+		m.bangMode = true
+		m.bangWasEmpty = false
+		m.textarea.SetValue(val[1:])
+		m.textarea.MoveToBegin()
+	} else if !hasBang && m.bangMode {
+		m.bangMode = false
+		m.bangWasEmpty = false
+	}
+	yolo := m.com.Workspace.PermissionSkipRequests()
+	m.setEditorPrompt(yolo)
 }
 
 // historyPrev changes the text area content to the previous message in the history
@@ -125,6 +150,7 @@ func (m *UI) historyPrev() bool {
 	m.textarea.Reset()
 	m.textarea.InsertString(m.promptHistory.messages[nextIndex])
 	m.textarea.MoveToBegin()
+	m.syncBangModeFromTextarea()
 	return true
 }
 
@@ -139,11 +165,13 @@ func (m *UI) historyNext() bool {
 		m.promptHistory.index = -1
 		m.textarea.Reset()
 		m.textarea.InsertString(m.promptHistory.draft)
+		m.syncBangModeFromTextarea()
 		return true
 	}
 	m.promptHistory.index = nextIndex
 	m.textarea.Reset()
 	m.textarea.InsertString(m.promptHistory.messages[nextIndex])
+	m.syncBangModeFromTextarea()
 	return true
 }
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -966,6 +966,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		prevHeight := m.textarea.Height()
 		m.textarea.SetValue(msg.Text)
 		m.textarea.MoveToEnd()
+		m.syncBangModeFromTextarea()
 		cmds = append(cmds, m.updateTextareaWithPrevHeight(msg, prevHeight))
 	case shellStreamMsg:
 		if item := m.chat.MessageItem(msg.PendingID); item != nil {
@@ -1557,7 +1558,11 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			cmds = append(cmds, util.ReportWarn("Agent is working, please wait..."))
 			break
 		}
-		cmds = append(cmds, m.openEditor(m.textarea.Value()))
+		editorValue := m.textarea.Value()
+		if m.bangMode {
+			editorValue = "!" + editorValue
+		}
+		cmds = append(cmds, m.openEditor(editorValue))
 		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionToggleCompactMode:
 		cmds = append(cmds, m.toggleCompactMode())
@@ -2117,7 +2122,11 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					cmds = append(cmds, util.ReportWarn("Agent is working, please wait..."))
 					break
 				}
-				cmds = append(cmds, m.openEditor(m.textarea.Value()))
+				editorValue := m.textarea.Value()
+				if m.bangMode {
+					editorValue = "!" + editorValue
+				}
+				cmds = append(cmds, m.openEditor(editorValue))
 			case key.Matches(msg, m.keyMap.Editor.Newline):
 				prevHeight := m.textarea.Height()
 				m.textarea.InsertRune('\n')

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode"
 	"time"
 
 	"charm.land/bubbles/v2/help"
@@ -2182,19 +2183,24 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				cmds = append(cmds, m.updateTextareaWithPrevHeight(msg, prevHeight))
 
 				// Bang mode: enter when "!" is typed at the start of the
-				// prompt (either on an empty prompt or prepended to existing
-				// text). Exit on backspace clearing the last character.
+				// prompt, optionally preceded by whitespace (either on an
+				// empty/whitespace-only prompt or prepended to existing text).
+				// Exit on backspace clearing the last character.
 				newVal := m.textarea.Value()
-				if !m.bangMode && strings.HasPrefix(newVal, "!") && !strings.HasPrefix(curValue, "!") {
+				trimmedNew := strings.TrimLeftFunc(newVal, unicode.IsSpace)
+				trimmedCur := strings.TrimLeftFunc(curValue, unicode.IsSpace)
+				if !m.bangMode && strings.HasPrefix(trimmedNew, "!") && !strings.HasPrefix(trimmedCur, "!") {
 					m.bangMode = true
 					m.bangWasEmpty = len(strings.TrimSpace(curValue)) == 0
-					// Strip the leading "!" from the textarea while preserving
-					// the cursor position relative to the command text.
+					// Strip leading whitespace and the "!" from the textarea
+					// while preserving the cursor position relative to the
+					// command text.
 					col := m.textarea.Column()
 					line := m.textarea.Line()
-					m.textarea.SetValue(newVal[1:])
-					m.textarea.SetCursorColumn(max(0, col-1))
-					_ = line // cursor line doesn't change; first char removed
+					stripped := trimmedNew[1:]
+					m.textarea.SetValue(stripped)
+					m.textarea.SetCursorColumn(max(0, col-(len(newVal)-len(stripped))))
+					_ = line // cursor line doesn't change; prefix removed
 					yolo := m.com.Workspace.PermissionSkipRequests()
 					m.setEditorPrompt(yolo)
 				} else if m.bangMode && newVal == "" && curValue != "" {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -17,8 +17,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"unicode"
 	"time"
+	"unicode"
 
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
@@ -3879,6 +3879,28 @@ func (m *UI) newSession() tea.Cmd {
 	)
 }
 
+// checkBangModeAfterPaste engages bang mode when pasted text starts with
+// optional whitespace followed by "!". It strips the prefix and adjusts
+// the cursor, mirroring the keypress bang-mode entry logic.
+func (m *UI) checkBangModeAfterPaste() {
+	if m.bangMode {
+		return
+	}
+	val := m.textarea.Value()
+	trimmed := strings.TrimLeftFunc(val, unicode.IsSpace)
+	if !strings.HasPrefix(trimmed, "!") {
+		return
+	}
+	m.bangMode = true
+	m.bangWasEmpty = true
+	stripped := trimmed[1:]
+	m.textarea.SetValue(stripped)
+	col := m.textarea.Column()
+	m.textarea.SetCursorColumn(max(0, col-(len(val)-len(stripped))))
+	yolo := m.com.Workspace.PermissionSkipRequests()
+	m.setEditorPrompt(yolo)
+}
+
 // handlePasteMsg handles a paste message.
 func (m *UI) handlePasteMsg(msg tea.PasteMsg) tea.Cmd {
 	// Normalize \r\n before the textarea sanitizer sees it.
@@ -3939,7 +3961,9 @@ func (m *UI) handlePasteMsg(msg tea.PasteMsg) tea.Cmd {
 	}
 	if !allExistsAndValid() {
 		prevHeight := m.textarea.Height()
-		return m.updateTextareaWithPrevHeight(msg, prevHeight)
+		cmd := m.updateTextareaWithPrevHeight(msg, prevHeight)
+		m.checkBangModeAfterPaste()
+		return cmd
 	}
 
 	var cmds []tea.Cmd

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1014,6 +1014,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, cmd)
 			}
 		}
+		cmds = append(cmds, m.loadPromptHistory())
 	case hyperRefreshDoneMsg:
 		if cmd := m.handleSelectModel(msg.action); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -2080,7 +2081,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					m.setEditorPrompt(yolo)
 					m.randomizePlaceholders()
 					m.historyReset()
-					return tea.Batch(m.runShellCommand(value), m.loadPromptHistory())
+					return tea.Batch(m.runShellCommand(value))
 				}
 
 				attachments := m.attachments.List()


### PR DESCRIPTION
This fixes a series of UX edge cases with Bang Mode:

* If there’s whitespace preceding a `!`, engage bang mode  (e.g. `     !ls` or `\n\n!ls`)
* When pasting text with a preceding `!`, engage bang mode
* Include bang commands in history and engage and disengage accordingly
* Sync bang mode state when entering and leaving the external editor