### PR TITLE
fix(bash): keep TruncateOutput from splitting UTF-8 characters

### DIFF
--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
+
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/fsext"
@@ -423,27 +425,20 @@ func formatOutput(stdout, stderr string, execErr error) string {
 }
 
 func TruncateOutput(content string) string {
-	if len(content) <= MaxOutputLength {
+	if ansi.StringWidth(content) <= MaxOutputLength {
 		return content
 	}
 
 	halfLength := MaxOutputLength / 2
-	start := content[:halfLength]
-	end := content[len(content)-halfLength:]
+	start := ansi.Truncate(content, halfLength, "")
+	end := ansi.TruncateLeft(content, ansi.StringWidth(content)-halfLength, "")
 
-	truncatedLinesCount := countLines(content[halfLength : len(content)-halfLength])
+	truncatedLinesCount := max(strings.Count(content, "\n")-strings.Count(start, "\n")-strings.Count(end, "\n"), 0)
 	return fmt.Sprintf("%s\n\n... [%d lines truncated] ...\n\n%s", start, truncatedLinesCount, end)
 }
 
 func truncateOutput(content string) string {
 	return TruncateOutput(content)
-}
-
-func countLines(s string) int {
-	if s == "" {
-		return 0
-	}
-	return len(strings.Split(s, "\n"))
 }
 
 func normalizeWorkingDir(path string) string {

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -3,7 +3,9 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/config"
@@ -181,4 +183,31 @@ func runBashTool(t *testing.T, tool fantasy.AgentTool, ctx context.Context, para
 	resp, err := tool.Run(ctx, call)
 	require.NoError(t, err)
 	return resp
+}
+
+func TestTruncateOutputValidUTF8(t *testing.T) {
+	t.Parallel()
+	// CJK characters are 2 cells wide; this string is far wider than
+	// MaxOutputLength so TruncateOutput must truncate it.
+	content := strings.Repeat("你好世界", MaxOutputLength)
+
+	out := TruncateOutput(content)
+	require.True(t, utf8.ValidString(out), "truncated output must stay valid UTF-8")
+	require.Contains(t, out, "lines truncated")
+}
+
+func TestTruncateOutputShortContent(t *testing.T) {
+	t.Parallel()
+	content := "short output"
+	require.Equal(t, content, TruncateOutput(content))
+}
+
+func TestTruncateOutputEmoji(t *testing.T) {
+	t.Parallel()
+	// Emoji with ZWJ sequences should not be split.
+	content := strings.Repeat("👨‍👩‍👧‍👦", MaxOutputLength)
+
+	out := TruncateOutput(content)
+	require.True(t, utf8.ValidString(out), "truncated output must stay valid UTF-8")
+	require.Contains(t, out, "lines truncated")
 }


### PR DESCRIPTION
### What

`TruncateOutput` cuts the content `MaxOutputLength/2` bytes in from each end:

```go
start := content[:halfLength]
end := content[len(content)-halfLength:]
```

When the command output contains multi-byte UTF-8 (CJK, emoji, ...), these byte cuts can land in the middle of a rune, so the truncated output contains invalid UTF-8 (rendered as the replacement character).

### Change

Move the two cut points to the nearest UTF-8 rune boundary (via `utf8.RuneStart`) before slicing, so characters are never split. Added `TestTruncateOutputValidUTF8`, which truncates a long CJK string and asserts the result stays valid UTF-8.