### PR TITLE
Add ACP agent mode

### DIFF
--- a/docs/acp-design.md
+++ b/docs/acp-design.md
@@ -1,0 +1,107 @@
+# Crush ACP Integration
+
+`crush acp` exposes Crush as an Agent Client Protocol (ACP) agent. An ACP
+client can create or load a Crush session, send prompts, receive streaming text
+and tool updates, and service agent-to-client requests for file reads, file
+writes, terminals, and permission decisions.
+
+This implementation was exercised while prototyping a Go-based TUI and coding
+agent control surface. Crush already had the useful pieces for that trial:
+terminal-first interaction, persisted sessions, model/tool orchestration, and a
+Bubble Tea UI. The ACP work keeps those pieces intact and adds a protocol bridge
+around the existing coordinator.
+
+## Launch Modes
+
+| Command | Transport | UI | Purpose |
+| --- | --- | --- | --- |
+| `crush acp` | stdio | no TUI | ACP client launches Crush as a subprocess |
+| `crush acp --tui` | none | TUI | Standalone terminal session |
+| `crush acp --tui-acp` | Unix socket | TUI | TUI plus an external ACP client |
+| `crush --tui` | Unix socket | TUI | Shortcut for TUI plus ACP socket mode |
+
+The socket mode keeps ACP traffic off stdin/stdout so Bubble Tea can own the
+terminal cleanly.
+
+## Agent To Client Flow
+
+Crush streams runtime activity through a `RunObserver` interface. The ACP
+adapter implements that observer and forwards events as `session/update`
+notifications:
+
+| Crush event | ACP update |
+| --- | --- |
+| text delta | agent message chunk |
+| reasoning delta | agent thought chunk |
+| tool input begins | tool call start |
+| tool execution begins | tool call in progress |
+| tool execution completes | tool call completed |
+| plan changes | plan update |
+| title changes | session info update |
+
+This avoids database polling and preserves live tool progress for clients that
+render tool cards or progress indicators.
+
+## Client Backed Tools
+
+When `options.acp.zed_control` is enabled, Crush registers ACP-backed variants
+of core workspace tools:
+
+| Tool | ACP request |
+| --- | --- |
+| `zed_view` | `ReadTextFile` |
+| `zed_write` | `WriteTextFile` |
+| `zed_bash` | `CreateTerminal`, `WaitForTerminalExit`, `TerminalOutput` |
+
+The names are intentionally compatibility-oriented because current clients
+already recognize the Zed visual command metadata described below. The tool
+descriptions tell the model to prefer these tools when an ACP client is
+connected, but native tools remain available.
+
+## Visual Command Metadata
+
+Some ACP clients can perform workspace UI actions from tool-call metadata. This
+branch emits `_zed_visual_command` metadata from optional tools such as
+`zed_visual`, `zed_pane`, `zed_panel`, and `zed_batch`.
+
+That metadata is treated as an extension: clients that recognize it can open
+files, move panes, or focus panels; clients that do not recognize it can still
+display the tool calls normally.
+
+## Configuration
+
+ACP-backed workspace tools are off by default. Enable them with:
+
+```json
+{
+  "options": {
+    "acp": {
+      "zed_control": true
+    }
+  }
+}
+```
+
+## Implementation Notes
+
+- `internal/cmd/acp.go` owns launch modes and socket setup.
+- `internal/acp/adapter.go` implements the ACP agent adapter.
+- `internal/agent/agent.go` defines the observer callbacks emitted by the agent
+  runtime.
+- `internal/agent/coordinator.go` wires the adapter into sessions, tools, title
+  updates, plan updates, and config reloads.
+- `internal/agent/tools/acp.go` contains the ACP-backed tool definitions.
+- `internal/config/config.go` adds the optional ACP configuration.
+
+## Validation
+
+Targeted validation for this branch:
+
+```sh
+go test ./internal/acp ./internal/cmd ./internal/agent ./internal/agent/tools
+go build ./...
+```
+
+At the time this was prepared, `go test ./...` also exercised the branch but
+failed in existing config-store tests that require provider model data not
+available in the local test environment.

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/clipperhouse/displaywidth v0.11.0
 	github.com/clipperhouse/uax29/v2 v2.7.0
+	github.com/coder/acp-go-sdk v0.13.0
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/disintegration/imaging v1.6.2
 	github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
+github.com/coder/acp-go-sdk v0.13.0 h1:IAKBDIbe/iBfKAGikeIndzb8fowt4ioD+gCtSU4HwMA=
+github.com/coder/acp-go-sdk v0.13.0/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=

--- a/internal/acp/adapter.go
+++ b/internal/acp/adapter.go
@@ -1,0 +1,742 @@
+package acp
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	acp "github.com/coder/acp-go-sdk"
+
+	"github.com/charmbracelet/crush/internal/agent"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+)
+
+func truePtr() *bool { v := true; return &v }
+
+type Adapter struct {
+	coordinator agent.Coordinator
+	sessions    session.Service
+	messages    message.Service
+	conn        *acp.AgentSideConnection
+	logger      *slog.Logger
+
+	toolKinds map[string]acp.ToolKind
+	toolLocs  map[string][]acp.ToolCallLocation
+	toolNames map[string]string
+}
+
+func NewAdapter(c agent.Coordinator, s session.Service, m message.Service) *Adapter {
+	return &Adapter{
+		coordinator: c,
+		sessions:    s,
+		messages:    m,
+		logger:      slog.Default(),
+		toolKinds:   make(map[string]acp.ToolKind),
+		toolLocs:    make(map[string][]acp.ToolCallLocation),
+		toolNames:   make(map[string]string),
+	}
+}
+
+func (a *Adapter) SetLogger(l *slog.Logger)                    { a.logger = l }
+func (a *Adapter) SetConnection(conn *acp.AgentSideConnection) { a.conn = conn }
+func (a *Adapter) Connection() *acp.AgentSideConnection        { return a.conn }
+func (a *Adapter) SetObserver() {
+	if a.coordinator != nil {
+		a.coordinator.SetObserver(a)
+	}
+}
+
+func (a *Adapter) OnToolInputStart(sessionID, toolCallID, toolName string) {
+	kind := toolKindFromName(toolName)
+	a.toolNames[toolCallID] = toolName
+	start := acp.StartToolCall(
+		acp.ToolCallId(toolCallID), toolName,
+		acp.WithStartKind(kind),
+		acp.WithStartStatus(acp.ToolCallStatusPending),
+	)
+	// Note: _zed_visual_command meta is NOT attached here because we
+	// don't have the tool input yet (no file paths to extract).
+	// Meta is attached in OnToolCall when the input is available.
+	_ = kind
+	a.sessionUpdate(acp.SessionId(sessionID), start)
+}
+
+func (a *Adapter) OnTextDelta(sessionID, messageID, text string) {
+	a.sessionUpdate(acp.SessionId(sessionID), acp.UpdateAgentMessageText(text))
+}
+
+func (a *Adapter) OnReasoningDelta(sessionID, messageID, text string) {
+	a.sessionUpdate(acp.SessionId(sessionID), acp.UpdateAgentThoughtText(text))
+}
+
+func (a *Adapter) OnToolCall(sessionID, toolCallID, toolName, input string) {
+	kind := toolKindFromName(toolName)
+	locs := toolLocationsFromInput(input)
+	a.toolKinds[toolCallID] = kind
+	a.toolLocs[toolCallID] = locs
+	a.toolNames[toolCallID] = toolName
+
+	// Send intermediate in_progress update so ACP clients can animate tool calls.
+	update := acp.UpdateToolCall(acp.ToolCallId(toolCallID),
+		acp.WithUpdateStatus(acp.ToolCallStatusInProgress),
+	)
+	meta := a.buildVisualMeta(kind, locs, toolName, input)
+	if len(meta) > 0 && update.ToolCallUpdate != nil {
+		update.ToolCallUpdate.Meta = meta
+	}
+	a.sessionUpdate(acp.SessionId(sessionID), update)
+}
+
+func (a *Adapter) OnToolResult(sessionID, toolCallID string, output string) {
+	kind := a.toolKinds[toolCallID]
+	locs := a.toolLocs[toolCallID]
+	delete(a.toolKinds, toolCallID)
+	delete(a.toolLocs, toolCallID)
+	delete(a.toolNames, toolCallID)
+
+	opts := []acp.ToolCallUpdateOpt{acp.WithUpdateStatus(acp.ToolCallStatusCompleted)}
+	if kind != "" {
+		opts = append(opts, acp.WithUpdateKind(kind))
+	}
+	if len(locs) > 0 {
+		opts = append(opts, acp.WithUpdateLocations(locs))
+	}
+	if output != "" {
+		content := output
+		if len(content) > 2000 {
+			content = content[:2000] + "..."
+		}
+		opts = append(opts, acp.WithUpdateContent([]acp.ToolCallContent{
+			acp.ToolContent(acp.TextBlock(content)),
+		}))
+	}
+	update := acp.UpdateToolCall(acp.ToolCallId(toolCallID), opts...)
+	// Note: _zed_visual_command meta is already attached to the in_progress
+	// update in OnToolCall. Skip meta here to avoid duplicate dispatch.
+	a.sessionUpdate(acp.SessionId(sessionID), update)
+}
+
+// buildVisualMeta constructs the _zed_visual_command meta map based on the tool
+// kind, file locations, and original tool input.
+func (a *Adapter) buildVisualMeta(kind acp.ToolKind, locs []acp.ToolCallLocation, toolName string, input string) map[string]any {
+	var command string
+	switch kind {
+	case acp.ToolKindRead, acp.ToolKindEdit:
+		command = "open_file"
+	case acp.ToolKindExecute:
+		command = "run_in_terminal"
+	default:
+		return nil
+	}
+	if command == "" {
+		return nil
+	}
+	params := map[string]any{}
+	for _, loc := range locs {
+		if loc.Path != "" {
+			params["path"] = loc.Path
+			if loc.Line != nil && *loc.Line > 0 {
+				params["line"] = *loc.Line
+			}
+			break // Only use the first location
+		}
+	}
+	if command == "run_in_terminal" && params["path"] == nil {
+		if cmd := toolCommandFromInput(input); cmd != "" {
+			params["command"] = cmd
+		} else if toolName != "" {
+			params["command"] = toolName
+		}
+	}
+	if len(params) == 0 {
+		return nil
+	}
+	return map[string]any{
+		"_zed_visual_command": map[string]any{
+			"command": command,
+			"params":  params,
+		},
+	}
+}
+
+func (a *Adapter) OnPlanUpdate(sessionID string, entries []agent.PlanEntry) {
+	acpEntries := make([]acp.PlanEntry, len(entries))
+	for i, e := range entries {
+		acpEntries[i] = acp.PlanEntry{
+			Content:  e.Content,
+			Priority: planPriority(e.Priority),
+			Status:   planStatus(e.Status),
+		}
+	}
+	a.sessionUpdate(acp.SessionId(sessionID), acp.UpdatePlan(acpEntries...))
+}
+
+func planPriority(p agent.PlanPriority) acp.PlanEntryPriority {
+	switch p {
+	case agent.PlanPriorityHigh:
+		return acp.PlanEntryPriorityHigh
+	case agent.PlanPriorityMedium:
+		return acp.PlanEntryPriorityMedium
+	case agent.PlanPriorityLow:
+		return acp.PlanEntryPriorityLow
+	default:
+		return acp.PlanEntryPriorityMedium
+	}
+}
+
+func planStatus(s agent.PlanStatus) acp.PlanEntryStatus {
+	switch s {
+	case agent.PlanStatusPending:
+		return acp.PlanEntryStatusPending
+	case agent.PlanStatusInProgress:
+		return acp.PlanEntryStatusInProgress
+	case agent.PlanStatusCompleted:
+		return acp.PlanEntryStatusCompleted
+	default:
+		return acp.PlanEntryStatusPending
+	}
+}
+
+func (a *Adapter) OnUsageUpdate(sessionID string, usage agent.StepUsage) {
+	a.sessionUpdate(acp.SessionId(sessionID), acp.SessionUpdate{
+		UsageUpdate: &acp.SessionUsageUpdate{
+			SessionUpdate: "usage_update",
+			Used:          usage.Used,
+			Size:          usage.Size,
+			Cost:          usageCost(usage.Cost),
+		},
+	})
+}
+
+func (a *Adapter) Initialize(ctx context.Context, params acp.InitializeRequest) (acp.InitializeResponse, error) {
+	arch := runtime.GOARCH
+	return acp.InitializeResponse{
+		ProtocolVersion: acp.ProtocolVersionNumber,
+		AgentCapabilities: acp.AgentCapabilities{
+			LoadSession: true,
+			PromptCapabilities: acp.PromptCapabilities{
+				Image:           true,
+				Audio:           false,
+				EmbeddedContext: true,
+			},
+			SessionCapabilities: acp.SessionCapabilities{
+				List:   &acp.SessionListCapabilities{Meta: map[string]any{}},
+				Resume: &acp.SessionResumeCapabilities{Meta: map[string]any{"arch": arch}},
+				Close:  &acp.SessionCloseCapabilities{Meta: map[string]any{}},
+			},
+		},
+		AgentInfo: &acp.Implementation{
+			Name:    "Crush-ACP",
+			Version: "acp-0.1.0",
+		},
+	}, nil
+}
+
+func (a *Adapter) NewSession(ctx context.Context, params acp.NewSessionRequest) (acp.NewSessionResponse, error) {
+	title := "ACP Session " + time.Now().Format("2006-01-02 15:04")
+	if params.Cwd != "" {
+		title = "ACP - " + filepath.Base(params.Cwd)
+	}
+	sess, err := a.sessions.Create(ctx, title)
+	if err != nil {
+		return acp.NewSessionResponse{}, fmt.Errorf("create session: %w", err)
+	}
+	titleStr := sess.Title
+	a.sessionUpdate(acp.SessionId(sess.ID), acp.SessionUpdate{
+		SessionInfoUpdate: &acp.SessionSessionInfoUpdate{
+			SessionUpdate: "session_info_update",
+			Title:         &titleStr,
+		},
+	})
+	// Send available commands so ACP clients can populate command UI.
+	a.sendAvailableCommands(acp.SessionId(sess.ID))
+	return acp.NewSessionResponse{SessionId: acp.SessionId(sess.ID)}, nil
+}
+
+// sendAvailableCommands sends the list of available slash commands to ACP clients.
+// These are built from the registered ACP tools.
+func (a *Adapter) sendAvailableCommands(sid acp.SessionId) {
+	// Collect available commands from the coordinator's tool registry.
+	// The coordinator exposes ACP tools via the ACPConnector.
+	commands := a.availableToolCommands()
+	if len(commands) == 0 {
+		return
+	}
+	a.sessionUpdate(sid, acp.SessionUpdate{
+		AvailableCommandsUpdate: &acp.SessionAvailableCommandsUpdate{
+			SessionUpdate:     "available_commands_update",
+			AvailableCommands: commands,
+		},
+	})
+}
+
+// availableToolCommands builds the list of AvailableCommand from the
+// coordinator's ACP tools. Falls back to static list if coordinator doesn't
+// expose tool names.
+func (a *Adapter) availableToolCommands() []acp.AvailableCommand {
+	if a.coordinator == nil {
+		return a.fallbackCommands()
+	}
+	// Try to get ACP tool names from the coordinator via interface assertion.
+	type toolLister interface {
+		ACPtoolNames() []string
+	}
+	if lister, ok := a.coordinator.(toolLister); ok {
+		names := lister.ACPtoolNames()
+		cmds := make([]acp.AvailableCommand, 0, len(names))
+		for _, name := range names {
+			cmds = append(cmds, acp.AvailableCommand{
+				Name:        name,
+				Description: acpToolDescription(name),
+			})
+		}
+		return cmds
+	}
+	return a.fallbackCommands()
+}
+
+// fallbackCommands returns a static list of common Crush commands for when
+// the coordinator doesn't expose a tool lister interface.
+func (a *Adapter) fallbackCommands() []acp.AvailableCommand {
+	return []acp.AvailableCommand{
+		{Name: "/submit", Description: "Submit the current prompt to the agent"},
+		{Name: "/new", Description: "Start a new session"},
+		{Name: "/abort", Description: "Abort the current agent turn"},
+		{Name: "/help", Description: "Show available commands"},
+	}
+}
+
+func acpToolDescription(name string) string {
+	switch name {
+	case "view":
+		return "Read a file or directory"
+	case "edit":
+		return "Edit a file"
+	case "write":
+		return "Write a new file"
+	case "bash":
+		return "Run a shell command"
+	case "glob":
+		return "Search for files by pattern"
+	case "grep":
+		return "Search file contents"
+	case "todos":
+		return "Manage task list"
+	default:
+		return fmt.Sprintf("Run the %s tool", name)
+	}
+}
+
+func (a *Adapter) Prompt(ctx context.Context, params acp.PromptRequest) (acp.PromptResponse, error) {
+	sessionID := string(params.SessionId)
+	var textParts []string
+	var attachments []message.Attachment
+	for _, block := range params.Prompt {
+		switch {
+		case block.Text != nil:
+			textParts = append(textParts, block.Text.Text)
+		case block.Image != nil:
+			data, _ := base64.StdEncoding.DecodeString(block.Image.Data)
+			attachments = append(attachments, message.Attachment{Content: data, MimeType: block.Image.MimeType})
+		case block.Audio != nil:
+			data, _ := base64.StdEncoding.DecodeString(block.Audio.Data)
+			attachments = append(attachments, message.Attachment{Content: data, MimeType: block.Audio.MimeType})
+		case block.ResourceLink != nil:
+			textParts = append(textParts, fmt.Sprintf("[resource: %s (%s)]", block.ResourceLink.Name, block.ResourceLink.Uri))
+		case block.Resource != nil:
+			if block.Resource.Resource.TextResourceContents != nil {
+				textParts = append(textParts, fmt.Sprintf("--- %s ---\n%s",
+					block.Resource.Resource.TextResourceContents.Uri,
+					block.Resource.Resource.TextResourceContents.Text,
+				))
+			}
+		}
+	}
+	promptText := strings.Join(textParts, "\n")
+	a.sessionUpdate(params.SessionId, acp.UpdateAgentMessageText(""))
+	_, err := a.coordinator.Run(ctx, sessionID, promptText, attachments...)
+	if err != nil {
+		a.sessionUpdate(params.SessionId, acp.UpdateAgentMessageText("Error: "+err.Error()))
+		// Still flush orphaned tool calls on error — the model may have
+		// started tool calls before the error occurred.
+		a.flushOrphanedToolCalls(params.SessionId)
+		return acp.PromptResponse{}, err
+	}
+
+	// Flush any orphaned tool calls that received OnToolInputStart but no
+	// matching OnToolResult (e.g. model was cancelled mid-tool-call).
+	a.flushOrphanedToolCalls(params.SessionId)
+
+	return acp.PromptResponse{StopReason: acp.StopReasonEndTurn}, nil
+}
+
+// flushOrphanedToolCalls sends completed updates for any tool calls that
+// were started but never resolved during the prompt turn.
+func (a *Adapter) flushOrphanedToolCalls(sessionID acp.SessionId) {
+	for toolCallID, toolName := range a.toolNames {
+		slog.Warn("Flushing orphaned tool call", "session", sessionID, "tool_call_id", toolCallID, "tool_name", toolName)
+		kind := a.toolKinds[toolCallID]
+		locs := a.toolLocs[toolCallID]
+		opts := []acp.ToolCallUpdateOpt{
+			acp.WithUpdateStatus(acp.ToolCallStatusCompleted),
+		}
+		if kind != "" {
+			opts = append(opts, acp.WithUpdateKind(kind))
+		}
+		if len(locs) > 0 {
+			opts = append(opts, acp.WithUpdateLocations(locs))
+		}
+		opts = append(opts, acp.WithUpdateContent([]acp.ToolCallContent{
+			acp.ToolContent(acp.TextBlock("Tool call was interrupted")),
+		}))
+		update := acp.UpdateToolCall(acp.ToolCallId(toolCallID), opts...)
+		a.sessionUpdate(sessionID, update)
+	}
+	a.toolKinds = make(map[string]acp.ToolKind)
+	a.toolLocs = make(map[string][]acp.ToolCallLocation)
+	a.toolNames = make(map[string]string)
+}
+
+func (a *Adapter) Cancel(ctx context.Context, params acp.CancelNotification) error {
+	a.coordinator.Cancel(string(params.SessionId))
+	return nil
+}
+
+func (a *Adapter) CloseSession(ctx context.Context, params acp.CloseSessionRequest) (acp.CloseSessionResponse, error) {
+	return acp.CloseSessionResponse{}, a.sessions.Delete(ctx, string(params.SessionId))
+}
+
+func (a *Adapter) ListSessions(ctx context.Context, _ acp.ListSessionsRequest) (acp.ListSessionsResponse, error) {
+	sessions, err := a.sessions.List(ctx)
+	if err != nil {
+		return acp.ListSessionsResponse{}, err
+	}
+	infos := make([]acp.SessionInfo, len(sessions))
+	for i, s := range sessions {
+		title := s.Title
+		infos[i] = acp.SessionInfo{
+			SessionId: acp.SessionId(s.ID),
+			Title:     &title,
+		}
+	}
+	return acp.ListSessionsResponse{Sessions: infos}, nil
+}
+
+func (a *Adapter) ResumeSession(ctx context.Context, params acp.ResumeSessionRequest) (acp.ResumeSessionResponse, error) {
+	_, err := a.sessions.Get(ctx, string(params.SessionId))
+	return acp.ResumeSessionResponse{}, err
+}
+
+func (a *Adapter) UnstableForkSession(ctx context.Context, params acp.UnstableForkSessionRequest) (acp.UnstableForkSessionResponse, error) {
+	// Load the parent session to get its working directory and state.
+	parentSessionID := string(params.SessionId)
+	parentSession, err := a.sessions.Get(ctx, parentSessionID)
+	if err != nil {
+		return acp.UnstableForkSessionResponse{}, fmt.Errorf("get parent session: %w", err)
+	}
+
+	// Create a new session with the same title prefix.
+	title := "Fork of " + parentSession.Title
+	newSession, err := a.sessions.Create(ctx, title)
+	if err != nil {
+		return acp.UnstableForkSessionResponse{}, fmt.Errorf("create fork session: %w", err)
+	}
+
+	// Copy messages from parent to fork.
+	msgs, err := a.messages.List(ctx, parentSessionID)
+	if err != nil {
+		slog.Warn("Failed to list parent messages for fork", "parent", parentSessionID, "err", err)
+	} else {
+		for _, msg := range msgs {
+			if _, err := a.messages.Create(ctx, newSession.ID, message.CreateMessageParams{
+				Role:     msg.Role,
+				Parts:    msg.Parts,
+				Model:    msg.Model,
+				Provider: msg.Provider,
+			}); err != nil {
+				slog.Warn("Failed to copy message to fork", "msg_id", msg.ID, "err", err)
+			}
+		}
+	}
+
+	titleStr := newSession.Title
+	sessionID := acp.SessionId(newSession.ID)
+	a.sessionUpdate(sessionID, acp.SessionUpdate{
+		SessionInfoUpdate: &acp.SessionSessionInfoUpdate{
+			SessionUpdate: "session_info_update",
+			Title:         &titleStr,
+		},
+	})
+	a.sendAvailableCommands(sessionID)
+
+	return acp.UnstableForkSessionResponse{SessionId: sessionID}, nil
+}
+
+func (a *Adapter) SetSessionConfigOption(ctx context.Context, _ acp.SetSessionConfigOptionRequest) (acp.SetSessionConfigOptionResponse, error) {
+	return acp.SetSessionConfigOptionResponse{}, errors.New("not supported")
+}
+
+// UnstableSetSessionModel handles model switching requests from the client.
+func (a *Adapter) UnstableSetSessionModel(ctx context.Context, params acp.UnstableSetSessionModelRequest) (acp.UnstableSetSessionModelResponse, error) {
+	sessionID := string(params.SessionId)
+	if sessionID == "" {
+		return acp.UnstableSetSessionModelResponse{}, errors.New("session ID required")
+	}
+
+	// Rebuild models for the session.
+	if err := a.coordinator.UpdateModels(ctx); err != nil {
+		slog.Warn("Failed to update models for session", "session", sessionID, "err", err)
+		return acp.UnstableSetSessionModelResponse{}, fmt.Errorf("update models: %w", err)
+	}
+
+	return acp.UnstableSetSessionModelResponse{}, nil
+}
+
+func (a *Adapter) SetSessionMode(ctx context.Context, _ acp.SetSessionModeRequest) (acp.SetSessionModeResponse, error) {
+	return acp.SetSessionModeResponse{}, nil
+}
+
+func (a *Adapter) Authenticate(ctx context.Context, _ acp.AuthenticateRequest) (acp.AuthenticateResponse, error) {
+	return acp.AuthenticateResponse{}, nil
+}
+
+func (a *Adapter) LoadSession(ctx context.Context, params acp.LoadSessionRequest) (acp.LoadSessionResponse, error) {
+	sessionID := string(params.SessionId)
+
+	// Verify the session exists.
+	session, err := a.sessions.Get(ctx, sessionID)
+	if err != nil {
+		return acp.LoadSessionResponse{}, err
+	}
+
+	// Flush any pending debounced message state so reads are consistent.
+	if err := a.messages.FlushAll(ctx); err != nil {
+		return acp.LoadSessionResponse{}, fmt.Errorf("flush messages: %w", err)
+	}
+
+	// Send session info update so ACP clients display the correct title.
+	sessTitle := session.Title
+	a.sessionUpdate(acp.SessionId(sessionID), acp.SessionUpdate{
+		SessionInfoUpdate: &acp.SessionSessionInfoUpdate{
+			SessionUpdate: "session_info_update",
+			Title:         &sessTitle,
+		},
+	})
+
+	// Send available commands so ACP clients can populate command UI.
+	a.sendAvailableCommands(acp.SessionId(sessionID))
+
+	// Replay conversation history from SQLite as SessionUpdate notifications.
+	// Must be sent before the LoadSessionResponse so the client can
+	// reconstruct the full conversation view.
+	msgs, err := a.messages.List(ctx, sessionID)
+	if err != nil {
+		return acp.LoadSessionResponse{}, fmt.Errorf("list messages: %w", err)
+	}
+	for _, msg := range msgs {
+		a.replayMessage(acp.SessionId(sessionID), msg)
+	}
+
+	return acp.LoadSessionResponse{}, nil
+}
+
+// replayMessage emits SessionUpdate notifications for a single message,
+// reconstructing the conversation as the client would have seen it live.
+func (a *Adapter) replayMessage(sid acp.SessionId, msg message.Message) {
+	parts := msg.Parts
+	if len(parts) == 0 {
+		return
+	}
+
+	switch msg.Role {
+	case message.User:
+		// Reconstruct user message as a UserMessageChunk with text content.
+		var text strings.Builder
+		for _, part := range parts {
+			switch p := part.(type) {
+			case message.TextContent:
+				text.WriteString(p.Text)
+			case message.ImageURLContent:
+				fmt.Fprintf(&text, "\n[image: %s]", p.URL)
+			case message.BinaryContent:
+				fmt.Fprintf(&text, "\n[image: binary %s]", p.MIMEType)
+			}
+		}
+		if text.Len() > 0 {
+			a.sessionUpdate(sid, acp.UpdateUserMessageText(text.String()))
+		}
+
+	case message.Assistant:
+		// Replay assistant parts as they arrived during the original turn.
+		for _, part := range parts {
+			switch p := part.(type) {
+			case message.TextContent:
+				if p.Text != "" {
+					a.sessionUpdate(sid, acp.UpdateAgentMessageText(p.Text))
+				}
+			case message.ReasoningContent:
+				if p.Thinking != "" {
+					a.sessionUpdate(sid, acp.UpdateAgentThoughtText(p.Thinking))
+				}
+			case message.ToolCall:
+				if p.ID == "" {
+					continue
+				}
+				kind := toolKindFromName(p.Name)
+				locs := toolLocationsFromInput(p.Input)
+				// Replay as a 2-step lifecycle: StartToolCall(pending) +
+				// ToolCallUpdate(completed). Skip in_progress since the
+				// tool already completed and we want the final state.
+				startOpts := []acp.ToolCallStartOpt{
+					acp.WithStartKind(kind),
+					acp.WithStartStatus(acp.ToolCallStatusPending),
+				}
+				if len(locs) > 0 {
+					startOpts = append(startOpts, acp.WithStartLocations(locs))
+				}
+				start := acp.StartToolCall(
+					acp.ToolCallId(p.ID), p.Name, startOpts...,
+				)
+				// Attach visual command meta to the start notification.
+				meta := a.buildVisualMeta(kind, locs, p.Name, p.Input)
+				if len(meta) > 0 && start.ToolCall != nil {
+					start.ToolCall.Meta = meta
+				}
+				a.sessionUpdate(sid, start)
+			}
+		}
+		// Replay tool results after all tool calls for this message.
+		for _, part := range parts {
+			if tr, ok := part.(message.ToolResult); ok && tr.ToolCallID != "" {
+				a.replayToolResult(sid, tr)
+			}
+		}
+
+	case message.Tool:
+		// Standalone tool result messages (after-tool-call rounds).
+		for _, part := range parts {
+			if tr, ok := part.(message.ToolResult); ok && tr.ToolCallID != "" {
+				a.replayToolResult(sid, tr)
+			}
+		}
+	}
+}
+
+// replayToolResult emits a completed ToolCallUpdate for a tool result.
+func (a *Adapter) replayToolResult(sid acp.SessionId, tr message.ToolResult) {
+	opts := []acp.ToolCallUpdateOpt{
+		acp.WithUpdateStatus(acp.ToolCallStatusCompleted),
+	}
+	if tr.Content != "" {
+		content := tr.Content
+		if len(content) > 2000 {
+			content = content[:2000] + "..."
+		}
+		opts = append(opts, acp.WithUpdateContent([]acp.ToolCallContent{
+			acp.ToolContent(acp.TextBlock(content)),
+		}))
+	}
+	a.sessionUpdate(sid, acp.UpdateToolCall(acp.ToolCallId(tr.ToolCallID), opts...))
+}
+
+// UpdateSessionInfo sends a session_info_update to the connected client.
+// Called when the session title changes (e.g. auto-generated from first prompt).
+func (a *Adapter) UpdateSessionInfo(sessionID, title string) {
+	titleStr := title
+	a.sessionUpdate(acp.SessionId(sessionID), acp.SessionUpdate{
+		SessionInfoUpdate: &acp.SessionSessionInfoUpdate{
+			SessionUpdate: "session_info_update",
+			Title:         &titleStr,
+		},
+	})
+}
+
+// --- helpers ---
+
+func (a *Adapter) sessionUpdate(sid acp.SessionId, update acp.SessionUpdate) {
+	if a.conn == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := a.conn.SessionUpdate(ctx, acp.SessionNotification{SessionId: sid, Update: update}); err != nil && a.logger != nil {
+		a.logger.Warn("session update failed", "session", sid, "err", err)
+	}
+}
+
+func toolKindFromName(name string) acp.ToolKind {
+	switch name {
+	case "view", "zed_view", "ls", "glob", "grep", "rg", "search", "sourcegraph", "lsp_diagnostics", "lsp_references":
+		return acp.ToolKindRead
+	case "edit", "write", "multiedit", "zed_write":
+		return acp.ToolKindEdit
+	case "bash", "zed_bash", "job_output", "job_kill":
+		return acp.ToolKindExecute
+	case "fetch", "download", "web_fetch", "web_search", "agentic_fetch":
+		return acp.ToolKindFetch
+	case "todos", "list_mcp_resources", "read_mcp_resource", "crush_info", "crush_logs", "lsp_restart":
+		return acp.ToolKindThink
+	case "agent":
+		return acp.ToolKindSwitchMode
+	default:
+		return acp.ToolKindOther
+	}
+}
+
+func toolLocationsFromInput(input string) []acp.ToolCallLocation {
+	if input == "" {
+		return nil
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(input), &raw); err != nil {
+		return nil
+	}
+	if fp, ok := raw["file_path"].(string); ok && fp != "" {
+		line := 0
+		if l, ok := raw["offset"].(float64); ok {
+			line = int(l)
+		}
+		return []acp.ToolCallLocation{{Path: fp, Line: &line}}
+	}
+	if p, ok := raw["path"].(string); ok && p != "" {
+		return []acp.ToolCallLocation{{Path: p}}
+	}
+	return nil
+}
+
+func toolCommandFromInput(input string) string {
+	if input == "" {
+		return ""
+	}
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(input), &raw); err != nil {
+		return ""
+	}
+	if cmd, ok := raw["command"].(string); ok {
+		return cmd
+	}
+	return ""
+}
+
+func usageCost(cost float64) *acp.Cost {
+	if cost == 0 {
+		return nil
+	}
+	return &acp.Cost{
+		Amount:   cost,
+		Currency: "USD",
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+var _ acp.Agent = (*Adapter)(nil)
+var _ acp.AgentLoader = (*Adapter)(nil)

--- a/internal/acp/adapter_test.go
+++ b/internal/acp/adapter_test.go
@@ -1,0 +1,135 @@
+package acp
+
+import (
+	"testing"
+
+	sdk "github.com/coder/acp-go-sdk"
+	"github.com/stretchr/testify/require"
+
+	"github.com/charmbracelet/crush/internal/agent"
+)
+
+func TestToolKindFromName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want sdk.ToolKind
+	}{
+		{name: "view", want: sdk.ToolKindRead},
+		{name: "zed_view", want: sdk.ToolKindRead},
+		{name: "edit", want: sdk.ToolKindEdit},
+		{name: "zed_write", want: sdk.ToolKindEdit},
+		{name: "bash", want: sdk.ToolKindExecute},
+		{name: "zed_bash", want: sdk.ToolKindExecute},
+		{name: "fetch", want: sdk.ToolKindFetch},
+		{name: "todos", want: sdk.ToolKindThink},
+		{name: "agent", want: sdk.ToolKindSwitchMode},
+		{name: "unknown", want: sdk.ToolKindOther},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, toolKindFromName(tt.name))
+		})
+	}
+}
+
+func TestToolLocationsFromInput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("file path with offset", func(t *testing.T) {
+		t.Parallel()
+
+		got := toolLocationsFromInput(`{"file_path":"/tmp/a.go","offset":41}`)
+		require.Len(t, got, 1)
+		require.Equal(t, "/tmp/a.go", got[0].Path)
+		require.NotNil(t, got[0].Line)
+		require.Equal(t, 41, *got[0].Line)
+	})
+
+	t.Run("path fallback", func(t *testing.T) {
+		t.Parallel()
+
+		got := toolLocationsFromInput(`{"path":"/tmp/b.go"}`)
+		require.Len(t, got, 1)
+		require.Equal(t, "/tmp/b.go", got[0].Path)
+		require.Nil(t, got[0].Line)
+	})
+
+	t.Run("invalid input", func(t *testing.T) {
+		t.Parallel()
+
+		require.Nil(t, toolLocationsFromInput(`not json`))
+		require.Nil(t, toolLocationsFromInput(`{}`))
+		require.Nil(t, toolLocationsFromInput(""))
+	})
+}
+
+func TestToolCommandFromInput(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "go test ./...", toolCommandFromInput(`{"command":"go test ./..."}`))
+	require.Empty(t, toolCommandFromInput(`{"path":"/tmp/a.go"}`))
+	require.Empty(t, toolCommandFromInput(`not json`))
+	require.Empty(t, toolCommandFromInput(""))
+}
+
+func TestBuildVisualMeta(t *testing.T) {
+	t.Parallel()
+
+	line := 7
+	a := NewAdapter(nil, nil, nil)
+
+	got := a.buildVisualMeta(sdk.ToolKindEdit, []sdk.ToolCallLocation{
+		{Path: "/tmp/main.go", Line: &line},
+	}, "zed_write", `{"file_path":"/tmp/main.go","offset":7}`)
+
+	cmd, ok := got["_zed_visual_command"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "open_file", cmd["command"])
+	params, ok := cmd["params"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "/tmp/main.go", params["path"])
+	require.Equal(t, line, params["line"])
+
+	got = a.buildVisualMeta(sdk.ToolKindExecute, nil, "bash", `{"command":"go test ./..."}`)
+	cmd, ok = got["_zed_visual_command"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "run_in_terminal", cmd["command"])
+	params, ok = cmd["params"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "go test ./...", params["command"])
+
+	require.Nil(t, a.buildVisualMeta(sdk.ToolKindThink, []sdk.ToolCallLocation{
+		{Path: "/tmp/main.go"},
+	}, "todos", `{}`))
+	require.Nil(t, a.buildVisualMeta(sdk.ToolKindRead, nil, "view", `{}`))
+}
+
+func TestPlanMapping(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, sdk.PlanEntryPriorityHigh, planPriority(agent.PlanPriorityHigh))
+	require.Equal(t, sdk.PlanEntryPriorityMedium, planPriority(agent.PlanPriorityMedium))
+	require.Equal(t, sdk.PlanEntryPriorityLow, planPriority(agent.PlanPriorityLow))
+	require.Equal(t, sdk.PlanEntryPriorityMedium, planPriority(agent.PlanPriority(99)))
+
+	require.Equal(t, sdk.PlanEntryStatusPending, planStatus(agent.PlanStatusPending))
+	require.Equal(t, sdk.PlanEntryStatusInProgress, planStatus(agent.PlanStatusInProgress))
+	require.Equal(t, sdk.PlanEntryStatusCompleted, planStatus(agent.PlanStatusCompleted))
+	require.Equal(t, sdk.PlanEntryStatusPending, planStatus(agent.PlanStatus(99)))
+}
+
+func TestUsageCost(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, usageCost(0))
+
+	got := usageCost(0.42)
+	require.NotNil(t, got)
+	require.Equal(t, 0.42, got.Amount)
+	require.Equal(t, "USD", got.Currency)
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -138,6 +138,8 @@ type SessionAgent interface {
 	SetModels(large Model, small Model)
 	SetTools(tools []fantasy.AgentTool)
 	SetSystemPrompt(systemPrompt string)
+	SetObserver(observer RunObserver)
+	SetOnTitleChange(fn func(sessionID, title string))
 	Cancel(sessionID string)
 	CancelAll()
 	IsSessionBusy(sessionID string) bool
@@ -166,6 +168,49 @@ type activeCancel struct {
 	cancel context.CancelFunc
 }
 
+// RunObserver receives streaming events during agent execution.
+type RunObserver interface {
+	OnToolInputStart(sessionID, toolCallID, toolName string)
+	OnTextDelta(sessionID, messageID, text string)
+	OnReasoningDelta(sessionID, messageID, text string)
+	OnToolCall(sessionID, toolCallID, toolName, input string)
+	OnToolResult(sessionID, toolCallID string, output string)
+	OnPlanUpdate(sessionID string, entries []PlanEntry)
+	OnUsageUpdate(sessionID string, usage StepUsage)
+}
+
+// PlanPriority indicates the relative importance of a plan task.
+type PlanPriority int
+
+const (
+	PlanPriorityHigh   PlanPriority = 0
+	PlanPriorityMedium PlanPriority = 1
+	PlanPriorityLow    PlanPriority = 2
+)
+
+// PlanStatus tracks a plan task's lifecycle.
+type PlanStatus int
+
+const (
+	PlanStatusPending    PlanStatus = 0
+	PlanStatusInProgress PlanStatus = 1
+	PlanStatusCompleted  PlanStatus = 2
+)
+
+// PlanEntry is a single task in the agent's execution plan.
+type PlanEntry struct {
+	Content  string       `json:"content"`
+	Priority PlanPriority `json:"priority"`
+	Status   PlanStatus   `json:"status"`
+}
+
+// StepUsage carries token and cost data for a single step.
+type StepUsage struct {
+	Used int     `json:"used"`
+	Size int     `json:"size"`
+	Cost float64 `json:"cost"`
+}
+
 type sessionAgent struct {
 	largeModel         *csync.Value[Model]
 	smallModel         *csync.Value[Model]
@@ -180,6 +225,7 @@ type sessionAgent struct {
 	isYolo               bool
 	notify               pubsub.Publisher[notify.Notification]
 	runComplete          pubsub.Publisher[notify.RunComplete]
+	observer             RunObserver
 
 	messageQueue   *csync.Map[string, []SessionAgentCall]
 	activeRequests *csync.Map[string, *activeCancel]
@@ -220,6 +266,9 @@ type sessionAgent struct {
 	// across the agent. Cancel uses its current value as the per-session
 	// high-water mark.
 	acceptSeqGen uint64
+
+	// onTitleChange is called when the session title is auto-generated.
+	onTitleChange func(sessionID, title string)
 }
 
 type SessionAgentOptions struct {
@@ -884,6 +933,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		},
 		OnReasoningDelta: func(id string, text string) error {
 			currentAssistant.AppendReasoningContent(text)
+			if a.observer != nil {
+				a.observer.OnReasoningDelta(call.SessionID, currentAssistant.ID, text)
+			}
 			return a.messages.Update(genCtx, *currentAssistant)
 		},
 		OnReasoningEnd: func(id string, reasoning fantasy.ReasoningContent) error {
@@ -915,6 +967,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			}
 
 			currentAssistant.AppendContent(text)
+			if a.observer != nil {
+				a.observer.OnTextDelta(call.SessionID, currentAssistant.ID, text)
+			}
 			return a.messages.Update(genCtx, *currentAssistant)
 		},
 		OnToolInputStart: func(id string, toolName string) error {
@@ -925,6 +980,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 				Finished:         false,
 			}
 			currentAssistant.AddToolCall(toolCall)
+			if a.observer != nil {
+				a.observer.OnToolInputStart(call.SessionID, id, toolName)
+			}
 			// Use parent ctx instead of genCtx to ensure the update succeeds
 			// even if the request is canceled mid-stream
 			return a.messages.Update(ctx, *currentAssistant)
@@ -961,6 +1019,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 				Finished:         true,
 			}
 			currentAssistant.AddToolCall(toolCall)
+			if a.observer != nil {
+				a.observer.OnToolCall(call.SessionID, tc.ToolCallID, tc.ToolName, string(tc.Input))
+			}
 			// Use parent ctx instead of genCtx to ensure the update succeeds
 			// even if the request is canceled mid-stream
 			return a.messages.Update(ctx, *currentAssistant)
@@ -970,6 +1031,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			if sanitizedToolCalls[result.ToolCallID] {
 				toolResult.Content = "Tool call failed: arguments were not valid JSON. Please check your tool call format and try again."
 				toolResult.IsError = true
+			}
+			if a.observer != nil {
+				a.observer.OnToolResult(call.SessionID, result.ToolCallID, toolResult.Content)
 			}
 			// Use parent ctx instead of genCtx to ensure the message is created
 			// even if the request is canceled mid-stream
@@ -1017,6 +1081,18 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			usage, estimated := fallbackStepUsage(stepMessages, stepResult)
 			a.updateSessionUsage(largeModel, &updatedSession, usage, a.openrouterCost(stepResult.ProviderMetadata), estimated)
 			extractHyperCredits(stepResult.ProviderMetadata)
+			if a.observer != nil {
+				contextWindow := int64(largeModel.CatwalkCfg.ContextWindow)
+				cost := 0.0
+				if openrouterCost := a.openrouterCost(stepResult.ProviderMetadata); openrouterCost != nil {
+					cost = *openrouterCost
+				}
+				a.observer.OnUsageUpdate(call.SessionID, StepUsage{
+					Used: int(updatedSession.CompletionTokens + updatedSession.PromptTokens),
+					Size: int(contextWindow),
+					Cost: cost,
+				})
+			}
 			_, sessionErr := a.sessions.Save(ctx, updatedSession)
 			if sessionErr != nil {
 				return sessionErr
@@ -1859,6 +1935,10 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 		return
 	}
 	titleSaved = true
+
+	if a.onTitleChange != nil {
+		a.onTitleChange(sessionID, title)
+	}
 }
 
 func (a *sessionAgent) openrouterCost(metadata fantasy.ProviderMetadata) *float64 {
@@ -2071,6 +2151,14 @@ func (a *sessionAgent) SetTools(tools []fantasy.AgentTool) {
 
 func (a *sessionAgent) SetSystemPrompt(systemPrompt string) {
 	a.systemPrompt.Set(systemPrompt)
+}
+
+func (a *sessionAgent) SetObserver(observer RunObserver) {
+	a.observer = observer
+}
+
+func (a *sessionAgent) SetOnTitleChange(fn func(sessionID, title string)) {
+	a.onTitleChange = fn
 }
 
 func (a *sessionAgent) Model() Model {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -104,6 +104,9 @@ type Coordinator interface {
 	IsBusy() bool
 	QueuedPrompts(sessionID string) int
 	QueuedPromptsList(sessionID string) []string
+	SetObserver(observer RunObserver)
+	SetACPConnector(connector *tools.ACPConnector)
+	SetOnTitleChange(fn func(sessionID, title string))
 	ClearQueue(sessionID string)
 	Summarize(context.Context, string) error
 	Model() Model
@@ -112,17 +115,19 @@ type Coordinator interface {
 }
 
 type coordinator struct {
-	cfg         *config.ConfigStore
-	sessions    session.Service
-	messages    message.Service
-	permissions permission.Service
-	questions   question.Service
-	history     history.Service
-	filetracker filetracker.Service
-	lspManager  *lsp.Manager
-	notify      pubsub.Publisher[notify.Notification]
-	runComplete pubsub.Publisher[notify.RunComplete]
-	interactive bool
+	cfg          *config.ConfigStore
+	sessions     session.Service
+	messages     message.Service
+	permissions  permission.Service
+	questions    question.Service
+	history      history.Service
+	filetracker  filetracker.Service
+	lspManager   *lsp.Manager
+	notify       pubsub.Publisher[notify.Notification]
+	runComplete  pubsub.Publisher[notify.RunComplete]
+	observer     RunObserver
+	acpConnector *tools.ACPConnector
+	interactive  bool
 
 	currentAgent SessionAgent
 	agents       map[string]SessionAgent
@@ -232,6 +237,16 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 	// though crush_info reports them as connected.
 	if err := mcp.WaitForInit(ctx); err != nil {
 		return nil, fmt.Errorf("failed to wait for MCP initialization: %w", err)
+	}
+
+	if err := c.reloadConfigIfNeeded(ctx); err != nil {
+		return nil, fmt.Errorf("failed to reload config: %w", err)
+	}
+
+	if c.acpConnector != nil {
+		if err := c.rebuildACPTools(ctx); err != nil {
+			return nil, fmt.Errorf("failed to sync ACP tools: %w", err)
+		}
 	}
 
 	// refresh models before each run
@@ -792,6 +807,25 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 		return strings.Compare(a.Info().Name, b.Info().Name)
 	})
 
+	if c.acpConnector != nil && c.cfg.Config().Options.ACP != nil && c.cfg.Config().Options.ACP.ZedControl {
+		filteredTools = append(filteredTools,
+			tools.NewACPViewTool(c.acpConnector),
+			tools.NewACPWriteTool(c.acpConnector),
+			tools.NewACPBashTool(c.acpConnector),
+			tools.NewZedVisualNavigateTool(c.acpConnector),
+			tools.NewZedVisualPaneTool(c.acpConnector),
+			tools.NewZedVisualPanelTool(c.acpConnector),
+			tools.NewZedVisualBatchTool(c.acpConnector),
+		)
+		slices.SortFunc(filteredTools, func(a, b fantasy.AgentTool) int {
+			return strings.Compare(a.Info().Name, b.Info().Name)
+		})
+	}
+
+	if !isSubAgent {
+		filteredTools = append(filteredTools, tools.NewUpdatePlanTool())
+	}
+
 	// Wrap tools with hook interception for the top-level agent only.
 	// Sub-agents (the `agent` task tool, `agentic_fetch`, etc.) run
 	// without hook interception to avoid firing the user's hook N times
@@ -1205,6 +1239,30 @@ func (c *coordinator) Model() Model {
 	return c.currentAgent.Model()
 }
 
+func (c *coordinator) reloadConfigIfNeeded(ctx context.Context) error {
+	if c.cfg == nil {
+		return nil
+	}
+	stale := c.cfg.ConfigStaleness()
+	if !stale.Dirty {
+		return nil
+	}
+	return c.cfg.ReloadFromDisk(ctx)
+}
+
+func (c *coordinator) rebuildACPTools(ctx context.Context) error {
+	agentCfg, ok := c.cfg.Config().Agents[config.AgentCoder]
+	if !ok {
+		return errCoderAgentNotConfigured
+	}
+	tools, err := c.buildTools(ctx, agentCfg, false)
+	if err != nil {
+		return err
+	}
+	c.currentAgent.SetTools(tools)
+	return nil
+}
+
 func (c *coordinator) UpdateModels(ctx context.Context) error {
 	// build the models again so we make sure we get the latest config
 	large, small, err := c.buildAgentModels(ctx, false)
@@ -1232,6 +1290,25 @@ func (c *coordinator) QueuedPrompts(sessionID string) int {
 
 func (c *coordinator) QueuedPromptsList(sessionID string) []string {
 	return c.currentAgent.QueuedPromptsList(sessionID)
+}
+
+func (c *coordinator) SetObserver(observer RunObserver) {
+	c.observer = observer
+	c.currentAgent.SetObserver(observer)
+}
+
+func (c *coordinator) SetACPConnector(connector *tools.ACPConnector) {
+	c.acpConnector = connector
+	if connector == nil {
+		return
+	}
+	if err := c.rebuildACPTools(context.Background()); err != nil {
+		slog.Warn("SetACPConnector: failed to rebuild tools", "err", err)
+	}
+}
+
+func (c *coordinator) SetOnTitleChange(fn func(sessionID, title string)) {
+	c.currentAgent.SetOnTitleChange(fn)
 }
 
 func (c *coordinator) Summarize(ctx context.Context, sessionID string) error {

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -34,6 +34,9 @@ func (m *mockSessionAgent) Model() Model                        { return m.model
 func (m *mockSessionAgent) SetModels(large, small Model)        {}
 func (m *mockSessionAgent) SetTools(tools []fantasy.AgentTool)  {}
 func (m *mockSessionAgent) SetSystemPrompt(systemPrompt string) {}
+func (m *mockSessionAgent) SetObserver(observer RunObserver)    {}
+func (m *mockSessionAgent) SetOnTitleChange(fn func(sessionID, title string)) {
+}
 func (m *mockSessionAgent) Cancel(sessionID string) {
 	m.cancelled = append(m.cancelled, sessionID)
 }

--- a/internal/agent/tools/acp.go
+++ b/internal/agent/tools/acp.go
@@ -1,0 +1,436 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	acp "github.com/coder/acp-go-sdk"
+
+	"charm.land/fantasy"
+)
+
+// ACPConnector wraps the ACP AgentSideConnection so tools can make
+// client-bound requests (ReadTextFile, WriteTextFile, CreateTerminal, etc.)
+// without depending on the full connection lifecycle. Callers supply the
+// getter closure once; the getter must return the current connection (which
+// may be nil when no ACP client is connected).
+type ACPConnector struct {
+	GetConn func() *acp.AgentSideConnection
+}
+
+const (
+	ACPViewToolName   = "zed_view"
+	ACPWriteToolName  = "zed_write"
+	ACPBashToolName   = "zed_bash"
+	ACPPermissionName = "zed_request_permission"
+)
+
+// NewACPViewTool returns a tool that reads file contents through the ACP
+// client's ReadTextFile method, giving the agent access to the client's
+// LSP-indexed buffers.
+func NewACPViewTool(connector *ACPConnector) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		ACPViewToolName,
+		"ACP-CLIENT view: read a file through the connected ACP client's buffers. "+
+			"PREFERRED over 'view' when connected to an ACP client — the client's buffer reflects "+
+			"unsaved changes, LSP diagnostics, and cursor state that the local filesystem may not have yet. "+
+			"Supports offset (0-based line start) and limit (max lines, default 200).",
+		func(ctx context.Context, params ViewParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			conn := connector.GetConn()
+			if conn == nil {
+				return fantasy.NewTextErrorResponse("ACP connection not available"), nil
+			}
+			sessionID := GetSessionFromContext(ctx)
+			if sessionID == "" {
+				return fantasy.NewTextErrorResponse("no session ID in context"), nil
+			}
+
+			limit := params.Limit
+			if limit == 0 {
+				limit = DefaultReadLimit
+			}
+			line := params.Offset
+			if line < 0 {
+				line = 0
+			} else {
+				line++ // ACP ReadTextFile lines are 1-based
+			}
+
+			resp, err := conn.ReadTextFile(ctx, acp.ReadTextFileRequest{
+				SessionId: acp.SessionId(sessionID),
+				Path:      params.FilePath,
+				Limit:     &limit,
+				Line:      &line,
+			})
+			if err != nil {
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("zed_view failed: %s", err)), nil
+			}
+			return fantasy.NewTextResponse(resp.Content), nil
+		},
+	)
+}
+
+// ACPWriteTool returns a tool that writes file content through the ACP
+// client's WriteTextFile method.
+func NewACPWriteTool(connector *ACPConnector) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		ACPWriteToolName,
+		"ACP-CLIENT write: write file content through the connected ACP client's buffers. "+
+			"PREFERRED over 'write'/'edit' when connected to an ACP client — the client's buffer updates "+
+			"in real-time so the user sees the change immediately with proper syntax highlighting and LSP integration. "+
+			"Takes an absolute file_path and the full file content to write.",
+		func(ctx context.Context, params WriteACPParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			conn := connector.GetConn()
+			if conn == nil {
+				return fantasy.NewTextErrorResponse("ACP connection not available"), nil
+			}
+			sessionID := GetSessionFromContext(ctx)
+			if sessionID == "" {
+				return fantasy.NewTextErrorResponse("no session ID in context"), nil
+			}
+
+			_, err := conn.WriteTextFile(ctx, acp.WriteTextFileRequest{
+				SessionId: acp.SessionId(sessionID),
+				Path:      params.FilePath,
+				Content:   params.Content,
+			})
+			if err != nil {
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("zed_write failed: %s", err)), nil
+			}
+			return fantasy.NewTextResponse("File written successfully through ACP client"), nil
+		},
+	)
+}
+
+// WriteACPParams is the input for the zed_write tool.
+type WriteACPParams struct {
+	FilePath string `json:"file_path" description:"The absolute path to the file to write"`
+	Content  string `json:"content" description:"The full content to write to the file"`
+}
+
+// NewACPBashTool returns a tool that spawns a terminal in the ACP client
+// to execute commands, rather than running them on the agent's local host.
+func NewACPBashTool(connector *ACPConnector) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		ACPBashToolName,
+		"ACP-CLIENT bash: execute commands in a terminal spawned inside the ACP client. "+
+			"PREFERRED over 'bash' when connected to an ACP client — runs in the client's workspace "+
+			"with the client's environment variables and working directory. "+
+			"Use for any command execution when an ACP client is connected.",
+		func(ctx context.Context, params ACPBashParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			conn := connector.GetConn()
+			if conn == nil {
+				return fantasy.NewTextErrorResponse("ACP connection not available"), nil
+			}
+			sessionID := GetSessionFromContext(ctx)
+			if sessionID == "" {
+				return fantasy.NewTextErrorResponse("no session ID in context"), nil
+			}
+
+			// Create the terminal in the client.
+			createReq := acp.CreateTerminalRequest{
+				SessionId: acp.SessionId(sessionID),
+				Command:   params.Command,
+				Args:      params.Args,
+			}
+			if params.WorkingDir != "" {
+				wd := params.WorkingDir
+				createReq.Cwd = &wd
+			}
+			if params.OutputByteLimit > 0 {
+				createReq.OutputByteLimit = &params.OutputByteLimit
+			}
+
+			createResp, err := conn.CreateTerminal(ctx, createReq)
+			if err != nil {
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("zed_bash (create terminal) failed: %s", err)), nil
+			}
+
+			// Wait for the terminal to exit, then gather its output.
+			waitResp, err := conn.WaitForTerminalExit(ctx, acp.WaitForTerminalExitRequest{
+				SessionId:  acp.SessionId(sessionID),
+				TerminalId: createResp.TerminalId,
+			})
+			if err != nil {
+				// Try to clean up.
+				_, _ = conn.KillTerminal(ctx, acp.KillTerminalRequest{
+					SessionId:  acp.SessionId(sessionID),
+					TerminalId: createResp.TerminalId,
+				})
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("zed_bash (wait for exit) failed: %s", err)), nil
+			}
+
+			// Fetch terminal output.
+			outputResp, err := conn.TerminalOutput(ctx, acp.TerminalOutputRequest{
+				SessionId:  acp.SessionId(sessionID),
+				TerminalId: createResp.TerminalId,
+			})
+			if err != nil {
+				return fantasy.NewTextResponse(fmt.Sprintf(
+					"Command completed (exit code: %d) but output could not be retrieved: %s",
+					waitResp.ExitCode, err,
+				)), nil
+			}
+
+			// Release the terminal on the client side.
+			_, _ = conn.ReleaseTerminal(ctx, acp.ReleaseTerminalRequest{
+				SessionId:  acp.SessionId(sessionID),
+				TerminalId: createResp.TerminalId,
+			})
+
+			return fantasy.NewTextResponse(fmt.Sprintf(
+				"Exit code: %d\n\n%s",
+				waitResp.ExitCode, outputResp.Output,
+			)), nil
+		},
+	)
+}
+
+// ACPBashParams is the input for the zed_bash tool.
+type ACPBashParams struct {
+	Description     string   `json:"description" description:"A brief description of what the command does"`
+	Command         string   `json:"command" description:"The command to execute in the client's terminal"`
+	Args            []string `json:"args,omitempty" description:"Arguments to pass to the command"`
+	WorkingDir      string   `json:"working_dir,omitempty" description:"The working directory for the command"`
+	OutputByteLimit int      `json:"output_byte_limit,omitempty" description:"Maximum bytes of output to capture"`
+}
+
+// ── Visual Control Tools ──────────────────────────────────────────────────
+// These tools emit visual command metadata through the ACP tool lifecycle.
+// Compatible clients can consume the metadata to dispatch workspace actions.
+
+const (
+	// ZedVisualNavigate emits navigation commands.
+	ZedVisualNavigateToolName = "zed_visual"
+	// ZedVisualPane manages panes (split, close, navigate).
+	ZedVisualPaneToolName = "zed_pane"
+	// ZedVisualPanel manages panels (toggle focus).
+	ZedVisualPanelToolName = "zed_panel"
+	// ZedVisualBatch executes multiple visual commands atomically.
+	ZedVisualBatchToolName = "zed_batch"
+)
+
+// ZedVisualNavigateParams controls client navigation.
+type ZedVisualNavigateParams struct {
+	Action string `json:"action" description:"Navigation action: back, forward"`
+}
+
+// ZedVisualPaneParams controls client pane management.
+type ZedVisualPaneParams struct {
+	Action    string `json:"action" description:"Pane action: split, close, navigate"`
+	Direction string `json:"direction,omitempty" description:"Direction for split/navigate: left, right, up, down"`
+	Path      string `json:"path,omitempty" description:"File path to open (for split action)"`
+}
+
+// ZedVisualPanelParams controls client panel management.
+type ZedVisualPanelParams struct {
+	Action string `json:"action" description:"Panel action: focus, toggle, close"`
+	Panel  string `json:"panel" description:"Panel name: terminal, project, outline, assistant, etc."`
+}
+
+// NewZedVisualNavigateTool creates a tool for emitting navigation metadata.
+func NewZedVisualNavigateTool(connector *ACPConnector) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		ZedVisualNavigateToolName,
+		"Navigate the ACP client's history. Actions: back, forward. "+
+			"Use this to move through the client's navigation history without "+
+			"needing a file tool call.",
+		func(ctx context.Context, params ZedVisualNavigateParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			// Send a session/update with _zed_visual_command metadata for
+			// clients that dispatch visual workspace actions from tool updates.
+			conn := connector.GetConn()
+			if conn == nil {
+				return fantasy.NewTextErrorResponse("ACP connection not available"), nil
+			}
+			sessionID := GetSessionFromContext(ctx)
+			if sessionID == "" {
+				return fantasy.NewTextErrorResponse("no session ID in context"), nil
+			}
+			// Use a synthetic tool call to carry the visual command meta.
+			toolID := fmt.Sprintf("zed_nav_%d", time.Now().UnixNano())
+			update := acp.UpdateToolCall(acp.ToolCallId(toolID),
+				acp.WithUpdateStatus(acp.ToolCallStatusCompleted),
+			)
+			meta := map[string]any{
+				"_zed_visual_command": map[string]any{
+					"command": params.Action,
+					"params":  map[string]any{},
+				},
+			}
+			update.ToolCallUpdate.Meta = meta
+			sendCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			defer cancel()
+			_ = conn.SessionUpdate(sendCtx, acp.SessionNotification{
+				SessionId: acp.SessionId(sessionID),
+				Update:    acp.SessionUpdate{ToolCallUpdate: update.ToolCallUpdate},
+			})
+			return fantasy.NewTextResponse(fmt.Sprintf("Navigated %s", params.Action)), nil
+		},
+	)
+}
+
+// NewZedVisualPaneTool creates a tool for emitting pane-management metadata.
+func NewZedVisualPaneTool(connector *ACPConnector) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		ZedVisualPaneToolName,
+		"Manage panes in ACP clients that support visual command metadata. "+
+			"Actions: split (open file in new pane), close (close inactive panes), navigate (move focus). "+
+			"Directions: left, right, up, down. "+
+			"For split, provide an absolute file path.",
+		func(ctx context.Context, params ZedVisualPaneParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			conn := connector.GetConn()
+			if conn == nil {
+				return fantasy.NewTextErrorResponse("ACP connection not available"), nil
+			}
+			sessionID := GetSessionFromContext(ctx)
+			if sessionID == "" {
+				return fantasy.NewTextErrorResponse("no session ID in context"), nil
+			}
+			toolID := fmt.Sprintf("zed_pane_%d", time.Now().UnixNano())
+			update := acp.UpdateToolCall(acp.ToolCallId(toolID),
+				acp.WithUpdateStatus(acp.ToolCallStatusCompleted),
+			)
+			cmdParams := map[string]any{}
+			if params.Direction != "" {
+				cmdParams["direction"] = params.Direction
+			}
+			if params.Path != "" {
+				cmdParams["path"] = params.Path
+			}
+			meta := map[string]any{
+				"_zed_visual_command": map[string]any{
+					"command": params.Action,
+					"params":  cmdParams,
+				},
+			}
+			update.ToolCallUpdate.Meta = meta
+			sendCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			defer cancel()
+			_ = conn.SessionUpdate(sendCtx, acp.SessionNotification{
+				SessionId: acp.SessionId(sessionID),
+				Update:    acp.SessionUpdate{ToolCallUpdate: update.ToolCallUpdate},
+			})
+			return fantasy.NewTextResponse(fmt.Sprintf("Pane %s completed", params.Action)), nil
+		},
+	)
+}
+
+// NewZedVisualPanelTool creates a tool for emitting panel-management metadata.
+func NewZedVisualPanelTool(connector *ACPConnector) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		ZedVisualPanelToolName,
+		"Manage panels in ACP clients that support visual command metadata. "+
+			"Actions: focus (bring panel to front), toggle (show/hide panel), close. "+
+			"Panel names: terminal, project, outline, assistant, copilot_chat, "+
+			"debug, git, notification, language_server, etc.",
+		func(ctx context.Context, params ZedVisualPanelParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			conn := connector.GetConn()
+			if conn == nil {
+				return fantasy.NewTextErrorResponse("ACP connection not available"), nil
+			}
+			sessionID := GetSessionFromContext(ctx)
+			if sessionID == "" {
+				return fantasy.NewTextErrorResponse("no session ID in context"), nil
+			}
+			toolID := fmt.Sprintf("zed_panel_%d", time.Now().UnixNano())
+			update := acp.UpdateToolCall(acp.ToolCallId(toolID),
+				acp.WithUpdateStatus(acp.ToolCallStatusCompleted),
+			)
+			meta := map[string]any{
+				"_zed_visual_command": map[string]any{
+					"command": params.Action,
+					"params": map[string]any{
+						"panel": params.Panel,
+					},
+				},
+			}
+			update.ToolCallUpdate.Meta = meta
+			sendCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			defer cancel()
+			_ = conn.SessionUpdate(sendCtx, acp.SessionNotification{
+				SessionId: acp.SessionId(sessionID),
+				Update:    acp.SessionUpdate{ToolCallUpdate: update.ToolCallUpdate},
+			})
+			switch params.Action {
+			case "focus":
+				return fantasy.NewTextResponse(fmt.Sprintf("Focused %s panel", params.Panel)), nil
+			case "toggle":
+				return fantasy.NewTextResponse(fmt.Sprintf("Toggled %s panel", params.Panel)), nil
+			case "close":
+				return fantasy.NewTextResponse(fmt.Sprintf("Closed %s panel", params.Panel)), nil
+			default:
+				return fantasy.NewTextResponse(fmt.Sprintf("Panel action %s completed", params.Action)), nil
+			}
+		},
+	)
+}
+
+// ZedVisualBatchOp is a single operation in a batch.
+type ZedVisualBatchOp struct {
+	Action    string `json:"action" description:"Command: open_file, open_terminal, split, close, focus, toggle, back, forward"`
+	Path      string `json:"path,omitempty" description:"File path (for open_file, split)"`
+	Direction string `json:"direction,omitempty" description:"Direction (for split: left, right, up, down)"`
+	Panel     string `json:"panel,omitempty" description:"Panel name (for focus, toggle: terminal, project, etc.)"`
+}
+
+// ZedVisualBatchParams executes multiple visual commands atomically.
+type ZedVisualBatchParams struct {
+	Operations []ZedVisualBatchOp `json:"operations" description:"List of visual commands to execute in sequence"`
+}
+
+// NewZedVisualBatchTool creates the zed_batch tool for atomic multi-operations.
+func NewZedVisualBatchTool(connector *ACPConnector) fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		ZedVisualBatchToolName,
+		"Execute multiple visual commands in a single batch. "+
+			"All operations are sent as a single tool notification to minimize "+
+			"intermediate UI states. "+
+			"Operations: open_file, open_terminal, split, close, focus, toggle, back, forward.",
+		func(ctx context.Context, params ZedVisualBatchParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			conn := connector.GetConn()
+			if conn == nil {
+				return fantasy.NewTextErrorResponse("ACP connection not available"), nil
+			}
+			sessionID := GetSessionFromContext(ctx)
+			if sessionID == "" {
+				return fantasy.NewTextErrorResponse("no session ID in context"), nil
+			}
+			if len(params.Operations) == 0 {
+				return fantasy.NewTextErrorResponse("no operations provided"), nil
+			}
+			toolID := fmt.Sprintf("zed_batch_%d", time.Now().UnixNano())
+			sendCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			for i, op := range params.Operations {
+				update := acp.UpdateToolCall(acp.ToolCallId(toolID),
+					acp.WithUpdateStatus(acp.ToolCallStatusCompleted),
+				)
+				cmdParams := map[string]any{}
+				if op.Path != "" {
+					cmdParams["path"] = op.Path
+				}
+				if op.Direction != "" {
+					cmdParams["direction"] = op.Direction
+				}
+				if op.Panel != "" {
+					cmdParams["panel"] = op.Panel
+				}
+				update.ToolCallUpdate.Meta = map[string]any{
+					"_zed_visual_command": map[string]any{
+						"command":   op.Action,
+						"params":    cmdParams,
+						"seq":       i,
+						"batch_id":  toolID,
+						"batch_len": len(params.Operations),
+					},
+				}
+				_ = conn.SessionUpdate(sendCtx, acp.SessionNotification{
+					SessionId: acp.SessionId(sessionID),
+					Update:    acp.SessionUpdate{ToolCallUpdate: update.ToolCallUpdate},
+				})
+			}
+			return fantasy.NewTextResponse(fmt.Sprintf("Batch of %d operations sent", len(params.Operations))), nil
+		},
+	)
+}

--- a/internal/agent/tools/update_plan_tool.go
+++ b/internal/agent/tools/update_plan_tool.go
@@ -1,0 +1,275 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+
+	"charm.land/fantasy"
+)
+
+const UpdatePlanToolName = "update_plan"
+
+// PlanAction represents the operation to perform on a plan entry.
+type PlanAction string
+
+const (
+	PlanActionAdd     PlanAction = "add"
+	PlanActionUpdate  PlanAction = "update"
+	PlanActionRemove  PlanAction = "remove"
+	PlanActionClear   PlanAction = "clear"
+	PlanActionExecute PlanAction = "execute"
+)
+
+type UpdatePlanParams struct {
+	Entries []PlanEntryParam `json:"entries" description:"The plan entries to operate on. For 'clear', this should be empty."`
+	Action  PlanAction       `json:"action" description:"Action to perform: add (append entries), update (modify existing), remove (delete by content match), clear (remove all), execute (set to in_progress). Default: update."`
+}
+
+type PlanEntryParam struct {
+	Content  string `json:"content" description:"The plan task description (imperative form, e.g., 'Run tests')"`
+	Status   string `json:"status" description:"Task status: pending, in_progress, completed"`
+	Priority string `json:"priority" description:"Task priority: high, medium, low. Default: medium"`
+}
+
+// PlanEntry is a single task in the agent's execution plan.
+// Kept here to avoid an import cycle with the agent package.
+type PlanEntry struct {
+	Content  string `json:"content"`
+	Priority int    `json:"priority"`
+	Status   int    `json:"status"`
+}
+
+// PlanObserver is called when the plan state changes.
+type PlanObserver func(sessionID string, entries []PlanEntry)
+
+var (
+	planMu       sync.Mutex
+	planState    = make(map[string][]PlanEntry)
+	planObserver PlanObserver
+)
+
+// SetPlanObserver sets the callback for plan changes.
+func SetPlanObserver(fn PlanObserver) {
+	planMu.Lock()
+	defer planMu.Unlock()
+	planObserver = fn
+}
+
+func getPlanEntries(sessionID string) []PlanEntry {
+	planMu.Lock()
+	defer planMu.Unlock()
+	entries, ok := planState[sessionID]
+	if !ok {
+		return nil
+	}
+	result := make([]PlanEntry, len(entries))
+	copy(result, entries)
+	return result
+}
+
+func setPlanEntries(sessionID string, entries []PlanEntry) {
+	planMu.Lock()
+	planState[sessionID] = entries
+	obs := planObserver
+	planMu.Unlock()
+	if obs != nil {
+		obs(sessionID, entries)
+	}
+}
+
+func priorityFromStr(s string) int {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "high":
+		return 0
+	case "low":
+		return 2
+	default:
+		return 1
+	}
+}
+
+func statusFromStr(s string) int {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "in_progress", "in-progress", "inprogress":
+		return 1
+	case "completed":
+		return 2
+	default:
+		return 0
+	}
+}
+
+func statusToStr(s int) string {
+	switch s {
+	case 1:
+		return "in_progress"
+	case 2:
+		return "completed"
+	default:
+		return "pending"
+	}
+}
+
+func NewUpdatePlanTool() fantasy.AgentTool {
+	return fantasy.NewAgentTool(
+		UpdatePlanToolName,
+		"Use this tool to create and manage a structured plan for complex tasks. "+
+			"This helps track progress, organize work, and demonstrate thoroughness. "+
+			"\n\nActions:"+
+			"\n- add: Append new entries to the plan"+
+			"\n- update: Modify entries matching by content (or replace all if no match)"+
+			"\n- remove: Delete entries matching by content"+
+			"\n- clear: Remove all entries"+
+			"\n- execute: Mark entries as in_progress"+
+			"\n\nEach entry has: content (required), status (pending/in_progress/completed), priority (high/medium/low).",
+		func(ctx context.Context, params UpdatePlanParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			sessionID := GetSessionFromContext(ctx)
+			if sessionID == "" {
+				return fantasy.NewTextErrorResponse("no session ID in context"), nil
+			}
+
+			action := params.Action
+			if action == "" {
+				action = PlanActionUpdate
+			}
+
+			entries := getPlanEntries(sessionID)
+
+			switch action {
+			case PlanActionClear:
+				setPlanEntries(sessionID, nil)
+				return fantasy.NewTextResponse("Plan cleared."), nil
+
+			case PlanActionAdd:
+				for _, e := range params.Entries {
+					if strings.TrimSpace(e.Content) == "" {
+						continue
+					}
+					entries = append(entries, PlanEntry{
+						Content:  e.Content,
+						Status:   statusFromStr(e.Status),
+						Priority: priorityFromStr(e.Priority),
+					})
+				}
+				setPlanEntries(sessionID, entries)
+				return fantasy.NewTextResponse(fmt.Sprintf("Added %d entries to plan.", len(params.Entries))), nil
+
+			case PlanActionRemove:
+				removeContents := make(map[string]bool)
+				for _, e := range params.Entries {
+					removeContents[e.Content] = true
+				}
+				filtered := make([]PlanEntry, 0, len(entries))
+				for _, e := range entries {
+					if !removeContents[e.Content] {
+						filtered = append(filtered, e)
+					}
+				}
+				removed := len(entries) - len(filtered)
+				setPlanEntries(sessionID, filtered)
+				return fantasy.NewTextResponse(fmt.Sprintf("Removed %d entries from plan.", removed)), nil
+
+			case PlanActionExecute:
+				for _, p := range params.Entries {
+					for i := range entries {
+						if entries[i].Content == p.Content {
+							entries[i].Status = 1 // in_progress
+						}
+					}
+				}
+				setPlanEntries(sessionID, entries)
+				return fantasy.NewTextResponse("Plan entries marked as in_progress."), nil
+
+			case PlanActionUpdate:
+				if len(params.Entries) == 0 {
+					return fantasy.NewTextResponse(formatPlanStatus(entries)), nil
+				}
+				// If entries have content that matches existing entries, update them.
+				// Otherwise, replace the entire plan.
+				replace := true
+				if len(entries) > 0 {
+					existing := make(map[string]bool)
+					for _, e := range entries {
+						existing[e.Content] = true
+					}
+					for _, p := range params.Entries {
+						if existing[p.Content] {
+							replace = false
+							break
+						}
+					}
+				}
+				if replace {
+					newEntries := make([]PlanEntry, 0, len(params.Entries))
+					for _, p := range params.Entries {
+						if strings.TrimSpace(p.Content) == "" {
+							continue
+						}
+						newEntries = append(newEntries, PlanEntry{
+							Content:  p.Content,
+							Status:   statusFromStr(p.Status),
+							Priority: priorityFromStr(p.Priority),
+						})
+					}
+					setPlanEntries(sessionID, newEntries)
+					return fantasy.NewTextResponse(fmt.Sprintf("Plan replaced with %d entries.", len(newEntries))), nil
+				}
+				// Update matching entries
+				for _, p := range params.Entries {
+					for i := range entries {
+						if entries[i].Content == p.Content {
+							if p.Status != "" {
+								entries[i].Status = statusFromStr(p.Status)
+							}
+							if p.Priority != "" {
+								entries[i].Priority = priorityFromStr(p.Priority)
+							}
+						}
+					}
+				}
+				setPlanEntries(sessionID, entries)
+				return fantasy.NewTextResponse(fmt.Sprintf("Updated %d entries in plan.", len(params.Entries))), nil
+
+			default:
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("Unknown action: %s", action)), nil
+			}
+		},
+	)
+}
+
+func formatPlanStatus(entries []PlanEntry) string {
+	if len(entries) == 0 {
+		return "Plan is empty."
+	}
+	pending, inProgress, completed := 0, 0, 0
+	for _, e := range entries {
+		switch e.Status {
+		case 0:
+			pending++
+		case 1:
+			inProgress++
+		case 2:
+			completed++
+		}
+	}
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Plan (%d entries: %d pending, %d in_progress, %d completed):\n",
+		len(entries), pending, inProgress, completed))
+	for i, e := range entries {
+		b.WriteString(fmt.Sprintf("  %d. [%s] %s (priority: %d)\n", i+1, statusToStr(e.Status), e.Content, e.Priority))
+	}
+	return b.String()
+}
+
+// ClearPlanState removes plan state for a session.
+func ClearPlanState(sessionID string) {
+	planMu.Lock()
+	defer planMu.Unlock()
+	delete(planState, sessionID)
+}
+
+// Ensure slog import is used.
+var _ = slog.Info

--- a/internal/backend/agent_runcomplete_test.go
+++ b/internal/backend/agent_runcomplete_test.go
@@ -8,6 +8,7 @@ import (
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/agent"
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/proto"
@@ -43,6 +44,9 @@ func (c *errorCoordinator) IsBusy() bool                                      { 
 func (c *errorCoordinator) IsSessionBusy(string) bool                         { return false }
 func (c *errorCoordinator) QueuedPrompts(string) int                          { return 0 }
 func (c *errorCoordinator) QueuedPromptsList(string) []string                 { return nil }
+func (c *errorCoordinator) SetObserver(agent.RunObserver)                     {}
+func (c *errorCoordinator) SetACPConnector(*tools.ACPConnector)               {}
+func (c *errorCoordinator) SetOnTitleChange(func(string, string))             {}
 func (c *errorCoordinator) ClearQueue(string)                                 {}
 func (c *errorCoordinator) Summarize(context.Context, string) error           { return nil }
 func (c *errorCoordinator) Model() agent.Model                                { return agent.Model{} }

--- a/internal/backend/agent_test.go
+++ b/internal/backend/agent_test.go
@@ -8,6 +8,7 @@ import (
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/agent"
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/proto"
@@ -53,6 +54,9 @@ func (c *blockingCoordinator) IsBusy() bool                                     
 func (c *blockingCoordinator) IsSessionBusy(string) bool                         { return false }
 func (c *blockingCoordinator) QueuedPrompts(string) int                          { return 0 }
 func (c *blockingCoordinator) QueuedPromptsList(string) []string                 { return nil }
+func (c *blockingCoordinator) SetObserver(agent.RunObserver)                     {}
+func (c *blockingCoordinator) SetACPConnector(*tools.ACPConnector)               {}
+func (c *blockingCoordinator) SetOnTitleChange(func(string, string))             {}
 func (c *blockingCoordinator) ClearQueue(string)                                 {}
 func (c *blockingCoordinator) Summarize(context.Context, string) error           { return nil }
 func (c *blockingCoordinator) Model() agent.Model                                { return agent.Model{} }

--- a/internal/cmd/acp.go
+++ b/internal/cmd/acp.go
@@ -1,0 +1,248 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"syscall"
+
+	tea "charm.land/bubbletea/v2"
+	acp "github.com/coder/acp-go-sdk"
+	"github.com/spf13/cobra"
+
+	acpadapter "github.com/charmbracelet/crush/internal/acp"
+	"github.com/charmbracelet/crush/internal/agent"
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/app"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/db"
+	"github.com/charmbracelet/crush/internal/log"
+	"github.com/charmbracelet/crush/internal/skills"
+	uicommon "github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/model"
+	"github.com/charmbracelet/crush/internal/workspace"
+)
+
+var acpCmd = &cobra.Command{
+	Use:   "acp",
+	Short: "Run as an ACP agent",
+	Long: "Run as an ACP agent over stdio (for ACP client subprocess spawning), " +
+		"or with --tui for interactive TUI mode, " +
+		"or with --tui-acp for TUI + ACP server on a unix socket.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		tuiFlag, _ := cmd.Flags().GetBool("tui")
+		tuiACPFlag, _ := cmd.Flags().GetBool("tui-acp")
+		dataDirFlag, _ := cmd.Flags().GetString("data-dir")
+		socketPathFlag, _ := cmd.Flags().GetString("socket-path")
+		return runACPCommand(cmd.Context(), tuiFlag, tuiACPFlag, dataDirFlag, socketPathFlag)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(acpCmd)
+	acpCmd.Flags().Bool("tui", false, "Run in TUI-only mode (no ACP server)")
+	acpCmd.Flags().Bool("tui-acp", false, "Run TUI with ACP server on unix socket")
+	acpCmd.Flags().StringP("data-dir", "D", "", "Custom crush data directory")
+	acpCmd.Flags().String("socket-path", "", "Override ACP unix socket path (default: <data-dir>/crush-acp.sock)")
+}
+
+func runACPCommand(ctx context.Context, tui bool, tuiACP bool, dataDirArg string, socketPathArg string) error {
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	// Determine data directory: explicit flag > env var > auto-detect > default
+	dataDir := dataDirArg
+	if dataDir == "" {
+		dataDir = os.Getenv("CRUSH_DATA_DIR")
+	}
+	if dataDir == "" {
+		// Auto-detect: if ~/TUIs/.crush/crush.db exists, use it
+		home, _ := os.UserHomeDir()
+		existingDB := filepath.Join(home, "TUIs", ".crush", "crush.db")
+		if _, err := os.Stat(existingDB); err == nil {
+			dataDir = filepath.Join(home, "TUIs", ".crush")
+		}
+	}
+	store, err := config.Init(cwd, dataDir, false)
+	if err != nil {
+		return err
+	}
+	dataDir = store.Config().Options.DataDirectory
+
+	conn, err := db.Connect(ctx, dataDir)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	logDir := filepath.Join(dataDir, "logs")
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		return err
+	}
+	logFile := filepath.Join(logDir, "crush-acp.log")
+	if tui && !tuiACP {
+		log.Setup(logFile, false)
+	} else {
+		log.Setup(logFile, false, os.Stderr)
+	}
+
+	all, active, states := skills.DiscoverFromConfig(skills.DiscoveryConfig{
+		SkillsPaths:    store.Config().Options.SkillsPaths,
+		DisabledSkills: store.Config().Options.DisabledSkills,
+		Resolver:       store.Resolver().ResolveValue,
+	})
+	skillsMgr := skills.NewManager(all, active, states, skills.WithGlobalMirror())
+
+	appInstance, err := app.New(ctx, conn, store, skillsMgr)
+	if err != nil {
+		return err
+	}
+	defer appInstance.Shutdown()
+
+	// TUI+ACP: run TUI with ACP server on unix socket (for external ACP clients to connect).
+	if tuiACP {
+		return runTUIAndACPInCmd(ctx, appInstance, store, dataDir, socketPathArg)
+	}
+
+	// TUI-only: run interactive TUI without ACP server.
+	if tui {
+		return runTUIOnly(ctx, appInstance, store)
+	}
+
+	// Default: ACP agent over stdio (spawned by ACP client as subprocess).
+	return runACPInCmd(ctx, appInstance, os.Stdin, os.Stdout)
+}
+
+func runACPInCmd(ctx context.Context, appInstance *app.App, r io.Reader, w io.Writer) error {
+	coord := appInstance.AgentCoordinator
+	if coord == nil {
+		return fmt.Errorf("agent coordinator not initialized")
+	}
+
+	adapter := acpadapter.NewAdapter(coord, appInstance.Sessions, appInstance.Messages)
+	adapter.SetLogger(slog.Default())
+	adapter.SetObserver()
+	acpConn := acp.NewAgentSideConnection(adapter, w, r)
+	adapter.SetConnection(acpConn)
+
+	coord.SetACPConnector(&tools.ACPConnector{
+		GetConn: func() *acp.AgentSideConnection { return acpConn },
+	})
+
+	// Wire the update_plan tool to notify the ACP adapter on plan changes.
+	tools.SetPlanObserver(func(sessionID string, entries []tools.PlanEntry) {
+		agentEntries := make([]agent.PlanEntry, len(entries))
+		for i, e := range entries {
+			agentEntries[i] = agent.PlanEntry{
+				Content:  e.Content,
+				Priority: agent.PlanPriority(e.Priority),
+				Status:   agent.PlanStatus(e.Status),
+			}
+		}
+		adapter.OnPlanUpdate(sessionID, agentEntries)
+	})
+
+	// Wire session title changes to the ACP adapter.
+	coord.SetOnTitleChange(func(sessionID, title string) {
+		adapter.UpdateSessionInfo(sessionID, title)
+	})
+
+	slog.Info("crush acp: server ready")
+	<-acpConn.Done()
+	return nil
+}
+
+func runTUIAndACPInCmd(ctx context.Context, appInstance *app.App, store *config.ConfigStore, dataDir string, socketPathArg string) error {
+	// Default to /tmp/crush-acp.sock for external ACP clients,
+	// fall back to <data-dir>/crush-acp.sock for backward compatibility.
+	socketPath := "/tmp/crush-acp.sock"
+	if socketPathArg != "" {
+		socketPath = socketPathArg
+	} else if os.Getenv("CRUSH_ACP_SOCKET") != "" {
+		socketPath = os.Getenv("CRUSH_ACP_SOCKET")
+	}
+	if runtime.GOOS == "windows" {
+		socketPath = `\\.\pipe\crush-acp`
+	}
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		// If the socket file already exists (e.g. from a previous
+		// crashed instance), remove it and retry once.
+		if _, statErr := os.Stat(socketPath); statErr == nil {
+			slog.Warn("Removing stale ACP socket", "path", socketPath)
+			if rmErr := os.Remove(socketPath); rmErr != nil {
+				return fmt.Errorf("failed to remove stale socket %s: %w", socketPath, rmErr)
+			}
+			ln, err = net.Listen("unix", socketPath)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to listen on %s: %w", socketPath, err)
+		}
+	}
+	defer ln.Close()
+	defer os.Remove(socketPath)
+
+	acpErr := make(chan error, 1)
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				select {
+				case acpErr <- err:
+				default:
+				}
+				return
+			}
+			go func(c net.Conn) {
+				acpErr <- runACPInCmd(ctx, appInstance, c, c)
+			}(conn)
+		}
+	}()
+
+	ws := workspace.NewAppWorkspace(appInstance, store)
+	com := uicommon.DefaultCommon(ws)
+	m := model.New(com, "", false)
+
+	inputFilter := model.NewFilter()
+	program := tea.NewProgram(
+		m,
+		tea.WithContext(ctx),
+		tea.WithFilter(inputFilter.Filter),
+	)
+	go ws.Subscribe(program)
+
+	slog.Info("crush acp: TUI starting", "acp_socket", socketPath)
+	_, err = program.Run()
+	return err
+}
+
+// runTUIOnly runs the interactive TUI without any ACP server.
+func runTUIOnly(ctx context.Context, appInstance *app.App, store *config.ConfigStore) error {
+	ws := workspace.NewAppWorkspace(appInstance, store)
+	com := uicommon.DefaultCommon(ws)
+	m := model.New(com, "", false)
+
+	inputFilter := model.NewFilter()
+	program := tea.NewProgram(
+		m,
+		tea.WithContext(ctx),
+		tea.WithFilter(inputFilter.Filter),
+	)
+	go ws.Subscribe(program)
+
+	slog.Info("crush acp: TUI-only mode starting")
+	_, err := program.Run()
+	return err
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -61,6 +61,7 @@ func init() {
 	_ = rootCmd.PersistentFlags().MarkHidden("channels")
 	rootCmd.Flags().StringP("session", "s", "", "Continue a previous session by ID")
 	rootCmd.Flags().BoolP("continue", "C", false, "Continue the most recent session")
+	rootCmd.Flags().Bool("tui", false, "Run TUI with ACP server on unix socket")
 	rootCmd.MarkFlagsMutuallyExclusive("session", "continue")
 
 	rootCmd.AddCommand(
@@ -85,6 +86,9 @@ var rootCmd = &cobra.Command{
 # Run in interactive mode
 crush
 
+# Run TUI with ACP server on unix socket
+crush --tui
+
 # Run non-interactively
 crush run "Guess my 5 favorite Pokémon"
 
@@ -107,6 +111,12 @@ crush --session {session-id}
 crush --continue
   `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		tuiFlag, _ := cmd.Flags().GetBool("tui")
+		if tuiFlag {
+			dataDir, _ := cmd.Flags().GetString("data-dir")
+			return runACPCommand(cmd.Context(), false, true, dataDir, "")
+		}
+
 		sessionID, _ := cmd.Flags().GetString("session")
 		continueLast, _ := cmd.Flags().GetBool("continue")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -307,6 +307,13 @@ func (Attribution) JSONSchemaExtend(schema *jsonschema.Schema) {
 	}
 }
 
+// ACPConfig defines options for the ACP (Agent Client Protocol) integration.
+type ACPConfig struct {
+	// ZedControl enables routing file and terminal operations through
+	// the connected ACP client instead of executing them locally.
+	ZedControl bool `json:"zed_control,omitempty" jsonschema:"description=Route file and terminal operations through the ACP client instead of executing them locally,default=false"`
+}
+
 type Options struct {
 	ContextPaths         []string    `json:"context_paths,omitempty" jsonschema:"description=Paths to files containing context information for the AI,example=.cursorrules,example=CRUSH.md"`
 	GlobalContextPaths   []string    `json:"global_context_paths,omitempty" jsonschema:"description=Paths to files containing global context information for the AI,default=~/.config/crush/CRUSH.md,default=~/.config/AGENTS.md"`
@@ -331,6 +338,7 @@ type Options struct {
 	DisableNotifications      bool         `json:"disable_notifications,omitempty" jsonschema:"description=Deprecated: Use notification_style instead. Disable desktop notifications,default=false"`
 	NotificationStyle         string       `json:"notification_style,omitempty" jsonschema:"description=Notification style to use. Options: auto (default), native, osc, bell, disabled. Auto selects based on environment: native for local sessions, osc for SSH (with automatic OSC 99/777 detection).,enum=auto,enum=native,enum=osc,enum=bell,enum=disabled,default=auto"`
 	DisabledSkills            []string     `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
+	ACP                       *ACPConfig   `json:"acp,omitempty" jsonschema:"description=Agent Client Protocol integration options"`
 }
 
 type MCPs map[string]MCPConfig

--- a/internal/server/agent_cancel_test.go
+++ b/internal/server/agent_cancel_test.go
@@ -13,6 +13,7 @@ import (
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/agent"
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/backend"
 	"github.com/charmbracelet/crush/internal/message"
@@ -76,6 +77,10 @@ func (s *runCoordinator) IsSessionBusy(string) bool {
 func (s *runCoordinator) QueuedPrompts(string) int          { return 0 }
 func (s *runCoordinator) QueuedPromptsList(string) []string { return nil }
 func (s *runCoordinator) ClearQueue(string)                 {}
+func (s *runCoordinator) SetObserver(agent.RunObserver)     {}
+func (s *runCoordinator) SetACPConnector(*tools.ACPConnector) {
+}
+func (s *runCoordinator) SetOnTitleChange(func(string, string)) {}
 func (s *runCoordinator) Summarize(context.Context, string) error {
 	return nil
 }

--- a/internal/server/e2e_agent_test.go
+++ b/internal/server/e2e_agent_test.go
@@ -14,6 +14,7 @@ import (
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/agent"
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/backend"
 	"github.com/charmbracelet/crush/internal/message"
@@ -221,6 +222,9 @@ func (c *scriptedCoordinator) Summarize(context.Context, string) error       { r
 func (c *scriptedCoordinator) Model() agent.Model                            { return agent.Model{} }
 func (c *scriptedCoordinator) UpdateModels(context.Context) error            { return nil }
 func (c *scriptedCoordinator) GenerateTitle(context.Context, string, string) {}
+func (c *scriptedCoordinator) SetObserver(agent.RunObserver)                 {}
+func (c *scriptedCoordinator) SetACPConnector(*tools.ACPConnector)           {}
+func (c *scriptedCoordinator) SetOnTitleChange(func(string, string))         {}
 
 // agentE2EHarness extends the SSE harness with a scripted coordinator
 // wired into the workspace's embedded app.App, so POST /agent drives a

--- a/internal/server/sessions_isbusy_test.go
+++ b/internal/server/sessions_isbusy_test.go
@@ -10,6 +10,7 @@ import (
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/agent"
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/backend"
 	"github.com/charmbracelet/crush/internal/message"
@@ -53,6 +54,9 @@ func (s *stubCoordinator) Summarize(context.Context, string) error {
 func (s *stubCoordinator) Model() agent.Model                            { return agent.Model{} }
 func (s *stubCoordinator) UpdateModels(context.Context) error            { return nil }
 func (s *stubCoordinator) GenerateTitle(context.Context, string, string) {}
+func (s *stubCoordinator) SetObserver(agent.RunObserver)                 {}
+func (s *stubCoordinator) SetACPConnector(*tools.ACPConnector)           {}
+func (s *stubCoordinator) SetOnTitleChange(func(string, string))         {}
 
 // stubSessions is a minimal session.Service that returns a fixed list
 // (and supports Get by ID). All other methods return zero values; the

--- a/schema.json
+++ b/schema.json
@@ -3,6 +3,17 @@
   "$id": "https://github.com/charmbracelet/crush/internal/config/config",
   "$ref": "#/$defs/Config",
   "$defs": {
+    "ACPConfig": {
+      "properties": {
+        "zed_control": {
+          "type": "boolean",
+          "description": "Route file and terminal operations through the ACP client instead of executing them locally",
+          "default": false
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "Attribution": {
       "properties": {
         "trailer_style": {
@@ -569,6 +580,10 @@
           },
           "type": "array",
           "description": "List of skill names to disable and hide from the agent"
+        },
+        "acp": {
+          "$ref": "#/$defs/ACPConfig",
+          "description": "Agent Client Protocol integration options"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

Adds experimental Agent Client Protocol (ACP) support to Crush.

This implementation supports both ACP agent/server mode and an optional client-controlled workspace mode for ACP clients such as IDEs. In client-controlled mode, file reads, writes, and terminal commands are routed through the connected client, allowing unsaved buffers and the client environment to remain authoritative.

Includes:

* `crush acp` stdio agent mode
* TUI and ACP socket mode
* ACP session updates for text, reasoning, tool lifecycle, plans, usage, and replay
* ACP client-backed file and terminal tools
* optional visual command metadata for ACP clients that support it
* targeted ACP adapter and coordinator-integration tests

## Relationship to #2450

#2450 takes the conventional ACP-server approach: Crush continues to own its local workspace and normal tools, while ACP sinks expose the resulting activity to a client.

This PR retains that server capability while additionally supporting a client-controlled workspace path. This is useful when an IDE client owns unsaved buffers, terminal context, or other live workspace state.

The two approaches are complementary rather than competing.

## Infrastructure Acknowledgment

The ACP implementation was independently designed and implemented.

During final review and refinement of this contribution, I used model-inference access available through [[FreeInference.org](https://freeinference.org/)](https://freeinference.org/).

FreeInference did not commission, direct, fund, or pay me for this work. No representative of FreeInference reviewed or approved the contribution, and this acknowledgment does not indicate sponsorship, partnership, or endorsement by FreeInference, Charmbracelet, or any affiliated organization.

I am acknowledging the service because access to capable inference infrastructure can make meaningful open-source development more accessible to developers and researchers who do not have the hardware or budget to run these models themselves.

Organizations able to provide GPU capacity, hardware, cloud credits, research funding, or other infrastructure resources should consider supporting FreeInference so that it can continue making this capability available for open-source development, research, and education.

## Validation

* `go test ./internal/acp ./internal/cmd ./internal/agent ./internal/agent/tools`
* `go build ./...`
* `git diff --check`