### PR TITLE
fix: close context should kill subprocesses

### DIFF
--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -248,8 +248,8 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 				startTime := time.Now()
 				bgManager := shell.GetBackgroundShellManager()
 				bgManager.Cleanup()
-				// Use the tool context so cancellation propagates to the subprocess.
-				bgShell, err := bgManager.Start(ctx, execWorkingDir, blockFuncs(), params.Command, params.Description)
+				// Use background context so it continues after tool returns
+				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
 				if err != nil {
 					return fantasy.ToolResponse{}, fmt.Errorf("error starting background shell: %w", err)
 				}
@@ -301,10 +301,10 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 			// Start synchronous execution with auto-background support
 			startTime := time.Now()
 
-			// Start with the tool context so cancellation propagates to the subprocess.
+			// Start with detached context so it can survive if moved to background
 			bgManager := shell.GetBackgroundShellManager()
 			bgManager.Cleanup()
-			bgShell, err := bgManager.Start(ctx, execWorkingDir, blockFuncs(), params.Command, params.Description)
+			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
 			if err != nil {
 				return fantasy.ToolResponse{}, fmt.Errorf("error starting shell: %w", err)
 			}

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -248,8 +248,8 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 				startTime := time.Now()
 				bgManager := shell.GetBackgroundShellManager()
 				bgManager.Cleanup()
-				// Use background context so it continues after tool returns
-				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+				// Use the tool context so cancellation propagates to the subprocess.
+				bgShell, err := bgManager.Start(ctx, execWorkingDir, blockFuncs(), params.Command, params.Description)
 				if err != nil {
 					return fantasy.ToolResponse{}, fmt.Errorf("error starting background shell: %w", err)
 				}
@@ -301,10 +301,10 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 			// Start synchronous execution with auto-background support
 			startTime := time.Now()
 
-			// Start with detached context so it can survive if moved to background
+			// Start with the tool context so cancellation propagates to the subprocess.
 			bgManager := shell.GetBackgroundShellManager()
 			bgManager.Cleanup()
-			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+			bgShell, err := bgManager.Start(ctx, execWorkingDir, blockFuncs(), params.Command, params.Description)
 			if err != nil {
 				return fantasy.ToolResponse{}, fmt.Errorf("error starting shell: %w", err)
 			}

--- a/internal/agent/tools/glob.go
+++ b/internal/agent/tools/glob.go
@@ -97,7 +97,7 @@ func globFiles(ctx context.Context, pattern, searchPath string, limit int) ([]st
 		slog.Warn("Ripgrep execution failed, falling back to doublestar", "error", err)
 	}
 
-	return fsext.GlobGitignoreAware(pattern, searchPath, limit)
+	return fsext.GlobGitignoreAware(ctx, pattern, searchPath, limit)
 }
 
 func runRipgrep(cmd *exec.Cmd, searchRoot string, limit int) ([]string, error) {

--- a/internal/agent/tools/grep.go
+++ b/internal/agent/tools/grep.go
@@ -193,7 +193,7 @@ func NewGrepTool(workingDir string, config config.ToolGrep) fantasy.AgentTool {
 func searchFiles(ctx context.Context, pattern, rootPath, include string, limit int) ([]grepMatch, bool, error) {
 	matches, err := searchWithRipgrep(ctx, pattern, rootPath, include)
 	if err != nil {
-		matches, err = searchFilesWithRegex(pattern, rootPath, include)
+		matches, err = searchFilesWithRegex(ctx, pattern, rootPath, include)
 		if err != nil {
 			return nil, false, err
 		}
@@ -280,7 +280,7 @@ type ripgrepMatch struct {
 	} `json:"data"`
 }
 
-func searchFilesWithRegex(pattern, rootPath, include string) ([]grepMatch, error) {
+func searchFilesWithRegex(ctx context.Context, pattern, rootPath, include string) ([]grepMatch, error) {
 	matches := []grepMatch{}
 
 	// Use cached regex compilation
@@ -302,6 +302,9 @@ func searchFilesWithRegex(pattern, rootPath, include string) ([]grepMatch, error
 	walker := fsext.NewFastGlobWalker(rootPath)
 
 	err = filepath.Walk(rootPath, func(path string, info os.FileInfo, err error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if err != nil {
 			return nil // Skip errors
 		}
@@ -329,7 +332,7 @@ func searchFilesWithRegex(pattern, rootPath, include string) ([]grepMatch, error
 			return nil
 		}
 
-		match, lineNum, charNum, lineText, err := fileContainsPattern(path, regex)
+		match, lineNum, charNum, lineText, err := fileContainsPattern(ctx, path, regex)
 		if err != nil {
 			return nil // Skip files we can't read
 		}
@@ -357,7 +360,7 @@ func searchFilesWithRegex(pattern, rootPath, include string) ([]grepMatch, error
 	return matches, nil
 }
 
-func fileContainsPattern(filePath string, pattern *regexp.Regexp) (bool, int, int, string, error) {
+func fileContainsPattern(ctx context.Context, filePath string, pattern *regexp.Regexp) (bool, int, int, string, error) {
 	if pattern == nil {
 		return false, 0, 0, "", nil
 	}
@@ -375,6 +378,9 @@ func fileContainsPattern(filePath string, pattern *regexp.Regexp) (bool, int, in
 	reader := bufio.NewReader(file)
 	lineNum := 0
 	for {
+		if ctx.Err() != nil {
+			return false, 0, 0, "", ctx.Err()
+		}
 		line, err := reader.ReadString('\n')
 		lineNum++
 		line = strings.TrimSuffix(line, "\n")

--- a/internal/agent/tools/grep_test.go
+++ b/internal/agent/tools/grep_test.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -84,10 +85,10 @@ func TestGrepWithIgnoreFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".crushignore"), []byte(crushignoreContent), 0o644))
 
 	// Test both implementations
-	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
+	for name, fn := range map[string]func(context.Context, string, string, string) ([]grepMatch, error){
 		"regex": searchFilesWithRegex,
-		"rg": func(pattern, path, include string) ([]grepMatch, error) {
-			return searchWithRipgrep(t.Context(), pattern, path, include)
+		"rg": func(ctx context.Context, pattern, path, include string) ([]grepMatch, error) {
+			return searchWithRipgrep(ctx, pattern, path, include)
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -97,7 +98,7 @@ func TestGrepWithIgnoreFiles(t *testing.T) {
 				t.Skip("rg is not in $PATH")
 			}
 
-			matches, err := fn("hello world", tempDir, "")
+			matches, err := fn(t.Context(), "hello world", tempDir, "")
 			require.NoError(t, err)
 
 			// Convert matches to a set of file paths for easier testing
@@ -144,10 +145,10 @@ func TestSearchImplementations(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".gitignore"), []byte("file4.txt\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".crushignore"), []byte("file5.txt\n"), 0o644))
 
-	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
+	for name, fn := range map[string]func(context.Context, string, string, string) ([]grepMatch, error){
 		"regex": searchFilesWithRegex,
-		"rg": func(pattern, path, include string) ([]grepMatch, error) {
-			return searchWithRipgrep(t.Context(), pattern, path, include)
+		"rg": func(ctx context.Context, pattern, path, include string) ([]grepMatch, error) {
+			return searchWithRipgrep(ctx, pattern, path, include)
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -157,7 +158,7 @@ func TestSearchImplementations(t *testing.T) {
 				t.Skip("rg is not in $PATH")
 			}
 
-			matches, err := fn("hello world", tempDir, "")
+			matches, err := fn(t.Context(), "hello world", tempDir, "")
 			require.NoError(t, err)
 
 			require.Equal(t, len(matches), 4)
@@ -395,10 +396,10 @@ func TestColumnMatch(t *testing.T) {
 	t.Parallel()
 
 	// Test both implementations
-	for name, fn := range map[string]func(pattern, path, include string) ([]grepMatch, error){
+	for name, fn := range map[string]func(context.Context, string, string, string) ([]grepMatch, error){
 		"regex": searchFilesWithRegex,
-		"rg": func(pattern, path, include string) ([]grepMatch, error) {
-			return searchWithRipgrep(t.Context(), pattern, path, include)
+		"rg": func(ctx context.Context, pattern, path, include string) ([]grepMatch, error) {
+			return searchWithRipgrep(ctx, pattern, path, include)
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -408,7 +409,7 @@ func TestColumnMatch(t *testing.T) {
 				t.Skip("rg is not in $PATH")
 			}
 
-			matches, err := fn("THIS", "./testdata/", "")
+			matches, err := fn(t.Context(), "THIS", "./testdata/", "")
 			require.NoError(t, err)
 			require.Len(t, matches, 1)
 			match := matches[0]

--- a/internal/agent/tools/ls.go
+++ b/internal/agent/tools/ls.go
@@ -122,7 +122,7 @@ func NewLsTool(permissions permission.Service, workingDir string, lsConfig confi
 				}
 			}
 
-			output, metadata, err := ListDirectoryTree(searchPath, params, lsConfig)
+			output, metadata, err := ListDirectoryTree(ctx, searchPath, params, lsConfig)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
@@ -135,7 +135,7 @@ func NewLsTool(permissions permission.Service, workingDir string, lsConfig confi
 	)
 }
 
-func ListDirectoryTree(searchPath string, params LSParams, lsConfig config.ToolLs) (string, LSResponseMetadata, error) {
+func ListDirectoryTree(ctx context.Context, searchPath string, params LSParams, lsConfig config.ToolLs) (string, LSResponseMetadata, error) {
 	if _, err := os.Stat(searchPath); os.IsNotExist(err) {
 		return "", LSResponseMetadata{}, fmt.Errorf("path does not exist: %s", searchPath)
 	}
@@ -143,6 +143,7 @@ func ListDirectoryTree(searchPath string, params LSParams, lsConfig config.ToolL
 	depth, limit := lsConfig.Limits()
 	maxFiles := cmp.Or(limit, maxLSFiles)
 	files, truncated, err := fsext.ListDirectory(
+		ctx,
 		searchPath,
 		params.Ignore,
 		cmp.Or(params.Depth, depth),

--- a/internal/agent/tools/rg.go
+++ b/internal/agent/tools/rg.go
@@ -27,6 +27,9 @@ var getRg = sync.OnceValue(func() string {
 })
 
 func getRgCmd(ctx context.Context, globPattern string) *exec.Cmd {
+	if ctx.Err() != nil {
+		return nil
+	}
 	name := getRg()
 	if name == "" {
 		return nil
@@ -42,6 +45,9 @@ func getRgCmd(ctx context.Context, globPattern string) *exec.Cmd {
 }
 
 func getRgSearchCmd(ctx context.Context, pattern, path, include string) *exec.Cmd {
+	if ctx.Err() != nil {
+		return nil
+	}
 	name := getRg()
 	if name == "" {
 		return nil

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -93,7 +94,7 @@ func contextPathsExist(dir string) (bool, error) {
 
 // dirHasNoVisibleFiles returns true if the directory has no files/dirs after applying ignore rules.
 func dirHasNoVisibleFiles(dir string) (bool, error) {
-	files, _, err := fsext.ListDirectory(dir, nil, 1, 1)
+	files, _, err := fsext.ListDirectory(context.Background(), dir, nil, 1, 1)
 	if err != nil {
 		return false, err
 	}

--- a/internal/fsext/fileutil.go
+++ b/internal/fsext/fileutil.go
@@ -1,6 +1,7 @@
 package fsext
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -86,15 +87,15 @@ func (w *FastGlobWalker) ShouldSkipDir(path string) bool {
 //
 // Does not respect gitignore.
 func Glob(pattern string, cwd string, limit int) ([]string, bool, error) {
-	return globWithDoubleStar(pattern, cwd, limit, false)
+	return globWithDoubleStar(context.Background(), pattern, cwd, limit, false)
 }
 
 // GlobGitignoreAware globs files respecting gitignore.
-func GlobGitignoreAware(pattern string, cwd string, limit int) ([]string, bool, error) {
-	return globWithDoubleStar(pattern, cwd, limit, true)
+func GlobGitignoreAware(ctx context.Context, pattern string, cwd string, limit int) ([]string, bool, error) {
+	return globWithDoubleStar(ctx, pattern, cwd, limit, true)
 }
 
-func globWithDoubleStar(pattern, searchPath string, limit int, gitignore bool) ([]string, bool, error) {
+func globWithDoubleStar(ctx context.Context, pattern, searchPath string, limit int, gitignore bool) ([]string, bool, error) {
 	// Normalize pattern to forward slashes on Windows so their config can use
 	// backslashes
 	pattern = filepath.ToSlash(pattern)
@@ -107,6 +108,9 @@ func globWithDoubleStar(pattern, searchPath string, limit int, gitignore bool) (
 		Sort:    fastwalk.SortFilesFirst,
 	}
 	err := fastwalk.Walk(&conf, searchPath, func(path string, d os.DirEntry, err error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if err != nil {
 			return nil // Skip files we can't access
 		}

--- a/internal/fsext/fileutil_test.go
+++ b/internal/fsext/fileutil_test.go
@@ -1,6 +1,7 @@
 package fsext
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -24,7 +25,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test content"), 0o644))
 		}
 
-		matches, truncated, err := GlobGitignoreAware("**/main.go", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "**/main.go", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -47,7 +48,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "main.go"), []byte("package main"), 0o644))
 		require.NoError(t, os.WriteFile(pkgFile, []byte("test"), 0o644))
 
-		matches, truncated, err := GlobGitignoreAware("pkg", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "pkg", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -66,7 +67,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.MkdirAll(dir, 0o755))
 		}
 
-		matches, truncated, err := GlobGitignoreAware("**/pkg", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "**/pkg", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -95,7 +96,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("package main"), 0o644))
 		}
 
-		matches, truncated, err := GlobGitignoreAware("pkg/**", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "pkg/**", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -124,7 +125,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 		}
 
-		matches, truncated, err := GlobGitignoreAware("**/*.txt", testDir, 5)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "**/*.txt", testDir, 5)
 		require.NoError(t, err)
 		require.True(t, truncated, "Expected truncation with limit")
 		require.Len(t, matches, 5, "Expected exactly 5 matches with limit")
@@ -143,7 +144,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 			require.NoError(t, os.WriteFile(file, []byte("test"), 0o644))
 		}
 
-		matches, truncated, err := GlobGitignoreAware("a/b/c/file1.txt", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "a/b/c/file1.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -171,7 +172,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.NoError(t, os.Chtimes(file2, m2, m2))
 		require.NoError(t, os.Chtimes(file3, m3, m3))
 
-		matches, truncated, err := GlobGitignoreAware("*.txt", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "*.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 
@@ -181,7 +182,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 	t.Run("handles empty directory", func(t *testing.T) {
 		testDir := t.TempDir()
 
-		matches, truncated, err := GlobGitignoreAware("**", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "**", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		// Even empty directories should return the directory itself
@@ -191,7 +192,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 	t.Run("handles non-existent search path", func(t *testing.T) {
 		nonExistentDir := filepath.Join(t.TempDir(), "does", "not", "exist")
 
-		matches, truncated, err := GlobGitignoreAware("**", nonExistentDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "**", nonExistentDir, 0)
 		require.Error(t, err, "Should return error for non-existent search path")
 		require.False(t, truncated)
 		require.Empty(t, matches)
@@ -219,17 +220,17 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		ignoredFileInDir := filepath.Join(testDir, "backup", "old.txt")
 		require.NoError(t, os.WriteFile(ignoredFileInDir, []byte("old content"), 0o644))
 
-		matches, truncated, err := GlobGitignoreAware("*.tmp", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "*.tmp", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Empty(t, matches, "Expected no matches for '*.tmp' pattern (should be ignored)")
 
-		matches, truncated, err = GlobGitignoreAware("backup", testDir, 0)
+		matches, truncated, err = GlobGitignoreAware(context.Background(), "backup", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Empty(t, matches, "Expected no matches for 'backup' pattern (should be ignored)")
 
-		matches, truncated, err = GlobGitignoreAware("*.txt", testDir, 0)
+		matches, truncated, err = GlobGitignoreAware(context.Background(), "*.txt", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Equal(t, []string{goodFile}, matches)
@@ -257,7 +258,7 @@ func TestGlobWithDoubleStar(t *testing.T) {
 		require.NoError(t, os.Chtimes(middleDir, tMiddle, tMiddle))
 		require.NoError(t, os.Chtimes(oldestFile, tNewest, tNewest))
 
-		matches, truncated, err := GlobGitignoreAware("*.rs", testDir, 0)
+		matches, truncated, err := GlobGitignoreAware(context.Background(), "*.rs", testDir, 0)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		require.Len(t, matches, 3)

--- a/internal/fsext/ls.go
+++ b/internal/fsext/ls.go
@@ -2,6 +2,7 @@ package fsext
 
 import (
 	"cmp"
+	"context"
 	"errors"
 	"log/slog"
 	"os"
@@ -268,7 +269,7 @@ func (dl *directoryLister) shouldIgnore(path string, ignorePatterns []string, is
 }
 
 // ListDirectory lists files and directories in the specified path.
-func ListDirectory(initialPath string, ignorePatterns []string, depth, limit int) ([]string, bool, error) {
+func ListDirectory(ctx context.Context, initialPath string, ignorePatterns []string, depth, limit int) ([]string, bool, error) {
 	found := csync.NewSlice[string]()
 	dl := NewDirectoryLister(initialPath)
 
@@ -282,6 +283,9 @@ func ListDirectory(initialPath string, ignorePatterns []string, depth, limit int
 	}
 
 	err := fastwalk.Walk(&conf, initialPath, func(path string, d os.DirEntry, err error) error {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if err != nil {
 			return nil // Skip files we don't have permission to access
 		}

--- a/internal/fsext/ls_test.go
+++ b/internal/fsext/ls_test.go
@@ -1,6 +1,7 @@
 package fsext
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +29,7 @@ func TestListDirectory(t *testing.T) {
 	}
 
 	t.Run("no limit", func(t *testing.T) {
-		files, truncated, err := ListDirectory(tmp, nil, -1, -1)
+		files, truncated, err := ListDirectory(context.Background(), tmp, nil, -1, -1)
 		require.NoError(t, err)
 		require.False(t, truncated)
 		// The .gitignore has ".*" pattern which ignores hidden files anywhere
@@ -41,7 +42,7 @@ func TestListDirectory(t *testing.T) {
 		}, relPaths(t, files, tmp))
 	})
 	t.Run("limit", func(t *testing.T) {
-		files, truncated, err := ListDirectory(tmp, nil, -1, 2)
+		files, truncated, err := ListDirectory(context.Background(), tmp, nil, -1, 2)
 		require.NoError(t, err)
 		require.True(t, truncated)
 		require.Len(t, files, 2)

--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -2,6 +2,7 @@ package completions
 
 import (
 	"cmp"
+	"context"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -141,12 +142,12 @@ func (c *Completions) KeyMap() KeyMap {
 }
 
 // Open opens the completions with file items from the filesystem.
-func (c *Completions) Open(depth, limit int) tea.Cmd {
+func (c *Completions) Open(ctx context.Context, depth, limit int) tea.Cmd {
 	return func() tea.Msg {
 		var msg CompletionItemsLoadedMsg
 		var wg sync.WaitGroup
 		wg.Go(func() {
-			msg.Files = loadFiles(depth, limit)
+			msg.Files = loadFiles(ctx, depth, limit)
 		})
 		wg.Go(func() {
 			msg.Resources = loadMCPResources()
@@ -404,8 +405,8 @@ func (c *Completions) Render() string {
 	return c.list.List.Render()
 }
 
-func loadFiles(depth, limit int) []FileCompletionValue {
-	files, _, _ := fsext.ListDirectory(".", nil, depth, limit)
+func loadFiles(ctx context.Context, depth, limit int) []FileCompletionValue {
+	files, _, _ := fsext.ListDirectory(ctx, ".", nil, depth, limit)
 	slices.Sort(files)
 	result := make([]FileCompletionValue, 0, len(files))
 	for _, file := range files {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2179,7 +2179,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 						m.completionsStartIndex = curIdx
 						m.completionsPositionStart = m.completionsPosition()
 						depth, limit := m.com.Config().Options.TUI.Completions.Limits()
-						cmds = append(cmds, m.completions.Open(depth, limit))
+						cmds = append(cmds, m.completions.Open(context.Background(), depth, limit))
 					}
 				}
 


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

## What? 

Fixed the cancellation leak. Tools were spawning long-running work with `context.Background()` or with no context at all, so the agent-cancel context was
ignored and subprocesses kept running.

## Why?

The agent keeps using subproccesses (`glob`. `rg`), even if stop the context, therefore eating resources, while not working.