### PR TITLE
feat: make DuckDuckGo search base URL configurable via web_search.bas…

### DIFF
--- a/internal/agent/agentic_fetch_tool.go
+++ b/internal/agent/agentic_fetch_tool.go
@@ -163,7 +163,7 @@ func (c *coordinator) agenticFetchTool(_ context.Context, client *http.Client) (
 			}
 
 			webFetchTool := tools.NewWebFetchTool(tmpDir, client)
-			webSearchTool := tools.NewWebSearchTool(client)
+			webSearchTool := tools.NewWebSearchTool(client, c.cfg.Config().Tools.WebSearch.GetBaseURL())
 			fetchTools := []fantasy.AgentTool{
 				webFetchTool,
 				webSearchTool,

--- a/internal/agent/tools/search.go
+++ b/internal/agent/tools/search.go
@@ -45,12 +45,15 @@ var acceptLanguages = []string{
 	"en-CA,en;q=0.9,en-US;q=0.8",
 }
 
-func searchDuckDuckGo(ctx context.Context, client *http.Client, query string, maxResults int) ([]SearchResult, error) {
+func searchDuckDuckGo(ctx context.Context, client *http.Client, query string, maxResults int, baseURL string) ([]SearchResult, error) {
 	if maxResults <= 0 {
 		maxResults = 10
 	}
 
-	searchURL := "https://lite.duckduckgo.com/lite/?q=" + url.QueryEscape(query)
+	if baseURL == "" {
+		baseURL = "https://lite.duckduckgo.com/lite/"
+	}
+	searchURL := baseURL + "?q=" + url.QueryEscape(query)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", searchURL, nil)
 	if err != nil {

--- a/internal/agent/tools/web_search.go
+++ b/internal/agent/tools/web_search.go
@@ -20,7 +20,7 @@ var webSearchDescriptionTpl = template.Must(
 )
 
 // NewWebSearchTool creates a web search tool for sub-agents (no permissions needed).
-func NewWebSearchTool(client *http.Client) fantasy.AgentTool {
+func NewWebSearchTool(client *http.Client, baseURL string) fantasy.AgentTool {
 	if client == nil {
 		transport := http.DefaultTransport.(*http.Transport).Clone()
 		transport.MaxIdleConns = 100
@@ -50,7 +50,7 @@ func NewWebSearchTool(client *http.Client) fantasy.AgentTool {
 			}
 
 			maybeDelaySearch()
-			results, err := searchDuckDuckGo(ctx, client, params.Query, maxResults)
+			results, err := searchDuckDuckGo(ctx, client, params.Query, maxResults, baseURL)
 			slog.Debug("Web search completed", "query", params.Query, "results", len(results), "err", err)
 			if err != nil {
 				return fantasy.NewTextErrorResponse("Failed to search: " + err.Error()), nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -533,9 +533,10 @@ type Agent struct {
 }
 
 type Tools struct {
-	Ls   ToolLs   `json:"ls,omitzero"`
-	Grep ToolGrep `json:"grep,omitzero"`
-	Glob ToolGlob `json:"glob,omitzero"`
+	Ls        ToolLs        `json:"ls,omitzero"`
+	Grep      ToolGrep      `json:"grep,omitzero"`
+	Glob      ToolGlob      `json:"glob,omitzero"`
+	WebSearch ToolWebSearch `json:"web_search,omitzero"`
 }
 
 type ToolLs struct {
@@ -564,6 +565,18 @@ type ToolGlob struct {
 // GetTimeout returns the user-defined timeout or the default.
 func (t ToolGlob) GetTimeout() time.Duration {
 	return ptrValOr(t.Timeout, 30*time.Second)
+}
+
+type ToolWebSearch struct {
+	BaseURL string `json:"base_url,omitempty" jsonschema:"description=Base URL for the web search engine,default=https://lite.duckduckgo.com/lite/,example=https://lite.duckduckgo.com/lite/"`
+}
+
+// GetBaseURL returns the user-defined base URL or the default.
+func (t ToolWebSearch) GetBaseURL() string {
+	if t.BaseURL != "" {
+		return t.BaseURL
+	}
+	return "https://lite.duckduckgo.com/lite/"
 }
 
 // HookConfig defines a user-configured shell command that fires on a hook


### PR DESCRIPTION
…e_url

Add a `web_search.base_url` option in crush.json so users can customize or override the search endpoint. The default remains `https://lite.duckduckgo.com/lite/`.

💘 Generated with Crush

Assisted-by: Crush:deepseek-v4-flash

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
