### PR TITLE
fix: limit number of concurrent ripgrep processes

### DIFF
--- a/internal/agent/tools/glob.go
+++ b/internal/agent/tools/glob.go
@@ -100,7 +100,7 @@ func globFiles(ctx context.Context, pattern, searchPath string, limit int) ([]st
 	return fsext.GlobGitignoreAware(pattern, searchPath, limit)
 }
 
-func runRipgrep(cmd *exec.Cmd, searchRoot string, limit int) ([]string, error) {
+func runRipgrep(cmd *rgCmd, searchRoot string, limit int) ([]string, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 1 {

--- a/internal/agent/tools/rg.go
+++ b/internal/agent/tools/rg.go
@@ -1,7 +1,9 @@
 package tools
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +13,13 @@ import (
 
 	"github.com/charmbracelet/crush/internal/log"
 )
+
+// rgMaxConcurrency limits the number of concurrent ripgrep processes spawned
+// by this package. A bounded number prevents a runaway agent from spawning
+// an unbounded number of expensive searches.
+const rgMaxConcurrency = 8
+
+var rgSem = make(chan struct{}, rgMaxConcurrency)
 
 var getRg = sync.OnceValue(func() string {
 	if testing.Testing() {
@@ -26,7 +35,7 @@ var getRg = sync.OnceValue(func() string {
 	return path
 })
 
-func getRgCmd(ctx context.Context, globPattern string) *exec.Cmd {
+func getRgCmd(ctx context.Context, globPattern string) *rgCmd {
 	name := getRg()
 	if name == "" {
 		return nil
@@ -38,10 +47,10 @@ func getRgCmd(ctx context.Context, globPattern string) *exec.Cmd {
 		}
 		args = append(args, "--glob", globPattern)
 	}
-	return exec.CommandContext(ctx, name, args...)
+	return newRgCmd(ctx, name, args...)
 }
 
-func getRgSearchCmd(ctx context.Context, pattern, path, include string) *exec.Cmd {
+func getRgSearchCmd(ctx context.Context, pattern, path, include string) *rgCmd {
 	name := getRg()
 	if name == "" {
 		return nil
@@ -53,5 +62,78 @@ func getRgSearchCmd(ctx context.Context, pattern, path, include string) *exec.Cm
 	}
 	args = append(args, path)
 
-	return exec.CommandContext(ctx, name, args...)
+	return newRgCmd(ctx, name, args...)
+}
+
+// rgCmd wraps an exec.Cmd with a package-level semaphore that limits the
+// number of concurrent ripgrep processes. Callers can use the standard
+// *exec.Cmd methods; the wrapper blocks on Start until a slot is available
+// and releases the slot after Wait returns.
+type rgCmd struct {
+	*exec.Cmd
+	ctx context.Context
+}
+
+func newRgCmd(ctx context.Context, name string, args ...string) *rgCmd {
+	return &rgCmd{Cmd: exec.CommandContext(ctx, name, args...), ctx: ctx}
+}
+
+func (c *rgCmd) acquire() error {
+	select {
+	case rgSem <- struct{}{}:
+		return nil
+	case <-c.ctx.Done():
+		return c.ctx.Err()
+	}
+}
+
+func (c *rgCmd) release() {
+	<-rgSem
+}
+
+func (c *rgCmd) Start() error {
+	if err := c.acquire(); err != nil {
+		return err
+	}
+	if err := c.Cmd.Start(); err != nil {
+		c.release()
+		return err
+	}
+	return nil
+}
+
+func (c *rgCmd) Run() error {
+	if err := c.Start(); err != nil {
+		return err
+	}
+	return c.Wait()
+}
+
+func (c *rgCmd) Wait() error {
+	defer c.release()
+	return c.Cmd.Wait()
+}
+
+func (c *rgCmd) Output() ([]byte, error) {
+	if c.Stdout != nil {
+		return nil, errors.New("exec: Stdout already set")
+	}
+	var b bytes.Buffer
+	c.Stdout = &b
+	err := c.Run()
+	return b.Bytes(), err
+}
+
+func (c *rgCmd) CombinedOutput() ([]byte, error) {
+	if c.Stdout != nil {
+		return nil, errors.New("exec: Stdout already set")
+	}
+	if c.Stderr != nil {
+		return nil, errors.New("exec: Stderr already set")
+	}
+	var b bytes.Buffer
+	c.Stdout = &b
+	c.Stderr = &b
+	err := c.Run()
+	return b.Bytes(), err
 }


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
## What?

Wraps ripgrep  `exec.Cmd`  instances in `internal/agent/tools/rg.go`  with a package-level semaphore (`rgMaxConcurrency = 8`) that is acquired on `Start` and released on `Wait`. `getRgCmd` and `getRgSearchCmd` now return `*rgCmd`, and `runRipgrep` in `glob.go` was updated to accept the wrapped type.

## Why? 

A runaway agent could previously spawn an unbounded number of concurrent ripgrep searches, which can thrash CPU and I/O on large repositories. Bounding the concurrency prevents resource exhaustion.