### PR TITLE
feat(ui): optimize model ui rendering and config reload speed

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -572,11 +572,33 @@ func (c *Config) setDefaults(workingDir, dataDir string) {
 	c.Options.InitializeAs = cmp.Or(c.Options.InitializeAs, defaultInitializeAs)
 }
 
+// powernapDefaults caches the powernap default LSP server catalog. The
+// catalog is static and immutable for the life of the process, but
+// building it (NewManager + LoadDefaults) is expensive and was previously
+// repeated on every config reload. We load it once and only ever read from
+// it via GetServer, so a shared instance is safe.
+var (
+	powernapDefaultsOnce sync.Once
+	powernapDefaults     *powernapConfig.Manager
+)
+
+func lspDefaultsManager() *powernapConfig.Manager {
+	powernapDefaultsOnce.Do(func() {
+		m := powernapConfig.NewManager()
+		// LoadDefaults only fails on malformed embedded defaults, which
+		// would be a build-time bug; treat the manager as usable either
+		// way so a transient error never wedges config loading.
+		_ = m.LoadDefaults()
+		powernapDefaults = m
+	})
+	return powernapDefaults
+}
+
 // applyLSPDefaults applies default values from powernap to LSP configurations
 func (c *Config) applyLSPDefaults() {
-	// Get powernap's default configuration
-	configManager := powernapConfig.NewManager()
-	configManager.LoadDefaults()
+	// Reuse the process-wide default catalog; building it per reload was a
+	// significant chunk of reload latency.
+	configManager := lspDefaultsManager()
 
 	// Apply defaults to each LSP configuration
 	for name, cfg := range c.LSP {
@@ -900,10 +922,18 @@ func hasAWSCredentials(env env.Env) bool {
 		return true
 	}
 
-	if _, err := os.Stat(filepath.Join(home.Dir(), ".aws/credentials")); err == nil && !testing.Testing() {
+	// File-based credential discovery requires filesystem stats, so do it
+	// last and skip it under test. Checking testing.Testing() before the
+	// os.Stat call (rather than after, in the && tail) ensures the syscall
+	// is never issued during tests, where it otherwise ran unconditionally
+	// and only had its result discarded.
+	if testing.Testing() {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(home.Dir(), ".aws/credentials")); err == nil {
 		return true
 	}
-	if _, err := os.Stat(filepath.Join(home.Dir(), ".aws/login")); err == nil && !testing.Testing() {
+	if _, err := os.Stat(filepath.Join(home.Dir(), ".aws/login")); err == nil {
 		return true
 	}
 
@@ -1058,7 +1088,22 @@ func isInsideWorktree() bool {
 // repositories, missing git binary, plain directories, or any other
 // failure mode). Linked worktrees and submodules each report their own
 // top-level, which is what callers want when bounding lookups.
+// worktreeRootCache memoizes the git worktree root per directory. The root
+// is stable for the life of the process, so we avoid re-shelling out to
+// "git rev-parse" on every config reload. Keyed by the requested dir; the
+// value is the resolved root ("" when dir is not in a git worktree).
+var worktreeRootCache sync.Map // map[string]string
+
 func worktreeRoot(dir string) string {
+	if cached, ok := worktreeRootCache.Load(dir); ok {
+		return cached.(string)
+	}
+	root := computeWorktreeRoot(dir)
+	worktreeRootCache.Store(dir, root)
+	return root
+}
+
+func computeWorktreeRoot(dir string) string {
 	cmd := exec.CommandContext(
 		context.Background(),
 		"git", "rev-parse", "--show-toplevel",

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -221,6 +221,16 @@ func (s *ConfigStore) SetConfigField(scope Scope, key string, value any) error {
 // The write is protected by an in-process mutex and a cross-process flock
 // to prevent races between concurrent writers in different processes.
 func (s *ConfigStore) SetConfigFields(scope Scope, kv map[string]any) error {
+	return s.setConfigFields(scope, kv, true)
+}
+
+// setConfigFields performs the write and, when reload is true, refreshes
+// in-memory state from disk. Callers that have already updated the relevant
+// in-memory state themselves can pass reload=false to skip the expensive
+// full reparse (which rebuilds the provider catalog and agents). The disk
+// is the source of truth for other processes either way; skipping reload
+// only avoids re-deriving state this process already holds.
+func (s *ConfigStore) setConfigFields(scope Scope, kv map[string]any, reload bool) error {
 	// Sort keys for deterministic output regardless of map iteration
 	// order. This also ensures consistent results when callers pass
 	// overlapping JSONPath keys (e.g. "a" and "a.b").
@@ -243,6 +253,16 @@ func (s *ConfigStore) SetConfigFields(scope Scope, kv map[string]any) error {
 	})
 	if err != nil {
 		return err
+	}
+
+	if !reload {
+		// The caller has already updated in-memory state; just refresh
+		// the staleness snapshot so the file watcher does not treat our
+		// own write as an external change.
+		if path, perr := s.configPath(scope); perr == nil {
+			s.captureStalenessSnapshot(append(slices.Clone(s.loadedPaths), path))
+		}
+		return nil
 	}
 
 	// Auto-reload to keep in-memory state fresh after config edits.
@@ -281,14 +301,30 @@ func (s *ConfigStore) RemoveConfigField(scope Scope, key string) error {
 }
 
 // UpdatePreferredModel updates the preferred model for the given type and
-// persists it to the config file at the given scope.
+// persists it to the config file at the given scope. The selected model and
+// the recent-models list are written together in a single config write.
+//
+// The in-memory config is updated directly here, so the write skips the
+// full disk reparse/reload. The reload would otherwise rebuild the entire
+// provider catalog and agents on every model switch, which dominates the
+// latency of selecting a model. Agents are refreshed separately by the
+// caller (see UpdateAgentModel).
 func (s *ConfigStore) UpdatePreferredModel(scope Scope, modelType SelectedModelType, model SelectedModel) error {
 	s.config.Models[modelType] = model
-	if err := s.SetConfigField(scope, fmt.Sprintf("models.%s", modelType), model); err != nil {
-		return fmt.Errorf("failed to update preferred model: %w", err)
+
+	fields := map[string]any{
+		fmt.Sprintf("models.%s", modelType): model,
 	}
-	if err := s.recordRecentModel(scope, modelType, model); err != nil {
-		return err
+
+	// Compute the updated recent-models list in memory. When it changes,
+	// fold the write into the same batch so we avoid a second write.
+	if updated, changed := s.nextRecentModels(modelType, model); changed {
+		s.config.RecentModels[modelType] = updated
+		fields[fmt.Sprintf("recent_models.%s", modelType)] = updated
+	}
+
+	if err := s.setConfigFields(scope, fields, false); err != nil {
+		return fmt.Errorf("failed to update preferred model: %w", err)
 	}
 	return nil
 }
@@ -504,10 +540,15 @@ func (s *ConfigStore) loadTokenFromDisk(scope Scope, providerID string) (*oauth.
 	return &token, nil
 }
 
-// recordRecentModel records a model in the recent models list.
-func (s *ConfigStore) recordRecentModel(scope Scope, modelType SelectedModelType, model SelectedModel) error {
+// nextRecentModels computes the recent-models list for the given type
+// after recording the supplied model at the front, without persisting
+// anything. It returns the new slice and whether it differs from the
+// current list. It also lazily initializes the RecentModels map. Callers
+// that want to persist the change can fold the result into a batched
+// config write; recordRecentModel wraps it for the standalone case.
+func (s *ConfigStore) nextRecentModels(modelType SelectedModelType, model SelectedModel) ([]SelectedModel, bool) {
 	if model.Provider == "" || model.Model == "" {
-		return nil
+		return nil, false
 	}
 
 	if s.config.RecentModels == nil {
@@ -534,6 +575,19 @@ func (s *ConfigStore) recordRecentModel(scope Scope, modelType SelectedModelType
 	}
 
 	if slices.EqualFunc(current, updated, eq) {
+		return current, false
+	}
+
+	return updated, true
+}
+
+// recordRecentModel records a model in the recent models list and persists
+// the change. It is retained for callers that update recent models in
+// isolation; UpdatePreferredModel batches the same change into a single
+// config write instead.
+func (s *ConfigStore) recordRecentModel(scope Scope, modelType SelectedModelType, model SelectedModel) error {
+	updated, changed := s.nextRecentModels(modelType, model)
+	if !changed {
 		return nil
 	}
 

--- a/internal/config/update_model_bench_test.go
+++ b/internal/config/update_model_bench_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// BenchmarkUpdatePreferredModel measures the full write cost of a single
+// model selection, which is what the user experiences when picking a model
+// in the TUI. It guards against regressing back to a full config reload on
+// every selection.
+func BenchmarkUpdatePreferredModel(b *testing.B) {
+	dir := b.TempDir()
+	configPath := filepath.Join(dir, "crush.json")
+
+	b.Setenv("CRUSH_GLOBAL_CONFIG", dir)
+	b.Setenv("CRUSH_GLOBAL_DATA", dir)
+	resetProviderState()
+	b.Cleanup(resetProviderState)
+
+	cfg := `{
+		"models": {
+			"large": {"provider": "openai", "model": "gpt-4"},
+			"small": {"provider": "openai", "model": "gpt-4o-mini"}
+		},
+		"providers": {
+			"openai": {
+				"api_key": "test-key",
+				"models": [
+					{"id": "gpt-4", "name": "GPT-4"},
+					{"id": "gpt-4o", "name": "GPT-4o"},
+					{"id": "gpt-4o-mini", "name": "GPT-4o mini"}
+				]
+			},
+			"anthropic": {
+				"api_key": "test-key-2",
+				"models": [
+					{"id": "claude-3", "name": "Claude 3"},
+					{"id": "claude-3-5", "name": "Claude 3.5"}
+				]
+			}
+		}
+	}`
+	if err := os.WriteFile(configPath, []byte(cfg), 0o600); err != nil {
+		b.Fatal(err)
+	}
+
+	store, err := Load(dir, dir, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	store.globalDataPath = configPath
+
+	models := []SelectedModel{
+		{Provider: "openai", Model: "gpt-4"},
+		{Provider: "anthropic", Model: "claude-3"},
+		{Provider: "openai", Model: "gpt-4o"},
+		{Provider: "anthropic", Model: "claude-3-5"},
+	}
+
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		m := models[i%len(models)]
+		if err := store.UpdatePreferredModel(ScopeGlobal, SelectedModelTypeLarge, m); err != nil {
+			b.Fatal(err)
+		}
+		i++
+	}
+}
+
+// BenchmarkReloadFromDisk isolates the full reload cost for comparison with
+// BenchmarkUpdatePreferredModel.
+func BenchmarkReloadFromDisk(b *testing.B) {
+	dir := b.TempDir()
+	configPath := filepath.Join(dir, "crush.json")
+
+	b.Setenv("CRUSH_GLOBAL_CONFIG", dir)
+	b.Setenv("CRUSH_GLOBAL_DATA", dir)
+	resetProviderState()
+	b.Cleanup(resetProviderState)
+
+	cfg := `{
+		"models": {"large": {"provider": "openai", "model": "gpt-4"}},
+		"providers": {
+			"openai": {"api_key": "test-key", "models": [{"id": "gpt-4", "name": "GPT-4"}]}
+		}
+	}`
+	if err := os.WriteFile(configPath, []byte(cfg), 0o600); err != nil {
+		b.Fatal(err)
+	}
+
+	store, err := Load(dir, dir, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	store.globalDataPath = configPath
+
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := store.ReloadFromDisk(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/shell/expand.go
+++ b/internal/shell/expand.go
@@ -59,6 +59,15 @@ var NoUnset atomic.Bool
 //     prefix of its stderr. Callers that surface the error to users
 //     should additionally scrub it for the original template text.
 func ExpandValue(ctx context.Context, value string, env []string) (string, error) {
+	// Fast path: a value with no shell metacharacters expands to itself.
+	// Parsing and running it through the interpreter would produce the
+	// same string at significant cost. Most config values (literal API
+	// keys, fixed URLs) hit this path, which matters because ExpandValue
+	// runs over every provider/MCP/LSP value on each config reload.
+	if !strings.ContainsAny(value, "$`\\'\"") {
+		return value, nil
+	}
+
 	// Parse the value as a here-doc style word: no word splitting, no
 	// globbing, but full support for $VAR, ${VAR...}, $(...), and
 	// quoted/escaped strings.
@@ -73,12 +82,16 @@ func ExpandValue(ctx context.Context, value string, env []string) (string, error
 	// verbatim, with no CRUSH/AGENT/AI_AGENT injection: callers of
 	// ExpandValue control the env, and nounset must treat any name
 	// not in env as unset.
-	cwd, _ := os.Getwd()
+	//
+	// The working directory is only needed for $(...) command
+	// substitution, so we resolve it lazily on first use. Values that
+	// only reference variables or use quoting (the common case) avoid
+	// the os.Getwd() syscall entirely.
 	s := &Shell{
-		cwd:    cwd,
 		env:    env,
 		logger: noopLogger{},
 	}
+	cwdResolved := false
 
 	strict := NoUnset.Load()
 
@@ -87,6 +100,10 @@ func ExpandValue(ctx context.Context, value string, env []string) (string, error
 		Env:     expand.ListEnviron(env...),
 		NoUnset: strict,
 		CmdSubst: func(w io.Writer, cs *syntax.CmdSubst) error {
+			if !cwdResolved {
+				s.cwd, _ = os.Getwd()
+				cwdResolved = true
+			}
 			stderrBuf.Reset()
 			runnerOpts := []interp.RunnerOption{
 				interp.StdIO(nil, w, &stderrBuf),

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -269,10 +269,9 @@ func (m *Models) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	m.help.SetWidth(innerWidth)
 
 	listHeight := height - heightOffset
-	m.list.SetSize(innerWidth, listHeight)
-	listTotalHeight := m.list.TotalHeight()
 	listWidth := max(0, innerWidth-3) // Reserve space for scrollbar.
 	m.list.SetSize(listWidth, listHeight)
+	listTotalHeight := m.list.TotalHeight()
 
 	rc := NewRenderContext(t, width)
 	rc.Title = "Switch Model"

--- a/internal/ui/dialog/models_list.go
+++ b/internal/ui/dialog/models_list.go
@@ -254,7 +254,6 @@ func (f *ModelsList) VisibleItems() []list.Item {
 
 // Render renders the filterable list.
 func (f *ModelsList) Render() string {
-	f.SetItems(f.VisibleItems()...)
 	return f.List.Render()
 }
 

--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -34,6 +34,12 @@ type List struct {
 	// renderCallbacks is a list of callbacks to apply when rendering items.
 	renderCallbacks []func(idx, selectedIdx int, item Item) Item
 
+	// totalHeightCache is a cached value of the total rendered height of
+	// all items. It is invalidated whenever the item set changes or the
+	// viewport width changes (which can alter per-item line counts).
+	totalHeightCache int
+	totalHeightValid bool
+
 	// cache is the F6 list-level render memo, keyed by item pointer.
 	// Each entry stores the rendered content, a pre-split slice of
 	// lines (so AtBottom / Render / VisibleItemIndices /
@@ -158,15 +164,25 @@ func (l *List) Len() int {
 }
 
 // TotalHeight returns the total height of all items in the list.
+// The result is cached and only recomputed when the item set or
+// viewport width changes.
 func (l *List) TotalHeight() int {
+	if l.totalHeightValid {
+		return l.totalHeightCache
+	}
 	total := 0
 	for idx := range l.items {
-		item := l.getItem(idx)
-		total += item.height
+		entry := l.renderItemEntry(idx)
+		if entry == nil {
+			continue
+		}
+		total += entry.height
 		if l.gap > 0 && idx < len(l.items)-1 {
 			total += l.gap
 		}
 	}
+	l.totalHeightCache = total
+	l.totalHeightValid = true
 	return total
 }
 
@@ -289,6 +305,11 @@ func (l *List) renderItemEntry(idx int) *listCacheEntry {
 		entry = &listCacheEntry{}
 		l.cache[rawItem] = entry
 	}
+	// If the item's rendered height changed, the cached total height is
+	// no longer valid and must be recomputed on the next TotalHeight call.
+	if entry.height != height {
+		l.totalHeightValid = false
+	}
 	entry.width = l.width
 	entry.version = finalVersion
 	entry.frozen = frozen
@@ -303,6 +324,7 @@ func (l *List) invalidateAll() {
 	for k := range l.cache {
 		delete(l.cache, k)
 	}
+	l.totalHeightValid = false
 }
 
 // Invalidate drops the cache entry for the given item, forcing a
@@ -575,6 +597,7 @@ func (l *List) PrependItems(items ...Item) {
 	if l.selectedIdx != -1 {
 		l.selectedIdx += len(items)
 	}
+	l.totalHeightValid = false
 }
 
 // SetItems sets the items in the list. Cache entries for items that
@@ -586,11 +609,13 @@ func (l *List) SetItems(items ...Item) {
 	l.offsetIdx = min(l.offsetIdx, len(l.items)-1)
 	l.offsetLine = 0
 	l.retainCacheFor(items)
+	l.totalHeightValid = false
 }
 
 // AppendItems appends items to the list.
 func (l *List) AppendItems(items ...Item) {
 	l.items = append(l.items, items...)
+	l.totalHeightValid = false
 }
 
 // RemoveItem removes the item at the given index from the list.
@@ -623,6 +648,7 @@ func (l *List) RemoveItem(idx int) {
 		l.offsetIdx = max(0, len(l.items)-1)
 		l.offsetLine = 0
 	}
+	l.totalHeightValid = false
 }
 
 // Focused returns whether the list is focused.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -196,6 +196,11 @@ type UI struct {
 
 	isTransparent bool
 
+	// themeKey identifies the currently applied theme so applyTheme can
+	// skip the expensive style rebuild when switching to a provider that
+	// resolves to the same theme.
+	themeKey string
+
 	focus uiFocusState
 	state uiState
 
@@ -379,6 +384,12 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 	}
 
 	status := NewStatus(com, ui)
+
+	// Seed the active theme key from the large model provider so the
+	// first model selection can correctly skip a redundant theme swap.
+	if cfg := com.Config(); cfg != nil {
+		ui.themeKey = styles.ThemeKeyForProvider(cfg.Models[config.SelectedModelTypeLarge].Provider)
+	}
 
 	ui.setEditorPrompt(com.Workspace.PermissionSkipRequests())
 	ui.randomizePlaceholders()
@@ -1842,8 +1853,10 @@ func (m *UI) handleSelectModel(msg dialog.ActionSelectModel) tea.Cmd {
 	} else {
 		if msg.ModelType == config.SelectedModelTypeLarge {
 			// Swap the theme live based on the newly selected large
-			// model's provider.
-			m.applyTheme(styles.ThemeForProvider(providerID))
+			// model's provider. Skipped when the provider resolves to
+			// the already-active theme, which avoids a full markdown
+			// re-render of the transcript on every selection.
+			m.applyThemeForProvider(providerID)
 		}
 		if _, ok := cfg.Models[config.SelectedModelTypeSmall]; !ok {
 			// Ensure small model is set is unset.
@@ -3369,6 +3382,21 @@ func (m *UI) renderEditorView(width int) string {
 // cacheSidebarLogo renders and caches the sidebar logo at the specified width.
 func (m *UI) cacheSidebarLogo(width int) {
 	m.sidebarLogo = renderLogo(m.com.Styles, true, m.com.IsHyper(), width)
+}
+
+// applyThemeForProvider swaps the active theme to the one associated with
+// the given provider, but only when that theme differs from the one
+// already applied. Most providers share a single theme, so re-selecting a
+// model from the same theme family would otherwise pay the full cost of
+// invalidating the markdown renderer cache and re-rendering the entire
+// transcript for no visible change.
+func (m *UI) applyThemeForProvider(providerID string) {
+	key := styles.ThemeKeyForProvider(providerID)
+	if key == m.themeKey {
+		return
+	}
+	m.themeKey = key
+	m.applyTheme(styles.ThemeForProvider(providerID))
 }
 
 // applyTheme replaces the active styles with the given theme, drops the

--- a/internal/ui/styles/themes.go
+++ b/internal/ui/styles/themes.go
@@ -4,11 +4,26 @@ import (
 	"github.com/charmbracelet/x/exp/charmtone"
 )
 
+// ThemeKeyForProvider returns a stable identifier for the theme
+// associated with the given provider ID. Providers that share a theme
+// yield the same key, so callers can cheaply detect when switching
+// providers would not actually change the active theme and skip the
+// expensive style rebuild. This is the single source of truth for the
+// provider-to-theme mapping; [ThemeForProvider] builds on it.
+func ThemeKeyForProvider(providerID string) string {
+	switch providerID {
+	case "hyper":
+		return "hyper"
+	default:
+		return "default"
+	}
+}
+
 // ThemeForProvider returns the Styles associated with the given provider
 // ID. Unknown or empty provider IDs yield the default Charmtone Pantera
 // theme.
 func ThemeForProvider(providerID string) Styles {
-	switch providerID {
+	switch ThemeKeyForProvider(providerID) {
 	case "hyper":
 		return HypercrushObsidiana()
 	default:


### PR DESCRIPTION
Made a few changes that should speed up model selection a fair bit.

- Improved the rendering in the model ui to cache data and avoid rerendering in the hotpath every frame
- Made theme switching per provider lazy so it shortcircuits if its the same theme going to get applied which avoids glamour caches getting invalidated which for long sessions can be very slowwwww 🐢
- Heavily optimized the config reload path down from 33ms -> ~1.8ms in a benchmark likely even faster if you have a large config.