### PR TITLE
docs: add missing XAI_API_KEY to environment variables table

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ That said, you can also set environment variables for preferred providers:
 | `AZURE_OPENAI_API_KEY`      | Azure OpenAI models (optional when using Entra ID) |
 | `AZURE_OPENAI_API_VERSION`  | Azure OpenAI models                                |
 | `MOONSHOT_API_KEY`          | Moonshot                                           |
+| `XAI_API_KEY`               | xAI                                                |
 
 [hyper]: https://hyper.charm.land
 


### PR DESCRIPTION
## Summary
- xAI is a fully supported provider — catwalk's `xai.json` config (`charm.land/catwalk`, the provider registry crush depends on) declares `"api_key": "$XAI_API_KEY"` for it — but `XAI_API_KEY` was never added to the README's environment variables table alongside every other supported provider
- Confirmed by checking the actual `catwalk@v0.49.4` provider config, not guessing at the env var name

Fixes #3105

## Test plan
- Docs-only change (one row added to a markdown table), no code path affected