### PR TITLE
fix(config): restore unset environment variables

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -176,18 +176,23 @@ func PushPopCrushEnv() func() {
 			found = append(found, strings.TrimPrefix(pair[0], "CRUSH_"))
 		}
 	}
-	backups := make(map[string]string)
+	backups := make(map[string]*string)
 	for _, ev := range found {
-		backups[ev] = os.Getenv(ev)
-	}
-
-	for _, ev := range found {
+		if value, ok := os.LookupEnv(ev); ok {
+			backups[ev] = &value
+		} else {
+			backups[ev] = nil
+		}
 		os.Setenv(ev, os.Getenv("CRUSH_"+ev))
 	}
 
 	restore := func() {
 		for k, v := range backups {
-			os.Setenv(k, v)
+			if v != nil {
+				os.Setenv(k, *v)
+			} else {
+				os.Unsetenv(k)
+			}
 		}
 	}
 	return restore

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -26,6 +26,34 @@ func TestMain(m *testing.M) {
 	os.Exit(exitVal)
 }
 
+func TestPushPopCrushEnv(t *testing.T) {
+	t.Run("restores an existing variable", func(t *testing.T) {
+		t.Setenv("CRUSH_TEST_PUSH_POP_EXISTING", "override")
+		t.Setenv("TEST_PUSH_POP_EXISTING", "original")
+
+		restore := PushPopCrushEnv()
+		t.Cleanup(restore)
+		require.Equal(t, "override", os.Getenv("TEST_PUSH_POP_EXISTING"))
+
+		restore()
+		require.Equal(t, "original", os.Getenv("TEST_PUSH_POP_EXISTING"))
+	})
+
+	t.Run("unsets a variable that did not exist", func(t *testing.T) {
+		t.Setenv("CRUSH_TEST_PUSH_POP_UNSET", "temporary")
+		require.NoError(t, os.Unsetenv("TEST_PUSH_POP_UNSET"))
+		t.Cleanup(func() { _ = os.Unsetenv("TEST_PUSH_POP_UNSET") })
+
+		restore := PushPopCrushEnv()
+		t.Cleanup(restore)
+		require.Equal(t, "temporary", os.Getenv("TEST_PUSH_POP_UNSET"))
+
+		restore()
+		_, exists := os.LookupEnv("TEST_PUSH_POP_UNSET")
+		require.False(t, exists)
+	})
+}
+
 func TestConfig_LoadFromBytes(t *testing.T) {
 	data1 := []byte(`{"providers": {"openai": {"api_key": "key1", "base_url": "https://api.openai.com/v1"}}}`)
 	data2 := []byte(`{"providers": {"openai": {"api_key": "key2", "base_url": "https://api.openai.com/v2"}}}`)


### PR DESCRIPTION
## Summary

- preserve whether each unprefixed environment variable existed before applying its `CRUSH_` override
- unset temporary variables during restore instead of leaving them present with an empty value
- cover restoration for both existing and previously unset variables

## Why

`PushPopCrushEnv` used `os.Getenv` for backups, which cannot distinguish an unset variable from one explicitly set to an empty string. After provider configuration, a previously absent variable was therefore left present as an empty value. Code using `os.LookupEnv` could observe a different environment after the temporary override was restored.

## Testing

- `go test ./internal/config -run "^TestPushPopCrushEnv$" -count=1`
- `go test ./internal/config -count=1`