### PR TITLE
feat(pubsub): add broker observability for diagnosing backpressure

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -142,6 +142,11 @@ tasks:
     cmds:
       - go tool pprof -http :6061 'http://localhost:6060/debug/pprof/allocs'
 
+  profile:pubsub:
+    desc: Pubsub broker buffer stats
+    cmds:
+      - curl -s 'http://localhost:6060/debug/pubsub' | jq .
+
   schema:
     desc: Generate JSON schema for configuration
     cmds:

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -55,7 +55,7 @@ func (s *ClientSession) Close() error {
 var (
 	sessions = csync.NewMap[string, *ClientSession]()
 	states   = csync.NewMap[string, ClientInfo]()
-	broker   = pubsub.NewBroker[Event]()
+	broker   = pubsub.NewBrokerWithName[Event]("mcp")
 	initOnce sync.Once
 	initDone = make(chan struct{})
 )

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -114,11 +114,11 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 
 		config: store,
 
-		events:             pubsub.NewBroker[tea.Msg](),
+		events:             pubsub.NewBrokerWithName[tea.Msg]("events"),
 		serviceEventsWG:    &sync.WaitGroup{},
 		tuiWG:              &sync.WaitGroup{},
-		agentNotifications: pubsub.NewBroker[notify.Notification](),
-		runCompletions:     pubsub.NewBroker[notify.RunComplete](),
+		agentNotifications: pubsub.NewBrokerWithName[notify.Notification]("agent_notifications"),
+		runCompletions:     pubsub.NewBrokerWithName[notify.RunComplete]("run_completions"),
 	}
 
 	app.setupEvents()
@@ -637,6 +637,24 @@ func (app *App) Subscribe(program *tea.Program) {
 			program.Send(ev.Payload)
 		}
 	}
+}
+
+// PubsubStats returns a snapshot of all broker buffer occupancies and
+// drop counters. Intended for the /debug/pubsub pprof endpoint.
+func (app *App) PubsubStats() map[string]pubsub.BrokerStats {
+	stats := make(map[string]pubsub.BrokerStats, 7)
+	for _, s := range []pubsub.BrokerStats{
+		app.events.Stats(),
+		app.agentNotifications.Stats(),
+		app.runCompletions.Stats(),
+		app.Sessions.Stats(),
+		app.Messages.Stats(),
+		app.History.Stats(),
+		app.Permissions.Stats(),
+	} {
+		stats[s.Name] = s
+	}
+	return stats
 }
 
 // Shutdown performs a graceful shutdown of the application.

--- a/internal/app/lsp_events.go
+++ b/internal/app/lsp_events.go
@@ -38,7 +38,7 @@ type LSPClientInfo struct {
 
 var (
 	lspStates = csync.NewMap[string, LSPClientInfo]()
-	lspBroker = pubsub.NewBroker[LSPEvent]()
+	lspBroker = pubsub.NewBrokerWithName[LSPEvent]("lsp")
 )
 
 // SubscribeLSPEvents returns a channel for LSP events

--- a/internal/app/resolve_session_test.go
+++ b/internal/app/resolve_session_test.go
@@ -89,6 +89,10 @@ func (m *mockSessionService) IsAgentToolSession(sessionID string) bool {
 	return ok
 }
 
+func (m *mockSessionService) Stats() pubsub.BrokerStats {
+	return pubsub.BrokerStats{}
+}
+
 func newTestApp(sessions session.Service) *App {
 	return &App{Sessions: sessions}
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	_ "embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -307,6 +308,14 @@ func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error
 		_ = conn.Close()
 		slog.Error("Failed to create app instance", "error", err)
 		return nil, nil, err
+	}
+
+	// Register pubsub debug endpoints when profiling is enabled.
+	if os.Getenv("CRUSH_PROFILE") != "" {
+		http.HandleFunc("/debug/pubsub", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(appInstance.PubsubStats())
+		})
 	}
 
 	if shouldEnableMetrics(cfg) {

--- a/internal/history/file.go
+++ b/internal/history/file.go
@@ -39,6 +39,9 @@ type Service interface {
 	ListLatestSessionFiles(ctx context.Context, sessionID string) ([]File, error)
 	Delete(ctx context.Context, id string) error
 	DeleteSessionFiles(ctx context.Context, sessionID string) error
+
+	// Stats returns broker health metrics for diagnostics.
+	Stats() pubsub.BrokerStats
 }
 
 type service struct {
@@ -49,7 +52,7 @@ type service struct {
 
 func NewService(q *db.Queries, db *sql.DB) Service {
 	return &service{
-		Broker: pubsub.NewBroker[File](),
+		Broker: pubsub.NewBrokerWithName[File]("history"),
 		q:      q,
 		db:     db,
 	}

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -65,6 +65,9 @@ type Service interface {
 	// message known to the service. Intended for shutdown and
 	// session-switch paths.
 	FlushAll(ctx context.Context) error
+
+	// Stats returns broker health metrics for diagnostics.
+	Stats() pubsub.BrokerStats
 }
 
 // pendingState holds the in-memory coalescing buffer for a single
@@ -123,7 +126,7 @@ func WithDebounce(d time.Duration) ServiceOption {
 
 func NewService(q db.Querier, opts ...ServiceOption) Service {
 	s := &service{
-		Broker:   pubsub.NewBroker[Message](),
+		Broker:   pubsub.NewBrokerWithName[Message]("messages"),
 		q:        q,
 		debounce: defaultUpdateDebounce,
 		pending:  make(map[string]*pendingState),

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -82,6 +82,9 @@ type Service interface {
 	SetSkipRequests(skip bool)
 	SkipRequests() bool
 	SubscribeNotifications(ctx context.Context) <-chan pubsub.Event[PermissionNotification]
+
+	// Stats returns broker health metrics for diagnostics.
+	Stats() pubsub.BrokerStats
 }
 
 // PermissionKey is a composite key for session permission lookups.
@@ -297,8 +300,8 @@ func (s *permissionService) SkipRequests() bool {
 
 func NewPermissionService(workingDir string, skip bool, allowedTools []string) Service {
 	svc := &permissionService{
-		Broker:              pubsub.NewBroker[PermissionRequest](),
-		notificationBroker:  pubsub.NewBroker[PermissionNotification](),
+		Broker:              pubsub.NewBrokerWithName[PermissionRequest]("permissions"),
+		notificationBroker:  pubsub.NewBrokerWithName[PermissionNotification]("permissions_notifications"),
 		workingDir:          workingDir,
 		sessionPermissions:  csync.NewMap[PermissionKey, bool](),
 		autoApproveSessions: make(map[string]bool),

--- a/internal/pubsub/broker.go
+++ b/internal/pubsub/broker.go
@@ -54,10 +54,40 @@ type Broker[T any] struct {
 	mustDeliverTimeout   time.Duration
 	dropCount            atomic.Uint64
 	mustDeliverDropCount atomic.Uint64
+
+	// Name identifies this broker in log messages. Set via
+	// NewBrokerWithName; empty for brokers created with NewBroker.
+	Name string
+
+	// lastDropLog gates drop warnings to at most one per interval to
+	// avoid flooding logs during burst drops.
+	lastDropLog atomic.Int64
+
+	// lastDropCount snapshots the drop count at the time of the last
+	// log message so we can report the delta (drops since last log)
+	// rather than just the cumulative total.
+	lastDropCount atomic.Uint64
+
+	// lastMustDeliverLog gates must-deliver timeout errors similarly.
+	lastMustDeliverLog atomic.Int64
+
+	// lastMustDeliverDropCount snapshots the must-deliver drop count
+	// at the time of the last log message.
+	lastMustDeliverDropCount atomic.Uint64
 }
 
 func NewBroker[T any]() *Broker[T] {
 	return NewBrokerWithOptions[T](bufferSize)
+}
+
+// NewBrokerWithName creates a broker with a human-readable name used in
+// log messages and debug endpoints. Prefer this over NewBroker for any
+// broker that will be registered in app.setupEvents so drop warnings
+// identify the source.
+func NewBrokerWithName[T any](name string) *Broker[T] {
+	b := NewBrokerWithOptions[T](bufferSize)
+	b.Name = name
+	return b
 }
 
 func NewBrokerWithOptions[T any](channelBufferSize int) *Broker[T] {
@@ -143,6 +173,36 @@ func (b *Broker[T]) GetSubscriberCount() int {
 	return b.subCount
 }
 
+// BrokerStats holds a point-in-time snapshot of broker health.
+type BrokerStats struct {
+	Name             string `json:"name"`
+	Subscribers      int    `json:"subscribers"`
+	BufferCap        int    `json:"buffer_cap"`
+	BufferLengths    []int  `json:"buffer_lengths"`
+	DropCount        uint64 `json:"drop_count"`
+	MustDeliverDrops uint64 `json:"must_deliver_drops"`
+}
+
+// Stats returns a point-in-time snapshot of broker health including
+// per-subscriber buffer occupancy and cumulative drop counts.
+func (b *Broker[T]) Stats() BrokerStats {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	lengths := make([]int, 0, len(b.subs))
+	for sub := range b.subs {
+		lengths = append(lengths, len(sub))
+	}
+	return BrokerStats{
+		Name:             b.Name,
+		Subscribers:      len(b.subs),
+		BufferCap:        b.channelBufferSize,
+		BufferLengths:    lengths,
+		DropCount:        b.dropCount.Load(),
+		MustDeliverDrops: b.mustDeliverDropCount.Load(),
+	}
+}
+
 // DropCount returns the cumulative number of events dropped by
 // [Broker.Publish] because a subscriber's channel was full.
 func (b *Broker[T]) DropCount() uint64 {
@@ -154,6 +214,64 @@ func (b *Broker[T]) DropCount() uint64 {
 // expired.
 func (b *Broker[T]) MustDeliverDropCount() uint64 {
 	return b.mustDeliverDropCount.Load()
+}
+
+// logDrop emits a rate-limited warning when events are dropped. At most
+// one warning per second to prevent log flooding during burst drops
+// (e.g., when fan-in goroutines drain full source buffers faster than
+// the downstream consumer can process). Reports the number of drops
+// since the last log message so you can see the rate, not just the
+// cumulative total.
+func (b *Broker[T]) logDrop(t EventType) {
+	now := time.Now().UnixNano()
+	last := b.lastDropLog.Load()
+	if now-last < int64(time.Second) {
+		return
+	}
+	if !b.lastDropLog.CompareAndSwap(last, now) {
+		return // Another goroutine won the race; skip.
+	}
+	total := b.dropCount.Load()
+	delta := total - b.lastDropCount.Load()
+	b.lastDropCount.Store(total)
+	name := b.Name
+	if name == "" {
+		name = "unknown"
+	}
+	slog.Warn("Pubsub buffer full; dropping events",
+		"broker", name,
+		"type", t,
+		"dropsLastSecond", delta,
+		"totalDrops", total,
+	)
+}
+
+// logMustDeliverDrop emits a rate-limited error when must-deliver events
+// time out. Same cadence as logDrop to prevent log flooding during
+// sustained backpressure. Reports drops since last log.
+func (b *Broker[T]) logMustDeliverDrop(t EventType, timeout time.Duration) {
+	now := time.Now().UnixNano()
+	last := b.lastMustDeliverLog.Load()
+	if now-last < int64(time.Second) {
+		return
+	}
+	if !b.lastMustDeliverLog.CompareAndSwap(last, now) {
+		return
+	}
+	total := b.mustDeliverDropCount.Load()
+	delta := total - b.lastMustDeliverDropCount.Load()
+	b.lastMustDeliverDropCount.Store(total)
+	name := b.Name
+	if name == "" {
+		name = "unknown"
+	}
+	slog.Error("PublishMustDeliver timed out delivering events",
+		"broker", name,
+		"type", t,
+		"timeout", timeout,
+		"dropsLastSecond", delta,
+		"totalDrops", total,
+	)
 }
 
 // Publish delivers an event to every active subscriber.
@@ -182,7 +300,7 @@ func (b *Broker[T]) Publish(t EventType, payload T) {
 			// Lossy by design; counted and logged so saturation is
 			// observable.
 			b.dropCount.Add(1)
-			slog.Warn("Pubsub buffer full; dropping event", "type", t)
+			b.logDrop(t)
 		}
 	}
 }
@@ -226,8 +344,7 @@ func (b *Broker[T]) PublishMustDeliver(ctx context.Context, t EventType, payload
 			timer.Stop()
 		case <-timer.C:
 			b.mustDeliverDropCount.Add(1)
-			slog.Error("PublishMustDeliver timed out delivering event",
-				"type", t, "timeout", timeout)
+			b.logMustDeliverDrop(t, timeout)
 		case <-ctx.Done():
 			timer.Stop()
 			return

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -79,6 +79,9 @@ type Service interface {
 	CreateAgentToolSessionID(messageID, toolCallID string) string
 	ParseAgentToolSessionID(sessionID string) (messageID string, toolCallID string, ok bool)
 	IsAgentToolSession(sessionID string) bool
+
+	// Stats returns broker health metrics for diagnostics.
+	Stats() pubsub.BrokerStats
 }
 
 type service struct {
@@ -338,7 +341,7 @@ func unmarshalTodos(data string) ([]Todo, error) {
 }
 
 func NewService(q *db.Queries, conn *sql.DB) Service {
-	broker := pubsub.NewBroker[Session]()
+	broker := pubsub.NewBrokerWithName[Session]("sessions")
 	return &service{
 		Broker:         broker,
 		db:             conn,

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -75,7 +75,7 @@ func NewManager(allSkills, activeSkills []*Skill, states []*SkillState, opts ...
 		allSkills:    allSkills,
 		activeSkills: activeSkills,
 		states:       states,
-		broker:       pubsub.NewBroker[Event](),
+		broker:       pubsub.NewBrokerWithName[Event]("skills_manager"),
 	}
 	for _, opt := range opts {
 		opt(m)

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -72,7 +72,7 @@ type Event struct {
 	States []*SkillState
 }
 
-var broker = pubsub.NewBroker[Event]()
+var broker = pubsub.NewBrokerWithName[Event]("skills")
 
 // SubscribeEvents returns a channel that receives events when skill discovery state changes.
 func SubscribeEvents(ctx context.Context) <-chan pubsub.Event[Event] {


### PR DESCRIPTION
Rate-limit drop warnings to 1/sec with per-second delta counts so burst cascades produce useful logs instead of thousands of identical lines. Name all brokers so logs identify the bottleneck. Expose buffer stats via /debug/pubsub endpoint and Stats() on service interfaces for live diagnostics during profiling.