### PR TITLE
fix(docs): note npm install covers macOS, Linux, and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Use a package manager:
 # Homebrew
 brew install charmbracelet/tap/crush
 
-# NPM
+# NPM (macOS, Linux, and Windows)
 npm install -g @charmland/crush
 
 # Arch Linux (btw)


### PR DESCRIPTION
## What

Annotates the `# NPM` line in the install section to note it covers macOS, Linux, and Windows.

## Why

Closes #3175. The npm package is published by GoReleaser's npm pipe, which [only ships archives for `linux`, `darwin`, and `windows`](https://goreleaser.com/customization/publish/npm/#supported-platforms-and-formats). On any other platform the postinstall script throws `No archive available for <platform>-<arch>` (e.g. `openbsd-x64`), which reads as a contradiction next to the "first-class support ... FreeBSD, OpenBSD, and NetBSD" line at the top of the README.

OpenBSD/FreeBSD/NetBSD/Android are genuinely supported, just not through npm: the release binaries cover them (the README already says so a bit further down) and so does `go install`. This change keeps every existing claim and only sets the right expectation on the npm line itself, so a BSD user reaches for the binary download instead of hitting the npm error.

One-line README change, no code touched.