### PR TITLE
fix(auth): stop two Crush instances from invalidating each other's login

### DIFF
--- a/internal/config/refresh_singleflight_test.go
+++ b/internal/config/refresh_singleflight_test.go
@@ -1,0 +1,175 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/stretchr/testify/require"
+)
+
+// newRefreshTestStore builds a ConfigStore whose hyper provider holds an
+// expired OAuth token, persisted both in memory and on disk at configPath.
+// Stores that share a configPath also share the per-provider refresh lock,
+// which lets a single test process faithfully simulate two crush instances:
+// lock.File opens a fresh descriptor per call, so two stores block each
+// other on the same lock file exactly as two processes would.
+func newRefreshTestStore(t *testing.T, configPath string, exchange func(ctx context.Context, providerID, refreshToken string) (*oauth.Token, error)) *ConfigStore {
+	t.Helper()
+
+	expired := &oauth.Token{
+		AccessToken:  "at0",
+		RefreshToken: "rt0",
+		ExpiresIn:    3600,
+		ExpiresAt:    time.Now().Add(-time.Hour).Unix(),
+	}
+	configContent := `{
+		"providers": {
+			"hyper": {
+				"oauth": {
+					"access_token": "at0",
+					"refresh_token": "rt0",
+					"expires_in": 3600,
+					"expires_at": ` + fmt.Sprintf("%d", expired.ExpiresAt) + `
+				}
+			}
+		}
+	}`
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o600))
+
+	providers := csync.NewMap[string, ProviderConfig]()
+	providers.Set("hyper", ProviderConfig{
+		ID:         "hyper",
+		Name:       "Hyper",
+		APIKey:     expired.AccessToken,
+		OAuthToken: expired,
+	})
+
+	return &ConfigStore{
+		config:         &Config{Providers: providers},
+		globalDataPath: configPath,
+		workingDir:     filepath.Dir(configPath),
+		exchangeToken:  exchange,
+	}
+}
+
+// TestRefreshOAuthToken_InProcessSingleFlight verifies that a storm of
+// concurrent refresh calls for the same provider collapses into a single
+// token exchange.
+func TestRefreshOAuthToken_InProcessSingleFlight(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "crush.json")
+
+	var exchanges atomic.Int64
+	store := newRefreshTestStore(t, configPath, func(ctx context.Context, providerID, refreshToken string) (*oauth.Token, error) {
+		exchanges.Add(1)
+		time.Sleep(50 * time.Millisecond) // hold the flight open so peers join
+		return &oauth.Token{
+			AccessToken:  "at1",
+			RefreshToken: "rt1",
+			ExpiresIn:    3600,
+			ExpiresAt:    time.Now().Add(time.Hour).Unix(),
+		}, nil
+	})
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, goroutines)
+	for range goroutines {
+		wg.Go(func() {
+			<-start
+			errs <- store.RefreshOAuthToken(context.Background(), ScopeGlobal, "hyper")
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int64(1), exchanges.Load(), "concurrent refreshes should collapse into one exchange")
+
+	pc, ok := store.config.Providers.Get("hyper")
+	require.True(t, ok)
+	require.Equal(t, "at1", pc.OAuthToken.AccessToken)
+	require.Equal(t, "rt1", pc.OAuthToken.RefreshToken)
+}
+
+// TestRefreshOAuthToken_CrossProcessAdopt verifies that when two instances
+// share a credential, only one performs the token exchange and the other
+// adopts the rotated token from disk rather than reusing the consumed
+// refresh token. The fake exchange models a rotating provider: reusing a
+// refresh token it has already rotated returns an error, so a second
+// exchange would be observable as a failure.
+func TestRefreshOAuthToken_CrossProcessAdopt(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "crush.json")
+
+	var (
+		mu          sync.Mutex
+		current     = "rt0" // the only refresh token the server will accept
+		exchanges   atomic.Int64
+		reuseErrors atomic.Int64
+	)
+	exchange := func(ctx context.Context, providerID, refreshToken string) (*oauth.Token, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if refreshToken != current {
+			reuseErrors.Add(1)
+			return nil, fmt.Errorf("refresh token revoked")
+		}
+		exchanges.Add(1)
+		time.Sleep(50 * time.Millisecond) // hold the lock so the peer must wait
+		current = "rt1"
+		return &oauth.Token{
+			AccessToken:  "at1",
+			RefreshToken: "rt1",
+			ExpiresIn:    3600,
+			ExpiresAt:    time.Now().Add(time.Hour).Unix(),
+		}, nil
+	}
+
+	// Two stores sharing the same config file and refresh lock = two
+	// "processes".
+	a := newRefreshTestStore(t, configPath, exchange)
+	b := newRefreshTestStore(t, configPath, exchange)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	for _, s := range []*ConfigStore{a, b} {
+		wg.Go(func() {
+			<-start
+			errs <- s.RefreshOAuthToken(context.Background(), ScopeGlobal, "hyper")
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, int64(1), exchanges.Load(), "only one instance should exchange")
+	require.Equal(t, int64(0), reuseErrors.Load(), "no instance should reuse a rotated refresh token")
+
+	// Both instances converge on the rotated token.
+	for name, s := range map[string]*ConfigStore{"a": a, "b": b} {
+		pc, ok := s.config.Providers.Get("hyper")
+		require.True(t, ok, name)
+		require.Equal(t, "at1", pc.OAuthToken.AccessToken, name)
+		require.Equal(t, "rt1", pc.OAuthToken.RefreshToken, name)
+	}
+}

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -20,12 +20,22 @@ import (
 	"github.com/charmbracelet/crush/internal/oauth/hyper"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"golang.org/x/sync/singleflight"
 )
 
 // configLockDeadline bounds how long lockConfig waits for the
 // cross-process flock before giving up. A few seconds is plenty for
 // honest contention; longer suggests something is wedged.
 const configLockDeadline = 5 * time.Second
+
+// refreshLockDeadline bounds how long RefreshOAuthToken waits for the
+// per-provider cross-process refresh lock. It must exceed the token
+// exchange HTTP timeout (30s) so that a peer mid-exchange is given time
+// to finish and publish its result, which we then adopt instead of
+// running our own exchange. Running our own would reuse an
+// already-rotated refresh token and trip the provider's reuse detection,
+// revoking the whole token family.
+const refreshLockDeadline = 45 * time.Second
 
 // fileSnapshot captures metadata about a config file at a point in time.
 type fileSnapshot struct {
@@ -68,6 +78,18 @@ type ConfigStore struct {
 
 	mu       sync.Mutex // serialises config file writes
 	reloadMu sync.Mutex // serialises ReloadFromDisk calls
+
+	// refreshSF collapses concurrent in-process OAuth refreshes for the
+	// same provider into a single attempt. Combined with the per-provider
+	// cross-process refresh lock, it ensures only one token exchange runs
+	// at a time. See RefreshOAuthToken.
+	refreshSF singleflight.Group
+
+	// exchangeToken performs the provider-specific OAuth token exchange.
+	// It is a field so tests can substitute a fake exchange without making
+	// real network calls. Production code leaves it nil, and exchange falls
+	// back to the real provider clients.
+	exchangeToken func(ctx context.Context, providerID, refreshToken string) (*oauth.Token, error)
 }
 
 // Config returns the pure-data config struct (read-only after load).
@@ -376,63 +398,81 @@ func (s *ConfigStore) SetProviderAPIKey(scope Scope, providerID string, apiKey a
 
 // RefreshOAuthToken refreshes the OAuth token for the given provider.
 //
-// It uses two-phase locking: the pre-check (reading the config file to
-// see if another process already refreshed) happens under the config
-// lock, then the HTTP exchange runs without any lock held, and finally
-// the result is persisted via SetConfigFields (which acquires the lock
-// internally). If the exchange fails — e.g. because another process
-// already rotated the refresh token — the disk is re-checked under lock
-// to recover the other process's token.
+// Providers like Hyper rotate refresh tokens: each exchange consumes the
+// caller's refresh token, issues a new pair, and revokes the old one. If
+// two crush instances (or two goroutines) refresh concurrently with the
+// same stored refresh token, the second exchange reuses an already-revoked
+// token, trips the provider's reuse detection, and revokes the entire
+// token family — leaving both with dead tokens even though each refresh
+// "succeeded".
+//
+// To prevent that, refreshes are single-flighted at two levels:
+//
+//   - In-process: refreshSF collapses concurrent goroutines for the same
+//     provider into one attempt.
+//   - Cross-process: a per-provider advisory lock is held across the whole
+//     read-decide-exchange-write cycle, so only one process exchanges at a
+//     time. A process that acquires the lock after a peer rotated finds the
+//     peer's fresh token on disk and adopts it instead of exchanging.
 func (s *ConfigStore) RefreshOAuthToken(ctx context.Context, scope Scope, providerID string) error {
+	key := fmt.Sprintf("%d\x00%s", scope, providerID)
+	_, err, _ := s.refreshSF.Do(key, func() (any, error) {
+		return nil, s.refreshOAuthTokenLocked(ctx, scope, providerID)
+	})
+	return err
+}
+
+// refreshOAuthTokenLocked performs the cross-process single-flighted
+// refresh. It is invoked through refreshSF, so at most one goroutine per
+// provider runs it at a time within this process.
+func (s *ConfigStore) refreshOAuthTokenLocked(ctx context.Context, scope Scope, providerID string) error {
 	providerConfig, exists := s.config.Providers.Get(providerID)
 	if !exists {
 		return fmt.Errorf("provider %s not found", providerID)
 	}
-
 	if providerConfig.OAuthToken == nil {
 		return fmt.Errorf("provider %s does not have an OAuth token", providerID)
 	}
+	entryToken := providerConfig.OAuthToken
 
-	// Phase 1: Pre-check under lock — did another process already refresh?
-	release, lockErr := s.lockConfig(scope)
+	// Acquire the per-provider cross-process refresh lock. This is a
+	// dedicated lock file, not the config-write lock, and it does not take
+	// s.mu — so the network exchange below cannot stall unrelated config
+	// operations. The deadline exceeds the exchange timeout so that a peer
+	// mid-exchange has time to publish a token we can adopt. Lock ordering:
+	// the refresh lock is always taken before the config-write lock (via
+	// SetConfigFields), never the reverse, so no deadlock is possible.
+	lockCtx, cancel := context.WithTimeout(ctx, refreshLockDeadline)
+	defer cancel()
+	release, lockErr := lock.File(lockCtx, s.refreshLockPath(providerID))
 	if lockErr != nil {
-		slog.Warn("Failed to lock config for pre-check, proceeding anyway", "provider", providerID, "error", lockErr)
-	} else {
-		diskToken, err := s.loadTokenFromDisk(scope, providerID)
-		release()
-		if err != nil {
-			slog.Warn("Failed to read token from config file", "provider", providerID, "error", err)
-		} else if diskToken != nil && !diskToken.IsExpired() && diskToken.AccessToken != providerConfig.OAuthToken.AccessToken {
-			slog.Info("Using token refreshed by another session", "provider", providerID)
+		// Could not acquire the lock (peer wedged or deadline hit). Prefer a
+		// usable token already on disk over forcing our own exchange, which
+		// would risk reusing a rotated refresh token.
+		if diskToken := s.adoptableDiskToken(scope, providerID, entryToken); diskToken != nil {
+			slog.Warn("Refresh lock unavailable; adopting token from disk", "provider", providerID, "error", lockErr)
 			return s.applyToken(providerConfig, diskToken, providerID)
 		}
+		return fmt.Errorf("acquire refresh lock for provider %s: %w", providerID, lockErr)
+	}
+	defer release()
+
+	// Did a peer rotate the token while we waited for the lock? If disk now
+	// holds a different, unexpired token, adopt it instead of exchanging.
+	if diskToken := s.adoptableDiskToken(scope, providerID, entryToken); diskToken != nil {
+		slog.Info("Adopting token refreshed by another session", "provider", providerID)
+		return s.applyToken(providerConfig, diskToken, providerID)
 	}
 
-	// Phase 2: HTTP exchange — no lock held.
-	var refreshedToken *oauth.Token
-	var refreshErr error
-	switch providerID {
-	case string(catwalk.InferenceProviderCopilot):
-		refreshedToken, refreshErr = copilot.RefreshToken(ctx, providerConfig.OAuthToken.RefreshToken)
-	case hyperp.Name:
-		refreshedToken, refreshErr = hyper.ExchangeToken(ctx, providerConfig.OAuthToken.RefreshToken)
-	default:
-		return fmt.Errorf("OAuth refresh not supported for provider %s", providerID)
-	}
+	// Disk still holds our token (or no usable peer token exists) and we hold
+	// the lock, so we are the sole exchanger. Perform the exchange.
+	refreshedToken, refreshErr := s.exchange(ctx, providerID, entryToken.RefreshToken)
 	if refreshErr != nil {
-		// Phase 3: Fallback — re-check disk under lock. The exchange may
-		// have failed because another process already rotated the refresh
-		// token.
-		if release, lockErr := s.lockConfig(scope); lockErr == nil {
-			diskToken, diskErr := s.loadTokenFromDisk(scope, providerID)
-			release()
-			if diskErr == nil &&
-				diskToken != nil &&
-				!diskToken.IsExpired() &&
-				diskToken.AccessToken != providerConfig.OAuthToken.AccessToken {
-				slog.Info("Using token refreshed by another session after exchange failure", "provider", providerID)
-				return s.applyToken(providerConfig, diskToken, providerID)
-			}
+		// The exchange may have failed because a peer rotated the refresh
+		// token in a window we did not cover. Re-check disk and adopt.
+		if diskToken := s.adoptableDiskToken(scope, providerID, entryToken); diskToken != nil {
+			slog.Info("Adopting token refreshed by another session after exchange failure", "provider", providerID)
+			return s.applyToken(providerConfig, diskToken, providerID)
 		}
 		return fmt.Errorf("failed to refresh OAuth token for provider %s: %w", providerID, refreshErr)
 	}
@@ -440,12 +480,9 @@ func (s *ConfigStore) RefreshOAuthToken(ctx context.Context, scope Scope, provid
 	slog.Info("Successfully refreshed OAuth token", "provider", providerID)
 	providerConfig.OAuthToken = refreshedToken
 	providerConfig.APIKey = refreshedToken.AccessToken
-
-	switch providerID {
-	case string(catwalk.InferenceProviderCopilot):
+	if providerID == string(catwalk.InferenceProviderCopilot) {
 		providerConfig.SetupGitHubCopilot()
 	}
-
 	s.config.Providers.Set(providerID, providerConfig)
 
 	if err := s.SetConfigFields(scope, map[string]any{
@@ -454,8 +491,55 @@ func (s *ConfigStore) RefreshOAuthToken(ctx context.Context, scope Scope, provid
 	}); err != nil {
 		return fmt.Errorf("failed to persist refreshed token: %w", err)
 	}
-
 	return nil
+}
+
+// adoptableDiskToken returns the on-disk token for the provider when it is
+// usable and differs from entryToken — i.e. when another session has
+// already refreshed it and we should adopt that result rather than running
+// our own exchange. It returns nil when there is nothing newer to adopt.
+func (s *ConfigStore) adoptableDiskToken(scope Scope, providerID string, entryToken *oauth.Token) *oauth.Token {
+	diskToken, err := s.loadTokenFromDisk(scope, providerID)
+	if err != nil {
+		slog.Warn("Failed to read token from config file", "provider", providerID, "error", err)
+		return nil
+	}
+	if diskToken == nil || diskToken.IsExpired() {
+		return nil
+	}
+	if diskToken.AccessToken == entryToken.AccessToken {
+		// Same token we started with; nobody refreshed since.
+		return nil
+	}
+	return diskToken
+}
+
+// exchange performs the provider-specific OAuth token exchange. Tests may
+// override it via the exchangeToken field; production uses the real
+// provider clients.
+func (s *ConfigStore) exchange(ctx context.Context, providerID, refreshToken string) (*oauth.Token, error) {
+	if s.exchangeToken != nil {
+		return s.exchangeToken(ctx, providerID, refreshToken)
+	}
+	switch providerID {
+	case string(catwalk.InferenceProviderCopilot):
+		return copilot.RefreshToken(ctx, refreshToken)
+	case hyperp.Name:
+		return hyper.ExchangeToken(ctx, refreshToken)
+	default:
+		return nil, fmt.Errorf("OAuth refresh not supported for provider %s", providerID)
+	}
+}
+
+// refreshLockPath returns the path to the per-provider cross-process refresh
+// lock file. Lock files live under a dedicated locks/ subdirectory of the
+// data dir so they do not clutter the config directory. The file is created
+// on demand by lock.File and is never removed (flock keys on inode, not
+// path).
+func (s *ConfigStore) refreshLockPath(providerID string) string {
+	dir := filepath.Join(filepath.Dir(s.globalDataPath), "locks")
+	_ = os.MkdirAll(dir, 0o755)
+	return filepath.Join(dir, fmt.Sprintf("%s.refresh.lock", providerID))
 }
 
 // applyToken updates the in-memory provider config with the given token.


### PR DESCRIPTION
## What

Coordinates OAuth token refresh so concurrent Crush instances sharing one login stop fighting over it.

## Why

When two Crush instances shared a single OAuth login for a provider that rotates refresh tokens (Hyper does), each instance refreshed on its own schedule. Every refresh retires the previous token, so the two instances kept revoking the credential the other was actively using. The result was a stream of `authentication failed` (401) errors with a valid-looking, non-expired token on disk, where every refresh logged "success" yet nothing recovered.

This surfaced in real logs: refresh succeeds, the next Hyper request 401s, repeat indefinitely. Two independent `crush` processes were running against the same global credential.

## How

Refresh is now single-flighted at two levels:

- **In-process:** concurrent goroutines refreshing the same provider collapse into one attempt.
- **Cross-process:** a per-provider advisory lock is held across the whole read → decide → exchange → write cycle, so only one process exchanges at a time. A process that acquires the lock after a peer already rotated finds the fresh token on disk and **adopts it instead of exchanging again** — so instances converge on one working token rather than cannibalizing each other.

Safety details: the refresh lock is separate from the config-write lock and never holds the in-process config mutex across the network call; lock ordering is fixed (refresh lock before config-write lock) so no deadlock is possible; the wait is bounded and degrades to adopting a usable disk token on timeout; lock files live under a `locks/` subdirectory to avoid cluttering the config dir.

## Notes

- This prevents *new* conflicts. A login already mutually revoked still needs one manual re-auth to recover.
- A complementary mitigation on the provider side (a short reuse grace window) would make any concurrent client more robust, but is out of scope here.

## Tests

- `TestRefreshOAuthToken_InProcessSingleFlight`: 20 concurrent refreshes collapse to a single exchange.
- `TestRefreshOAuthToken_CrossProcessAdopt`: two instances sharing one credential perform exactly one exchange, never reuse a rotated token, and converge on the same token.

Both pass under `-race`.

💘 Generated with Crush