### PR TITLE
feat(server): expose client-to-session mapping via GET /workspaces/{id}/clients

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -92,6 +92,7 @@ type clientState struct {
 	streams          int
 	holdTimer        *time.Timer
 	currentSessionID string
+	pid              int
 }
 
 // Workspace represents a running [app.App] workspace with its
@@ -405,7 +406,7 @@ func skillStatesToProto(states []*skills.SkillState) []proto.SkillState {
 // ws.clientsMu (under b.mu), no concurrent teardown can succeed without
 // re-checking the (now non-empty) clients map. Lock order is the
 // canonical b.mu -> ws.clientsMu.
-func (b *Backend) AttachClient(workspaceID, clientID string) error {
+func (b *Backend) AttachClient(workspaceID, clientID string, pid int) error {
 	if _, err := validateClientID(clientID); err != nil {
 		return err
 	}
@@ -424,12 +425,15 @@ func (b *Backend) AttachClient(workspaceID, clientID string) error {
 		// Defensive: SSE attach without a prior CreateWorkspace by
 		// this client still installs a stream claim so the stream
 		// stays alive for its duration.
-		ws.clients[clientID] = &clientState{streams: 1}
+		ws.clients[clientID] = &clientState{streams: 1, pid: pid}
 		return nil
 	}
 	if cs.holdTimer != nil {
 		cs.holdTimer.Stop()
 		cs.holdTimer = nil
+	}
+	if pid != 0 {
+		cs.pid = pid
 	}
 	cs.streams++
 	return nil
@@ -630,6 +634,29 @@ func (b *Backend) AttachedClients(workspaceID, sessionID string) (int, error) {
 		return 0, ErrWorkspaceNotFound
 	}
 	return ws.AttachedClientsForSession(sessionID), nil
+}
+
+// ListClients returns information about all attached clients for the
+// given workspace. Only clients with at least one live SSE stream are
+// included. Returns [ErrWorkspaceNotFound] if the workspace is unknown.
+func (b *Backend) ListClients(workspaceID string) ([]proto.ClientInfo, error) {
+	ws, ok := b.workspaces.Get(workspaceID)
+	if !ok {
+		return nil, ErrWorkspaceNotFound
+	}
+	ws.clientsMu.Lock()
+	defer ws.clientsMu.Unlock()
+	out := make([]proto.ClientInfo, 0, len(ws.clients))
+	for id, cs := range ws.clients {
+		if cs.streams > 0 {
+			out = append(out, proto.ClientInfo{
+				ClientID:         id,
+				CurrentSessionID: cs.currentSessionID,
+				PID:              cs.pid,
+			})
+		}
+	}
+	return out, nil
 }
 
 // AttachedClientsForSession returns the number of clients in this

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -123,7 +123,7 @@ func TestAttachClient_ConsumesHold(t *testing.T) {
 
 	cid := newClientID(t)
 	b.registerClient(ws, cid)
-	require.NoError(t, b.AttachClient(ws.ID, cid))
+	require.NoError(t, b.AttachClient(ws.ID, cid, 0))
 
 	ws.clientsMu.Lock()
 	require.Len(t, ws.clients, 1)
@@ -143,7 +143,7 @@ func TestAttachClient_WithoutPriorCreate(t *testing.T) {
 	ws, _ := insertTestWorkspace(t, b, "/tmp/a")
 
 	cid := newClientID(t)
-	require.NoError(t, b.AttachClient(ws.ID, cid))
+	require.NoError(t, b.AttachClient(ws.ID, cid, 0))
 
 	ws.clientsMu.Lock()
 	defer ws.clientsMu.Unlock()
@@ -159,8 +159,8 @@ func TestAttachClient_DuplicateStreams(t *testing.T) {
 	ws, shutdowns := insertTestWorkspace(t, b, "/tmp/a")
 
 	cid := newClientID(t)
-	require.NoError(t, b.AttachClient(ws.ID, cid))
-	require.NoError(t, b.AttachClient(ws.ID, cid))
+	require.NoError(t, b.AttachClient(ws.ID, cid, 0))
+	require.NoError(t, b.AttachClient(ws.ID, cid, 0))
 
 	ws.clientsMu.Lock()
 	require.Equal(t, 2, ws.clients[cid].streams)
@@ -184,7 +184,7 @@ func TestDetachClient_LastStreamTearsDown(t *testing.T) {
 
 	cid := newClientID(t)
 	b.registerClient(ws, cid)
-	require.NoError(t, b.AttachClient(ws.ID, cid))
+	require.NoError(t, b.AttachClient(ws.ID, cid, 0))
 	b.DetachClient(ws.ID, cid)
 
 	require.Equal(t, int32(1), wsShutdowns.Load())
@@ -231,7 +231,7 @@ func TestReleaseHold_WithActiveStream(t *testing.T) {
 
 	cid := newClientID(t)
 	b.registerClient(ws, cid)
-	require.NoError(t, b.AttachClient(ws.ID, cid))
+	require.NoError(t, b.AttachClient(ws.ID, cid, 0))
 	require.NoError(t, b.releaseHold(ws.ID, cid))
 
 	ws.clientsMu.Lock()
@@ -252,7 +252,7 @@ func TestReleaseHoldThenAttach(t *testing.T) {
 
 	cid := newClientID(t)
 	require.NoError(t, b.releaseHold(ws.ID, cid)) // no entry yet — no-op.
-	require.NoError(t, b.AttachClient(ws.ID, cid))
+	require.NoError(t, b.AttachClient(ws.ID, cid, 0))
 	ws.clientsMu.Lock()
 	require.Equal(t, 1, ws.clients[cid].streams)
 	ws.clientsMu.Unlock()
@@ -271,9 +271,9 @@ func TestRefcountWithSecondClient(t *testing.T) {
 	cidA := newClientID(t)
 	cidB := newClientID(t)
 	b.registerClient(ws, cidA)
-	require.NoError(t, b.AttachClient(ws.ID, cidA))
+	require.NoError(t, b.AttachClient(ws.ID, cidA, 0))
 	b.registerClient(ws, cidB)
-	require.NoError(t, b.AttachClient(ws.ID, cidB))
+	require.NoError(t, b.AttachClient(ws.ID, cidB, 0))
 
 	b.DetachClient(ws.ID, cidA)
 	ws.clientsMu.Lock()
@@ -292,8 +292,8 @@ func TestAttachClient_InvalidID(t *testing.T) {
 	b, _ := newTestBackend(t)
 	ws, _ := insertTestWorkspace(t, b, "/tmp/a")
 
-	require.ErrorIs(t, b.AttachClient(ws.ID, ""), ErrInvalidClientID)
-	require.ErrorIs(t, b.AttachClient(ws.ID, "not-a-uuid"), ErrInvalidClientID)
+	require.ErrorIs(t, b.AttachClient(ws.ID, "", 0), ErrInvalidClientID)
+	require.ErrorIs(t, b.AttachClient(ws.ID, "not-a-uuid", 0), ErrInvalidClientID)
 }
 
 func TestDeleteWorkspace_RejectsBadClientID(t *testing.T) {
@@ -322,7 +322,7 @@ func TestHoldExpiry_RaceWithAttach(t *testing.T) {
 		b.registerClient(ws, cid)
 		// Attach concurrently with the very short grace timer.
 		errCh := make(chan error, 1)
-		go func() { errCh <- b.AttachClient(ws.ID, cid) }()
+		go func() { errCh <- b.AttachClient(ws.ID, cid, 0) }()
 		<-errCh
 
 		// Wait for any pending timer to settle.
@@ -364,7 +364,7 @@ func TestConcurrentAttachDetach(t *testing.T) {
 
 	cid := newClientID(t)
 	b.registerClient(ws, cid)
-	require.NoError(t, b.AttachClient(ws.ID, cid)) // ensure refcount stays > 0.
+	require.NoError(t, b.AttachClient(ws.ID, cid, 0)) // ensure refcount stays > 0.
 
 	const n = 50
 	var wg sync.WaitGroup
@@ -373,7 +373,7 @@ func TestConcurrentAttachDetach(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			cid2 := newClientID(t)
-			_ = b.AttachClient(ws.ID, cid2)
+			_ = b.AttachClient(ws.ID, cid2, 0)
 			b.DetachClient(ws.ID, cid2)
 		}()
 	}
@@ -793,11 +793,11 @@ func TestRaceTwoClientsAttachOneDetaches(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		require.NoError(t, b.AttachClient(ws.ID, cidA))
+		require.NoError(t, b.AttachClient(ws.ID, cidA, 0))
 	}()
 	go func() {
 		defer wg.Done()
-		require.NoError(t, b.AttachClient(ws.ID, cidB))
+		require.NoError(t, b.AttachClient(ws.ID, cidB, 0))
 	}()
 	wg.Wait()
 
@@ -837,7 +837,7 @@ func TestExplicitDeleteThenAttach(t *testing.T) {
 	// Anchor client keeps the workspace registered in
 	// b.workspaces across the cid's releaseHold below.
 	anchor := newClientID(t)
-	require.NoError(t, b.AttachClient(ws.ID, anchor))
+	require.NoError(t, b.AttachClient(ws.ID, anchor, 0))
 
 	cid := newClientID(t)
 	// Real hold via registerClient (mirrors CreateWorkspace).
@@ -859,7 +859,7 @@ func TestExplicitDeleteThenAttach(t *testing.T) {
 
 	// AttachClient creates a fresh entry with streams==1 and no
 	// hold timer.
-	require.NoError(t, b.AttachClient(ws.ID, cid))
+	require.NoError(t, b.AttachClient(ws.ID, cid, 0))
 	ws.clientsMu.Lock()
 	require.Contains(t, ws.clients, cid, "fresh entry must be created")
 	require.Equal(t, 1, ws.clients[cid].streams, "fresh attach must start at streams=1")
@@ -905,7 +905,7 @@ func TestAttachClient_RacesWithTeardown(t *testing.T) {
 		// imminent DetachClient(cidA) will be the *only* claim
 		// drop, so teardown will run.
 		cidA := newClientID(t)
-		require.NoError(t, b.AttachClient(ws.ID, cidA))
+		require.NoError(t, b.AttachClient(ws.ID, cidA, 0))
 
 		// cidB attempts to attach concurrently with the detach
 		// that will tear the workspace down.
@@ -915,7 +915,7 @@ func TestAttachClient_RacesWithTeardown(t *testing.T) {
 		detachDone := make(chan struct{})
 		go func() {
 			<-start
-			errCh <- b.AttachClient(ws.ID, cidB)
+			errCh <- b.AttachClient(ws.ID, cidB, 0)
 		}()
 		go func() {
 			<-start
@@ -983,8 +983,8 @@ func TestSetCurrentSession_BasicAttachAndSwitch(t *testing.T) {
 
 	cidA := newClientID(t)
 	cidB := newClientID(t)
-	require.NoError(t, b.AttachClient(ws.ID, cidA))
-	require.NoError(t, b.AttachClient(ws.ID, cidB))
+	require.NoError(t, b.AttachClient(ws.ID, cidA, 0))
+	require.NoError(t, b.AttachClient(ws.ID, cidB, 0))
 
 	require.NoError(t, b.SetCurrentSession(ws.ID, cidA, "S1"))
 	ws.clientsMu.Lock()
@@ -1028,10 +1028,10 @@ func TestSetCurrentSession_DetachClearsEntry(t *testing.T) {
 	// Anchor client so the workspace is not torn down when cid
 	// detaches.
 	anchor := newClientID(t)
-	require.NoError(t, b.AttachClient(ws.ID, anchor))
+	require.NoError(t, b.AttachClient(ws.ID, anchor, 0))
 
 	cid := newClientID(t)
-	require.NoError(t, b.AttachClient(ws.ID, cid))
+	require.NoError(t, b.AttachClient(ws.ID, cid, 0))
 	require.NoError(t, b.SetCurrentSession(ws.ID, cid, "S2"))
 
 	b.DetachClient(ws.ID, cid)
@@ -1115,8 +1115,8 @@ func TestSetCurrentSession_RaceWithDetach(t *testing.T) {
 
 	cidA := newClientID(t)
 	cidB := newClientID(t)
-	require.NoError(t, b.AttachClient(ws.ID, cidA))
-	require.NoError(t, b.AttachClient(ws.ID, cidB))
+	require.NoError(t, b.AttachClient(ws.ID, cidA, 0))
+	require.NoError(t, b.AttachClient(ws.ID, cidB, 0))
 
 	var wg sync.WaitGroup
 	const updates = 200
@@ -1170,7 +1170,7 @@ func TestAttachedClients_BasicLifecycle(t *testing.T) {
 
 	// Attach A, set to S1. Count for S1 is 1; count for S2 is 0.
 	cidA := newClientID(t)
-	require.NoError(t, b.AttachClient(ws.ID, cidA))
+	require.NoError(t, b.AttachClient(ws.ID, cidA, 0))
 	require.NoError(t, b.SetCurrentSession(ws.ID, cidA, "S1"))
 
 	n, err = b.AttachedClients(ws.ID, "S1")
@@ -1182,7 +1182,7 @@ func TestAttachedClients_BasicLifecycle(t *testing.T) {
 
 	// Attach B, set to S1. Count for S1 is 2.
 	cidB := newClientID(t)
-	require.NoError(t, b.AttachClient(ws.ID, cidB))
+	require.NoError(t, b.AttachClient(ws.ID, cidB, 0))
 	require.NoError(t, b.SetCurrentSession(ws.ID, cidB, "S1"))
 
 	n, _ = b.AttachedClients(ws.ID, "S1")
@@ -1213,7 +1213,7 @@ func TestAttachedClients_BasicLifecycle(t *testing.T) {
 	// against the empty session id (which represents the landing
 	// screen).
 	cidC := newClientID(t)
-	require.NoError(t, b.AttachClient(ws.ID, cidC))
+	require.NoError(t, b.AttachClient(ws.ID, cidC, 0))
 	n, _ = b.AttachedClients(ws.ID, "S1")
 	require.Equal(t, 1, n, "stream-only client with empty currentSessionID must not be counted toward S1")
 	n, _ = b.AttachedClients(ws.ID, "")

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -11,6 +11,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/charmbracelet/crush/internal/config"
@@ -113,7 +115,10 @@ func (c *Client) SetCurrentSession(ctx context.Context, workspaceID, sessionID s
 // SubscribeEvents subscribes to server-sent events for a workspace.
 func (c *Client) SubscribeEvents(ctx context.Context, id string) (<-chan any, error) {
 	events := make(chan any, 100)
-	q := url.Values{"client_id": []string{c.clientID}}
+	q := url.Values{
+		"client_id": []string{c.clientID},
+		"pid":       []string{strconv.Itoa(os.Getpid())},
+	}
 	//nolint:bodyclose
 	rsp, err := c.get(ctx, fmt.Sprintf("/workspaces/%s/events", id), q, http.Header{
 		"Accept":        []string{"text/event-stream"},

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -46,6 +46,13 @@ type CurrentSession struct {
 	SessionID string `json:"session_id"`
 }
 
+// ClientInfo describes a single attached client within a workspace.
+type ClientInfo struct {
+	ClientID         string `json:"client_id"`
+	CurrentSessionID string `json:"current_session_id,omitempty"`
+	PID              int    `json:"pid,omitempty"`
+}
+
 // RunComplete is the authoritative end-of-run signal for a session,
 // emitted exactly once per top-level agent turn after all message
 // updates for the turn have flushed. Clients that need a reliable

--- a/internal/server/multiclient_test.go
+++ b/internal/server/multiclient_test.go
@@ -218,7 +218,7 @@ func TestPostCurrentSession_AttachedClientSucceeds(t *testing.T) {
 	ws := installSyntheticWorkspace(t, c)
 
 	cid := uuid.New().String()
-	require.NoError(t, c.backend.AttachClient(ws.ID, cid))
+	require.NoError(t, c.backend.AttachClient(ws.ID, cid, 0))
 	t.Cleanup(func() { c.backend.DetachClient(ws.ID, cid) })
 
 	rec := postCurrentSession(t, c, ws.ID, cid, "S1")

--- a/internal/server/proto.go
+++ b/internal/server/proto.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/charmbracelet/crush/internal/backend"
 	"github.com/charmbracelet/crush/internal/proto"
@@ -184,6 +185,26 @@ func (c *controllerV1) handlePostWorkspaceCurrentSession(w http.ResponseWriter, 
 	}
 }
 
+// handleGetWorkspaceClients returns all attached clients for a workspace.
+//
+//	@Summary		List attached clients
+//	@Tags			workspaces
+//	@Produce		json
+//	@Param			id	path		string	true	"Workspace ID"
+//	@Success		200	{array}		proto.ClientInfo
+//	@Failure		404	{object}	proto.Error
+//	@Failure		500	{object}	proto.Error
+//	@Router			/workspaces/{id}/clients [get]
+func (c *controllerV1) handleGetWorkspaceClients(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	clients, err := c.backend.ListClients(id)
+	if err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	jsonEncode(w, clients)
+}
+
 // handleDeleteWorkspaces deletes a workspace.
 //
 //	@Summary		Delete workspace
@@ -271,7 +292,8 @@ func (c *controllerV1) handleGetWorkspaceEvents(w http.ResponseWriter, r *http.R
 		c.handleError(w, r, err)
 		return
 	}
-	if err := c.backend.AttachClient(id, clientID); err != nil {
+	pid, _ := strconv.Atoi(r.URL.Query().Get("pid"))
+	if err := c.backend.AttachClient(id, clientID, pid); err != nil {
 		c.handleError(w, r, err)
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -156,6 +156,7 @@ func (s *Server) installHandler() {
 	mux.HandleFunc("POST /v1/workspaces", c.handlePostWorkspaces)
 	mux.HandleFunc("DELETE /v1/workspaces/{id}", c.handleDeleteWorkspaces)
 	mux.HandleFunc("POST /v1/workspaces/{id}/current-session", c.handlePostWorkspaceCurrentSession)
+	mux.HandleFunc("GET /v1/workspaces/{id}/clients", c.handleGetWorkspaceClients)
 	mux.HandleFunc("GET /v1/workspaces/{id}", c.handleGetWorkspace)
 	mux.HandleFunc("GET /v1/workspaces/{id}/config", c.handleGetWorkspaceConfig)
 	mux.HandleFunc("GET /v1/workspaces/{id}/events", c.handleGetWorkspaceEvents)

--- a/internal/server/sessions_isbusy_test.go
+++ b/internal/server/sessions_isbusy_test.go
@@ -248,7 +248,7 @@ func TestSessionListIncludesAttachedClients(t *testing.T) {
 
 	// Attach A, set to S1: S1=1.
 	cidA := uuid.New().String()
-	require.NoError(t, c.backend.AttachClient(ws.ID, cidA))
+	require.NoError(t, c.backend.AttachClient(ws.ID, cidA, 0))
 	t.Cleanup(func() { c.backend.DetachClient(ws.ID, cidA) })
 	require.NoError(t, c.backend.SetCurrentSession(ws.ID, cidA, "S1"))
 	counts = countsBySessionID(listSessions(t, c, ws.ID))
@@ -257,7 +257,7 @@ func TestSessionListIncludesAttachedClients(t *testing.T) {
 
 	// Attach B, set to S1: S1=2.
 	cidB := uuid.New().String()
-	require.NoError(t, c.backend.AttachClient(ws.ID, cidB))
+	require.NoError(t, c.backend.AttachClient(ws.ID, cidB, 0))
 	require.NoError(t, c.backend.SetCurrentSession(ws.ID, cidB, "S1"))
 	counts = countsBySessionID(listSessions(t, c, ws.ID))
 	require.Equal(t, 2, counts["S1"])
@@ -300,7 +300,7 @@ func TestSessionListExcludesUnselectedAttachedClient(t *testing.T) {
 	c, ws := buildMultiSessionWorkspace(t, "S1")
 
 	cid := uuid.New().String()
-	require.NoError(t, c.backend.AttachClient(ws.ID, cid))
+	require.NoError(t, c.backend.AttachClient(ws.ID, cid, 0))
 	t.Cleanup(func() { c.backend.DetachClient(ws.ID, cid) })
 	// Intentionally do NOT call SetCurrentSession.
 
@@ -316,7 +316,7 @@ func TestSessionGetIncludesAttachedClients(t *testing.T) {
 	c, ws := buildMultiSessionWorkspace(t, "S1")
 
 	cid := uuid.New().String()
-	require.NoError(t, c.backend.AttachClient(ws.ID, cid))
+	require.NoError(t, c.backend.AttachClient(ws.ID, cid, 0))
 	t.Cleanup(func() { c.backend.DetachClient(ws.ID, cid) })
 	require.NoError(t, c.backend.SetCurrentSession(ws.ID, cid, "S1"))
 


### PR DESCRIPTION
Add a new API endpoint that returns attached clients with their PID and current session ID. This enables external tooling (e.g. tmux session restore) to map running Crush processes to their active sessions.

Changes:
- Client sends OS PID as query param on SSE connect
- Server stores PID in clientState
- New `GET /v1/workspaces/{id}/clients` endpoint returns `[{client_id, current_session_id, pid}]`

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
