### PR TITLE
fix(agent): omit function.strict from openai-compat tool requests

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -929,6 +929,8 @@ func (c *coordinator) buildOpenaiCompatProvider(baseURL, apiKey string, headers 
 		opts = append(opts, openaicompat.WithSDKOptions(openaisdk.WithJSONSet(extraKey, extraValue)))
 	}
 
+	opts = append(opts, openaicompat.WithSDKOptions(openAICompatSDKOptions()...))
+
 	return openaicompat.New(opts...)
 }
 

--- a/internal/agent/openaicompat_prepare.go
+++ b/internal/agent/openaicompat_prepare.go
@@ -1,0 +1,70 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	openaisdk "github.com/charmbracelet/openai-go/option"
+)
+
+func openAICompatSDKOptions() []openaisdk.RequestOption {
+	return []openaisdk.RequestOption{
+		openaisdk.WithMiddleware(stripFunctionStrictMiddleware),
+	}
+}
+
+func stripFunctionStrictMiddleware(req *http.Request, next openaisdk.MiddlewareNext) (*http.Response, error) {
+	if req.Body == nil || req.Method != http.MethodPost {
+		return next(req)
+	}
+
+	body, err := io.ReadAll(req.Body)
+	_ = req.Body.Close()
+	if err != nil {
+		req.Body = io.NopCloser(bytes.NewReader(body))
+		return next(req)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		req.Body = io.NopCloser(bytes.NewReader(body))
+		req.ContentLength = int64(len(body))
+		return next(req)
+	}
+
+	if stripFunctionStrictFromPayload(payload) {
+		if updated, err := json.Marshal(payload); err == nil {
+			body = updated
+		}
+	}
+
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+	return next(req)
+}
+
+func stripFunctionStrictFromPayload(payload map[string]any) bool {
+	tools, ok := payload["tools"].([]any)
+	if !ok {
+		return false
+	}
+
+	changed := false
+	for _, rawTool := range tools {
+		tool, ok := rawTool.(map[string]any)
+		if !ok {
+			continue
+		}
+		function, ok := tool["function"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, exists := function["strict"]; exists {
+			delete(function, "strict")
+			changed = true
+		}
+	}
+	return changed
+}

--- a/internal/agent/openaicompat_prepare_test.go
+++ b/internal/agent/openaicompat_prepare_test.go
@@ -1,0 +1,92 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripFunctionStrictMiddleware(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return stripFunctionStrictMiddleware(req, http.DefaultTransport.RoundTrip)
+		}),
+	}
+
+	payload := map[string]any{
+		"model": "test-model",
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":   "echo",
+					"strict": false,
+				},
+			},
+		},
+	}
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, server.URL, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err = client.Do(req)
+	require.NoError(t, err)
+
+	tools, ok := capturedBody["tools"].([]any)
+	require.True(t, ok)
+	function, ok := tools[0].(map[string]any)["function"].(map[string]any)
+	require.True(t, ok)
+	_, hasStrict := function["strict"]
+	require.False(t, hasStrict)
+}
+
+func TestStripFunctionStrictFromPayload(t *testing.T) {
+	t.Parallel()
+
+	payload := map[string]any{
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":   "echo",
+					"strict": false,
+				},
+			},
+		},
+	}
+
+	changed := stripFunctionStrictFromPayload(payload)
+	require.True(t, changed)
+
+	tools := payload["tools"].([]any)
+	function := tools[0].(map[string]any)["function"].(map[string]any)
+	_, hasStrict := function["strict"]
+	require.False(t, hasStrict)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/agent/openaicompat_prepare_test.go
+++ b/internal/agent/openaicompat_prepare_test.go
@@ -50,8 +50,9 @@ func TestStripFunctionStrictMiddleware(t *testing.T) {
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 
-	_, err = client.Do(req)
+	resp, err := client.Do(req)
 	require.NoError(t, err)
+	defer resp.Body.Close()
 
 	tools, ok := capturedBody["tools"].([]any)
 	require.True(t, ok)


### PR DESCRIPTION
## Summary

Strip the OpenAI-only `function.strict` field from chat completion JSON bodies sent through `openai-compat` providers.

## Motivation

NVIDIA NIM and several other OpenAI-compatible endpoints reject tool definitions that include `function.strict`, even when the value is `false`. Crush currently sends this field for all openai-compat traffic because the underlying fantasy/openai stack always serializes `strict: false`.

Fixes #2472

## Changes

- Add an OpenAI SDK request middleware that removes `tools[].function.strict` from outgoing JSON bodies.
- Wire the middleware into `buildOpenaiCompatProvider` via `openaicompat.WithSDKOptions(...)`.
- Add unit tests for the middleware and payload helper.

## Tests

- `go test ./internal/agent/ -run 'TestStripFunctionStrict' -count=1` — PASS
- `go test ./internal/agent/ -count=1` — PASS

## Notes

- Native OpenAI provider paths are unchanged.
- Longer term, omitting `Strict` in fantasy for openai-compat would be a cleaner upstream fix; this is a minimal crush-side workaround until then.