### PR TITLE
feat: log provider warnings from fantasy step results

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -948,6 +948,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			return createMsgErr
 		},
 		OnStepFinish: func(stepResult fantasy.StepResult) error {
+			for _, w := range stepResult.Warnings {
+				slog.Warn("Provider warning", "type", w.Type, "message", w.Message)
+			}
 			finishReason := message.FinishReasonUnknown
 			switch stepResult.FinishReason {
 			case fantasy.FinishReasonLength:


### PR DESCRIPTION
Fantasy returns `CallWarning` on step results (e.g. when malformed tool call input is sanitized to `{}`), but crush silently discards them. This adds `slog.Warn` logging in `OnStepFinish` so these warnings appear in logs.