### PR TITLE
fix: collapse clean hook output to a one-line summary

### DIFF
--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -765,6 +765,15 @@ func toolOutputHookIndicator(sty *styles.Styles, metadata string, width int) str
 		return ""
 	}
 
+	// A tool call can trigger several hooks, each printing its own "OK"
+	// line; when nothing interesting happened this is pure noise that
+	// crowds out the tool's actual output. Collapse to a one-line summary
+	// unless a hook denied the call or rewrote its input, since that's
+	// the kind of result a user actually needs to see.
+	if allHooksClean(h.Hooks) {
+		return renderHookSummary(sty, len(h.Hooks))
+	}
+
 	// Sanitize names (replace newlines with ¶) and compute max widths
 	// for the name, matcher, and detail columns so they align. The name
 	// column is capped at maxHookNameWidth characters.
@@ -817,6 +826,32 @@ func toolOutputHookIndicator(sty *styles.Styles, metadata string, width int) str
 		lines = append(lines, renderHookLine(sty, hi, name, details[i], maxNameWidth, maxMatcherWidth))
 	}
 	return strings.Join(lines, "\n")
+}
+
+// allHooksClean reports whether every hook in the list simply passed —
+// no denial, no input rewrite — meaning per-hook detail has nothing
+// worth showing.
+func allHooksClean(his []hooks.HookInfo) bool {
+	for _, hi := range his {
+		if hi.Decision == "deny" || hi.InputRewrite {
+			return false
+		}
+	}
+	return true
+}
+
+// renderHookSummary renders the collapsed one-line summary shown when
+// every hook that ran simply passed.
+func renderHookSummary(sty *styles.Styles, count int) string {
+	noun := "hook"
+	if count != 1 {
+		noun = "hooks"
+	}
+	return fmt.Sprintf(
+		"%s %s",
+		sty.Tool.HookLabel.Render(fmt.Sprintf("%d %s ran, all", count, noun)),
+		sty.Tool.HookOK.Render("OK"),
+	)
 }
 
 // truncateHookName truncates a hook name to fit within maxWidth cells,

--- a/internal/ui/chat/tools_test.go
+++ b/internal/ui/chat/tools_test.go
@@ -1,0 +1,98 @@
+package chat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/hooks"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/stretchr/testify/require"
+)
+
+func hookMetadataJSON(t *testing.T, hookInfos []hooks.HookInfo) string {
+	t.Helper()
+	meta := struct {
+		Hook *hooks.HookMetadata `json:"hook"`
+	}{
+		Hook: &hooks.HookMetadata{
+			HookCount: len(hookInfos),
+			Hooks:     hookInfos,
+		},
+	}
+	b, err := json.Marshal(meta)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func TestToolOutputHookIndicatorCollapsesCleanHooks(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	styPtr := &sty
+	metadata := hookMetadataJSON(t, []hooks.HookInfo{
+		{Name: "rtk", Decision: "allow"},
+		{Name: "safety", Decision: "allow"},
+		{Name: "audit", Decision: "allow"},
+	})
+
+	line := toolOutputHookIndicator(styPtr, metadata, 80)
+
+	require.Contains(t, line, "3 hooks ran, all")
+	require.NotContains(t, line, "rtk", "individual hook names should not appear in the collapsed summary")
+}
+
+func TestToolOutputHookIndicatorSingleCleanHookUsesSingular(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	styPtr := &sty
+	metadata := hookMetadataJSON(t, []hooks.HookInfo{
+		{Name: "rtk", Decision: "allow"},
+	})
+
+	line := toolOutputHookIndicator(styPtr, metadata, 80)
+
+	require.Contains(t, line, "1 hook ran, all")
+}
+
+func TestToolOutputHookIndicatorShowsDetailOnDenial(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	styPtr := &sty
+	metadata := hookMetadataJSON(t, []hooks.HookInfo{
+		{Name: "rtk", Decision: "allow"},
+		{Name: "safety", Decision: "deny", Reason: "blocked rm -rf"},
+	})
+
+	line := toolOutputHookIndicator(styPtr, metadata, 80)
+
+	require.Contains(t, line, "rtk", "clean hooks should still be listed when any hook is denied")
+	require.Contains(t, line, "safety")
+	require.Contains(t, line, "blocked rm -rf")
+}
+
+func TestToolOutputHookIndicatorShowsDetailOnInputRewrite(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	styPtr := &sty
+	metadata := hookMetadataJSON(t, []hooks.HookInfo{
+		{Name: "rtk", Decision: "allow", InputRewrite: true},
+	})
+
+	line := toolOutputHookIndicator(styPtr, metadata, 80)
+
+	require.Contains(t, line, "rtk")
+	require.NotContains(t, line, "ran, all", "a rewrite should not be collapsed into the clean summary")
+}
+
+func TestToolOutputHookIndicatorEmptyWithNoHooks(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	styPtr := &sty
+
+	require.Equal(t, "", toolOutputHookIndicator(styPtr, "", 80))
+	require.Equal(t, "", toolOutputHookIndicator(styPtr, hookMetadataJSON(t, nil), 80))
+}


### PR DESCRIPTION
## Summary
- A tool call can trigger several `PreToolUse` hooks, each printing its own `Hook <name> ... -> OK` line
- With five or six hooks configured (a realistic setup — rtk, a safety check, git, security, commands, audit), that's five or six repeated lines of pure noise on *every single tool call*, crowding out the tool's actual output — see the example in the issue
- Collapses to `N hooks ran, all OK` when every hook in the batch simply passed (no denial, no input rewrite)
- Falls back to the existing full per-hook detail (names, matchers, reasons) whenever any hook denied the call or rewrote its input — that's exactly the result a user needs to see, so it's never hidden

**Scoped narrower than the issue's full request:** the issue also asks for a config option to fully suppress hook output when everything passes. That's a separate, more invasive change (needs a new config field threaded from `config.Options` down through the render call chain) — left as a follow-up. This PR ships the primary ask (collapse the noise by default) as a self-contained fix.

Fixes #2917

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/ui/chat/...` — all pass, no regressions
- [x] Added `TestToolOutputHookIndicator*` (5 cases): collapses N clean hooks to a summary, singular "1 hook" phrasing, falls back to full detail on denial, falls back to full detail on input rewrite, empty string when no hook metadata present
- [x] Semgrep (`p/security-audit`, `p/secrets`, `p/golang`, Trail of Bits Go rules) on the changed files — 0 findings