### PR TITLE
fix: respect client-server mode during login

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -8,13 +8,12 @@ import (
 	"os/signal"
 
 	"charm.land/lipgloss/v2"
-	"github.com/charmbracelet/crush/internal/client"
 	"github.com/charmbracelet/crush/internal/clipboard"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/charmbracelet/crush/internal/oauth/copilot"
 	"github.com/charmbracelet/crush/internal/oauth/hyper"
-	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/crush/internal/workspace"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
@@ -44,17 +43,11 @@ crush login -f copilot
 	},
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c, ws, cleanup, err := connectToServer(cmd)
+		ws, cleanup, err := setupWorkspaceWithProgressBar(cmd)
 		if err != nil {
 			return err
 		}
 		defer cleanup()
-
-		progressEnabled := ws.Config.Options.Progress == nil || *ws.Config.Options.Progress
-		if progressEnabled && supportsProgressBar() {
-			_, _ = fmt.Fprintf(os.Stderr, ansi.SetIndeterminateProgressBar)
-			defer func() { _, _ = fmt.Fprintf(os.Stderr, ansi.ResetProgressBar) }()
-		}
 
 		provider := "hyper"
 		if len(args) > 0 {
@@ -63,9 +56,9 @@ crush login -f copilot
 		force, _ := cmd.Flags().GetBool("force")
 		switch provider {
 		case "hyper":
-			return loginHyper(c, ws.ID, force)
+			return loginHyper(ws, force)
 		case "copilot", "github", "github-copilot":
-			return loginCopilot(c, ws.ID, force)
+			return loginCopilot(ws, force)
 		default:
 			return fmt.Errorf("unknown platform: %s", args[0])
 		}
@@ -76,12 +69,12 @@ func init() {
 	loginCmd.Flags().BoolP("force", "f", false, "Force re-authentication even if already logged in")
 }
 
-func loginHyper(c *client.Client, wsID string, force bool) error {
+func loginHyper(ws workspace.Workspace, force bool) error {
 	ctx := getLoginContext()
 
 	if !force {
-		cfg, err := c.GetConfig(ctx, wsID)
-		if err == nil && cfg != nil {
+		cfg := ws.Config()
+		if cfg != nil {
 			if pc, ok := cfg.Providers.Get("hyper"); ok && pc.OAuthToken != nil {
 				fmt.Println("You are already logged in to Hyper.")
 				fmt.Println("Use --force to re-authenticate.")
@@ -132,8 +125,8 @@ func loginHyper(c *client.Client, wsID string, force bool) error {
 	}
 
 	if err := cmp.Or(
-		c.SetConfigField(ctx, wsID, config.ScopeGlobal, "providers.hyper.api_key", token.AccessToken),
-		c.SetConfigField(ctx, wsID, config.ScopeGlobal, "providers.hyper.oauth", token),
+		ws.SetConfigField(config.ScopeGlobal, "providers.hyper.api_key", token.AccessToken),
+		ws.SetConfigField(config.ScopeGlobal, "providers.hyper.oauth", token),
 	); err != nil {
 		return err
 	}
@@ -143,12 +136,12 @@ func loginHyper(c *client.Client, wsID string, force bool) error {
 	return nil
 }
 
-func loginCopilot(c *client.Client, wsID string, force bool) error {
+func loginCopilot(ws workspace.Workspace, force bool) error {
 	loginCtx := getLoginContext()
 
 	if !force {
-		cfg, err := c.GetConfig(loginCtx, wsID)
-		if err == nil && cfg != nil {
+		cfg := ws.Config()
+		if cfg != nil {
 			if pc, ok := cfg.Providers.Get("copilot"); ok && pc.OAuthToken != nil {
 				fmt.Println("You are already logged in to GitHub Copilot.")
 				fmt.Println("Use --force to re-authenticate.")
@@ -203,8 +196,8 @@ func loginCopilot(c *client.Client, wsID string, force bool) error {
 	}
 
 	if err := cmp.Or(
-		c.SetConfigField(loginCtx, wsID, config.ScopeGlobal, "providers.copilot.api_key", token.AccessToken),
-		c.SetConfigField(loginCtx, wsID, config.ScopeGlobal, "providers.copilot.oauth", token),
+		ws.SetConfigField(config.ScopeGlobal, "providers.copilot.api_key", token.AccessToken),
+		ws.SetConfigField(config.ScopeGlobal, "providers.copilot.oauth", token),
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
The login command was unconditionally connecting to a server process via Unix socket, causing authentication to fail when client-server mode is disabled. Now uses the standard workspace setup flow which respects the CRUSH_CLIENT_SERVER environment variable.

Assisted-by: Crush:qwen3.7-plus