### PR TITLE
fix: surface api_key/base_url resolution errors instead of discarding them

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -1040,8 +1040,14 @@ func (c *coordinator) buildProvider(providerCfg config.ProviderConfig, model con
 		}
 	}
 
-	apiKey, _ := c.cfg.Resolve(providerCfg.APIKey)
-	baseURL, _ := c.cfg.Resolve(providerCfg.BaseURL)
+	apiKey, err := c.cfg.Resolve(providerCfg.APIKey)
+	if err != nil {
+		return nil, fmt.Errorf("resolving api_key for provider %q: %w", providerCfg.ID, err)
+	}
+	baseURL, err := c.cfg.Resolve(providerCfg.BaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("resolving base_url for provider %q: %w", providerCfg.ID, err)
+	}
 
 	switch providerCfg.ID {
 	case string(catwalk.InferenceProviderOpenCodeGo), string(catwalk.InferenceProviderOpenCodeZen):

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -552,3 +552,39 @@ func TestGetProviderOptionsReasoningEffortFallback(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "enabled", thinking["type"])
 }
+
+func TestBuildProviderSurfacesResolveErrors(t *testing.T) {
+	const providerID = "test-provider"
+	model := config.SelectedModel{Provider: providerID}
+
+	t.Run("api_key resolution failure is returned, not silently dropped", func(t *testing.T) {
+		env := testEnv(t)
+		providerCfg := config.ProviderConfig{
+			ID:     providerID,
+			Type:   catwalk.Type(openaicompat.Name),
+			APIKey: "${CRUSH_TEST_MISSING_VAR_3011:?required for test}",
+		}
+		coord := newTestCoordinator(t, env, providerID, providerCfg)
+
+		_, err := coord.buildProvider(providerCfg, model, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "api_key")
+		assert.Contains(t, err.Error(), providerID)
+	})
+
+	t.Run("base_url resolution failure is returned, not silently dropped", func(t *testing.T) {
+		env := testEnv(t)
+		providerCfg := config.ProviderConfig{
+			ID:      providerID,
+			Type:    catwalk.Type(openaicompat.Name),
+			APIKey:  "test-key",
+			BaseURL: "${CRUSH_TEST_MISSING_VAR_3011:?required for test}",
+		}
+		coord := newTestCoordinator(t, env, providerID, providerCfg)
+
+		_, err := coord.buildProvider(providerCfg, model, false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "base_url")
+		assert.Contains(t, err.Error(), providerID)
+	})
+}


### PR DESCRIPTION
## Summary
- `buildProvider` discarded the error from `c.cfg.Resolve()` for both `api_key` and `base_url` with the blank identifier (`apiKey, _ := ...`)
- A malformed template, a failed `\$(command)` substitution, or a required `\${VAR:?message}` check firing all failed silently — the provider was then built with an empty/wrong value, and the resulting auth failure surfaced far from the real root cause, deep inside the provider's own request path instead of at config load time
- Fix: check and return both errors, wrapped with which field and provider ID failed

**Deliberately scoped narrower than the issue's literal suggestion:** the issue proposes failing whenever `api_key` resolves to empty, but that would be a real regression — Bedrock (AWS credential/profile auth) and Azure OpenAI with Entra ID both legitimately have no `api_key` configured. crush's resolver already supports opting into a hard failure per-provider via `\${VAR:?message}` syntax in the provider's own `api_key` template (documented in `internal/config/resolve.go`), so the actual bug here is the discarded *resolution error*, not missing empty-string validation.

Fixes #3011

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/agent/...` — all pass, no regressions (pre-existing unrelated Windows path-separator failure in `internal/agent/tools` confirmed present on unmodified `main` too)
- [x] Added `TestBuildProviderSurfacesResolveErrors` — confirms both `api_key` and `base_url` resolution failures (via `\${VAR:?message}`) now return an error naming the field and provider, instead of silently proceeding
- [x] Semgrep (`p/security-audit`, `p/secrets`, `p/golang`, Trail of Bits Go rules) on the changed files — 0 findings