### PR TITLE
docs: Add Hyper subscription plan to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ That said, you can also set environment variables for preferred providers.
 If you prefer subscription-based usage, here are some plans that work well in
 Crush:
 
+- [Charm Hyper](https://hyper.charm.land)
 - [Synthetic](https://synthetic.new/pricing)
 - [GLM Coding Plan](https://z.ai/subscribe)
 - [Kimi Code](https://www.kimi.com/membership/pricing)


### PR DESCRIPTION
As the title suggests, this PR adds Charm Hyper to the list of subscription plans that work well with Crush in the README.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).