### PR TITLE
feat(ui): add minimize keybinding to diff permission dialogs

### DIFF
--- a/internal/ui/dialog/dialog.go
+++ b/internal/ui/dialog/dialog.go
@@ -90,6 +90,20 @@ func (d *Overlay) HasDialogs() bool {
 	return len(d.dialogs) > 0
 }
 
+// HasVisibleDialogs checks if there are any visible (non-minimized) dialogs.
+func (d *Overlay) HasVisibleDialogs() bool {
+	for _, dialog := range d.dialogs {
+		// Check if this is a minimized permission dialog
+		if perm, ok := dialog.(*Permissions); ok {
+			if perm.HasDiffView() && perm.IsMinimized() {
+				continue // Skip minimized permission dialogs
+			}
+		}
+		return true
+	}
+	return false
+}
+
 // ContainsDialog checks if a dialog with the specified ID exists.
 func (d *Overlay) ContainsDialog(dialogID string) bool {
 	for _, dialog := range d.dialogs {

--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -55,10 +55,11 @@ const (
 
 // Permissions represents a dialog for permission requests.
 type Permissions struct {
-	com          *common.Common
-	windowWidth  int // Terminal window dimensions.
-	windowHeight int
-	fullscreen   bool // true when dialog is fullscreen
+	com           *common.Common
+	windowWidth   int // Terminal window dimensions.
+	windowHeight  int
+	fullscreen    bool // true when dialog is fullscreen
+	diffMinimized bool // true when diff view is minimized
 
 	permission     permission.PermissionRequest
 	selectedOption int // 0: Allow, 1: Allow for session, 2: Deny
@@ -79,22 +80,23 @@ type Permissions struct {
 }
 
 type permissionsKeyMap struct {
-	Left             key.Binding
-	Right            key.Binding
-	Tab              key.Binding
-	Select           key.Binding
-	Allow            key.Binding
-	AllowSession     key.Binding
-	Deny             key.Binding
-	Close            key.Binding
-	ToggleDiffMode   key.Binding
-	ToggleFullscreen key.Binding
-	ScrollUp         key.Binding
-	ScrollDown       key.Binding
-	ScrollLeft       key.Binding
-	ScrollRight      key.Binding
-	Choose           key.Binding
-	Scroll           key.Binding
+	Left                key.Binding
+	Right               key.Binding
+	Tab                 key.Binding
+	Select              key.Binding
+	Allow               key.Binding
+	AllowSession        key.Binding
+	Deny                key.Binding
+	Close               key.Binding
+	ToggleDiffMode      key.Binding
+	ToggleFullscreen    key.Binding
+	ToggleDiffMinimized key.Binding
+	ScrollUp            key.Binding
+	ScrollDown          key.Binding
+	ScrollLeft          key.Binding
+	ScrollRight         key.Binding
+	Choose              key.Binding
+	Scroll              key.Binding
 }
 
 func defaultPermissionsKeyMap() permissionsKeyMap {
@@ -135,6 +137,10 @@ func defaultPermissionsKeyMap() permissionsKeyMap {
 		ToggleFullscreen: key.NewBinding(
 			key.WithKeys("f"),
 			key.WithHelp("f", "toggle fullscreen"),
+		),
+		ToggleDiffMinimized: key.NewBinding(
+			key.WithKeys("m"),
+			key.WithHelp("m", "minimize/restore"),
 		),
 		ScrollUp: key.NewBinding(
 			key.WithKeys("shift+up", "K"),
@@ -230,8 +236,42 @@ func (p *Permissions) ToolCallID() string {
 	return p.permission.ToolCallID
 }
 
+// IsMinimized returns whether the diff view is minimized.
+func (p *Permissions) IsMinimized() bool {
+	return p.diffMinimized && p.hasDiffView()
+}
+
+// HasDiffView returns whether this permission dialog has a diff view.
+func (p *Permissions) HasDiffView() bool {
+	return p.hasDiffView()
+}
+
+// SetMinimized sets the minimized state.
+func (p *Permissions) SetMinimized(minimized bool) {
+	p.diffMinimized = minimized
+	p.viewportDirty = true
+}
+
+// KeyMap returns the key map.
+func (p *Permissions) KeyMap() permissionsKeyMap {
+	return p.keyMap
+}
+
 // HandleMsg implements [Dialog].
 func (p *Permissions) HandleMsg(msg tea.Msg) Action {
+	// If diff is minimized, only handle the m key to restore it.
+	// All other keys should pass through to the chat.
+	if p.diffMinimized && p.hasDiffView() {
+		if keyMsg, ok := msg.(tea.KeyPressMsg); ok {
+			if key.Matches(keyMsg, p.keyMap.ToggleDiffMinimized) {
+				p.diffMinimized = false
+				p.viewportDirty = true
+				return nil
+			}
+		}
+		return nil
+	}
+
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		switch {
@@ -260,6 +300,11 @@ func (p *Permissions) HandleMsg(msg tea.Msg) Action {
 		case key.Matches(msg, p.keyMap.ToggleFullscreen):
 			if p.hasDiffView() {
 				p.fullscreen = !p.fullscreen
+			}
+		case key.Matches(msg, p.keyMap.ToggleDiffMinimized):
+			if p.hasDiffView() {
+				p.diffMinimized = !p.diffMinimized
+				p.viewportDirty = true
 			}
 		case key.Matches(msg, p.keyMap.ScrollDown):
 			p.viewport, _ = p.viewport.Update(msg)
@@ -346,7 +391,6 @@ func (p *Permissions) scrollRight() {
 	p.viewportDirty = true
 }
 
-// Draw implements [Dialog].
 // dialogSize returns the outer dialog width and maximum height for the
 // given screen area, and whether the window is too small so the dialog
 // must fill it. Diff views get more room than simple prompts.
@@ -383,6 +427,13 @@ func (p *Permissions) contentViewportHeight(forceFullscreen bool, maxHeight, fix
 
 func (p *Permissions) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	t := p.com.Styles
+
+	// When minimized, do not draw the dialog at all; the UI renders a banner
+	// in the editor area instead.
+	if p.diffMinimized && p.hasDiffView() {
+		return nil
+	}
+
 	width, maxHeight, forceFullscreen := p.dialogSize(area)
 	dialogStyle := t.Dialog.View.Width(width).Padding(0, 1)
 	// The dialog fills the screen when forced small or when a diff is
@@ -808,6 +859,7 @@ func (p *Permissions) ShortHelp() []key.Binding {
 			bindings,
 			p.keyMap.ToggleDiffMode,
 			p.keyMap.ToggleFullscreen,
+			p.keyMap.ToggleDiffMinimized,
 		)
 	}
 

--- a/internal/ui/dialog/permissions_test.go
+++ b/internal/ui/dialog/permissions_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/styles"
@@ -18,6 +19,23 @@ func newTestPermissions(t *testing.T) *Permissions {
 		ID:         "perm-test",
 		ToolCallID: "tool-call-test",
 		ToolName:   "bash",
+	}
+	return NewPermissions(com, perm)
+}
+
+func newTestDiffPermissions(t *testing.T) *Permissions {
+	t.Helper()
+	s := styles.CharmtonePantera()
+	com := &common.Common{Styles: &s}
+	perm := permission.PermissionRequest{
+		ID:         "perm-diff-test",
+		ToolCallID: "tool-call-diff-test",
+		ToolName:   "edit",
+		Params: tools.EditPermissionsParams{
+			FilePath:   "main.go",
+			OldContent: "hello",
+			NewContent: "world",
+		},
 	}
 	return NewPermissions(com, perm)
 }
@@ -95,4 +113,70 @@ func TestPermissions_EscapeDenies(t *testing.T) {
 	resp, ok := action.(ActionPermissionResponse)
 	require.True(t, ok)
 	require.Equal(t, PermissionDeny, resp.Action)
+}
+
+// TestPermissions_MinimizeTogglesDiffDialog verifies that pressing m on a diff
+// permission dialog toggles the minimized state.
+func TestPermissions_MinimizeTogglesDiffDialog(t *testing.T) {
+	t.Parallel()
+
+	p := newTestDiffPermissions(t)
+	require.False(t, p.IsMinimized())
+
+	p.HandleMsg(keyMsg('m'))
+	require.True(t, p.IsMinimized())
+
+	p.HandleMsg(keyMsg('m'))
+	require.False(t, p.IsMinimized())
+}
+
+// TestPermissions_MinimizeBlocksActionsWhenMinimized verifies that action keys
+// are ignored while the dialog is minimized.
+func TestPermissions_MinimizeBlocksActionsWhenMinimized(t *testing.T) {
+	t.Parallel()
+
+	actionKeys := []tea.KeyPressMsg{
+		keyMsg('a'), keyMsg('d'), keyMsg('s'),
+		{Code: tea.KeyEnter},
+		{Code: tea.KeyEscape},
+	}
+
+	for _, k := range actionKeys {
+		p := newTestDiffPermissions(t)
+		p.HandleMsg(keyMsg('m'))
+		require.True(t, p.IsMinimized())
+
+		action := p.HandleMsg(k)
+		require.Nil(t, action, "key %q should be blocked when minimized", k.Text)
+	}
+}
+
+// TestPermissions_MinimizeOnlyWorksWithDiffView verifies that m does nothing
+// on a non-diff permission dialog (e.g. bash).
+func TestPermissions_MinimizeOnlyWorksWithDiffView(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPermissions(t) // bash — no diff view
+	p.HandleMsg(keyMsg('m'))
+	require.False(t, p.IsMinimized())
+}
+
+// TestPermissions_HasVisibleDialogsRespectsMinimized verifies that the overlay
+// considers a minimized diff dialog as not visible.
+func TestPermissions_HasVisibleDialogsRespectsMinimized(t *testing.T) {
+	t.Parallel()
+
+	overlay := NewOverlay()
+	overlay.OpenDialog(newTestDiffPermissions(t))
+
+	require.True(t, overlay.HasVisibleDialogs())
+
+	perm := overlay.Dialog(PermissionsID).(*Permissions)
+	perm.HandleMsg(keyMsg('m'))
+
+	require.True(t, overlay.HasDialogs())
+	require.False(t, overlay.HasVisibleDialogs())
+
+	perm.HandleMsg(keyMsg('m'))
+	require.True(t, overlay.HasVisibleDialogs())
 }

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -957,7 +957,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.chat.HandleDelayedClick(msg)
 	case tea.MouseClickMsg:
 		// Pass mouse events to dialogs first if any are open.
-		if m.dialog.HasDialogs() {
+		if m.dialog.HasVisibleDialogs() {
 			m.dialog.Update(msg)
 			return m, tea.Batch(cmds...)
 		}
@@ -1008,7 +1008,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.MouseMotionMsg:
 		// Pass mouse events to dialogs first if any are open.
-		if m.dialog.HasDialogs() {
+		if m.dialog.HasVisibleDialogs() {
 			m.dialog.Update(msg)
 			return m, tea.Batch(cmds...)
 		}
@@ -1063,7 +1063,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.MouseReleaseMsg:
 		// Pass mouse events to dialogs first if any are open.
-		if m.dialog.HasDialogs() {
+		if m.dialog.HasVisibleDialogs() {
 			m.dialog.Update(msg)
 			return m, tea.Batch(cmds...)
 		}
@@ -1095,7 +1095,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Pass mouse events to dialogs first if any are open.
-		if m.dialog.HasDialogs() {
+		if m.dialog.HasVisibleDialogs() {
 			m.dialog.Update(msg)
 			return m, tea.Batch(cmds...)
 		}
@@ -1173,7 +1173,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.sidebarScrollbarVisible = false
 		}
 	case spinner.TickMsg:
-		if m.dialog.HasDialogs() {
+		if m.dialog.HasVisibleDialogs() {
 			// route to dialog
 			if cmd := m.handleDialogMsg(msg); cmd != nil {
 				cmds = append(cmds, cmd)
@@ -1307,7 +1307,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 	default:
-		if m.dialog.HasDialogs() {
+		if m.dialog.HasVisibleDialogs() {
 			if cmd := m.handleDialogMsg(msg); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
@@ -2281,8 +2281,61 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		return tea.Batch(cmds...)
 	}
 
+	// When a permission dialog is minimized, intercept keys: restore on m,
+	// allow chat scroll keys, block everything else.
+	if perm := m.minimizedPermission(); perm != nil {
+		if key.Matches(msg, perm.KeyMap().ToggleDiffMinimized) {
+			perm.SetMinimized(false)
+			return nil
+		}
+		// Allow chat scroll keys through.
+		switch {
+		case key.Matches(msg, m.keyMap.Chat.UpOneItem):
+			m.chat.SelectPrev()
+			if cmd := m.chat.ScrollToSelectedAndAnimate(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		case key.Matches(msg, m.keyMap.Chat.DownOneItem):
+			m.chat.SelectNext()
+			if cmd := m.chat.ScrollToSelectedAndAnimate(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		case key.Matches(msg, m.keyMap.Chat.PageUp):
+			if cmd := m.chat.ScrollByAndAnimate(-m.chat.Height()); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			m.chat.SelectFirstInView()
+		case key.Matches(msg, m.keyMap.Chat.PageDown):
+			if cmd := m.chat.ScrollByAndAnimate(m.chat.Height()); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			m.chat.SelectLastInView()
+		case key.Matches(msg, m.keyMap.Chat.HalfPageUp):
+			if cmd := m.chat.ScrollByAndAnimate(-m.chat.Height() / 2); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			m.chat.SelectFirstInView()
+		case key.Matches(msg, m.keyMap.Chat.HalfPageDown):
+			if cmd := m.chat.ScrollByAndAnimate(m.chat.Height() / 2); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			m.chat.SelectLastInView()
+		case key.Matches(msg, m.keyMap.Chat.Home):
+			if cmd := m.chat.ScrollToTopAndAnimate(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			m.chat.SelectFirst()
+		case key.Matches(msg, m.keyMap.Chat.End):
+			if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			m.chat.SelectLast()
+		}
+		return tea.Batch(cmds...)
+	}
+
 	// Route all messages to dialog if one is open.
-	if m.dialog.HasDialogs() {
+	if m.dialog.HasVisibleDialogs() {
 		return m.handleDialogMsg(msg)
 	}
 
@@ -2794,6 +2847,9 @@ func (m *UI) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 			} else {
 				m.inlineCursor = m.activeInline.Draw(scr, layout.editor)
 			}
+		} else if perm := m.minimizedPermission(); perm != nil {
+			m.drawMinimizedPermissionBanner(scr, layout.editor, perm)
+			m.inlineCursor = nil
 		} else {
 			editorWidth := scr.Bounds().Dx()
 			if !m.isCompact {
@@ -2849,7 +2905,7 @@ func (m *UI) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	// This needs to come last to overlay on top of everything. We always pass
 	// the full screen bounds because the dialogs will position themselves
 	// accordingly.
-	if m.dialog.HasDialogs() {
+	if m.dialog.HasVisibleDialogs() {
 		return m.dialog.Draw(scr, scr.Bounds())
 	}
 
@@ -3241,6 +3297,27 @@ func (m *UI) handleTextareaHeightChange(prevHeight int) tea.Cmd {
 		return m.chat.ScrollToBottomAndAnimate()
 	}
 	return nil
+}
+
+// minimizedPermission returns the minimized Permissions dialog if one exists.
+func (m *UI) minimizedPermission() *dialog.Permissions {
+	if d := m.dialog.Dialog(dialog.PermissionsID); d != nil {
+		if perm, ok := d.(*dialog.Permissions); ok && perm.IsMinimized() {
+			return perm
+		}
+	}
+	return nil
+}
+
+// drawMinimizedPermissionBanner draws a banner in the editor area indicating
+// a permission dialog is minimized and how to restore it.
+func (m *UI) drawMinimizedPermissionBanner(scr uv.Screen, area uv.Rectangle, _ *dialog.Permissions) {
+	t := m.com.Styles
+	banner := t.Dialog.SecondaryText.
+		Width(area.Dx()).
+		Align(lipgloss.Center).
+		Render("⚠ Permission pending · press m to restore diff view")
+	uv.NewStyledString(banner).Draw(scr, area)
 }
 
 // updateTextarea updates the textarea for msg and then reconciles layout if
@@ -4491,7 +4568,7 @@ func (m *UI) handlePasteMsg(msg tea.PasteMsg) tea.Cmd {
 	// Normalize \r\n before the textarea sanitizer sees it.
 	msg.Content = strings.ReplaceAll(msg.Content, "\r\n", "\n")
 
-	if m.dialog.HasDialogs() {
+	if m.dialog.HasVisibleDialogs() {
 		return m.handleDialogMsg(msg)
 	}
 


### PR DESCRIPTION
When Crush asks for permission to edit a file, the diff view takes over the entire screen. There's no way to scroll back through the conversation to check context — what the agent was trying to do, what files it already touched — before deciding to allow or deny. This makes it hard to make an informed decision, especially in longer sessions.

This adds an `m` keybinding to diff permission dialogs (edit, write, multi-edit) that completely hides the dialog and gives back the full chat view. While minimized, the editor input is replaced by a `⚠ Permission pending` banner so the state is always visible, and only scroll keys are active — typing is intentionally blocked since a decision is still pending. Pressing `m` again restores the dialog exactly as it was.

<img width="1296" height="920" alt="Screenshot 2026-06-23 at 14 55 44" src="https://github.com/user-attachments/assets/e726ff5b-ee77-4d08-a04d-6c79727aea9b" />
<img width="1293" height="925" alt="Screenshot 2026-06-23 at 14 55 33" src="https://github.com/user-attachments/assets/cf31e11a-d308-4d10-b110-526964f79a9b" />


AI attribution: Claude Sonnet (eu.anthropic.claude-sonnet-4-6) via Crush.