### PR TITLE
feat: scrollable sidebar

### DIFF
--- a/internal/ui/logo/logo.go
+++ b/internal/ui/logo/logo.go
@@ -154,9 +154,6 @@ func SmallRender(t *styles.Styles, width int, o Opts) string {
 		name = "HYPERCRUSH"
 	}
 	charm := "Charm™"
-	if !o.Hyper {
-		charm = " " + charm
-	}
 	title := t.Logo.SmallCharm.Render(charm)
 	title = fmt.Sprintf("%s %s", title, styles.ApplyBoldForegroundGrad(t.Logo.GradCanvas, name, t.Logo.SmallGradFromColor, t.Logo.SmallGradToColor))
 	remainingWidth := width - lipgloss.Width(title) - 1 // 1 for the space after the name

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -37,6 +37,11 @@ type scrollbarHideMsg struct {
 	seq int // sequence number to ignore stale messages
 }
 
+// sidebarScrollbarHideMsg is sent to hide the sidebar scrollbar after timeout.
+type sidebarScrollbarHideMsg struct {
+	seq int
+}
+
 // scrollbarHideCmd returns a command that sends a scrollbarHideMsg after the timeout.
 func scrollbarHideCmd(seq int) tea.Cmd {
 	return tea.Tick(scrollbarHideDuration, func(_ time.Time) tea.Msg {

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -76,6 +76,14 @@ func chatWarmCmd(seq int, delay time.Duration) tea.Cmd {
 	})
 }
 
+// sidebarScrollbarHideCmd returns a command that sends a sidebarScrollbarHideMsg
+// after the timeout.
+func sidebarScrollbarHideCmd(seq int) tea.Cmd {
+	return tea.Tick(scrollbarHideDuration, func(_ time.Time) tea.Msg {
+		return sidebarScrollbarHideMsg{seq: seq}
+	})
+}
+
 // Chat represents the chat UI model that handles chat interactions and
 // messages.
 type Chat struct {

--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -49,6 +49,8 @@ type KeyMap struct {
 		Expand         key.Binding
 		ScrollLeft     key.Binding
 		ScrollRight    key.Binding
+		FocusSidebar   key.Binding
+		FocusChat      key.Binding
 	}
 
 	Initialize struct {
@@ -259,6 +261,14 @@ func DefaultKeyMap() KeyMap {
 	km.Chat.ScrollRight = key.NewBinding(
 		key.WithKeys("shift+right", "L"),
 		key.WithHelp("shift+→/L", "scroll right"),
+	)
+	km.Chat.FocusSidebar = key.NewBinding(
+		key.WithKeys("l", "right"),
+		key.WithHelp("l/→", "focus sidebar"),
+	)
+	km.Chat.FocusChat = key.NewBinding(
+		key.WithKeys("h", "left"),
+		key.WithHelp("h/←", "focus chat"),
 	)
 	km.Initialize.Yes = key.NewBinding(
 		key.WithKeys("y", "Y"),

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -66,7 +66,7 @@ func (m *UI) sidebarMaxOffset() int {
 	return m.sidebarMaxOffsetVal
 }
 
-// drawSidebar renders the chat sidebar with a fixed header and a
+// drawSidebar renders the chat sidebar with a fixed logo and a
 // virtual-scrolling content area with an auto-hiding scrollbar. While the
 // sidebar is focused, the scrollbar stays visible.
 func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
@@ -90,27 +90,11 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 			Hyper: m.com.IsHyper(),
 		})
 	}
-	blocks := []string{
-		sidebarLogo,
-		title,
-		"",
-		cwd,
-		"",
-		m.modelInfo(contentWidth),
-		"",
-	}
-
-	sidebarHeader := lipgloss.JoinVertical(
-		lipgloss.Left,
-		blocks...,
-	)
-
-	// Split the sidebar into a fixed header and a scrollable content area.
-	var headerRect, contentRect image.Rectangle
+	var logoRect, contentRect image.Rectangle
 	layout.Vertical(
-		layout.Len(lipgloss.Height(sidebarHeader)),
+		layout.Len(lipgloss.Height(sidebarLogo)),
 		layout.Fill(1),
-	).Split(area).Assign(&headerRect, &contentRect)
+	).Split(area).Assign(&logoRect, &contentRect)
 
 	contentHeight := contentRect.Dy()
 
@@ -123,6 +107,12 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	// Build the scrollable content.
 	content := lipgloss.JoinVertical(
 		lipgloss.Left,
+		title,
+		"",
+		cwd,
+		"",
+		m.modelInfo(contentWidth),
+		"",
 		filesSection,
 		"",
 		lspSection,
@@ -160,13 +150,13 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	// auto-hide.
 	scrollbarVisible := totalLines > contentHeight && (m.sidebarScrollbarVisible || m.focus == uiFocusSidebar)
 
-	// Draw the fixed header.
+	// Draw the fixed logo.
 	uv.NewStyledString(
 		lipgloss.NewStyle().
 			MaxWidth(contentWidth).
-			MaxHeight(lipgloss.Height(sidebarHeader)).
-			Render(sidebarHeader),
-	).Draw(scr, headerRect)
+			MaxHeight(lipgloss.Height(sidebarLogo)).
+			Render(sidebarLogo),
+	).Draw(scr, logoRect)
 
 	// Draw the visible content in the scrollable area.
 	uv.NewStyledString(

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -219,6 +219,13 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	m.sidebarScrollable = totalLines > height
 	m.sidebarMaxOffsetVal = max(0, totalLines-height)
 
+	// If the sidebar is focused but no longer scrollable (e.g. after a
+	// resize), return focus to the chat.
+	if m.focus == uiFocusSidebar && !m.sidebarScrollable {
+		m.focus = uiFocusMain
+		m.chat.Focus()
+	}
+
 	// Clamp sidebarOffset.
 	maxOffset := m.sidebarMaxOffsetVal
 	if m.sidebarOffset > maxOffset {

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -146,11 +146,13 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	width := area.Dx()
 	height := area.Dy()
 
-	title := t.Sidebar.SessionTitle.Width(width).MaxHeight(2).Render(m.session.Title)
-	cwd := common.PrettyPath(t, m.com.Workspace.WorkingDir(), width)
+	contentWidth := max(width-1, 1)
+
+	title := t.Sidebar.SessionTitle.Width(contentWidth).MaxHeight(2).Render(m.session.Title)
+	cwd := common.PrettyPath(t, m.com.Workspace.WorkingDir(), contentWidth)
 	sidebarLogo := m.sidebarLogo
 	if height < logoHeightBreakpoint {
-		sidebarLogo = logo.SmallRender(m.com.Styles, width, logo.Opts{
+		sidebarLogo = logo.SmallRender(m.com.Styles, contentWidth, logo.Opts{
 			Hyper: m.com.IsHyper(),
 		})
 	}
@@ -160,7 +162,7 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 		"",
 		cwd,
 		"",
-		m.modelInfo(width),
+		m.modelInfo(contentWidth),
 		"",
 	}
 
@@ -192,10 +194,10 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 
 	maxFiles, maxLSPs, maxMCPs, maxSkills := getDynamicHeightLimits(maxAvailableHeight, filesCount, lspsCount, mcpsCount, skillsCount)
 
-	lspSection := m.lspInfo(width, maxLSPs, true)
-	mcpSection := m.mcpInfo(width, maxMCPs, true)
-	skillsSection := m.skillsInfo(width, maxSkills, true)
-	filesSection := m.filesInfo(m.com.Workspace.WorkingDir(), width, maxFiles, true)
+	lspSection := m.lspInfo(contentWidth, maxLSPs, true)
+	mcpSection := m.mcpInfo(contentWidth, maxMCPs, true)
+	skillsSection := m.skillsInfo(contentWidth, maxSkills, true)
+	filesSection := m.filesInfo(m.com.Workspace.WorkingDir(), contentWidth, maxFiles, true)
 
 	// Build the full sidebar content.
 	fullContent := lipgloss.JoinVertical(
@@ -231,12 +233,6 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	// Determine scrollbar visibility: always visible when focused, otherwise
 	// auto-hide.
 	scrollbarVisible := totalLines > height && (m.sidebarScrollbarVisible || m.focus == uiFocusSidebar)
-
-	// Always reserve 1 column for the scrollbar.
-	contentWidth := width - 1
-	if contentWidth < 1 {
-		contentWidth = 1
-	}
 
 	uv.NewStyledString(
 		lipgloss.NewStyle().

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -7,9 +7,12 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	mcp "github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/logo"
 	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/ultraviolet/layout"
 )
 
 // modelInfo renders the current model information including reasoning
@@ -57,84 +60,15 @@ func (m *UI) modelInfo(width int) string {
 	return common.ModelInfo(m.com.Styles, modelName, providerName, reasoningInfo, modelContext, width, m.hyperCredits)
 }
 
-// getDynamicHeightLimits will give us the num of items to show in each section based on the height
-// some items are more important than others.
-func getDynamicHeightLimits(availableHeight, fileCount, lspCount, mcpCount, skillCount int) (maxFiles, maxLSPs, maxMCPs, maxSkills int) {
-	const (
-		minItemsPerSection = 2
-		// Keep these high so dynamic layout uses available sidebar space
-		// instead of hitting small hard limits.
-		defaultMaxFilesShown    = 1000
-		defaultMaxLSPsShown     = 1000
-		defaultMaxMCPsShown     = 1000
-		defaultMaxSkillsShown   = 1000
-		minAvailableHeightLimit = 10
-	)
-
-	if availableHeight < minAvailableHeightLimit {
-		return minItemsPerSection, minItemsPerSection, minItemsPerSection, minItemsPerSection
-	}
-
-	maxFiles = minItemsPerSection
-	maxLSPs = minItemsPerSection
-	maxMCPs = minItemsPerSection
-	maxSkills = minItemsPerSection
-
-	remainingHeight := max(0, availableHeight-(minItemsPerSection*4))
-
-	sectionValues := []*int{&maxFiles, &maxLSPs, &maxMCPs, &maxSkills}
-	sectionCaps := []int{defaultMaxFilesShown, defaultMaxLSPsShown, defaultMaxMCPsShown, defaultMaxSkillsShown}
-	sectionNeeds := []int{max(0, fileCount-maxFiles), max(0, lspCount-maxLSPs), max(0, mcpCount-maxMCPs), max(0, skillCount-maxSkills)}
-
-	for remainingHeight > 0 {
-		allocated := false
-		for i, section := range sectionValues {
-			if remainingHeight == 0 {
-				break
-			}
-			if sectionNeeds[i] == 0 || *section >= sectionCaps[i] {
-				continue
-			}
-			*section = *section + 1
-			sectionNeeds[i]--
-			remainingHeight--
-			allocated = true
-		}
-		if !allocated {
-			break
-		}
-	}
-
-	for remainingHeight > 0 {
-		allocated := false
-		for i, section := range sectionValues {
-			if remainingHeight == 0 {
-				break
-			}
-			if *section >= sectionCaps[i] {
-				continue
-			}
-			*section = *section + 1
-			remainingHeight--
-			allocated = true
-		}
-		if !allocated {
-			break
-		}
-	}
-
-	return maxFiles, maxLSPs, maxMCPs, maxSkills
-}
-
 // sidebarMaxOffset returns the maximum sidebar scroll offset based on
 // the last drawn content height. The value is computed during drawSidebar.
 func (m *UI) sidebarMaxOffset() int {
 	return m.sidebarMaxOffsetVal
 }
 
-// drawSidebar renders the chat sidebar with virtual scrolling and an
-// auto-hiding scrollbar. While the sidebar is focused, the scrollbar stays
-// visible.
+// drawSidebar renders the chat sidebar with a fixed header and a
+// virtual-scrolling content area with an auto-hiding scrollbar. While the
+// sidebar is focused, the scrollbar stays visible.
 func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	if m.session == nil {
 		return
@@ -171,38 +105,24 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 		blocks...,
 	)
 
-	// Give a very large available height so all items are rendered.
-	const maxAvailableHeight = 100000
-	filesCount := 0
-	for _, f := range m.sessionFiles {
-		if f.Additions == 0 && f.Deletions == 0 {
-			continue
-		}
-		filesCount++
-	}
+	// Split the sidebar into a fixed header and a scrollable content area.
+	var headerRect, contentRect image.Rectangle
+	layout.Vertical(
+		layout.Len(lipgloss.Height(sidebarHeader)),
+		layout.Fill(1),
+	).Split(area).Assign(&headerRect, &contentRect)
 
-	lspsCount := len(m.lspStates)
+	contentHeight := contentRect.Dy()
 
-	mcpsCount := 0
-	for _, mcpCfg := range m.com.Config().MCP.Sorted() {
-		if _, ok := m.mcpStates[mcpCfg.Name]; ok {
-			mcpsCount++
-		}
-	}
+	// Render all items without truncation; virtual scrolling handles overflow.
+	lspSection := m.lspInfo(contentWidth, len(m.lspStates), true)
+	mcpSection := m.mcpInfo(contentWidth, mcpCount(m.com.Config().MCP.Sorted(), m.mcpStates), true)
+	skillsSection := m.skillsInfo(contentWidth, len(m.skillStatusItems()), true)
+	filesSection := m.filesInfo(m.com.Workspace.WorkingDir(), contentWidth, fileChangeCount(m.sessionFiles), true)
 
-	skillsCount := len(m.skillStatusItems())
-
-	maxFiles, maxLSPs, maxMCPs, maxSkills := getDynamicHeightLimits(maxAvailableHeight, filesCount, lspsCount, mcpsCount, skillsCount)
-
-	lspSection := m.lspInfo(contentWidth, maxLSPs, true)
-	mcpSection := m.mcpInfo(contentWidth, maxMCPs, true)
-	skillsSection := m.skillsInfo(contentWidth, maxSkills, true)
-	filesSection := m.filesInfo(m.com.Workspace.WorkingDir(), contentWidth, maxFiles, true)
-
-	// Build the full sidebar content.
-	fullContent := lipgloss.JoinVertical(
+	// Build the scrollable content.
+	content := lipgloss.JoinVertical(
 		lipgloss.Left,
-		sidebarHeader,
 		filesSection,
 		"",
 		lspSection,
@@ -213,11 +133,10 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	)
 
 	// Split into lines for virtual scrolling.
-	lines := strings.Split(fullContent, "\n")
-	// Update scrollable flag and store max offset.
+	lines := strings.Split(content, "\n")
 	totalLines := len(lines)
-	m.sidebarScrollable = totalLines > height
-	m.sidebarMaxOffsetVal = max(0, totalLines-height)
+	m.sidebarScrollable = totalLines > contentHeight
+	m.sidebarMaxOffsetVal = max(0, totalLines-contentHeight)
 
 	// If the sidebar is focused but no longer scrollable (e.g. after a
 	// resize), return focus to the chat.
@@ -233,30 +152,63 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	}
 
 	// Slice visible lines.
-	end := min(m.sidebarOffset+height, totalLines)
+	end := min(m.sidebarOffset+contentHeight, totalLines)
 	visibleLines := lines[m.sidebarOffset:end]
 	visibleStr := strings.Join(visibleLines, "\n")
 
 	// Determine scrollbar visibility: always visible when focused, otherwise
 	// auto-hide.
-	scrollbarVisible := totalLines > height && (m.sidebarScrollbarVisible || m.focus == uiFocusSidebar)
+	scrollbarVisible := totalLines > contentHeight && (m.sidebarScrollbarVisible || m.focus == uiFocusSidebar)
 
+	// Draw the fixed header.
 	uv.NewStyledString(
 		lipgloss.NewStyle().
 			MaxWidth(contentWidth).
-			MaxHeight(height).
+			MaxHeight(lipgloss.Height(sidebarHeader)).
+			Render(sidebarHeader),
+	).Draw(scr, headerRect)
+
+	// Draw the visible content in the scrollable area.
+	uv.NewStyledString(
+		lipgloss.NewStyle().
+			MaxWidth(contentWidth).
+			MaxHeight(contentHeight).
 			Render(visibleStr),
-	).Draw(scr, area)
+	).Draw(scr, contentRect)
 
 	// Draw scrollbar in the reserved column.
 	if scrollbarVisible {
-		scrollbar := common.Scrollbar(m.com.Styles, height, totalLines, height, m.sidebarOffset)
+		scrollbar := common.Scrollbar(m.com.Styles, contentHeight, totalLines, contentHeight, m.sidebarOffset)
 		if scrollbar != "" {
 			scrollbarArea := image.Rectangle{
-				Min: image.Point{X: area.Max.X - 1, Y: area.Min.Y},
-				Max: area.Max,
+				Min: image.Point{X: area.Max.X - 1, Y: contentRect.Min.Y},
+				Max: image.Point{X: area.Max.X, Y: area.Max.Y},
 			}
 			uv.NewStyledString(scrollbar).Draw(scr, scrollbarArea)
 		}
 	}
+}
+
+// fileChangeCount returns the number of session files with non-zero additions
+// or deletions.
+func fileChangeCount(files []SessionFile) int {
+	count := 0
+	for _, f := range files {
+		if f.Additions == 0 && f.Deletions == 0 {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+// mcpCount returns the number of MCP servers that have a state entry.
+func mcpCount(mcpCfgs []config.MCP, states map[string]mcp.ClientInfo) int {
+	count := 0
+	for _, cfg := range mcpCfgs {
+		if _, ok := states[cfg.Name]; ok {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -86,9 +86,9 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	cwd := common.PrettyPath(t, m.com.Workspace.WorkingDir(), contentWidth)
 	sidebarLogo := m.sidebarLogo
 	if height < logoHeightBreakpoint {
-		sidebarLogo = logo.SmallRender(m.com.Styles, contentWidth, logo.Opts{
+		sidebarLogo = lipgloss.JoinVertical(lipgloss.Left, logo.SmallRender(m.com.Styles, contentWidth, logo.Opts{
 			Hyper: m.com.IsHyper(),
-		})
+		}), "")
 	}
 	var logoRect, contentRect image.Rectangle
 	layout.Vertical(

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -146,7 +146,7 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	width := area.Dx()
 	height := area.Dy()
 
-	contentWidth := max(width-1, 1)
+	contentWidth := max(width-2, 1)
 
 	title := t.Sidebar.SessionTitle.Width(contentWidth).MaxHeight(2).Render(m.session.Title)
 	cwd := common.PrettyPath(t, m.com.Workspace.WorkingDir(), contentWidth)

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -232,10 +232,10 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	// auto-hide.
 	scrollbarVisible := totalLines > height && (m.sidebarScrollbarVisible || m.focus == uiFocusSidebar)
 
-	// Draw content.
-	contentWidth := width
-	if scrollbarVisible {
-		contentWidth = width - 1
+	// Always reserve 1 column for the scrollbar.
+	contentWidth := width - 1
+	if contentWidth < 1 {
+		contentWidth = 1
 	}
 
 	uv.NewStyledString(
@@ -245,7 +245,7 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 			Render(visibleStr),
 	).Draw(scr, area)
 
-	// Draw scrollbar if visible.
+	// Draw scrollbar in the reserved column.
 	if scrollbarVisible {
 		scrollbar := common.Scrollbar(m.com.Styles, height, totalLines, height, m.sidebarOffset)
 		if scrollbar != "" {

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -4,12 +4,12 @@ import (
 	"cmp"
 	"fmt"
 	"image"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/logo"
 	uv "github.com/charmbracelet/ultraviolet"
-	"github.com/charmbracelet/ultraviolet/layout"
 )
 
 // modelInfo renders the current model information including reasoning
@@ -126,8 +126,15 @@ func getDynamicHeightLimits(availableHeight, fileCount, lspCount, mcpCount, skil
 	return maxFiles, maxLSPs, maxMCPs, maxSkills
 }
 
-// sidebar renders the chat sidebar containing session title, working
-// directory, model info, file list, LSP status, and MCP status.
+// sidebarMaxOffset returns the maximum sidebar scroll offset based on
+// the last drawn content height. The value is computed during drawSidebar.
+func (m *UI) sidebarMaxOffset() int {
+	return m.sidebarMaxOffsetVal
+}
+
+// drawSidebar renders the chat sidebar with virtual scrolling and an
+// auto-hiding scrollbar. While the sidebar is focused, the scrollbar stays
+// visible.
 func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	if m.session == nil {
 		return
@@ -162,12 +169,8 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 		blocks...,
 	)
 
-	var remainingHeightArea image.Rectangle
-	layout.Vertical(
-		layout.Len(lipgloss.Height(sidebarHeader)),
-		layout.Fill(1),
-	).Split(m.layout.sidebar).Assign(new(image.Rectangle), &remainingHeightArea)
-	remainingHeight := remainingHeightArea.Dy() - 6
+	// Give a very large available height so all items are rendered.
+	const maxAvailableHeight = 100000
 	filesCount := 0
 	for _, f := range m.sessionFiles {
 		if f.Additions == 0 && f.Deletions == 0 {
@@ -187,29 +190,70 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 
 	skillsCount := len(m.skillStatusItems())
 
-	maxFiles, maxLSPs, maxMCPs, maxSkills := getDynamicHeightLimits(remainingHeight, filesCount, lspsCount, mcpsCount, skillsCount)
+	maxFiles, maxLSPs, maxMCPs, maxSkills := getDynamicHeightLimits(maxAvailableHeight, filesCount, lspsCount, mcpsCount, skillsCount)
 
 	lspSection := m.lspInfo(width, maxLSPs, true)
 	mcpSection := m.mcpInfo(width, maxMCPs, true)
 	skillsSection := m.skillsInfo(width, maxSkills, true)
 	filesSection := m.filesInfo(m.com.Workspace.WorkingDir(), width, maxFiles, true)
 
+	// Build the full sidebar content.
+	fullContent := lipgloss.JoinVertical(
+		lipgloss.Left,
+		sidebarHeader,
+		filesSection,
+		"",
+		lspSection,
+		"",
+		mcpSection,
+		"",
+		skillsSection,
+	)
+
+	// Split into lines for virtual scrolling.
+	lines := strings.Split(fullContent, "\n")
+	// Update scrollable flag and store max offset.
+	totalLines := len(lines)
+	m.sidebarScrollable = totalLines > height
+	m.sidebarMaxOffsetVal = max(0, totalLines-height)
+
+	// Clamp sidebarOffset.
+	maxOffset := m.sidebarMaxOffsetVal
+	if m.sidebarOffset > maxOffset {
+		m.sidebarOffset = maxOffset
+	}
+
+	// Slice visible lines.
+	end := min(m.sidebarOffset+height, totalLines)
+	visibleLines := lines[m.sidebarOffset:end]
+	visibleStr := strings.Join(visibleLines, "\n")
+
+	// Determine scrollbar visibility: always visible when focused, otherwise
+	// auto-hide.
+	scrollbarVisible := totalLines > height && (m.sidebarScrollbarVisible || m.focus == uiFocusSidebar)
+
+	// Draw content.
+	contentWidth := width
+	if scrollbarVisible {
+		contentWidth = width - 1
+	}
+
 	uv.NewStyledString(
 		lipgloss.NewStyle().
-			MaxWidth(width).
+			MaxWidth(contentWidth).
 			MaxHeight(height).
-			Render(
-				lipgloss.JoinVertical(
-					lipgloss.Left,
-					sidebarHeader,
-					filesSection,
-					"",
-					lspSection,
-					"",
-					mcpSection,
-					"",
-					skillsSection,
-				),
-			),
+			Render(visibleStr),
 	).Draw(scr, area)
+
+	// Draw scrollbar if visible.
+	if scrollbarVisible {
+		scrollbar := common.Scrollbar(m.com.Styles, height, totalLines, height, m.sidebarOffset)
+		if scrollbar != "" {
+			scrollbarArea := image.Rectangle{
+				Min: image.Point{X: area.Max.X - 1, Y: area.Min.Y},
+				Max: area.Max,
+			}
+			uv.NewStyledString(scrollbar).Draw(scr, scrollbarArea)
+		}
+	}
 }

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -60,25 +60,19 @@ func (m *UI) modelInfo(width int) string {
 	return common.ModelInfo(m.com.Styles, modelName, providerName, reasoningInfo, modelContext, width, m.hyperCredits)
 }
 
-// sidebarMaxOffset returns the maximum sidebar scroll offset based on
-// the last drawn content height. The value is computed during drawSidebar.
-func (m *UI) sidebarMaxOffset() int {
-	return m.sidebarMaxOffsetVal
-}
-
-// drawSidebar renders the chat sidebar with a fixed logo and a
-// virtual-scrolling content area with an auto-hiding scrollbar. While the
-// sidebar is focused, the scrollbar stays visible.
-func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
-	if m.session == nil {
+// updateSidebarScrollState renders the sidebar content and computes scroll
+// state (scrollability, max offset, clamp) before drawing. This keeps all
+// state mutation in the update path rather than in the draw function.
+func (m *UI) updateSidebarScrollState() {
+	if m.session == nil || m.isCompact {
 		return
 	}
 
 	const logoHeightBreakpoint = 30
 
 	t := m.com.Styles
-	width := area.Dx()
-	height := area.Dy()
+	width := m.layout.sidebar.Dx()
+	height := m.layout.sidebar.Dy()
 
 	contentWidth := max(width-2, 1)
 
@@ -90,11 +84,12 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 			Hyper: m.com.IsHyper(),
 		}), "")
 	}
+
 	var logoRect, contentRect image.Rectangle
 	layout.Vertical(
 		layout.Len(lipgloss.Height(sidebarLogo)),
 		layout.Fill(1),
-	).Split(area).Assign(&logoRect, &contentRect)
+	).Split(m.layout.sidebar).Assign(&logoRect, &contentRect)
 
 	contentHeight := contentRect.Dy()
 
@@ -122,9 +117,12 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 		skillsSection,
 	)
 
-	// Split into lines for virtual scrolling.
-	lines := strings.Split(content, "\n")
-	totalLines := len(lines)
+	totalLines := strings.Count(content, "\n") + 1
+	m.sidebarContent = content
+	m.sidebarTotalLines = totalLines
+	m.sidebarContentWidth = contentWidth
+	m.sidebarContentHeight = contentHeight
+	m.sidebarDrawLogo = sidebarLogo
 	m.sidebarScrollable = totalLines > contentHeight
 	m.sidebarMaxOffsetVal = max(0, totalLines-contentHeight)
 
@@ -136,13 +134,33 @@ func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
 	}
 
 	// Clamp sidebarOffset.
-	maxOffset := m.sidebarMaxOffsetVal
-	if m.sidebarOffset > maxOffset {
-		m.sidebarOffset = maxOffset
+	if m.sidebarOffset > m.sidebarMaxOffsetVal {
+		m.sidebarOffset = m.sidebarMaxOffsetVal
 	}
+}
+
+// drawSidebar renders the chat sidebar with a fixed logo and a
+// virtual-scrolling content area with an auto-hiding scrollbar. While the
+// sidebar is focused, the scrollbar stays visible.
+func (m *UI) drawSidebar(scr uv.Screen, area uv.Rectangle) {
+	if m.session == nil {
+		return
+	}
+
+	sidebarLogo := m.sidebarDrawLogo
+	contentWidth := m.sidebarContentWidth
+	contentHeight := m.sidebarContentHeight
+	totalLines := m.sidebarTotalLines
+
+	var logoRect, contentRect image.Rectangle
+	layout.Vertical(
+		layout.Len(lipgloss.Height(sidebarLogo)),
+		layout.Fill(1),
+	).Split(area).Assign(&logoRect, &contentRect)
 
 	// Slice visible lines.
 	end := min(m.sidebarOffset+contentHeight, totalLines)
+	lines := strings.Split(m.sidebarContent, "\n")
 	visibleLines := lines[m.sidebarOffset:end]
 	visibleStr := strings.Join(visibleLines, "\n")
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2459,7 +2459,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				cmds = append(cmds, m.textarea.Focus())
 				m.chat.Blur()
 			case key.Matches(msg, m.keyMap.Chat.FocusSidebar):
-				if m.state == uiChat && !m.isCompact && m.hasSession() && m.sidebarScrollable {
+				if m.state == uiChat && !m.isCompact && m.hasSession() {
 					m.focus = uiFocusSidebar
 					m.chat.Blur()
 				}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3181,7 +3181,7 @@ func (m *UI) generateLayout(w, h int) uiLayout {
 		}
 	}
 	// The sidebar width
-	sidebarWidth := 30
+	sidebarWidth := 32
 	// The header height
 	const landingHeaderHeight = 4
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1017,6 +1017,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.sidebarOffset = max(0, min(m.sidebarOffset+lines, m.sidebarMaxOffset()))
 					m.sidebarScrollbarSeq++
 					m.sidebarScrollbarVisible = true
+					cmds = append(cmds, sidebarScrollbarHideCmd(m.sidebarScrollbarSeq))
 				}
 				break
 			}
@@ -1442,9 +1443,11 @@ func (m *UI) handleClickFocus(msg tea.MouseClickMsg) (cmd tea.Cmd) {
 		} else {
 			cmd = m.textarea.Focus()
 		}
+		m.sidebarScrollbarVisible = false
 		m.chat.Blur()
 	case m.focus != uiFocusMain && image.Pt(msg.X, msg.Y).In(m.layout.main):
 		m.focus = uiFocusMain
+		m.sidebarScrollbarVisible = false
 		m.textarea.Blur()
 		m.chat.Focus()
 	}
@@ -2466,6 +2469,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			switch {
 			case key.Matches(msg, m.keyMap.Tab):
 				m.focus = uiFocusEditor
+				m.sidebarScrollbarVisible = false
 				cmds = append(cmds, m.textarea.Focus())
 				m.chat.Blur()
 			case key.Matches(msg, m.keyMap.Chat.FocusSidebar):
@@ -2576,9 +2580,11 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				m.sidebarScrollbarSeq++
 			case key.Matches(msg, m.keyMap.Chat.FocusChat):
 				m.focus = uiFocusMain
+				m.sidebarScrollbarVisible = false
 				m.chat.Focus()
 			case key.Matches(msg, m.keyMap.Tab):
 				m.focus = uiFocusEditor
+				m.sidebarScrollbarVisible = false
 				cmds = append(cmds, m.textarea.Focus())
 				m.chat.Blur()
 			default:

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1420,7 +1420,7 @@ func (m *UI) handleClickFocus(msg tea.MouseClickMsg) (cmd tea.Cmd) {
 	switch {
 	case m.state != uiChat:
 		return nil
-	case m.focus != uiFocusSidebar && image.Pt(msg.X, msg.Y).In(m.layout.sidebar):
+	case m.focus != uiFocusSidebar && image.Pt(msg.X, msg.Y).In(m.layout.sidebar) && m.sidebarScrollable:
 		m.focus = uiFocusSidebar
 		m.textarea.Blur()
 		m.chat.Blur()
@@ -2459,7 +2459,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				cmds = append(cmds, m.textarea.Focus())
 				m.chat.Blur()
 			case key.Matches(msg, m.keyMap.Chat.FocusSidebar):
-				if m.state == uiChat && !m.isCompact && m.hasSession() {
+				if m.state == uiChat && !m.isCompact && m.hasSession() && m.sidebarScrollable {
 					m.focus = uiFocusSidebar
 					m.chat.Blur()
 				}
@@ -2993,6 +2993,7 @@ func (m *UI) FullHelp() [][]key.Binding {
 					k.Chat.HalfPageDown,
 					k.Chat.Home,
 					k.Chat.End,
+					k.Chat.FocusSidebar,
 				},
 				[]key.Binding{
 					k.Chat.Copy,

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -99,6 +99,7 @@ const (
 	uiFocusNone uiFocusState = iota
 	uiFocusEditor
 	uiFocusMain
+	uiFocusSidebar
 )
 
 type uiState uint8
@@ -282,6 +283,13 @@ type UI struct {
 
 	// sidebarLogo keeps a cached version of the sidebar sidebarLogo.
 	sidebarLogo string
+
+	// Sidebar scroll state for virtual scrolling.
+	sidebarOffset           int  // current scroll offset in lines
+	sidebarScrollable       bool // true when sidebar content exceeds available height
+	sidebarScrollbarVisible bool
+	sidebarScrollbarSeq     int // sequence number for auto-hide timer
+	sidebarMaxOffsetVal     int // max scroll offset, recomputed in drawSidebar
 
 	// Notification state
 	notifyBackend       notification.Backend
@@ -640,6 +648,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.setState(uiChat, m.focus)
 		m.session = msg.session
+		m.sidebarOffset = 0
 		m.sessionFiles = msg.files
 		cmds = append(cmds, m.startLSPs(msg.lspFilePaths()))
 		msgs, err := m.com.Workspace.ListMessages(context.Background(), m.session.ID)
@@ -1052,6 +1061,10 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.updateLayoutAndSize()
 			}
 		}
+	case sidebarScrollbarHideMsg:
+		if msg.seq == m.sidebarScrollbarSeq && m.focus != uiFocusSidebar {
+			m.sidebarScrollbarVisible = false
+		}
 	case spinner.TickMsg:
 		if m.dialog.HasDialogs() {
 			// route to dialog
@@ -1407,7 +1420,10 @@ func (m *UI) handleClickFocus(msg tea.MouseClickMsg) (cmd tea.Cmd) {
 	switch {
 	case m.state != uiChat:
 		return nil
-	case image.Pt(msg.X, msg.Y).In(m.layout.sidebar):
+	case m.focus != uiFocusSidebar && image.Pt(msg.X, msg.Y).In(m.layout.sidebar):
+		m.focus = uiFocusSidebar
+		m.textarea.Blur()
+		m.chat.Blur()
 		return nil
 	case m.focus != uiFocusEditor && image.Pt(msg.X, msg.Y).In(m.layout.editor):
 		m.focus = uiFocusEditor
@@ -2442,6 +2458,11 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				m.focus = uiFocusEditor
 				cmds = append(cmds, m.textarea.Focus())
 				m.chat.Blur()
+			case key.Matches(msg, m.keyMap.Chat.FocusSidebar):
+				if m.state == uiChat && !m.isCompact && m.hasSession() && m.sidebarScrollable {
+					m.focus = uiFocusSidebar
+					m.chat.Blur()
+				}
 			case key.Matches(msg, m.keyMap.Chat.NewSession):
 				if !m.hasSession() {
 					break
@@ -2522,6 +2543,36 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				} else {
 					handleGlobalKeys(msg)
 				}
+			}
+		case uiFocusSidebar:
+			if m.state != uiChat || m.isCompact || !m.hasSession() {
+				break
+			}
+			switch {
+			case key.Matches(msg, m.keyMap.Chat.Up):
+				m.sidebarOffset = max(0, m.sidebarOffset-4)
+				m.sidebarScrollbarSeq++
+			case key.Matches(msg, m.keyMap.Chat.Down):
+				maxOffset := m.sidebarMaxOffset()
+				if m.sidebarOffset < maxOffset {
+					m.sidebarOffset = min(m.sidebarOffset+4, maxOffset)
+					m.sidebarScrollbarSeq++
+				}
+			case key.Matches(msg, m.keyMap.Chat.Home):
+				m.sidebarOffset = 0
+				m.sidebarScrollbarSeq++
+			case key.Matches(msg, m.keyMap.Chat.End):
+				m.sidebarOffset = m.sidebarMaxOffset()
+				m.sidebarScrollbarSeq++
+			case key.Matches(msg, m.keyMap.Chat.FocusChat):
+				m.focus = uiFocusMain
+				m.chat.Focus()
+			case key.Matches(msg, m.keyMap.Tab):
+				m.focus = uiFocusEditor
+				cmds = append(cmds, m.textarea.Focus())
+				m.chat.Blur()
+			default:
+				handleGlobalKeys(msg)
 			}
 		default:
 			handleGlobalKeys(msg)
@@ -2778,9 +2829,10 @@ func (m *UI) ShortHelp() []key.Binding {
 			binds = append(binds, cancelBinding)
 		}
 
-		if m.focus == uiFocusEditor {
+		switch m.focus {
+		case uiFocusEditor:
 			tab.SetHelp("tab", "focus chat")
-		} else {
+		default:
 			tab.SetHelp("tab", "focus editor")
 		}
 
@@ -2796,6 +2848,12 @@ func (m *UI) ShortHelp() []key.Binding {
 			binds = append(
 				binds,
 				k.Editor.Newline,
+			)
+		case uiFocusSidebar:
+			binds = append(
+				binds,
+				k.Chat.UpDown,
+				k.Chat.FocusChat,
 			)
 		case uiFocusMain:
 			binds = append(
@@ -2869,9 +2927,10 @@ func (m *UI) FullHelp() [][]key.Binding {
 
 		mainBinds := []key.Binding{}
 		tab := k.Tab
-		if m.focus == uiFocusEditor {
+		switch m.focus {
+		case uiFocusEditor:
 			tab.SetHelp("tab", "focus chat")
-		} else {
+		default:
 			tab.SetHelp("tab", "focus editor")
 		}
 
@@ -2910,6 +2969,16 @@ func (m *UI) FullHelp() [][]key.Binding {
 					},
 				)
 			}
+		case uiFocusSidebar:
+			binds = append(
+				binds,
+				[]key.Binding{
+					k.Chat.UpDown,
+				},
+				[]key.Binding{
+					k.Chat.FocusChat,
+				},
+			)
 		case uiFocusMain:
 			binds = append(
 				binds,
@@ -4203,6 +4272,7 @@ func (m *UI) newSession() tea.Cmd {
 	}
 
 	m.session = nil
+	m.sidebarOffset = 0
 	m.sessionFiles = nil
 	m.sessionFileReads = nil
 	m.setState(uiLanding, uiFocusEditor)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -288,8 +288,13 @@ type UI struct {
 	sidebarOffset           int  // current scroll offset in lines
 	sidebarScrollable       bool // true when sidebar content exceeds available height
 	sidebarScrollbarVisible bool
-	sidebarScrollbarSeq     int // sequence number for auto-hide timer
-	sidebarMaxOffsetVal     int // max scroll offset, recomputed in drawSidebar
+	sidebarScrollbarSeq     int    // sequence number for auto-hide timer
+	sidebarMaxOffsetVal     int    // max scroll offset, computed in updateSidebarScrollState
+	sidebarContent          string // cached rendered sidebar content
+	sidebarTotalLines       int    // total lines in sidebarContent
+	sidebarContentHeight    int    // available height for sidebar content
+	sidebarContentWidth     int    // available width for sidebar content
+	sidebarDrawLogo         string // logo to render (may differ from sidebarLogo for short heights)
 
 	// Notification state
 	notifyBackend       notification.Backend
@@ -1014,7 +1019,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.focus == uiFocusSidebar {
 				lines := int(msg.DeltaY)
 				if lines != 0 {
-					m.sidebarOffset = max(0, min(m.sidebarOffset+lines, m.sidebarMaxOffset()))
+					m.sidebarOffset = max(0, min(m.sidebarOffset+lines, m.sidebarMaxOffsetVal))
 					m.sidebarScrollbarSeq++
 					m.sidebarScrollbarVisible = true
 					cmds = append(cmds, sidebarScrollbarHideCmd(m.sidebarScrollbarSeq))
@@ -2567,7 +2572,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				m.sidebarOffset = max(0, m.sidebarOffset-4)
 				m.sidebarScrollbarSeq++
 			case key.Matches(msg, m.keyMap.Chat.Down):
-				maxOffset := m.sidebarMaxOffset()
+				maxOffset := m.sidebarMaxOffsetVal
 				if m.sidebarOffset < maxOffset {
 					m.sidebarOffset = min(m.sidebarOffset+4, maxOffset)
 					m.sidebarScrollbarSeq++
@@ -2576,7 +2581,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				m.sidebarOffset = 0
 				m.sidebarScrollbarSeq++
 			case key.Matches(msg, m.keyMap.Chat.End):
-				m.sidebarOffset = m.sidebarMaxOffset()
+				m.sidebarOffset = m.sidebarMaxOffsetVal
 				m.sidebarScrollbarSeq++
 			case key.Matches(msg, m.keyMap.Chat.FocusChat):
 				m.focus = uiFocusMain
@@ -2627,6 +2632,10 @@ func (m *UI) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		// renderPills, but only when the layout actually differs;
 		// this catches the steady-state case.
 		m.renderPills()
+	}
+
+	if m.state == uiChat && m.hasSession() && !m.isCompact {
+		m.updateSidebarScrollState()
 	}
 
 	// Clear the screen first

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1010,6 +1010,16 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// others send DeltaY=1.
 		switch m.state {
 		case uiChat:
+			// When sidebar is focused, route wheel events to sidebar scrolling.
+			if m.focus == uiFocusSidebar {
+				lines := int(msg.DeltaY)
+				if lines != 0 {
+					m.sidebarOffset = max(0, min(m.sidebarOffset+lines, m.sidebarMaxOffset()))
+					m.sidebarScrollbarSeq++
+					m.sidebarScrollbarVisible = true
+				}
+				break
+			}
 			if msg.DeltaX != 0 {
 				m.chat.ScrollSelectedShellHorizontal(int(msg.DeltaX))
 			}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2994,6 +2994,10 @@ func (m *UI) FullHelp() [][]key.Binding {
 				[]key.Binding{
 					k.Chat.FocusChat,
 				},
+				[]key.Binding{
+					k.Chat.Home,
+					k.Chat.End,
+				},
 			)
 		case uiFocusMain:
 			binds = append(


### PR DESCRIPTION
This makes the sidebar scrollable when it's taller than the window height.

<p><img width="600" src="https://github.com/user-attachments/assets/dfceb292-45e5-4946-8f75-fc6659b75c46" /></p>

Mouse: click to focus, scroll wheel scrolls.

We _could_ make it scrollable with the wheel on hover, but it would greatly increase the number of events (`Msg`s) flowing through Crush, so I'm opting not to do this yet.

Keyboard:

* When focused on the chat view: <kbd>l</kbd> or <kbd>right arrow</kbd> focuses on the sidebar
* <kbd>j/k</kbd> or <kbd>up/down arrow</kbd> scrolls up and down
* <kbd>g</kbd> scrolls to top <kbd>shift+g</kbd> scrolls to the bottom
* <kbd>h</kbd> or <kbd>left arrow</kbd> focuses back on the chat view
* <kbd>tab</kbd> always returns focus to the editor
