### PR TITLE
fix: propagate context cancellation to background jobs and handle interrupted waits

### DIFF
--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -245,13 +245,13 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 				}
 			}
 
-			// If explicitly requested as background, start immediately with detached context
+			// If explicitly requested as background, start with the agent context
+			// so Esc/session cancellation can propagate to the background job.
 			if params.RunInBackground {
 				startTime := time.Now()
 				bgManager := shell.GetBackgroundShellManager()
 				bgManager.Cleanup()
-				// Use background context so it continues after tool returns
-				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+				bgShell, err := bgManager.Start(ctx, execWorkingDir, blockFuncs(), params.Command, params.Description)
 				if err != nil {
 					return fantasy.ToolResponse{}, fmt.Errorf("error starting background shell: %w", err)
 				}
@@ -306,7 +306,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 			// Start with detached context so it can survive if moved to background
 			bgManager := shell.GetBackgroundShellManager()
 			bgManager.Cleanup()
-			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+			bgShell, err := bgManager.Start(ctx, execWorkingDir, blockFuncs(), params.Command, params.Description)
 			if err != nil {
 				return fantasy.ToolResponse{}, fmt.Errorf("error starting shell: %w", err)
 			}

--- a/internal/agent/tools/job_output.go
+++ b/internal/agent/tools/job_output.go
@@ -46,7 +46,23 @@ func NewJobOutputTool() fantasy.AgentTool {
 			}
 
 			if params.Wait {
-				bgShell.WaitContext(ctx)
+				if !bgShell.WaitContext(ctx) {
+					stdout, stderr, _, _ := bgShell.GetOutput()
+					output := stdout + stderr
+					if output == "" {
+						output = BashNoOutput
+					}
+					output = TruncateOutput(output)
+					metadata := JobOutputResponseMetadata{
+						ShellID:          params.ShellID,
+						Command:          bgShell.Command,
+						Description:      bgShell.Description,
+						Done:             false,
+						WorkingDirectory: bgShell.WorkingDir,
+					}
+					result := fmt.Sprintf("Status: interrupted\n\nWait was interrupted before the job completed. Use job_output without wait to check current progress.\n\n%s", output)
+					return fantasy.WithResponseMetadata(fantasy.NewTextResponse(result), metadata), nil
+				}
 			}
 
 			stdout, stderr, done, err := bgShell.GetOutput()

--- a/internal/agent/tools/job_test.go
+++ b/internal/agent/tools/job_test.go
@@ -2,10 +2,12 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"runtime"
 	"testing"
 	"time"
 
+	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/shell"
 	"github.com/stretchr/testify/require"
 )
@@ -331,4 +333,112 @@ func TestBackgroundShell_AutoBackground(t *testing.T) {
 		require.True(t, ok, "Should be able to retrieve background shell")
 		require.Equal(t, bgShell.ID, retrieved.ID)
 	})
+}
+
+func TestJobOutput_WaitContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	bgManager := shell.GetBackgroundShellManager()
+
+	// Start a long-running background job that won't complete
+	bgShell, err := bgManager.Start(context.Background(), workingDir, nil, "sleep 3600", "long-running test")
+	require.NoError(t, err)
+	defer bgManager.Kill(bgShell.ID)
+
+	jobTool := NewJobOutputTool()
+
+	paramsJSON, err := json.Marshal(JobOutputParams{
+		ShellID: bgShell.ID,
+		Wait:    true,
+	})
+	require.NoError(t, err)
+
+	// Context that is already canceled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	resp, err := jobTool.Run(ctx, fantasy.ToolCall{
+		ID:    "test-call",
+		Name:  JobOutputToolName,
+		Input: string(paramsJSON),
+	})
+	require.NoError(t, err)
+
+	require.Contains(t, resp.Content, "Status: interrupted")
+	require.Contains(t, resp.Content, "Wait was interrupted")
+
+	var meta JobOutputResponseMetadata
+	require.NoError(t, json.Unmarshal([]byte(resp.Metadata), &meta))
+	require.False(t, meta.Done)
+}
+
+func TestJobOutput_WaitCompletes(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	bgManager := shell.GetBackgroundShellManager()
+
+	bgShell, err := bgManager.Start(context.Background(), workingDir, nil, "echo 'hello from job'", "quick test")
+	require.NoError(t, err)
+	defer bgManager.Kill(bgShell.ID)
+
+	jobTool := NewJobOutputTool()
+
+	paramsJSON, err := json.Marshal(JobOutputParams{
+		ShellID: bgShell.ID,
+		Wait:    true,
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	resp, err := jobTool.Run(ctx, fantasy.ToolCall{
+		ID:    "test-call",
+		Name:  JobOutputToolName,
+		Input: string(paramsJSON),
+	})
+	require.NoError(t, err)
+
+	require.Contains(t, resp.Content, "Status: completed")
+	require.Contains(t, resp.Content, "hello from job")
+
+	var meta JobOutputResponseMetadata
+	require.NoError(t, json.Unmarshal([]byte(resp.Metadata), &meta))
+	require.True(t, meta.Done)
+}
+
+func TestJobOutput_NoWaitReturnsRunning(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	bgManager := shell.GetBackgroundShellManager()
+
+	bgShell, err := bgManager.Start(context.Background(), workingDir, nil, "sleep 3600", "long-running test")
+	require.NoError(t, err)
+	defer bgManager.Kill(bgShell.ID)
+
+	jobTool := NewJobOutputTool()
+
+	paramsJSON, err := json.Marshal(JobOutputParams{
+		ShellID: bgShell.ID,
+		Wait:    false,
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	start := time.Now()
+	resp, err := jobTool.Run(ctx, fantasy.ToolCall{
+		ID:    "test-call",
+		Name:  JobOutputToolName,
+		Input: string(paramsJSON),
+	})
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	require.Less(t, elapsed, 2*time.Second, "no-wait should return immediately")
+	require.Contains(t, resp.Content, "Status: running")
+
+	var meta JobOutputResponseMetadata
+	require.NoError(t, json.Unmarshal([]byte(resp.Metadata), &meta))
+	require.False(t, meta.Done)
 }


### PR DESCRIPTION
## What

Background shell jobs were launched with `context.Background()`, making them immune to Esc (agent cancellation) and session shutdown. This left zombie processes that couldn't be cleaned up without manual `job_kill`.

Additionally, `job_output` with `wait=true` silently discarded the `WaitContext` return value, so context cancellation during a wait was invisible — the tool returned stale output as if nothing happened.

## Changes

### `internal/agent/tools/bash.go`
- Both `run_in_background` and synchronous auto-background paths now use the agent's request context (`ctx`) instead of `context.Background()` when calling `bgManager.Start`.
- When the agent is canceled (Esc or session shutdown), the context cancellation propagates through `shellCtx` → `exec.CommandContext` → process killed → goroutine exits → `done` channel closes.

### `internal/agent/tools/job_output.go`
- `WaitContext` return value is now checked. When it returns `false` (context canceled), the tool returns an `"interrupted"` status with the current partial output, instead of silently falling through to the normal path.

### `internal/agent/tools/job_test.go`
- Added 3 new tests:
  - `TestJobOutput_WaitContextCanceled` — canceled context returns "interrupted"
  - `TestJobOutput_WaitCompletes` — normal completion returns "completed"
  - `TestJobOutput_NoWaitReturnsRunning` — no-wait path returns immediately with "running"

## Why

- Background jobs (servers, long builds) started by the agent now get properly cleaned up on Esc
- `job_output` wait path no longer silently ignores context cancellation
- No API changes, no new dependencies
- All existing tests pass unchanged


💘 Generated with Crush



Assisted-by: Crush:deepseek-v4-pro