### PR TITLE
fix(bangmode): don't add extra ! when browsing history

### DIFF
--- a/internal/ui/model/history.go
+++ b/internal/ui/model/history.go
@@ -120,12 +120,14 @@ func (m *UI) updateHistoryDraft(oldValue string) {
 func (m *UI) syncBangModeFromTextarea() {
 	val := m.textarea.Value()
 	hasBang := strings.HasPrefix(val, "!")
-	if hasBang && !m.bangMode {
-		m.bangMode = true
-		m.bangWasEmpty = false
-		m.textarea.SetValue(val[1:])
+	if hasBang {
+		if !m.bangMode {
+			m.bangMode = true
+			m.bangWasEmpty = false
+		}
+		m.textarea.SetValue(strings.TrimPrefix(val, "!"))
 		m.textarea.MoveToBegin()
-	} else if !hasBang && m.bangMode {
+	} else if m.bangMode {
 		m.bangMode = false
 		m.bangWasEmpty = false
 	}

--- a/internal/ui/model/history_test.go
+++ b/internal/ui/model/history_test.go
@@ -1,0 +1,38 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+type historyWorkspace struct {
+	workspace.Workspace
+}
+
+func (historyWorkspace) Config() *config.Config {
+	return &config.Config{}
+}
+
+func (historyWorkspace) PermissionSkipRequests() bool {
+	return false
+}
+
+func TestHistoryBangCommandStripsPrefixWhileAlreadyInBangMode(t *testing.T) {
+	t.Parallel()
+
+	u := newTestUI()
+	u.com.Workspace = historyWorkspace{}
+	u.promptHistory.messages = []string{"!echo one", "!echo two"}
+	u.promptHistory.index = -1
+
+	require.True(t, u.historyPrev())
+	require.True(t, u.bangMode)
+	require.Equal(t, "echo one", u.textarea.Value())
+
+	require.True(t, u.historyPrev())
+	require.True(t, u.bangMode)
+	require.Equal(t, "echo two", u.textarea.Value())
+}


### PR DESCRIPTION
Sometimes when browsing history an extra ! would be prepended to bang mode items, making them un-runnable. This fixes that logic.