### PR TITLE
fix: seed MCP sidebar state on a timer to fix stuck "None" panel

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -142,6 +142,11 @@ type (
 	mcpStateChangedMsg struct {
 		states map[string]mcp.ClientInfo
 	}
+	// mcpRefreshTickMsg periodically re-seeds MCP client states, so servers
+	// that connected (and published their one and only EventStateChanged)
+	// before the TUI's event subscription went live still appear in the
+	// sidebar instead of being stuck on "None" for the rest of the session.
+	mcpRefreshTickMsg struct{}
 	// sendMessageMsg is sent to send a message.
 	// currently only used for mcp prompts.
 	sendMessageMsg struct {
@@ -446,6 +451,7 @@ func (m *UI) Init() tea.Cmd {
 	if m.com.IsHyper() {
 		cmds = append(cmds, m.fetchHyperCredits())
 	}
+	cmds = append(cmds, mcpRefreshTick())
 	return tea.Batch(cmds...)
 }
 
@@ -687,6 +693,8 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case mcpStateChangedMsg:
 		m.mcpStates = msg.states
+	case mcpRefreshTickMsg:
+		return m, tea.Batch(m.refreshMCPStates(), mcpRefreshTick())
 	case mcpPromptsLoadedMsg:
 		m.mcpPrompts = msg.Prompts
 		dia := m.dialog.Dialog(dialog.CommandsID)
@@ -4281,6 +4289,22 @@ func (m *UI) handleStateChanged() tea.Cmd {
 			states: m.com.Workspace.MCPGetStates(),
 		}
 	}
+}
+
+// refreshMCPStates re-seeds MCP client states without handleStateChanged's
+// UpdateAgentModel side effect, so it is safe to call on a timer.
+func (m *UI) refreshMCPStates() tea.Cmd {
+	return func() tea.Msg {
+		return mcpStateChangedMsg{states: m.com.Workspace.MCPGetStates()}
+	}
+}
+
+const mcpRefreshInterval = 2 * time.Second
+
+func mcpRefreshTick() tea.Cmd {
+	return tea.Tick(mcpRefreshInterval, func(time.Time) tea.Msg {
+		return mcpRefreshTickMsg{}
+	})
 }
 
 func handleMCPPromptsEvent(ws workspace.Workspace, name string) tea.Cmd {

--- a/internal/ui/model/ui_test.go
+++ b/internal/ui/model/ui_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/csync"
 	"github.com/charmbracelet/crush/internal/ui/common"
@@ -87,9 +88,37 @@ func newTestUIWithConfig(t *testing.T, cfg *config.Config) *UI {
 // testWorkspace is a minimal [workspace.Workspace] stub for unit tests.
 type testWorkspace struct {
 	workspace.Workspace
-	cfg *config.Config
+	cfg       *config.Config
+	mcpStates map[string]mcp.ClientInfo
 }
 
 func (w *testWorkspace) Config() *config.Config {
 	return w.cfg
+}
+
+func (w *testWorkspace) MCPGetStates() map[string]mcp.ClientInfo {
+	return w.mcpStates
+}
+
+// TestRefreshMCPStates verifies that a fast MCP connection whose only
+// EventStateChanged fired before the TUI subscribed still ends up in
+// m.mcpStates once refreshMCPStates re-seeds from the authoritative
+// MCPGetStates(), instead of the sidebar showing "None" forever.
+func TestRefreshMCPStates(t *testing.T) {
+	t.Parallel()
+
+	states := map[string]mcp.ClientInfo{
+		"example": {State: mcp.StateConnected},
+	}
+	ui := &UI{
+		com: &common.Common{
+			Workspace: &testWorkspace{mcpStates: states},
+		},
+	}
+	require.Empty(t, ui.mcpStates, "mcpStates should start empty, as if the connect event was missed")
+
+	msg := ui.refreshMCPStates()()
+	changed, ok := msg.(mcpStateChangedMsg)
+	require.True(t, ok, "refreshMCPStates should return a mcpStateChangedMsg")
+	require.Equal(t, states, changed.states)
 }


### PR DESCRIPTION
## Summary
- `mcp.Initialize` runs in a goroutine concurrently with the TUI starting up (`internal/app/app.go:140`)
- A fast-connecting MCP server can reach `StateConnected` and publish its one and only `EventStateChanged` before the TUI's event subscription is live, so the event is missed
- `mcpStates` is never seeded any other way (`Init()` doesn't seed it, and for a stable connection no further state event ever fires), so the sidebar shows **None** for that server for the rest of the session even though its tools work fine (they're registered in a separate global registry, independent of `mcpStates`)
- Adds a 2-second re-seed tick that re-reads `MCPGetStates()` into `mcpStates` via a new `refreshMCPStates()` (deliberately skips `handleStateChanged`'s `UpdateAgentModel` side effect, so it's safe to call on a timer) — self-heals a missed initial event within a couple of seconds, and also picks up later connects/disconnects the same way

Fixes #3279

Root-caused by the issue reporter with exact file/line references and a manually-verified patch; this PR implements their proposed periodic re-seed approach.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/ui/...` — all packages pass, no regressions
- [x] Added `TestRefreshMCPStates` — confirms `refreshMCPStates()` returns a `mcpStateChangedMsg` reflecting the workspace's current `MCPGetStates()`, simulating a state that was set before the sidebar's `mcpStates` map was ever seeded
- [x] Semgrep (`p/security-audit`, `p/secrets`, `p/golang`, Trail of Bits Go rules) on the changed files — 0 findings