### PR TITLE
fix(agent): deduplicate tool call IDs

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -665,10 +665,11 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		agentTools[len(agentTools)-1].SetProviderOptions(a.getCacheControlOptions())
 	}
 
+	toolCallDeduplicator := newToolCallDeduplicator()
 	agent := fantasy.NewAgent(
 		largeModel.Model,
 		fantasy.WithSystemPrompt(systemPrompt),
-		fantasy.WithTools(agentTools...),
+		fantasy.WithTools(toolCallDeduplicator.wrapTools(agentTools)...),
 		fantasy.WithUserAgent(userAgent),
 	)
 
@@ -799,13 +800,14 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		TopK:             call.TopK,
 		FrequencyPenalty: call.FrequencyPenalty,
 		PrepareStep: func(callContext context.Context, options fantasy.PrepareStepFunctionOptions) (_ context.Context, prepared fantasy.PrepareStepResult, err error) {
-			prepared.Messages = options.Messages
+			toolCallDeduplicator.reset()
+			prepared.Messages = deduplicateToolCallMessages(options.Messages)
 			for i := range prepared.Messages {
 				prepared.Messages[i].ProviderOptions = nil
 			}
 
 			// Use latest tools (updated by SetTools when MCP tools change).
-			prepared.Tools = a.tools.Copy()
+			prepared.Tools = toolCallDeduplicator.wrapTools(a.tools.Copy())
 
 			// Drain queued follow-up prompts for this step. Calls covered
 			// by a cancel recorded while they sat in the queue are dropped:
@@ -910,6 +912,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			return a.messages.Update(genCtx, *currentAssistant)
 		},
 		OnToolInputStart: func(id string, toolName string) error {
+			if !toolCallDeduplicator.start(id) {
+				return nil
+			}
 			toolCall := message.ToolCall{
 				ID:               id,
 				Name:             toolName,
@@ -925,6 +930,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			slog.Warn("Provider request failed, retrying", providerRetryLogFields(err, delay)...)
 		},
 		OnToolCall: func(tc fantasy.ToolCallContent) error {
+			if !toolCallDeduplicator.finish(tc.ToolCallID) {
+				return nil
+			}
 			input, wasSanitized := sanitizeToolInput(tc.ToolName, tc.ToolCallID, tc.Input)
 			if wasSanitized {
 				sanitizedToolCalls[tc.ToolCallID] = true
@@ -942,6 +950,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			return a.messages.Update(ctx, *currentAssistant)
 		},
 		OnToolResult: func(result fantasy.ToolResultContent) error {
+			if !toolCallDeduplicator.result(result.ToolCallID) {
+				return nil
+			}
 			toolResult := a.convertToToolResult(result)
 			if sanitizedToolCalls[result.ToolCallID] {
 				toolResult.Content = "Tool call failed: arguments were not valid JSON. Please check your tool call format and try again."
@@ -1344,7 +1355,7 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		Messages:        aiMsgs,
 		ProviderOptions: opts,
 		PrepareStep: func(callContext context.Context, options fantasy.PrepareStepFunctionOptions) (_ context.Context, prepared fantasy.PrepareStepResult, err error) {
-			prepared.Messages = options.Messages
+			prepared.Messages = deduplicateToolCallMessages(options.Messages)
 			if systemPromptPrefix != "" {
 				prepared.Messages = append([]fantasy.Message{fantasy.NewSystemMessage(systemPromptPrefix)}, prepared.Messages...)
 			}
@@ -1699,7 +1710,7 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 	streamCall := fantasy.AgentStreamCall{
 		Prompt: fmt.Sprintf("Generate a concise title for the following content:\n\n%s\n <think>\n\n</think>", userPrompt),
 		PrepareStep: func(callCtx context.Context, opts fantasy.PrepareStepFunctionOptions) (_ context.Context, prepared fantasy.PrepareStepResult, err error) {
-			prepared.Messages = opts.Messages
+			prepared.Messages = deduplicateToolCallMessages(opts.Messages)
 			if systemPromptPrefix != "" {
 				prepared.Messages = append([]fantasy.Message{
 					fantasy.NewSystemMessage(systemPromptPrefix),

--- a/internal/agent/duplicate_tool_call_test.go
+++ b/internal/agent/duplicate_tool_call_test.go
@@ -1,0 +1,178 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const duplicateToolCallID = "dup_id_0001"
+
+type duplicateToolCallModel struct {
+	mu                  sync.Mutex
+	calls               int
+	followupToolCalls   int
+	followupToolResults int
+}
+
+func (m *duplicateToolCallModel) Provider() string { return "fake" }
+func (m *duplicateToolCallModel) Model() string    { return "fake-model" }
+
+func (m *duplicateToolCallModel) Generate(context.Context, fantasy.Call) (*fantasy.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *duplicateToolCallModel) Stream(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+	m.mu.Lock()
+	m.calls++
+	callNumber := m.calls
+	if callNumber == 2 {
+		for _, msg := range call.Prompt {
+			for _, part := range msg.Content {
+				if tc, ok := fantasy.AsMessagePart[fantasy.ToolCallPart](part); ok && tc.ToolCallID == duplicateToolCallID {
+					m.followupToolCalls++
+				}
+				if tr, ok := fantasy.AsMessagePart[fantasy.ToolResultPart](part); ok && tr.ToolCallID == duplicateToolCallID {
+					m.followupToolResults++
+				}
+			}
+		}
+	}
+	m.mu.Unlock()
+
+	return func(yield func(fantasy.StreamPart) bool) {
+		if callNumber == 1 {
+			for range 2 {
+				if !yield(fantasy.StreamPart{
+					Type:         fantasy.StreamPartTypeToolInputStart,
+					ID:           duplicateToolCallID,
+					ToolCallName: "counted",
+				}) {
+					return
+				}
+				if !yield(fantasy.StreamPart{
+					Type:  fantasy.StreamPartTypeToolInputDelta,
+					ID:    duplicateToolCallID,
+					Delta: `{"value":"same"}`,
+				}) {
+					return
+				}
+				if !yield(fantasy.StreamPart{
+					Type: fantasy.StreamPartTypeToolInputEnd,
+					ID:   duplicateToolCallID,
+				}) {
+					return
+				}
+				if !yield(fantasy.StreamPart{
+					Type:          fantasy.StreamPartTypeToolCall,
+					ID:            duplicateToolCallID,
+					ToolCallName:  "counted",
+					ToolCallInput: `{"value":"same"}`,
+				}) {
+					return
+				}
+			}
+			yield(fantasy.StreamPart{
+				Type:         fantasy.StreamPartTypeFinish,
+				FinishReason: fantasy.FinishReasonToolCalls,
+			})
+			return
+		}
+
+		if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "text-1"}) {
+			return
+		}
+		if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "text-1", Delta: "done"}) {
+			return
+		}
+		if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "text-1"}) {
+			return
+		}
+		yield(fantasy.StreamPart{
+			Type:         fantasy.StreamPartTypeFinish,
+			FinishReason: fantasy.FinishReasonStop,
+		})
+	}, nil
+}
+
+func (m *duplicateToolCallModel) GenerateObject(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *duplicateToolCallModel) StreamObject(context.Context, fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *duplicateToolCallModel) followupCounts() (int, int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.followupToolCalls, m.followupToolResults
+}
+
+func TestSessionAgent_DeduplicatesToolCallIDs(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	model := &duplicateToolCallModel{}
+	var toolRuns atomic.Int32
+	tool := fantasy.NewParallelAgentTool(
+		"counted",
+		"Count executions.",
+		func(context.Context, struct {
+			Value string `json:"value"`
+		}, fantasy.ToolCall,
+		) (fantasy.ToolResponse, error) {
+			toolRuns.Add(1)
+			time.Sleep(20 * time.Millisecond)
+			return fantasy.NewTextResponse("ok"), nil
+		},
+	)
+	agent := testSessionAgent(env, model, &finishStreamModel{text: "title"}, "system", tool)
+
+	sess, err := env.sessions.Create(t.Context(), "Existing session")
+	require.NoError(t, err)
+	_, err = env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role:  message.User,
+		Parts: []message.ContentPart{message.TextContent{Text: "Existing prompt"}},
+	})
+	require.NoError(t, err)
+
+	_, err = agent.Run(t.Context(), SessionAgentCall{
+		Prompt:    "Run the counted tool",
+		SessionID: sess.ID,
+	})
+	require.NoError(t, err)
+
+	followupToolCalls, followupToolResults := model.followupCounts()
+	msgs, err := env.messages.List(t.Context(), sess.ID)
+	require.NoError(t, err)
+
+	var storedToolCalls int
+	var storedToolResults int
+	for _, msg := range msgs {
+		for _, tc := range msg.ToolCalls() {
+			if tc.ID == duplicateToolCallID {
+				storedToolCalls++
+			}
+		}
+		for _, tr := range msg.ToolResults() {
+			if tr.ToolCallID == duplicateToolCallID {
+				storedToolResults++
+			}
+		}
+	}
+
+	assert.Equal(t, int32(1), toolRuns.Load())
+	assert.Equal(t, 1, followupToolCalls)
+	assert.Equal(t, 1, followupToolResults)
+	assert.Equal(t, 1, storedToolCalls)
+	assert.Equal(t, 1, storedToolResults)
+}

--- a/internal/agent/tool_call_dedup.go
+++ b/internal/agent/tool_call_dedup.go
@@ -1,0 +1,213 @@
+package agent
+
+import (
+	"context"
+	"sync"
+
+	"charm.land/fantasy"
+)
+
+// Tool call deduplication operates at three layers because providers
+// sometimes emit duplicate tool call IDs within a single stream response,
+// and each layer protects a different boundary:
+//
+//  1. Event gating (start/finish/result): prevents duplicate stream events
+//     from producing duplicate DB writes or UI updates.
+//  2. Execution coalescing (execute): prevents concurrent tool.Run calls
+//     for the same ID from executing the tool twice. Late arrivals block
+//     on the first caller's result via a shared done channel.
+//  3. Message sanitization (deduplicateToolCallMessages): scrubs persisted
+//     message history before sending to the provider, because previously
+//     stored duplicates (from older sessions or edge cases) would cause
+//     providers to reject the request.
+//
+// The deduplicator is scoped to a single agentic step (one LLM call + its
+// tool executions). It is reset at the start of each PrepareStep so entries
+// do not accumulate across the session lifetime.
+
+// toolCallEntry unifies dedup state and execution coalescing for one ID.
+type toolCallEntry struct {
+	started  bool
+	finished bool
+	resulted bool
+	done     chan struct{} // closed when execution completes; nil until execute claims ownership
+	response fantasy.ToolResponse
+	err      error
+}
+
+type toolCallDeduplicator struct {
+	mu      sync.Mutex
+	entries map[string]*toolCallEntry
+}
+
+func newToolCallDeduplicator() *toolCallDeduplicator {
+	return &toolCallDeduplicator{
+		entries: make(map[string]*toolCallEntry),
+	}
+}
+
+// reset clears all entries. Call at the start of each agentic step so the
+// deduplicator does not accumulate state across steps or leak memory.
+func (d *toolCallDeduplicator) reset() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	clear(d.entries)
+}
+
+// start records that a tool call has begun streaming. Returns false if this
+// ID was already seen.
+func (d *toolCallDeduplicator) start(id string) bool {
+	if id == "" {
+		return true
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, exists := d.entries[id]; exists {
+		return false
+	}
+	d.entries[id] = &toolCallEntry{started: true}
+	return true
+}
+
+// finish records that a tool call's input is complete. Returns false if this
+// ID was already finished.
+func (d *toolCallDeduplicator) finish(id string) bool {
+	if id == "" {
+		return true
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	e, exists := d.entries[id]
+	if !exists || e.finished {
+		return false
+	}
+	e.finished = true
+	return true
+}
+
+// result records that a tool result has been received. Returns false if this
+// ID already had a result.
+func (d *toolCallDeduplicator) result(id string) bool {
+	if id == "" {
+		return true
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	e, exists := d.entries[id]
+	if !exists || e.resulted {
+		return false
+	}
+	e.resulted = true
+	return true
+}
+
+func (d *toolCallDeduplicator) wrapTools(tools []fantasy.AgentTool) []fantasy.AgentTool {
+	wrapped := make([]fantasy.AgentTool, len(tools))
+	for i, tool := range tools {
+		wrapped[i] = &deduplicatingTool{
+			inner:        tool,
+			deduplicator: d,
+		}
+	}
+	return wrapped
+}
+
+// execute runs the tool, coalescing concurrent calls with the same ID onto a
+// single execution. Late arrivals block on the first caller's result.
+func (d *toolCallDeduplicator) execute(
+	ctx context.Context,
+	tool fantasy.AgentTool,
+	call fantasy.ToolCall,
+) (fantasy.ToolResponse, error) {
+	if call.ID == "" {
+		return tool.Run(ctx, call)
+	}
+
+	d.mu.Lock()
+	e, exists := d.entries[call.ID]
+	if !exists {
+		e = &toolCallEntry{done: make(chan struct{})}
+		d.entries[call.ID] = e
+	} else if e.done == nil {
+		// Entry was created by start() but execute hasn't claimed it yet.
+		e.done = make(chan struct{})
+		exists = false // we are the first executor
+	}
+	d.mu.Unlock()
+
+	if exists {
+		select {
+		case <-e.done:
+			return e.response, e.err
+		case <-ctx.Done():
+			return fantasy.ToolResponse{}, ctx.Err()
+		}
+	}
+
+	e.response, e.err = tool.Run(ctx, call)
+	close(e.done)
+	return e.response, e.err
+}
+
+type deduplicatingTool struct {
+	inner        fantasy.AgentTool
+	deduplicator *toolCallDeduplicator
+}
+
+func (t *deduplicatingTool) Info() fantasy.ToolInfo {
+	return t.inner.Info()
+}
+
+func (t *deduplicatingTool) ProviderOptions() fantasy.ProviderOptions {
+	return t.inner.ProviderOptions()
+}
+
+func (t *deduplicatingTool) SetProviderOptions(opts fantasy.ProviderOptions) {
+	t.inner.SetProviderOptions(opts)
+}
+
+func (t *deduplicatingTool) Run(ctx context.Context, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+	return t.deduplicator.execute(ctx, t.inner, call)
+}
+
+// deduplicateToolCallMessages removes duplicate tool call and tool result parts
+// from a message history, keeping only the first occurrence of each ID.
+// Messages that become empty after filtering are dropped entirely, since
+// providers reject empty-content assistant and tool messages.
+//
+// This sanitizes persisted history before sending to the provider. It is
+// independent of the stream-level dedup (start/finish/result/execute) which
+// prevents duplicates from being stored in the first place.
+func deduplicateToolCallMessages(messages []fantasy.Message) []fantasy.Message {
+	seenCalls := make(map[string]struct{})
+	seenResults := make(map[string]struct{})
+	deduplicated := make([]fantasy.Message, 0, len(messages))
+
+	for _, msg := range messages {
+		content := make([]fantasy.MessagePart, 0, len(msg.Content))
+		for _, part := range msg.Content {
+			if call, ok := fantasy.AsMessagePart[fantasy.ToolCallPart](part); ok && call.ToolCallID != "" {
+				if _, exists := seenCalls[call.ToolCallID]; exists {
+					continue
+				}
+				seenCalls[call.ToolCallID] = struct{}{}
+			}
+			if result, ok := fantasy.AsMessagePart[fantasy.ToolResultPart](part); ok && result.ToolCallID != "" {
+				if _, exists := seenResults[result.ToolCallID]; exists {
+					continue
+				}
+				seenResults[result.ToolCallID] = struct{}{}
+			}
+			content = append(content, part)
+		}
+		// Drop messages whose content was entirely duplicate tool parts.
+		// Providers reject empty-content assistant and tool messages.
+		if len(msg.Content) > 0 && len(content) == 0 {
+			continue
+		}
+		msg.Content = content
+		deduplicated = append(deduplicated, msg)
+	}
+
+	return deduplicated
+}


### PR DESCRIPTION
Fixes #3121.

When a provider emits the same tool-call ID more than once, Crush currently processes every call and result. This can execute the same tool twice and carry duplicate `role=tool` entries into later provider requests.

This change keeps the first call for an ID, coalesces concurrent duplicate executions onto the first result, and filters repeated calls and results from stored and provider history. The same history filtering is applied to the main, title, and summarization agent paths.

I reproduced the issue with the local mock-provider scenario from the report. Before the change, the command side effect ran twice and the follow-up request contained two calls and two results for `dup_id_0001`. After the change, the side effect runs once and every provider request contains at most one call and one result for that ID.

Validation:
- `go test -race -failfast ./...`
- `go build -race ./...`
- `GOEXPERIMENT= golangci-lint run --path-mode=abs --config=.golangci.yml --timeout=10m`
- `./scripts/check_log_capitalization.sh`