### PR TITLE
fix: enforce .gitignore/.crushignore in view, edit, write, multiedit

### DIFF
--- a/internal/agent/tools/edit.go
+++ b/internal/agent/tools/edit.go
@@ -76,6 +76,10 @@ func NewEditTool(
 
 			params.FilePath = filepathext.SmartJoin(workingDir, params.FilePath)
 
+			if fsext.ShouldExcludeFile(workingDir, params.FilePath) {
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("File is ignored by .gitignore or .crushignore: %s", params.FilePath)), nil
+			}
+
 			var response fantasy.ToolResponse
 			var err error
 

--- a/internal/agent/tools/edit_test.go
+++ b/internal/agent/tools/edit_test.go
@@ -1,0 +1,44 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEditToolRespectsCrushignore(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workingDir, ".crushignore"), []byte("_*.md\n"), 0o644))
+	testFile := filepath.Join(workingDir, "_secret.md")
+	require.NoError(t, os.WriteFile(testFile, []byte("line 1\n"), 0o644))
+
+	ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+	tool := NewEditTool(nil, &mockPermissionService{}, &mockHistoryService{}, mockFileTrackerService{}, workingDir)
+
+	input, err := json.Marshal(EditParams{
+		FilePath:  "_secret.md",
+		OldString: "line 1",
+		NewString: "LINE 1",
+	})
+	require.NoError(t, err)
+
+	resp, err := tool.Run(ctx, fantasy.ToolCall{
+		ID:    "test-call",
+		Name:  EditToolName,
+		Input: string(input),
+	})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "ignored")
+
+	content, err := os.ReadFile(testFile)
+	require.NoError(t, err)
+	require.Equal(t, "line 1\n", string(content), "file should not have been modified")
+}

--- a/internal/agent/tools/multiedit.go
+++ b/internal/agent/tools/multiedit.go
@@ -78,6 +78,10 @@ func NewMultiEditTool(
 
 			params.FilePath = filepathext.SmartJoin(workingDir, params.FilePath)
 
+			if fsext.ShouldExcludeFile(workingDir, params.FilePath) {
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("File is ignored by .gitignore or .crushignore: %s", params.FilePath)), nil
+			}
+
 			// Validate all edits before applying any
 			if err := validateEdits(params.Edits); err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil

--- a/internal/agent/tools/multiedit_test.go
+++ b/internal/agent/tools/multiedit_test.go
@@ -2,10 +2,12 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/history"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/pubsub"
@@ -74,6 +76,37 @@ func (m *mockHistoryService) Delete(ctx context.Context, id string) error {
 
 func (m *mockHistoryService) DeleteSessionFiles(ctx context.Context, sessionID string) error {
 	return nil
+}
+
+func TestMultiEditToolRespectsCrushignore(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workingDir, ".crushignore"), []byte("_*.md\n"), 0o644))
+	testFile := filepath.Join(workingDir, "_secret.md")
+	require.NoError(t, os.WriteFile(testFile, []byte("line 1\n"), 0o644))
+
+	ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+	tool := NewMultiEditTool(nil, &mockPermissionService{}, &mockHistoryService{}, mockFileTrackerService{}, workingDir)
+
+	input, err := json.Marshal(MultiEditParams{
+		FilePath: "_secret.md",
+		Edits:    []MultiEditOperation{{OldString: "line 1", NewString: "LINE 1"}},
+	})
+	require.NoError(t, err)
+
+	resp, err := tool.Run(ctx, fantasy.ToolCall{
+		ID:    "test-call",
+		Name:  MultiEditToolName,
+		Input: string(input),
+	})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "ignored")
+
+	content, err := os.ReadFile(testFile)
+	require.NoError(t, err)
+	require.Equal(t, "line 1\n", string(content), "file should not have been modified")
 }
 
 func TestApplyEditToContentPartialSuccess(t *testing.T) {

--- a/internal/agent/tools/view.go
+++ b/internal/agent/tools/view.go
@@ -19,6 +19,7 @@ import (
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/filepathext"
 	"github.com/charmbracelet/crush/internal/filetracker"
+	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/lsp"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/skills"
@@ -126,6 +127,10 @@ func NewViewTool(
 			relPath, err := filepath.Rel(absWorkingDir, absFilePath)
 			isOutsideWorkDir := err != nil || strings.HasPrefix(relPath, "..")
 			isSkillFile := isInSkillsPath(absFilePath, skillsPaths)
+
+			if !isSkillFile && fsext.ShouldExcludeFile(workingDir, absFilePath) {
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("File is ignored by .gitignore or .crushignore: %s", filePath)), nil
+			}
 
 			sessionID := GetSessionFromContext(ctx)
 			if sessionID == "" {

--- a/internal/agent/tools/view_test.go
+++ b/internal/agent/tools/view_test.go
@@ -270,6 +270,21 @@ func runViewTool(t *testing.T, tool fantasy.AgentTool, ctx context.Context, para
 	return resp
 }
 
+func TestViewToolRespectsCrushignore(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workingDir, ".crushignore"), []byte("_*.md\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(workingDir, "_secret.md"), []byte("do not read"), 0o644))
+
+	tool := newViewToolForTest(workingDir)
+	ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+
+	resp := runViewTool(t, tool, ctx, ViewParams{FilePath: "_secret.md"})
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "ignored")
+}
+
 var _ filetracker.Service = mockFileTracker{}
 
 func TestReadBuiltinFile(t *testing.T) {

--- a/internal/agent/tools/write.go
+++ b/internal/agent/tools/write.go
@@ -65,6 +65,10 @@ func NewWriteTool(
 
 			filePath := filepathext.SmartJoin(workingDir, params.FilePath)
 
+			if fsext.ShouldExcludeFile(workingDir, filePath) {
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("File is ignored by .gitignore or .crushignore: %s", filePath)), nil
+			}
+
 			fileInfo, err := os.Stat(filePath)
 			if err == nil {
 				if fileInfo.IsDir() {

--- a/internal/agent/tools/write_test.go
+++ b/internal/agent/tools/write_test.go
@@ -24,6 +24,31 @@ func (m mockFileTrackerService) ListReadFiles(ctx context.Context, sessionID str
 	return nil, nil
 }
 
+func TestWriteToolRespectsCrushignore(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workingDir, ".crushignore"), []byte("_*.md\n"), 0o644))
+
+	ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+	tool := NewWriteTool(nil, &mockPermissionService{}, &mockHistoryService{}, mockFileTrackerService{}, workingDir)
+
+	input, err := json.Marshal(WriteParams{FilePath: "_secret.md", Content: "sneaky"})
+	require.NoError(t, err)
+
+	resp, err := tool.Run(ctx, fantasy.ToolCall{
+		ID:    "test-call",
+		Name:  WriteToolName,
+		Input: string(input),
+	})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "ignored")
+
+	_, statErr := os.Stat(filepath.Join(workingDir, "_secret.md"))
+	require.True(t, os.IsNotExist(statErr), "file should not have been created")
+}
+
 func TestWriteToolWritesEmptyNewFile(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `ls` and `grep` already respect `.gitignore`/`.crushignore` (via `fsext.ListDirectory` and `fsext.NewFastGlobWalker`), and `fsext.ShouldExcludeFile` already existed and was unit-tested for exactly this purpose — but nothing outside of `ls`/`grep` called it
- `view`, `edit`, `write`, and `multiedit` could read or modify any file regardless of `.crushignore`/`.gitignore`, contrary to the README's claim that Crush "respects `.gitignore` files by default" and "should ignore" `.crushignore` matches
- Wires the existing `fsext.ShouldExcludeFile(workingDir, path)` check into each tool's entry point (right after path resolution, before any stat/read/write), returning a text error response instead of silently proceeding
- Skill files are exempted from the check in `view` (they're intentionally-loaded resources, not user project files)

Fixes #3116

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/agent/tools/...` — all existing tests pass, no regressions
- [x] Added `TestViewToolRespectsCrushignore`, `TestEditToolRespectsCrushignore`, `TestWriteToolRespectsCrushignore`, `TestMultiEditToolRespectsCrushignore` — each writes a `.crushignore` excluding `_*.md`, then confirms the tool rejects the matching file and makes no filesystem changes
- [x] Semgrep (`p/security-audit`, `p/secrets`, `p/golang`, Trail of Bits Go rules) on the changed files — 0 findings