### PR TITLE
Fix startup deadlock when configured model ID is invalid

### DIFF
--- a/internal/config/deadlock_repro_test.go
+++ b/internal/config/deadlock_repro_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeadlockOnInvalidModel(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Write a mock config with a configured provider but a non-existent model.
+	configJSON := `{
+  "providers": {
+    "openai": { "api_key": "sk-xxxx" }
+  },
+  "models": {
+    "large": {
+      "provider": "openai",
+      "model": "this-model-does-not-exist"
+    }
+  }
+}`
+	configPath := filepath.Join(tempDir, "crush.json")
+	err := os.WriteFile(configPath, []byte(configJSON), 0o600)
+	require.NoError(t, err)
+
+	// Set env vars so Load picks up this config
+	t.Setenv("CRUSH_GLOBAL_CONFIG", tempDir)
+	t.Setenv("CRUSH_GLOBAL_DATA", tempDir)
+
+	// We run this in a channel to detect timeout/deadlock.
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		store, loadErr := Load(tempDir, tempDir, false)
+		if loadErr != nil {
+			t.Logf("Load completed with error: %v", loadErr)
+			return
+		}
+		t.Logf("Loaded config models: %+v", store.config.Models)
+	}()
+
+	select {
+	case <-done:
+		// Read files in tempDir
+		data, readErr := os.ReadFile(configPath)
+		require.NoError(t, readErr)
+		t.Logf("crush.json content after Load: %s", string(data))
+		
+		dataPath := filepath.Join(tempDir, "crush", "crush.json")
+		if data2, err := os.ReadFile(dataPath); err == nil {
+			t.Logf("crush data path content: %s", string(data2))
+		} else {
+			t.Logf("No data file: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("DEADLOCK DETECTED: Load hung for more than 3 seconds!")
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -729,7 +729,7 @@ func configureSelectedModels(store *ConfigStore, knownProviders []catwalk.Provid
 		if model == nil {
 			large = defaultLarge
 			if persist {
-				if err := store.UpdatePreferredModel(ScopeGlobal, SelectedModelTypeLarge, large); err != nil {
+				if err := store.updatePreferredModelLocked(ScopeGlobal, SelectedModelTypeLarge, large); err != nil {
 					return fmt.Errorf("failed to update preferred large model: %w", err)
 				}
 			}
@@ -775,7 +775,7 @@ func configureSelectedModels(store *ConfigStore, knownProviders []catwalk.Provid
 		if model == nil {
 			small = defaultSmall
 			if persist {
-				if err := store.UpdatePreferredModel(ScopeGlobal, SelectedModelTypeSmall, small); err != nil {
+				if err := store.updatePreferredModelLocked(ScopeGlobal, SelectedModelTypeSmall, small); err != nil {
 					return fmt.Errorf("failed to update preferred small model: %w", err)
 				}
 			}

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -328,14 +328,8 @@ func (s *ConfigStore) mutateInMemory(mutate func(*Config)) {
 	s.setConfig(nc)
 }
 
-// update applies a copy-on-write change and persists the reported fields.
-// mutate edits the clone and returns the JSON-path fields to write to disk;
-// because the clone already reflects the change, no reload is needed.
-// Returning an empty map publishes the clone without a disk write.
-func (s *ConfigStore) update(scope Scope, mutate func(*Config) map[string]any) error {
-	s.writeMu.Lock()
-	defer s.writeMu.Unlock()
-
+// updateLocked is the lock-free version of update. Caller must hold writeMu.
+func (s *ConfigStore) updateLocked(scope Scope, mutate func(*Config) map[string]any) error {
 	nc := s.Config().cloneForWrite()
 	fields := mutate(nc)
 	s.setConfig(nc)
@@ -346,12 +340,22 @@ func (s *ConfigStore) update(scope Scope, mutate func(*Config) map[string]any) e
 		return err
 	}
 	// Refresh the staleness snapshot so the file watcher does not treat
-	// our own write as an external change. Safe to touch the snapshot map
-	// here because we hold writeMu.
+	// our own write as an external change.
 	if path, err := s.configPath(scope); err == nil {
 		s.captureStalenessSnapshot(append(slices.Clone(s.loadedPaths), path))
 	}
 	return nil
+}
+
+// update applies a copy-on-write change and persists the reported fields.
+// mutate edits the clone and returns the JSON-path fields to write to disk;
+// because the clone already reflects the change, no reload is needed.
+// Returning an empty map publishes the clone without a disk write.
+func (s *ConfigStore) update(scope Scope, mutate func(*Config) map[string]any) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	return s.updateLocked(scope, mutate)
 }
 
 // OverridePreferredModel sets the preferred model for the given type in
@@ -389,6 +393,30 @@ func (s *ConfigStore) RemoveConfigField(scope Scope, key string) error {
 	}
 
 	return nil
+}
+
+// updatePreferredModelLocked updates the preferred model for the given type and
+// persists it to the config file at the given scope, without locking writeMu.
+// Used internally during startup when the loader already holds writeMu.
+func (s *ConfigStore) updatePreferredModelLocked(scope Scope, modelType SelectedModelType, model SelectedModel) error {
+	return s.updateLocked(scope, func(c *Config) map[string]any {
+		if c.Models == nil {
+			c.Models = make(map[SelectedModelType]SelectedModel)
+		}
+		c.Models[modelType] = model
+
+		fields := map[string]any{
+			fmt.Sprintf("models.%s", modelType): model,
+		}
+		if updated, changed := nextRecentModels(c, modelType, model); changed {
+			if c.RecentModels == nil {
+				c.RecentModels = make(map[SelectedModelType][]SelectedModel)
+			}
+			c.RecentModels[modelType] = updated
+			fields[fmt.Sprintf("recent_models.%s", modelType)] = updated
+		}
+		return fields
+	})
 }
 
 // UpdatePreferredModel updates the preferred model for the given type and


### PR DESCRIPTION
## Summary

This PR resolves a startup self-deadlock that occurs when a configured model ID in `crush.json` is invalid or not found in the model catalog.

During load, `Load()` acquires the configuration store's `writeMu` mutex. When `configureSelectedModels` encounters an invalid model ID, it attempts to fall back to a default model and call `UpdatePreferredModel` to persist it. This function tries to acquire `writeMu` again, causing a self-deadlock.

We resolve this by:
1. Adding an unlocked helper `updateLocked` that performs the config mutation and persistence without locking `writeMu`.
2. Adding an unexported helper `updatePreferredModelLocked` that delegates to `updateLocked`.
3. Updating both model fallback paths in `configureSelectedModels` to use `updatePreferredModelLocked`.

## Testing

I verified this by adding a regression test case `TestDeadlockOnInvalidModel` in `internal/config/deadlock_repro_test.go` that simulates loading a configuration with an invalid model ID. The test runs with a timeout to detect hangs.
- Run targeted test: `go test -v -run TestDeadlockOnInvalidModel ./internal/config`
- Run all package tests: `go test -v ./internal/config`

Fixes #3224