### PR TITLE
fix(config): prevent stale ReasoningEffort from leaking across providers

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -719,6 +719,8 @@ func configureSelectedModels(store *ConfigStore, knownProviders []catwalk.Provid
 			}
 			if largeModelSelected.ReasoningEffort != "" {
 				large.ReasoningEffort = largeModelSelected.ReasoningEffort
+			} else {
+				large.ReasoningEffort = model.DefaultReasoningEffort
 			}
 			large.Think = largeModelSelected.Think
 			if largeModelSelected.Temperature != nil {
@@ -763,6 +765,8 @@ func configureSelectedModels(store *ConfigStore, knownProviders []catwalk.Provid
 			}
 			if smallModelSelected.ReasoningEffort != "" {
 				small.ReasoningEffort = smallModelSelected.ReasoningEffort
+			} else {
+				small.ReasoningEffort = model.DefaultReasoningEffort
 			}
 			if smallModelSelected.Temperature != nil {
 				small.Temperature = smallModelSelected.Temperature


### PR DESCRIPTION
## Problem

When a user selects a model from a different provider than the auto-detected default, the default provider's `ReasoningEffort` leaks into the selected model.

For example: if Anthropic is the first provider with an API key, `defaultModelSelection()` picks `claude-sonnet-4-6` and sets `ReasoningEffort = "high"` (from catwalk's `DefaultReasoningEffort`). When the user's config then selects `zai/glm-5.2`, `configureSelectedModels()` overrides the provider and model but only overwrites `ReasoningEffort` when the user explicitly sets it (`load.go:720`: `if largeModelSelected.ReasoningEffort != ""`). If the user doesn't set it, the stale `"high"` persists, causing `thinking: {"type": "enabled"}` to be incorrectly sent to a model that may not support reasoning.

## Fix

In `configureSelectedModels()`, when the user doesn't explicitly set `reasoning_effort`, use the **selected model's** `DefaultReasoningEffort` instead of retaining the default provider's value:

```go
if largeModelSelected.ReasoningEffort != "" {
    large.ReasoningEffort = largeModelSelected.ReasoningEffort
} else {
    large.ReasoningEffort = model.DefaultReasoningEffort
}
```

Same fix applied to the small model selection.

This ensures `ReasoningEffort` always reflects the actual selected model's capabilities rather than leaking across providers.