### PR TITLE
fix(agent): give reasoning models a token budget in Summarize

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1309,6 +1309,28 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	return a.Run(ctx, firstQueuedMessage)
 }
 
+// summarizeSystemPrompt appends /no_think to base so local reasoning models
+// (Qwen/GLM-style) don't burn their entire output budget on a
+// <think>...</think> block for a short summarization call, leaving no room
+// for the actual summary. Same directive GenerateTitle already relies on.
+func summarizeSystemPrompt(base string) string {
+	return base + "\n /no_think"
+}
+
+// summarizeMaxOutputTokens returns the token budget to request for the
+// summarization call, or nil to leave it unset. Reasoning-capable models
+// need a larger, reasoning-sized budget (mirroring GenerateTitle's same
+// workaround) since a small or provider-default budget can be exhausted by
+// the model's thinking trace before it emits any summary text. Non-reasoning
+// models already work fine with the budget left unset.
+func summarizeMaxOutputTokens(model Model) *int64 {
+	if !model.CatwalkCfg.CanReason {
+		return nil
+	}
+	tok := model.CatwalkCfg.DefaultMaxTokens
+	return &tok
+}
+
 func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fantasy.ProviderOptions) error {
 	if a.IsSessionBusy(sessionID) {
 		return ErrSessionBusy
@@ -1343,11 +1365,14 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		}
 	}()
 
-	agent := fantasy.NewAgent(
-		largeModel.Model,
-		fantasy.WithSystemPrompt(string(summaryPrompt)),
+	agentOpts := []fantasy.AgentOption{
+		fantasy.WithSystemPrompt(summarizeSystemPrompt(string(summaryPrompt))),
 		fantasy.WithUserAgent(userAgent),
-	)
+	}
+	if tok := summarizeMaxOutputTokens(largeModel); tok != nil {
+		agentOpts = append(agentOpts, fantasy.WithMaxOutputTokens(*tok))
+	}
+	agent := fantasy.NewAgent(largeModel.Model, agentOpts...)
 	summaryMessage, err := a.messages.Create(ctx, sessionID, message.CreateMessageParams{
 		Role:             message.Assistant,
 		Model:            largeModel.ModelCfg.Model,

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1013,3 +1013,25 @@ func TestProviderRetryLogFields(t *testing.T) {
 		}, fields)
 	})
 }
+
+func TestSummarizeSystemPrompt(t *testing.T) {
+	// /no_think must always be appended so local reasoning models
+	// (Qwen/GLM-style) don't burn their entire output budget on a
+	// <think>...</think> block instead of producing the summary.
+	got := summarizeSystemPrompt("Summarize the conversation.")
+	require.Equal(t, "Summarize the conversation.\n /no_think", got)
+}
+
+func TestSummarizeMaxOutputTokens(t *testing.T) {
+	t.Run("non-reasoning model leaves budget unset", func(t *testing.T) {
+		model := Model{CatwalkCfg: catwalk.Model{CanReason: false, DefaultMaxTokens: 8192}}
+		require.Nil(t, summarizeMaxOutputTokens(model))
+	})
+
+	t.Run("reasoning model gets a reasoning-sized budget", func(t *testing.T) {
+		model := Model{CatwalkCfg: catwalk.Model{CanReason: true, DefaultMaxTokens: 32000}}
+		tok := summarizeMaxOutputTokens(model)
+		require.NotNil(t, tok)
+		require.Equal(t, int64(32000), *tok)
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #3284.

`Summarize` builds its agent like this:

```go
agent := fantasy.NewAgent(
    largeModel.Model,
    fantasy.WithSystemPrompt(string(summaryPrompt)),
    fantasy.WithUserAgent(userAgent),
)
```

No `MaxOutputTokens` cap, no `/no_think` directive. `GenerateTitle`, a few
hundred lines below in the same file, already works around the exact same
problem for its own short utility call:

```go
fantasy.WithSystemPrompt(string(p)+"\n /no_think"),
fantasy.WithMaxOutputTokens(tok), // tok = DefaultMaxTokens when CanReason
```

Local reasoning-capable models (Qwen/GLM-style, served via llama.cpp per
the issue) spend their entire output budget on a `<think>...</think>`
block before producing any visible text. For `Summarize` — no cap set, so
whatever the provider defaults to (small, for some local servers) gets
consumed entirely by thinking, the summary message ends up empty, and the
session falls back to "Untitled Session". `GenerateTitle` doesn't hit this
because it already guards against it; `Summarize` never got the same
treatment.

## Fix

Extracted the same workaround into two small helpers and applied them in
`Summarize`:

- `summarizeSystemPrompt` — always appends `/no_think` (harmless no-op for
  non-reasoning models, same as `GenerateTitle` does unconditionally)
- `summarizeMaxOutputTokens` — returns `nil` (budget stays unset, unchanged
  behavior) for non-reasoning models, or `DefaultMaxTokens` for
  reasoning-capable ones, mirroring `GenerateTitle`'s `tok` selection

## Caveat

I don't have a local llama.cpp thinking-model server to reproduce the
original failure live, so this is a code-level diagnosis rather than an
end-to-end repro: `Summarize` and `GenerateTitle` build near-identical
agents for the same class of short, non-conversational utility call, and
`GenerateTitle` already carries this exact workaround for this exact
provider gap. Flagging this explicitly in case a maintainer with a local
thinking-model setup wants to confirm before merging.

## Testing

- `go build ./...`: success
- `go test ./internal/agent/...`: 331 passed (1 pre-existing unrelated
  failure in `internal/agent/tools`, a Windows temp-path issue — confirmed
  present on `main` with this change stashed out, not caused by this PR)
- 4 new unit tests on the extracted helpers (`TestSummarizeSystemPrompt`,
  `TestSummarizeMaxOutputTokens`)
- `go vet ./internal/agent/...`: clean