### PR TITLE
feat(enricher): add llamaswap enricher

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,8 +771,8 @@ To add specific models to the configuration, configure as such:
 ### Local Models
 
 Crush can auto-discovers models from local providers. Add a custom provider
-with `type` set to `llamacpp`, `omlx`, `lmstudio`, `litellm`, or `ollama`
-and leave out the models list. Crush will populate the model list
+with `type` set to `llamacpp`, `llamaswap`, `omlx`, `lmstudio`, `litellm`,
+or `ollama` and leave out the models list. Crush will populate the model list
 automatically.
 
 ```json
@@ -800,6 +800,15 @@ For llama.cpp (`llama-server`), point at the server's base URL:
   }
 }
 ```
+
+#### llama-swap auto-discovery
+
+Unlike many other local providers, llama-swap does not provide the additional
+properties needed for auto-discovery in its API, such as the display name or
+context length. However it does provide a `metadata` dictionary that you may
+use to define additional metadata for a model in your llama-swap configuration
+that will be included in the `/v1/models` response. Any field that you may
+configure for a model in `crush.json` is supported.
 
 #### Manual Model Configuration
 

--- a/internal/discover/litellm_test.go
+++ b/internal/discover/litellm_test.go
@@ -167,6 +167,7 @@ func TestIsKnownCustomProvider(t *testing.T) {
 	require.True(t, IsKnownCustomProvider("ollama"))
 	require.True(t, IsKnownCustomProvider("omlx"))
 	require.True(t, IsKnownCustomProvider("lmstudio"))
+	require.True(t, IsKnownCustomProvider("llamaswap"))
 	require.False(t, IsKnownCustomProvider("openai-compat"))
 	require.False(t, IsKnownCustomProvider("anthropic"))
 	require.False(t, IsKnownCustomProvider(""))

--- a/internal/discover/llamaswap.go
+++ b/internal/discover/llamaswap.go
@@ -1,0 +1,98 @@
+package discover
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+func init() {
+	RegisterEnricher("llamaswap", &llamaswapEnricher{})
+}
+
+// llamaswapModelsResponse mirrors the response from llama-swaps's
+// GET /models endpoint.
+type llamaswapModelsResponse struct {
+	Data []llamaswapModelEntry `json:"data"`
+}
+
+// llamaswapModelEntry is a single entry from /models.
+type llamaswapModelEntry struct {
+	ID   string                 `json:"id"`
+	Meta llamaswapModelMetadata `json:"meta"`
+}
+
+// llamaswapModelMetadata is the provider-specific metadata for a model.
+type llamaswapModelMetadata struct {
+	// Since llama-swap allows the user to supply any values they want to be
+	// included in the metadata for a model in its config, we don't define our
+	// own llamaswapUserDefinedProperties type like other enrichers do.
+	// Instead we support configuring *any* property that a user could
+	// configure for a model in crush.json by using catwalk.Model directly.
+	LlamaSwap catwalk.Model `json:"llamaswap"`
+}
+
+// llamaswapEnricher fetches user-defined model metadata from llama-swap's
+// /models endpoint and populates the context window, display name,
+// and other select supported properties that the user may define in the
+// llama-swap "metadata" on discovered models.
+type llamaswapEnricher struct{}
+
+func (e *llamaswapEnricher) EnrichModels(ctx context.Context, cfg Config, resolver Resolver, models []catwalk.Model) ([]catwalk.Model, error) {
+	resp, err := doRequest(ctx, http.MethodGet, cfg.BaseURL, "/models", cfg.APIKey, cfg.ExtraHeaders, resolver, nil)
+	if err != nil {
+		return models, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return models, nil
+	}
+
+	var modelsResp llamaswapModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&modelsResp); err != nil {
+		return models, nil
+	}
+
+	// Index the model data by ID for quick lookup.
+	metaByID := make(map[string]catwalk.Model, len(modelsResp.Data))
+	for _, m := range modelsResp.Data {
+		metaByID[m.ID] = m.Meta.LlamaSwap
+	}
+
+	for i := range models {
+		meta, ok := metaByID[models[i].ID]
+		if !ok {
+			continue
+		}
+
+		if models[i].Name == models[i].ID && meta.Name != "" {
+			models[i].Name = meta.Name
+		}
+		if models[i].ContextWindow == 0 && meta.ContextWindow != 0 {
+			models[i].ContextWindow = meta.ContextWindow
+		}
+		if models[i].DefaultMaxTokens == 0 && meta.DefaultMaxTokens != 0 {
+			models[i].DefaultMaxTokens = meta.DefaultMaxTokens
+		}
+		if models[i].CostPer1MIn == 0 && meta.CostPer1MIn != 0 {
+			models[i].CostPer1MIn = meta.CostPer1MIn
+		}
+		if models[i].CostPer1MOut == 0 && meta.CostPer1MOut != 0 {
+			models[i].CostPer1MOut = meta.CostPer1MOut
+		}
+		if models[i].CostPer1MInCached == 0 && meta.CostPer1MInCached != 0 {
+			models[i].CostPer1MInCached = meta.CostPer1MInCached
+		}
+		if models[i].CostPer1MOutCached == 0 && meta.CostPer1MOutCached != 0 {
+			models[i].CostPer1MOutCached = meta.CostPer1MOutCached
+		}
+		if len(models[i].ReasoningLevels) == 0 {
+			models[i].ReasoningLevels = meta.ReasoningLevels
+		}
+	}
+
+	return models, nil
+}

--- a/internal/discover/llamaswap_test.go
+++ b/internal/discover/llamaswap_test.go
@@ -1,0 +1,270 @@
+package discover
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLammaswapEnricher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("populates context window and name from /models", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/models", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{
+				"data": [
+					{
+						"id": "qwen2.5-7b-instruct",
+						"object": "model",
+						"created": 1781831908,
+						"owned_by": "llama-swap",
+						"meta": {
+							"llamaswap": {
+								"name": "Qwen 2.5 7B Instruct",
+								"context_window": 32768,
+								"default_max_tokens": 8192
+							}
+						}
+					},
+					{
+						"id": "llama-3.1-8b",
+						"object": "model",
+						"created": 1781837945,
+						"owned_by": "llama-swap",
+						"meta": {
+							"llamaswap": {
+								"name": "Llama 3.1 8B",
+								"context_window": 131072,
+								"default_max_tokens": 16384
+							}
+						}
+					}
+				]
+			}`))
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-llamaswap", BaseURL: srv.URL}
+		models := []catwalk.Model{
+			{ID: "qwen2.5-7b-instruct", Name: "qwen2.5-7b-instruct"},
+			{ID: "llama-3.1-8b", Name: "llama-3.1-8b"},
+			{ID: "unknown-model", Name: "unknown-model"},
+		}
+
+		e := &llamaswapEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 3)
+		require.Equal(t, int64(8192), result[0].DefaultMaxTokens)
+		require.Equal(t, int64(32768), result[0].ContextWindow)
+		require.Equal(t, "Qwen 2.5 7B Instruct", result[0].Name)
+		require.Equal(t, int64(16384), result[1].DefaultMaxTokens)
+		require.Equal(t, int64(131072), result[1].ContextWindow)
+		require.Equal(t, "Llama 3.1 8B", result[1].Name)
+		require.Equal(t, int64(0), result[2].DefaultMaxTokens)
+		require.Equal(t, int64(0), result[2].ContextWindow)
+		require.Equal(t, "unknown-model", result[2].Name)
+	})
+
+	t.Run("preserves existing non-zero values", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{
+				"data": [
+					{
+						"id": "m1",
+						"object": "model",
+						"created": 1781831908,
+						"owned_by": "llama-swap",
+						"meta": {
+							"llamaswap": {
+								"name": "Should Not Override",
+								"context_window": 131072,
+								"default_max_tokens": 8192
+							}
+						}
+					}
+				]
+			}`))
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-llamaswap", BaseURL: srv.URL}
+		models := []catwalk.Model{
+			{ID: "m1", Name: "My Custom Name", ContextWindow: 65536},
+		}
+
+		e := &llamaswapEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, int64(65536), result[0].ContextWindow)
+		require.Equal(t, "My Custom Name", result[0].Name)
+	})
+
+	t.Run("returns models unchanged on HTTP error", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-llamaswap", BaseURL: srv.URL}
+		models := []catwalk.Model{{ID: "m1"}}
+
+		e := &llamaswapEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, int64(0), result[0].ContextWindow)
+	})
+
+	t.Run("does not override custom name with display name", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{
+				"data": [
+					{
+						"id": "m1",
+						"object": "model",
+						"created": 1781831908,
+						"owned_by": "llama-swap",
+						"meta": {
+							"llamaswap": {
+								"name": "API Name"
+							}
+						}
+					}
+				]
+			}`))
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-llamaswap", BaseURL: srv.URL}
+		models := []catwalk.Model{{ID: "m1", Name: "User Name"}}
+
+		e := &llamaswapEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, "User Name", result[0].Name)
+	})
+
+	t.Run("populates cost fields", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{
+				"data": [
+					{
+						"id": "m1",
+						"object": "model",
+						"created": 1781831908,
+						"owned_by": "llama-swap",
+						"meta": {
+							"llamaswap": {
+								"cost_per_1m_in": 2.5,
+								"cost_per_1m_out": 10.0,
+								"cost_per_1m_in_cached": 0.5,
+								"cost_per_1m_out_cached": 0.5
+							}
+						}
+					}
+				]
+			}`))
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-llamaswap", BaseURL: srv.URL}
+		models := []catwalk.Model{{ID: "m1"}}
+
+		e := &llamaswapEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, float64(2.5), result[0].CostPer1MIn)
+		require.Equal(t, float64(10.0), result[0].CostPer1MOut)
+		require.Equal(t, float64(0.5), result[0].CostPer1MInCached)
+		require.Equal(t, float64(0.5), result[0].CostPer1MOutCached)
+	})
+
+	t.Run("populates reasoning levels", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{
+				"data": [
+					{
+						"id": "m1",
+						"object": "model",
+						"created": 1781831908,
+						"owned_by": "llama-swap",
+						"meta": {
+							"llamaswap": {
+								"reasoning_levels": ["low", "medium", "high"]
+							}
+						}
+					}
+				]
+			}`))
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-llamaswap", BaseURL: srv.URL}
+		models := []catwalk.Model{{ID: "m1"}}
+
+		e := &llamaswapEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, []string{"low", "medium", "high"}, result[0].ReasoningLevels)
+	})
+
+	t.Run("handles empty data array", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"data": []}`))
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-llamaswap", BaseURL: srv.URL}
+		models := []catwalk.Model{{ID: "m1"}}
+
+		e := &llamaswapEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+	})
+
+	t.Run("handles missing metadata", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{
+				"data": [
+					{
+						"id": "m1",
+						"object": "model",
+						"created": 1781831908,
+						"owned_by": "llama-swap"
+					}
+				]
+			}`))
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-llamaswap", BaseURL: srv.URL}
+		models := []catwalk.Model{{ID: "m1"}}
+
+		e := &llamaswapEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+	})
+}

--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -130,7 +130,7 @@ reviewed.
 }
 ```
 
-- `type` (required): `openai`, `openai-compat`, `anthropic`, or a local provider type (`llamacpp`, `omlx`, `lmstudio`, `litellm`, `ollama`)
+- `type` (required): `openai`, `openai-compat`, `anthropic`, or a local provider type (`llamacpp`, `llamaswap`, `omlx`, `lmstudio`, `litellm`, `ollama`)
 - `api_key`, `base_url`, `api_endpoint`, and `extra_headers` are shell-expanded (see [Shell Expansion](#shell-expansion)).
 - `extra_body` is a JSON passthrough and is **not** expanded.
 - Additional fields: `disable`, `system_prompt_prefix`, `extra_headers`, `extra_body`, `provider_options`.


### PR DESCRIPTION
Fetch model configuration (name, context window, max tokens, etc.) from llama-swap's `/v1/models` endpoint for discovered models. This works much like the other existing enrichers except that llama-swap doesn't provide any of this information by default. The user must configure the "metadata" dictionary in their llama-swap configuration file with the additional properties they'd like to set. Since llama-swap doesn't provide it by default, and we could choose whatever names for the properties we wanted, the llamaswap enricher looks for the same field names as you could provide for a model in your Crush config.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
