### PR TITLE
feat(ui): preserve newlines in expanded tool content

### DIFF
--- a/internal/ui/chat/agent.go
+++ b/internal/ui/chat/agent.go
@@ -134,7 +134,9 @@ func (r *AgentToolRenderContext) RenderTool(sty *styles.Styles, width int, opts 
 	_ = json.Unmarshal([]byte(opts.ToolCall.Input), &params)
 
 	prompt := params.Prompt
-	prompt = strings.ReplaceAll(prompt, "\n", " ")
+	if !opts.ExpandedContent {
+		prompt = strings.ReplaceAll(prompt, "\n", " ")
+	}
 
 	header := toolHeader(sty, opts.Status, "Agent", cappedWidth, opts)
 	if opts.Compact {
@@ -295,7 +297,9 @@ func (r *AgenticFetchToolRenderContext) RenderTool(sty *styles.Styles, width int
 	_ = json.Unmarshal([]byte(opts.ToolCall.Input), &params)
 
 	prompt := params.Prompt
-	prompt = strings.ReplaceAll(prompt, "\n", " ")
+	if !opts.ExpandedContent {
+		prompt = strings.ReplaceAll(prompt, "\n", " ")
+	}
 
 	// Build header with optional URL param.
 	var toolParams []string

--- a/internal/ui/chat/bash.go
+++ b/internal/ui/chat/bash.go
@@ -62,7 +62,10 @@ func (b *BashToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *
 	}
 
 	// Regular bash command.
-	cmd := strings.ReplaceAll(params.Command, "\n", " ")
+	cmd := params.Command
+	if !opts.ExpandedContent {
+		cmd = strings.ReplaceAll(cmd, "\n", " ")
+	}
 	cmd = strings.ReplaceAll(cmd, "\t", "    ")
 	toolParams := []string{cmd}
 	if params.RunInBackground {


### PR DESCRIPTION
allows stuff like this instead of mushing the line together

<img width="694" height="265" alt="image" src="https://github.com/user-attachments/assets/ee925d8a-dea4-4b68-833f-dc8fda185ce4" />

<img width="862" height="276" alt="image" src="https://github.com/user-attachments/assets/235366dd-764a-4043-9be7-f91e3056a975" />
