### PR TITLE
fix: log actual providers cache path instead of function reference

### DIFF
--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -85,7 +85,7 @@ func UpdateProviders(pathOrURL string) error {
 		return fmt.Errorf("failed to save providers to cache: %w", err)
 	}
 
-	slog.Info("Providers updated successfully", "count", len(providers), "from", pathOrURL, "to", cachePathFor)
+	slog.Info("Providers updated successfully", "count", len(providers), "from", pathOrURL, "to", cachePathFor("providers"))
 	return nil
 }
 


### PR DESCRIPTION
## What

In `UpdateProviders`, the `slog.Info` call was passing `cachePathFor` (the function itself) as the `"to"` log attribute instead of invoking it with `"providers"` to get the resolved path string.

`go
// Before
slog.Info("Providers updated successfully", "count", len(providers), "from", pathOrURL, "to", cachePathFor)

// After
slog.Info("Providers updated successfully", "count", len(providers), "from", pathOrURL, "to", cachePathFor("providers"))
`

## Why it matters

This caused the structured log line to record the **function pointer address** (e.g. `0x6c3f40`) as the `to` field instead of the actual file path, making it impossible to tell from logs where providers were written to disk.

Compare with `UpdateHyper` 33 lines below, which already calls `cachePathFor("hyper")` correctly. This commit applies the same pattern to `UpdateProviders`.

## Testing

Run `crush update-providers` and check that the log line now shows the full cache file path under the `to` key.