### PR TITLE
client-server: fix race condition where two crush instances could knock each other offline

### DIFF
--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -8,8 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"sync"
 	"time"
 
@@ -42,6 +44,18 @@ var (
 // stream after creating a workspace before its creation hold is
 // released. Exposed as a package variable so tests can shorten it.
 var DefaultCreateGrace = 30 * time.Second
+
+// DefaultIdleShutdownDelay is how long the server stays alive after its
+// last workspace is released before it shuts itself down. The delay
+// exists so a client that closes one session and opens another moments
+// later (the same directory or a different one) reuses the still-running
+// server instead of racing its shutdown: with an immediate shutdown the
+// new client can attach to — or create a workspace on — a server that is
+// already tearing down, and then observe its coder agent as "offline".
+// Any workspace create within the window cancels the pending shutdown.
+// Overridable via CRUSH_SERVER_IDLE_TIMEOUT (seconds; 0 restores the
+// old shut-down-immediately behavior).
+var DefaultIdleShutdownDelay = 60 * time.Second
 
 // ShutdownFunc is called when the backend needs to trigger a server
 // shutdown (e.g. when the last workspace is removed).
@@ -76,12 +90,17 @@ type Backend struct {
 	// shut the whole server down out from under the workspace being
 	// born.
 	pending int
-	mu      sync.Mutex
+	// shutdownTimer, when non-nil, is an armed idle-shutdown timer
+	// waiting out lingerDelay before it shuts the server down. It is
+	// guarded by mu and cancelled the moment a new create arrives.
+	shutdownTimer *time.Timer
+	mu            sync.Mutex
 
 	cfg         *config.ConfigStore
 	ctx         context.Context
 	shutdownFn  ShutdownFunc
 	createGrace time.Duration
+	lingerDelay time.Duration
 }
 
 // clientState tracks one client's claim on a workspace.
@@ -205,7 +224,19 @@ func New(ctx context.Context, cfg *config.ConfigStore, shutdownFn ShutdownFunc) 
 		ctx:         ctx,
 		shutdownFn:  shutdownFn,
 		createGrace: DefaultCreateGrace,
+		lingerDelay: idleShutdownDelayFromEnv(),
 	}
+}
+
+// idleShutdownDelayFromEnv returns the idle-shutdown delay, honoring a
+// CRUSH_SERVER_IDLE_TIMEOUT override (in seconds; 0 disables lingering).
+func idleShutdownDelayFromEnv() time.Duration {
+	if v := os.Getenv("CRUSH_SERVER_IDLE_TIMEOUT"); v != "" {
+		if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return DefaultIdleShutdownDelay
 }
 
 // SetCreateGrace overrides the create-grace window. Intended for tests
@@ -214,6 +245,15 @@ func (b *Backend) SetCreateGrace(d time.Duration) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.createGrace = d
+}
+
+// SetIdleShutdownDelay overrides how long the server lingers after its
+// last workspace is released before shutting down. A value <= 0 restores
+// the shut-down-immediately behavior. Intended for tests.
+func (b *Backend) SetIdleShutdownDelay(d time.Duration) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.lingerDelay = d
 }
 
 // GetWorkspace retrieves a workspace by ID.
@@ -257,6 +297,9 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 	}
 
 	b.mu.Lock()
+	// A client is arriving: cancel any pending idle shutdown so we never
+	// hand back a workspace on a server that is about to tear itself down.
+	b.cancelShutdownLocked()
 	if existingID, ok := b.pathIndex[key]; ok {
 		if ws, found := b.workspaces.Get(existingID); found {
 			// Hold b.mu while registering: teardown also
@@ -292,12 +335,12 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 		// If this create ended up registering nothing (it failed, or
 		// deduped onto an existing workspace that has since gone) and
 		// it was holding the last teardown back, the server may now be
-		// idle with no pending work. Reap it here so a failed create
-		// racing the last teardown does not leak an empty server that
-		// a plain teardown already declined to shut down.
-		idle := b.pending == 0 && b.workspaces.Len() == 0
+		// idle with no pending work. Arm the idle-shutdown timer here so
+		// a failed create racing the last teardown does not leak an
+		// empty server that a plain teardown already declined to reap.
+		shutdownNow := b.scheduleShutdownIfIdleLocked()
 		b.mu.Unlock()
-		if idle && b.shutdownFn != nil {
+		if shutdownNow {
 			slog.Info("No workspaces remain after create settled, shutting down server...")
 			b.shutdownFn()
 		}
@@ -611,19 +654,72 @@ func (b *Backend) teardown(ws *Workspace) {
 		delete(b.pathIndex, ws.resolvedPath)
 	}
 	b.workspaces.Del(ws.ID)
-	remaining := b.workspaces.Len()
-	pending := b.pending
+	// Arm (or, with lingering disabled, request) the idle shutdown. It
+	// only proceeds once there is genuinely nothing left: no live
+	// workspaces AND no create in flight. Deferring via the linger lets a
+	// client returning moments later reuse this server instead of racing
+	// its shutdown.
+	shutdownNow := b.scheduleShutdownIfIdleLocked()
 	b.mu.Unlock()
 
 	ws.invokeShutdown()
 
-	// Only shut the server down once there is genuinely nothing left:
-	// no live workspaces AND no create in flight. Ignoring pending here
-	// is what let a teardown race a concurrent create and kill the
-	// server while a new workspace was still being initialized.
-	if remaining == 0 && pending == 0 && b.shutdownFn != nil {
+	if shutdownNow {
 		slog.Info("Last workspace removed, shutting down server...")
 		b.shutdownFn()
+	}
+}
+
+// scheduleShutdownIfIdleLocked decides what to do about server shutdown
+// after a workspace count or pending-create change. It must be called
+// with b.mu held.
+//
+// It returns true only when the caller should shut the server down
+// synchronously (after releasing b.mu) — that is, when the server is idle
+// and lingering is disabled (lingerDelay <= 0). When lingering is enabled
+// it instead arms a one-shot timer that re-checks idleness after
+// lingerDelay and shuts down then, and returns false. When the server is
+// not idle (a workspace is live or a create is in flight) it does
+// nothing and returns false.
+func (b *Backend) scheduleShutdownIfIdleLocked() (shutdownNow bool) {
+	if b.shutdownFn == nil {
+		return false
+	}
+	if b.workspaces.Len() != 0 || b.pending != 0 {
+		return false
+	}
+	if b.lingerDelay <= 0 {
+		return true
+	}
+	if b.shutdownTimer == nil {
+		b.shutdownTimer = time.AfterFunc(b.lingerDelay, b.maybeShutdown)
+	}
+	return false
+}
+
+// cancelShutdownLocked stops any armed idle-shutdown timer. It must be
+// called with b.mu held.
+func (b *Backend) cancelShutdownLocked() {
+	if b.shutdownTimer != nil {
+		b.shutdownTimer.Stop()
+		b.shutdownTimer = nil
+	}
+}
+
+// maybeShutdown is the idle-shutdown timer callback. It shuts the server
+// down only if it is still idle when the linger window elapses; any
+// create that arrived in the meantime cancelled the timer (or bumped
+// pending / the workspace count), so this re-check makes the linger
+// race-free.
+func (b *Backend) maybeShutdown() {
+	b.mu.Lock()
+	b.shutdownTimer = nil
+	idle := b.workspaces.Len() == 0 && b.pending == 0
+	fn := b.shutdownFn
+	b.mu.Unlock()
+	if idle && fn != nil {
+		slog.Info("Server idle, shutting down...")
+		fn()
 	}
 }
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -66,7 +66,17 @@ type Backend struct {
 	// concurrent CreateWorkspace calls at the same path deduplicate
 	// deterministically.
 	pathIndex map[string]string
-	mu        sync.Mutex
+	// pending counts CreateWorkspace calls that have committed to the
+	// slow initialization path (config/db/app setup) but have not yet
+	// registered their workspace in the map. It is guarded by mu.
+	// teardown must observe pending == 0 in addition to an empty
+	// workspace map before triggering server shutdown: otherwise a
+	// teardown of the last live workspace could race ahead of a
+	// concurrent create — which releases mu during its slow init — and
+	// shut the whole server down out from under the workspace being
+	// born.
+	pending int
+	mu      sync.Mutex
 
 	cfg         *config.ConfigStore
 	ctx         context.Context
@@ -268,7 +278,30 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 		// removed; clean the stale entry and fall through.
 		delete(b.pathIndex, key)
 	}
+	// Commit to the slow creation path. Mark this create as pending
+	// while mu is still held so a teardown that runs during the
+	// unlocked init below cannot observe an empty backend and shut the
+	// server down. The deferred decrement runs after the workspace has
+	// been registered (or the create has failed), keeping the invariant
+	// that pending only drops once the workspace is visible in the map.
+	b.pending++
 	b.mu.Unlock()
+	defer func() {
+		b.mu.Lock()
+		b.pending--
+		// If this create ended up registering nothing (it failed, or
+		// deduped onto an existing workspace that has since gone) and
+		// it was holding the last teardown back, the server may now be
+		// idle with no pending work. Reap it here so a failed create
+		// racing the last teardown does not leak an empty server that
+		// a plain teardown already declined to shut down.
+		idle := b.pending == 0 && b.workspaces.Len() == 0
+		b.mu.Unlock()
+		if idle && b.shutdownFn != nil {
+			slog.Info("No workspaces remain after create settled, shutting down server...")
+			b.shutdownFn()
+		}
+	}()
 
 	id := uuid.New().String()
 	cfg, err := config.Init(args.Path, args.DataDir, args.Debug)
@@ -579,11 +612,16 @@ func (b *Backend) teardown(ws *Workspace) {
 	}
 	b.workspaces.Del(ws.ID)
 	remaining := b.workspaces.Len()
+	pending := b.pending
 	b.mu.Unlock()
 
 	ws.invokeShutdown()
 
-	if remaining == 0 && b.shutdownFn != nil {
+	// Only shut the server down once there is genuinely nothing left:
+	// no live workspaces AND no create in flight. Ignoring pending here
+	// is what let a teardown race a concurrent create and kill the
+	// server while a new workspace was still being initialized.
+	if remaining == 0 && pending == 0 && b.shutdownFn != nil {
 		slog.Info("Last workspace removed, shutting down server...")
 		b.shutdownFn()
 	}

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -1317,3 +1317,46 @@ func TestAttachedClients_UnknownWorkspace(t *testing.T) {
 	_, err := b.AttachedClients("00000000-0000-0000-0000-000000000000", "S1")
 	require.ErrorIs(t, err, ErrWorkspaceNotFound)
 }
+
+// TestTeardown_DefersShutdownWhileCreatePending verifies the core of the
+// "coder agent offline after more than one session" fix: tearing down the
+// last live workspace must NOT shut the server down while another
+// CreateWorkspace is mid-flight (it has committed to the slow init path
+// but not yet registered its workspace). Without the pending guard, the
+// teardown observed an empty workspace map and killed the whole server
+// out from under the workspace being born.
+func TestTeardown_DefersShutdownWhileCreatePending(t *testing.T) {
+	t.Parallel()
+
+	b, serverShutdowns := newTestBackend(t)
+	ws, wsShutdowns := insertTestWorkspace(t, b, "/tmp/pending-guard")
+
+	// Simulate a concurrent create that has passed the pending++ point
+	// but has not yet registered its workspace.
+	b.mu.Lock()
+	b.pending = 1
+	b.mu.Unlock()
+
+	b.teardown(ws)
+
+	require.Equal(t, int32(1), wsShutdowns.Load(),
+		"the torn-down workspace's own resources must still be released")
+	require.Equal(t, int32(0), serverShutdowns.Load(),
+		"server must not shut down while a create is in flight")
+}
+
+// TestTeardown_ShutsDownWhenIdleAndNoPending is the control for the guard
+// above: with no create in flight, tearing down the last workspace still
+// triggers the server shutdown, preserving the "shut down when empty"
+// behavior.
+func TestTeardown_ShutsDownWhenIdleAndNoPending(t *testing.T) {
+	t.Parallel()
+
+	b, serverShutdowns := newTestBackend(t)
+	ws, _ := insertTestWorkspace(t, b, "/tmp/idle-shutdown")
+
+	b.teardown(ws)
+
+	require.Equal(t, int32(1), serverShutdowns.Load(),
+		"server must shut down once the last workspace is gone and nothing is pending")
+}

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -1422,3 +1422,65 @@ func TestCreateWorkspace_PendingBalancedAndReapsOnFailure(t *testing.T) {
 	require.Equal(t, int32(1), shutdownCount.Load(),
 		"a failed create that leaves the server idle must reap it")
 }
+
+// TestServer_CreateCancelsPendingIdleShutdown is the regression test for
+// the coder-agent-offline handoff: when the last client of a session
+// leaves, the server must linger (not shut down immediately), and a
+// client returning within the linger window — the same directory or a
+// different one — must cancel that pending shutdown so it is never handed
+// a workspace on a server that is about to die.
+func TestServer_CreateCancelsPendingIdleShutdown(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("CRUSH_DISABLE_PROVIDER_AUTO_UPDATE", "1")
+
+	b, shutdownCount := newTestBackend(t)
+	b.SetIdleShutdownDelay(10 * time.Second) // long enough not to fire mid-test
+	b.SetCreateGrace(time.Hour)
+	t.Cleanup(func() { drainBackend(t, b) })
+
+	// Session 1: a workspace that is attached then leaves, arming the
+	// idle-shutdown timer.
+	wsA, _ := insertTestWorkspace(t, b, "/tmp/linger-A")
+	cidA := newClientID(t)
+	require.NoError(t, b.AttachClient(wsA.ID, cidA))
+	b.DetachClient(wsA.ID, cidA)
+
+	b.mu.Lock()
+	armed := b.shutdownTimer != nil
+	b.mu.Unlock()
+	require.True(t, armed, "idle-shutdown timer must be armed after the last client leaves")
+	require.Equal(t, int32(0), shutdownCount.Load(), "server must linger, not shut down immediately")
+
+	// Session 2 arrives within the linger window: creating a workspace
+	// must cancel the pending shutdown.
+	_, _, err := b.CreateWorkspace(protoWS(t.TempDir(), t.TempDir(), uuid.New().String()))
+	require.NoError(t, err)
+
+	b.mu.Lock()
+	stillArmed := b.shutdownTimer != nil
+	b.mu.Unlock()
+	require.False(t, stillArmed, "a create within the linger window must cancel the pending shutdown")
+	require.Equal(t, int32(0), shutdownCount.Load(), "server must not shut down after a client returns")
+}
+
+// TestServer_ShutsDownAfterLingerWhenIdle confirms the linger still ends
+// in a shutdown when no client returns: the server is not leaked.
+func TestServer_ShutsDownAfterLingerWhenIdle(t *testing.T) {
+	t.Parallel()
+
+	b, shutdownCount := newTestBackend(t)
+	b.SetIdleShutdownDelay(100 * time.Millisecond)
+
+	wsA, _ := insertTestWorkspace(t, b, "/tmp/linger-idle")
+	cidA := newClientID(t)
+	require.NoError(t, b.AttachClient(wsA.ID, cidA))
+	b.DetachClient(wsA.ID, cidA)
+
+	// Nobody returns: after the linger elapses the server shuts down.
+	require.Eventually(t, func() bool { return shutdownCount.Load() == 1 },
+		2*time.Second, 10*time.Millisecond,
+		"idle server must shut down after the linger window")
+}

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -1360,3 +1360,65 @@ func TestTeardown_ShutsDownWhenIdleAndNoPending(t *testing.T) {
 	require.Equal(t, int32(1), serverShutdowns.Load(),
 		"server must shut down once the last workspace is gone and nothing is pending")
 }
+
+// TestCreateWorkspace_PendingBalancedOnSuccess drives the real
+// CreateWorkspace path and asserts the in-flight `pending` counter it
+// uses to hold off server shutdown is balanced back to zero once the
+// workspace is registered. This guards the bookkeeping the unit-level
+// teardown tests stub out: a refactor that drops the increment or
+// misplaces the deferred decrement would reintroduce the shutdown race.
+func TestCreateWorkspace_PendingBalancedOnSuccess(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	b, shutdownCount := newTestBackend(t)
+	// Keep the create hold alive so its grace timer can't fire and tear
+	// the workspace down mid-assertion.
+	b.SetCreateGrace(time.Hour)
+	t.Cleanup(func() { drainBackend(t, b) })
+
+	_, _, err := b.CreateWorkspace(protoWS(t.TempDir(), t.TempDir(), uuid.New().String()))
+	require.NoError(t, err)
+
+	b.mu.Lock()
+	pending := b.pending
+	b.mu.Unlock()
+	require.Equal(t, 0, pending, "pending must return to zero after a successful create")
+	require.Equal(t, int32(0), shutdownCount.Load(), "a live workspace must not trigger shutdown")
+}
+
+// TestCreateWorkspace_PendingBalancedAndReapsOnFailure asserts that a
+// create which fails during its slow init still decrements `pending`, and
+// that the deferred reap shuts an otherwise-idle server down (the safety
+// net that keeps a failed create racing the last teardown from leaking an
+// empty server the plain teardown declined to close).
+func TestCreateWorkspace_PendingBalancedAndReapsOnFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	b, shutdownCount := newTestBackend(t)
+
+	// A data dir whose parent is a regular file makes the workspace's
+	// data-directory creation fail deterministically, after the pending
+	// counter has been incremented.
+	tmp := t.TempDir()
+	fileAsParent := filepath.Join(tmp, "notadir")
+	require.NoError(t, os.WriteFile(fileAsParent, []byte("x"), 0o600))
+	badDataDir := filepath.Join(fileAsParent, "data")
+
+	_, _, err := b.CreateWorkspace(protoWS(tmp, badDataDir, uuid.New().String()))
+	require.Error(t, err, "create must fail when the data dir cannot be created")
+
+	b.mu.Lock()
+	pending := b.pending
+	remaining := b.workspaces.Len()
+	b.mu.Unlock()
+	require.Equal(t, 0, pending, "pending must return to zero after a failed create")
+	require.Zero(t, remaining, "no workspace should be registered after a failed create")
+	require.Equal(t, int32(1), shutdownCount.Load(),
+		"a failed create that leaves the server idle must reap it")
+}

--- a/internal/server/e2e_test.go
+++ b/internal/server/e2e_test.go
@@ -567,10 +567,14 @@ func TestE2E_KillingClientASSEDoesNotBreakClientB(t *testing.T) {
 
 // TestE2E_ShutdownCallbackFiresWhenLastClientLeaves covers PLAN
 // item 6 scenario 4: once both clients disconnect, the backend
-// runs its "last workspace removed -> server shutdown" path.
+// runs its "last workspace removed -> server shutdown" path — now
+// after the idle-linger window rather than immediately.
 func TestE2E_ShutdownCallbackFiresWhenLastClientLeaves(t *testing.T) {
 	t.Parallel()
 	h := newE2EHarness(t)
+	// Shorten the idle linger so the test doesn't wait out the
+	// production window; the callback still fires, just after the delay.
+	h.backend.SetIdleShutdownDelay(200 * time.Millisecond)
 
 	ctxA, cancelA := context.WithCancel(t.Context())
 	ctxB, cancelB := context.WithCancel(t.Context())
@@ -599,7 +603,7 @@ func TestE2E_ShutdownCallbackFiresWhenLastClientLeaves(t *testing.T) {
 	killB()
 	require.Eventually(t, h.shutdownHit.Load,
 		3*time.Second, 10*time.Millisecond,
-		"shutdown callback must fire once the last client disconnects")
+		"shutdown callback must fire once the last client disconnects (after the idle linger)")
 
 	// Workspace must be gone from the index.
 	_, err := h.backend.GetWorkspace(h.workspace.ID)

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -46,6 +46,14 @@ type countingWorkspace struct {
 func (w *countingWorkspace) AgentIsReady() bool { w.readyCalls++; return w.ready }
 func (w *countingWorkspace) AgentIsBusy() bool  { w.agentBusyCalls++; return w.agentBusy }
 
+func (w *countingWorkspace) AgentReadyErr() error {
+	w.readyCalls++
+	if w.ready {
+		return nil
+	}
+	return workspace.ErrAgentNotInitialized
+}
+
 func (w *countingWorkspace) AgentQueuedPrompts(string) int {
 	w.queuedCalls++
 	return len(w.queued)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3885,8 +3885,8 @@ func (m *UI) attachSkill(skillID, name string) tea.Cmd {
 
 // sendMessage sends a message with the given content and attachments.
 func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.Cmd {
-	if !m.com.Workspace.AgentIsReady() {
-		return util.ReportError(fmt.Errorf("coder agent is not initialized"))
+	if err := m.com.Workspace.AgentReadyErr(); err != nil {
+		return util.ReportError(err)
 	}
 
 	// Start the turn timer.

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -192,6 +192,13 @@ func (w *AppWorkspace) AgentIsReady() bool {
 	return w.app.AgentCoordinator != nil
 }
 
+func (w *AppWorkspace) AgentReadyErr() error {
+	if w.app.AgentCoordinator == nil {
+		return ErrAgentNotInitialized
+	}
+	return nil
+}
+
 func (w *AppWorkspace) AgentQueuedPrompts(sessionID string) int {
 	if w.app.AgentCoordinator == nil {
 		return 0

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -248,11 +248,21 @@ func (w *ClientWorkspace) AgentModel() AgentModel {
 }
 
 func (w *ClientWorkspace) AgentIsReady() bool {
+	return w.AgentReadyErr() == nil
+}
+
+func (w *ClientWorkspace) AgentReadyErr() error {
 	info, err := w.client.GetAgentInfo(context.Background(), w.workspaceID())
 	if err != nil {
-		return false
+		// The workspace/server could not be reached. This is distinct
+		// from an initialized-but-not-ready agent: the server may have
+		// torn the workspace down or restarted underneath us.
+		return fmt.Errorf("%w: %v", ErrServerUnreachable, err)
 	}
-	return info.IsReady
+	if !info.IsReady {
+		return ErrAgentNotInitialized
+	}
+	return nil
 }
 
 func (w *ClientWorkspace) AgentQueuedPrompts(sessionID string) int {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -42,10 +42,23 @@ type ClientWorkspace struct {
 	ws     proto.Workspace
 	skills *skills.Manager
 
+	// subCtx bounds the lifetime of the event subscription (and its
+	// reconnect loop). Shutdown cancels it so Subscribe stops
+	// reconnecting instead of racing the teardown.
+	subCtx    context.Context
+	subCancel context.CancelFunc
+
 	// herdrClient reports agent state to herdr when running inside
 	// a herdr-managed pane. Nil when not in a herdr environment.
 	herdrClient *herdr.Client
 }
+
+// SSE reconnect backoff bounds for the workspace event stream. Declared
+// as vars (not consts) so tests can shrink the delays.
+var (
+	sseReconnectInitialBackoff = 250 * time.Millisecond
+	sseReconnectMaxBackoff     = 10 * time.Second
+)
 
 // NewClientWorkspace creates a new ClientWorkspace that proxies all
 // operations through the given client SDK. The ws parameter is the
@@ -61,10 +74,13 @@ func NewClientWorkspace(c *client.Client, ws proto.Workspace) *ClientWorkspace {
 	}
 	states := protoToSkillStates(ws.Skills)
 	mgr := skills.NewManager(nil, nil, states, skills.WithGlobalMirror())
+	subCtx, subCancel := context.WithCancel(context.Background())
 	return &ClientWorkspace{
 		client:      c,
 		ws:          ws,
 		skills:      mgr,
+		subCtx:      subCtx,
+		subCancel:   subCancel,
 		herdrClient: herdr.Init(),
 	}
 }
@@ -683,13 +699,68 @@ func (w *ClientWorkspace) Subscribe(program *tea.Program) {
 		program.Quit()
 	})
 
-	evc, err := w.client.SubscribeEvents(context.Background(), w.workspaceID())
-	if err != nil {
-		slog.Error("Failed to subscribe to events", "error", err)
-		return
-	}
+	w.runSubscription(program.Send)
+}
 
-	w.consumeEvents(evc, program.Send)
+// runSubscription subscribes to the workspace event stream and forwards
+// translated events to send, reconnecting with capped exponential
+// backoff whenever the stream drops. It returns only when the
+// subscription context is cancelled (via Shutdown). Split out from
+// Subscribe so it can be tested without a real *tea.Program.
+func (w *ClientWorkspace) runSubscription(send func(tea.Msg)) {
+	backoff := sseReconnectInitialBackoff
+	for {
+		if w.subCtx.Err() != nil {
+			return
+		}
+
+		evc, err := w.client.SubscribeEvents(w.subCtx, w.workspaceID())
+		if err != nil {
+			if w.subCtx.Err() != nil {
+				return
+			}
+			slog.Error("Failed to subscribe to workspace events; retrying",
+				"error", err, "retry_in", backoff)
+			if !w.sleepOrDone(backoff) {
+				return
+			}
+			backoff = min(backoff*2, sseReconnectMaxBackoff)
+			continue
+		}
+
+		// Connected: reset the backoff and pump events until the
+		// stream drops.
+		backoff = sseReconnectInitialBackoff
+		w.consumeEvents(evc, send)
+
+		// The event channel closed: the server restarted, the stream
+		// was interrupted, or the workspace briefly went away.
+		// Reconnect after a short delay instead of leaving the TUI
+		// permanently orphaned, which is what surfaced as a stuck
+		// "coder agent is offline".
+		if w.subCtx.Err() != nil {
+			return
+		}
+		slog.Warn("Workspace event stream closed; reconnecting", "retry_in", backoff)
+		if !w.sleepOrDone(backoff) {
+			return
+		}
+		backoff = min(backoff*2, sseReconnectMaxBackoff)
+	}
+}
+
+// sleepOrDone waits for d or until the subscription context is
+// cancelled. It reports false when the context was cancelled, signalling
+// the caller to stop reconnecting.
+func (w *ClientWorkspace) sleepOrDone(d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-w.subCtx.Done():
+		return false
+	}
 }
 
 // consumeEvents drives the workspace event loop. It is split out from
@@ -715,6 +786,11 @@ func (w *ClientWorkspace) consumeEvents(evc <-chan any, send func(tea.Msg)) {
 }
 
 func (w *ClientWorkspace) Shutdown() {
+	// Stop the event subscription's reconnect loop before releasing the
+	// workspace so it doesn't race to re-subscribe during teardown.
+	if w.subCancel != nil {
+		w.subCancel()
+	}
 	w.herdrClient.Close()
 	_ = w.client.DeleteWorkspace(context.Background(), w.workspaceID())
 }

--- a/internal/workspace/client_workspace_test.go
+++ b/internal/workspace/client_workspace_test.go
@@ -392,3 +392,54 @@ func TestClientWorkspace_SubscriptionStopsWhenServerDown(t *testing.T) {
 		t.Fatal("runSubscription did not return after Shutdown while server was down")
 	}
 }
+
+// TestClientWorkspace_AgentReadyErr distinguishes a server that reports
+// an uninitialized agent from a server that cannot be reached, so the UI
+// can show an actionable message instead of a blanket "agent offline".
+func TestClientWorkspace_AgentReadyErr(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ready", func(t *testing.T) {
+		t.Parallel()
+		ws := agentInfoWorkspace(t, proto.AgentInfo{IsReady: true})
+		require.NoError(t, ws.AgentReadyErr())
+		require.True(t, ws.AgentIsReady())
+	})
+
+	t.Run("not initialized", func(t *testing.T) {
+		t.Parallel()
+		ws := agentInfoWorkspace(t, proto.AgentInfo{IsReady: false})
+		err := ws.AgentReadyErr()
+		require.ErrorIs(t, err, ErrAgentNotInitialized)
+		require.NotErrorIs(t, err, ErrServerUnreachable)
+		require.False(t, ws.AgentIsReady())
+	})
+
+	t.Run("server unreachable", func(t *testing.T) {
+		t.Parallel()
+		c, err := client.NewClient(t.TempDir(), "tcp", "127.0.0.1:1")
+		require.NoError(t, err)
+		ws := NewClientWorkspace(c, proto.Workspace{ID: "ws-1"})
+		readyErr := ws.AgentReadyErr()
+		require.ErrorIs(t, readyErr, ErrServerUnreachable)
+		require.NotErrorIs(t, readyErr, ErrAgentNotInitialized)
+		require.False(t, ws.AgentIsReady())
+	})
+}
+
+// agentInfoWorkspace returns a ClientWorkspace whose server answers the
+// agent-info endpoint with the given info.
+func agentInfoWorkspace(t *testing.T, info proto.AgentInfo) *ClientWorkspace {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/workspaces/ws-1/agent", r.URL.Path)
+		require.NoError(t, json.NewEncoder(w).Encode(info))
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	c, err := client.NewClient(t.TempDir(), "tcp", u.Host)
+	require.NoError(t, err)
+	return NewClientWorkspace(c, proto.Workspace{ID: "ws-1"})
+}

--- a/internal/workspace/client_workspace_test.go
+++ b/internal/workspace/client_workspace_test.go
@@ -6,8 +6,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/client"
 	"github.com/charmbracelet/crush/internal/commands"
@@ -294,4 +298,97 @@ func TestClientWorkspaceListMCPPromptsServerError(t *testing.T) {
 	_, err = workspace.ListMCPPrompts(t.Context())
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 500")
+}
+
+// TestClientWorkspace_ReconnectsOnStreamDrop verifies that the event
+// subscription loop reconnects after the SSE stream drops instead of
+// leaving the TUI permanently orphaned (which surfaced as a stuck
+// "coder agent is offline"), and that Shutdown stops the loop.
+func TestClientWorkspace_ReconnectsOnStreamDrop(t *testing.T) {
+	// Shrink the backoff so several reconnects happen quickly.
+	origInitial, origMax := sseReconnectInitialBackoff, sseReconnectMaxBackoff
+	sseReconnectInitialBackoff = 5 * time.Millisecond
+	sseReconnectMaxBackoff = 20 * time.Millisecond
+	t.Cleanup(func() {
+		sseReconnectInitialBackoff = origInitial
+		sseReconnectMaxBackoff = origMax
+	})
+
+	var subscribes atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/events") {
+			// Any other bookkeeping call (e.g. GetWorkspace) just
+			// gets an empty OK; the test only cares about the stream.
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		subscribes.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		// Drop the stream immediately so the client must reconnect.
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	c, err := client.NewClient(t.TempDir(), "tcp", u.Host)
+	require.NoError(t, err)
+
+	ws := NewClientWorkspace(c, proto.Workspace{ID: "ws-1"})
+
+	done := make(chan struct{})
+	go func() {
+		ws.runSubscription(func(tea.Msg) {})
+		close(done)
+	}()
+
+	// The loop must reconnect several times as the server keeps
+	// dropping the stream.
+	require.Eventually(t, func() bool { return subscribes.Load() >= 3 },
+		2*time.Second, 5*time.Millisecond,
+		"subscription loop should reconnect after the stream drops")
+
+	// Shutdown cancels the subscription context; the loop must return.
+	ws.Shutdown()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runSubscription did not return after Shutdown")
+	}
+}
+
+// TestClientWorkspace_SubscriptionStopsWhenServerDown verifies the
+// reconnect loop does not spin forever after Shutdown even when it can
+// never connect (server unreachable).
+func TestClientWorkspace_SubscriptionStopsWhenServerDown(t *testing.T) {
+	origInitial, origMax := sseReconnectInitialBackoff, sseReconnectMaxBackoff
+	sseReconnectInitialBackoff = 5 * time.Millisecond
+	sseReconnectMaxBackoff = 20 * time.Millisecond
+	t.Cleanup(func() {
+		sseReconnectInitialBackoff = origInitial
+		sseReconnectMaxBackoff = origMax
+	})
+
+	// Port 1 is not listening: SubscribeEvents fails on every attempt.
+	c, err := client.NewClient(t.TempDir(), "tcp", "127.0.0.1:1")
+	require.NoError(t, err)
+	ws := NewClientWorkspace(c, proto.Workspace{ID: "ws-1"})
+
+	done := make(chan struct{})
+	go func() {
+		ws.runSubscription(func(tea.Msg) {})
+		close(done)
+	}()
+
+	// Let it retry a few times, then shut down.
+	time.Sleep(30 * time.Millisecond)
+	ws.Shutdown()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runSubscription did not return after Shutdown while server was down")
+	}
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -6,6 +6,7 @@ package workspace
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -22,6 +23,19 @@ import (
 	"github.com/charmbracelet/crush/internal/question"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/skills"
+)
+
+// Reasons the coder agent may be unavailable, returned by
+// Workspace.AgentReadyErr so callers can tell a genuinely
+// uninitialized agent apart from a lost server connection.
+var (
+	// ErrAgentNotInitialized means the workspace exists but its coder
+	// agent has not been configured/initialized (e.g. no model set).
+	ErrAgentNotInitialized = errors.New("coder agent is not initialized")
+	// ErrServerUnreachable means the client could not reach the server
+	// to determine the agent's status (server down, or the workspace was
+	// torn down out from under the client).
+	ErrServerUnreachable = errors.New("lost connection to the crush server")
 )
 
 // LSPClientInfo holds information about an LSP client's state. This is
@@ -91,6 +105,13 @@ type Workspace interface {
 	AgentIsSessionBusy(sessionID string) bool
 	AgentModel() AgentModel
 	AgentIsReady() bool
+	// AgentReadyErr reports nil when the coder agent is ready to accept
+	// work, or a descriptive error otherwise: ErrAgentNotInitialized
+	// when the agent simply isn't set up, or ErrServerUnreachable
+	// (wrapped) when the client could not reach the server to find out.
+	// It lets the UI show an actionable message instead of collapsing
+	// both cases into "agent offline".
+	AgentReadyErr() error
 	AgentQueuedPrompts(sessionID string) int
 	AgentQueuedPromptsList(sessionID string) []string
 	AgentClearQueue(sessionID string)


### PR DESCRIPTION
Basically, if you're using one client-server instance, and then you open another the first instance would silently get shut down. It's super annoying, and this patch fixes that.