### PR TITLE
feat: wire LM Studio vision capabilities to SupportsImages

### DIFF
--- a/internal/discover/lmstudio.go
+++ b/internal/discover/lmstudio.go
@@ -22,10 +22,17 @@ type lmstudioModelsResponse struct {
 
 // lmstudioModelEntry is a single entry from /api/v1/models.
 type lmstudioModelEntry struct {
-	Key              string             `json:"key"`
-	DisplayName      string             `json:"display_name"`
-	MaxContextLength int64              `json:"max_context_length"`
-	LoadedInstances  []lmstudioInstance `json:"loaded_instances"`
+	Key              string                `json:"key"`
+	DisplayName      string                `json:"display_name"`
+	MaxContextLength int64                 `json:"max_context_length"`
+	LoadedInstances  []lmstudioInstance    `json:"loaded_instances"`
+	Capabilities     lmstudioCapabilities  `json:"capabilities"`
+}
+
+// lmstudioCapabilities holds optional model capability flags from
+// LM Studio's /api/v1/models endpoint.
+type lmstudioCapabilities struct {
+	Vision bool `json:"vision"`
 }
 
 // lmstudioInstance is a currently loaded model instance with its
@@ -40,8 +47,8 @@ type lmstudioInstanceConfig struct {
 }
 
 // lmstudioEnricher fetches model metadata from LM Studio's native
-// /api/v1/models endpoint and populates context window and display
-// name on discovered models.
+// /api/v1/models endpoint and populates context window, display name,
+// and vision support on discovered models.
 type lmstudioEnricher struct{}
 
 func (e *lmstudioEnricher) EnrichModels(ctx context.Context, cfg Config, resolver Resolver, models []catwalk.Model) ([]catwalk.Model, error) {
@@ -87,8 +94,10 @@ func (e *lmstudioEnricher) EnrichModels(ctx context.Context, cfg Config, resolve
 			models[i].Name = meta.DisplayName
 		}
 
-		// TODO: populate vision/tool-use flags when catwalk.Model
-		// gains dedicated fields for them.
+		// Vision support from capabilities.
+		if meta.Capabilities.Vision {
+			models[i].SupportsImages = true
+		}
 	}
 
 	return models, nil

--- a/internal/discover/lmstudio.go
+++ b/internal/discover/lmstudio.go
@@ -22,11 +22,11 @@ type lmstudioModelsResponse struct {
 
 // lmstudioModelEntry is a single entry from /api/v1/models.
 type lmstudioModelEntry struct {
-	Key              string                `json:"key"`
-	DisplayName      string                `json:"display_name"`
-	MaxContextLength int64                 `json:"max_context_length"`
-	LoadedInstances  []lmstudioInstance    `json:"loaded_instances"`
-	Capabilities     lmstudioCapabilities  `json:"capabilities"`
+	Key              string               `json:"key"`
+	DisplayName      string               `json:"display_name"`
+	MaxContextLength int64                `json:"max_context_length"`
+	LoadedInstances  []lmstudioInstance   `json:"loaded_instances"`
+	Capabilities     lmstudioCapabilities `json:"capabilities"`
 }
 
 // lmstudioCapabilities holds optional model capability flags from
@@ -95,9 +95,7 @@ func (e *lmstudioEnricher) EnrichModels(ctx context.Context, cfg Config, resolve
 		}
 
 		// Vision support from capabilities.
-		if meta.Capabilities.Vision {
-			models[i].SupportsImages = true
-		}
+		models[i].SupportsImages = meta.Capabilities.Vision
 	}
 
 	return models, nil

--- a/internal/discover/lmstudio_test.go
+++ b/internal/discover/lmstudio_test.go
@@ -151,4 +151,47 @@ func TestLmstudioEnricher(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "User Name", result[0].Name)
 	})
+
+	t.Run("populates SupportsImages from capabilities.vision", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"models": [
+					{
+						"key": "vision-model",
+						"display_name": "Vision Model",
+						"max_context_length": 131072,
+						"capabilities": {"vision": true}
+					},
+					{
+						"key": "text-only-model",
+						"display_name": "Text Only",
+						"max_context_length": 32768,
+						"capabilities": {"vision": false}
+					},
+					{
+						"key": "no-capabilities",
+						"display_name": "No Capabilities Field",
+						"max_context_length": 8192
+					}
+				]
+			}`))
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-lmstudio", BaseURL: srv.URL}
+		models := []catwalk.Model{
+			{ID: "vision-model", Name: "vision-model"},
+			{ID: "text-only-model", Name: "text-only-model"},
+			{ID: "no-capabilities", Name: "no-capabilities"},
+		}
+
+		e := &lmstudioEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.True(t, result[0].SupportsImages, "vision model should have SupportsImages=true")
+		require.False(t, result[1].SupportsImages, "text-only model should have SupportsImages=false")
+		require.False(t, result[2].SupportsImages, "model without capabilities should default to false")
+	})
 }


### PR DESCRIPTION
## Summary

LM Studio's `/api/v1/models` endpoint returns `capabilities.vision` for each model, but the enricher ignored it. This wires that field to `catwalk.Model.SupportsImages` so Crush can auto-detect vision-capable local models.

## Changes

- Add `lmstudioCapabilities` struct to parse `capabilities.vision`
- Set `SupportsImages = true` when the model reports vision support
- Add test covering vision=true, vision=false, and missing capabilities field

## Impact

Models like `qwen/qwen3.6-27b` now correctly report vision support when discovered via LM Studio auto-discovery. No manual config override needed.

Verified against a live LM Studio instance — `qwen/qwen3.6-27b` correctly shows `SupportsImages: true`.