### PR TITLE
feat: add disableThinkingOptions to force-disable reasoning for backg…

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1346,7 +1346,7 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		Prompt:          summaryPromptText,
 		Messages:        aiMsgs,
 		Headers:         sessionHeaders(sessionID),
-		ProviderOptions: disableThinkingOptions(opts),
+		ProviderOptions: disableThinkingOptions(opts, largeModel.CatwalkCfg.CanReason),
 		PrepareStep: func(callContext context.Context, options fantasy.PrepareStepFunctionOptions) (_ context.Context, prepared fantasy.PrepareStepResult, err error) {
 			prepared.Messages = options.Messages
 			if systemPromptPrefix != "" {
@@ -1441,7 +1441,11 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 // reasoning/thinking for models that support it. This ensures that small
 // background requests (like summarization) do not fail when using local
 // Llama.cpp servers or other thinking-capable models.
-func disableThinkingOptions(opts fantasy.ProviderOptions) fantasy.ProviderOptions {
+func disableThinkingOptions(opts fantasy.ProviderOptions, canReason bool) fantasy.ProviderOptions {
+	if !canReason {
+		return opts
+	}
+
 	summaryOpts := make(fantasy.ProviderOptions, len(opts)+2)
 	for k, v := range opts {
 		summaryOpts[k] = v
@@ -1790,7 +1794,7 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 		if attempt.model.CatwalkCfg.CanReason {
 			tok = attempt.model.CatwalkCfg.DefaultMaxTokens
 		}
-		streamCall.ProviderOptions = disableThinkingOptions(nil)
+		streamCall.ProviderOptions = disableThinkingOptions(nil, attempt.model.CatwalkCfg.CanReason)
 		agent := newAgent(attempt.model.Model, titlePrompt, tok)
 		resp, err = agent.Stream(ctx, streamCall)
 		if err == nil && resp.Response.FinishReason != fantasy.FinishReasonLength {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -32,6 +32,7 @@ import (
 	"charm.land/fantasy/providers/bedrock"
 	"charm.land/fantasy/providers/google"
 	"charm.land/fantasy/providers/openai"
+	"charm.land/fantasy/providers/openaicompat"
 	"charm.land/fantasy/providers/openrouter"
 	"charm.land/fantasy/providers/vercel"
 	"charm.land/lipgloss/v2"
@@ -1345,7 +1346,7 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		Prompt:          summaryPromptText,
 		Messages:        aiMsgs,
 		Headers:         sessionHeaders(sessionID),
-		ProviderOptions: opts,
+		ProviderOptions: disableThinkingOptions(opts),
 		PrepareStep: func(callContext context.Context, options fantasy.PrepareStepFunctionOptions) (_ context.Context, prepared fantasy.PrepareStepResult, err error) {
 			prepared.Messages = options.Messages
 			if systemPromptPrefix != "" {
@@ -1434,6 +1435,51 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	a.messageQueue.Set(sessionID, queuedMessages[1:])
 	_, qErr := a.Run(ctx, firstQueuedMessage)
 	return qErr
+}
+
+// disableThinkingOptions injects provider-specific options to disable
+// reasoning/thinking for models that support it. This ensures that small
+// background requests (like summarization) do not fail when using local
+// Llama.cpp servers or other thinking-capable models.
+func disableThinkingOptions(opts fantasy.ProviderOptions) fantasy.ProviderOptions {
+	summaryOpts := make(fantasy.ProviderOptions, len(opts)+2)
+	for k, v := range opts {
+		summaryOpts[k] = v
+	}
+
+	// Disable for Anthropic
+	var anthropicOpts *anthropic.ProviderOptions
+	if a, ok := summaryOpts[anthropic.Name].(*anthropic.ProviderOptions); ok && a != nil {
+		copyOpts := *a
+		anthropicOpts = &copyOpts
+	} else {
+		anthropicOpts = &anthropic.ProviderOptions{}
+	}
+	omitted := anthropic.ThinkingDisplayOmitted
+	anthropicOpts.ThinkingDisplay = &omitted
+	summaryOpts[anthropic.Name] = anthropicOpts
+
+	// Disable for OpenAI-compatible (Ollama/Llama.cpp)
+	var openaicompatOpts *openaicompat.ProviderOptions
+	if o, ok := summaryOpts[openaicompat.Name].(*openaicompat.ProviderOptions); ok && o != nil {
+		copyOpts := *o
+		openaicompatOpts = &copyOpts
+	} else {
+		openaicompatOpts = &openaicompat.ProviderOptions{}
+	}
+	if openaicompatOpts.ExtraBody == nil {
+		openaicompatOpts.ExtraBody = make(map[string]any)
+	} else {
+		newBody := make(map[string]any, len(openaicompatOpts.ExtraBody)+1)
+		for k, v := range openaicompatOpts.ExtraBody {
+			newBody[k] = v
+		}
+		openaicompatOpts.ExtraBody = newBody
+	}
+	openaicompatOpts.ExtraBody["thinking"] = false
+	summaryOpts[openaicompat.Name] = openaicompatOpts
+
+	return summaryOpts
 }
 
 func (a *sessionAgent) getCacheControlOptions() fantasy.ProviderOptions {
@@ -1744,6 +1790,7 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 		if attempt.model.CatwalkCfg.CanReason {
 			tok = attempt.model.CatwalkCfg.DefaultMaxTokens
 		}
+		streamCall.ProviderOptions = disableThinkingOptions(nil)
 		agent := newAgent(attempt.model.Model, titlePrompt, tok)
 		resp, err = agent.Stream(ctx, streamCall)
 		if err == nil && resp.Response.FinishReason != fantasy.FinishReasonLength {


### PR DESCRIPTION
What

Background tasks like Summarize and GenerateTitle were failing or taking excessively long when using thinking/reasoning-capable models (e.g., Anthropic's Claude 3.7 Sonnet or Llama.cpp instances with thinking enabled). The chain-of-thought overhead is unnecessary for these simple background operations and can break strict JSON parsing.

Changes

Added a disableThinkingOptions helper in internal/agent/agent.go to safely inject provider overrides without mutating the original configuration.
Intercepts Anthropic options to set ThinkingDisplay to anthropic.ThinkingDisplayOmitted.
Intercepts OpenAI-compatible options to add "thinking": false to the ExtraBody payload.
Wrapped the opts with disableThinkingOptions in the Summarize method and applied it to the stream call in GenerateTitle.
Why

Closes #3284.

Force-disabling reasoning for small background tasks ensures fast, deterministic responses and prevents summarizations from crashing (falling back to "Untitled Session") when the primary chat session is using a thinking model (like a local Llama.cpp server).