### PR TITLE
fix(copilot): guard nil request body in initiator transport

### DIFF
--- a/internal/oauth/copilot/client.go
+++ b/internal/oauth/copilot/client.go
@@ -37,8 +37,10 @@ func (t *initiatorTransport) RoundTrip(req *http.Request) (*http.Response, error
 	if req == nil {
 		return nil, fmt.Errorf("HTTP request is nil")
 	}
-	if req.Body == http.NoBody {
-		// No body to inspect; default to user.
+	if req.Body == nil || req.Body == http.NoBody {
+		// No body to inspect; default to user. A nil Body is valid for
+		// bodyless requests (e.g. GET), and is distinct from http.NoBody,
+		// so both must be handled before reading below.
 		req.Header.Set(xInitiatorHeader, userInitiator)
 		slog.Debug("Setting X-Initiator header to user (no request body)")
 		return t.roundTrip(req)

--- a/internal/oauth/copilot/client_test.go
+++ b/internal/oauth/copilot/client_test.go
@@ -51,11 +51,11 @@ func TestInitiatorTransportSetsHeader(t *testing.T) {
 			var err error
 			switch kind {
 			case 0:
-				req, err = http.NewRequest(http.MethodGet, srv.URL, nil)
+				req, err = http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
 			case -1:
-				req, err = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+				req, err = http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, http.NoBody)
 			default:
-				req, err = http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(payload))
+				req, err = http.NewRequestWithContext(t.Context(), http.MethodPost, srv.URL, strings.NewReader(payload))
 			}
 			require.NoError(t, err)
 

--- a/internal/oauth/copilot/client_test.go
+++ b/internal/oauth/copilot/client_test.go
@@ -1,0 +1,70 @@
+package copilot
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitiatorTransportSetsHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		// body builds the request body; nil means a bodyless request.
+		body func() (int, string)
+		want string
+	}{
+		{
+			name: "nil body defaults to user",
+			body: func() (int, string) { return 0, "" }, // req.Body == nil
+			want: "user",
+		},
+		{
+			name: "NoBody defaults to user",
+			body: func() (int, string) { return -1, "" }, // req.Body == http.NoBody
+			want: "user",
+		},
+		{
+			name: "user-only history stays user",
+			body: func() (int, string) { return 1, `{"messages":[{"role":"user"}]}` },
+			want: "user",
+		},
+		{
+			name: "assistant history becomes agent",
+			body: func() (int, string) { return 1, `{"messages":[{"role":"assistant"}]}` },
+			want: "agent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Get("X-Initiator")
+			}))
+			defer srv.Close()
+
+			kind, payload := tt.body()
+			var req *http.Request
+			var err error
+			switch kind {
+			case 0:
+				req, err = http.NewRequest(http.MethodGet, srv.URL, nil)
+			case -1:
+				req, err = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			default:
+				req, err = http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(payload))
+			}
+			require.NoError(t, err)
+
+			client := &http.Client{Transport: &initiatorTransport{}}
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			resp.Body.Close()
+
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3245.

`initiatorTransport.RoundTrip` only guarded `req.Body == http.NoBody` before calling `io.ReadAll(req.Body)`. A bodyless request carries `req.Body == nil`, which is a distinct value from `http.NoBody`, so it fell through to `io.ReadAll(nil)` and panicked with a nil pointer dereference. Because this can happen on a retried request whose body was already consumed (reported via `GenerateTitle`), the panic fires on a background goroutine and takes the session down.

The fix treats a nil body the same as `http.NoBody`: default `X-Initiator` to `user` and skip the read.

Verified the panic with the guard reverted (test hits `io.ReadAll({0x0, 0x0})` and fails); with the guard in place all four cases pass. Added `client_test.go` covering nil body, `http.NoBody`, user-only history, and assistant history.

Fix written with AI assistance; I verified the repro and the diff myself.