### PR TITLE
feat(ui/config): performance tuneup on model select dialog and config reloading

### DIFF
--- a/internal/agent/agenttest/coordinator.go
+++ b/internal/agent/agenttest/coordinator.go
@@ -55,8 +55,8 @@ func NewCoordinator(
 		Models:  []catwalk.Model{{ID: modelID, DefaultMaxTokens: 4096}},
 	})
 	selected := config.SelectedModel{Provider: providerID, Model: modelID}
-	cfg.Config().Models[config.SelectedModelTypeLarge] = selected
-	cfg.Config().Models[config.SelectedModelTypeSmall] = selected
+	cfg.OverridePreferredModel(config.SelectedModelTypeLarge, selected)
+	cfg.OverridePreferredModel(config.SelectedModelTypeSmall, selected)
 	cfg.SetupAgents()
 
 	// Keep buildTools light: no sub-agent or agentic-fetch construction.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -433,10 +433,10 @@ func (app *App) overrideModelsForNonInteractive(ctx context.Context, largeModel,
 		}
 		largeProviderID = found.provider
 		slog.Info("Overriding large model for non-interactive run", "provider", found.provider, "model", found.modelID)
-		app.config.Config().Models[config.SelectedModelTypeLarge] = config.SelectedModel{
+		app.config.OverridePreferredModel(config.SelectedModelTypeLarge, config.SelectedModel{
 			Provider: found.provider,
 			Model:    found.modelID,
-		}
+		})
 	}
 
 	// Override small model.
@@ -447,15 +447,15 @@ func (app *App) overrideModelsForNonInteractive(ctx context.Context, largeModel,
 			return err
 		}
 		slog.Info("Overriding small model for non-interactive run", "provider", found.provider, "model", found.modelID)
-		app.config.Config().Models[config.SelectedModelTypeSmall] = config.SelectedModel{
+		app.config.OverridePreferredModel(config.SelectedModelTypeSmall, config.SelectedModel{
 			Provider: found.provider,
 			Model:    found.modelID,
-		}
+		})
 
 	case largeModel != "":
 		// No small model specified, but large model was - use provider's default.
 		smallCfg := app.GetDefaultSmallModel(largeProviderID)
-		app.config.Config().Models[config.SelectedModelTypeSmall] = smallCfg
+		app.config.OverridePreferredModel(config.SelectedModelTypeSmall, smallCfg)
 	}
 
 	return app.AgentCoordinator.UpdateModels(ctx)

--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -222,13 +222,13 @@ func (b *Backend) EnableDockerMCP(ctx context.Context, workspaceID string) error
 
 	if err := mcptools.InitializeSingle(ctx, config.DockerMCPName, ws.Cfg); err != nil {
 		disableErr := mcptools.DisableSingle(ws.Cfg, config.DockerMCPName)
-		delete(ws.Cfg.Config().MCP, config.DockerMCPName)
+		ws.Cfg.RemoveDockerMCPInMemory()
 		return fmt.Errorf("failed to start docker MCP: %w", errors.Join(err, disableErr))
 	}
 
 	if err := ws.Cfg.PersistDockerMCPConfig(mcpConfig); err != nil {
 		disableErr := mcptools.DisableSingle(ws.Cfg, config.DockerMCPName)
-		delete(ws.Cfg.Config().MCP, config.DockerMCPName)
+		ws.Cfg.RemoveDockerMCPInMemory()
 		return fmt.Errorf("docker MCP started but failed to persist configuration: %w", errors.Join(err, disableErr))
 	}
 

--- a/internal/config/clone_test.go
+++ b/internal/config/clone_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCloneForWrite_Isolation verifies that mutating a clone never reaches
+// back into the original Config. This is the contract the store's
+// copy-on-write mutators depend on for race-free publishing.
+func TestCloneForWrite_Isolation(t *testing.T) {
+	t.Parallel()
+
+	orig := &Config{
+		Models: map[SelectedModelType]SelectedModel{
+			SelectedModelTypeLarge: {Provider: "openai", Model: "gpt-4"},
+		},
+		RecentModels: map[SelectedModelType][]SelectedModel{
+			SelectedModelTypeLarge: {{Provider: "openai", Model: "gpt-4"}},
+		},
+		MCP:       MCPs{"a": {}},
+		Providers: csync.NewMap[string, ProviderConfig](),
+		Options: &Options{
+			TUI: &TUIOptions{CompactMode: false},
+		},
+	}
+
+	clone := orig.cloneForWrite()
+
+	// Mutate every field the typed mutators touch.
+	clone.Models[SelectedModelTypeLarge] = SelectedModel{Provider: "anthropic", Model: "claude"}
+	clone.RecentModels[SelectedModelTypeLarge] = []SelectedModel{{Provider: "anthropic", Model: "claude"}}
+	clone.MCP["b"] = MCPConfig{}
+	clone.Options.TUI.CompactMode = true
+	enabled := true
+	clone.Options.TUI.Transparent = &enabled
+
+	// The original must be untouched.
+	require.Equal(t, "openai", orig.Models[SelectedModelTypeLarge].Provider, "Models leaked")
+	require.Equal(t, "openai", orig.RecentModels[SelectedModelTypeLarge][0].Provider, "RecentModels leaked")
+	require.NotContains(t, orig.MCP, "b", "MCP leaked")
+	require.False(t, orig.Options.TUI.CompactMode, "Options.TUI.CompactMode leaked")
+	require.Nil(t, orig.Options.TUI.Transparent, "Options.TUI.Transparent leaked")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -609,6 +609,45 @@ type Config struct {
 	Agents map[string]Agent `json:"-"`
 }
 
+// cloneForWrite returns a copy of c that the store's typed field mutators
+// may modify without racing readers of the currently published Config.
+//
+// Reads of a published Config take no lock beyond the pointer load, so a
+// mutator must never write through the live pointer. Instead it clones,
+// mutates the clone, and atomically swaps it in. The clone gives fresh
+// copies of every field a typed mutator touches in place — Models,
+// RecentModels, MCP, and Options (with its nested TUI pointer). Providers
+// is a *csync.Map (internally synchronized) and is shared by reference;
+// the remaining fields are immutable after load from the mutators'
+// standpoint and are likewise shared.
+func (c *Config) cloneForWrite() *Config {
+	nc := *c
+	nc.Models = maps.Clone(c.Models)
+	nc.RecentModels = maps.Clone(c.RecentModels)
+	nc.MCP = maps.Clone(c.MCP)
+	if c.Options != nil {
+		opts := *c.Options
+		if c.Options.TUI != nil {
+			tui := *c.Options.TUI
+			opts.TUI = &tui
+		}
+		nc.Options = &opts
+	}
+	return &nc
+}
+
+// ensureTUI returns c.Options.TUI, allocating Options and TUI as needed so
+// callers can assign TUI fields without nil checks.
+func (c *Config) ensureTUI() *TUIOptions {
+	if c.Options == nil {
+		c.Options = &Options{}
+	}
+	if c.Options.TUI == nil {
+		c.Options.TUI = &TUIOptions{}
+	}
+	return c.Options.TUI
+}
+
 func (c *Config) EnabledProviders() []ProviderConfig {
 	var enabled []ProviderConfig
 	for p := range c.Providers.Seq() {

--- a/internal/config/docker_mcp.go
+++ b/internal/config/docker_mcp.go
@@ -88,10 +88,13 @@ func (s *ConfigStore) PrepareDockerMCPConfig() (MCPConfig, error) {
 	}
 
 	mcpConfig := DockerMCPConfig()
-	if s.config.MCP == nil {
-		s.config.MCP = make(map[string]MCPConfig)
-	}
-	s.config.MCP[DockerMCPName] = mcpConfig
+	// In-memory only; persistence happens in PersistDockerMCPConfig.
+	s.mutateInMemory(func(c *Config) {
+		if c.MCP == nil {
+			c.MCP = make(map[string]MCPConfig)
+		}
+		c.MCP[DockerMCPName] = mcpConfig
+	})
 	return mcpConfig, nil
 }
 
@@ -118,17 +121,21 @@ func (s *ConfigStore) EnableDockerMCP() error {
 
 // DisableDockerMCP removes Docker MCP configuration and persists the change.
 func (s *ConfigStore) DisableDockerMCP() error {
-	if s.config.MCP == nil {
-		return nil
-	}
+	return s.update(ScopeGlobal, func(c *Config) map[string]any {
+		if c.MCP == nil {
+			return nil
+		}
+		delete(c.MCP, DockerMCPName)
+		return map[string]any{"mcp": c.MCP}
+	})
+}
 
-	// Remove from in-memory config.
-	delete(s.config.MCP, DockerMCPName)
-
-	// Persist the updated MCP map to the config file.
-	if err := s.SetConfigField(ScopeGlobal, "mcp", s.config.MCP); err != nil {
-		return fmt.Errorf("failed to persist docker mcp removal: %w", err)
-	}
-
-	return nil
+// RemoveDockerMCPInMemory removes the Docker MCP entry from the in-memory
+// config via copy-on-write, without persisting to disk. It rolls back a
+// staged PrepareDockerMCPConfig when starting or persisting the server
+// fails, so callers must not mutate Config().MCP directly.
+func (s *ConfigStore) RemoveDockerMCPInMemory() {
+	s.mutateInMemory(func(c *Config) {
+		delete(c.MCP, DockerMCPName)
+	})
 }

--- a/internal/config/docker_mcp_test.go
+++ b/internal/config/docker_mcp_test.go
@@ -75,9 +75,10 @@ func TestEnableDockerMCP(t *testing.T) {
 		err := store.EnableDockerMCP()
 		require.NoError(t, err)
 
-		// Check in-memory config.
-		require.True(t, cfg.IsDockerMCPEnabled())
-		mcpConfig, exists := cfg.MCP[DockerMCPName]
+		// Check in-memory config via the store (copy-on-write publishes
+		// a new Config; the captured cfg pointer stays unchanged).
+		require.True(t, store.Config().IsDockerMCPEnabled())
+		mcpConfig, exists := store.Config().MCP[DockerMCPName]
 		require.True(t, exists)
 		require.Equal(t, MCPStdio, mcpConfig.Type)
 		require.Equal(t, "docker", mcpConfig.Command)
@@ -145,9 +146,10 @@ func TestDisableDockerMCP(t *testing.T) {
 		err := store.DisableDockerMCP()
 		require.NoError(t, err)
 
-		// Check in-memory config.
-		require.False(t, cfg.IsDockerMCPEnabled())
-		_, exists := cfg.MCP[DockerMCPName]
+		// Check in-memory config via the store (copy-on-write publishes a
+		// new Config; the original cfg pointer is intentionally unchanged).
+		require.False(t, store.Config().IsDockerMCPEnabled())
+		_, exists := store.Config().MCP[DockerMCPName]
 		require.False(t, exists)
 	})
 
@@ -189,5 +191,5 @@ func TestEnableDockerMCPWithRealDockerWhenAvailable(t *testing.T) {
 
 	err := store.EnableDockerMCP()
 	require.NoError(t, err)
-	require.True(t, cfg.IsDockerMCPEnabled())
+	require.True(t, store.Config().IsDockerMCPEnabled())
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -111,10 +111,10 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 	valueResolver := NewShellVariableResolver(env)
 	store.resolver = valueResolver
 
-	// Hold reloadMu during initial load to prevent configureProviders
+	// Hold writeMu during initial load to prevent configureProviders
 	// from triggering auto-reload via RemoveConfigField.
-	store.reloadMu.Lock()
-	defer store.reloadMu.Unlock()
+	store.writeMu.Lock()
+	defer store.writeMu.Unlock()
 
 	if err := cfg.configureProviders(context.Background(), store, env, valueResolver, store.knownProviders); err != nil {
 		return nil, fmt.Errorf("failed to configure providers: %w", err)

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -572,11 +572,33 @@ func (c *Config) setDefaults(workingDir, dataDir string) {
 	c.Options.InitializeAs = cmp.Or(c.Options.InitializeAs, defaultInitializeAs)
 }
 
+// powernapDefaults caches the powernap default LSP server catalog. The
+// catalog is static and immutable for the life of the process, but
+// building it (NewManager + LoadDefaults) is expensive and was previously
+// repeated on every config reload. We load it once and only ever read from
+// it via GetServer, so a shared instance is safe.
+var (
+	powernapDefaultsOnce sync.Once
+	powernapDefaults     *powernapConfig.Manager
+)
+
+func lspDefaultsManager() *powernapConfig.Manager {
+	powernapDefaultsOnce.Do(func() {
+		m := powernapConfig.NewManager()
+		// LoadDefaults only fails on malformed embedded defaults, which
+		// would be a build-time bug; treat the manager as usable either
+		// way so a transient error never wedges config loading.
+		_ = m.LoadDefaults()
+		powernapDefaults = m
+	})
+	return powernapDefaults
+}
+
 // applyLSPDefaults applies default values from powernap to LSP configurations
 func (c *Config) applyLSPDefaults() {
-	// Get powernap's default configuration
-	configManager := powernapConfig.NewManager()
-	configManager.LoadDefaults()
+	// Reuse the process-wide default catalog; building it per reload was a
+	// significant chunk of reload latency.
+	configManager := lspDefaultsManager()
 
 	// Apply defaults to each LSP configuration
 	for name, cfg := range c.LSP {
@@ -900,10 +922,18 @@ func hasAWSCredentials(env env.Env) bool {
 		return true
 	}
 
-	if _, err := os.Stat(filepath.Join(home.Dir(), ".aws/credentials")); err == nil && !testing.Testing() {
+	// File-based credential discovery requires filesystem stats, so do it
+	// last and skip it under test. Checking testing.Testing() before the
+	// os.Stat call (rather than after, in the && tail) ensures the syscall
+	// is never issued during tests, where it otherwise ran unconditionally
+	// and only had its result discarded.
+	if testing.Testing() {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(home.Dir(), ".aws/credentials")); err == nil {
 		return true
 	}
-	if _, err := os.Stat(filepath.Join(home.Dir(), ".aws/login")); err == nil && !testing.Testing() {
+	if _, err := os.Stat(filepath.Join(home.Dir(), ".aws/login")); err == nil {
 		return true
 	}
 
@@ -1058,7 +1088,22 @@ func isInsideWorktree() bool {
 // repositories, missing git binary, plain directories, or any other
 // failure mode). Linked worktrees and submodules each report their own
 // top-level, which is what callers want when bounding lookups.
+// worktreeRootCache memoizes the git worktree root per directory. The root
+// is stable for the life of the process, so we avoid re-shelling out to
+// "git rev-parse" on every config reload. Keyed by the requested dir; the
+// value is the resolved root ("" when dir is not in a git worktree).
+var worktreeRootCache sync.Map // map[string]string
+
 func worktreeRoot(dir string) string {
+	if cached, ok := worktreeRootCache.Load(dir); ok {
+		return cached.(string)
+	}
+	root := computeWorktreeRoot(dir)
+	worktreeRootCache.Store(dir, root)
+	return root
+}
+
+func computeWorktreeRoot(dir string) string {
 	cmd := exec.CommandContext(
 		context.Background(),
 		"git", "rev-parse", "--show-toplevel",

--- a/internal/config/recent_models_test.go
+++ b/internal/config/recent_models_test.go
@@ -39,158 +39,76 @@ func testStoreWithPath(cfg *Config, dir string) *ConfigStore {
 	}
 }
 
-func TestRecordRecentModel_AddsAndPersists(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	cfg := &Config{}
-	cfg.setDefaults(dir, "")
-	store := testStoreWithPath(cfg, dir)
-
-	err := store.recordRecentModel(ScopeGlobal, SelectedModelTypeLarge, SelectedModel{Provider: "openai", Model: "gpt-4o"})
-	require.NoError(t, err)
-
-	// in-memory state
-	require.Len(t, cfg.RecentModels[SelectedModelTypeLarge], 1)
-	require.Equal(t, "openai", cfg.RecentModels[SelectedModelTypeLarge][0].Provider)
-	require.Equal(t, "gpt-4o", cfg.RecentModels[SelectedModelTypeLarge][0].Model)
-
-	// persisted state
-	rm := readRecentModels(t, store.globalDataPath)
-	large, ok := rm[string(SelectedModelTypeLarge)].([]any)
-	require.True(t, ok)
-	require.Len(t, large, 1)
-	item, ok := large[0].(map[string]any)
-	require.True(t, ok)
-	require.Equal(t, "openai", item["provider"])
-	require.Equal(t, "gpt-4o", item["model"])
+// configWithRecents builds a Config seeded with the given recent models for
+// the large type, for exercising the pure nextRecentModels helper.
+func configWithRecents(recents ...SelectedModel) *Config {
+	return &Config{
+		RecentModels: map[SelectedModelType][]SelectedModel{
+			SelectedModelTypeLarge: recents,
+		},
+	}
 }
 
-func TestRecordRecentModel_DedupeAndMoveToFront(t *testing.T) {
+func TestNextRecentModels_AddsToFront(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	cfg := &Config{}
-	cfg.setDefaults(dir, "")
-	store := testStoreWithPath(cfg, dir)
-
-	// Add two entries
-	require.NoError(t, store.recordRecentModel(ScopeGlobal, SelectedModelTypeLarge, SelectedModel{Provider: "openai", Model: "gpt-4o"}))
-	require.NoError(t, store.recordRecentModel(ScopeGlobal, SelectedModelTypeLarge, SelectedModel{Provider: "anthropic", Model: "claude"}))
-	// Re-add first; should move to front and not duplicate
-	require.NoError(t, store.recordRecentModel(ScopeGlobal, SelectedModelTypeLarge, SelectedModel{Provider: "openai", Model: "gpt-4o"}))
-
-	got := cfg.RecentModels[SelectedModelTypeLarge]
-	require.Len(t, got, 2)
-	require.Equal(t, SelectedModel{Provider: "openai", Model: "gpt-4o"}, got[0])
-	require.Equal(t, SelectedModel{Provider: "anthropic", Model: "claude"}, got[1])
+	cfg := configWithRecents()
+	updated, changed := nextRecentModels(cfg, SelectedModelTypeLarge, SelectedModel{Provider: "openai", Model: "gpt-4o"})
+	require.True(t, changed)
+	require.Equal(t, []SelectedModel{{Provider: "openai", Model: "gpt-4o"}}, updated)
 }
 
-func TestRecordRecentModel_TrimsToMax(t *testing.T) {
+func TestNextRecentModels_DedupeAndMoveToFront(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	cfg := &Config{}
-	cfg.setDefaults(dir, "")
-	store := testStoreWithPath(cfg, dir)
-
-	// Insert 6 unique models; max is 5
-	entries := []SelectedModel{
-		{Provider: "p1", Model: "m1"},
-		{Provider: "p2", Model: "m2"},
-		{Provider: "p3", Model: "m3"},
-		{Provider: "p4", Model: "m4"},
-		{Provider: "p5", Model: "m5"},
-		{Provider: "p6", Model: "m6"},
-	}
-	for _, e := range entries {
-		require.NoError(t, store.recordRecentModel(ScopeGlobal, SelectedModelTypeLarge, e))
-	}
-
-	// in-memory state
-	got := cfg.RecentModels[SelectedModelTypeLarge]
-	require.Len(t, got, 5)
-	// Newest first, capped at 5: p6..p2
-	require.Equal(t, SelectedModel{Provider: "p6", Model: "m6"}, got[0])
-	require.Equal(t, SelectedModel{Provider: "p5", Model: "m5"}, got[1])
-	require.Equal(t, SelectedModel{Provider: "p4", Model: "m4"}, got[2])
-	require.Equal(t, SelectedModel{Provider: "p3", Model: "m3"}, got[3])
-	require.Equal(t, SelectedModel{Provider: "p2", Model: "m2"}, got[4])
-
-	// persisted state: verify trimmed to 5 and newest-first order
-	rm := readRecentModels(t, store.globalDataPath)
-	large, ok := rm[string(SelectedModelTypeLarge)].([]any)
-	require.True(t, ok)
-	require.Len(t, large, 5)
-	// Build provider:model IDs and verify order
-	var ids []string
-	for _, v := range large {
-		m := v.(map[string]any)
-		ids = append(ids, m["provider"].(string)+":"+m["model"].(string))
-	}
-	require.Equal(t, []string{"p6:m6", "p5:m5", "p4:m4", "p3:m3", "p2:m2"}, ids)
+	cfg := configWithRecents(
+		SelectedModel{Provider: "anthropic", Model: "claude"},
+		SelectedModel{Provider: "openai", Model: "gpt-4o"},
+	)
+	updated, changed := nextRecentModels(cfg, SelectedModelTypeLarge, SelectedModel{Provider: "openai", Model: "gpt-4o"})
+	require.True(t, changed)
+	require.Equal(t, []SelectedModel{
+		{Provider: "openai", Model: "gpt-4o"},
+		{Provider: "anthropic", Model: "claude"},
+	}, updated)
 }
 
-func TestRecordRecentModel_SkipsEmptyValues(t *testing.T) {
+func TestNextRecentModels_TrimsToMax(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	cfg := &Config{}
-	cfg.setDefaults(dir, "")
-	store := testStoreWithPath(cfg, dir)
-
-	// Missing provider
-	require.NoError(t, store.recordRecentModel(ScopeGlobal, SelectedModelTypeLarge, SelectedModel{Provider: "", Model: "m"}))
-	// Missing model
-	require.NoError(t, store.recordRecentModel(ScopeGlobal, SelectedModelTypeLarge, SelectedModel{Provider: "p", Model: ""}))
-
-	_, ok := cfg.RecentModels[SelectedModelTypeLarge]
-	// Map may be initialized, but should have no entries
-	if ok {
-		require.Len(t, cfg.RecentModels[SelectedModelTypeLarge], 0)
+	var seed []SelectedModel
+	for _, id := range []string{"m5", "m4", "m3", "m2", "m1"} {
+		seed = append(seed, SelectedModel{Provider: "p", Model: id})
 	}
-	// No file should be written (stat via fs.FS)
-	baseDir := filepath.Dir(store.globalDataPath)
-	fileName := filepath.Base(store.globalDataPath)
-	_, err := fs.Stat(os.DirFS(baseDir), fileName)
-	require.True(t, os.IsNotExist(err))
+	cfg := configWithRecents(seed...)
+
+	updated, changed := nextRecentModels(cfg, SelectedModelTypeLarge, SelectedModel{Provider: "p", Model: "m6"})
+	require.True(t, changed)
+	require.Len(t, updated, maxRecentModelsPerType)
+	require.Equal(t, SelectedModel{Provider: "p", Model: "m6"}, updated[0])
+	require.Equal(t, SelectedModel{Provider: "p", Model: "m2"}, updated[maxRecentModelsPerType-1])
 }
 
-func TestRecordRecentModel_NoPersistOnNoop(t *testing.T) {
+func TestNextRecentModels_SkipsEmptyValues(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	cfg := &Config{}
-	cfg.setDefaults(dir, "")
-	store := testStoreWithPath(cfg, dir)
+	cfg := configWithRecents()
+	_, changed := nextRecentModels(cfg, SelectedModelTypeLarge, SelectedModel{Provider: "", Model: "m"})
+	require.False(t, changed)
+	_, changed = nextRecentModels(cfg, SelectedModelTypeLarge, SelectedModel{Provider: "p", Model: ""})
+	require.False(t, changed)
+}
+
+func TestNextRecentModels_NoChangeWhenAlreadyFront(t *testing.T) {
+	t.Parallel()
 
 	entry := SelectedModel{Provider: "openai", Model: "gpt-4o"}
-	require.NoError(t, store.recordRecentModel(ScopeGlobal, SelectedModelTypeLarge, entry))
-
-	baseDir := filepath.Dir(store.globalDataPath)
-	fileName := filepath.Base(store.globalDataPath)
-	before, err := fs.ReadFile(os.DirFS(baseDir), fileName)
-	require.NoError(t, err)
-
-	// Get file ModTime to verify no write occurs
-	stBefore, err := fs.Stat(os.DirFS(baseDir), fileName)
-	require.NoError(t, err)
-	beforeMod := stBefore.ModTime()
-
-	// Re-record same entry should be a no-op (no write)
-	require.NoError(t, store.recordRecentModel(ScopeGlobal, SelectedModelTypeLarge, entry))
-
-	after, err := fs.ReadFile(os.DirFS(baseDir), fileName)
-	require.NoError(t, err)
-	require.Equal(t, string(before), string(after))
-
-	// Verify ModTime unchanged to ensure truly no write occurred
-	stAfter, err := fs.Stat(os.DirFS(baseDir), fileName)
-	require.NoError(t, err)
-	require.True(t, stAfter.ModTime().Equal(beforeMod), "file ModTime should not change on noop")
+	cfg := configWithRecents(entry)
+	_, changed := nextRecentModels(cfg, SelectedModelTypeLarge, entry)
+	require.False(t, changed)
 }
 
-func TestUpdatePreferredModel_UpdatesRecents(t *testing.T) {
+func TestUpdatePreferredModel_PersistsModelAndRecents(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -199,20 +117,24 @@ func TestUpdatePreferredModel_UpdatesRecents(t *testing.T) {
 	store := testStoreWithPath(cfg, dir)
 
 	sel := SelectedModel{Provider: "openai", Model: "gpt-4o"}
-	require.NoError(t, store.UpdatePreferredModel(ScopeGlobal, SelectedModelTypeSmall, sel))
+	require.NoError(t, store.UpdatePreferredModel(ScopeGlobal, SelectedModelTypeLarge, sel))
 
-	// in-memory
-	require.Equal(t, sel, cfg.Models[SelectedModelTypeSmall])
-	require.Len(t, cfg.RecentModels[SelectedModelTypeSmall], 1)
+	// in-memory state (read through the store; copy-on-write publishes a
+	// new Config, so the seed cfg pointer is intentionally unchanged).
+	require.Equal(t, sel, store.Config().Models[SelectedModelTypeLarge])
+	require.Len(t, store.Config().RecentModels[SelectedModelTypeLarge], 1)
 
-	// persisted (read via fs.FS)
+	// persisted state
 	rm := readRecentModels(t, store.globalDataPath)
-	small, ok := rm[string(SelectedModelTypeSmall)].([]any)
+	large, ok := rm[string(SelectedModelTypeLarge)].([]any)
 	require.True(t, ok)
-	require.Len(t, small, 1)
+	require.Len(t, large, 1)
+	item := large[0].(map[string]any)
+	require.Equal(t, "openai", item["provider"])
+	require.Equal(t, "gpt-4o", item["model"])
 }
 
-func TestRecordRecentModel_TypeIsolation(t *testing.T) {
+func TestUpdatePreferredModel_TypeIsolation(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -220,42 +142,17 @@ func TestRecordRecentModel_TypeIsolation(t *testing.T) {
 	cfg.setDefaults(dir, "")
 	store := testStoreWithPath(cfg, dir)
 
-	// Add models to both large and small types
 	largeModel := SelectedModel{Provider: "openai", Model: "gpt-4o"}
 	smallModel := SelectedModel{Provider: "anthropic", Model: "claude"}
+	require.NoError(t, store.UpdatePreferredModel(ScopeGlobal, SelectedModelTypeLarge, largeModel))
+	require.NoError(t, store.UpdatePreferredModel(ScopeGlobal, SelectedModelTypeSmall, smallModel))
 
-	require.NoError(t, store.recordRecentModel(ScopeGlobal, SelectedModelTypeLarge, largeModel))
-	require.NoError(t, store.recordRecentModel(ScopeGlobal, SelectedModelTypeSmall, smallModel))
-
-	// in-memory: verify types maintain separate histories
-	require.Len(t, cfg.RecentModels[SelectedModelTypeLarge], 1)
-	require.Len(t, cfg.RecentModels[SelectedModelTypeSmall], 1)
-	require.Equal(t, largeModel, cfg.RecentModels[SelectedModelTypeLarge][0])
-	require.Equal(t, smallModel, cfg.RecentModels[SelectedModelTypeSmall][0])
-
-	// Add another to large, verify small unchanged
+	// Adding to large leaves small untouched.
 	anotherLarge := SelectedModel{Provider: "google", Model: "gemini"}
-	require.NoError(t, store.recordRecentModel(ScopeGlobal, SelectedModelTypeLarge, anotherLarge))
+	require.NoError(t, store.UpdatePreferredModel(ScopeGlobal, SelectedModelTypeLarge, anotherLarge))
 
-	require.Len(t, cfg.RecentModels[SelectedModelTypeLarge], 2)
-	require.Len(t, cfg.RecentModels[SelectedModelTypeSmall], 1)
-	require.Equal(t, smallModel, cfg.RecentModels[SelectedModelTypeSmall][0])
-
-	// persisted state: verify both types exist with correct lengths and contents
-	rm := readRecentModels(t, store.globalDataPath)
-
-	large, ok := rm[string(SelectedModelTypeLarge)].([]any)
-	require.True(t, ok)
-	require.Len(t, large, 2)
-	// Verify newest first for large type
-	require.Equal(t, "google", large[0].(map[string]any)["provider"])
-	require.Equal(t, "gemini", large[0].(map[string]any)["model"])
-	require.Equal(t, "openai", large[1].(map[string]any)["provider"])
-	require.Equal(t, "gpt-4o", large[1].(map[string]any)["model"])
-
-	small, ok := rm[string(SelectedModelTypeSmall)].([]any)
-	require.True(t, ok)
-	require.Len(t, small, 1)
-	require.Equal(t, "anthropic", small[0].(map[string]any)["provider"])
-	require.Equal(t, "claude", small[0].(map[string]any)["model"])
+	require.Len(t, store.Config().RecentModels[SelectedModelTypeLarge], 2)
+	require.Equal(t, anotherLarge, store.Config().RecentModels[SelectedModelTypeLarge][0])
+	require.Len(t, store.Config().RecentModels[SelectedModelTypeSmall], 1)
+	require.Equal(t, smallModel, store.Config().RecentModels[SelectedModelTypeSmall][0])
 }

--- a/internal/config/refresh_singleflight_test.go
+++ b/internal/config/refresh_singleflight_test.go
@@ -1,0 +1,175 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/stretchr/testify/require"
+)
+
+// newRefreshTestStore builds a ConfigStore whose hyper provider holds an
+// expired OAuth token, persisted both in memory and on disk at configPath.
+// Stores that share a configPath also share the per-provider refresh lock,
+// which lets a single test process faithfully simulate two crush instances:
+// lock.File opens a fresh descriptor per call, so two stores block each
+// other on the same lock file exactly as two processes would.
+func newRefreshTestStore(t *testing.T, configPath string, exchange func(ctx context.Context, providerID, refreshToken string) (*oauth.Token, error)) *ConfigStore {
+	t.Helper()
+
+	expired := &oauth.Token{
+		AccessToken:  "at0",
+		RefreshToken: "rt0",
+		ExpiresIn:    3600,
+		ExpiresAt:    time.Now().Add(-time.Hour).Unix(),
+	}
+	configContent := `{
+		"providers": {
+			"hyper": {
+				"oauth": {
+					"access_token": "at0",
+					"refresh_token": "rt0",
+					"expires_in": 3600,
+					"expires_at": ` + fmt.Sprintf("%d", expired.ExpiresAt) + `
+				}
+			}
+		}
+	}`
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o600))
+
+	providers := csync.NewMap[string, ProviderConfig]()
+	providers.Set("hyper", ProviderConfig{
+		ID:         "hyper",
+		Name:       "Hyper",
+		APIKey:     expired.AccessToken,
+		OAuthToken: expired,
+	})
+
+	return &ConfigStore{
+		config:         &Config{Providers: providers},
+		globalDataPath: configPath,
+		workingDir:     filepath.Dir(configPath),
+		exchangeToken:  exchange,
+	}
+}
+
+// TestRefreshOAuthToken_InProcessSingleFlight verifies that a storm of
+// concurrent refresh calls for the same provider collapses into a single
+// token exchange.
+func TestRefreshOAuthToken_InProcessSingleFlight(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "crush.json")
+
+	var exchanges atomic.Int64
+	store := newRefreshTestStore(t, configPath, func(ctx context.Context, providerID, refreshToken string) (*oauth.Token, error) {
+		exchanges.Add(1)
+		time.Sleep(50 * time.Millisecond) // hold the flight open so peers join
+		return &oauth.Token{
+			AccessToken:  "at1",
+			RefreshToken: "rt1",
+			ExpiresIn:    3600,
+			ExpiresAt:    time.Now().Add(time.Hour).Unix(),
+		}, nil
+	})
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, goroutines)
+	for range goroutines {
+		wg.Go(func() {
+			<-start
+			errs <- store.RefreshOAuthToken(context.Background(), ScopeGlobal, "hyper")
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int64(1), exchanges.Load(), "concurrent refreshes should collapse into one exchange")
+
+	pc, ok := store.config.Providers.Get("hyper")
+	require.True(t, ok)
+	require.Equal(t, "at1", pc.OAuthToken.AccessToken)
+	require.Equal(t, "rt1", pc.OAuthToken.RefreshToken)
+}
+
+// TestRefreshOAuthToken_CrossProcessAdopt verifies that when two instances
+// share a credential, only one performs the token exchange and the other
+// adopts the rotated token from disk rather than reusing the consumed
+// refresh token. The fake exchange models a rotating provider: reusing a
+// refresh token it has already rotated returns an error, so a second
+// exchange would be observable as a failure.
+func TestRefreshOAuthToken_CrossProcessAdopt(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "crush.json")
+
+	var (
+		mu          sync.Mutex
+		current     = "rt0" // the only refresh token the server will accept
+		exchanges   atomic.Int64
+		reuseErrors atomic.Int64
+	)
+	exchange := func(ctx context.Context, providerID, refreshToken string) (*oauth.Token, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if refreshToken != current {
+			reuseErrors.Add(1)
+			return nil, fmt.Errorf("refresh token revoked")
+		}
+		exchanges.Add(1)
+		time.Sleep(50 * time.Millisecond) // hold the lock so the peer must wait
+		current = "rt1"
+		return &oauth.Token{
+			AccessToken:  "at1",
+			RefreshToken: "rt1",
+			ExpiresIn:    3600,
+			ExpiresAt:    time.Now().Add(time.Hour).Unix(),
+		}, nil
+	}
+
+	// Two stores sharing the same config file and refresh lock = two
+	// "processes".
+	a := newRefreshTestStore(t, configPath, exchange)
+	b := newRefreshTestStore(t, configPath, exchange)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	for _, s := range []*ConfigStore{a, b} {
+		wg.Go(func() {
+			<-start
+			errs <- s.RefreshOAuthToken(context.Background(), ScopeGlobal, "hyper")
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, int64(1), exchanges.Load(), "only one instance should exchange")
+	require.Equal(t, int64(0), reuseErrors.Load(), "no instance should reuse a rotated refresh token")
+
+	// Both instances converge on the rotated token.
+	for name, s := range map[string]*ConfigStore{"a": a, "b": b} {
+		pc, ok := s.config.Providers.Get("hyper")
+		require.True(t, ok, name)
+		require.Equal(t, "at1", pc.OAuthToken.AccessToken, name)
+		require.Equal(t, "rt1", pc.OAuthToken.RefreshToken, name)
+	}
+}

--- a/internal/config/scopeb_race_test.go
+++ b/internal/config/scopeb_race_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestScopeB_InPlaceMutationRace probes whether the store's in-place field
+// mutators (e.g. SetCompactMode) race with concurrent Config() readers that
+// walk the same field. This is the "Scope B" race left open after the
+// pointer-swap fix. Run with -race.
+// TestScopeB_InPlaceMutationRace verifies that the store's typed field
+// mutators (e.g. SetCompactMode) no longer race concurrent Config()
+// readers walking the same field. Copy-on-write publishing means the
+// mutator swaps in a fresh Config rather than writing through the live
+// pointer, so a reader always sees an immutable snapshot. Run with -race.
+func TestScopeB_InPlaceMutationRace(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "crush.json")
+
+	t.Setenv("CRUSH_GLOBAL_CONFIG", dir)
+	t.Setenv("CRUSH_GLOBAL_DATA", dir)
+	resetProviderState()
+	t.Cleanup(resetProviderState)
+
+	cfg := `{
+		"models": {"large": {"provider": "openai", "model": "gpt-4"}},
+		"providers": {"openai": {"api_key": "k", "models": [{"id": "gpt-4", "name": "GPT-4"}]}},
+		"options": {"tui": {"compact_mode": false}}
+	}`
+	if err := os.WriteFile(configPath, []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := Load(dir, dir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.globalDataPath = configPath
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Reader: walks Options.TUI.CompactMode, the field SetCompactMode writes.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				c := store.Config()
+				if c != nil && c.Options != nil {
+					_ = c.Options.TUI.CompactMode
+				}
+			}
+		}
+	}()
+
+	// Writer: flips compact mode, mutating Options in place.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			_ = store.SetCompactMode(ScopeGlobal, i%2 == 0)
+		}
+		close(stop)
+	}()
+
+	wg.Wait()
+}

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -51,9 +51,14 @@ type RuntimeOverrides struct {
 // goroutine races and, together with the shared lock.File, cross-process
 // races on the config file.
 //
-// reloadMu serialises ReloadFromDisk calls to prevent concurrent reloads
-// from racing on store fields. autoReload uses TryLock on reloadMu to
-// skip redundant reloads when one is already in progress.
+// writeMu serialises every operation that produces a new in-memory Config:
+// the typed copy-on-write mutators (SetCompactMode, UpdatePreferredModel,
+// ...) and ReloadFromDisk. Typed mutators take Lock; autoReload takes
+// TryLock so a write triggered re-entrantly during a reload (e.g.
+// configureProviders calling RemoveConfigField) skips the nested reload
+// instead of deadlocking. This is what lets published Configs be treated
+// as immutable: a mutator clones, mutates the clone, and swaps it in under
+// writeMu rather than mutating the live Config in place.
 type ConfigStore struct {
 	config             *Config
 	workingDir         string
@@ -66,13 +71,37 @@ type ConfigStore struct {
 	trackedConfigPaths []string                // unique, normalized config file paths
 	snapshots          map[string]fileSnapshot // path -> snapshot at last capture
 
-	mu       sync.Mutex // serialises config file writes
-	reloadMu sync.Mutex // serialises ReloadFromDisk calls
+	// configMu guards the config pointer field against concurrent
+	// readers (Config) and the writeMu-serialised swap (setConfig). It
+	// protects the pointer word only; the pointed-to Config is treated
+	// as immutable once published, since both reloads and typed mutators
+	// build a fresh Config rather than mutating the live one.
+	configMu sync.RWMutex
+
+	mu      sync.Mutex // serialises config file writes
+	writeMu sync.Mutex // serialises in-memory config production (mutators + reload)
 }
 
 // Config returns the pure-data config struct (read-only after load).
+//
+// The pointer read is guarded by configMu so it can never tear against
+// the reload swap in reloadFromDiskLocked. Reloads build a brand-new
+// Config and swap it in rather than mutating the live one, so holding the
+// returned pointer stays safe even across a concurrent reload — the reader
+// keeps reading its (now immutable) snapshot.
 func (s *ConfigStore) Config() *Config {
+	s.configMu.RLock()
+	defer s.configMu.RUnlock()
 	return s.config
+}
+
+// setConfig atomically swaps the active config pointer under configMu.
+// Used by the reload path; in-place field mutators leave the pointer
+// untouched and run under mu instead.
+func (s *ConfigStore) setConfig(cfg *Config) {
+	s.configMu.Lock()
+	defer s.configMu.Unlock()
+	s.config = cfg
 }
 
 // WorkingDir returns the current working directory.
@@ -100,7 +129,7 @@ func (s *ConfigStore) KnownProviders() []catwalk.Provider {
 
 // SetupAgents configures the coder and task agents on the config.
 func (s *ConfigStore) SetupAgents() {
-	s.config.SetupAgents()
+	s.Config().SetupAgents()
 }
 
 // Overrides returns the runtime overrides for this store.
@@ -212,25 +241,36 @@ func (s *ConfigStore) SetConfigField(scope Scope, key string, value any) error {
 	return s.SetConfigFields(scope, map[string]any{key: value})
 }
 
-// SetConfigFields sets multiple key/value pairs in the config file for the given
-// scope in a single write. After a successful write, it automatically reloads
-// config to keep in-memory state fresh. This is preferred over multiple
-// SetConfigField calls when writing several fields atomically to avoid
-// intermediate reloads with partial state.
+// SetConfigFields sets multiple key/value pairs in the config file for the
+// given scope in a single write, then reloads in-memory state from disk.
+//
+// Use this for arbitrary external edits where the in-memory effect of the
+// change is not known ahead of time. The typed mutators (which know exactly
+// what changed) go through update instead and skip the reload.
 //
 // The write is protected by an in-process mutex and a cross-process flock
 // to prevent races between concurrent writers in different processes.
 func (s *ConfigStore) SetConfigFields(scope Scope, kv map[string]any) error {
-	return s.setConfigFields(scope, kv, true)
+	if err := s.writeConfigFields(scope, kv); err != nil {
+		return err
+	}
+	// Auto-reload to keep in-memory state fresh after config edits.
+	// We use context.Background() since this is an internal operation that
+	// shouldn't be cancelled by user context.
+	if err := s.autoReload(context.Background()); err != nil {
+		// Log warning but don't fail the write - disk is already updated.
+		slog.Warn("Config file updated but failed to reload in-memory state", "error", err)
+	}
+	return nil
 }
 
-// setConfigFields performs the write and, when reload is true, refreshes
-// in-memory state from disk. Callers that have already updated the relevant
-// in-memory state themselves can pass reload=false to skip the expensive
-// full reparse (which rebuilds the provider catalog and agents). The disk
-// is the source of truth for other processes either way; skipping reload
-// only avoids re-deriving state this process already holds.
-func (s *ConfigStore) setConfigFields(scope Scope, kv map[string]any, reload bool) error {
+// writeConfigFields persists key/value pairs to the config file. It does not
+// touch in-memory config state or the staleness snapshot: callers either
+// reload (SetConfigFields, whose reload recaptures the snapshot) or have
+// already published an updated clone and capture the snapshot themselves
+// (update). Both of those run under writeMu, which is what keeps the
+// snapshot map free of concurrent writers.
+func (s *ConfigStore) writeConfigFields(scope Scope, kv map[string]any) error {
 	// Sort keys for deterministic output regardless of map iteration
 	// order. This also ensures consistent results when callers pass
 	// overlapping JSONPath keys (e.g. "a" and "a.b").
@@ -240,40 +280,69 @@ func (s *ConfigStore) setConfigFields(scope Scope, kv map[string]any, reload boo
 	}
 	slices.Sort(keys)
 
-	err := s.atomicWrite(scope, func(data []byte) ([]byte, error) {
+	return s.atomicWrite(scope, func(data []byte) ([]byte, error) {
 		v := string(data)
 		for _, key := range keys {
 			var sErr error
-			v, sErr = sjson.Set(v, key, kv[key])
-			if sErr != nil {
+			if v, sErr = sjson.Set(v, key, kv[key]); sErr != nil {
 				return nil, fmt.Errorf("failed to set config field %s: %w", key, sErr)
 			}
 		}
 		return []byte(v), nil
 	})
-	if err != nil {
-		return err
-	}
+}
 
-	if !reload {
-		// The caller has already updated in-memory state; just refresh
-		// the staleness snapshot so the file watcher does not treat our
-		// own write as an external change.
-		if path, perr := s.configPath(scope); perr == nil {
-			s.captureStalenessSnapshot(append(slices.Clone(s.loadedPaths), path))
-		}
+// mutateInMemory applies a copy-on-write change to the config without
+// persisting. Under writeMu it clones the live config, lets mutate edit the
+// clone, and publishes it. This is the single primitive every in-memory
+// config change goes through, so a published Config is never mutated in
+// place and readers always see a consistent snapshot.
+func (s *ConfigStore) mutateInMemory(mutate func(*Config)) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	nc := s.Config().cloneForWrite()
+	mutate(nc)
+	s.setConfig(nc)
+}
+
+// update applies a copy-on-write change and persists the reported fields.
+// mutate edits the clone and returns the JSON-path fields to write to disk;
+// because the clone already reflects the change, no reload is needed.
+// Returning an empty map publishes the clone without a disk write.
+func (s *ConfigStore) update(scope Scope, mutate func(*Config) map[string]any) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	nc := s.Config().cloneForWrite()
+	fields := mutate(nc)
+	s.setConfig(nc)
+	if len(fields) == 0 {
 		return nil
 	}
-
-	// Auto-reload to keep in-memory state fresh after config edits.
-	// We use context.Background() since this is an internal operation that
-	// shouldn't be cancelled by user context.
-	if err := s.autoReload(context.Background()); err != nil {
-		// Log warning but don't fail the write - disk is already updated.
-		slog.Warn("Config file updated but failed to reload in-memory state", "error", err)
+	if err := s.writeConfigFields(scope, fields); err != nil {
+		return err
 	}
-
+	// Refresh the staleness snapshot so the file watcher does not treat
+	// our own write as an external change. Safe to touch the snapshot map
+	// here because we hold writeMu.
+	if path, err := s.configPath(scope); err == nil {
+		s.captureStalenessSnapshot(append(slices.Clone(s.loadedPaths), path))
+	}
 	return nil
+}
+
+// OverridePreferredModel sets the preferred model for the given type in
+// memory only, without persisting. It is for per-run overrides (such as the
+// non-interactive --model flags) that must not be written to the user's
+// config file.
+func (s *ConfigStore) OverridePreferredModel(modelType SelectedModelType, model SelectedModel) {
+	s.mutateInMemory(func(c *Config) {
+		if c.Models == nil {
+			c.Models = make(map[SelectedModelType]SelectedModel)
+		}
+		c.Models[modelType] = model
+	})
 }
 
 // RemoveConfigField removes a key from the config file for the given scope.
@@ -304,47 +373,45 @@ func (s *ConfigStore) RemoveConfigField(scope Scope, key string) error {
 // persists it to the config file at the given scope. The selected model and
 // the recent-models list are written together in a single config write.
 //
-// The in-memory config is updated directly here, so the write skips the
-// full disk reparse/reload. The reload would otherwise rebuild the entire
-// provider catalog and agents on every model switch, which dominates the
-// latency of selecting a model. Agents are refreshed separately by the
-// caller (see UpdateAgentModel).
+// The write skips the full disk reparse/reload (which would rebuild the
+// provider catalog and agents on every model switch and dominate selection
+// latency); agents are refreshed separately by the caller (see
+// UpdateAgentModel).
 func (s *ConfigStore) UpdatePreferredModel(scope Scope, modelType SelectedModelType, model SelectedModel) error {
-	s.config.Models[modelType] = model
+	return s.update(scope, func(c *Config) map[string]any {
+		if c.Models == nil {
+			c.Models = make(map[SelectedModelType]SelectedModel)
+		}
+		c.Models[modelType] = model
 
-	fields := map[string]any{
-		fmt.Sprintf("models.%s", modelType): model,
-	}
-
-	// Compute the updated recent-models list in memory. When it changes,
-	// fold the write into the same batch so we avoid a second write.
-	if updated, changed := s.nextRecentModels(modelType, model); changed {
-		s.config.RecentModels[modelType] = updated
-		fields[fmt.Sprintf("recent_models.%s", modelType)] = updated
-	}
-
-	if err := s.setConfigFields(scope, fields, false); err != nil {
-		return fmt.Errorf("failed to update preferred model: %w", err)
-	}
-	return nil
+		fields := map[string]any{
+			fmt.Sprintf("models.%s", modelType): model,
+		}
+		if updated, changed := nextRecentModels(c, modelType, model); changed {
+			if c.RecentModels == nil {
+				c.RecentModels = make(map[SelectedModelType][]SelectedModel)
+			}
+			c.RecentModels[modelType] = updated
+			fields[fmt.Sprintf("recent_models.%s", modelType)] = updated
+		}
+		return fields
+	})
 }
 
 // SetCompactMode sets the compact mode setting and persists it.
 func (s *ConfigStore) SetCompactMode(scope Scope, enabled bool) error {
-	if s.config.Options == nil {
-		s.config.Options = &Options{}
-	}
-	s.config.Options.TUI.CompactMode = enabled
-	return s.SetConfigField(scope, "options.tui.compact_mode", enabled)
+	return s.update(scope, func(c *Config) map[string]any {
+		c.ensureTUI().CompactMode = enabled
+		return map[string]any{"options.tui.compact_mode": enabled}
+	})
 }
 
 // SetTransparentBackground sets the transparent background setting and persists it.
 func (s *ConfigStore) SetTransparentBackground(scope Scope, enabled bool) error {
-	if s.config.Options == nil {
-		s.config.Options = &Options{}
-	}
-	s.config.Options.TUI.Transparent = &enabled
-	return s.SetConfigField(scope, "options.tui.transparent", enabled)
+	return s.update(scope, func(c *Config) map[string]any {
+		c.ensureTUI().Transparent = &enabled
+		return map[string]any{"options.tui.transparent": enabled}
+	})
 }
 
 // SetProviderAPIKey sets the API key for a provider and persists it.
@@ -376,10 +443,11 @@ func (s *ConfigStore) SetProviderAPIKey(scope Scope, providerID string, apiKey a
 		}
 	}
 
-	providerConfig, exists = s.config.Providers.Get(providerID)
+	cfg := s.Config()
+	providerConfig, exists = cfg.Providers.Get(providerID)
 	if exists {
 		setKeyOrToken()
-		s.config.Providers.Set(providerID, providerConfig)
+		cfg.Providers.Set(providerID, providerConfig)
 		return nil
 	}
 
@@ -406,7 +474,7 @@ func (s *ConfigStore) SetProviderAPIKey(scope Scope, providerID string, apiKey a
 	} else {
 		return fmt.Errorf("provider with ID %s not found in known providers", providerID)
 	}
-	s.config.Providers.Set(providerID, providerConfig)
+	cfg.Providers.Set(providerID, providerConfig)
 	return nil
 }
 
@@ -420,7 +488,8 @@ func (s *ConfigStore) SetProviderAPIKey(scope Scope, providerID string, apiKey a
 // already rotated the refresh token — the disk is re-checked under lock
 // to recover the other process's token.
 func (s *ConfigStore) RefreshOAuthToken(ctx context.Context, scope Scope, providerID string) error {
-	providerConfig, exists := s.config.Providers.Get(providerID)
+	cfg := s.Config()
+	providerConfig, exists := cfg.Providers.Get(providerID)
 	if !exists {
 		return fmt.Errorf("provider %s not found", providerID)
 	}
@@ -482,7 +551,7 @@ func (s *ConfigStore) RefreshOAuthToken(ctx context.Context, scope Scope, provid
 		providerConfig.SetupGitHubCopilot()
 	}
 
-	s.config.Providers.Set(providerID, providerConfig)
+	cfg.Providers.Set(providerID, providerConfig)
 
 	if err := s.SetConfigFields(scope, map[string]any{
 		fmt.Sprintf("providers.%s.api_key", providerID): refreshedToken.AccessToken,
@@ -501,7 +570,7 @@ func (s *ConfigStore) applyToken(providerConfig ProviderConfig, token *oauth.Tok
 	if providerID == string(catwalk.InferenceProviderCopilot) {
 		providerConfig.SetupGitHubCopilot()
 	}
-	s.config.Providers.Set(providerID, providerConfig)
+	s.Config().Providers.Set(providerID, providerConfig)
 	return nil
 }
 
@@ -541,18 +610,13 @@ func (s *ConfigStore) loadTokenFromDisk(scope Scope, providerID string) (*oauth.
 }
 
 // nextRecentModels computes the recent-models list for the given type
-// after recording the supplied model at the front, without persisting
-// anything. It returns the new slice and whether it differs from the
-// current list. It also lazily initializes the RecentModels map. Callers
-// that want to persist the change can fold the result into a batched
-// config write; recordRecentModel wraps it for the standalone case.
-func (s *ConfigStore) nextRecentModels(modelType SelectedModelType, model SelectedModel) ([]SelectedModel, bool) {
+// after recording the supplied model at the front, operating on the
+// provided config without persisting anything. It returns the new slice
+// and whether it differs from cfg's current list. Callers fold the result
+// into a clone they are about to publish.
+func nextRecentModels(cfg *Config, modelType SelectedModelType, model SelectedModel) ([]SelectedModel, bool) {
 	if model.Provider == "" || model.Model == "" {
 		return nil, false
-	}
-
-	if s.config.RecentModels == nil {
-		s.config.RecentModels = make(map[SelectedModelType][]SelectedModel)
 	}
 
 	eq := func(a, b SelectedModel) bool {
@@ -564,7 +628,7 @@ func (s *ConfigStore) nextRecentModels(modelType SelectedModelType, model Select
 		Model:    model.Model,
 	}
 
-	current := s.config.RecentModels[modelType]
+	current := cfg.RecentModels[modelType]
 	withoutCurrent := slices.DeleteFunc(slices.Clone(current), func(existing SelectedModel) bool {
 		return eq(existing, entry)
 	})
@@ -579,25 +643,6 @@ func (s *ConfigStore) nextRecentModels(modelType SelectedModelType, model Select
 	}
 
 	return updated, true
-}
-
-// recordRecentModel records a model in the recent models list and persists
-// the change. It is retained for callers that update recent models in
-// isolation; UpdatePreferredModel batches the same change into a single
-// config write instead.
-func (s *ConfigStore) recordRecentModel(scope Scope, modelType SelectedModelType, model SelectedModel) error {
-	updated, changed := s.nextRecentModels(modelType, model)
-	if !changed {
-		return nil
-	}
-
-	s.config.RecentModels[modelType] = updated
-
-	if err := s.SetConfigField(scope, fmt.Sprintf("recent_models.%s", modelType), updated); err != nil {
-		return fmt.Errorf("failed to persist recent models: %w", err)
-	}
-
-	return nil
 }
 
 // NewTestStore creates a ConfigStore for testing purposes.
@@ -777,17 +822,17 @@ func (s *ConfigStore) captureStalenessSnapshot(paths []string) {
 // ReloadFromDisk re-runs the config load/merge flow and updates the in-memory
 // config atomically. It rebuilds the staleness snapshot after successful reload.
 // On failure, the store state is rolled back to its previous state.
-// Concurrent calls are serialised via reloadMu.
+// Concurrent calls are serialised via writeMu.
 func (s *ConfigStore) ReloadFromDisk(ctx context.Context) error {
 	if s.workingDir == "" {
 		return fmt.Errorf("cannot reload: working directory not set")
 	}
-	s.reloadMu.Lock()
-	defer s.reloadMu.Unlock()
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
 	return s.reloadFromDiskLocked(ctx)
 }
 
-// reloadFromDiskLocked performs the actual reload. Caller must hold reloadMu.
+// reloadFromDiskLocked performs the actual reload. Caller must hold writeMu.
 func (s *ConfigStore) reloadFromDiskLocked(ctx context.Context) error {
 	// Migrate deprecated disable_notifications before reloading config.
 	migrateDisableNotifications()
@@ -800,8 +845,8 @@ func (s *ConfigStore) reloadFromDiskLocked(ctx context.Context) error {
 
 	// Apply defaults (using existing data directory if set)
 	var dataDir string
-	if s.config != nil && s.config.Options != nil {
-		dataDir = s.config.Options.DataDirectory
+	if cur := s.Config(); cur != nil && cur.Options != nil {
+		dataDir = cur.Options.DataDirectory
 	}
 	cfg.setDefaults(s.workingDir, dataDir)
 
@@ -842,7 +887,7 @@ func (s *ConfigStore) reloadFromDiskLocked(ctx context.Context) error {
 	}
 
 	// Save current state for potential rollback
-	oldConfig := s.config
+	oldConfig := s.Config()
 	oldLoadedPaths := s.loadedPaths
 	oldResolver := s.resolver
 	oldKnownProviders := s.knownProviders
@@ -850,7 +895,7 @@ func (s *ConfigStore) reloadFromDiskLocked(ctx context.Context) error {
 	oldWorkspacePath := s.workspacePath
 
 	// Update store state BEFORE running model/agent setup (so they see new config)
-	s.config = cfg
+	s.setConfig(cfg)
 	s.loadedPaths = loadedPaths
 	s.resolver = resolver
 	s.knownProviders = providers
@@ -871,7 +916,7 @@ func (s *ConfigStore) reloadFromDiskLocked(ctx context.Context) error {
 
 	// Rollback on setup failure
 	if setupErr != nil {
-		s.config = oldConfig
+		s.setConfig(oldConfig)
 		s.loadedPaths = oldLoadedPaths
 		s.resolver = oldResolver
 		s.knownProviders = oldKnownProviders
@@ -904,9 +949,9 @@ func (s *ConfigStore) autoReload(ctx context.Context) error {
 	// are rare and the next user action or file-watch tick will pick
 	// up the change. Callers that need guaranteed fresh state after a
 	// write should call ReloadFromDisk explicitly.
-	if !s.reloadMu.TryLock() {
+	if !s.writeMu.TryLock() {
 		return nil
 	}
-	defer s.reloadMu.Unlock()
+	defer s.writeMu.Unlock()
 	return s.reloadFromDiskLocked(ctx)
 }

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -20,12 +20,22 @@ import (
 	"github.com/charmbracelet/crush/internal/oauth/hyper"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"golang.org/x/sync/singleflight"
 )
 
 // configLockDeadline bounds how long lockConfig waits for the
 // cross-process flock before giving up. A few seconds is plenty for
 // honest contention; longer suggests something is wedged.
 const configLockDeadline = 5 * time.Second
+
+// refreshLockDeadline bounds how long RefreshOAuthToken waits for the
+// per-provider cross-process refresh lock. It must exceed the token
+// exchange HTTP timeout (30s) so that a peer mid-exchange is given time
+// to finish and publish its result, which we then adopt instead of
+// running our own exchange. Running our own would reuse an
+// already-rotated refresh token and trip the provider's reuse detection,
+// revoking the whole token family.
+const refreshLockDeadline = 45 * time.Second
 
 // fileSnapshot captures metadata about a config file at a point in time.
 type fileSnapshot struct {
@@ -80,6 +90,18 @@ type ConfigStore struct {
 
 	mu      sync.Mutex // serialises config file writes
 	writeMu sync.Mutex // serialises in-memory config production (mutators + reload)
+
+	// refreshSF collapses concurrent in-process OAuth refreshes for the
+	// same provider into a single attempt. Combined with the per-provider
+	// cross-process refresh lock, it ensures only one token exchange runs
+	// at a time. See RefreshOAuthToken.
+	refreshSF singleflight.Group
+
+	// exchangeToken performs the provider-specific OAuth token exchange.
+	// It is a field so tests can substitute a fake exchange without making
+	// real network calls. Production code leaves it nil, and exchange falls
+	// back to the real provider clients.
+	exchangeToken func(ctx context.Context, providerID, refreshToken string) (*oauth.Token, error)
 }
 
 // Config returns the pure-data config struct (read-only after load).
@@ -480,64 +502,82 @@ func (s *ConfigStore) SetProviderAPIKey(scope Scope, providerID string, apiKey a
 
 // RefreshOAuthToken refreshes the OAuth token for the given provider.
 //
-// It uses two-phase locking: the pre-check (reading the config file to
-// see if another process already refreshed) happens under the config
-// lock, then the HTTP exchange runs without any lock held, and finally
-// the result is persisted via SetConfigFields (which acquires the lock
-// internally). If the exchange fails — e.g. because another process
-// already rotated the refresh token — the disk is re-checked under lock
-// to recover the other process's token.
+// Providers like Hyper rotate refresh tokens: each exchange consumes the
+// caller's refresh token, issues a new pair, and revokes the old one. If
+// two crush instances (or two goroutines) refresh concurrently with the
+// same stored refresh token, the second exchange reuses an already-revoked
+// token, trips the provider's reuse detection, and revokes the entire
+// token family — leaving both with dead tokens even though each refresh
+// "succeeded".
+//
+// To prevent that, refreshes are single-flighted at two levels:
+//
+//   - In-process: refreshSF collapses concurrent goroutines for the same
+//     provider into one attempt.
+//   - Cross-process: a per-provider advisory lock is held across the whole
+//     read-decide-exchange-write cycle, so only one process exchanges at a
+//     time. A process that acquires the lock after a peer rotated finds the
+//     peer's fresh token on disk and adopts it instead of exchanging.
 func (s *ConfigStore) RefreshOAuthToken(ctx context.Context, scope Scope, providerID string) error {
+	key := fmt.Sprintf("%d\x00%s", scope, providerID)
+	_, err, _ := s.refreshSF.Do(key, func() (any, error) {
+		return nil, s.refreshOAuthTokenLocked(ctx, scope, providerID)
+	})
+	return err
+}
+
+// refreshOAuthTokenLocked performs the cross-process single-flighted
+// refresh. It is invoked through refreshSF, so at most one goroutine per
+// provider runs it at a time within this process.
+func (s *ConfigStore) refreshOAuthTokenLocked(ctx context.Context, scope Scope, providerID string) error {
 	cfg := s.Config()
 	providerConfig, exists := cfg.Providers.Get(providerID)
 	if !exists {
 		return fmt.Errorf("provider %s not found", providerID)
 	}
-
 	if providerConfig.OAuthToken == nil {
 		return fmt.Errorf("provider %s does not have an OAuth token", providerID)
 	}
+	entryToken := providerConfig.OAuthToken
 
-	// Phase 1: Pre-check under lock — did another process already refresh?
-	release, lockErr := s.lockConfig(scope)
+	// Acquire the per-provider cross-process refresh lock. This is a
+	// dedicated lock file, not the config-write lock, and it does not take
+	// s.mu — so the network exchange below cannot stall unrelated config
+	// operations. The deadline exceeds the exchange timeout so that a peer
+	// mid-exchange has time to publish a token we can adopt. Lock ordering:
+	// the refresh lock is always taken before the config-write lock (via
+	// SetConfigFields), never the reverse, so no deadlock is possible.
+	lockCtx, cancel := context.WithTimeout(ctx, refreshLockDeadline)
+	defer cancel()
+	release, lockErr := lock.File(lockCtx, s.refreshLockPath(providerID))
 	if lockErr != nil {
-		slog.Warn("Failed to lock config for pre-check, proceeding anyway", "provider", providerID, "error", lockErr)
-	} else {
-		diskToken, err := s.loadTokenFromDisk(scope, providerID)
-		release()
-		if err != nil {
-			slog.Warn("Failed to read token from config file", "provider", providerID, "error", err)
-		} else if diskToken != nil && !diskToken.IsExpired() && diskToken.AccessToken != providerConfig.OAuthToken.AccessToken {
-			slog.Info("Using token refreshed by another session", "provider", providerID)
+		// Could not acquire the lock (peer wedged or deadline hit). Prefer a
+		// usable token already on disk over forcing our own exchange, which
+		// would risk reusing a rotated refresh token.
+		if diskToken := s.adoptableDiskToken(scope, providerID, entryToken); diskToken != nil {
+			slog.Warn("Refresh lock unavailable; adopting token from disk", "provider", providerID, "error", lockErr)
 			return s.applyToken(providerConfig, diskToken, providerID)
 		}
+		return fmt.Errorf("acquire refresh lock for provider %s: %w", providerID, lockErr)
+	}
+	defer release()
+
+	// Did a peer rotate the token while we waited for the lock? If disk now
+	// holds a different, unexpired token, adopt it instead of exchanging.
+	if diskToken := s.adoptableDiskToken(scope, providerID, entryToken); diskToken != nil {
+		slog.Info("Adopting token refreshed by another session", "provider", providerID)
+		return s.applyToken(providerConfig, diskToken, providerID)
 	}
 
-	// Phase 2: HTTP exchange — no lock held.
-	var refreshedToken *oauth.Token
-	var refreshErr error
-	switch providerID {
-	case string(catwalk.InferenceProviderCopilot):
-		refreshedToken, refreshErr = copilot.RefreshToken(ctx, providerConfig.OAuthToken.RefreshToken)
-	case hyperp.Name:
-		refreshedToken, refreshErr = hyper.ExchangeToken(ctx, providerConfig.OAuthToken.RefreshToken)
-	default:
-		return fmt.Errorf("OAuth refresh not supported for provider %s", providerID)
-	}
+	// Disk still holds our token (or no usable peer token exists) and we hold
+	// the lock, so we are the sole exchanger. Perform the exchange.
+	refreshedToken, refreshErr := s.exchange(ctx, providerID, entryToken.RefreshToken)
 	if refreshErr != nil {
-		// Phase 3: Fallback — re-check disk under lock. The exchange may
-		// have failed because another process already rotated the refresh
-		// token.
-		if release, lockErr := s.lockConfig(scope); lockErr == nil {
-			diskToken, diskErr := s.loadTokenFromDisk(scope, providerID)
-			release()
-			if diskErr == nil &&
-				diskToken != nil &&
-				!diskToken.IsExpired() &&
-				diskToken.AccessToken != providerConfig.OAuthToken.AccessToken {
-				slog.Info("Using token refreshed by another session after exchange failure", "provider", providerID)
-				return s.applyToken(providerConfig, diskToken, providerID)
-			}
+		// The exchange may have failed because a peer rotated the refresh
+		// token in a window we did not cover. Re-check disk and adopt.
+		if diskToken := s.adoptableDiskToken(scope, providerID, entryToken); diskToken != nil {
+			slog.Info("Adopting token refreshed by another session after exchange failure", "provider", providerID)
+			return s.applyToken(providerConfig, diskToken, providerID)
 		}
 		return fmt.Errorf("failed to refresh OAuth token for provider %s: %w", providerID, refreshErr)
 	}
@@ -545,12 +585,9 @@ func (s *ConfigStore) RefreshOAuthToken(ctx context.Context, scope Scope, provid
 	slog.Info("Successfully refreshed OAuth token", "provider", providerID)
 	providerConfig.OAuthToken = refreshedToken
 	providerConfig.APIKey = refreshedToken.AccessToken
-
-	switch providerID {
-	case string(catwalk.InferenceProviderCopilot):
+	if providerID == string(catwalk.InferenceProviderCopilot) {
 		providerConfig.SetupGitHubCopilot()
 	}
-
 	cfg.Providers.Set(providerID, providerConfig)
 
 	if err := s.SetConfigFields(scope, map[string]any{
@@ -559,8 +596,55 @@ func (s *ConfigStore) RefreshOAuthToken(ctx context.Context, scope Scope, provid
 	}); err != nil {
 		return fmt.Errorf("failed to persist refreshed token: %w", err)
 	}
-
 	return nil
+}
+
+// adoptableDiskToken returns the on-disk token for the provider when it is
+// usable and differs from entryToken — i.e. when another session has
+// already refreshed it and we should adopt that result rather than running
+// our own exchange. It returns nil when there is nothing newer to adopt.
+func (s *ConfigStore) adoptableDiskToken(scope Scope, providerID string, entryToken *oauth.Token) *oauth.Token {
+	diskToken, err := s.loadTokenFromDisk(scope, providerID)
+	if err != nil {
+		slog.Warn("Failed to read token from config file", "provider", providerID, "error", err)
+		return nil
+	}
+	if diskToken == nil || diskToken.IsExpired() {
+		return nil
+	}
+	if diskToken.AccessToken == entryToken.AccessToken {
+		// Same token we started with; nobody refreshed since.
+		return nil
+	}
+	return diskToken
+}
+
+// exchange performs the provider-specific OAuth token exchange. Tests may
+// override it via the exchangeToken field; production uses the real
+// provider clients.
+func (s *ConfigStore) exchange(ctx context.Context, providerID, refreshToken string) (*oauth.Token, error) {
+	if s.exchangeToken != nil {
+		return s.exchangeToken(ctx, providerID, refreshToken)
+	}
+	switch providerID {
+	case string(catwalk.InferenceProviderCopilot):
+		return copilot.RefreshToken(ctx, refreshToken)
+	case hyperp.Name:
+		return hyper.ExchangeToken(ctx, refreshToken)
+	default:
+		return nil, fmt.Errorf("OAuth refresh not supported for provider %s", providerID)
+	}
+}
+
+// refreshLockPath returns the path to the per-provider cross-process refresh
+// lock file. Lock files live under a dedicated locks/ subdirectory of the
+// data dir so they do not clutter the config directory. The file is created
+// on demand by lock.File and is never removed (flock keys on inode, not
+// path).
+func (s *ConfigStore) refreshLockPath(providerID string) string {
+	dir := filepath.Join(filepath.Dir(s.globalDataPath), "locks")
+	_ = os.MkdirAll(dir, 0o755)
+	return filepath.Join(dir, fmt.Sprintf("%s.refresh.lock", providerID))
 }
 
 // applyToken updates the in-memory provider config with the given token.

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -221,6 +221,16 @@ func (s *ConfigStore) SetConfigField(scope Scope, key string, value any) error {
 // The write is protected by an in-process mutex and a cross-process flock
 // to prevent races between concurrent writers in different processes.
 func (s *ConfigStore) SetConfigFields(scope Scope, kv map[string]any) error {
+	return s.setConfigFields(scope, kv, true)
+}
+
+// setConfigFields performs the write and, when reload is true, refreshes
+// in-memory state from disk. Callers that have already updated the relevant
+// in-memory state themselves can pass reload=false to skip the expensive
+// full reparse (which rebuilds the provider catalog and agents). The disk
+// is the source of truth for other processes either way; skipping reload
+// only avoids re-deriving state this process already holds.
+func (s *ConfigStore) setConfigFields(scope Scope, kv map[string]any, reload bool) error {
 	// Sort keys for deterministic output regardless of map iteration
 	// order. This also ensures consistent results when callers pass
 	// overlapping JSONPath keys (e.g. "a" and "a.b").
@@ -243,6 +253,16 @@ func (s *ConfigStore) SetConfigFields(scope Scope, kv map[string]any) error {
 	})
 	if err != nil {
 		return err
+	}
+
+	if !reload {
+		// The caller has already updated in-memory state; just refresh
+		// the staleness snapshot so the file watcher does not treat our
+		// own write as an external change.
+		if path, perr := s.configPath(scope); perr == nil {
+			s.captureStalenessSnapshot(append(slices.Clone(s.loadedPaths), path))
+		}
+		return nil
 	}
 
 	// Auto-reload to keep in-memory state fresh after config edits.
@@ -281,14 +301,30 @@ func (s *ConfigStore) RemoveConfigField(scope Scope, key string) error {
 }
 
 // UpdatePreferredModel updates the preferred model for the given type and
-// persists it to the config file at the given scope.
+// persists it to the config file at the given scope. The selected model and
+// the recent-models list are written together in a single config write.
+//
+// The in-memory config is updated directly here, so the write skips the
+// full disk reparse/reload. The reload would otherwise rebuild the entire
+// provider catalog and agents on every model switch, which dominates the
+// latency of selecting a model. Agents are refreshed separately by the
+// caller (see UpdateAgentModel).
 func (s *ConfigStore) UpdatePreferredModel(scope Scope, modelType SelectedModelType, model SelectedModel) error {
 	s.config.Models[modelType] = model
-	if err := s.SetConfigField(scope, fmt.Sprintf("models.%s", modelType), model); err != nil {
-		return fmt.Errorf("failed to update preferred model: %w", err)
+
+	fields := map[string]any{
+		fmt.Sprintf("models.%s", modelType): model,
 	}
-	if err := s.recordRecentModel(scope, modelType, model); err != nil {
-		return err
+
+	// Compute the updated recent-models list in memory. When it changes,
+	// fold the write into the same batch so we avoid a second write.
+	if updated, changed := s.nextRecentModels(modelType, model); changed {
+		s.config.RecentModels[modelType] = updated
+		fields[fmt.Sprintf("recent_models.%s", modelType)] = updated
+	}
+
+	if err := s.setConfigFields(scope, fields, false); err != nil {
+		return fmt.Errorf("failed to update preferred model: %w", err)
 	}
 	return nil
 }
@@ -504,10 +540,15 @@ func (s *ConfigStore) loadTokenFromDisk(scope Scope, providerID string) (*oauth.
 	return &token, nil
 }
 
-// recordRecentModel records a model in the recent models list.
-func (s *ConfigStore) recordRecentModel(scope Scope, modelType SelectedModelType, model SelectedModel) error {
+// nextRecentModels computes the recent-models list for the given type
+// after recording the supplied model at the front, without persisting
+// anything. It returns the new slice and whether it differs from the
+// current list. It also lazily initializes the RecentModels map. Callers
+// that want to persist the change can fold the result into a batched
+// config write; recordRecentModel wraps it for the standalone case.
+func (s *ConfigStore) nextRecentModels(modelType SelectedModelType, model SelectedModel) ([]SelectedModel, bool) {
 	if model.Provider == "" || model.Model == "" {
-		return nil
+		return nil, false
 	}
 
 	if s.config.RecentModels == nil {
@@ -534,6 +575,19 @@ func (s *ConfigStore) recordRecentModel(scope Scope, modelType SelectedModelType
 	}
 
 	if slices.EqualFunc(current, updated, eq) {
+		return current, false
+	}
+
+	return updated, true
+}
+
+// recordRecentModel records a model in the recent models list and persists
+// the change. It is retained for callers that update recent models in
+// isolation; UpdatePreferredModel batches the same change into a single
+// config write instead.
+func (s *ConfigStore) recordRecentModel(scope Scope, modelType SelectedModelType, model SelectedModel) error {
+	updated, changed := s.nextRecentModels(modelType, model)
+	if !changed {
 		return nil
 	}
 

--- a/internal/config/store_test.go
+++ b/internal/config/store_test.go
@@ -498,7 +498,7 @@ func TestAutoReloadDisabledDuringReload(t *testing.T) {
 	require.NoError(t, os.WriteFile(configPath, []byte(initialConfig), 0o600))
 
 	// Load will trigger configureProviders which removes anthropic OAuth config.
-	// This should NOT cause infinite recursion — reloadMu prevents re-entrant reloads.
+	// This should NOT cause infinite recursion — writeMu prevents re-entrant reloads.
 	store, err := Load(dir, dir, false)
 	require.NoError(t, err)
 

--- a/internal/config/update_model_bench_test.go
+++ b/internal/config/update_model_bench_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// BenchmarkUpdatePreferredModel measures the full write cost of a single
+// model selection, which is what the user experiences when picking a model
+// in the TUI. It guards against regressing back to a full config reload on
+// every selection.
+func BenchmarkUpdatePreferredModel(b *testing.B) {
+	dir := b.TempDir()
+	configPath := filepath.Join(dir, "crush.json")
+
+	b.Setenv("CRUSH_GLOBAL_CONFIG", dir)
+	b.Setenv("CRUSH_GLOBAL_DATA", dir)
+	resetProviderState()
+	b.Cleanup(resetProviderState)
+
+	cfg := `{
+		"models": {
+			"large": {"provider": "openai", "model": "gpt-4"},
+			"small": {"provider": "openai", "model": "gpt-4o-mini"}
+		},
+		"providers": {
+			"openai": {
+				"api_key": "test-key",
+				"models": [
+					{"id": "gpt-4", "name": "GPT-4"},
+					{"id": "gpt-4o", "name": "GPT-4o"},
+					{"id": "gpt-4o-mini", "name": "GPT-4o mini"}
+				]
+			},
+			"anthropic": {
+				"api_key": "test-key-2",
+				"models": [
+					{"id": "claude-3", "name": "Claude 3"},
+					{"id": "claude-3-5", "name": "Claude 3.5"}
+				]
+			}
+		}
+	}`
+	if err := os.WriteFile(configPath, []byte(cfg), 0o600); err != nil {
+		b.Fatal(err)
+	}
+
+	store, err := Load(dir, dir, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	store.globalDataPath = configPath
+
+	models := []SelectedModel{
+		{Provider: "openai", Model: "gpt-4"},
+		{Provider: "anthropic", Model: "claude-3"},
+		{Provider: "openai", Model: "gpt-4o"},
+		{Provider: "anthropic", Model: "claude-3-5"},
+	}
+
+	b.ReportAllocs()
+	i := 0
+	for b.Loop() {
+		m := models[i%len(models)]
+		if err := store.UpdatePreferredModel(ScopeGlobal, SelectedModelTypeLarge, m); err != nil {
+			b.Fatal(err)
+		}
+		i++
+	}
+}
+
+// BenchmarkReloadFromDisk isolates the full reload cost for comparison with
+// BenchmarkUpdatePreferredModel.
+func BenchmarkReloadFromDisk(b *testing.B) {
+	dir := b.TempDir()
+	configPath := filepath.Join(dir, "crush.json")
+
+	b.Setenv("CRUSH_GLOBAL_CONFIG", dir)
+	b.Setenv("CRUSH_GLOBAL_DATA", dir)
+	resetProviderState()
+	b.Cleanup(resetProviderState)
+
+	cfg := `{
+		"models": {"large": {"provider": "openai", "model": "gpt-4"}},
+		"providers": {
+			"openai": {"api_key": "test-key", "models": [{"id": "gpt-4", "name": "GPT-4"}]}
+		}
+	}`
+	if err := os.WriteFile(configPath, []byte(cfg), 0o600); err != nil {
+		b.Fatal(err)
+	}
+
+	store, err := Load(dir, dir, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	store.globalDataPath = configPath
+
+	ctx := context.Background()
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := store.ReloadFromDisk(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/shell/expand.go
+++ b/internal/shell/expand.go
@@ -59,6 +59,15 @@ var NoUnset atomic.Bool
 //     prefix of its stderr. Callers that surface the error to users
 //     should additionally scrub it for the original template text.
 func ExpandValue(ctx context.Context, value string, env []string) (string, error) {
+	// Fast path: a value with no shell metacharacters expands to itself.
+	// Parsing and running it through the interpreter would produce the
+	// same string at significant cost. Most config values (literal API
+	// keys, fixed URLs) hit this path, which matters because ExpandValue
+	// runs over every provider/MCP/LSP value on each config reload.
+	if !strings.ContainsAny(value, "$`\\'\"") {
+		return value, nil
+	}
+
 	// Parse the value as a here-doc style word: no word splitting, no
 	// globbing, but full support for $VAR, ${VAR...}, $(...), and
 	// quoted/escaped strings.
@@ -73,12 +82,16 @@ func ExpandValue(ctx context.Context, value string, env []string) (string, error
 	// verbatim, with no CRUSH/AGENT/AI_AGENT injection: callers of
 	// ExpandValue control the env, and nounset must treat any name
 	// not in env as unset.
-	cwd, _ := os.Getwd()
+	//
+	// The working directory is only needed for $(...) command
+	// substitution, so we resolve it lazily on first use. Values that
+	// only reference variables or use quoting (the common case) avoid
+	// the os.Getwd() syscall entirely.
 	s := &Shell{
-		cwd:    cwd,
 		env:    env,
 		logger: noopLogger{},
 	}
+	cwdResolved := false
 
 	strict := NoUnset.Load()
 
@@ -87,6 +100,10 @@ func ExpandValue(ctx context.Context, value string, env []string) (string, error
 		Env:     expand.ListEnviron(env...),
 		NoUnset: strict,
 		CmdSubst: func(w io.Writer, cs *syntax.CmdSubst) error {
+			if !cwdResolved {
+				s.cwd, _ = os.Getwd()
+				cwdResolved = true
+			}
 			stderrBuf.Reset()
 			runnerOpts := []interp.RunnerOption{
 				interp.StdIO(nil, w, &stderrBuf),

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -269,10 +269,9 @@ func (m *Models) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	m.help.SetWidth(innerWidth)
 
 	listHeight := height - heightOffset
-	m.list.SetSize(innerWidth, listHeight)
-	listTotalHeight := m.list.TotalHeight()
 	listWidth := max(0, innerWidth-3) // Reserve space for scrollbar.
 	m.list.SetSize(listWidth, listHeight)
+	listTotalHeight := m.list.TotalHeight()
 
 	rc := NewRenderContext(t, width)
 	rc.Title = "Switch Model"

--- a/internal/ui/dialog/models_list.go
+++ b/internal/ui/dialog/models_list.go
@@ -254,7 +254,6 @@ func (f *ModelsList) VisibleItems() []list.Item {
 
 // Render renders the filterable list.
 func (f *ModelsList) Render() string {
-	f.SetItems(f.VisibleItems()...)
 	return f.List.Render()
 }
 

--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -34,6 +34,12 @@ type List struct {
 	// renderCallbacks is a list of callbacks to apply when rendering items.
 	renderCallbacks []func(idx, selectedIdx int, item Item) Item
 
+	// totalHeightCache is a cached value of the total rendered height of
+	// all items. It is invalidated whenever the item set changes or the
+	// viewport width changes (which can alter per-item line counts).
+	totalHeightCache int
+	totalHeightValid bool
+
 	// cache is the F6 list-level render memo, keyed by item pointer.
 	// Each entry stores the rendered content, a pre-split slice of
 	// lines (so AtBottom / Render / VisibleItemIndices /
@@ -158,15 +164,25 @@ func (l *List) Len() int {
 }
 
 // TotalHeight returns the total height of all items in the list.
+// The result is cached and only recomputed when the item set or
+// viewport width changes.
 func (l *List) TotalHeight() int {
+	if l.totalHeightValid {
+		return l.totalHeightCache
+	}
 	total := 0
 	for idx := range l.items {
-		item := l.getItem(idx)
-		total += item.height
+		entry := l.renderItemEntry(idx)
+		if entry == nil {
+			continue
+		}
+		total += entry.height
 		if l.gap > 0 && idx < len(l.items)-1 {
 			total += l.gap
 		}
 	}
+	l.totalHeightCache = total
+	l.totalHeightValid = true
 	return total
 }
 
@@ -289,6 +305,11 @@ func (l *List) renderItemEntry(idx int) *listCacheEntry {
 		entry = &listCacheEntry{}
 		l.cache[rawItem] = entry
 	}
+	// If the item's rendered height changed, the cached total height is
+	// no longer valid and must be recomputed on the next TotalHeight call.
+	if entry.height != height {
+		l.totalHeightValid = false
+	}
 	entry.width = l.width
 	entry.version = finalVersion
 	entry.frozen = frozen
@@ -303,6 +324,7 @@ func (l *List) invalidateAll() {
 	for k := range l.cache {
 		delete(l.cache, k)
 	}
+	l.totalHeightValid = false
 }
 
 // Invalidate drops the cache entry for the given item, forcing a
@@ -575,6 +597,7 @@ func (l *List) PrependItems(items ...Item) {
 	if l.selectedIdx != -1 {
 		l.selectedIdx += len(items)
 	}
+	l.totalHeightValid = false
 }
 
 // SetItems sets the items in the list. Cache entries for items that
@@ -586,11 +609,13 @@ func (l *List) SetItems(items ...Item) {
 	l.offsetIdx = min(l.offsetIdx, len(l.items)-1)
 	l.offsetLine = 0
 	l.retainCacheFor(items)
+	l.totalHeightValid = false
 }
 
 // AppendItems appends items to the list.
 func (l *List) AppendItems(items ...Item) {
 	l.items = append(l.items, items...)
+	l.totalHeightValid = false
 }
 
 // RemoveItem removes the item at the given index from the list.
@@ -623,6 +648,7 @@ func (l *List) RemoveItem(idx int) {
 		l.offsetIdx = max(0, len(l.items)-1)
 		l.offsetLine = 0
 	}
+	l.totalHeightValid = false
 }
 
 // Focused returns whether the list is focused.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -196,6 +196,11 @@ type UI struct {
 
 	isTransparent bool
 
+	// themeKey identifies the currently applied theme so applyTheme can
+	// skip the expensive style rebuild when switching to a provider that
+	// resolves to the same theme.
+	themeKey string
+
 	focus uiFocusState
 	state uiState
 
@@ -379,6 +384,12 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 	}
 
 	status := NewStatus(com, ui)
+
+	// Seed the active theme key from the large model provider so the
+	// first model selection can correctly skip a redundant theme swap.
+	if cfg := com.Config(); cfg != nil {
+		ui.themeKey = styles.ThemeKeyForProvider(cfg.Models[config.SelectedModelTypeLarge].Provider)
+	}
 
 	ui.setEditorPrompt(com.Workspace.PermissionSkipRequests())
 	ui.randomizePlaceholders()
@@ -1842,8 +1853,10 @@ func (m *UI) handleSelectModel(msg dialog.ActionSelectModel) tea.Cmd {
 	} else {
 		if msg.ModelType == config.SelectedModelTypeLarge {
 			// Swap the theme live based on the newly selected large
-			// model's provider.
-			m.applyTheme(styles.ThemeForProvider(providerID))
+			// model's provider. Skipped when the provider resolves to
+			// the already-active theme, which avoids a full markdown
+			// re-render of the transcript on every selection.
+			m.applyThemeForProvider(providerID)
 		}
 		if _, ok := cfg.Models[config.SelectedModelTypeSmall]; !ok {
 			// Ensure small model is set is unset.
@@ -3369,6 +3382,21 @@ func (m *UI) renderEditorView(width int) string {
 // cacheSidebarLogo renders and caches the sidebar logo at the specified width.
 func (m *UI) cacheSidebarLogo(width int) {
 	m.sidebarLogo = renderLogo(m.com.Styles, true, m.com.IsHyper(), width)
+}
+
+// applyThemeForProvider swaps the active theme to the one associated with
+// the given provider, but only when that theme differs from the one
+// already applied. Most providers share a single theme, so re-selecting a
+// model from the same theme family would otherwise pay the full cost of
+// invalidating the markdown renderer cache and re-rendering the entire
+// transcript for no visible change.
+func (m *UI) applyThemeForProvider(providerID string) {
+	key := styles.ThemeKeyForProvider(providerID)
+	if key == m.themeKey {
+		return
+	}
+	m.themeKey = key
+	m.applyTheme(styles.ThemeForProvider(providerID))
 }
 
 // applyTheme replaces the active styles with the given theme, drops the

--- a/internal/ui/styles/themes.go
+++ b/internal/ui/styles/themes.go
@@ -4,11 +4,26 @@ import (
 	"github.com/charmbracelet/x/exp/charmtone"
 )
 
+// ThemeKeyForProvider returns a stable identifier for the theme
+// associated with the given provider ID. Providers that share a theme
+// yield the same key, so callers can cheaply detect when switching
+// providers would not actually change the active theme and skip the
+// expensive style rebuild. This is the single source of truth for the
+// provider-to-theme mapping; [ThemeForProvider] builds on it.
+func ThemeKeyForProvider(providerID string) string {
+	switch providerID {
+	case "hyper":
+		return "hyper"
+	default:
+		return "default"
+	}
+}
+
 // ThemeForProvider returns the Styles associated with the given provider
 // ID. Unknown or empty provider IDs yield the default Charmtone Pantera
 // theme.
 func ThemeForProvider(providerID string) Styles {
-	switch providerID {
+	switch ThemeKeyForProvider(providerID) {
 	case "hyper":
 		return HypercrushObsidiana()
 	default:

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -426,13 +426,13 @@ func (w *AppWorkspace) EnableDockerMCP(ctx context.Context) error {
 
 	if err := mcptools.InitializeSingle(ctx, config.DockerMCPName, w.store); err != nil {
 		disableErr := mcptools.DisableSingle(w.store, config.DockerMCPName)
-		delete(w.store.Config().MCP, config.DockerMCPName)
+		w.store.RemoveDockerMCPInMemory()
 		return fmt.Errorf("failed to start docker MCP: %w", errors.Join(err, disableErr))
 	}
 
 	if err := w.store.PersistDockerMCPConfig(mcpConfig); err != nil {
 		disableErr := mcptools.DisableSingle(w.store, config.DockerMCPName)
-		delete(w.store.Config().MCP, config.DockerMCPName)
+		w.store.RemoveDockerMCPInMemory()
 		return fmt.Errorf("docker MCP started but failed to persist configuration: %w", errors.Join(err, disableErr))
 	}
 


### PR DESCRIPTION
Made a few changes that should speed up model selection a fair bit.

- Improved the rendering in the model ui to cache data and avoid rerendering in the hotpath every frame
- Made theme switching per provider lazy so it shortcircuits if its the same theme going to get applied which avoids glamour caches getting invalidated which for long sessions can be very slowwwww 🐢
- Heavily optimized the config reload path down from 33ms -> ~1.8ms in a benchmark likely even faster if you have a large config.
- Added a new lock on the config pointer to avoid dataraces