### PR TITLE
feat(ui): hierarchical sub-menus in the command palette

### DIFF
--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -20,6 +20,11 @@ import (
 // CommandsID is the identifier for the commands dialog.
 const CommandsID = "commands"
 
+// menuLevel captures the parent state when navigating into a sub-menu.
+type menuLevel struct {
+	items []list.Item
+}
+
 // CommandType represents the type of commands being displayed.
 type CommandType uint
 
@@ -50,6 +55,7 @@ type Commands struct {
 		Previous,
 		Tab,
 		ShiftTab,
+		Back,
 		Close key.Binding
 	}
 
@@ -73,6 +79,9 @@ type Commands struct {
 
 	dockerMCPAvailable     *bool
 	dockerMCPCheckInFlight bool
+
+	menuStack  []menuLevel
+	breadcrumb []string
 }
 
 var _ Dialog = (*Commands)(nil)
@@ -129,6 +138,10 @@ func NewCommands(com *common.Common, sessionID string, hasSession, hasTodos, has
 		key.WithKeys("shift+tab"),
 		key.WithHelp("shift+tab", "switch selection prev"),
 	)
+	c.keyMap.Back = key.NewBinding(
+		key.WithKeys("backspace", "alt+left"),
+		key.WithHelp("backspace", "back"),
+	)
 	closeKey := CloseKey
 	closeKey.SetHelp("esc", "cancel")
 	c.keyMap.Close = closeKey
@@ -172,7 +185,18 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 	case tea.KeyPressMsg:
 		switch {
 		case key.Matches(msg, c.keyMap.Close):
+			if c.inSubMenu() {
+				c.popMenu()
+				return nil
+			}
 			return ActionClose{}
+		case key.Matches(msg, c.keyMap.Back) && c.inSubMenu():
+			// Backspace pops out of a sub-menu, but only while in one. At the
+			// top level it must fall through to the input so it can edit the
+			// type-ahead filter (otherwise the case swallows it and backspace
+			// does nothing).
+			c.popMenu()
+			return nil
 		case key.Matches(msg, c.keyMap.Previous):
 			c.list.Focus()
 			if c.list.IsSelectedFirst() {
@@ -192,16 +216,20 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 		case key.Matches(msg, c.keyMap.Select):
 			if selectedItem := c.list.SelectedItem(); selectedItem != nil {
 				if item, ok := selectedItem.(*CommandItem); ok && item != nil {
+					if item.HasChildren() {
+						c.pushMenu(item)
+						return nil
+					}
 					return item.Action()
 				}
 			}
 		case key.Matches(msg, c.keyMap.Tab):
-			if len(c.customCommands) > 0 || len(c.mcpPrompts) > 0 {
+			if !c.inSubMenu() && (len(c.customCommands) > 0 || len(c.mcpPrompts) > 0) {
 				c.selected = c.nextCommandType()
 				c.setCommandItems(c.selected)
 			}
 		case key.Matches(msg, c.keyMap.ShiftTab):
-			if len(c.customCommands) > 0 || len(c.mcpPrompts) > 0 {
+			if !c.inSubMenu() && (len(c.customCommands) > 0 || len(c.mcpPrompts) > 0) {
 				c.selected = c.previousCommandType()
 				c.setCommandItems(c.selected)
 			}
@@ -210,6 +238,10 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 			for _, item := range c.list.FilteredItems() {
 				if item, ok := item.(*CommandItem); ok && item != nil {
 					if msg.String() == item.Shortcut() {
+						if item.HasChildren() {
+							c.pushMenu(item)
+							return nil
+						}
 						return item.Action()
 					}
 				}
@@ -296,7 +328,11 @@ func (c *Commands) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	rc := NewRenderContext(t, width)
 	rc.Title = "Commands"
-	rc.TitleInfo = commandsRadioView(t, c.selected, len(c.customCommands) > 0, len(c.mcpPrompts) > 0)
+	if c.inSubMenu() {
+		rc.Title = "Commands ▸ " + strings.Join(c.breadcrumb, " ▸ ")
+	} else {
+		rc.TitleInfo = commandsRadioView(t, c.selected, len(c.customCommands) > 0, len(c.mcpPrompts) > 0)
+	}
 	inputView := t.Dialog.InputPrompt.Render(c.input.View())
 	rc.AddPart(inputView)
 	listView := t.Dialog.List.Height(c.list.Height()).Render(c.list.Render())
@@ -376,6 +412,60 @@ func (c *Commands) previousCommandType() CommandType {
 	default:
 		return SystemCommands
 	}
+}
+
+// inSubMenu reports whether the dialog is currently inside a sub-menu.
+func (c *Commands) inSubMenu() bool {
+	return len(c.menuStack) > 0
+}
+
+// pushMenu saves the current list state and navigates into a sub-menu.
+func (c *Commands) pushMenu(parent *CommandItem) {
+	// Clear any active filter before snapshotting so we save the FULL parent
+	// list, not just the currently-matched subset. Otherwise popping back would
+	// drop every top-level item that didn't match the filter that was active
+	// when the user entered the sub-menu.
+	c.input.SetValue("")
+	c.list.SetFilter("")
+
+	// Save current visible items (includes FilterableItem interface).
+	c.menuStack = append(c.menuStack, menuLevel{
+		items: c.list.FilteredItems(),
+	})
+	c.breadcrumb = append(c.breadcrumb, parent.title)
+
+	children := make([]list.FilterableItem, len(parent.children))
+	for i, child := range parent.children {
+		children[i] = child
+	}
+	c.list.SetItems(children...)
+	c.list.SetFilter("")
+	c.list.ScrollToTop()
+	c.list.SetSelected(0)
+	c.input.SetValue("")
+}
+
+// popMenu restores the previous menu level from the stack.
+func (c *Commands) popMenu() {
+	if len(c.menuStack) == 0 {
+		return
+	}
+	level := c.menuStack[len(c.menuStack)-1]
+	c.menuStack = c.menuStack[:len(c.menuStack)-1]
+	c.breadcrumb = c.breadcrumb[:len(c.breadcrumb)-1]
+
+	// Restore items by re-setting them as FilterableItems.
+	fitems := make([]list.FilterableItem, 0, len(level.items))
+	for _, item := range level.items {
+		if fi, ok := item.(list.FilterableItem); ok {
+			fitems = append(fitems, fi)
+		}
+	}
+	c.list.SetItems(fitems...)
+	c.list.SetFilter("")
+	c.list.ScrollToTop()
+	c.list.SetSelected(0)
+	c.input.SetValue("")
 }
 
 // setCommandItems sets the command items based on the specified command type.

--- a/internal/ui/dialog/commands_item.go
+++ b/internal/ui/dialog/commands_item.go
@@ -19,6 +19,7 @@ type CommandItem struct {
 	description string
 	action      Action
 	aliases     []string
+	children    []*CommandItem
 	t           *styles.Styles
 	m           fuzzy.Match
 	cache       map[int]string
@@ -56,6 +57,17 @@ func (c *CommandItem) WithAliases(aliases ...string) *CommandItem {
 func (c *CommandItem) WithDescription(desc string) *CommandItem {
 	c.description = desc
 	return c
+}
+
+// WithChildren returns the CommandItem with child sub-menu items.
+func (c *CommandItem) WithChildren(children ...*CommandItem) *CommandItem {
+	c.children = children
+	return c
+}
+
+// HasChildren reports whether the item has a sub-menu.
+func (c *CommandItem) HasChildren() bool {
+	return len(c.children) > 0
 }
 
 // Filter implements ListItem.

--- a/internal/ui/dialog/commands_test.go
+++ b/internal/ui/dialog/commands_test.go
@@ -1,0 +1,253 @@
+package dialog
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/list"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+type testCommandsWorkspace struct {
+	workspace.Workspace
+	cfg *config.Config
+}
+
+func (w *testCommandsWorkspace) Config() *config.Config {
+	return w.cfg
+}
+
+func newTestCommands(t *testing.T) *Commands {
+	t.Helper()
+	s := styles.CharmtonePantera()
+	cfg := &config.Config{}
+	com := &common.Common{
+		Workspace: &testCommandsWorkspace{cfg: cfg},
+		Styles:    &s,
+	}
+	c, err := NewCommands(com, "", false, false, false, nil, nil)
+	require.NoError(t, err)
+	return c
+}
+
+func TestCommands_SubMenuNavigation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		keys       []tea.KeyPressMsg
+		wantStack  int
+		wantBread  []string
+		wantClose  bool
+		wantAction bool
+	}{
+		{
+			name:      "enter parent pushes sub-menu, no action fires",
+			keys:      []tea.KeyPressMsg{{Code: tea.KeyEnter}},
+			wantStack: 1,
+			wantBread: []string{"Parent"},
+		},
+		{
+			name:      "esc in sub-menu pops back",
+			keys:      []tea.KeyPressMsg{{Code: tea.KeyEnter}, {Code: tea.KeyEscape}},
+			wantStack: 0,
+			wantBread: []string{},
+		},
+		{
+			name:      "backspace in sub-menu pops back",
+			keys:      []tea.KeyPressMsg{{Code: tea.KeyEnter}, {Code: tea.KeyBackspace}},
+			wantStack: 0,
+			wantBread: []string{},
+		},
+		{
+			name:      "esc at top level closes dialog",
+			keys:      []tea.KeyPressMsg{{Code: tea.KeyEscape}},
+			wantStack: 0,
+			wantClose: true,
+		},
+		{
+			name:       "leaf child action fires on enter",
+			keys:       []tea.KeyPressMsg{{Code: tea.KeyEnter}, {Code: tea.KeyEnter}, {Code: tea.KeyEnter}},
+			wantStack:  2,
+			wantBread:  []string{"Parent", "Child A"},
+			wantAction: true,
+		},
+		{
+			name:      "nested sub-menu pushes twice",
+			keys:      []tea.KeyPressMsg{{Code: tea.KeyEnter}, {Code: tea.KeyEnter}},
+			wantStack: 2,
+			wantBread: []string{"Parent", "Child A"},
+		},
+		{
+			name:      "pop from nested restores to first sub-menu",
+			keys:      []tea.KeyPressMsg{{Code: tea.KeyEnter}, {Code: tea.KeyEnter}, {Code: tea.KeyEscape}},
+			wantStack: 1,
+			wantBread: []string{"Parent"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := setupMenuHierarchy(t)
+
+			var gotAction Action
+			for _, k := range tc.keys {
+				gotAction = c.HandleMsg(k)
+			}
+
+			require.Equal(t, tc.wantStack, len(c.menuStack), "menu stack depth")
+			require.Equal(t, tc.wantBread, c.breadcrumb, "breadcrumb")
+
+			if tc.wantClose {
+				_, ok := gotAction.(ActionClose)
+				require.True(t, ok, "expected ActionClose")
+			}
+			if tc.wantAction {
+				require.NotNil(t, gotAction, "expected an action to fire")
+				_, ok := gotAction.(ActionNewSession)
+				require.True(t, ok, "expected ActionNewSession from leaf")
+			}
+		})
+	}
+}
+
+func TestCommands_FilterScopedToCurrentLevel(t *testing.T) {
+	t.Parallel()
+
+	c := setupMenuHierarchy(t)
+
+	// Navigate into the sub-menu.
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, c.inSubMenu())
+
+	// Type a filter that matches a child but not the parent.
+	c.HandleMsg(keyMsg('a'))
+
+	filtered := c.list.FilteredItems()
+	// Should have at least one item (Child A matches "a").
+	require.NotEmpty(t, filtered)
+
+	// None of the filtered items should be the parent.
+	for _, item := range filtered {
+		if ci, ok := item.(*CommandItem); ok {
+			require.NotEqual(t, ci.id, "parent", "filter should not show parent items")
+		}
+	}
+}
+
+func TestCommands_TabDisabledInSubMenu(t *testing.T) {
+	t.Parallel()
+
+	c := setupMenuHierarchy(t)
+	require.False(t, c.inSubMenu())
+
+	// Tab normally cycles command types (no-op here since no custom commands).
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.Equal(t, SystemCommands, c.selected)
+
+	// Navigate into sub-menu.
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, c.inSubMenu())
+
+	// Tab should be a no-op while in sub-menu (selected stays SystemCommands).
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.Equal(t, SystemCommands, c.selected)
+}
+
+func TestCommands_LeafEnterFiresActionAndCloses(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCommands(t)
+
+	// Add a leaf item to the system commands.
+	leaf := NewCommandItem(c.com.Styles, "leaf", "Leaf Item", "", ActionNewSession{})
+	items := make([]list.FilterableItem, 1)
+	items[0] = leaf
+	c.list.SetItems(items...)
+	c.list.SetSelected(0)
+
+	action := c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	_, ok := action.(ActionNewSession)
+	require.True(t, ok, "leaf item should fire its action")
+}
+
+func TestCommands_BreadcrumbDraw(t *testing.T) {
+	t.Parallel()
+
+	c := setupMenuHierarchy(t)
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, c.inSubMenu())
+	require.Equal(t, []string{"Parent"}, c.breadcrumb)
+}
+
+// setupMenuHierarchy creates a Commands dialog with a parent item that has
+// children, where one child is itself a parent with a nested leaf.
+func TestCommands_PopRestoresFullParentList(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCommands(t)
+
+	leaf := NewCommandItem(c.com.Styles, "leaf", "Leaf", "", ActionNewSession{})
+	parent := NewCommandItem(c.com.Styles, "parent", "Alpha", "", nil).WithChildren(leaf)
+	sibling := NewCommandItem(c.com.Styles, "sibling", "Zulu", "", ActionNewSession{})
+
+	items := []list.FilterableItem{parent, sibling}
+	c.list.SetItems(items...)
+	c.list.SetSelected(0)
+
+	// Filter so only the parent ("Alpha") matches, leaving the sibling hidden.
+	c.HandleMsg(keyMsg('a'))
+	require.Len(t, c.list.FilteredItems(), 1, "filter should narrow to the parent")
+
+	// Enter the parent's sub-menu, then pop back to the top level.
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, c.inSubMenu())
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEscape})
+	require.False(t, c.inSubMenu())
+
+	// Both top-level items must be restored — not just the previously-filtered
+	// subset. Regression guard for pushMenu snapshotting FilteredItems() while a
+	// filter was active.
+	require.Len(t, c.list.FilteredItems(), 2, "popping should restore the full parent list")
+}
+
+func TestCommands_BackspaceEditsTopLevelFilter(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCommands(t)
+
+	// Type into the top-level type-ahead filter.
+	c.HandleMsg(keyMsg('m'))
+	c.HandleMsg(keyMsg('c'))
+	c.HandleMsg(keyMsg('p'))
+	require.Equal(t, "mcp", c.input.Value())
+	require.False(t, c.inSubMenu())
+
+	// Backspace at the top level must edit the filter, not be swallowed by the
+	// Back (pop-sub-menu) key binding. Regression guard for the case matching
+	// backspace unconditionally.
+	c.HandleMsg(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	require.False(t, c.inSubMenu())
+	require.Equal(t, "mc", c.input.Value(), "backspace should delete a char from the top-level filter")
+}
+
+func setupMenuHierarchy(t *testing.T) *Commands {
+	t.Helper()
+	c := newTestCommands(t)
+
+	leaf := NewCommandItem(c.com.Styles, "leaf", "Leaf", "", ActionNewSession{})
+	nestedParent := NewCommandItem(c.com.Styles, "child_a", "Child A", "", nil).WithChildren(leaf)
+	leaf2 := NewCommandItem(c.com.Styles, "child_b", "Child B", "", ActionNewSession{})
+	parent := NewCommandItem(c.com.Styles, "parent", "Parent", "", nil).WithChildren(nestedParent, leaf2)
+
+	items := make([]list.FilterableItem, 1)
+	items[0] = parent
+	c.list.SetItems(items...)
+	c.list.SetSelected(0)
+	return c
+}


### PR DESCRIPTION
Adds nested sub-menus to the "/" command palette. A CommandItem can carry child items via WithChildren; selecting a parent pushes into its sub-menu with a breadcrumb title, and Escape/Backspace pops back to the parent level. Type-ahead filtering is scoped to the current menu depth, and existing flat command items are unchanged.

Backspace at the top level continues to edit the filter as before — it only pops when inside a sub-menu — so the palette's existing filter behaviour is preserved.

Table-driven tests cover push/pop navigation, depth-scoped filtering, breadcrumb titles, and that flat items behave exactly as before.

Coordinated in #3302; approach green-lit in #3298.


Assisted-by: Crush (glm-5-turbo)
Assisted-by: Claude Code
Claude-Session: https://claude.ai/code/session_01AtvfVcwLAeVKk9SkRjb7GN

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
