### PR TITLE
fix: correct model discovery enrichment for local providers

### DIFF
--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -17,6 +17,16 @@ import (
 // even if the caller forgets to set a context deadline.
 var httpClient = &http.Client{Timeout: 10 * time.Second}
 
+// stripV1Suffix removes a trailing /v1 from a base URL. Enricher
+// endpoints (e.g. Ollama's /api/show, LM Studio's /api/v1/models) are
+// served at the server root, not under the OpenAI-compatible /v1
+// prefix. Since provider configs typically include /v1 in the base URL
+// for chat completions, enrichers must strip it before constructing
+// their own request paths.
+func stripV1Suffix(baseURL string) string {
+	return strings.TrimSuffix(strings.TrimRight(baseURL, "/"), "/v1")
+}
+
 // doRequest builds and executes an authenticated HTTP request using the
 // shared client. It resolves variable references in the base URL, API
 // key, and extra headers via the provided Resolver. The path is joined

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -200,3 +200,22 @@ func TestDiscoverModels_NoAuthWhenNoAPIKey(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, models, 1)
 }
+
+func TestStripV1Suffix(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"http://localhost:8000/v1", "http://localhost:8000"},
+		{"http://localhost:8000/v1/", "http://localhost:8000"},
+		{"http://localhost:8000", "http://localhost:8000"},
+		{"http://localhost:8000/", "http://localhost:8000"},
+		{"http://localhost:8000/api/v1", "http://localhost:8000/api"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := stripV1Suffix(tt.input)
+		require.Equal(t, tt.want, got, "stripV1Suffix(%q)", tt.input)
+	}
+}

--- a/internal/discover/litellm.go
+++ b/internal/discover/litellm.go
@@ -41,7 +41,7 @@ func init() {
 type litellmEnricher struct{}
 
 func (e *litellmEnricher) EnrichModels(ctx context.Context, cfg Config, resolver Resolver, models []catwalk.Model) ([]catwalk.Model, error) {
-	resp, err := doRequest(ctx, http.MethodGet, cfg.BaseURL, "/model/info", cfg.APIKey, cfg.ExtraHeaders, resolver, nil)
+	resp, err := doRequest(ctx, http.MethodGet, stripV1Suffix(cfg.BaseURL), "/model/info", cfg.APIKey, cfg.ExtraHeaders, resolver, nil)
 	if err != nil {
 		return models, nil
 	}

--- a/internal/discover/litellm_test.go
+++ b/internal/discover/litellm_test.go
@@ -42,8 +42,10 @@ func TestLitellmEnricher(t *testing.T) {
 		defer srv.Close()
 
 		cfg := Config{
-			ID:      "test-litellm",
-			BaseURL: srv.URL,
+			ID: "test-litellm",
+			// Base URL includes /v1 (as Crush configures it); the
+			// enricher strips it so /model/info resolves at the root.
+			BaseURL: srv.URL + "/v1",
 			APIKey:  "test-key",
 		}
 		models := []catwalk.Model{

--- a/internal/discover/lmstudio.go
+++ b/internal/discover/lmstudio.go
@@ -13,10 +13,11 @@ func init() {
 }
 
 // lmstudioModelsResponse mirrors the response from LM Studio's native
-// GET /api/v1/models endpoint. Only the fields we care about are
-// decoded.
+// GET /api/v1/models endpoint. The model array is returned under the
+// "models" key (not "data" like the OpenAI-compatible endpoint). Only
+// the fields we care about are decoded.
 type lmstudioModelsResponse struct {
-	Data []lmstudioModelEntry `json:"data"`
+	Models []lmstudioModelEntry `json:"models"`
 }
 
 // lmstudioModelEntry is a single entry from /api/v1/models.
@@ -44,7 +45,7 @@ type lmstudioInstanceConfig struct {
 type lmstudioEnricher struct{}
 
 func (e *lmstudioEnricher) EnrichModels(ctx context.Context, cfg Config, resolver Resolver, models []catwalk.Model) ([]catwalk.Model, error) {
-	resp, err := doRequest(ctx, http.MethodGet, cfg.BaseURL, "/api/v1/models", cfg.APIKey, cfg.ExtraHeaders, resolver, nil)
+	resp, err := doRequest(ctx, http.MethodGet, stripV1Suffix(cfg.BaseURL), "/api/v1/models", cfg.APIKey, cfg.ExtraHeaders, resolver, nil)
 	if err != nil {
 		return models, nil
 	}
@@ -60,8 +61,8 @@ func (e *lmstudioEnricher) EnrichModels(ctx context.Context, cfg Config, resolve
 	}
 
 	// Index by key for O(1) lookup.
-	metaByKey := make(map[string]lmstudioModelEntry, len(modelsResp.Data))
-	for _, m := range modelsResp.Data {
+	metaByKey := make(map[string]lmstudioModelEntry, len(modelsResp.Models))
+	for _, m := range modelsResp.Models {
 		metaByKey[m.Key] = m
 	}
 

--- a/internal/discover/lmstudio_test.go
+++ b/internal/discover/lmstudio_test.go
@@ -19,24 +19,28 @@ func TestLmstudioEnricher(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			require.Equal(t, "/api/v1/models", r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(lmstudioModelsResponse{
-				Data: []lmstudioModelEntry{
+			// Raw JSON matching LM Studio's real /api/v1/models wire
+			// format: array under "models", not "data".
+			_, _ = w.Write([]byte(`{
+				"models": [
 					{
-						Key:              "qwen2.5-7b-instruct",
-						DisplayName:      "Qwen 2.5 7B Instruct",
-						MaxContextLength: 32768,
+						"key": "qwen2.5-7b-instruct",
+						"display_name": "Qwen 2.5 7B Instruct",
+						"max_context_length": 32768
 					},
 					{
-						Key:              "llama-3.1-8b",
-						DisplayName:      "Llama 3.1 8B",
-						MaxContextLength: 131072,
-					},
-				},
-			})
+						"key": "llama-3.1-8b",
+						"display_name": "Llama 3.1 8B",
+						"max_context_length": 131072
+					}
+				]
+			}`))
 		}))
 		defer srv.Close()
 
-		cfg := Config{ID: "test-lmstudio", BaseURL: srv.URL}
+		// Base URL includes /v1 (as Crush configures it); the enricher
+		// strips it so the native endpoint resolves at the server root.
+		cfg := Config{ID: "test-lmstudio", BaseURL: srv.URL + "/v1"}
 		models := []catwalk.Model{
 			{ID: "qwen2.5-7b-instruct", Name: "qwen2.5-7b-instruct"},
 			{ID: "llama-3.1-8b", Name: "llama-3.1-8b"},
@@ -60,7 +64,7 @@ func TestLmstudioEnricher(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(lmstudioModelsResponse{
-				Data: []lmstudioModelEntry{
+				Models: []lmstudioModelEntry{
 					{
 						Key:              "m1",
 						MaxContextLength: 131072,
@@ -87,7 +91,7 @@ func TestLmstudioEnricher(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(lmstudioModelsResponse{
-				Data: []lmstudioModelEntry{
+				Models: []lmstudioModelEntry{
 					{
 						Key:              "m1",
 						DisplayName:      "Should Not Override",
@@ -132,7 +136,7 @@ func TestLmstudioEnricher(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(lmstudioModelsResponse{
-				Data: []lmstudioModelEntry{
+				Models: []lmstudioModelEntry{
 					{Key: "m1", DisplayName: "API Name"},
 				},
 			})

--- a/internal/discover/ollama.go
+++ b/internal/discover/ollama.go
@@ -51,7 +51,7 @@ func (e *ollamaEnricher) EnrichModels(ctx context.Context, cfg Config, resolver 
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			resp, err := doRequest(ctx, http.MethodPost, cfg.BaseURL, "/api/show",
+			resp, err := doRequest(ctx, http.MethodPost, stripV1Suffix(cfg.BaseURL), "/api/show",
 				cfg.APIKey, cfg.ExtraHeaders, resolver,
 				map[string]string{"model": models[idx].ID})
 			if err != nil {

--- a/internal/discover/ollama_test.go
+++ b/internal/discover/ollama_test.go
@@ -43,7 +43,9 @@ func TestOllamaEnricher(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		cfg := Config{ID: "test-ollama", BaseURL: srv.URL}
+		// Base URL includes /v1 (as Crush configures it); the enricher
+		// strips it so /api/show resolves at the server root.
+		cfg := Config{ID: "test-ollama", BaseURL: srv.URL + "/v1"}
 		models := []catwalk.Model{
 			{ID: "llama3:latest", Name: "llama3:latest"},
 			{ID: "qwen2:latest", Name: "qwen2:latest"},

--- a/internal/discover/omlx.go
+++ b/internal/discover/omlx.go
@@ -13,7 +13,7 @@ func init() {
 }
 
 // omlxModelsStatusResponse mirrors the response from oMLX's
-// GET /v1/models/status endpoint, which returns model metadata
+// GET /models/status endpoint, which returns model metadata
 // including max_context_window and max_tokens.
 type omlxModelsStatusResponse struct {
 	Models []omlxModelStatus `json:"models"`
@@ -26,13 +26,16 @@ type omlxModelStatus struct {
 	MaxTokens        *int64 `json:"max_tokens"`
 }
 
-// omlxEnricher fetches model metadata from oMLX's /v1/models/status
+// omlxEnricher fetches model metadata from oMLX's /models/status
 // endpoint and populates context window and max tokens on discovered
 // models.
 type omlxEnricher struct{}
 
 func (e *omlxEnricher) EnrichModels(ctx context.Context, cfg Config, resolver Resolver, models []catwalk.Model) ([]catwalk.Model, error) {
-	resp, err := doRequest(ctx, http.MethodGet, cfg.BaseURL, "/v1/models/status", cfg.APIKey, cfg.ExtraHeaders, resolver, nil)
+	// oMLX serves /models/status under the OpenAI-compatible /v1
+	// namespace, so the path is relative to the configured base URL
+	// (which already includes /v1) rather than the server root.
+	resp, err := doRequest(ctx, http.MethodGet, cfg.BaseURL, "/models/status", cfg.APIKey, cfg.ExtraHeaders, resolver, nil)
 	if err != nil {
 		return models, nil
 	}

--- a/internal/discover/omlx_test.go
+++ b/internal/discover/omlx_test.go
@@ -17,6 +17,8 @@ func TestOmlxEnricher(t *testing.T) {
 	t.Run("populates context window and max tokens from /v1/models/status", func(t *testing.T) {
 		t.Parallel()
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// oMLX serves the status endpoint under /v1 (base URL
+			// includes /v1), so the resolved path keeps the prefix.
 			require.Equal(t, "/v1/models/status", r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(omlxModelsStatusResponse{
@@ -28,7 +30,7 @@ func TestOmlxEnricher(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		cfg := Config{ID: "test-omlx", BaseURL: srv.URL}
+		cfg := Config{ID: "test-omlx", BaseURL: srv.URL + "/v1"}
 		models := []catwalk.Model{
 			{ID: "qwen3:latest", Name: "qwen3:latest"},
 			{ID: "llama3:latest", Name: "llama3:latest"},


### PR DESCRIPTION
Local provider enrichers (oMLX, Ollama, LM Studio, LiteLLM) failed to populate context window sizes, so sessions showed 0% usage and auto-summarization was silently skipped.

The Enricher request paths doubled the /v1 prefix because base URLs already include it. Strip /v1 for providers whose metadata endpoints live at the server root (Ollama, LM Studio, LiteLLM); keep it for oMLX, whose status endpoint lives under /v1.

LM Studio's model list was decoded from the wrong JSON key, so no models matched and nothing was enriched.