### PR TITLE
docs(skill): document default_reasoning_effort in crush-config

### DIFF
--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -123,6 +123,14 @@ reviewed.
           "id": "deepseek-chat",
           "name": "Deepseek V3",
           "context_window": 64000
+        },
+        {
+          "id": "deepseek-reasoner",
+          "name": "Deepseek R1",
+          "context_window": 64000,
+          "can_reason": true,
+          "reasoning_levels": ["low", "medium", "high", "max"],
+          "default_reasoning_effort": "medium"
         }
       ]
     }
@@ -134,6 +142,16 @@ reviewed.
 - `api_key`, `base_url`, `api_endpoint`, and `extra_headers` are shell-expanded (see [Shell Expansion](#shell-expansion)).
 - `extra_body` is a JSON passthrough and is **not** expanded.
 - Additional fields: `disable`, `system_prompt_prefix`, `extra_headers`, `extra_body`, `provider_options`.
+- Per-model reasoning (only meaningful when the model supports it):
+  - `can_reason` (boolean, default `false`): enable reasoning for this model.
+  - `reasoning_levels` (array of strings): the effort levels the model accepts,
+    shown in the UI picker. Use provider-native names (e.g. `low`/`medium`/`high`,
+    or `xhigh`/`max`) — Crush does not translate them.
+  - `default_reasoning_effort` (string): the level sent when the user has not
+    picked one and one is required. Crush resolves the effective effort in this
+    order: user-selected level (if valid) → `default_reasoning_effort` (if valid)
+    → first entry of `reasoning_levels`. An invalid or missing
+    `default_reasoning_effort` is silently ignored, so omitting it is safe.
 
 ## LSP Configuration
 

--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -108,6 +108,59 @@ model small [<provider>/<id>] [flags]  # set the small slot; no arg prints it
 
 `large` is the primary coding model; `small` is used for summarization.
 
+#### Reasoning models
+
+Three model fields control reasoning; they matter only for models that
+actually support it:
+
+- `can_reason` (bool, default `false`) marks the model as reasoning-capable.
+  Set it with `model add --can-reason true`.
+- `reasoning_levels` (array of strings) lists the effort levels the model
+  accepts and populates the UI reasoning picker. Use the provider's native
+  names (`low`/`medium`/`high`, or `xhigh`/`max`, etc.) — Crush does not
+  translate them. There is no `model add` flag for this field; set it in
+  `crush.json` (see [Legacy JSON format](#legacy-json-format)).
+- `default_reasoning_effort` (string) is the level Crush sends when the user
+  has not chosen one. `model add --reasoning-effort <level>` writes this
+  field — note the flag is named after the value, not the JSON key.
+
+There are two `--reasoning-effort` flags and they set different things:
+
+- `model add … --reasoning-effort L` sets the model's
+  `default_reasoning_effort` (the per-model default).
+- `model large`/`model small … --reasoning-effort L` sets the selected slot's
+  `reasoning_effort` (the user's active choice).
+
+Crush resolves the effective effort in this order: the active
+`reasoning_effort` if it is one of `reasoning_levels` → `default_reasoning_effort`
+if valid → the first entry of `reasoning_levels`. An invalid or missing
+`default_reasoning_effort` is ignored, so omitting it is safe.
+
+Because `reasoning_levels` is JSON-only, a fully custom reasoning model is
+defined in `crush.json`:
+
+```json
+{
+  "providers": {
+    "deepseek": {
+      "type": "openai-compat",
+      "base_url": "https://api.deepseek.com/v1",
+      "api_key": "$DEEPSEEK_API_KEY",
+      "models": [
+        {
+          "id": "deepseek-reasoner",
+          "name": "Deepseek R1",
+          "context_window": 64000,
+          "can_reason": true,
+          "reasoning_levels": ["low", "medium", "high", "max"],
+          "default_reasoning_effort": "medium"
+        }
+      ]
+    }
+  }
+}
+```
+
 ### mcp
 
 ```bash


### PR DESCRIPTION
## What

Documents the three per-model reasoning fields in the `crush-config` skill: `can_reason`, `reasoning_levels`, and `default_reasoning_effort`. Docs-only — no code or behavior change.

Fixes #3119.

## Why

#3119 reported that the skill documented `reasoning_levels` but not `default_reasoning_effort`. Since then the skill was rewritten around the `crushrc` format, and in the current version **none** of the three reasoning fields are documented — so a user (or the model reading the skill) configuring a custom reasoning-capable provider has no reference for how they interrelate.

## What's added

A `#### Reasoning models` subsection under `### models` covering:

- Each field, its type/default, and how it surfaces in `crushrc` — including that `reasoning_levels` is **JSON-only** (it has no `model add` flag).
- The two same-named `--reasoning-effort` flags that set different things: `model add` writes the model's `default_reasoning_effort`; `model large`/`model small` writes the selected slot's `reasoning_effort`.
- The effort **resolution order** Crush applies.
- A `crush.json` example for a fully custom reasoning model.

## Accuracy

Every claim was checked against the code, in case that helps review:

- JSON keys — `catwalk` `Model` struct (`can_reason` / `reasoning_levels` / `default_reasoning_effort`).
- Flag → key mapping — `internal/shellconfig/model.go` (`model add --reasoning-effort` → `default_reasoning_effort`; `model large/small --reasoning-effort` → `reasoning_effort`); `reasoning_levels` is absent from the flag table, confirming it is JSON-only.
- Resolution order — `effectiveReasoningEffort` in `internal/agent/coordinator.go` (selected effort if valid → `default_reasoning_effort` if valid → first of `reasoning_levels`).

`go build ./internal/skills/...` and the skills package tests pass; no frontmatter changed.

- [x] I have read [CONTRIBUTING.md](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).

Fixes #3119