### PR TITLE
fix(discover): parse context_length from /v1/models response

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -413,7 +413,11 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 		wg.Go(func() {
 			models, err := discover.DiscoverModels(discoverCtx, cfg, resolver)
 			if err == nil && len(models) > 0 {
-				if enricher := discover.GetEnricher(string(providerType)); enricher != nil {
+				enricher := discover.GetEnricher(string(providerType))
+				if enricher == nil {
+					enricher = discover.GetGenericEnricher()
+				}
+				if enricher != nil {
 					models, _ = enricher.EnrichModels(discoverCtx, cfg, resolver, models)
 				}
 			}

--- a/internal/discover/enricher.go
+++ b/internal/discover/enricher.go
@@ -24,6 +24,22 @@ type Enricher interface {
 // load.go or any existing enricher.
 var enrichers = map[string]Enricher{}
 
+// genericEnricherInst is the fallback enricher applied to any provider
+// that doesn't have a provider-specific enricher registered. It reads
+// context_length and metadata from the /v1/models response.
+var genericEnricherInst Enricher
+
+// RegisterGenericEnricher sets the fallback enricher used for providers
+// without a registered provider-specific enricher.
+func RegisterGenericEnricher(e Enricher) {
+	genericEnricherInst = e
+}
+
+// GetGenericEnricher returns the fallback enricher, or nil if none is set.
+func GetGenericEnricher() Enricher {
+	return genericEnricherInst
+}
+
 // RegisterEnricher registers an Enricher for the given provider type.
 // Called from init() in each enricher implementation file.
 func RegisterEnricher(providerType string, e Enricher) {

--- a/internal/discover/generic.go
+++ b/internal/discover/generic.go
@@ -1,0 +1,79 @@
+package discover
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+func init() {
+	RegisterGenericEnricher(&genericEnricher{})
+}
+
+// genericModelsResponse captures only the fields needed for enrichment
+// from the /v1/models listing. The metadata map is untyped by design —
+// providers use different key names and the enricher only inspects a
+// known subset.
+type genericModelsResponse struct {
+	Data []genericModelEntry `json:"data"`
+}
+
+type genericModelEntry struct {
+	ID            string         `json:"id"`
+	ContextLength int64          `json:"context_length,omitempty"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
+}
+
+// genericEnricher reads context_length and metadata.max_model_len from
+// the /v1/models endpoint and populates ContextWindow on discovered
+// models. It is used as a fallback for any provider without a
+// provider-specific enricher.
+type genericEnricher struct{}
+
+func (e *genericEnricher) EnrichModels(ctx context.Context, cfg Config, resolver Resolver, models []catwalk.Model) ([]catwalk.Model, error) {
+	resp, err := doRequest(ctx, http.MethodGet, cfg.BaseURL, "/models", cfg.APIKey, cfg.ExtraHeaders, resolver, nil)
+	if err != nil {
+		return models, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return models, nil
+	}
+
+	var modelsResp genericModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&modelsResp); err != nil {
+		return models, nil
+	}
+
+	// Index by ID for O(1) lookup.
+	metaByID := make(map[string]genericModelEntry, len(modelsResp.Data))
+	for _, m := range modelsResp.Data {
+		metaByID[m.ID] = m
+	}
+
+	for i := range models {
+		if models[i].ContextWindow != 0 {
+			continue
+		}
+		entry, ok := metaByID[models[i].ID]
+		if !ok {
+			continue
+		}
+		if entry.ContextLength > 0 {
+			models[i].ContextWindow = entry.ContextLength
+		} else if v, ok := entry.Metadata["max_model_len"]; ok {
+			if f, ok := v.(float64); ok {
+				models[i].ContextWindow = int64(f)
+			}
+		} else if v, ok := entry.Metadata["max_context_length"]; ok {
+			if f, ok := v.(float64); ok {
+				models[i].ContextWindow = int64(f)
+			}
+		}
+	}
+
+	return models, nil
+}

--- a/internal/discover/generic_test.go
+++ b/internal/discover/generic_test.go
@@ -1,0 +1,166 @@
+package discover
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenericEnricher(t *testing.T) {
+	t.Parallel()
+
+	t.Run("populates context window from context_length", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/v1/models", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(genericModelsResponse{
+				Data: []genericModelEntry{
+					{ID: "glm-4.7", ContextLength: 131072},
+					{ID: "gemma-4", ContextLength: 262144},
+					{ID: "no-context"},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test", BaseURL: srv.URL + "/v1"}
+		models := []catwalk.Model{
+			{ID: "glm-4.7"},
+			{ID: "gemma-4"},
+			{ID: "no-context"},
+		}
+
+		e := &genericEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 3)
+		require.Equal(t, int64(131072), result[0].ContextWindow)
+		require.Equal(t, int64(262144), result[1].ContextWindow)
+		require.Equal(t, int64(0), result[2].ContextWindow)
+	})
+
+	t.Run("falls back to metadata.max_model_len", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(genericModelsResponse{
+				Data: []genericModelEntry{
+					{ID: "vllm-model", Metadata: map[string]any{"max_model_len": float64(65536)}},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test", BaseURL: srv.URL + "/v1"}
+		models := []catwalk.Model{{ID: "vllm-model"}}
+
+		e := &genericEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, int64(65536), result[0].ContextWindow)
+	})
+
+	t.Run("falls back to metadata.max_context_length", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(genericModelsResponse{
+				Data: []genericModelEntry{
+					{ID: "ctx-model", Metadata: map[string]any{"max_context_length": float64(32768)}},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test", BaseURL: srv.URL + "/v1"}
+		models := []catwalk.Model{{ID: "ctx-model"}}
+
+		e := &genericEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, int64(32768), result[0].ContextWindow)
+	})
+
+	t.Run("context_length takes precedence over metadata", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(genericModelsResponse{
+				Data: []genericModelEntry{
+					{ID: "both-model", ContextLength: 100000, Metadata: map[string]any{"max_model_len": float64(65536)}},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test", BaseURL: srv.URL + "/v1"}
+		models := []catwalk.Model{{ID: "both-model"}}
+
+		e := &genericEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, int64(100000), result[0].ContextWindow)
+	})
+
+	t.Run("preserves existing non-zero context window", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(genericModelsResponse{
+				Data: []genericModelEntry{
+					{ID: "m1", ContextLength: 131072},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test", BaseURL: srv.URL + "/v1"}
+		models := []catwalk.Model{{ID: "m1", ContextWindow: 65536}}
+
+		e := &genericEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, int64(65536), result[0].ContextWindow)
+	})
+
+	t.Run("returns models unchanged on HTTP error", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test", BaseURL: srv.URL + "/v1"}
+		models := []catwalk.Model{{ID: "m1"}}
+
+		e := &genericEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, int64(0), result[0].ContextWindow)
+	})
+
+	t.Run("returns models unchanged on invalid JSON", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("not json"))
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test", BaseURL: srv.URL + "/v1"}
+		models := []catwalk.Model{{ID: "m1"}}
+
+		e := &genericEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, int64(0), result[0].ContextWindow)
+	})
+}


### PR DESCRIPTION
The discover endpoint now reads context_length directly from the provider response and falls back to metadata.max_model_len and metadata.max_context_length. This fixes missing context window information for custom providers like llama-swap that expose it.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ x] I have created a discussion that was approved by a maintainer (for new features).
