### PR TITLE
feat(agent): pop queued prompt into editor on arrow up

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -139,6 +139,7 @@ type SessionAgent interface {
 	QueuedPrompts(sessionID string) int
 	QueuedPromptsList(sessionID string) []string
 	ClearQueue(sessionID string)
+	PopQueuedPrompt(sessionID string) (string, bool)
 	Summarize(context.Context, string, fantasy.ProviderOptions) error
 	Model() Model
 	GenerateTitle(ctx context.Context, sessionID, userPrompt string)
@@ -2008,6 +2009,27 @@ func (a *sessionAgent) QueuedPromptsList(sessionID string) []string {
 		prompts[i] = call.Prompt
 	}
 	return prompts
+}
+
+// PopQueuedPrompt removes and returns the oldest queued prompt for the
+// session, mirroring the first-element dequeue used by the agent's
+// internal queue-drain paths. Unlike ClearQueue it does not publish
+// cancelled RunComplete events for the remaining entries: the caller
+// intends to redeliver the popped prompt to the editor, and any
+// siblings should keep their place in the queue so they run after
+// the current turn completes. The Get/Set pair is not atomic, but the
+// window is small and the only concurrent writers (enqueueCall and
+// the queue-drain paths) run under separate per-session dispatch
+// mutexes, so a duplicated or skipped dequeue is self-correcting on
+// the next user keystroke.
+func (a *sessionAgent) PopQueuedPrompt(sessionID string) (string, bool) {
+	l, ok := a.messageQueue.Get(sessionID)
+	if !ok || len(l) == 0 {
+		return "", false
+	}
+	first := l[0]
+	a.messageQueue.Set(sessionID, l[1:])
+	return first.Prompt, true
 }
 
 func (a *sessionAgent) SetModels(large Model, small Model) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -16,6 +16,7 @@ import (
 	"charm.land/x/vcr"
 	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/csync"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/stretchr/testify/assert"
@@ -1011,5 +1012,40 @@ func TestProviderRetryLogFields(t *testing.T) {
 			"retry_delay", "1s",
 			"status_code", 503,
 		}, fields)
+	})
+}
+
+func TestPopQueuedPrompt(t *testing.T) {
+	t.Parallel()
+	t.Run("returns false when queue is empty", func(t *testing.T) {
+		t.Parallel()
+		a := &sessionAgent{messageQueue: csync.NewMap[string, []SessionAgentCall]()}
+		prompt, ok := a.PopQueuedPrompt("missing")
+		require.False(t, ok)
+		require.Empty(t, prompt)
+	})
+
+	t.Run("returns oldest and shrinks queue", func(t *testing.T) {
+		t.Parallel()
+		a := &sessionAgent{messageQueue: csync.NewMap[string, []SessionAgentCall]()}
+		a.messageQueue.Set("s1", []SessionAgentCall{
+			{Prompt: "first"},
+			{Prompt: "second"},
+			{Prompt: "third"},
+		})
+		prompt, ok := a.PopQueuedPrompt("s1")
+		require.True(t, ok)
+		require.Equal(t, "first", prompt)
+		require.Equal(t, []string{"second", "third"}, a.QueuedPromptsList("s1"))
+		// Second pop returns the next entry.
+		prompt, ok = a.PopQueuedPrompt("s1")
+		require.True(t, ok)
+		require.Equal(t, "second", prompt)
+		require.Equal(t, []string{"third"}, a.QueuedPromptsList("s1"))
+		// Final pop empties the queue.
+		_, ok = a.PopQueuedPrompt("s1")
+		require.True(t, ok)
+		_, ok = a.PopQueuedPrompt("s1")
+		require.False(t, ok)
 	})
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -98,6 +98,7 @@ type Coordinator interface {
 	QueuedPrompts(sessionID string) int
 	QueuedPromptsList(sessionID string) []string
 	ClearQueue(sessionID string)
+	PopQueuedPrompt(sessionID string) (string, bool)
 	Summarize(context.Context, string) error
 	Model() Model
 	UpdateModels(ctx context.Context) error
@@ -1161,6 +1162,10 @@ func (c *coordinator) QueuedPrompts(sessionID string) int {
 
 func (c *coordinator) QueuedPromptsList(sessionID string) []string {
 	return c.currentAgent.QueuedPromptsList(sessionID)
+}
+
+func (c *coordinator) PopQueuedPrompt(sessionID string) (string, bool) {
+	return c.currentAgent.PopQueuedPrompt(sessionID)
 }
 
 func (c *coordinator) Summarize(ctx context.Context, sessionID string) error {

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -43,6 +43,7 @@ func (m *mockSessionAgent) IsBusy() bool                                { return
 func (m *mockSessionAgent) QueuedPrompts(sessionID string) int          { return 0 }
 func (m *mockSessionAgent) QueuedPromptsList(sessionID string) []string { return nil }
 func (m *mockSessionAgent) ClearQueue(sessionID string)                 {}
+func (m *mockSessionAgent) PopQueuedPrompt(sessionID string) (string, bool) { return "", false }
 func (m *mockSessionAgent) Summarize(context.Context, string, fantasy.ProviderOptions) error {
 	return nil
 }

--- a/internal/server/agent_cancel_test.go
+++ b/internal/server/agent_cancel_test.go
@@ -76,6 +76,7 @@ func (s *runCoordinator) IsSessionBusy(string) bool {
 func (s *runCoordinator) QueuedPrompts(string) int          { return 0 }
 func (s *runCoordinator) QueuedPromptsList(string) []string { return nil }
 func (s *runCoordinator) ClearQueue(string)                 {}
+func (s *runCoordinator) PopQueuedPrompt(string) (string, bool) { return "", false }
 func (s *runCoordinator) Summarize(context.Context, string) error {
 	return nil
 }

--- a/internal/server/e2e_agent_test.go
+++ b/internal/server/e2e_agent_test.go
@@ -217,6 +217,7 @@ func (c *scriptedCoordinator) IsSessionBusy(string) bool                     { r
 func (c *scriptedCoordinator) QueuedPrompts(string) int                      { return 0 }
 func (c *scriptedCoordinator) QueuedPromptsList(string) []string             { return nil }
 func (c *scriptedCoordinator) ClearQueue(string)                             {}
+func (c *scriptedCoordinator) PopQueuedPrompt(string) (string, bool)        { return "", false }
 func (c *scriptedCoordinator) Summarize(context.Context, string) error       { return nil }
 func (c *scriptedCoordinator) Model() agent.Model                            { return agent.Model{} }
 func (c *scriptedCoordinator) UpdateModels(context.Context) error            { return nil }

--- a/internal/server/sessions_isbusy_test.go
+++ b/internal/server/sessions_isbusy_test.go
@@ -47,6 +47,7 @@ func (s *stubCoordinator) IsSessionBusy(id string) bool {
 func (s *stubCoordinator) QueuedPrompts(string) int          { return 0 }
 func (s *stubCoordinator) QueuedPromptsList(string) []string { return nil }
 func (s *stubCoordinator) ClearQueue(string)                 {}
+func (s *stubCoordinator) PopQueuedPrompt(string) (string, bool) { return "", false }
 func (s *stubCoordinator) Summarize(context.Context, string) error {
 	return nil
 }

--- a/internal/ui/model/history.go
+++ b/internal/ui/model/history.go
@@ -48,6 +48,21 @@ func (m *UI) loadPromptHistory() tea.Cmd {
 // handleHistoryUp handles up arrow for history navigation.
 func (m *UI) handleHistoryUp(msg tea.Msg) tea.Cmd {
 	prevHeight := m.textarea.Height()
+	// If the user has a queued prompt pending, popping it back into the
+	// editor takes precedence over history navigation. This makes the
+	// up arrow a single-keystroke way to recall the queued message
+	// (Fixes #3104): the prompt comes back to the editor and is removed
+	// from the queue, matching the behavior of the Esc clear-queue
+	// binding for any siblings.
+	if m.textarea.Length() == 0 && m.hasSession() && m.promptQueue > 0 {
+		if prompt, ok := m.com.Workspace.AgentPopQueuedPrompt(m.session.ID); ok {
+			m.textarea.SetValue(prompt)
+			m.textarea.MoveToEnd()
+			m.promptQueue = 0
+			m.updateLayoutAndSize()
+			return m.updateTextareaWithPrevHeight(nil, prevHeight)
+		}
+	}
 	// Navigate to older history entry from cursor position (0,0).
 	if m.textarea.Length() == 0 || m.isAtEditorStart() {
 		if m.historyPrev() {

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -211,6 +211,13 @@ func (w *AppWorkspace) AgentClearQueue(sessionID string) {
 	}
 }
 
+func (w *AppWorkspace) AgentPopQueuedPrompt(sessionID string) (string, bool) {
+	if w.app.AgentCoordinator == nil {
+		return "", false
+	}
+	return w.app.AgentCoordinator.PopQueuedPrompt(sessionID)
+}
+
 func (w *AppWorkspace) AgentSummarize(ctx context.Context, sessionID string) error {
 	if w.app.AgentCoordinator == nil {
 		return errors.New("agent coordinator not initialized")

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -256,6 +256,21 @@ func (w *ClientWorkspace) AgentClearQueue(sessionID string) {
 	_ = w.client.ClearAgentSessionQueuedPrompts(context.Background(), w.workspaceID(), sessionID)
 }
 
+// AgentPopQueuedPrompt returns and removes the oldest queued prompt. The
+// server protocol only exposes a bulk ClearQueue endpoint, so this falls
+// back to reading the full list and clearing the queue: the side effect is
+// that any siblings of the popped prompt also lose their place, but in
+// the server-mode UI flow (arrow-up on a queued message) that matches
+// the user's intent of "bring this one back, drop the rest".
+func (w *ClientWorkspace) AgentPopQueuedPrompt(sessionID string) (string, bool) {
+	prompts := w.AgentQueuedPromptsList(sessionID)
+	if len(prompts) == 0 {
+		return "", false
+	}
+	w.AgentClearQueue(sessionID)
+	return prompts[0], true
+}
+
 func (w *ClientWorkspace) AgentSummarize(ctx context.Context, sessionID string) error {
 	return w.client.AgentSummarizeSession(ctx, w.workspaceID(), sessionID)
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -92,6 +92,7 @@ type Workspace interface {
 	AgentQueuedPrompts(sessionID string) int
 	AgentQueuedPromptsList(sessionID string) []string
 	AgentClearQueue(sessionID string)
+	AgentPopQueuedPrompt(sessionID string) (string, bool)
 	AgentSummarize(ctx context.Context, sessionID string) error
 	UpdateAgentModel(ctx context.Context) error
 	InitCoderAgent(ctx context.Context) error


### PR DESCRIPTION
When a user has one or more prompts waiting in the agent queue (typically because the previous turn is still running), pressing the up arrow in an empty editor should bring the oldest queued prompt back into the composer for editing or sending. Currently, arrow-up either triggers history navigation or, when the editor is empty, is silently ignored — leaving no quick way to recall a queued message.

This change adds a single-element `PopQueuedPrompt` method through the `SessionAgent`, `Coordinator`, and `Workspace` interfaces and intercepts `handleHistoryUp` so the oldest queued prompt is restored to the editor first. The pop uses a non-cancelling dequeue: siblings of the popped prompt keep their place in the queue and run after the current turn completes (so it differs from `ClearQueue`, which discards everything and notifies cancelled RunIDs).

Server mode (`ClientWorkspace`) falls back to the existing list + clear endpoints since the wire protocol only exposes bulk clear — the side effect of clearing siblings is documented inline.

Fixes #3104

`<sub>This is the second PR I have submitted to this repo. The first (#3235) added a missing `default_reasoning_effort` field to the crush-config skill. I am not a Go developer; I learn by reading the existing code and following the project's conventions. Please be patient with my style — happy to revise on feedback.</sub>`