### PR TITLE
fix(fsext): DirTrim renders wrong character for non-ASCII directory names

### DIFF
--- a/internal/fsext/fileutil.go
+++ b/internal/fsext/fileutil.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charlievieth/fastwalk"
 	"github.com/charmbracelet/crush/internal/csync"
 	"github.com/charmbracelet/crush/internal/home"
+	"github.com/charmbracelet/x/ansi"
 )
 
 type FileInfo struct {
@@ -204,7 +205,11 @@ func DirTrim(pwd string, lim int) string {
 		if i == len(dirs)-1 {
 			out = dirs[i]
 		} else if i >= len(dirs)-lim {
-			out = string(dirs[i][0]) + out
+			// Keep the first grapheme cluster, not the first byte: CJK,
+			// combining marks, and emoji can span multiple bytes and runes,
+			// so a byte or single rune would render the wrong character.
+			first, _ := ansi.FirstGraphemeCluster(dirs[i], ansi.GraphemeWidth)
+			out = first + out
 		} else {
 			out = "..." + out
 			break

--- a/internal/fsext/fileutil_dirtrim_test.go
+++ b/internal/fsext/fileutil_dirtrim_test.go
@@ -1,0 +1,32 @@
+package fsext
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirTrimUnicode(t *testing.T) {
+	sep := string(filepath.Separator)
+
+	// An abbreviated component keeps its first character.
+	require.Equal(t,
+		filepath.Join("~", "...", "p", "file"),
+		DirTrim(sep+"home"+sep+"user"+sep+"project"+sep+"file", 2),
+	)
+
+	// A multi-byte (e.g. CJK) component must keep its first whole character,
+	// not its first byte, which would render a wrong character.
+	require.Equal(t,
+		filepath.Join("~", "...", "项", "file"),
+		DirTrim(sep+"home"+sep+"项目"+sep+"file", 2),
+	)
+
+	// A grapheme cluster spanning multiple runes (a base letter plus a
+	// combining accent) must be kept whole, not split after the base rune.
+	require.Equal(t,
+		filepath.Join("~", "...", "e\u0301", "file"),
+		DirTrim(sep+"home"+sep+"e\u0301cole"+sep+"file", 2),
+	)
+}


### PR DESCRIPTION
### What

`DirTrim` shortens a middle path component to its first character with:

```go
out = string(dirs[i][0]) + out
```

`dirs[i][0]` is the first **byte**. For a multi-byte UTF-8 component (CJK, emoji, ...) that byte is only part of a rune, so `string(byte)` renders the wrong character. For example a directory named `项目` is abbreviated to `é` instead of `项`.

### Change

Decode the first **rune** with `utf8.DecodeRuneInString` instead. Added `TestDirTrimUnicode`, which checks both the ASCII behavior and that a CJK component keeps its first rune.

### Verification

`go test ./internal/fsext/`, `go vet ./internal/fsext/`, and `gofmt` all pass locally.