### PR TITLE
fix: prevent flaky diffview golden tests on Windows CI

### DIFF
--- a/internal/ui/diffview/diffview_test.go
+++ b/internal/ui/diffview/diffview_test.go
@@ -212,8 +212,6 @@ func TestDiffViewWidth(t *testing.T) {
 				}
 
 				t.Run(fmt.Sprintf("WidthOf%03d", width), func(t *testing.T) {
-					t.Parallel()
-
 					dv := diffview.New().
 						Before("main.go", TestMultipleHunksBefore).
 						After("main.go", TestMultipleHunksAfter).
@@ -237,8 +235,6 @@ func TestDiffViewHeight(t *testing.T) {
 		t.Run(layoutName, func(t *testing.T) {
 			for height := 1; height <= 20; height++ {
 				t.Run(fmt.Sprintf("HeightOf%03d", height), func(t *testing.T) {
-					t.Parallel()
-
 					dv := diffview.New().
 						Before("main.go", TestMultipleHunksBefore).
 						After("main.go", TestMultipleHunksAfter).
@@ -260,8 +256,6 @@ func TestDiffViewXOffset(t *testing.T) {
 		t.Run(layoutName, func(t *testing.T) {
 			for xOffset := range 21 {
 				t.Run(fmt.Sprintf("XOffsetOf%02d", xOffset), func(t *testing.T) {
-					t.Parallel()
-
 					dv := diffview.New().
 						Before("main.go", TestDefaultBefore).
 						After("main.go", TestDefaultAfter).
@@ -286,8 +280,6 @@ func TestDiffViewYOffset(t *testing.T) {
 		t.Run(layoutName, func(t *testing.T) {
 			for yOffset := range 17 {
 				t.Run(fmt.Sprintf("YOffsetOf%02d", yOffset), func(t *testing.T) {
-					t.Parallel()
-
 					dv := diffview.New().
 						Before("main.go", TestMultipleHunksBefore).
 						After("main.go", TestMultipleHunksAfter).
@@ -310,8 +302,6 @@ func TestDiffViewYOffsetInfinite(t *testing.T) {
 		t.Run(layoutName, func(t *testing.T) {
 			for yOffset := range 17 {
 				t.Run(fmt.Sprintf("YOffsetOf%02d", yOffset), func(t *testing.T) {
-					t.Parallel()
-
 					dv := diffview.New().
 						Before("main.go", TestMultipleHunksBefore).
 						After("main.go", TestMultipleHunksAfter).


### PR DESCRIPTION
Chroma's regexp2 engine has a hardcoded 250ms match timeout. On Windows CI with -race and 110+ parallel subtests, CPU contention causes regex matches to exceed this timeout, silently skipping rules and producing different token types (NameOther instead of NameFunction). Remove t.Parallel() from innermost subtests to reduce contention while keeping parent-level parallelism.