### PR TITLE
fix(config): hide disabled known providers from model picker

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -192,6 +192,9 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 		config, configExists := c.Providers.Get(string(p.ID))
 		// if the user configured a known provider we need to allow it to override a couple of parameters
 		if configExists {
+			if config.Disable {
+				continue
+			}
 			if config.BaseURL != "" {
 				p.APIEndpoint = config.BaseURL
 			}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -751,26 +751,49 @@ func TestConfig_configureProvidersWithDisabledProvider(t *testing.T) {
 		},
 	}
 
-	cfg := &Config{
-		Providers: csync.NewMapFrom(map[string]ProviderConfig{
-			"openai": {
-				Disable: true,
-			},
-		}),
-	}
-	cfg.setDefaults("/tmp", "")
+	t.Run("with API key", func(t *testing.T) {
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"openai": {
+					Disable: true,
+				},
+			}),
+		}
+		cfg.setDefaults("/tmp", "")
 
-	env := env.NewFromMap(map[string]string{
-		"OPENAI_API_KEY": "test-key",
+		env := env.NewFromMap(map[string]string{
+			"OPENAI_API_KEY": "test-key",
+		})
+		resolver := NewShellVariableResolver(env)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, cfg.Providers.Len())
+		prov, exists := cfg.Providers.Get("openai")
+		require.True(t, exists)
+		require.True(t, prov.Disable)
 	})
-	resolver := NewShellVariableResolver(env)
-	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
-	require.NoError(t, err)
 
-	require.Equal(t, cfg.Providers.Len(), 1)
-	prov, exists := cfg.Providers.Get("openai")
-	require.True(t, exists)
-	require.True(t, prov.Disable)
+	t.Run("without API key", func(t *testing.T) {
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"openai": {
+					Disable: true,
+				},
+			}),
+		}
+		cfg.setDefaults("/tmp", "")
+
+		env := env.NewFromMap(map[string]string{})
+		resolver := NewShellVariableResolver(env)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, cfg.Providers.Len())
+		prov, exists := cfg.Providers.Get("openai")
+		require.True(t, exists)
+		require.True(t, prov.Disable)
+	})
 }
 
 func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes #3046: a known provider set to `"disable": true` (without credentials) still appeared in the TUI model picker.
- Root cause: the missing-credential check in `configureProviders` dropped such providers from `cfg.Providers`, erasing the disable flag. The model picker then re-added them from the known-providers list.
- Fix: skip disabled known providers before credential setup, leaving the disable flag in `cfg.Providers` so the picker can filter them out.

## Test plan
- [x] `go test ./internal/config/ -run TestConfig_configureProvidersWithDisabledProvider -v` (added a `without API key` subtest that fails before the fix, passes after)
- [x] `go build ./...`
- [x] Manual: with `anthropic`/`openai`/`zhipu` set to `disable: true` and no API keys, the model picker no longer lists them