### PR TITLE
fix(config): preserve provider-specific options

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -281,6 +281,7 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 			SystemPromptPrefix: config.SystemPromptPrefix,
 			ExtraHeaders:       headers,
 			ExtraBody:          config.ExtraBody,
+			ProviderOptions:    config.ProviderOptions,
 			ExtraParams:        make(map[string]string),
 			Models:             p.Models,
 		}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -376,6 +376,48 @@ func TestConfig_configureProvidersWithOverride(t *testing.T) {
 	require.Equal(t, "Updated", pc.Models[0].Name)
 }
 
+func TestConfig_configureProvidersWithProviderOptions(t *testing.T) {
+	knownProviders := []catwalk.Provider{
+		{
+			ID:          "openai",
+			APIKey:      "$OPENAI_API_KEY",
+			APIEndpoint: "https://api.openai.com/v1",
+			Models: []catwalk.Model{{
+				ID: "test-model",
+			}},
+		},
+	}
+
+	cfg := &Config{
+		Providers: csync.NewMap[string, ProviderConfig](),
+	}
+	cfg.Providers.Set("openai", ProviderConfig{
+		ProviderOptions: map[string]any{
+			"include_usage": false,
+			"reasoning": map[string]any{
+				"max_tokens": float64(2000),
+			},
+		},
+	})
+	cfg.setDefaults("/tmp", "")
+
+	env := env.NewFromMap(map[string]string{
+		"OPENAI_API_KEY": "test-key",
+	})
+	resolver := NewShellVariableResolver(env)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
+	require.NoError(t, err)
+
+	pc, ok := cfg.Providers.Get("openai")
+	require.True(t, ok)
+	require.Equal(t, map[string]any{
+		"include_usage": false,
+		"reasoning": map[string]any{
+			"max_tokens": float64(2000),
+		},
+	}, pc.ProviderOptions)
+}
+
 func TestConfig_configureProvidersWithNewProvider(t *testing.T) {
 	knownProviders := []catwalk.Provider{
 		{


### PR DESCRIPTION
## Summary

- copy configured `provider_options` into prepared known-provider configs
- add regression coverage for provider options on a known provider

## Why

Known providers merge user overrides into a prepared `ProviderConfig`, but `ProviderOptions` was not copied there. That made provider-level options from `crush.json` disappear before requests could use them.

Fixes #1472

## Validation

- `GOTOOLCHAIN=auto go test ./internal/config -run TestConfig_configureProvidersWithProviderOptions -count=1` — failed before the fix, passed after
- `GOTOOLCHAIN=auto go test ./internal/config -count=1` — passed
- `GOTOOLCHAIN=auto go test ./...` — passed

## Notes

I did not test against a live provider.