### PR TITLE
chore(clipboard): allow making the executable fully static

### DIFF
--- a/internal/clipboard/clipboard_not_supported.go
+++ b/internal/clipboard/clipboard_not_supported.go
@@ -1,4 +1,4 @@
-//go:build !((darwin || linux || windows || freebsd || openbsd || netbsd) && !ios && !android)
+//go:build crush_omit_native || !((darwin || linux || windows || freebsd || openbsd || netbsd) && !ios && !android)
 
 package clipboard
 

--- a/internal/clipboard/clipboard_supported.go
+++ b/internal/clipboard/clipboard_supported.go
@@ -1,4 +1,4 @@
-//go:build (darwin || linux || windows || freebsd || openbsd || netbsd) && !ios && !android
+//go:build !crush_omit_native && (darwin || linux || windows || freebsd || openbsd || netbsd) && !ios && !android
 
 package clipboard
 


### PR DESCRIPTION
github.com/ebitengine/purego will make the executable depend on libc because the use of cgo_import_dynamic.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
