### PR TITLE
fix(config): prevent startup deadlock when configured model ID is invalid

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -125,8 +125,27 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 		return store, nil
 	}
 
-	if err := configureSelectedModels(store, store.knownProviders, true); err != nil {
+	resolved, err := resolveSelectedModels(cfg, store.knownProviders)
+	if err != nil {
 		return nil, fmt.Errorf("failed to configure selected models: %w", err)
+	}
+	cfg.Models[SelectedModelTypeLarge] = resolved.Large
+	cfg.Models[SelectedModelTypeSmall] = resolved.Small
+
+	// Persist any fallback corrections while we still hold writeMu.
+	if resolved.LargeFallback {
+		if err := store.updateLocked(ScopeGlobal, func(c *Config) map[string]any {
+			return store.updatePreferredModelFields(c, SelectedModelTypeLarge, resolved.Large)
+		}); err != nil {
+			return nil, fmt.Errorf("failed to update preferred large model: %w", err)
+		}
+	}
+	if resolved.SmallFallback {
+		if err := store.updateLocked(ScopeGlobal, func(c *Config) map[string]any {
+			return store.updatePreferredModelFields(c, SelectedModelTypeSmall, resolved.Small)
+		}); err != nil {
+			return nil, fmt.Errorf("failed to update preferred small model: %w", err)
+		}
 	}
 	store.SetupAgents()
 
@@ -709,15 +728,29 @@ func (c *Config) defaultModelSelection(knownProviders []catwalk.Provider) (large
 	return largeModel, smallModel, err
 }
 
-func configureSelectedModels(store *ConfigStore, knownProviders []catwalk.Provider, persist bool) error {
-	c := store.config
-	defaultLarge, defaultSmall, err := c.defaultModelSelection(knownProviders)
+// resolvedModels holds the result of resolving user-configured model
+// selections against the provider catalog.
+type resolvedModels struct {
+	Large         SelectedModel
+	Small         SelectedModel
+	LargeFallback bool // true if Large was corrected to a default
+	SmallFallback bool // true if Small was corrected to a default
+}
+
+// resolveSelectedModels validates the user's configured model selections
+// against the provider catalog, falling back to defaults when a model ID is
+// invalid. It is pure resolution logic: it does not mutate the store or
+// touch disk. The caller assigns the results to c.Models and persists any
+// fallback corrections as appropriate.
+func resolveSelectedModels(cfg *Config, knownProviders []catwalk.Provider) (resolvedModels, error) {
+	var result resolvedModels
+	defaultLarge, defaultSmall, err := cfg.defaultModelSelection(knownProviders)
 	if err != nil {
-		return fmt.Errorf("failed to select default models: %w", err)
+		return result, fmt.Errorf("failed to select default models: %w", err)
 	}
 	large, small := defaultLarge, defaultSmall
 
-	largeModelSelected, largeModelConfigured := c.Models[SelectedModelTypeLarge]
+	largeModelSelected, largeModelConfigured := cfg.Models[SelectedModelTypeLarge]
 	if largeModelConfigured {
 		if largeModelSelected.Model != "" {
 			large.Model = largeModelSelected.Model
@@ -725,14 +758,10 @@ func configureSelectedModels(store *ConfigStore, knownProviders []catwalk.Provid
 		if largeModelSelected.Provider != "" {
 			large.Provider = largeModelSelected.Provider
 		}
-		model := c.GetModel(large.Provider, large.Model)
+		model := cfg.GetModel(large.Provider, large.Model)
 		if model == nil {
 			large = defaultLarge
-			if persist {
-				if err := store.UpdatePreferredModel(ScopeGlobal, SelectedModelTypeLarge, large); err != nil {
-					return fmt.Errorf("failed to update preferred large model: %w", err)
-				}
-			}
+			result.LargeFallback = true
 		} else {
 			if largeModelSelected.MaxTokens > 0 {
 				large.MaxTokens = largeModelSelected.MaxTokens
@@ -762,7 +791,7 @@ func configureSelectedModels(store *ConfigStore, knownProviders []catwalk.Provid
 			}
 		}
 	}
-	smallModelSelected, smallModelConfigured := c.Models[SelectedModelTypeSmall]
+	smallModelSelected, smallModelConfigured := cfg.Models[SelectedModelTypeSmall]
 	if smallModelConfigured {
 		if smallModelSelected.Model != "" {
 			small.Model = smallModelSelected.Model
@@ -771,14 +800,10 @@ func configureSelectedModels(store *ConfigStore, knownProviders []catwalk.Provid
 			small.Provider = smallModelSelected.Provider
 		}
 
-		model := c.GetModel(small.Provider, small.Model)
+		model := cfg.GetModel(small.Provider, small.Model)
 		if model == nil {
 			small = defaultSmall
-			if persist {
-				if err := store.UpdatePreferredModel(ScopeGlobal, SelectedModelTypeSmall, small); err != nil {
-					return fmt.Errorf("failed to update preferred small model: %w", err)
-				}
-			}
+			result.SmallFallback = true
 		} else {
 			if smallModelSelected.MaxTokens > 0 {
 				small.MaxTokens = smallModelSelected.MaxTokens
@@ -827,9 +852,9 @@ func configureSelectedModels(store *ConfigStore, knownProviders []catwalk.Provid
 		}
 	}
 
-	c.Models[SelectedModelTypeLarge] = large
-	c.Models[SelectedModelTypeSmall] = small
-	return nil
+	result.Large = large
+	result.Small = small
+	return result, nil
 }
 
 // lookupConfigs searches config files starting at cwd and walking up

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"charm.land/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/csync"
@@ -1687,14 +1688,17 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 		err := cfg.configureProviders(context.Background(), store, env, resolver, knownProviders)
 		require.NoError(t, err)
 
-		err = configureSelectedModels(store, knownProviders, false)
-		require.NoError(t, err)
+		resolved, resolveErr := resolveSelectedModels(cfg, knownProviders)
+		require.NoError(t, resolveErr)
+		cfg.Models[SelectedModelTypeLarge] = resolved.Large
+		cfg.Models[SelectedModelTypeSmall] = resolved.Small
 
 		// In-memory falls back to default.
+		require.True(t, resolved.LargeFallback)
 		require.Equal(t, "openai", cfg.Models[SelectedModelTypeLarge].Provider)
 		require.Equal(t, "large-model", cfg.Models[SelectedModelTypeLarge].Model)
 
-		// Disk remains unchanged in reload mode.
+		// Disk remains unchanged (resolveSelectedModels never persists).
 		data, readErr := os.ReadFile(globalPath)
 		require.NoError(t, readErr)
 		require.Contains(t, string(data), `"provider":"ghost"`)
@@ -1737,8 +1741,10 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
-		err = configureSelectedModels(testStore(cfg), knownProviders, true)
-		require.NoError(t, err)
+		resolved, resolveErr := resolveSelectedModels(cfg, knownProviders)
+		require.NoError(t, resolveErr)
+		cfg.Models[SelectedModelTypeLarge] = resolved.Large
+		cfg.Models[SelectedModelTypeSmall] = resolved.Small
 		large := cfg.Models[SelectedModelTypeLarge]
 		small := cfg.Models[SelectedModelTypeSmall]
 		require.Equal(t, "larger-model", large.Model)
@@ -1799,8 +1805,10 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
-		err = configureSelectedModels(testStore(cfg), knownProviders, true)
-		require.NoError(t, err)
+		resolved, resolveErr := resolveSelectedModels(cfg, knownProviders)
+		require.NoError(t, resolveErr)
+		cfg.Models[SelectedModelTypeLarge] = resolved.Large
+		cfg.Models[SelectedModelTypeSmall] = resolved.Small
 		large := cfg.Models[SelectedModelTypeLarge]
 		small := cfg.Models[SelectedModelTypeSmall]
 		require.Equal(t, "large-model", large.Model)
@@ -1844,12 +1852,90 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
 		require.NoError(t, err)
 
-		err = configureSelectedModels(testStore(cfg), knownProviders, true)
-		require.NoError(t, err)
+		resolved, resolveErr := resolveSelectedModels(cfg, knownProviders)
+		require.NoError(t, resolveErr)
+		cfg.Models[SelectedModelTypeLarge] = resolved.Large
+		cfg.Models[SelectedModelTypeSmall] = resolved.Small
 		large := cfg.Models[SelectedModelTypeLarge]
 		require.Equal(t, "large-model", large.Model)
 		require.Equal(t, "openai", large.Provider)
 		require.Equal(t, int64(100), large.MaxTokens)
+	})
+	t.Run("resolve and persist fallback under writeMu does not deadlock", func(t *testing.T) {
+		dir := t.TempDir()
+		globalPath := filepath.Join(dir, "crush.json")
+		require.NoError(t, os.WriteFile(globalPath, []byte(`{}`), 0o600))
+
+		knownProviders := []catwalk.Provider{
+			{
+				ID:                  "openai",
+				APIKey:              "abc",
+				DefaultLargeModelID: "large-model",
+				DefaultSmallModelID: "small-model",
+				Models: []catwalk.Model{
+					{ID: "large-model", DefaultMaxTokens: 1000},
+					{ID: "small-model", DefaultMaxTokens: 500},
+				},
+			},
+		}
+
+		cfg := &Config{
+			Models: map[SelectedModelType]SelectedModel{
+				SelectedModelTypeLarge: {Provider: "openai", Model: "this-model-does-not-exist"},
+				SelectedModelTypeSmall: {Provider: "openai", Model: "also-does-not-exist"},
+			},
+		}
+		cfg.setDefaults(dir, "")
+		store := &ConfigStore{config: cfg, globalDataPath: globalPath}
+		env := env.NewFromMap(map[string]string{})
+		resolver := NewShellVariableResolver(env)
+		err := cfg.configureProviders(context.Background(), store, env, resolver, knownProviders)
+		require.NoError(t, err)
+
+		// Simulate the Load path: resolve (pure), then persist fallbacks
+		// under writeMu using updateLocked. Before the refactor, the
+		// combined configureSelectedModels(persist=true) self-deadlocked
+		// because UpdatePreferredModel re-acquired writeMu.
+		done := make(chan error, 1)
+		go func() {
+			resolved, resolveErr := resolveSelectedModels(cfg, knownProviders)
+			if resolveErr != nil {
+				done <- resolveErr
+				return
+			}
+			cfg.Models[SelectedModelTypeLarge] = resolved.Large
+			cfg.Models[SelectedModelTypeSmall] = resolved.Small
+
+			store.writeMu.Lock()
+			defer store.writeMu.Unlock()
+			if resolved.LargeFallback {
+				if err := store.updateLocked(ScopeGlobal, func(c *Config) map[string]any {
+					return store.updatePreferredModelFields(c, SelectedModelTypeLarge, resolved.Large)
+				}); err != nil {
+					done <- err
+					return
+				}
+			}
+			if resolved.SmallFallback {
+				if err := store.updateLocked(ScopeGlobal, func(c *Config) map[string]any {
+					return store.updatePreferredModelFields(c, SelectedModelTypeSmall, resolved.Small)
+				}); err != nil {
+					done <- err
+					return
+				}
+			}
+			done <- nil
+		}()
+
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+			// Should have fallen back to defaults.
+			require.Equal(t, "large-model", cfg.Models[SelectedModelTypeLarge].Model)
+			require.Equal(t, "small-model", cfg.Models[SelectedModelTypeSmall].Model)
+		case <-time.After(5 * time.Second):
+			t.Fatal("resolve + persist deadlocked under writeMu")
+		}
 	})
 }
 

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -335,7 +335,11 @@ func (s *ConfigStore) mutateInMemory(mutate func(*Config)) {
 func (s *ConfigStore) update(scope Scope, mutate func(*Config) map[string]any) error {
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
+	return s.updateLocked(scope, mutate)
+}
 
+// updateLocked is the lock-free core of update. Caller must hold writeMu.
+func (s *ConfigStore) updateLocked(scope Scope, mutate func(*Config) map[string]any) error {
 	nc := s.Config().cloneForWrite()
 	fields := mutate(nc)
 	s.setConfig(nc)
@@ -401,23 +405,30 @@ func (s *ConfigStore) RemoveConfigField(scope Scope, key string) error {
 // UpdateAgentModel).
 func (s *ConfigStore) UpdatePreferredModel(scope Scope, modelType SelectedModelType, model SelectedModel) error {
 	return s.update(scope, func(c *Config) map[string]any {
-		if c.Models == nil {
-			c.Models = make(map[SelectedModelType]SelectedModel)
-		}
-		c.Models[modelType] = model
-
-		fields := map[string]any{
-			fmt.Sprintf("models.%s", modelType): model,
-		}
-		if updated, changed := nextRecentModels(c, modelType, model); changed {
-			if c.RecentModels == nil {
-				c.RecentModels = make(map[SelectedModelType][]SelectedModel)
-			}
-			c.RecentModels[modelType] = updated
-			fields[fmt.Sprintf("recent_models.%s", modelType)] = updated
-		}
-		return fields
+		return s.updatePreferredModelFields(c, modelType, model)
 	})
+}
+
+// updatePreferredModelFields builds the fields map for persisting a preferred
+// model change. Shared between UpdatePreferredModel and direct updateLocked
+// callers (e.g. Load).
+func (s *ConfigStore) updatePreferredModelFields(c *Config, modelType SelectedModelType, model SelectedModel) map[string]any {
+	if c.Models == nil {
+		c.Models = make(map[SelectedModelType]SelectedModel)
+	}
+	c.Models[modelType] = model
+
+	fields := map[string]any{
+		fmt.Sprintf("models.%s", modelType): model,
+	}
+	if updated, changed := nextRecentModels(c, modelType, model); changed {
+		if c.RecentModels == nil {
+			c.RecentModels = make(map[SelectedModelType][]SelectedModel)
+		}
+		c.RecentModels[modelType] = updated
+		fields[fmt.Sprintf("recent_models.%s", modelType)] = updated
+	}
+	return fields
 }
 
 // SetCompactMode sets the compact mode setting and persists it.
@@ -986,14 +997,17 @@ func (s *ConfigStore) reloadFromDiskLocked(ctx context.Context) error {
 	s.overrides = overrides
 	s.workspacePath = workspacePath
 
-	// Mirror startup flow: setup models and agents against NEW config
+	// Mirror startup flow: setup models and agents against NEW config.
 	var setupErr error
 	if !cfg.IsConfigured() {
 		slog.Warn("No providers configured after reload")
 	} else {
-		if err := configureSelectedModels(s, providers, false); err != nil {
-			setupErr = fmt.Errorf("failed to configure selected models during reload: %w", err)
+		resolved, resolveErr := resolveSelectedModels(cfg, providers)
+		if resolveErr != nil {
+			setupErr = fmt.Errorf("failed to configure selected models during reload: %w", resolveErr)
 		} else {
+			cfg.Models[SelectedModelTypeLarge] = resolved.Large
+			cfg.Models[SelectedModelTypeSmall] = resolved.Small
 			s.SetupAgents()
 		}
 	}


### PR DESCRIPTION
Separate model resolution from persistence in configureSelectedModels. The old design used a persist bool flag that silently toggled disk writes, but the write path had a hidden precondition (caller must hold writeMu) that was not enforced by the type system. When Load held writeMu and called configureSelectedModels(persist=true) with an invalid model ID, UpdatePreferredModel re-acquired the same mutex, causing a self-deadlock.

resolveSelectedModels is now a pure function that returns corrected model selections and fallback flags without touching the store or disk. Callers assign results and persist fallbacks explicitly, making the locking contract visible at each call site.

fixes #3224 