### PR TITLE
fix(bash): report elapsed time when command moves to background

### DIFF
--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -296,7 +296,8 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 					Background:       true,
 					ShellID:          bgShell.ID,
 				}
-				response := fmt.Sprintf("Background shell started with ID: %s\n\nUse job_output tool to view output or job_kill to terminate.", bgShell.ID)
+				elapsed := time.Since(startTime).Round(100 * time.Millisecond)
+			response := fmt.Sprintf("Background shell started with ID: %s\n\nElapsed: %s. Use job_output tool to view output or job_kill to terminate.", bgShell.ID, elapsed)
 				return fantasy.WithResponseMetadata(fantasy.NewTextResponse(response), metadata), nil
 			}
 
@@ -380,7 +381,8 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 				Background:       true,
 				ShellID:          bgShell.ID,
 			}
-			response := fmt.Sprintf("Command is taking longer than expected and has been moved to background.\n\nBackground shell ID: %s\n\nUse job_output tool to view output or job_kill to terminate.", bgShell.ID)
+			elapsed := time.Since(startTime).Round(100 * time.Millisecond)
+			response := fmt.Sprintf("Command ran for %s (threshold: %ds) and has been moved to background.\n\nBackground shell ID: %s\n\nUse job_output tool to view output or job_kill to terminate.", elapsed, autoBackgroundAfter, bgShell.ID)
 			return fantasy.WithResponseMetadata(fantasy.NewTextResponse(response), metadata), nil
 		},
 	)


### PR DESCRIPTION
When Crush's bash tool auto-backgrounds a long-running command, neither the user nor the LLM knows how long the command already ran. The message just says "taking longer than expected" without any timing context.

This change adds elapsed time (rounded to 100ms) and the configured threshold to both background-job messages:

- Fast-failure background path: "Background shell started with ID: X\n\nElapsed: Ys"
- Auto-background path: "Command ran for Xs (threshold: Ys) and has been moved to background."

This gives the LLM precise information to decide whether the delay is normal or indicates a problem.

- [x] I have read [CONTRIBUTING.md](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).

Fixes #2977