### PR TITLE
fix(shell): drop spurious trailing empty line in jq -R raw input

### DIFF
--- a/internal/shell/jq.go
+++ b/internal/shell/jq.go
@@ -245,17 +245,20 @@ func readInputs(ctx context.Context, stdin io.Reader, files []string, nullInput,
 		}
 
 		if rawInput {
-			lines := strings.Split(string(data), "\n")
 			if slurp {
-				vals = append(vals, strings.Join(lines, "\n"))
+				vals = append(vals, string(data))
 			} else {
-				for _, line := range lines {
+				// A terminating newline is a line terminator, not a
+				// separator: "a\nb\n" is two lines, not three. Drop a
+				// single trailing newline before splitting so we don't
+				// emit a spurious empty string, while preserving any
+				// interior empty lines. Matches jq -R.
+				s := strings.TrimSuffix(string(data), "\n")
+				for _, line := range strings.Split(s, "\n") {
 					if err := ctx.Err(); err != nil {
 						return nil, err
 					}
-					if line != "" || !slurp {
-						vals = append(vals, line)
-					}
+					vals = append(vals, line)
 				}
 			}
 			continue

--- a/internal/shell/jq_test.go
+++ b/internal/shell/jq_test.go
@@ -210,3 +210,38 @@ func TestJQ_Success(t *testing.T) {
 		t.Fatalf("stdout = %q, want %q", got, "1\n")
 	}
 }
+
+// TestJQ_RawInputTrailingNewline verifies that `jq -R` treats a terminating
+// newline as a line terminator, not a separator: "a\nb\n" is two lines and
+// must not produce a spurious trailing empty string. Interior empty lines are
+// preserved.
+func TestJQ_RawInputTrailingNewline(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name, in, want string
+	}{
+		{"trailing newline", "a\nb\n", "\"a\"\n\"b\"\n"},
+		{"interior empty preserved", "a\n\nb\n", "\"a\"\n\"\"\n\"b\"\n"},
+		{"single line with newline", "a\n", "\"a\"\n"},
+		{"no trailing newline", "a\nb", "\"a\"\n\"b\"\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var stdout bytes.Buffer
+			err := handleJQ(
+				t.Context(),
+				[]string{"jq", "-R", "."},
+				strings.NewReader(tc.in),
+				&stdout, io.Discard,
+			)
+			if err != nil {
+				t.Fatalf("handleJQ returned error: %v", err)
+			}
+			if got := stdout.String(); got != tc.want {
+				t.Fatalf("stdout = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Problem

The built-in `jq -R` (raw input) handling in `internal/shell/jq.go` (`readInputs`) splits stdin on `"\n"` and appends every resulting element. A terminating newline is a line *terminator*, not a *separator*, so input ending in `\n` produces a spurious trailing empty string — which real `jq -R` does not emit:

| stdin | before | real jq / expected |
|---|---|---|
| `"a\nb\n"` | `"a" "b" ""` | `"a" "b"` |
| `"a\n\nb\n"` | `"a" "" "b" ""` | `"a" "" "b"` |
| `"a\n"` | `"a" ""` | `"a"` |
| `"a\nb"` (no trailing NL) | `"a" "b"` | `"a" "b"` (already OK) |

The `line != "" || !slurp` guard looks like it was meant to drop the empty element, but in the non-slurp branch `!slurp` is always `true`, so the guard is dead. A blanket `line != ""` filter would be wrong too — it would drop legitimate *interior* empty lines.

### Fix

Trim a single trailing newline before splitting (preserving interior empty lines), matching `jq -R`:

```go
s := strings.TrimSuffix(string(data), "\n")
for _, line := range strings.Split(s, "\n") {
    if err := ctx.Err(); err != nil {
        return nil, err
    }
    vals = append(vals, line)
}
```

The slurp branch is unchanged in behavior (simplified to `string(data)`, which equals the previous split-then-join identity).

### Tests

Added `TestJQ_RawInputTrailingNewline` (`internal/shell/jq_test.go`) covering the trailing-newline, interior-empty, single-line, and no-trailing-newline cases. Verified RED→GREEN with `go test ./internal/shell/`; `gofmt` and `go vet` clean; no regressions in the existing jq/shell suite.
