### PR TITLE
feat(tui): configurable session logo style (wordmark/gradient/hidden)

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,29 @@ To disable desktop notifications, set `disable_notifications` to `true` in your
 configuration. On macOS, notifications currently lack icons due to platform
 limitations.
 
+### Session logo
+
+The session logo (shown in the sidebar in normal mode, and in the header in
+compact mode) can be styled or hidden with the `options.tui.logo` setting:
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "options": {
+    "tui": {
+      "logo": "gradient"
+    }
+  }
+}
+```
+
+- `wordmark` (default): the Crush wordmark.
+- `gradient`: a text-free diagonal field using the theme's title gradient.
+- `hidden`: no logo at all.
+
+You can also switch it at runtime from the commands palette (Ctrl+P →
+**Session Logo**); the choice is saved to your global config.
+
 ### Initialization
 
 When you initialize a project, Crush analyzes your codebase and creates

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -218,9 +218,25 @@ type LSPConfig struct {
 	Timeout     int               `json:"timeout,omitempty" jsonschema:"description=Timeout in seconds for LSP server initialization,default=30,example=60,example=120"`
 }
 
+// LogoStyle selects how the session logo is rendered in the TUI. It applies
+// to the sidebar logo in normal mode and the header logo in compact mode.
+type LogoStyle string
+
+const (
+	// LogoStyleWordmark renders the Crush wordmark. This is the default and is
+	// also used when the value is empty.
+	LogoStyleWordmark LogoStyle = "wordmark"
+	// LogoStyleGradient renders a text-free diagonal field using the title
+	// gradient, dropping the wordmark.
+	LogoStyleGradient LogoStyle = "gradient"
+	// LogoStyleHidden renders no logo at all.
+	LogoStyleHidden LogoStyle = "hidden"
+)
+
 type TUIOptions struct {
-	CompactMode bool   `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
-	DiffMode    string `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
+	CompactMode bool      `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
+	DiffMode    string    `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
+	Logo        LogoStyle `json:"logo,omitempty" jsonschema:"description=Session logo style for the TUI. Applies to the sidebar logo in normal mode and the header logo in compact mode,enum=wordmark,enum=gradient,enum=hidden,default=wordmark"`
 	// Here we can add themes later or any TUI related options
 	//
 

--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -192,6 +192,7 @@ reviewed.
     "tui": {
       "compact_mode": false,
       "diff_mode": "unified",
+      "logo": "wordmark",
       "transparent": false
     },
     "auto_lsp": true,

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -56,6 +56,11 @@ type (
 	ActionSelectNotificationStyle struct {
 		Style string
 	}
+	// ActionSelectLogoStyle is sent when a session logo style is selected from
+	// the logo picker dialog.
+	ActionSelectLogoStyle struct {
+		Style string
+	}
 	ActionToggleTransparentBackground struct{}
 	ActionInitializeProject           struct{}
 	ActionSummarize                   struct {

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -515,6 +515,9 @@ func (c *Commands) defaultCommands() []*CommandItem {
 	notificationLabel := "Notification Style"
 	commands = append(commands, NewCommandItem(c.com.Styles, "select_notifications", notificationLabel, "", ActionOpenDialog{DialogID: NotificationsID}))
 
+	// Add a command for selecting the session logo style via picker dialog.
+	commands = append(commands, NewCommandItem(c.com.Styles, "select_logo", "Session Logo", "", ActionOpenDialog{DialogID: LogoID}))
+
 	commands = append(
 		commands,
 		NewCommandItem(c.com.Styles, "toggle_yolo", "Toggle Yolo Mode", "ctrl+y", ActionToggleYoloMode{}),

--- a/internal/ui/dialog/logo.go
+++ b/internal/ui/dialog/logo.go
@@ -1,0 +1,309 @@
+package dialog
+
+import (
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/list"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/sahilm/fuzzy"
+)
+
+const (
+	// LogoID is the identifier for the session logo style picker dialog.
+	LogoID              = "logo"
+	logoDialogMaxWidth  = 50
+	logoDialogMaxHeight = 12
+)
+
+// LogoOption represents a session logo style option.
+type LogoOption struct {
+	ID          string
+	Title       string
+	Description string
+}
+
+// AllLogoStyles lists all available session logo styles in order.
+var AllLogoStyles = []LogoOption{
+	{ID: string(config.LogoStyleWordmark), Title: "Wordmark", Description: "Show the Crush wordmark (default)"},
+	{ID: string(config.LogoStyleGradient), Title: "Gradient", Description: "Text-free gradient field, no wordmark"},
+	{ID: string(config.LogoStyleHidden), Title: "Hidden", Description: "Hide the logo entirely"},
+}
+
+// Logo represents a dialog for selecting the session logo style.
+type Logo struct {
+	com   *common.Common
+	help  help.Model
+	list  *list.FilterableList
+	input textinput.Model
+
+	keyMap struct {
+		Select   key.Binding
+		Next     key.Binding
+		Previous key.Binding
+		UpDown   key.Binding
+		Close    key.Binding
+	}
+}
+
+// LogoItem represents a logo style list item.
+type LogoItem struct {
+	*list.Versioned
+	opt       LogoOption
+	isCurrent bool
+	t         *styles.Styles
+	m         fuzzy.Match
+	cache     map[int]string
+	focused   bool
+}
+
+// Finished implements list.Item. Logo items are render-stable outside of
+// explicit SetFocused / SetMatch.
+func (l *LogoItem) Finished() bool {
+	return true
+}
+
+var (
+	_ Dialog   = (*Logo)(nil)
+	_ ListItem = (*LogoItem)(nil)
+)
+
+// NewLogo creates a new session logo style picker dialog.
+func NewLogo(com *common.Common) *Logo {
+	l := &Logo{com: com}
+
+	h := help.New()
+	h.Styles = com.Styles.DialogHelpStyles()
+	l.help = h
+
+	l.list = list.NewFilterableList()
+	l.list.Focus()
+
+	l.input = textinput.New()
+	l.input.SetVirtualCursor(false)
+	l.input.Placeholder = "Type to filter"
+	l.input.SetStyles(com.Styles.TextInput)
+	l.input.Focus()
+
+	l.keyMap.Select = key.NewBinding(
+		key.WithKeys("enter", "ctrl+y"),
+		key.WithHelp("enter", "confirm"),
+	)
+	l.keyMap.Next = key.NewBinding(
+		key.WithKeys("down", "ctrl+n"),
+		key.WithHelp("↓", "next item"),
+	)
+	l.keyMap.Previous = key.NewBinding(
+		key.WithKeys("up", "ctrl+p"),
+		key.WithHelp("↑", "previous item"),
+	)
+	l.keyMap.UpDown = key.NewBinding(
+		key.WithKeys("up", "down"),
+		key.WithHelp("↑/↓", "choose"),
+	)
+	l.keyMap.Close = CloseKey
+
+	l.setItems()
+	return l
+}
+
+// ID implements Dialog.
+func (l *Logo) ID() string {
+	return LogoID
+}
+
+// HandleMsg implements [Dialog].
+func (l *Logo) HandleMsg(msg tea.Msg) Action {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, l.keyMap.Close):
+			return ActionClose{}
+		case key.Matches(msg, l.keyMap.Previous):
+			l.list.Focus()
+			if l.list.IsSelectedFirst() {
+				l.list.SelectLast()
+				l.list.ScrollToBottom()
+				break
+			}
+			l.list.SelectPrev()
+			l.list.ScrollToSelected()
+		case key.Matches(msg, l.keyMap.Next):
+			l.list.Focus()
+			if l.list.IsSelectedLast() {
+				l.list.SelectFirst()
+				l.list.ScrollToTop()
+				break
+			}
+			l.list.SelectNext()
+			l.list.ScrollToSelected()
+		case key.Matches(msg, l.keyMap.Select):
+			selectedItem := l.list.SelectedItem()
+			if selectedItem == nil {
+				break
+			}
+			logoItem, ok := selectedItem.(*LogoItem)
+			if !ok {
+				break
+			}
+			return ActionSelectLogoStyle{Style: logoItem.opt.ID}
+		default:
+			var cmd tea.Cmd
+			l.input, cmd = l.input.Update(msg)
+			value := l.input.Value()
+			l.list.SetFilter(value)
+			l.list.ScrollToTop()
+			l.list.SetSelected(0)
+			return ActionCmd{cmd}
+		}
+	}
+	return nil
+}
+
+// Cursor returns the cursor position relative to the dialog.
+func (l *Logo) Cursor() *tea.Cursor {
+	return InputCursor(l.com.Styles, l.input.Cursor())
+}
+
+// Draw implements [Dialog].
+func (l *Logo) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	t := l.com.Styles
+	width := max(0, min(logoDialogMaxWidth, area.Dx()))
+	height := max(0, min(logoDialogMaxHeight, area.Dy()))
+	innerWidth := width - t.Dialog.View.GetHorizontalFrameSize()
+	heightOffset := t.Dialog.Title.GetVerticalFrameSize() + titleContentHeight +
+		t.Dialog.InputPrompt.GetVerticalFrameSize() + inputContentHeight +
+		t.Dialog.HelpView.GetVerticalFrameSize() +
+		t.Dialog.View.GetVerticalFrameSize()
+
+	l.input.SetWidth(innerWidth - t.Dialog.InputPrompt.GetHorizontalFrameSize() - 1)
+	l.list.SetSize(innerWidth, height-heightOffset)
+	l.help.SetWidth(innerWidth)
+
+	rc := NewRenderContext(t, width)
+	rc.Title = "Session Logo"
+	inputView := t.Dialog.InputPrompt.Render(l.input.View())
+	rc.AddPart(inputView)
+
+	visibleCount := len(l.list.FilteredItems())
+	if l.list.Height() >= visibleCount {
+		l.list.ScrollToTop()
+	} else {
+		l.list.ScrollToSelected()
+	}
+
+	listView := t.Dialog.List.Height(l.list.Height()).Render(l.list.Render())
+	rc.AddPart(listView)
+	rc.Help = l.help.View(l)
+
+	view := rc.Render()
+
+	cur := l.Cursor()
+	DrawCenterCursor(scr, area, view, cur)
+	return cur
+}
+
+// ShortHelp implements [help.KeyMap].
+func (l *Logo) ShortHelp() []key.Binding {
+	return []key.Binding{
+		l.keyMap.UpDown,
+		l.keyMap.Select,
+		l.keyMap.Close,
+	}
+}
+
+// FullHelp implements [help.KeyMap].
+func (l *Logo) FullHelp() [][]key.Binding {
+	m := [][]key.Binding{}
+	slice := []key.Binding{
+		l.keyMap.Select,
+		l.keyMap.Next,
+		l.keyMap.Previous,
+		l.keyMap.Close,
+	}
+	for i := 0; i < len(slice); i += 4 {
+		end := min(i+4, len(slice))
+		m = append(m, slice[i:end])
+	}
+	return m
+}
+
+func (l *Logo) setItems() {
+	cfg := l.com.Config()
+	currentStyle := string(config.LogoStyleWordmark)
+	if cfg != nil && cfg.Options != nil && cfg.Options.TUI != nil && cfg.Options.TUI.Logo != "" {
+		currentStyle = string(cfg.Options.TUI.Logo)
+	}
+
+	items := make([]list.FilterableItem, 0, len(AllLogoStyles))
+	selectedIndex := 0
+	for i, opt := range AllLogoStyles {
+		item := &LogoItem{
+			Versioned: list.NewVersioned(),
+			opt:       opt,
+			isCurrent: opt.ID == currentStyle,
+			t:         l.com.Styles,
+		}
+		items = append(items, item)
+		if opt.ID == currentStyle {
+			selectedIndex = i
+		}
+	}
+
+	l.list.SetItems(items...)
+	l.list.SetSelected(selectedIndex)
+	l.list.ScrollToSelected()
+}
+
+// Filter returns the filter value for the logo item.
+func (l *LogoItem) Filter() string {
+	return l.opt.Title
+}
+
+// ID returns the unique identifier for the logo style.
+func (l *LogoItem) ID() string {
+	return l.opt.ID
+}
+
+// SetFocused sets the focus state of the logo item.
+func (l *LogoItem) SetFocused(focused bool) {
+	if l.focused == focused {
+		return
+	}
+	l.cache = nil
+	l.focused = focused
+	if l.Versioned != nil {
+		l.Bump()
+	}
+}
+
+// SetMatch sets the fuzzy match for the logo item.
+func (l *LogoItem) SetMatch(m fuzzy.Match) {
+	if sameFuzzyMatch(l.m, m) {
+		return
+	}
+	l.cache = nil
+	l.m = m
+	if l.Versioned != nil {
+		l.Bump()
+	}
+}
+
+// Render returns the string representation of the logo item.
+func (l *LogoItem) Render(width int) string {
+	info := ""
+	if l.isCurrent {
+		info = "current"
+	}
+	st := ListItemStyles{
+		ItemBlurred:     l.t.Dialog.NormalItem,
+		ItemFocused:     l.t.Dialog.SelectedItem,
+		InfoTextBlurred: l.t.Dialog.ListItem.InfoBlurred,
+		InfoTextFocused: l.t.Dialog.ListItem.InfoFocused,
+	}
+	return renderItem(st, l.opt.Title, info, l.focused, width, l.cache, &l.m)
+}

--- a/internal/ui/logo/logo.go
+++ b/internal/ui/logo/logo.go
@@ -28,6 +28,11 @@ type Opts struct {
 	Width        int         // width of the rendered logo, used for truncation
 	Hyper        bool        // whether it is Crush or Hypercrush
 
+	// TextFree renders a gradient diagonal field with no wordmark, using the
+	// title gradient (TitleColorA -> TitleColorB). Used for the "gradient" logo
+	// style.
+	TextFree bool
+
 	// When true, stretch a random letterform on each render. Has no effect in
 	// compact mode. Mainly for testing. In production you will want to cache
 	// the stretched letterform to keep the logo from jittering on resize.
@@ -107,7 +112,18 @@ func Render(base lipgloss.Style, version string, compact bool, o Opts) string {
 	// Narrow version. If this is Hypercrush, this is also a stacked version.
 	if compact {
 		field := fg(o.FieldColor, strings.Repeat(diag, crushWidth))
-		return strings.Join([]string{field, field, crush, field, ""}, "\n")
+		block := strings.Join([]string{field, field, crush, field, ""}, "\n")
+		if o.TextFree {
+			// Replace the wordmark with a text-free gradient field of the same
+			// height so the surrounding layout does not shift.
+			line := strings.Repeat(diag, crushWidth)
+			rows := make([]string, lipgloss.Height(block))
+			for i := range rows {
+				rows[i] = styles.ApplyForegroundGrad(base, line, o.TitleColorA, o.TitleColorB)
+			}
+			return strings.Join(rows, "\n")
+		}
+		return block
 	}
 
 	fieldHeight := lipgloss.Height(crush)
@@ -149,6 +165,15 @@ func Render(base lipgloss.Style, version string, compact bool, o Opts) string {
 // SmallRender renders a smaller version of the Crush logo, suitable for
 // smaller windows or sidebar usage.
 func SmallRender(t *styles.Styles, width int, o Opts) string {
+	if o.TextFree {
+		// Single-line text-free gradient field for the compact sidebar.
+		return styles.ApplyForegroundGrad(
+			t.Logo.GradCanvas,
+			strings.Repeat(diag, max(0, width)),
+			t.Logo.SmallGradFromColor,
+			t.Logo.SmallGradToColor,
+		)
+	}
 	name := "Crush"
 	if o.Hyper {
 		name = "HYPERCRUSH"

--- a/internal/ui/logo/logo_test.go
+++ b/internal/ui/logo/logo_test.go
@@ -1,0 +1,68 @@
+package logo
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func textFreeOpts(width int) Opts {
+	return Opts{
+		FieldColor:  lipgloss.Color("#444444"),
+		TitleColorA: lipgloss.Color("#ff0000"),
+		TitleColorB: lipgloss.Color("#0000ff"),
+		Width:       width,
+		TextFree:    true,
+	}
+}
+
+// onlyDiagonals returns any glyphs left after stripping the diagonal field
+// character and layout whitespace. It must be empty for a text-free logo.
+func onlyDiagonals(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '╱', '\n', ' ', '\t':
+			return -1
+		}
+		return r
+	}, ansi.Strip(s))
+}
+
+func TestRenderTextFreeHasNoWordmark(t *testing.T) {
+	t.Parallel()
+
+	// The version string would appear in the wordmark meta row; the text-free
+	// field must drop it along with the letterforms.
+	out := Render(lipgloss.NewStyle(), "v1.2.3", true, textFreeOpts(30))
+	require.Contains(t, ansi.Strip(out), "╱")
+	require.Empty(t, onlyDiagonals(out),
+		"text-free logo should render only the diagonal field")
+}
+
+func TestRenderTextFreeMatchesWordmarkHeight(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	mk := func(textFree bool) string {
+		o := textFreeOpts(30)
+		o.TextFree = textFree
+		return Render(base, "v1.2.3", true, o)
+	}
+	require.Equal(t, lipgloss.Height(mk(false)), lipgloss.Height(mk(true)),
+		"text-free logo must match the wordmark height to avoid layout shift")
+}
+
+func TestSmallRenderTextFree(t *testing.T) {
+	t.Parallel()
+
+	s := styles.ThemeForProvider("")
+	out := SmallRender(&s, 20, Opts{TextFree: true})
+	require.NotContains(t, ansi.Strip(out), "\n", "small logo is a single line")
+	require.Contains(t, ansi.Strip(out), "╱")
+	require.Empty(t, onlyDiagonals(out),
+		"text-free small logo should render only the diagonal field")
+}

--- a/internal/ui/model/header.go
+++ b/internal/ui/model/header.go
@@ -54,8 +54,25 @@ func (h *header) refresh() {
 	if isHyper {
 		name = "HYPERCRUSH"
 	}
-	h.compactLogo = t.Header.Charm.Render(charm) + " " +
+	wordmark := t.Header.Charm.Render(charm) + " " +
 		styles.ApplyBoldForegroundGrad(t.Header.LogoGradCanvas, name, t.Header.LogoGradFromColor, t.Header.LogoGradToColor) + " "
+
+	style := config.LogoStyleWordmark
+	if h.com != nil && h.com.Workspace != nil {
+		style = sessionLogoStyle(h.com.Config())
+	}
+	switch style {
+	case config.LogoStyleHidden:
+		h.compactLogo = ""
+	case config.LogoStyleGradient:
+		// Text-free gradient field the same width as the wordmark so the header
+		// details layout is unaffected.
+		field := strings.Repeat(headerDiag, max(0, lipgloss.Width(wordmark)-1))
+		h.compactLogo = styles.ApplyForegroundGrad(t.Header.LogoGradCanvas, field, t.Header.LogoGradFromColor, t.Header.LogoGradToColor) + " "
+	default:
+		h.compactLogo = wordmark
+	}
+
 	// Force drawHeader to re-render the wide logo on the next frame.
 	h.width = 0
 	h.logo = ""
@@ -73,7 +90,9 @@ func (h *header) drawHeader(
 ) {
 	t := h.com.Styles
 	if width != h.width || compact != h.compact {
-		h.logo = renderLogo(h.com.Styles, compact, h.com.IsHyper(), width)
+		// The wide/landing logo keeps the wordmark; the configurable session
+		// logo style applies to the sidebar and the compact header logo.
+		h.logo = renderLogo(h.com.Styles, compact, h.com.IsHyper(), width, config.LogoStyleWordmark)
 	}
 
 	h.width = width

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -6,6 +6,7 @@ import (
 	"image"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/logo"
 	uv "github.com/charmbracelet/ultraviolet"
@@ -141,20 +142,25 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 
 	title := t.Sidebar.SessionTitle.Width(width).MaxHeight(2).Render(m.session.Title)
 	cwd := common.PrettyPath(t, m.com.Workspace.WorkingDir(), width)
+	style := m.logoStyle()
 	sidebarLogo := m.sidebarLogo
-	if height < logoHeightBreakpoint {
+	if height < logoHeightBreakpoint && style != config.LogoStyleHidden {
 		sidebarLogo = logo.SmallRender(m.com.Styles, width, logo.Opts{
-			Hyper: m.com.IsHyper(),
+			Hyper:    m.com.IsHyper(),
+			TextFree: style == config.LogoStyleGradient,
 		})
 	}
 	blocks := []string{
-		sidebarLogo,
 		title,
 		"",
 		cwd,
 		"",
 		m.modelInfo(width),
 		"",
+	}
+	if sidebarLogo != "" {
+		// The logo block carries its own trailing spacing.
+		blocks = append([]string{sidebarLogo}, blocks...)
 	}
 
 	sidebarHeader := lipgloss.JoinVertical(

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1528,6 +1528,24 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			m.notifyBackend = selectNotificationBackend(m.caps, cfg)
 		}
 		m.dialog.CloseDialog(dialog.NotificationsID)
+	case dialog.ActionSelectLogoStyle:
+		cfg := m.com.Config()
+		if cfg != nil && cfg.Options != nil && cfg.Options.TUI != nil {
+			cfg.Options.TUI.Logo = config.LogoStyle(msg.Style)
+			if err := m.com.Workspace.SetConfigField(config.ScopeGlobal, "options.tui.logo", msg.Style); err != nil {
+				cmds = append(cmds, util.ReportError(err))
+			} else {
+				// Rebuild cached logos and re-layout so the change is visible
+				// immediately in both normal and compact modes.
+				m.header.refresh()
+				if m.layout.sidebar.Dx() > 0 {
+					m.cacheSidebarLogo(m.layout.sidebar.Dx())
+				}
+				m.updateLayoutAndSize()
+				cmds = append(cmds, util.CmdHandler(util.NewInfoMsg("Logo: "+msg.Style)))
+			}
+		}
+		m.dialog.CloseDialog(dialog.LogoID)
 	case dialog.ActionNewSession:
 		if m.isAgentBusy() {
 			cmds = append(cmds, util.ReportWarn("Agent is busy, please wait before starting a new session..."))
@@ -3366,9 +3384,33 @@ func (m *UI) renderEditorView(width int) string {
 	}, "\n")
 }
 
+// sessionLogoStyle returns the configured session logo style, defaulting to
+// wordmark when unset.
+func sessionLogoStyle(cfg *config.Config) config.LogoStyle {
+	if cfg != nil {
+		if o := cfg.Options; o != nil && o.TUI != nil && o.TUI.Logo != "" {
+			return o.TUI.Logo
+		}
+	}
+	return config.LogoStyleWordmark
+}
+
+// logoStyle returns the configured session logo style, defaulting to wordmark.
+func (m *UI) logoStyle() config.LogoStyle {
+	if m.com == nil || m.com.Workspace == nil {
+		return config.LogoStyleWordmark
+	}
+	return sessionLogoStyle(m.com.Config())
+}
+
 // cacheSidebarLogo renders and caches the sidebar logo at the specified width.
 func (m *UI) cacheSidebarLogo(width int) {
-	m.sidebarLogo = renderLogo(m.com.Styles, true, m.com.IsHyper(), width)
+	style := m.logoStyle()
+	if style == config.LogoStyleHidden {
+		m.sidebarLogo = ""
+		return
+	}
+	m.sidebarLogo = renderLogo(m.com.Styles, true, m.com.IsHyper(), width, style)
 }
 
 // applyTheme replaces the active styles with the given theme, drops the
@@ -3640,6 +3682,10 @@ func (m *UI) openDialog(id string) tea.Cmd {
 		if cmd := m.openNotificationsDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+	case dialog.LogoID:
+		if cmd := m.openLogoDialog(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case dialog.FilePickerID:
 		if cmd := m.openFilesDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -3738,6 +3784,18 @@ func (m *UI) openNotificationsDialog() tea.Cmd {
 
 	notificationsDialog := dialog.NewNotifications(m.com)
 	m.dialog.OpenDialog(notificationsDialog)
+	return nil
+}
+
+// openLogoDialog opens the session logo style picker dialog.
+func (m *UI) openLogoDialog() tea.Cmd {
+	if m.dialog.ContainsDialog(dialog.LogoID) {
+		m.dialog.BringToFront(dialog.LogoID)
+		return nil
+	}
+
+	logoDialog := dialog.NewLogo(m.com)
+	m.dialog.OpenDialog(logoDialog)
 	return nil
 }
 
@@ -4259,7 +4317,7 @@ func (m *UI) disableDockerMCP() tea.Msg {
 }
 
 // renderLogo renders the Crush logo with the given styles and dimensions.
-func renderLogo(t *styles.Styles, compact, hyper bool, width int) string {
+func renderLogo(t *styles.Styles, compact, hyper bool, width int, style config.LogoStyle) string {
 	return logo.Render(t.Logo.GradCanvas, version.Version, compact, logo.Opts{
 		FieldColor:   t.Logo.FieldColor,
 		TitleColorA:  t.Logo.TitleColorA,
@@ -4268,5 +4326,6 @@ func renderLogo(t *styles.Styles, compact, hyper bool, width int) string {
 		VersionColor: t.Logo.VersionColor,
 		Width:        width,
 		Hyper:        hyper,
+		TextFree:     style == config.LogoStyleGradient,
 	})
 }

--- a/schema.json
+++ b/schema.json
@@ -747,6 +747,16 @@
           ],
           "description": "Diff mode for the TUI interface"
         },
+        "logo": {
+          "type": "string",
+          "enum": [
+            "wordmark",
+            "gradient",
+            "hidden"
+          ],
+          "description": "Session logo style for the TUI. Applies to the sidebar logo in normal mode and the header logo in compact mode",
+          "default": "wordmark"
+        },
         "completions": {
           "$ref": "#/$defs/Completions",
           "description": "Completions UI options"


### PR DESCRIPTION
## Summary

Adds `options.tui.logo` so the session logo can be styled or hidden:

| value | result |
| --- | --- |
| `wordmark` (default) | the Crush wordmark, unchanged |
| `gradient` | a text-free diagonal field using the theme's title gradient |
| `hidden` | no logo |

The setting applies to the logo in **both** layouts — the sidebar logo in
normal mode and the header logo in compact mode — so the choice is consistent
regardless of terminal width.

## Motivation

The wordmark is the only option today. Some users want a cleaner sidebar/header:
either no branding at all, or the diagonal gradient field without the wordmark
text. This makes it a per-config choice while keeping the current look as the
default.

## What's in the change

- **Config:** new `LogoStyle` enum + `TUIOptions.Logo` (`internal/config/config.go`);
  `schema.json` regenerated via `go run . schema`.
- **Rendering:** `logo.Opts.TextFree` renders the gradient field with no wordmark,
  at the **same height as the wordmark** so the surrounding layout never shifts
  (`internal/ui/logo/logo.go`).
- **Wiring:** the sidebar (`sidebar.go`) and compact header (`header.go`) honor the
  style; `hidden` drops the logo block entirely. The onboarding/landing splash logo
  is intentionally left as the wordmark.
- **Runtime toggle:** a "Session Logo" picker in the command palette
  (`internal/ui/dialog/logo.go`), mirroring the existing notification-style picker.
  The selection persists to the global config.
- **Docs:** README section + the `crush-config` skill.
- **Tests:** `logo` package tests covering the "no text" and height-invariance
  (no layout shift) guarantees.

## Usage

Config:

```json
{ "options": { "tui": { "logo": "gradient" } } }
```

Or at runtime: `Ctrl+P` → **Session Logo** → pick `wordmark` / `gradient` / `hidden`.

## Testing

- `go build ./...`, `go vet`, and `go test` for the affected packages
  (`config`, `ui/logo`, `ui/model`, `ui/dialog`, `cmd`) pass.
- `gofumpt` clean.
- New unit tests in `internal/ui/logo/logo_test.go`.

> Screenshots: gradient / hidden in the sidebar and compact header._

<img width="1544" height="744" alt="crush_the_logo" src="https://github.com/user-attachments/assets/42bf5b92-1e96-45e5-9651-6d976a58a0f0" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
