### PR TITLE
fix(scrolling): stale scrolling acceleration

### DIFF
--- a/internal/ui/model/filter.go
+++ b/internal/ui/model/filter.go
@@ -104,5 +104,5 @@ func wheelDeltas(mouse tea.Mouse) (float64, float64) {
 }
 
 func oppositeSign(a, b float64) bool {
-	return a < 0 && b > 0 || a > 0 && b < 0
+	return (a < 0 && b > 0) || (a > 0 && b < 0)
 }

--- a/internal/ui/model/filter.go
+++ b/internal/ui/model/filter.go
@@ -38,6 +38,12 @@ func (f *Filter) Filter(_ tea.Model, msg tea.Msg) tea.Msg {
 	case tea.MouseWheelMsg:
 		mouse := typed.Mouse()
 		dx, dy := wheelDeltas(mouse)
+		if oppositeSign(f.wheelDX, dx) {
+			f.wheelDX = 0
+		}
+		if oppositeSign(f.wheelDY, dy) {
+			f.wheelDY = 0
+		}
 		f.wheelDX += dx
 		f.wheelDY += dy
 		if !f.allow(&f.lastWheel) {
@@ -95,4 +101,8 @@ func wheelDeltas(mouse tea.Mouse) (float64, float64) {
 	default:
 		return 0, 0
 	}
+}
+
+func oppositeSign(a, b float64) bool {
+	return a < 0 && b > 0 || a > 0 && b < 0
 }

--- a/internal/ui/model/filter_test.go
+++ b/internal/ui/model/filter_test.go
@@ -61,7 +61,7 @@ func TestFilter_CoalescesSameDirection(t *testing.T) {
 	require.Equal(t, float64(3), msg.DeltaY, "should accumulate 3 down events")
 }
 
-func TestFilter_DirectionChangeResetsAccumulator(t *testing.T) {
+func TestFilter_DirectionChangeWithinWindowAccumulatesNewDirection(t *testing.T) {
 	t.Parallel()
 	f, now := newTestFilter(t)
 
@@ -81,7 +81,7 @@ func TestFilter_DirectionChangeResetsAccumulator(t *testing.T) {
 	require.Equal(t, float64(-2), msg.DeltaY, "should have 2 accumulated up events")
 }
 
-func TestFilter_DirectionChangeWithinWindowAccumulatesNewDirection(t *testing.T) {
+func TestFilter_DirectionChangeDropsStaleAccumulator(t *testing.T) {
 	t.Parallel()
 	f, now := newTestFilter(t)
 

--- a/internal/ui/model/filter_test.go
+++ b/internal/ui/model/filter_test.go
@@ -81,6 +81,31 @@ func TestFilter_DirectionChangeResetsAccumulator(t *testing.T) {
 	require.Equal(t, float64(-2), msg.DeltaY, "should have 2 accumulated up events")
 }
 
+func TestFilter_DirectionChangeDropsStaleAccumulator(t *testing.T) {
+	t.Parallel()
+	f, now := newTestFilter(t)
+
+	// Scroll up
+	f.Filter(nil, wheelUp())
+
+	// Scroll up again
+	*now = now.Add(5 * time.Millisecond)
+	result := f.Filter(nil, wheelUp())
+	require.Nil(t, result)
+
+	// Scroll down (accumulation should reset)
+	*now = now.Add(5 * time.Millisecond)
+	result = f.Filter(nil, wheelDown())
+	require.Nil(t, result)
+
+	// And scroll down again
+	*now = now.Add(20 * time.Millisecond)
+	result = f.Filter(nil, wheelDown())
+	msg, ok := result.(common.CoalescedWheelMsg)
+	require.True(t, ok)
+	require.Equal(t, float64(2), msg.DeltaY, "should drop stale opposite-direction events")
+}
+
 func TestFilter_WindowExpiryEmitsAccumulated(t *testing.T) {
 	t.Parallel()
 	f, now := newTestFilter(t)

--- a/internal/ui/model/filter_test.go
+++ b/internal/ui/model/filter_test.go
@@ -81,7 +81,7 @@ func TestFilter_DirectionChangeResetsAccumulator(t *testing.T) {
 	require.Equal(t, float64(-2), msg.DeltaY, "should have 2 accumulated up events")
 }
 
-func TestFilter_DirectionChangeDropsStaleAccumulator(t *testing.T) {
+func TestFilter_DirectionChangeWithinWindowAccumulatesNewDirection(t *testing.T) {
 	t.Parallel()
 	f, now := newTestFilter(t)
 


### PR DESCRIPTION
Assisted-By: openai/gpt-5.5 via Crush (modified ver.)

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- (N/A) I have created a discussion that was approved by a maintainer (for new features).

This PR includes solution provided by AI. I asked AI to address the cause. And it turns out to be a bug in the mouse delta calculation. The solution is resetting the delta when there is an opposite direction scroll.

The fix includes a new test case preventing stale scroll acceleration.

---

The below demo is from the bottom of a chat, do up -> up -> down -> down.

Before:
[crush-demo-before.webm](https://github.com/user-attachments/assets/98df5560-cf71-41bc-8e9f-1f15f7021a15)

After:
[crush-demo-after.webm](https://github.com/user-attachments/assets/1b56afb3-dedb-444e-837d-ec95c46726e2)
