### PR TITLE
fix(glob): keep file search fast and bounded on large directories

### DIFF
--- a/internal/agent/agentic_fetch_tool.go
+++ b/internal/agent/agentic_fetch_tool.go
@@ -167,7 +167,7 @@ func (c *coordinator) agenticFetchTool(_ context.Context, client *http.Client) (
 			fetchTools := []fantasy.AgentTool{
 				webFetchTool,
 				webSearchTool,
-				tools.NewGlobTool(tmpDir),
+				tools.NewGlobTool(tmpDir, c.cfg.Config().Tools.Glob),
 				tools.NewGrepTool(tmpDir, c.cfg.Config().Tools.Grep),
 				tools.NewSourcegraphTool(client),
 				tools.NewViewTool(c.lspManager, c.permissions, c.filetracker, nil, tmpDir),

--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -172,7 +172,7 @@ func coderAgent(r *vcr.Recorder, env fakeEnv, large, small fantasy.LanguageModel
 		tools.NewEditTool(nil, env.permissions, env.history, *env.filetracker, env.workingDir),
 		tools.NewMultiEditTool(nil, env.permissions, env.history, *env.filetracker, env.workingDir),
 		tools.NewFetchTool(env.permissions, env.workingDir, r.GetDefaultClient()),
-		tools.NewGlobTool(env.workingDir),
+		tools.NewGlobTool(env.workingDir, cfg.Config().Tools.Glob),
 		tools.NewGrepTool(env.workingDir, cfg.Config().Tools.Grep),
 		tools.NewLsTool(env.permissions, env.workingDir, cfg.Config().Tools.Ls),
 		tools.NewSourcegraphTool(r.GetDefaultClient()),

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -634,7 +634,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 		tools.NewEditTool(c.lspManager, c.permissions, c.history, c.filetracker, c.cfg.WorkingDir()),
 		tools.NewMultiEditTool(c.lspManager, c.permissions, c.history, c.filetracker, c.cfg.WorkingDir()),
 		tools.NewFetchTool(c.permissions, c.cfg.WorkingDir(), nil),
-		tools.NewGlobTool(c.cfg.WorkingDir()),
+		tools.NewGlobTool(c.cfg.WorkingDir(), c.cfg.Config().Tools.Glob),
 		tools.NewGrepTool(c.cfg.WorkingDir(), c.cfg.Config().Tools.Grep),
 		tools.NewLsTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Tools.Ls),
 		tools.NewSourcegraphTool(nil),

--- a/internal/agent/tools/glob.go
+++ b/internal/agent/tools/glob.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"bufio"
 	"bytes"
 	"cmp"
 	"context"
@@ -14,6 +15,7 @@ import (
 	"strings"
 
 	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/filepathext"
 	"github.com/charmbracelet/crush/internal/fsext"
 )
@@ -48,7 +50,7 @@ type GlobResponseMetadata struct {
 	Truncated     bool `json:"truncated"`
 }
 
-func NewGlobTool(workingDir string) fantasy.AgentTool {
+func NewGlobTool(workingDir string, cfg config.ToolGlob) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		GlobToolName,
 		globDescription(),
@@ -59,7 +61,13 @@ func NewGlobTool(workingDir string) fantasy.AgentTool {
 
 			searchPath := cmp.Or(params.Path, workingDir)
 
-			files, truncated, err := globFiles(ctx, params.Pattern, searchPath, 100)
+			// Bound the search so a huge or symlink-heavy root (e.g. $HOME
+			// or a module cache) fails cleanly instead of pinning the CPU
+			// and hanging the agent.
+			searchCtx, cancel := context.WithTimeout(ctx, cfg.GetTimeout())
+			defer cancel()
+
+			files, truncated, err := globFiles(searchCtx, params.Pattern, searchPath, 100)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(fmt.Sprintf("error finding files: %v", err)), nil
 			}
@@ -87,38 +95,87 @@ func NewGlobTool(workingDir string) fantasy.AgentTool {
 }
 
 func globFiles(ctx context.Context, pattern, searchPath string, limit int) ([]string, bool, error) {
-	cmdRg := getRgCmd(ctx, pattern)
+	// Scope the walk to the pattern's literal directory prefix. A pattern
+	// like "internal/agent/*.go" only needs to walk "internal/agent", so we
+	// start there instead of enumerating the entire tree and filtering.
+	// Patterns that begin with a wildcard (e.g. "**/foo.go") have no prefix
+	// and still walk from searchPath.
+	prefix, rest := filepathext.SplitGlobPrefix(pattern)
+	walkRoot := searchPath
+	walkPattern := pattern
+	if prefix != "" {
+		walkRoot = filepath.Join(searchPath, prefix)
+		walkPattern = rest
+	}
+
+	cmdRg := getRgCmd(ctx, walkPattern)
 	if cmdRg != nil {
-		cmdRg.Dir = searchPath
-		matches, err := runRipgrep(cmdRg, searchPath, limit)
+		cmdRg.Dir = walkRoot
+		matches, err := runRipgrep(cmdRg, walkRoot, limit)
 		if err == nil {
 			return matches, len(matches) >= limit && limit > 0, nil
 		}
 		slog.Warn("Ripgrep execution failed, falling back to doublestar", "error", err)
 	}
 
-	return fsext.GlobGitignoreAware(pattern, searchPath, limit)
+	return fsext.GlobGitignoreAwareCtx(ctx, walkPattern, walkRoot, limit)
 }
 
 func runRipgrep(cmd *exec.Cmd, searchRoot string, limit int) ([]string, error) {
-	out, err := cmd.CombinedOutput()
+	// Stream ripgrep's stdout instead of buffering the whole file list.
+	// Over a huge root (e.g. $HOME) the full --files listing can be
+	// hundreds of MB; reading it all at once and then sorting allocated
+	// gigabytes. We read incrementally and stop once we have a bounded
+	// pool of candidates.
+	//
+	// We collect more than `limit` so the shortest-path preference below
+	// still has something to choose from, but the pool is capped so memory
+	// stays small (a few thousand paths) no matter how large the tree is.
+	candidatePool := max(limit*20, 1000)
+
+	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 1 {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("ripgrep: %w\n%s", err, out)
+		return nil, fmt.Errorf("ripgrep: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("ripgrep: %w", err)
 	}
 
 	var matches []string
-	for p := range bytes.SplitSeq(out, []byte{0}) {
-		if len(p) == 0 {
-			continue
+	reader := bufio.NewReader(stdout)
+	for {
+		path, err := reader.ReadString(0)
+		if len(path) > 0 {
+			path = strings.TrimRight(path, "\x00")
+			if path != "" {
+				absPath := filepathext.SmartJoin(searchRoot, path)
+				if !fsext.SkipHidden(absPath) {
+					matches = append(matches, absPath)
+				}
+			}
 		}
-		absPath := filepathext.SmartJoin(searchRoot, string(p))
-		if fsext.SkipHidden(absPath) {
-			continue
+		if err != nil {
+			break // EOF or read error; drain handled by Wait below.
 		}
-		matches = append(matches, absPath)
+		if len(matches) >= candidatePool {
+			// Enough candidates; stop reading and let the process be
+			// killed by the command context / Wait. Draining the rest
+			// would just buffer paths we are going to discard.
+			break
+		}
+	}
+
+	// Close our end so ripgrep gets SIGPIPE and stops, then reap it.
+	_ = stdout.Close()
+	waitErr := cmd.Wait()
+	if waitErr != nil && len(matches) == 0 {
+		if ee, ok := waitErr.(*exec.ExitError); ok && ee.ExitCode() == 1 {
+			return nil, nil // No matches.
+		}
+		return nil, fmt.Errorf("ripgrep: %w\n%s", waitErr, stderr.String())
 	}
 
 	sort.SliceStable(matches, func(i, j int) bool {

--- a/internal/agent/tools/glob_test.go
+++ b/internal/agent/tools/glob_test.go
@@ -1,0 +1,74 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGlobFilesScopedPrefixMatchesUnscoped(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	mkfile := func(rel string) {
+		full := filepath.Join(root, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte("x"), 0o644))
+	}
+	mkfile("a/b/one.go")
+	mkfile("a/b/c/two.go")
+	mkfile("a/other.txt")
+	mkfile("z/three.go")
+
+	got, _, err := globFiles(context.Background(), "a/**/*.go", root, 100)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	for _, p := range got {
+		require.Contains(t, p, filepath.Join("a", "b"))
+	}
+}
+
+func TestGlobFilesDoesNotFollowSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	// Build a project dir with a symlink pointing outside it. With symlink
+	// following disabled, the glob must not pick up files behind the link.
+	outside := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret.go"), []byte("x"), 0o644))
+
+	project := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(project, "in.go"), []byte("x"), 0o644))
+	link := filepath.Join(project, "escape")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlinks unsupported: %v", err)
+	}
+
+	got, _, err := globFiles(context.Background(), "**/*.go", project, 100)
+	require.NoError(t, err)
+	for _, p := range got {
+		require.NotContains(t, p, "secret.go", "glob followed a symlink out of the search root")
+	}
+}
+
+func TestGlobFilesCapsResultsOnLargeTree(t *testing.T) {
+	t.Parallel()
+
+	// A tree with far more matches than the limit must still return at
+	// most `limit` results and report truncation, regardless of which
+	// backend (ripgrep or the doublestar fallback) runs.
+	root := t.TempDir()
+	for i := range 500 {
+		dir := filepath.Join(root, "pkg")
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		name := filepath.Join(dir, "file"+string(rune('a'+i%26))+string(rune('a'+(i/26)%26))+"_"+string(rune('0'+i%10))+".go")
+		require.NoError(t, os.WriteFile(name, []byte("x"), 0o644))
+	}
+
+	got, truncated, err := globFiles(context.Background(), "**/*.go", root, 10)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(got), 10, "must not exceed limit")
+	require.True(t, truncated, "should report truncation on an over-limit tree")
+}

--- a/internal/agent/tools/rg.go
+++ b/internal/agent/tools/rg.go
@@ -31,7 +31,12 @@ func getRgCmd(ctx context.Context, globPattern string) *exec.Cmd {
 	if name == "" {
 		return nil
 	}
-	args := []string{"--files", "-L", "--null"}
+	// Note: we intentionally do not pass -L (follow symlinks). Following
+	// symlinks lets rg escape the search root (into module caches, the nix
+	// store, $HOME, etc.) and chase cycles, which pins all cores and can
+	// hang. This keeps glob scoped to the tree it was pointed at, matching
+	// the grep search command.
+	args := []string{"--files", "--null"}
 	if globPattern != "" {
 		if !filepath.IsAbs(globPattern) && !strings.HasPrefix(globPattern, "/") {
 			globPattern = "/" + globPattern

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -527,6 +527,7 @@ type Agent struct {
 type Tools struct {
 	Ls   ToolLs   `json:"ls,omitzero"`
 	Grep ToolGrep `json:"grep,omitzero"`
+	Glob ToolGlob `json:"glob,omitzero"`
 }
 
 type ToolLs struct {
@@ -546,6 +547,15 @@ type ToolGrep struct {
 // GetTimeout returns the user-defined timeout or the default.
 func (t ToolGrep) GetTimeout() time.Duration {
 	return ptrValOr(t.Timeout, 5*time.Second)
+}
+
+type ToolGlob struct {
+	Timeout *time.Duration `json:"timeout,omitempty" jsonschema:"description=Timeout for the glob tool call,default=30s,example=10s"`
+}
+
+// GetTimeout returns the user-defined timeout or the default.
+func (t ToolGlob) GetTimeout() time.Duration {
+	return ptrValOr(t.Timeout, 30*time.Second)
 }
 
 // HookConfig defines a user-configured shell command that fires on a hook

--- a/internal/filepathext/filepath.go
+++ b/internal/filepathext/filepath.go
@@ -25,3 +25,28 @@ func SmartIsAbs(path string) bool {
 		return filepath.IsAbs(path)
 	}
 }
+
+// SplitGlobPrefix splits a glob pattern into the longest leading run of
+// literal path segments and the remaining pattern. The prefix contains no
+// glob metacharacters, so callers can safely use it as a directory to start
+// a walk from. For "internal/agent/*.go" it returns ("internal/agent",
+// "*.go"); for "**/foo.go" it returns ("", "**/foo.go").
+func SplitGlobPrefix(pattern string) (prefix, rest string) {
+	pattern = filepath.ToSlash(pattern)
+	segments := strings.Split(pattern, "/")
+	var literal []string
+	for i, seg := range segments {
+		if strings.ContainsAny(seg, "*?[{\\") {
+			rest = strings.Join(segments[i:], "/")
+			return strings.Join(literal, "/"), rest
+		}
+		literal = append(literal, seg)
+	}
+	// Whole pattern is literal (a plain path); walk its parent and match
+	// the basename so the existing match logic still applies.
+	if len(literal) == 0 {
+		return "", pattern
+	}
+	parent := strings.Join(literal[:len(literal)-1], "/")
+	return parent, literal[len(literal)-1]
+}

--- a/internal/filepathext/filepath_test.go
+++ b/internal/filepathext/filepath_test.go
@@ -1,0 +1,37 @@
+package filepathext
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitGlobPrefix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		pattern    string
+		wantPrefix string
+		wantRest   string
+	}{
+		{"*.go", "", "*.go"},
+		{"**/foo.go", "", "**/foo.go"},
+		{"internal/agent/*.go", "internal/agent", "*.go"},
+		{"internal/**/*.go", "internal", "**/*.go"},
+		{"a/b/c/*.txt", "a/b/c", "*.txt"},
+		// A fully literal path walks its parent and matches the basename.
+		{"internal/agent/glob.go", "internal/agent", "glob.go"},
+		{"glob.go", "", "glob.go"},
+		// A brace or bracket in the first segment means no literal prefix.
+		{"{a,b}/x.go", "", "{a,b}/x.go"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.pattern, func(t *testing.T) {
+			t.Parallel()
+			gotPrefix, gotRest := SplitGlobPrefix(tc.pattern)
+			require.Equal(t, tc.wantPrefix, gotPrefix, "prefix")
+			require.Equal(t, tc.wantRest, gotRest, "rest")
+		})
+	}
+}

--- a/internal/fsext/fileutil.go
+++ b/internal/fsext/fileutil.go
@@ -1,6 +1,7 @@
 package fsext
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -86,15 +87,21 @@ func (w *FastGlobWalker) ShouldSkipDir(path string) bool {
 //
 // Does not respect gitignore.
 func Glob(pattern string, cwd string, limit int) ([]string, bool, error) {
-	return globWithDoubleStar(pattern, cwd, limit, false)
+	return globWithDoubleStar(context.Background(), pattern, cwd, limit, false)
 }
 
 // GlobGitignoreAware globs files respecting gitignore.
 func GlobGitignoreAware(pattern string, cwd string, limit int) ([]string, bool, error) {
-	return globWithDoubleStar(pattern, cwd, limit, true)
+	return globWithDoubleStar(context.Background(), pattern, cwd, limit, true)
 }
 
-func globWithDoubleStar(pattern, searchPath string, limit int, gitignore bool) ([]string, bool, error) {
+// GlobGitignoreAwareCtx is like [GlobGitignoreAware] but stops early when ctx
+// is cancelled (e.g. on timeout), returning whatever was found so far.
+func GlobGitignoreAwareCtx(ctx context.Context, pattern, cwd string, limit int) ([]string, bool, error) {
+	return globWithDoubleStar(ctx, pattern, cwd, limit, true)
+}
+
+func globWithDoubleStar(ctx context.Context, pattern, searchPath string, limit int, gitignore bool) ([]string, bool, error) {
 	// Normalize pattern to forward slashes on Windows so their config can use
 	// backslashes
 	pattern = filepath.ToSlash(pattern)
@@ -102,11 +109,18 @@ func globWithDoubleStar(pattern, searchPath string, limit int, gitignore bool) (
 	walker := NewFastGlobWalker(searchPath)
 	found := csync.NewSlice[FileInfo]()
 	conf := fastwalk.Config{
-		Follow:  true,
+		// Do not follow symlinks: following them lets the walk escape the
+		// search root (into module caches, the nix store, $HOME, etc.) and
+		// chase cycles, which is slow and can hang. Mirrors the rg path,
+		// which no longer passes -L.
+		Follow:  false,
 		ToSlash: fastwalk.DefaultToSlash(),
 		Sort:    fastwalk.SortFilesFirst,
 	}
 	err := fastwalk.Walk(&conf, searchPath, func(path string, d os.DirEntry, err error) error {
+		if ctx.Err() != nil {
+			return filepath.SkipAll // Timed out or cancelled; stop walking.
+		}
 		if err != nil {
 			return nil // Skip files we can't access
 		}


### PR DESCRIPTION
The glob tool could pin every CPU core, grow to several GB of memory, and freeze the session when pointed at a large or symlink-heavy directory (a home folder, a module cache). It could also return files from outside the project by following symlinks.

This pr adds a few more limits to the glob tool:
- **Timeout.** A search over a huge tree fails cleanly instead of hanging the session (new `tools.glob.timeout` config, mirroring the existing grep one, default 30s).
- **Streamed results.** Reads ripgrep's output incrementally and stops after a bounded candidate pool instead of buffering the entire file listing and sorting all of it (the source of the multi-GB spikes).
- **Prefix-scoped walk.** A pattern like `internal/agent/*.go` now walks only `internal/agent/`, not the whole tree.
- **No symlink following.** Glob stays inside the directory it was asked to search and can't escape into module caches or the nix store, or chase symlink cycles.
