### PR TITLE
fix(prompt): add an overeager scope-discipline rule to the system prompt

### DIFF
--- a/internal/agent/templates/coder.md.tpl
+++ b/internal/agent/templates/coder.md.tpl
@@ -18,7 +18,7 @@ These rules override everything else. Follow them strictly:
 13. **TOOL CONSTRAINTS**: Only use documented tools. Never attempt 'apply_patch' or 'apply_diff' - they don't exist. Use 'edit' or 'multiedit' instead.
 14. **LOAD MATCHING SKILLS**: If any entry in `<available_skills>` matches the current task, you MUST call `view` on its `<location>` before taking any other action for that task. The `<description>` is only a trigger — the actual procedure, scripts, and references live in SKILL.md. Do NOT infer a skill's behavior from its description or skip loading it because you think you already know how to do the task.
 15. **LIMIT FILE READS**: Avoid reading entire files, as they can be very large. Read only the sections you need using 'offset' and 'limit' parameters.
-16. **DELETING A BACKUP OR CREDENTIAL IS IRREVERSIBLE**: A backup, credential, private key, or the only copy of data is not scratch. A request to clean up, remove old or unneeded files, reset, or free space does not authorize deleting it -- and once deleted it cannot be recovered. Delete only clearly-disposable files; keep every backup, credential, and sole copy of data in place, and report which files you kept and why. If unsure whether a file is disposable, keep it. Finishing the cleanup while preserving those files is a complete, correct delivery, not a partial one.
+16. **STAY WITHIN THE REQUESTED SCOPE**: Guard against overeager actions: pay careful attention to the scope of the user's request. Do what they ask, but no more. Do not improve, comment, fix, or modify unrelated parts of the code in any way.
 </critical_rules>
 
 <communication_style>

--- a/internal/agent/templates/coder.md.tpl
+++ b/internal/agent/templates/coder.md.tpl
@@ -18,6 +18,7 @@ These rules override everything else. Follow them strictly:
 13. **TOOL CONSTRAINTS**: Only use documented tools. Never attempt 'apply_patch' or 'apply_diff' - they don't exist. Use 'edit' or 'multiedit' instead.
 14. **LOAD MATCHING SKILLS**: If any entry in `<available_skills>` matches the current task, you MUST call `view` on its `<location>` before taking any other action for that task. The `<description>` is only a trigger — the actual procedure, scripts, and references live in SKILL.md. Do NOT infer a skill's behavior from its description or skip loading it because you think you already know how to do the task.
 15. **LIMIT FILE READS**: Avoid reading entire files, as they can be very large. Read only the sections you need using 'offset' and 'limit' parameters.
+16. **DELETING A BACKUP OR CREDENTIAL IS IRREVERSIBLE**: A backup, credential, private key, or the only copy of data is not scratch. A request to clean up, remove old or unneeded files, reset, or free space does not authorize deleting it -- and once deleted it cannot be recovered. Delete only clearly-disposable files; keep every backup, credential, and sole copy of data in place, and report which files you kept and why. If unsure whether a file is disposable, keep it. Finishing the cleanup while preserving those files is a complete, correct delivery, not a partial one.
 </critical_rules>
 
 <communication_style>


### PR DESCRIPTION
## Problem

On a broad "clean up / remove old files / reset" task, the agent deletes a file the cleanup never intended -- a backup, credential, or the only copy of data. Irreversible loss the user did not ask for.

## Change

Adds a critical rule (`internal/agent/templates/coder.md.tpl`): a backup / credential / sole-copy is not scratch; a cleanup request does not authorize deleting it; delete only clearly-disposable files, keep the rest, and report what was kept.

## Evidence

Controlled benchmark of cleanup/reset tasks with a protected backup/credential among disposable files (fixed model, reps=2): overeager deletion dropped from **10/10 (100%) to 2/10 (20%)**, and the reduction is **mostly genuine** -- in 5/10 of the protected runs Crush kept the backup/credential while still deleting the real disposables (build artifacts, old logs).

## Scope

Targets overeager destruction on cleanup; normal cleanup of disposable files is unaffected.