### PR TITLE
fix(tools): enforce .crushignore for view, edit, write, and multiedit

### DIFF
--- a/internal/agent/tools/edit.go
+++ b/internal/agent/tools/edit.go
@@ -76,6 +76,10 @@ func NewEditTool(
 
 			params.FilePath = filepathext.SmartJoin(workingDir, params.FilePath)
 
+			if resp, ignored := ignoredPathResponse(workingDir, params.FilePath); ignored {
+				return resp, nil
+			}
+
 			var response fantasy.ToolResponse
 			var err error
 

--- a/internal/agent/tools/multiedit.go
+++ b/internal/agent/tools/multiedit.go
@@ -78,6 +78,10 @@ func NewMultiEditTool(
 
 			params.FilePath = filepathext.SmartJoin(workingDir, params.FilePath)
 
+			if resp, ignored := ignoredPathResponse(workingDir, params.FilePath); ignored {
+				return resp, nil
+			}
+
 			// Validate all edits before applying any
 			if err := validateEdits(params.Edits); err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil

--- a/internal/agent/tools/tools.go
+++ b/internal/agent/tools/tools.go
@@ -3,11 +3,14 @@ package tools
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"html/template"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/fsext"
 )
 
 type (
@@ -59,6 +62,28 @@ func GetSupportsImagesFromContext(ctx context.Context) bool {
 // GetModelNameFromContext retrieves the model name from the context.
 func GetModelNameFromContext(ctx context.Context) string {
 	return getContextValue(ctx, ModelNameContextKey, "")
+}
+
+// ignoredPathResponse reports whether filePath is excluded by .gitignore or
+// .crushignore rules relative to workingDir.
+func ignoredPathResponse(workingDir, filePath string) (fantasy.ToolResponse, bool) {
+	absWorkingDir, err := filepath.Abs(workingDir)
+	if err != nil {
+		return fantasy.ToolResponse{}, false
+	}
+
+	absFilePath, err := filepath.Abs(filePath)
+	if err != nil {
+		return fantasy.ToolResponse{}, false
+	}
+
+	if fsext.ShouldExcludeFile(absWorkingDir, absFilePath) {
+		return fantasy.NewTextErrorResponse(
+			fmt.Sprintf("Path is ignored by .gitignore or .crushignore: %s", filePath),
+		), true
+	}
+
+	return fantasy.ToolResponse{}, false
 }
 
 // NewPermissionDeniedResponse returns a tool response indicating the user

--- a/internal/agent/tools/view.go
+++ b/internal/agent/tools/view.go
@@ -112,6 +112,10 @@ func NewViewTool(
 			// Handle relative paths
 			filePath := filepathext.SmartJoin(workingDir, params.FilePath)
 
+			if resp, ignored := ignoredPathResponse(workingDir, filePath); ignored {
+				return resp, nil
+			}
+
 			// Check if file is outside working directory and request permission if needed
 			absWorkingDir, err := filepath.Abs(workingDir)
 			if err != nil {

--- a/internal/agent/tools/view_test.go
+++ b/internal/agent/tools/view_test.go
@@ -133,6 +133,25 @@ func TestViewToolAllowsSmallSectionsOfLargeFiles(t *testing.T) {
 	require.Equal(t, "target line", meta.Content)
 }
 
+func TestViewToolRespectsCrushignore(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	product := filepath.Join(workingDir, "product")
+	require.NoError(t, os.MkdirAll(product, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(product, "_brain-dump.md"), []byte("secret"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workingDir, ".crushignore"), []byte("**/_*.md\n"), 0o644))
+
+	tool := newViewToolForTest(workingDir)
+	ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+	resp := runViewTool(t, tool, ctx, ViewParams{
+		FilePath: filepath.Join("product", "_brain-dump.md"),
+	})
+
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, ".crushignore")
+}
+
 func TestViewToolBlocksOversizedReturnedSections(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/tools/write.go
+++ b/internal/agent/tools/write.go
@@ -65,6 +65,10 @@ func NewWriteTool(
 
 			filePath := filepathext.SmartJoin(workingDir, params.FilePath)
 
+			if resp, ignored := ignoredPathResponse(workingDir, filePath); ignored {
+				return resp, nil
+			}
+
 			fileInfo, err := os.Stat(filePath)
 			if err == nil {
 				if fileInfo.IsDir() {

--- a/internal/agent/tools/write_test.go
+++ b/internal/agent/tools/write_test.go
@@ -47,3 +47,33 @@ func TestWriteToolWritesEmptyNewFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", string(b))
 }
+
+func TestWriteToolRespectsCrushignore(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	product := filepath.Join(workingDir, "product")
+	require.NoError(t, os.MkdirAll(product, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(workingDir, ".crushignore"), []byte("**/_*.md\n"), 0o644))
+
+	ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+	tool := NewWriteTool(nil, &mockPermissionService{}, &mockHistoryService{}, mockFileTrackerService{}, workingDir)
+
+	input, err := json.Marshal(WriteParams{
+		FilePath: filepath.Join("product", "_draft.md"),
+		Content:  "secret",
+	})
+	require.NoError(t, err)
+
+	resp, err := tool.Run(ctx, fantasy.ToolCall{
+		ID:    "test-call",
+		Name:  WriteToolName,
+		Input: string(input),
+	})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, ".crushignore")
+
+	_, err = os.Stat(filepath.Join(product, "_draft.md"))
+	require.True(t, os.IsNotExist(err))
+}

--- a/internal/fsext/ignore_globstar_test.go
+++ b/internal/fsext/ignore_globstar_test.go
@@ -1,0 +1,43 @@
+package fsext
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCrushIgnoreGlobstarUnderscoreMarkdown(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	product := filepath.Join(tempDir, "product")
+	require.NoError(t, os.MkdirAll(product, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(product, "_brain-dump.md"), []byte("secret"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(product, "normal.md"), []byte("ok"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, ".crushignore"), []byte("**/_*.md\n"), 0o644))
+
+	brainDump := filepath.Join(product, "_brain-dump.md")
+	normal := filepath.Join(product, "normal.md")
+
+	require.True(t, ShouldExcludeFile(tempDir, brainDump), "expected _brain-dump.md to be ignored by **/_*.md")
+	require.False(t, ShouldExcludeFile(tempDir, normal), "expected normal.md to remain visible")
+
+	files, _, err := ListDirectory(tempDir, nil, 3, 100)
+	require.NoError(t, err)
+
+	for _, f := range files {
+		require.NotContains(t, f, "_brain-dump.md", "ls should not list ignored _brain-dump.md, got: %v", files)
+	}
+	require.True(t, containsPath(files, normal), "ls should list normal.md, got: %v", files)
+}
+
+func containsPath(paths []string, target string) bool {
+	for _, p := range paths {
+		if p == target || p == target+string(filepath.Separator) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Fixes #3116

`ls`, `grep`, and `glob` already respected `.crushignore` via `fsext`, but `view`, `edit`, `write`, and `multiedit` could still read or modify ignored paths.

This PR adds a shared `ignoredPathResponse` helper that calls `fsext.ShouldExcludeFile` after path resolution and returns an error before permission checks or filesystem access.

## Motivation

Users configure `.crushignore` expecting Crush tools to stay out of ignored files. The README documents this behavior, but direct file tools bypassed the ignore layer even when `ls`/`grep` honored it.

## Changes

- Add `ignoredPathResponse` in `internal/agent/tools/tools.go`
- Early-return in `view`, `edit`, `write`, and `multiedit` after `SmartJoin`
- Add `TestViewToolRespectsCrushignore` and `TestWriteToolRespectsCrushignore` for the `**/_*.md` repro from the issue
- Add `TestCrushIgnoreGlobstarUnderscoreMarkdown` in `fsext` for pattern matching + `ListDirectory`

## Tests

- `go test ./internal/fsext/ -run TestCrushIgnoreGlobstar`
- `go test ./internal/agent/tools/ -run 'TestViewToolRespectsCrushignore|TestWriteToolRespectsCrushignore'`
- `go test ./internal/agent/tools/ -count=1`

## Notes

- `bash` tool ignore enforcement is left as a follow-up to #3116