### PR TITLE
fix: surface a clear hint when git commit fails from GPG signing

### DIFF
--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -411,6 +411,10 @@ func formatOutput(stdout, stderr string, execErr error) string {
 		errorMessage += fmt.Sprintf("Exit code %d", exitCode)
 	}
 
+	if strings.Contains(stderr, "gpg failed to sign the data") || strings.Contains(stderr, "gpg: signing failed") {
+		errorMessage += "\n\nHint: git commit signing needs GPG's pinentry to prompt for a passphrase, but commands run by this tool have no TTY for that prompt. Either pre-warm the gpg-agent passphrase cache before asking for a commit (e.g. `echo test | gpg --clearsign`), or switch to SSH-based commit signing (`git config --global gpg.format ssh`), which doesn't require a TTY."
+	}
+
 	hasBothOutputs := stdout != "" && stderr != ""
 
 	if hasBothOutputs {

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -183,6 +184,24 @@ func runBashTool(t *testing.T, tool fantasy.AgentTool, ctx context.Context, para
 	resp, err := tool.Run(ctx, call)
 	require.NoError(t, err)
 	return resp
+}
+
+func TestFormatOutputGpgSigningHint(t *testing.T) {
+	t.Parallel()
+
+	stderr := "error: gpg failed to sign the data\nfatal: failed to write commit object"
+	out := formatOutput("", stderr, errors.New("exit status 1"))
+
+	require.Contains(t, out, "gpg failed to sign the data")
+	require.Contains(t, out, "Hint:", "should explain why signing failed in a non-interactive tool")
+	require.Contains(t, out, "gpg.format ssh", "should suggest the TTY-free SSH signing workaround")
+}
+
+func TestFormatOutputNoHintForUnrelatedFailure(t *testing.T) {
+	t.Parallel()
+
+	out := formatOutput("", "command not found: foo", errors.New("exit status 127"))
+	require.NotContains(t, out, "Hint:")
 }
 
 func TestTruncateOutputValidUTF8(t *testing.T) {


### PR DESCRIPTION
## Summary
- With `commit.gpgsign = true`, `git commit` run via the bash tool fails with `error: gpg failed to sign the data` because GPG's `pinentry` needs a TTY to prompt for a passphrase, and commands run by this tool have none
- Previously this surfaced to the model/user as just a non-zero exit code plus git's own terse error — the root cause (no TTY for pinentry) wasn't explained anywhere
- Detects the known `gpg failed to sign the data` / `gpg: signing failed` failure strings in `formatOutput` (the single place bash tool output is assembled) and appends a hint explaining the TTY requirement, with two workarounds: pre-warming `gpg-agent`'s passphrase cache, or switching to TTY-free SSH commit signing (`git config --global gpg.format ssh`)
- This is option 2 ("Detect and surface") from the issue's suggested approaches — the minimal, non-invasive fix; the PTY-forwarding option would be a much larger change to the shell execution model for a comparatively rare setup

Fixes #3102

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/agent/tools/...` — no regressions (one pre-existing Windows path-separator test failure unrelated to this change, confirmed by reproducing it on unmodified `main`)
- [x] Added `TestFormatOutputGpgSigningHint` (hint appears for the known gpg failure string) and `TestFormatOutputNoHintForUnrelatedFailure` (hint does NOT appear for unrelated failures)
- [x] Semgrep (`p/security-audit`, `p/secrets`, `p/golang`, Trail of Bits Go rules) on the changed files — 0 findings