### PR TITLE
feat: add light theme with auto-detection for white backgrounds

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -261,15 +261,13 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 	progress = app.config.Config().Options.Progress == nil || *app.config.Config().Options.Progress
 
 	if !hideSpinner && stderrTTY {
-		t := styles.ThemeForProvider(app.config.Config().Models[config.SelectedModelTypeLarge].Provider)
-
-		// Detect background color to set the appropriate color for the
-		// spinner's 'Generating...' text. Without this, that text would be
-		// unreadable in light terminals.
+		// Detect background color so the theme can adapt to light
+		// terminals and the spinner label text is always legible.
 		hasDarkBG := true
 		if f, ok := output.(*os.File); ok && stdinTTY && stdoutTTY {
 			hasDarkBG = lipgloss.HasDarkBackground(os.Stdin, f)
 		}
+		t := styles.ThemeForProvider(app.config.Config().Models[config.SelectedModelTypeLarge].Provider, hasDarkBG)
 		defaultFG := lipgloss.LightDark(hasDarkBG)(charmtone.Pepper, t.WorkingLabelColor)
 
 		spinner = format.NewSpinner(ctx, cancel, anim.Settings{

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -191,12 +191,11 @@ func runNonInteractive(
 	progress = ws.Config.Options.Progress == nil || *ws.Config.Options.Progress
 
 	if !hideSpinner && stderrTTY {
-		t := styles.ThemeForProvider(ws.Config.Models[config.SelectedModelTypeLarge].Provider)
-
 		hasDarkBG := true
 		if stdinTTY && stdoutTTY {
 			hasDarkBG = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
 		}
+		t := styles.ThemeForProvider(ws.Config.Models[config.SelectedModelTypeLarge].Provider, hasDarkBG)
 		defaultFG := lipgloss.LightDark(hasDarkBG)(charmtone.Pepper, t.WorkingLabelColor)
 
 		spinner = format.NewSpinner(ctx, cancel, anim.Settings{

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -444,7 +444,8 @@ func outputSessionHuman(ctx context.Context, cfg *config.ConfigStore, sess sessi
 	if cfg != nil {
 		providerID = cfg.Config().Models[config.SelectedModelTypeLarge].Provider
 	}
-	styles := styles.ThemeForProvider(providerID)
+	hasDarkBG := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+	st := styles.ThemeForProvider(providerID, hasDarkBG)
 	toolResults := chat.BuildToolResultMap(msgs)
 
 	width := sessionOutputWidth
@@ -485,7 +486,7 @@ func outputSessionHuman(ctx context.Context, cfg *config.ConfigStore, sess sessi
 
 	first := true
 	for _, msg := range msgs {
-		items := chat.ExtractMessageItems(&styles, msg, toolResults)
+		items := chat.ExtractMessageItems(&st, msg, toolResults)
 		for _, item := range items {
 			if !first {
 				fmt.Fprintln(&buf)

--- a/internal/ui/common/common.go
+++ b/internal/ui/common/common.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/clipboard"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/ui/styles"
@@ -33,9 +34,11 @@ func (c *Common) Config() *config.Config {
 
 // DefaultCommon returns the default common UI configurations. When the
 // workspace has a large model selected, the theme is chosen based on its
-// provider; otherwise the default theme is used.
+// provider; otherwise the default theme is used. The terminal background
+// is auto-detected so light terminals get the appropriate theme variant.
 func DefaultCommon(ws workspace.Workspace) *Common {
-	s := styles.ThemeForProvider(largeModelProviderID(ws))
+	hasDarkBG := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+	s := styles.ThemeForProvider(largeModelProviderID(ws), hasDarkBG)
 	return &Common{
 		Workspace: ws,
 		Styles:    &s,

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1842,8 +1842,9 @@ func (m *UI) handleSelectModel(msg dialog.ActionSelectModel) tea.Cmd {
 	} else {
 		if msg.ModelType == config.SelectedModelTypeLarge {
 			// Swap the theme live based on the newly selected large
-			// model's provider.
-			m.applyTheme(styles.ThemeForProvider(providerID))
+			// model's provider and the terminal background.
+			hasDarkBG := lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+			m.applyTheme(styles.ThemeForProvider(providerID, hasDarkBG))
 		}
 		if _, ok := cfg.Models[config.SelectedModelTypeSmall]; !ok {
 			// Ensure small model is set is unset.

--- a/internal/ui/styles/themes.go
+++ b/internal/ui/styles/themes.go
@@ -1,18 +1,26 @@
 package styles
 
 import (
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/exp/charmtone"
 )
 
 // ThemeForProvider returns the Styles associated with the given provider
-// ID. Unknown or empty provider IDs yield the default Charmtone Pantera
-// theme.
-func ThemeForProvider(providerID string) Styles {
+// ID and terminal background. Unknown or empty provider IDs yield the
+// default Charmtone theme. When hasDarkBG is false, a light-friendly
+// variant is returned instead.
+func ThemeForProvider(providerID string, hasDarkBG bool) Styles {
 	switch providerID {
 	case "hyper":
-		return HypercrushObsidiana()
+		if hasDarkBG {
+			return HypercrushObsidiana()
+		}
+		return HypercrushLight()
 	default:
-		return CharmtonePantera()
+		if hasDarkBG {
+			return CharmtonePantera()
+		}
+		return CharmtoneLight()
 	}
 }
 
@@ -98,4 +106,115 @@ func CharmtonePantera() Styles {
 // HypercrushObsidiana returns the Hypercrush dark theme.
 func HypercrushObsidiana() Styles {
 	return CharmtonePantera()
+}
+
+// HypercrushLight returns the Hypercrush light theme.
+func HypercrushLight() Styles {
+	return CharmtoneLight()
+}
+
+// CharmtoneLight returns the Charmtone light theme for terminals with
+// light (white) backgrounds. It inverts the neutral ramp so that
+// foreground colors are dark and backgrounds are light, while keeping
+// brand colors and most status hues unchanged.
+func CharmtoneLight() Styles {
+	s := quickStyle(quickStyleOpts{
+		primary:   charmtone.Charple,
+		secondary: charmtone.Dolly,
+		accent:    charmtone.Bok,
+		keyword:   charmtone.Darple,
+
+		fgBase:       charmtone.Pepper,
+		fgMoreSubtle: charmtone.BBQ,
+		fgSubtle:     charmtone.Char,
+		fgMostSubtle: charmtone.Iron,
+
+		onPrimary: charmtone.Salt,
+
+		bgBase:         charmtone.Salt,
+		bgLeastVisible: charmtone.Soda,
+		bgLessVisible:  charmtone.Sash,
+		bgMostVisible:  charmtone.Oyster,
+
+		separator: charmtone.Steep,
+
+		destructive:       charmtone.Coral,
+		error:             charmtone.Sriracha,
+		warningSubtle:     charmtone.Yam,
+		warning:           charmtone.Paprika,
+		denied:            charmtone.Tang,
+		busy:              charmtone.Citron,
+		info:              charmtone.Malibu,
+		infoMoreSubtle:    charmtone.Sardine,
+		infoMostSubtle:    charmtone.Damson,
+		success:           charmtone.Julep,
+		successMoreSubtle: charmtone.Bok,
+		successMostSubtle: charmtone.Pickle,
+
+		ansiBlack:   charmtone.Pepper,
+		ansiRed:     charmtone.Coral,
+		ansiGreen:   charmtone.Pickle,
+		ansiYellow:  charmtone.Yam,
+		ansiBlue:    charmtone.Charple,
+		ansiMagenta: charmtone.Dolly,
+		ansiCyan:    charmtone.Malibu,
+		ansiWhite:   charmtone.Soda,
+
+		ansiBrightBlack:   charmtone.Iron,
+		ansiBrightRed:     charmtone.Tuna,
+		ansiBrightGreen:   charmtone.Julep,
+		ansiBrightYellow:  charmtone.Zest,
+		ansiBrightBlue:    charmtone.Guppy,
+		ansiBrightMagenta: charmtone.Blush,
+		ansiBrightCyan:    charmtone.Sardine,
+		ansiBrightWhite:   charmtone.Salt,
+	})
+
+	// Bang ! prompt overrides - use Darple/Larple/Charple colors on light.
+	s.Editor.PromptBangIconFocused = s.Editor.PromptBangIconFocused.
+		Foreground(charmtone.Salt).
+		Background(charmtone.Darple)
+	s.Editor.PromptBangDotsFocused = s.Editor.PromptBangDotsFocused.
+		Foreground(charmtone.Larple)
+	s.Editor.PromptBangDotsBlurred = s.Editor.PromptBangDotsBlurred.
+		Foreground(charmtone.Charple)
+
+	// Shell bar/prompt overrides.
+	s.Messages.ShellBarFocused = s.Messages.ShellBarFocused.
+		BorderForeground(charmtone.Charple)
+	s.Messages.ShellBarBlurred = s.Messages.ShellBarBlurred.
+		BorderForeground(charmtone.Oyster)
+	s.Messages.ShellPrompt = s.Messages.ShellPrompt.
+		Foreground(charmtone.Darple)
+	s.Messages.ShellPromptBlurred = s.Messages.ShellPromptBlurred.
+		Foreground(charmtone.Darple)
+
+	// Diff overrides - use light insert/delete backgrounds.
+	lightInsertNum := lipgloss.NewStyle().
+		Foreground(charmtone.Pickle).
+		Background(lipgloss.Color("#c8e6c9"))
+	lightInsertSym := lipgloss.NewStyle().
+		Foreground(charmtone.Pickle).
+		Background(lipgloss.Color("#e8f5e9"))
+	lightInsertCode := lipgloss.NewStyle().
+		Foreground(charmtone.Pepper).
+		Background(lipgloss.Color("#e8f5e9"))
+	lightDeleteNum := lipgloss.NewStyle().
+		Foreground(charmtone.Cherry).
+		Background(lipgloss.Color("#ffcdd2"))
+	lightDeleteSym := lipgloss.NewStyle().
+		Foreground(charmtone.Cherry).
+		Background(lipgloss.Color("#ffebee"))
+	lightDeleteCode := lipgloss.NewStyle().
+		Foreground(charmtone.Pepper).
+		Background(lipgloss.Color("#ffebee"))
+
+	s.Diff.InsertLine.LineNumber = lightInsertNum
+	s.Diff.InsertLine.Symbol = lightInsertSym
+	s.Diff.InsertLine.Code = lightInsertCode
+	s.Diff.DeleteLine.LineNumber = lightDeleteNum
+	s.Diff.DeleteLine.Symbol = lightDeleteSym
+	s.Diff.DeleteLine.Code = lightDeleteCode
+
+	return s
 }


### PR DESCRIPTION
Introduces CharmtoneLight theme that inverts the neutral color ramp for readability on light terminals. ThemeForProvider now accepts a hasDarkBG parameter and all call sites auto-detect via lipgloss.HasDarkBackground.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] The discussion happened here: #384 
