### PR TITLE
docs: add custom OpenAI-compatible gateway example

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,27 @@ API. Don't forget to set `DEEPSEEK_API_KEY` in your environment.
 }
 ```
 
+The same `openai-compat` pattern works for multi-model gateways that expose a
+custom OpenAI-compatible base URL. Point `base_url` at the gateway root (include
+`/v1` when the host serves the OpenAI API under that path), set your API key,
+and either list models or let Crush discover them. Model IDs are usually
+account-specific—confirm them with the gateway’s `/models` endpoint rather than
+copying a hard-coded ID from a public sample.
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "providers": {
+    "daoxe": {
+      "type": "openai-compat",
+      "base_url": "https://daoxe.com/v1",
+      "api_key": "$DAOXE_API_KEY",
+      "discover_models": true
+    }
+  }
+}
+```
+
 #### Anthropic-Compatible APIs
 
 Custom Anthropic-compatible providers follow this format:

--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -130,6 +130,23 @@ reviewed.
 }
 ```
 
+For multi-model OpenAI-compatible gateways with a custom base URL, use the same
+`openai-compat` shape. Model IDs are account-specific; prefer `discover_models`
+or the gateway `/models` list over hard-coding public sample IDs.
+
+```json
+{
+  "providers": {
+    "daoxe": {
+      "type": "openai-compat",
+      "base_url": "https://daoxe.com/v1",
+      "api_key": "$DAOXE_API_KEY",
+      "discover_models": true
+    }
+  }
+}
+```
+
 - `type` (required): `openai`, `openai-compat`, `anthropic`, or a local provider type (`llamacpp`, `omlx`, `lmstudio`, `litellm`, `ollama`)
 - `api_key`, `base_url`, `api_endpoint`, and `extra_headers` are shell-expanded (see [Shell Expansion](#shell-expansion)).
 - `extra_body` is a JSON passthrough and is **not** expanded.


### PR DESCRIPTION
## Summary
- Extends the existing OpenAI-compatible custom provider docs with a multi-model gateway example that uses a custom `base_url`.
- Uses DaoXE (`https://daoxe.com/v1`) as a concrete `openai-compat` sample with `discover_models`, without hard-coding account-specific model IDs.
- Mirrors the same example in the builtin `crush-config` skill so interactive config help stays consistent.

## Why
Crush already documents `openai-compat` + `base_url` (Deepseek). Many users also point Crush at multi-model OpenAI-compatible gateways; this makes that path explicit and steers people away from shipping hard-coded model IDs.

## Notes
- Docs only; no runtime/provider registration changes.
- Not claiming DaoXE is a built-in provider—just an example of the generic custom base URL flow.
- Model IDs remain account-specific; sample relies on discovery / `/models`.

## Test plan
- [ ] Preview README Custom Providers section renders correctly
- [ ] Confirm skill example is consistent with README
- [ ] Optional: with a gateway key, load the sample `crush.json` and verify model discovery works