### PR TITLE
feat: make dialogs resize better at smaller scales

### DIFF
--- a/internal/ui/chat/resize_bench_test.go
+++ b/internal/ui/chat/resize_bench_test.go
@@ -1,0 +1,77 @@
+package chat
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/db"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/list"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+)
+
+// BenchmarkResizeSession reproduces the resize re-render path over a real
+// session's messages. Point CRUSH_BENCH_SESSION at a full session id and
+// CRUSH_BENCH_DATADIR at the crush data dir (defaults to ./.crush).
+//
+//	CRUSH_BENCH_SESSION=e6368d820207a406 go test ./internal/ui/chat/ \
+//	  -run x -bench BenchmarkResizeSession -benchtime 20x -cpuprofile /tmp/cpu.out
+func BenchmarkResizeSession(b *testing.B) {
+	sessionID := os.Getenv("CRUSH_BENCH_SESSION")
+	if sessionID == "" {
+		b.Skip("set CRUSH_BENCH_SESSION to a full session id")
+	}
+	dataDir := os.Getenv("CRUSH_BENCH_DATADIR")
+	if dataDir == "" {
+		dataDir = ".crush"
+	}
+
+	ctx := context.Background()
+	conn, err := db.Connect(ctx, dataDir, db.WithDataDirLock(false))
+	if err != nil {
+		b.Fatalf("connect: %v", err)
+	}
+	// Note: intentionally not closing conn. db.Connect pools connections by
+	// path, and the testing framework may invoke this function more than
+	// once; closing would break the shared pooled *sql.DB on re-entry.
+
+	svc := message.NewService(db.New(conn))
+	msgs, err := svc.List(ctx, sessionID)
+	if err != nil {
+		b.Fatalf("list messages: %v", err)
+	}
+	if len(msgs) == 0 {
+		b.Fatalf("no messages for session %s", sessionID)
+	}
+	b.Logf("loaded %d messages", len(msgs))
+
+	ptrs := make([]*message.Message, len(msgs))
+	for i := range msgs {
+		ptrs[i] = &msgs[i]
+	}
+	toolResults := BuildToolResultMap(ptrs)
+
+	sty := styles.CharmtonePantera()
+	var items []list.Item
+	for _, m := range ptrs {
+		for _, it := range ExtractMessageItems(&sty, m, toolResults) {
+			items = append(items, it)
+		}
+	}
+	b.Logf("built %d items", len(items))
+
+	l := list.NewList(items...)
+
+	b.ResetTimer()
+	// Alternate widths so every iteration is a genuine width change, which
+	// is what invalidates the caches and forces a full re-render — exactly
+	// what a resize drag does.
+	widths := []int{100, 99}
+	i := 0
+	for b.Loop() {
+		l.SetSize(widths[i%2], 40)
+		_ = l.TotalHeight()
+		i++
+	}
+}

--- a/internal/ui/common/chromastyle.go
+++ b/internal/ui/common/chromastyle.go
@@ -1,0 +1,64 @@
+package common
+
+import (
+	"image/color"
+	"sync"
+
+	"github.com/alecthomas/chroma/v2"
+	chromastyles "github.com/alecthomas/chroma/v2/styles"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+)
+
+// Building a chroma style from a theme (chroma.MustNewStyle) parses every
+// token rule and resolves inheritance, which is expensive. Syntax
+// highlighting and diff formatting both did it on every call, so a chat
+// full of code views and diffs rebuilt the same style hundreds of times
+// per frame on resize. The result depends only on the theme (and, for
+// highlighting, an optional background override), so we memoize it.
+var (
+	chromaStyleMu   sync.Mutex
+	chromaStyleFor  *styles.Styles
+	chromaStyleBase *chroma.Style
+	chromaStyleByBg map[[3]uint8]*chroma.Style
+)
+
+// ChromaStyle returns the chroma style for the given theme, memoized. When
+// bg is non-nil the style's background is overridden with it (also
+// memoized per color). The cache resets whenever the active theme changes.
+func ChromaStyle(st *styles.Styles, bg color.Color) *chroma.Style {
+	chromaStyleMu.Lock()
+	defer chromaStyleMu.Unlock()
+
+	if chromaStyleFor != st {
+		chromaStyleFor = st
+		chromaStyleBase = nil
+		chromaStyleByBg = nil
+	}
+	if chromaStyleBase == nil {
+		chromaStyleBase = chroma.MustNewStyle("crush", st.ChromaTheme())
+	}
+	if bg == nil {
+		return chromaStyleBase
+	}
+
+	r, g, b, _ := bg.RGBA()
+	key := [3]uint8{uint8(r >> 8), uint8(g >> 8), uint8(b >> 8)}
+	if s, ok := chromaStyleByBg[key]; ok {
+		return s
+	}
+
+	built, err := chromaStyleBase.Builder().Transform(
+		func(t chroma.StyleEntry) chroma.StyleEntry {
+			t.Background = chroma.NewColour(key[0], key[1], key[2])
+			return t
+		},
+	).Build()
+	if err != nil {
+		built = chromastyles.Fallback
+	}
+	if chromaStyleByBg == nil {
+		chromaStyleByBg = map[[3]uint8]*chroma.Style{}
+	}
+	chromaStyleByBg[key] = built
+	return built
+}

--- a/internal/ui/common/diff.go
+++ b/internal/ui/common/diff.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"github.com/alecthomas/chroma/v2"
 	"github.com/charmbracelet/crush/internal/ui/diffview"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 )
@@ -10,7 +9,6 @@ import (
 // used to format diff outputs.
 func DiffFormatter(s *styles.Styles) *diffview.DiffView {
 	formatDiff := diffview.New()
-	style := chroma.MustNewStyle("crush", s.ChromaTheme())
-	diff := formatDiff.ChromaStyle(style).Style(s.Diff).TabWidth(4)
+	diff := formatDiff.ChromaStyle(ChromaStyle(s, nil)).Style(s.Diff).TabWidth(4)
 	return diff
 }

--- a/internal/ui/common/elements.go
+++ b/internal/ui/common/elements.go
@@ -225,8 +225,12 @@ func Section(t *styles.Styles, text string, width int, info ...string) string {
 }
 
 // DialogTitle renders a dialog title with a decorative line filling the
-// remaining width.
+// remaining width. When the title alone exceeds the available width it is
+// truncated with an ellipsis so it never wraps.
 func DialogTitle(t *styles.Styles, title string, width int, fromColor, toColor color.Color) string {
+	if width > 0 && lipgloss.Width(title) > width {
+		return ansi.Truncate(title, width, "…")
+	}
 	char := "╱"
 	length := lipgloss.Width(title) + 1
 	remainingWidth := width - length

--- a/internal/ui/common/highlight.go
+++ b/internal/ui/common/highlight.go
@@ -7,7 +7,6 @@ import (
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/formatters"
 	"github.com/alecthomas/chroma/v2/lexers"
-	chromastyles "github.com/alecthomas/chroma/v2/styles"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 )
 
@@ -31,19 +30,9 @@ func SyntaxHighlight(st *styles.Styles, source, fileName string, bg color.Color)
 		f = formatters.Fallback
 	}
 
-	style := chroma.MustNewStyle("crush", st.ChromaTheme())
-
-	// Modify the style to use the provided background
-	s, err := style.Builder().Transform(
-		func(t chroma.StyleEntry) chroma.StyleEntry {
-			r, g, b, _ := bg.RGBA()
-			t.Background = chroma.NewColour(uint8(r>>8), uint8(g>>8), uint8(b>>8))
-			return t
-		},
-	).Build()
-	if err != nil {
-		s = chromastyles.Fallback
-	}
+	// Memoized: building the style per call is expensive and only depends
+	// on the theme and background.
+	s := ChromaStyle(st, bg)
 
 	// Tokenize and format
 	it, err := l.Tokenise(nil, source)

--- a/internal/ui/common/highlight.go
+++ b/internal/ui/common/highlight.go
@@ -4,25 +4,25 @@ import (
 	"bytes"
 	"image/color"
 
-	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/formatters"
 	"github.com/alecthomas/chroma/v2/lexers"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/xchroma"
 )
 
 // SyntaxHighlight applies syntax highlighting to the given source code based
 // on the file name and background color. It returns the highlighted code as a
 // string.
 func SyntaxHighlight(st *styles.Styles, source, fileName string, bg color.Color) (string, error) {
-	// Determine the language lexer to use
-	l := lexers.Match(fileName)
+	// Determine the language lexer to use. The filename match is memoized
+	// (and already coalesced) since it is expensive and stable per name.
+	l := xchroma.MatchLexer(fileName)
 	if l == nil {
 		l = lexers.Analyse(source)
 	}
 	if l == nil {
 		l = lexers.Fallback
 	}
-	l = chroma.Coalesce(l)
 
 	// Get the formatter
 	f := formatters.Get("terminal16m")

--- a/internal/ui/dialog/api_key_input.go
+++ b/internal/ui/dialog/api_key_input.go
@@ -70,16 +70,13 @@ func NewAPIKeyInput(
 	m.provider = provider
 	m.model = model
 	m.modelType = modelType
-	m.width = 60
-
-	innerWidth := m.width - t.Dialog.View.GetHorizontalFrameSize() - 2
+	m.width = 0 // Set dynamically in Draw().
 
 	m.input = textinput.New()
 	m.input.SetVirtualCursor(false)
 	m.input.Placeholder = "Enter your API key..."
 	m.input.SetStyles(com.Styles.TextInput)
 	m.input.Focus()
-	m.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding
 
 	m.spinner = spinner.New(
 		spinner.WithSpinner(spinner.Dot),
@@ -160,6 +157,10 @@ func (m *APIKeyInput) HandleMsg(msg tea.Msg) Action {
 // Draw implements [Dialog].
 func (m *APIKeyInput) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	t := m.com.Styles
+
+	m.width = max(0, min(60, area.Dx()-t.Dialog.View.GetHorizontalBorderSize()))
+	innerWidth := m.width - t.Dialog.View.GetHorizontalFrameSize() - 2
+	m.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding
 
 	textStyle := t.Dialog.SecondaryText
 	helpStyle := t.Dialog.HelpView

--- a/internal/ui/dialog/api_key_input.go
+++ b/internal/ui/dialog/api_key_input.go
@@ -163,10 +163,9 @@ func (m *APIKeyInput) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	m.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding
 
 	textStyle := t.Dialog.SecondaryText
-	helpStyle := t.Dialog.HelpView
 	dialogStyle := t.Dialog.View.Width(m.width)
 	inputStyle := t.Dialog.InputPrompt
-	helpStyle = helpStyle.Width(m.width - dialogStyle.GetHorizontalFrameSize())
+	helpView := renderDialogHelp(t, &m.help, m, m.width-dialogStyle.GetHorizontalFrameSize())
 
 	m.input.Prompt = m.spinner.View()
 
@@ -176,7 +175,7 @@ func (m *APIKeyInput) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		textStyle.Render("This will be written in your global configuration:"),
 		textStyle.Render(config.GlobalConfigData()),
 		"",
-		helpStyle.Render(m.help.View(m)),
+		helpView,
 	}, "\n")
 
 	cur := m.Cursor()

--- a/internal/ui/dialog/arguments.go
+++ b/internal/ui/dialog/arguments.go
@@ -335,11 +335,7 @@ func (a *Arguments) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	a.viewport.SetHeight(viewportHeight)
 	a.viewport.SetContent(renderedFields)
 
-	scrollbar := common.Scrollbar(s, viewportHeight, a.viewport.TotalLineCount(), viewportHeight, a.viewport.YOffset())
-	content := a.viewport.View()
-	if scrollbar != "" {
-		content = lipgloss.JoinHorizontal(lipgloss.Top, content, scrollbar)
-	}
+	content := joinScrollbar(s, a.viewport.View(), viewportHeight, a.viewport.TotalLineCount(), viewportHeight, a.viewport.YOffset())
 	var contentParts []string
 	if description != "" {
 		contentParts = append(contentParts, description)

--- a/internal/ui/dialog/arguments.go
+++ b/internal/ui/dialog/arguments.go
@@ -323,7 +323,7 @@ func (a *Arguments) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		description = descStyle.Render(a.description)
 	}
 
-	helpView := s.Dialog.HelpView.Width(width).Render(a.help.View(a))
+	helpView := renderDialogHelp(s, &a.help, a, width)
 	if a.loading {
 		helpView = s.Dialog.HelpView.Width(width).Render(a.spinner.View() + " Generating Prompt...")
 	}

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -289,7 +289,7 @@ func (c *Commands) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		t.Dialog.HelpView.GetVerticalFrameSize() +
 		t.Dialog.View.GetVerticalFrameSize()
 
-	c.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding
+	c.input.SetWidth(dialogInputTextWidth(t, c.input, innerWidth))
 
 	c.list.SetSize(innerWidth, max(0, height-heightOffset))
 

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -292,7 +292,6 @@ func (c *Commands) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	c.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding
 
 	c.list.SetSize(innerWidth, height-heightOffset)
-	c.help.SetWidth(innerWidth)
 
 	rc := NewRenderContext(t, width)
 	rc.Title = "Commands"
@@ -301,10 +300,10 @@ func (c *Commands) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	rc.AddPart(inputView)
 	listView := t.Dialog.List.Height(c.list.Height()).Render(c.list.Render())
 	rc.AddPart(listView)
-	rc.Help = c.help.View(c)
+	rc.Help = renderDialogHelp(t, &c.help, c, innerWidth)
 
 	if c.loading {
-		rc.Help = c.spinner.View() + " Generating Prompt..."
+		rc.Help = t.Dialog.HelpView.Width(innerWidth).Render(c.spinner.View() + " Generating Prompt...")
 	}
 
 	view := rc.Render()

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -293,6 +293,9 @@ func (c *Commands) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	c.list.SetSize(innerWidth, max(0, height-heightOffset))
 
+	// Hide the shortcut hints uniformly when the widest would crowd names.
+	applyInfoColumnVisibility(c.list.FilteredItems(), innerWidth, commandInfoMaxPercent)
+
 	rc := NewRenderContext(t, width)
 	rc.Title = "Commands"
 	rc.TitleInfo = commandsRadioView(t, c.selected, len(c.customCommands) > 0, len(c.mcpPrompts) > 0)

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -291,7 +291,7 @@ func (c *Commands) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	c.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding
 
-	c.list.SetSize(innerWidth, height-heightOffset)
+	c.list.SetSize(innerWidth, max(0, height-heightOffset))
 
 	rc := NewRenderContext(t, width)
 	rc.Title = "Commands"

--- a/internal/ui/dialog/commands_item.go
+++ b/internal/ui/dialog/commands_item.go
@@ -23,6 +23,7 @@ type CommandItem struct {
 	m           fuzzy.Match
 	cache       map[int]string
 	focused     bool
+	hideInfo    bool
 }
 
 var _ ListItem = &CommandItem{Versioned: list.NewVersioned()}
@@ -109,6 +110,24 @@ func (c *CommandItem) Shortcut() string {
 	return c.shortcut
 }
 
+// InfoText implements infoColumnItem; the command shortcut is its info.
+func (c *CommandItem) InfoText() string {
+	return c.shortcut
+}
+
+// SetHideInfo controls whether the shortcut hint column is shown. The
+// dialog hides it uniformly when it would crowd the command names.
+func (c *CommandItem) SetHideInfo(v bool) {
+	if c.hideInfo == v {
+		return
+	}
+	c.cache = nil
+	c.hideInfo = v
+	if c.Versioned != nil {
+		c.Bump()
+	}
+}
+
 // Render implements ListItem.
 func (c *CommandItem) Render(width int) string {
 	styles := ListItemStyles{
@@ -117,7 +136,11 @@ func (c *CommandItem) Render(width int) string {
 		InfoTextBlurred: c.t.Dialog.ListItem.InfoBlurred,
 		InfoTextFocused: c.t.Dialog.ListItem.InfoFocused,
 	}
-	rendered := renderItem(styles, c.title, c.shortcut, c.focused, width, c.cache, &c.m)
+	shortcut := c.shortcut
+	if c.hideInfo {
+		shortcut = ""
+	}
+	rendered := renderItem(styles, c.title, shortcut, c.focused, width, c.cache, &c.m)
 	if c.description != "" {
 		descStyle := c.t.Dialog.SecondaryText
 		if c.focused {

--- a/internal/ui/dialog/common.go
+++ b/internal/ui/dialog/common.go
@@ -10,8 +10,48 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/list"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 )
+
+// Maximum share of a list row width the secondary info column may take
+// before it is hidden entirely, so it never crowds out the item name.
+// Command shortcuts are small and non-essential, so they yield sooner
+// than the larger, more useful session timestamps.
+const (
+	sessionInfoMaxPercent = 35
+	commandInfoMaxPercent = 25
+)
+
+// infoColumnItem is a list item with a secondary info column (a session
+// timestamp, a command shortcut) that can be hidden when space is tight.
+type infoColumnItem interface {
+	// InfoText returns the raw info string, or "" when there is none.
+	InfoText() string
+	// SetHideInfo toggles whether the info column is rendered.
+	SetHideInfo(bool)
+}
+
+// applyInfoColumnVisibility hides the secondary info column across every
+// item uniformly when its widest entry would take more than maxPercent of
+// rowWidth, so item names keep their room. It returns once rowWidth grows
+// enough for the widest entry to fit within the budget again.
+func applyInfoColumnVisibility(items []list.Item, rowWidth, maxPercent int) {
+	widest := 0
+	for _, it := range items {
+		if ic, ok := it.(infoColumnItem); ok {
+			if info := ic.InfoText(); info != "" {
+				widest = max(widest, lipgloss.Width(" "+info+" "))
+			}
+		}
+	}
+	hide := rowWidth > 0 && widest*100 > rowWidth*maxPercent
+	for _, it := range items {
+		if ic, ok := it.(infoColumnItem); ok {
+			ic.SetHideInfo(hide)
+		}
+	}
+}
 
 // renderDialogHelp renders keybind hints as a single padded footer line at
 // contentWidth (the dialog's inner width: total minus the View border). The

--- a/internal/ui/dialog/common.go
+++ b/internal/ui/dialog/common.go
@@ -28,6 +28,17 @@ func dialogInputTextWidth(t *styles.Styles, input textinput.Model, contentWidth 
 		cursorPadding)
 }
 
+// joinScrollbar appends a vertical scrollbar to the right of view when the
+// content overflows its viewport, and returns view unchanged otherwise.
+// contentSize is the total content height, viewportSize the visible height,
+// and offset the current scroll position.
+func joinScrollbar(t *styles.Styles, view string, height, contentSize, viewportSize, offset int) string {
+	if sb := common.Scrollbar(t, height, contentSize, viewportSize, offset); sb != "" {
+		return lipgloss.JoinHorizontal(lipgloss.Top, view, sb)
+	}
+	return view
+}
+
 // Maximum share of a list row width the secondary info column may take
 // before it is hidden entirely, so it never crowds out the item name.
 // Command shortcuts are small and non-essential, so they yield sooner

--- a/internal/ui/dialog/common.go
+++ b/internal/ui/dialog/common.go
@@ -1,15 +1,72 @@
 package dialog
 
 import (
+	"cmp"
 	"image/color"
 	"strings"
 
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/x/ansi"
 )
+
+// renderDialogHelp renders keybind hints as a single padded footer line at
+// contentWidth (the dialog's inner width: total minus the View border). The
+// hints are packed greedily and truncated with an ellipsis so the line never
+// wraps or overflows the border, and never ends on a dangling separator.
+func renderDialogHelp(t *styles.Styles, h *help.Model, km help.KeyMap, contentWidth int) string {
+	textWidth := max(0, contentWidth-t.Dialog.HelpView.GetHorizontalFrameSize())
+	return t.Dialog.HelpView.Render(shortHelpLine(h, km.ShortHelp(), textWidth))
+}
+
+// shortHelpLine builds a single-line short help view truncated to width.
+// It reimplements the bubbles help packing to avoid a component bug where
+// items are kept even when they overflow (when the ellipsis itself does not
+// fit), and to guarantee the line ends cleanly rather than on a separator.
+func shortHelpLine(h *help.Model, bindings []key.Binding, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	sep := h.Styles.ShortSeparator.Inline(true).Render(h.ShortSeparator)
+	ellipsis := h.Styles.Ellipsis.Inline(true).Render(cmp.Or(h.Ellipsis, "…"))
+
+	var b strings.Builder
+	total := 0
+	for _, kb := range bindings {
+		if !kb.Enabled() {
+			continue
+		}
+		seg := ""
+		if total > 0 {
+			seg = sep
+		}
+		seg += h.Styles.ShortKey.Inline(true).Render(kb.Help().Key) + " " +
+			h.Styles.ShortDesc.Inline(true).Render(kb.Help().Desc)
+		w := lipgloss.Width(seg)
+		if total+w > width {
+			// The next item doesn't fit; add an ellipsis if there's room.
+			// The separator belongs to this dropped item, so what we've
+			// written already ends on a real hint, not a dangling dot. A
+			// leading space joins the ellipsis to prior hints, but only
+			// when there are prior hints.
+			tail := ellipsis
+			if total > 0 {
+				tail = " " + ellipsis
+			}
+			if total+lipgloss.Width(tail) <= width {
+				b.WriteString(tail)
+			}
+			break
+		}
+		total += w
+		b.WriteString(seg)
+	}
+	return b.String()
+}
 
 // InputCursor adjusts the cursor position for an input field within a dialog.
 func InputCursor(t *styles.Styles, cur *tea.Cursor) *tea.Cursor {
@@ -85,8 +142,9 @@ type RenderContext struct {
 	TitleInfo string
 	// Parts are the rendered parts of the dialog.
 	Parts []string
-	// Help is the help view content. This will be appended to the content parts
-	// slice using the default dialog help style.
+	// Help is the fully rendered help footer line. Produce it with
+	// renderDialogHelp so it is sized and padded consistently; it is
+	// appended as-is without further styling.
 	Help string
 	// IsOnboarding indicates whether to render the dialog as part of the
 	// onboarding flow. This means that the content will be rendered at the
@@ -162,11 +220,7 @@ func (rc *RenderContext) Render() string {
 		if rc.Gap > 0 {
 			parts = append(parts, make([]string, rc.Gap)...)
 		}
-		helpWidth := rc.Width - dialogStyle.GetHorizontalFrameSize()
-		helpStyle := rc.Styles.Dialog.HelpView
-		helpStyle = helpStyle.Width(helpWidth)
-		helpView := ansi.Truncate(helpStyle.Render(rc.Help), helpWidth-1, "")
-		parts = append(parts, helpView)
+		parts = append(parts, rc.Help)
 	}
 
 	content := strings.Join(parts, "\n")

--- a/internal/ui/dialog/common.go
+++ b/internal/ui/dialog/common.go
@@ -122,16 +122,22 @@ func (rc *RenderContext) Render() string {
 	var parts []string
 
 	if len(rc.Title) > 0 {
+		contentWidth := rc.Width - dialogStyle.GetHorizontalFrameSize() -
+			titleStyle.GetHorizontalFrameSize()
 		var titleInfoWidth int
-		if len(rc.TitleInfo) > 0 {
-			titleInfoWidth = lipgloss.Width(rc.TitleInfo)
+		titleInfo := rc.TitleInfo
+		if len(titleInfo) > 0 {
+			titleInfoWidth = lipgloss.Width(titleInfo)
+			// Truncate TitleInfo if it would push past dialog width.
+			if titleInfoWidth > contentWidth {
+				titleInfo = ansi.Truncate(titleInfo, max(0, contentWidth), "…")
+				titleInfoWidth = lipgloss.Width(titleInfo)
+			}
 		}
 		title := common.DialogTitle(rc.Styles, rc.Title,
-			max(0, rc.Width-dialogStyle.GetHorizontalFrameSize()-
-				titleStyle.GetHorizontalFrameSize()-
-				titleInfoWidth), rc.TitleGradientFromColor, rc.TitleGradientToColor)
-		if len(rc.TitleInfo) > 0 {
-			title += rc.TitleInfo
+			max(0, contentWidth-titleInfoWidth), rc.TitleGradientFromColor, rc.TitleGradientToColor)
+		if len(titleInfo) > 0 {
+			title += titleInfo
 		}
 		parts = append(parts, titleStyle.Render(title))
 		if rc.Gap > 0 {

--- a/internal/ui/dialog/common.go
+++ b/internal/ui/dialog/common.go
@@ -11,7 +11,6 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/styles"
-	"github.com/charmbracelet/x/ansi"
 )
 
 // renderDialogHelp renders keybind hints as a single padded footer line at
@@ -182,15 +181,15 @@ func (rc *RenderContext) Render() string {
 	if len(rc.Title) > 0 {
 		contentWidth := rc.Width - dialogStyle.GetHorizontalFrameSize() -
 			titleStyle.GetHorizontalFrameSize()
-		var titleInfoWidth int
 		titleInfo := rc.TitleInfo
-		if len(titleInfo) > 0 {
-			titleInfoWidth = lipgloss.Width(titleInfo)
-			// Truncate TitleInfo if it would push past dialog width.
-			if titleInfoWidth > contentWidth {
-				titleInfo = ansi.Truncate(titleInfo, max(0, contentWidth), "…")
-				titleInfoWidth = lipgloss.Width(titleInfo)
-			}
+		titleInfoWidth := lipgloss.Width(titleInfo)
+		// Drop the title info entirely when it can't sit beside the title
+		// text with at least a one-cell gap. Title info is often styled
+		// (e.g. radio toggles with backgrounds and padding); truncating it
+		// mid-segment leaves broken colored fragments, so hide it instead.
+		if titleInfoWidth > 0 && lipgloss.Width(rc.Title)+1+titleInfoWidth > contentWidth {
+			titleInfo = ""
+			titleInfoWidth = 0
 		}
 		title := common.DialogTitle(rc.Styles, rc.Title,
 			max(0, contentWidth-titleInfoWidth), rc.TitleGradientFromColor, rc.TitleGradientToColor)

--- a/internal/ui/dialog/common.go
+++ b/internal/ui/dialog/common.go
@@ -7,12 +7,26 @@ import (
 
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/list"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 )
+
+// dialogInputTextWidth returns the text-area width for a dialog input so
+// that the input frame, its prompt (e.g. "> "), the text, and a trailing
+// cursor cell all fit within contentWidth. The prompt is rendered outside
+// the text area, so it must be subtracted or long values wrap past the
+// dialog border.
+func dialogInputTextWidth(t *styles.Styles, input textinput.Model, contentWidth int) int {
+	const cursorPadding = 1
+	return max(0, contentWidth-
+		t.Dialog.InputPrompt.GetHorizontalFrameSize()-
+		lipgloss.Width(input.Prompt)-
+		cursorPadding)
+}
 
 // Maximum share of a list row width the secondary info column may take
 // before it is hidden entirely, so it never crowds out the item name.

--- a/internal/ui/dialog/dialog.go
+++ b/internal/ui/dialog/dialog.go
@@ -253,9 +253,13 @@ func (d *Overlay) StopLoading() {
 }
 
 // DrawCenterCursor draws the given string view centered in the screen area and
-// adjusts the cursor position accordingly.
+// adjusts the cursor position accordingly. Content larger than the area is
+// clamped to fit.
 func DrawCenterCursor(scr uv.Screen, area uv.Rectangle, view string, cur *tea.Cursor) {
 	width, height := lipgloss.Size(view)
+	// Clamp to available area so oversized dialogs don't draw outside bounds.
+	width = min(width, area.Dx())
+	height = min(height, area.Dy())
 	center := common.CenterRect(area, width, height)
 	if cur != nil {
 		cur.X += center.Min.X
@@ -275,9 +279,12 @@ func DrawOnboarding(scr uv.Screen, area uv.Rectangle, view string) {
 }
 
 // DrawOnboardingCursor draws the given string view positioned at the bottom
-// left area of the screen.
+// left area of the screen. Content larger than the area is clamped to fit.
 func DrawOnboardingCursor(scr uv.Screen, area uv.Rectangle, view string, cur *tea.Cursor) {
 	width, height := lipgloss.Size(view)
+	// Clamp to available area so oversized dialogs don't draw outside bounds.
+	width = min(width, area.Dx())
+	height = min(height, area.Dy())
 	bottomLeft := common.BottomLeftRect(area, width, height)
 	if cur != nil {
 		cur.X += bottomLeft.Min.X

--- a/internal/ui/dialog/filepicker.go
+++ b/internal/ui/dialog/filepicker.go
@@ -221,30 +221,38 @@ const (
 
 // Draw renders the [FilePicker] dialog as a string.
 func (f *FilePicker) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
-	width := max(0, min(filePickerMinWidth, area.Dx()))
-	height := max(0, min(10, area.Dy()))
-	innerWidth := width - f.com.Styles.Dialog.View.GetHorizontalFrameSize()
-	imgPrevHeight := filePickerMinHeight*2 - f.com.Styles.Dialog.ImagePreview.GetVerticalFrameSize()
-	imgPrevWidth := innerWidth - f.com.Styles.Dialog.ImagePreview.GetHorizontalFrameSize()
+	t := f.com.Styles
+	width := max(0, min(filePickerMinWidth, area.Dx()-t.Dialog.View.GetHorizontalBorderSize()))
+	height := max(0, min(10, area.Dy()-t.Dialog.View.GetVerticalBorderSize()))
+	innerWidth := width - t.Dialog.View.GetHorizontalFrameSize()
+
+	// Scale down image preview on small screens. Hide it entirely
+	// when the dialog is too short to show both preview and files.
+	imgPrevHeight := 0
+	if height > 5 {
+		imgPrevHeight = filePickerMinHeight*2 - t.Dialog.ImagePreview.GetVerticalFrameSize()
+	}
+	imgPrevWidth := innerWidth - t.Dialog.ImagePreview.GetHorizontalFrameSize()
 	f.imgPrevWidth = imgPrevWidth
 	f.imgPrevHeight = imgPrevHeight
 	f.fp.SetHeight(height)
 
-	styles := f.com.Styles.FilePicker
+	styles := t.FilePicker
 	styles.File = styles.File.Width(innerWidth)
 	styles.Directory = styles.Directory.Width(innerWidth)
 	styles.Selected = styles.Selected.PaddingLeft(1).Width(innerWidth)
 	styles.DisabledSelected = styles.DisabledSelected.PaddingLeft(1).Width(innerWidth)
 	f.fp.Styles = styles
 
-	t := f.com.Styles
 	rc := NewRenderContext(t, width)
 	rc.Gap = 1
 	rc.Title = "Add Image"
 	rc.Help = f.help.View(f)
 
-	imgPreview := t.Dialog.ImagePreview.Align(lipgloss.Center).Width(innerWidth).Render(f.imagePreview(imgPrevWidth, imgPrevHeight))
-	rc.AddPart(imgPreview)
+	if imgPrevHeight > 0 {
+		imgPreview := t.Dialog.ImagePreview.Align(lipgloss.Center).Width(innerWidth).Render(f.imagePreview(imgPrevWidth, imgPrevHeight))
+		rc.AddPart(imgPreview)
+	}
 
 	files := strings.TrimSpace(f.fp.View())
 	rc.AddPart(files)

--- a/internal/ui/dialog/filepicker.go
+++ b/internal/ui/dialog/filepicker.go
@@ -247,7 +247,7 @@ func (f *FilePicker) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	rc := NewRenderContext(t, width)
 	rc.Gap = 1
 	rc.Title = "Add Image"
-	rc.Help = f.help.View(f)
+	rc.Help = renderDialogHelp(t, &f.help, f, innerWidth)
 
 	if imgPrevHeight > 0 {
 		imgPreview := t.Dialog.ImagePreview.Align(lipgloss.Center).Width(innerWidth).Render(f.imagePreview(imgPrevWidth, imgPrevHeight))

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -266,7 +266,6 @@ func (m *Models) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		t.Dialog.View.GetVerticalFrameSize()
 
 	m.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding
-	m.help.SetWidth(innerWidth)
 
 	listHeight := height - heightOffset
 	listWidth := max(0, innerWidth-3) // Reserve space for scrollbar.
@@ -292,7 +291,7 @@ func (m *Models) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	}
 	rc.AddPart(listView)
 
-	rc.Help = m.help.View(m)
+	rc.Help = renderDialogHelp(t, &m.help, m, innerWidth)
 
 	cur := m.Cursor()
 

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -267,7 +267,7 @@ func (m *Models) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	m.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding
 
-	listHeight := height - heightOffset
+	listHeight := max(0, height-heightOffset)
 	listWidth := max(0, innerWidth-3) // Reserve space for scrollbar.
 	m.list.SetSize(listWidth, listHeight)
 	listTotalHeight := m.list.TotalHeight()

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -10,7 +10,6 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/catwalk/pkg/catwalk"
-	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/util"
@@ -291,10 +290,7 @@ func (m *Models) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	rc.AddPart(inputView)
 
 	listView := t.Dialog.List.Height(m.list.Height()).Render(m.list.Render())
-	scrollbar := common.Scrollbar(t, listHeight, listTotalHeight, listHeight+1, m.list.Offset())
-	if scrollbar != "" {
-		listView = lipgloss.JoinHorizontal(lipgloss.Top, listView, scrollbar)
-	}
+	listView = joinScrollbar(t, listView, listHeight, listTotalHeight, listHeight+1, m.list.Offset())
 	rc.AddPart(listView)
 
 	rc.Help = renderDialogHelp(t, &m.help, m, innerWidth)

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -268,9 +268,15 @@ func (m *Models) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	m.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding
 
 	listHeight := max(0, height-heightOffset)
-	listWidth := max(0, innerWidth-3) // Reserve space for scrollbar.
-	m.list.SetSize(listWidth, listHeight)
 	listTotalHeight := m.list.TotalHeight()
+	// Reserve one column for the scrollbar only when it will actually
+	// show, so the list otherwise spans the full content width.
+	scrollbarWidth := 0
+	if listTotalHeight > listHeight+1 {
+		scrollbarWidth = 1
+	}
+	listWidth := max(0, innerWidth-scrollbarWidth)
+	m.list.SetSize(listWidth, listHeight)
 
 	rc := NewRenderContext(t, width)
 	rc.Title = "Switch Model"

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -265,7 +265,7 @@ func (m *Models) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		t.Dialog.HelpView.GetVerticalFrameSize() +
 		t.Dialog.View.GetVerticalFrameSize()
 
-	m.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding
+	m.input.SetWidth(dialogInputTextWidth(t, m.input, innerWidth))
 
 	listHeight := max(0, height-heightOffset)
 	listTotalHeight := m.list.TotalHeight()

--- a/internal/ui/dialog/models_item.go
+++ b/internal/ui/dialog/models_item.go
@@ -51,7 +51,16 @@ func (m *ModelGroup) Render(width int) string {
 	}
 
 	title := " " + m.Title + " "
-	title = ansi.Truncate(title, max(0, width-lipgloss.Width(configured)-1), "…")
+	// Keep the "Configured" badge only when the full title fits beside it
+	// (plus a separator). Otherwise drop it and let the title use the whole
+	// width, rather than truncating the title to reserve room for a badge
+	// that common.Section would then drop anyway, leaving dead space.
+	if configured != "" && lipgloss.Width(title)+lipgloss.Width(configured)+3 > width {
+		configured = ""
+	}
+	if configured == "" {
+		title = ansi.Truncate(title, max(0, width-1), "…")
+	}
 
 	return common.Section(m.t, title, width, configured)
 }

--- a/internal/ui/dialog/notifications.go
+++ b/internal/ui/dialog/notifications.go
@@ -181,7 +181,7 @@ func (n *Notifications) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		t.Dialog.HelpView.GetVerticalFrameSize() +
 		t.Dialog.View.GetVerticalFrameSize()
 
-	n.input.SetWidth(innerWidth - t.Dialog.InputPrompt.GetHorizontalFrameSize() - 1)
+	n.input.SetWidth(dialogInputTextWidth(t, n.input, innerWidth))
 	n.list.SetSize(innerWidth, max(0, height-heightOffset))
 
 	rc := NewRenderContext(t, width)

--- a/internal/ui/dialog/notifications.go
+++ b/internal/ui/dialog/notifications.go
@@ -182,7 +182,7 @@ func (n *Notifications) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		t.Dialog.View.GetVerticalFrameSize()
 
 	n.input.SetWidth(innerWidth - t.Dialog.InputPrompt.GetHorizontalFrameSize() - 1)
-	n.list.SetSize(innerWidth, height-heightOffset)
+	n.list.SetSize(innerWidth, max(0, height-heightOffset))
 
 	rc := NewRenderContext(t, width)
 	rc.Title = "Notification Style"

--- a/internal/ui/dialog/notifications.go
+++ b/internal/ui/dialog/notifications.go
@@ -183,7 +183,6 @@ func (n *Notifications) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	n.input.SetWidth(innerWidth - t.Dialog.InputPrompt.GetHorizontalFrameSize() - 1)
 	n.list.SetSize(innerWidth, height-heightOffset)
-	n.help.SetWidth(innerWidth)
 
 	rc := NewRenderContext(t, width)
 	rc.Title = "Notification Style"
@@ -199,7 +198,7 @@ func (n *Notifications) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	listView := t.Dialog.List.Height(n.list.Height()).Render(n.list.Render())
 	rc.AddPart(listView)
-	rc.Help = n.help.View(n)
+	rc.Help = renderDialogHelp(t, &n.help, n, innerWidth)
 
 	view := rc.Render()
 

--- a/internal/ui/dialog/notifications.go
+++ b/internal/ui/dialog/notifications.go
@@ -173,8 +173,8 @@ func (n *Notifications) Cursor() *tea.Cursor {
 // Draw implements [Dialog].
 func (n *Notifications) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	t := n.com.Styles
-	width := max(0, min(notificationsDialogMaxWidth, area.Dx()))
-	height := max(0, min(notificationsDialogMaxHeight, area.Dy()))
+	width := max(0, min(notificationsDialogMaxWidth, area.Dx()-t.Dialog.View.GetHorizontalBorderSize()))
+	height := max(0, min(notificationsDialogMaxHeight, area.Dy()-t.Dialog.View.GetVerticalBorderSize()))
 	innerWidth := width - t.Dialog.View.GetHorizontalFrameSize()
 	heightOffset := t.Dialog.Title.GetVerticalFrameSize() + titleContentHeight +
 		t.Dialog.InputPrompt.GetVerticalFrameSize() + inputContentHeight +

--- a/internal/ui/dialog/oauth.go
+++ b/internal/ui/dialog/oauth.go
@@ -286,11 +286,15 @@ func (m *OAuth) innerDialogContent() string {
 		statusTextStyle  = t.Dialog.OAuth.StatusText
 	)
 
+	// innerWidth is the dialog's content area: total width minus the
+	// View frame (border). Every block sizes to this so nothing gets
+	// re-wrapped when the dialog frame renders it.
+	innerWidth := m.width - t.Dialog.View.GetHorizontalFrameSize()
+
 	switch m.State {
 	case OAuthStateInitializing:
 		return lipgloss.NewStyle().
-			Margin(1, 1).
-			Width(m.width - 2).
+			Width(innerWidth).
 			Align(lipgloss.Center).
 			Render(
 				successStyle.Render(m.spinner.View()) +
@@ -298,34 +302,35 @@ func (m *OAuth) innerDialogContent() string {
 			)
 
 	case OAuthStateDisplay:
+		// Render each text segment with its own style. Wrapping the
+		// whole concatenation in a single style would lose the text
+		// color after enterKeyStyle's reset code.
+		instructionText := instructionStyle.Render("Press ") +
+			enterKeyStyle.Render("enter") +
+			instructionStyle.Render(" to copy the code below and open the browser.")
 		instructions := lipgloss.NewStyle().
-			Margin(0, 1).
-			Width(m.width - 2).
-			Render(
-				instructionStyle.Render("Press ") +
-					enterKeyStyle.Render("enter") +
-					instructionStyle.Render(" to copy the code below and open the browser."),
-			)
+			Width(innerWidth).
+			Padding(0, 1).
+			Render(instructionText)
 
 		codeBox := lipgloss.NewStyle().
-			Width(m.width-2).
+			Width(innerWidth).
 			Height(7).
 			Align(lipgloss.Center, lipgloss.Center).
 			Background(t.Dialog.OAuth.UserCodeBg).
-			Margin(0, 1).
 			Render(
 				t.Dialog.OAuth.UserCode.Render(m.userCode),
 			)
 
 		link := linkStyle.Hyperlink(m.verificationURL, "id=oauth-verify").Render(m.verificationURL)
 		url := statusTextStyle.
-			Margin(0, 1).
-			Width(m.width - 2).
+			Width(innerWidth).
+			Padding(0, 1).
 			Render("Browser not opening? Pay a visit to:\n" + link)
 
-		waiting := lipgloss.NewStyle().
-			Margin(0, 1).
-			Width(m.width - 2).
+		waiting := statusTextStyle.
+			Width(innerWidth).
+			Padding(0, 1).
 			Render(
 				successStyle.Render(m.spinner.View()) + statusTextStyle.Render("Verifying..."),
 			)
@@ -345,14 +350,13 @@ func (m *OAuth) innerDialogContent() string {
 
 	case OAuthStateSuccess:
 		return successStyle.
-			Margin(1).
-			Width(m.width - 2).
+			Width(innerWidth).
+			Padding(1).
 			Render("Authentication successful!")
 
 	case OAuthStateSaving:
 		return lipgloss.NewStyle().
-			Margin(1, 1).
-			Width(m.width - 2).
+			Width(innerWidth).
 			Align(lipgloss.Center).
 			Render(
 				successStyle.Render(m.spinner.View()) +
@@ -360,10 +364,10 @@ func (m *OAuth) innerDialogContent() string {
 			)
 
 	case OAuthStateError:
-		return lipgloss.NewStyle().
-			Margin(1).
-			Width(m.width - 2).
-			Render(errorStyle.Render("Authentication failed."))
+		return errorStyle.
+			Width(innerWidth).
+			Padding(1).
+			Render("Authentication failed.")
 
 	default:
 		return ""

--- a/internal/ui/dialog/oauth.go
+++ b/internal/ui/dialog/oauth.go
@@ -241,20 +241,18 @@ func (m *OAuth) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 }
 
 func (m *OAuth) dialogContent() string {
-	var (
-		t         = m.com.Styles
-		helpStyle = t.Dialog.HelpView
-	)
+	t := m.com.Styles
 
 	switch m.State {
 	case OAuthStateInitializing, OAuthStateSaving:
 		return m.innerDialogContent()
 
 	default:
+		innerWidth := m.width - t.Dialog.View.GetHorizontalFrameSize()
 		elements := []string{
 			m.headerContent(),
 			m.innerDialogContent(),
-			helpStyle.Render(m.help.View(m)),
+			renderDialogHelp(t, &m.help, m, innerWidth),
 		}
 		return strings.Join(elements, "\n")
 	}

--- a/internal/ui/dialog/oauth.go
+++ b/internal/ui/dialog/oauth.go
@@ -90,7 +90,7 @@ func newOAuth(
 	m.model = model
 	m.modelType = modelType
 	m.oAuthProvider = oAuthProvider
-	m.width = 60
+	m.width = 0 // Set dynamically in Draw().
 	m.State = OAuthStateInitializing
 
 	m.spinner = spinner.New(
@@ -226,8 +226,10 @@ type oauthSaveErrMsg struct {
 func (m *OAuth) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	var (
 		t           = m.com.Styles
-		dialogStyle = t.Dialog.View.Width(m.width)
+		dialogWidth = max(0, min(60, area.Dx()-t.Dialog.View.GetHorizontalBorderSize()))
+		dialogStyle = t.Dialog.View.Width(dialogWidth)
 	)
+	m.width = dialogWidth
 	if m.isOnboarding {
 		view := m.dialogContent()
 		DrawOnboarding(scr, area, view)

--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -373,7 +373,11 @@ func (p *Permissions) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	contentWidth := p.calculateContentWidth(width)
 	header := p.renderHeader(contentWidth)
 	buttons := p.renderButtons(contentWidth)
-	helpView := p.help.View(p)
+	// Pack the hints to the content width so they truncate cleanly instead
+	// of overflowing. The dialog frame supplies the padding, so this renders
+	// the hint line without the extra help view inset that renderDialogHelp
+	// applies for RenderContext dialogs.
+	helpView := shortHelpLine(&p.help, p.ShortHelp(), contentWidth)
 
 	// Calculate available height for content.
 	headerHeight := lipgloss.Height(header)

--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -347,27 +347,43 @@ func (p *Permissions) scrollRight() {
 }
 
 // Draw implements [Dialog].
-func (p *Permissions) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
-	t := p.com.Styles
-	// Force fullscreen when window is too small.
-	forceFullscreen := area.Dx() <= minWindowWidth || area.Dy() <= minWindowHeight
-
-	// Calculate dialog dimensions based on fullscreen state and content type.
-	var width, maxHeight int
-	if forceFullscreen || (p.fullscreen && p.hasDiffView()) {
-		// Use nearly full window for fullscreen.
-		width = area.Dx()
-		maxHeight = area.Dy()
-	} else if p.hasDiffView() {
+// dialogSize returns the outer dialog width and maximum height for the
+// given screen area, and whether the window is too small so the dialog
+// must fill it. Diff views get more room than simple prompts.
+func (p *Permissions) dialogSize(area uv.Rectangle) (width, maxHeight int, forceFullscreen bool) {
+	forceFullscreen = area.Dx() <= minWindowWidth || area.Dy() <= minWindowHeight
+	switch {
+	case forceFullscreen || (p.fullscreen && p.hasDiffView()):
+		width, maxHeight = area.Dx(), area.Dy()
+	case p.hasDiffView():
 		// Wide for side-by-side diffs, capped for readability.
 		width = min(int(float64(area.Dx())*diffSizeRatio), diffMaxWidth)
 		maxHeight = int(float64(area.Dy()) * diffSizeRatio)
-	} else {
-		// Narrower for simple content like commands/URLs.
+	default:
+		// Narrower for simple content like commands and URLs.
 		width = min(int(float64(area.Dx())*simpleSizeRatio), simpleMaxWidth)
 		maxHeight = int(float64(area.Dy()) * simpleHeightRatio)
 	}
+	return width, maxHeight, forceFullscreen
+}
 
+// contentViewportHeight returns the height for the scrollable content
+// viewport given the height taken by the fixed chrome (fixedHeight) and
+// the content's natural height. Simple prompts shrink to fit their
+// content; diff and fullscreen views always take all remaining height.
+func (p *Permissions) contentViewportHeight(forceFullscreen bool, maxHeight, fixedHeight, contentHeight int) int {
+	if p.hasDiffView() || forceFullscreen {
+		return maxHeight - fixedHeight
+	}
+	if fixedHeight+contentHeight < maxHeight {
+		return max(contentHeight, 3)
+	}
+	return max(maxHeight-fixedHeight, 3)
+}
+
+func (p *Permissions) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	t := p.com.Styles
+	width, maxHeight, forceFullscreen := p.dialogSize(area)
 	dialogStyle := t.Dialog.View.Width(width).Padding(0, 1)
 
 	contentWidth := p.calculateContentWidth(width)
@@ -379,32 +395,15 @@ func (p *Permissions) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	// applies for RenderContext dialogs.
 	helpView := shortHelpLine(&p.help, p.ShortHelp(), contentWidth)
 
-	// Calculate available height for content.
-	headerHeight := lipgloss.Height(header)
-	buttonsHeight := lipgloss.Height(buttons)
-	helpHeight := lipgloss.Height(helpView)
-	frameHeight := dialogStyle.GetVerticalFrameSize() + layoutSpacingLines
-
 	p.defaultDiffSplitMode = width >= splitModeMinWidth
 
-	// Pre-render content to measure its actual height.
+	// Pre-render content to measure its actual height, then fit the
+	// scrollable viewport into whatever height the fixed chrome leaves.
 	renderedContent := p.renderContent(contentWidth)
 	contentHeight := lipgloss.Height(renderedContent)
-
-	// For non-diff views, shrink dialog to fit content if it's smaller than max.
-	var availableHeight int
-	if !p.hasDiffView() && !forceFullscreen {
-		fixedHeight := headerHeight + buttonsHeight + helpHeight + frameHeight
-		neededHeight := fixedHeight + contentHeight
-		if neededHeight < maxHeight {
-			availableHeight = contentHeight
-		} else {
-			availableHeight = maxHeight - fixedHeight
-		}
-		availableHeight = max(availableHeight, 3)
-	} else {
-		availableHeight = maxHeight - headerHeight - buttonsHeight - helpHeight - frameHeight
-	}
+	fixedHeight := lipgloss.Height(header) + lipgloss.Height(buttons) +
+		lipgloss.Height(helpView) + dialogStyle.GetVerticalFrameSize() + layoutSpacingLines
+	availableHeight := p.contentViewportHeight(forceFullscreen, maxHeight, fixedHeight, contentHeight)
 
 	// Determine if scrollbar is needed.
 	needsScrollbar := p.hasDiffView() || contentHeight > availableHeight
@@ -420,7 +419,6 @@ func (p *Permissions) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	}
 
 	var content string
-	var scrollbar string
 	p.viewport.SetWidth(viewportWidth)
 	p.viewport.SetHeight(availableHeight)
 	if p.viewportDirty {
@@ -430,12 +428,7 @@ func (p *Permissions) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	}
 	content = p.viewport.View()
 	if needsScrollbar {
-		scrollbar = common.Scrollbar(t, availableHeight, p.viewport.TotalLineCount(), availableHeight, p.viewport.YOffset())
-	}
-
-	// Join content with scrollbar if present.
-	if scrollbar != "" {
-		content = lipgloss.JoinHorizontal(lipgloss.Top, content, scrollbar)
+		content = joinScrollbar(t, content, availableHeight, p.viewport.TotalLineCount(), availableHeight, p.viewport.YOffset())
 	}
 
 	parts := []string{header}

--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -385,10 +385,13 @@ func (p *Permissions) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	t := p.com.Styles
 	width, maxHeight, forceFullscreen := p.dialogSize(area)
 	dialogStyle := t.Dialog.View.Width(width).Padding(0, 1)
+	// The dialog fills the screen when forced small or when a diff is
+	// expanded; center the buttons then instead of hugging the far edge.
+	fullscreen := forceFullscreen || (p.fullscreen && p.hasDiffView())
 
 	contentWidth := p.calculateContentWidth(width)
 	header := p.renderHeader(contentWidth)
-	buttons := p.renderButtons(contentWidth)
+	buttons := p.renderButtons(contentWidth, fullscreen)
 	// Pack the hints to the content width so they truncate cleanly instead
 	// of overflowing. The dialog frame supplies the padding, so this renders
 	// the hint line without the extra help view inset that renderDialogHelp
@@ -731,7 +734,7 @@ func (p *Permissions) renderContentPanel(content string, width int) string {
 	return panelStyle.Width(width).Render(content)
 }
 
-func (p *Permissions) renderButtons(contentWidth int) string {
+func (p *Permissions) renderButtons(contentWidth int, fullscreen bool) string {
 	buttons := []common.ButtonOpts{
 		{Text: "Allow", UnderlineIndex: 0, Selected: p.selectedOption == 0},
 		{Text: "Allow for Session", UnderlineIndex: 10, Selected: p.selectedOption == 1},
@@ -740,18 +743,21 @@ func (p *Permissions) renderButtons(contentWidth int) string {
 
 	content := common.ButtonGroup(p.com.Styles, buttons, "  ")
 
-	// If buttons are too wide, stack them vertically.
+	// Center when stacked or when the dialog fills the screen; otherwise
+	// hug the right edge next to the content. Right-aligning across a
+	// full-screen width leaves the buttons stranded in the corner.
+	align := lipgloss.Right
+	if fullscreen {
+		align = lipgloss.Center
+	}
 	if lipgloss.Width(content) > contentWidth {
 		content = common.ButtonGroup(p.com.Styles, buttons, "\n")
-		return lipgloss.NewStyle().
-			Width(contentWidth).
-			Align(lipgloss.Center).
-			Render(content)
+		align = lipgloss.Center
 	}
 
 	return lipgloss.NewStyle().
 		Width(contentWidth).
-		Align(lipgloss.Right).
+		Align(align).
 		Render(content)
 }
 

--- a/internal/ui/dialog/quit.go
+++ b/internal/ui/dialog/quit.go
@@ -111,7 +111,12 @@ func (q *Quit) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		),
 	)
 
-	view := q.com.Styles.Dialog.Quit.Frame.Render(content)
+	frameStyle := q.com.Styles.Dialog.Quit.Frame
+	maxWidth := area.Dx() - frameStyle.GetHorizontalBorderSize()
+	if maxWidth < lipgloss.Width(content) {
+		frameStyle = frameStyle.Padding(1, 0)
+	}
+	view := frameStyle.Render(content)
 	DrawCenter(scr, area, view)
 	return nil
 }

--- a/internal/ui/dialog/reasoning.go
+++ b/internal/ui/dialog/reasoning.go
@@ -164,8 +164,8 @@ func (r *Reasoning) Cursor() *tea.Cursor {
 // Draw implements [Dialog].
 func (r *Reasoning) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	t := r.com.Styles
-	width := max(0, min(reasoningDialogMaxWidth, area.Dx()))
-	height := max(0, min(reasoningDialogMaxHeight, area.Dy()))
+	width := max(0, min(reasoningDialogMaxWidth, area.Dx()-t.Dialog.View.GetHorizontalBorderSize()))
+	height := max(0, min(reasoningDialogMaxHeight, area.Dy()-t.Dialog.View.GetVerticalBorderSize()))
 	innerWidth := width - t.Dialog.View.GetHorizontalFrameSize()
 	heightOffset := t.Dialog.Title.GetVerticalFrameSize() + titleContentHeight +
 		t.Dialog.InputPrompt.GetVerticalFrameSize() + inputContentHeight +

--- a/internal/ui/dialog/reasoning.go
+++ b/internal/ui/dialog/reasoning.go
@@ -172,7 +172,7 @@ func (r *Reasoning) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		t.Dialog.HelpView.GetVerticalFrameSize() +
 		t.Dialog.View.GetVerticalFrameSize()
 
-	r.input.SetWidth(innerWidth - t.Dialog.InputPrompt.GetHorizontalFrameSize() - 1)
+	r.input.SetWidth(dialogInputTextWidth(t, r.input, innerWidth))
 	r.list.SetSize(innerWidth, max(0, height-heightOffset))
 
 	rc := NewRenderContext(t, width)

--- a/internal/ui/dialog/reasoning.go
+++ b/internal/ui/dialog/reasoning.go
@@ -173,7 +173,7 @@ func (r *Reasoning) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		t.Dialog.View.GetVerticalFrameSize()
 
 	r.input.SetWidth(innerWidth - t.Dialog.InputPrompt.GetHorizontalFrameSize() - 1)
-	r.list.SetSize(innerWidth, height-heightOffset)
+	r.list.SetSize(innerWidth, max(0, height-heightOffset))
 
 	rc := NewRenderContext(t, width)
 	rc.Title = "Select Reasoning Effort"

--- a/internal/ui/dialog/reasoning.go
+++ b/internal/ui/dialog/reasoning.go
@@ -174,7 +174,6 @@ func (r *Reasoning) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	r.input.SetWidth(innerWidth - t.Dialog.InputPrompt.GetHorizontalFrameSize() - 1)
 	r.list.SetSize(innerWidth, height-heightOffset)
-	r.help.SetWidth(innerWidth)
 
 	rc := NewRenderContext(t, width)
 	rc.Title = "Select Reasoning Effort"
@@ -190,7 +189,7 @@ func (r *Reasoning) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	listView := t.Dialog.List.Height(r.list.Height()).Render(r.list.Render())
 	rc.AddPart(listView)
-	rc.Help = r.help.View(r)
+	rc.Help = renderDialogHelp(t, &r.help, r, innerWidth)
 
 	view := rc.Render()
 

--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -239,7 +239,14 @@ func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	s.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding
 	listHeight := max(0, height-heightOffset)
 	listTotalHeight := s.list.TotalHeight()
-	listWidth := max(0, innerWidth-3) // Reserve space for scrollbar.
+	// Reserve one column for the scrollbar only when it will actually
+	// show. The item's own right padding provides the gap before it, so
+	// the list otherwise spans the full content width with no dead space.
+	scrollbarWidth := 0
+	if listTotalHeight > listHeight {
+		scrollbarWidth = 1
+	}
+	listWidth := max(0, innerWidth-scrollbarWidth)
 	s.list.SetSize(listWidth, listHeight)
 
 	// Hide the timestamps uniformly when the widest would crowd the title.

--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -241,7 +241,6 @@ func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	listTotalHeight := s.list.TotalHeight()
 	listWidth := max(0, innerWidth-3) // Reserve space for scrollbar.
 	s.list.SetSize(listWidth, listHeight)
-	s.help.SetWidth(innerWidth)
 
 	// This makes it so we do not scroll the list if we don't have to
 	start, end := s.list.VisibleItemIndices()
@@ -317,7 +316,7 @@ func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		listView = lipgloss.JoinHorizontal(lipgloss.Top, listView, scrollbar)
 	}
 	rc.AddPart(listView)
-	rc.Help = s.help.View(s)
+	rc.Help = renderDialogHelp(t, &s.help, s, innerWidth)
 
 	view := rc.Render()
 

--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -321,10 +321,7 @@ func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		rc.AddPart(inputView)
 	}
 	listView := t.Dialog.List.Height(s.list.Height()).Render(s.list.Render())
-	scrollbar := common.Scrollbar(t, listHeight, listTotalHeight, listHeight, s.list.Offset())
-	if scrollbar != "" {
-		listView = lipgloss.JoinHorizontal(lipgloss.Top, listView, scrollbar)
-	}
+	listView = joinScrollbar(t, listView, listHeight, listTotalHeight, listHeight, s.list.Offset())
 	rc.AddPart(listView)
 	rc.Help = renderDialogHelp(t, &s.help, s, innerWidth)
 

--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -237,7 +237,7 @@ func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		t.Dialog.HelpView.GetVerticalFrameSize() +
 		t.Dialog.View.GetVerticalFrameSize()
 	s.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding
-	listHeight := height - heightOffset
+	listHeight := max(0, height-heightOffset)
 	listTotalHeight := s.list.TotalHeight()
 	listWidth := max(0, innerWidth-3) // Reserve space for scrollbar.
 	s.list.SetSize(listWidth, listHeight)

--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -236,7 +236,7 @@ func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		t.Dialog.InputPrompt.GetVerticalFrameSize() + inputContentHeight +
 		t.Dialog.HelpView.GetVerticalFrameSize() +
 		t.Dialog.View.GetVerticalFrameSize()
-	s.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1)) // (1) cursor padding
+	s.input.SetWidth(dialogInputTextWidth(t, s.input, innerWidth))
 	listHeight := max(0, height-heightOffset)
 	listTotalHeight := s.list.TotalHeight()
 	// Reserve one column for the scrollbar only when it will actually

--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -242,6 +242,9 @@ func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	listWidth := max(0, innerWidth-3) // Reserve space for scrollbar.
 	s.list.SetSize(listWidth, listHeight)
 
+	// Hide the timestamps uniformly when the widest would crowd the title.
+	applyInfoColumnVisibility(s.list.FilteredItems(), listWidth, sessionInfoMaxPercent)
+
 	// This makes it so we do not scroll the list if we don't have to
 	start, end := s.list.VisibleItemIndices()
 

--- a/internal/ui/dialog/sessions_item.go
+++ b/internal/ui/dialog/sessions_item.go
@@ -185,6 +185,12 @@ func renderItem(t ListItemStyles, title string, info string, focused bool, width
 	var infoText string
 	var infoWidth int
 	if len(info) > 0 {
+		// Cap the info column so a long value (e.g. a provider name) can
+		// truncate instead of overflowing the row or squeezing the title
+		// to nothing; the title keeps at least half the width.
+		if maxInfo := lineWidth / 2; lipgloss.Width(info)+2 > maxInfo {
+			info = ansi.Truncate(info, max(0, maxInfo-2), "…")
+		}
 		infoText = fmt.Sprintf(" %s ", info)
 		if focused {
 			infoText = t.InfoTextFocused.Render(infoText)

--- a/internal/ui/dialog/sessions_item.go
+++ b/internal/ui/dialog/sessions_item.go
@@ -155,9 +155,13 @@ func renderItem(t ListItemStyles, title string, info string, focused bool, width
 		style = t.ItemFocused
 	}
 
+	// Build content to the width left after the item style's own padding,
+	// so the final rendered line is exactly `width` wide. Otherwise the
+	// padding pushes the line past the list width and it wraps.
+	lineWidth := max(0, width-style.GetHorizontalFrameSize())
+
 	var infoText string
 	var infoWidth int
-	lineWidth := width
 	if len(info) > 0 {
 		infoText = fmt.Sprintf(" %s ", info)
 		if focused {

--- a/internal/ui/dialog/sessions_item.go
+++ b/internal/ui/dialog/sessions_item.go
@@ -51,6 +51,7 @@ type SessionItem struct {
 	cache            map[int]string
 	updateTitleInput textinput.Model
 	focused          bool
+	hideInfo         bool
 }
 
 // Finished implements list.Item. Session items are render-stable
@@ -104,9 +105,30 @@ func (s *SessionItem) Cursor() *tea.Cursor {
 	return s.updateTitleInput.Cursor()
 }
 
+// InfoText returns the secondary text shown on the right of the item.
+func (s *SessionItem) InfoText() string {
+	return humanize.Time(time.Unix(s.UpdatedAt, 0))
+}
+
+// SetHideInfo controls whether the timestamp info column is shown. The
+// dialog hides it uniformly when it would crowd the title.
+func (s *SessionItem) SetHideInfo(v bool) {
+	if s.hideInfo == v {
+		return
+	}
+	s.cache = nil
+	s.hideInfo = v
+	if s.Versioned != nil {
+		s.Bump()
+	}
+}
+
 // Render returns the string representation of the session item.
 func (s *SessionItem) Render(width int) string {
-	info := humanize.Time(time.Unix(s.UpdatedAt, 0))
+	info := s.InfoText()
+	if s.hideInfo {
+		info = ""
+	}
 	styles := ListItemStyles{
 		ItemBlurred:     s.t.Dialog.NormalItem,
 		ItemFocused:     s.t.Dialog.SelectedItem,

--- a/internal/ui/diffview/diffview.go
+++ b/internal/ui/diffview/diffview.go
@@ -801,10 +801,13 @@ func (dv *DiffView) getChromaLexer() chroma.Lexer {
 		return dv.cachedLexer
 	}
 
-	l := lexers.Match(dv.before.path)
-	if l == nil {
-		l = lexers.Analyse(dv.before.content)
+	// MatchLexer is memoized and already coalesced; the per-DiffView cache
+	// still avoids repeat lookups within a single render.
+	if l := xchroma.MatchLexer(dv.before.path); l != nil {
+		dv.cachedLexer = l
+		return dv.cachedLexer
 	}
+	l := lexers.Analyse(dv.before.content)
 	if l == nil {
 		l = lexers.Fallback
 	}

--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -186,6 +186,42 @@ func (l *List) TotalHeight() int {
 	return total
 }
 
+// Prewarm renders items in the range [from, from+batch) into the width
+// cache and returns the next index to warm (len(items) when done). It lets
+// a caller populate the per-item render cache incrementally across frames
+// so a later TotalHeight is instant instead of rendering everything at
+// once. Rendering is otherwise identical to what TotalHeight would do.
+func (l *List) Prewarm(from, batch int) int {
+	if from < 0 {
+		from = 0
+	}
+	end := min(from+batch, len(l.items))
+	for idx := from; idx < end; idx++ {
+		l.renderItemEntry(idx)
+	}
+	return end
+}
+
+// Overflows reports whether the items' total height exceeds the given
+// viewport height. It walks from the bottom and stops as soon as the
+// threshold is crossed, so for content taller than the viewport (the
+// common case) it renders only a viewport's worth of items rather than
+// all of them — much cheaper than TotalHeight when only the boolean is
+// needed (e.g. deciding whether a scrollbar is required).
+func (l *List) Overflows(height int) bool {
+	total := 0
+	for idx := len(l.items) - 1; idx >= 0; idx-- {
+		total += l.getItem(idx).height
+		if l.gap > 0 && idx < len(l.items)-1 {
+			total += l.gap
+		}
+		if total > height {
+			return true
+		}
+	}
+	return false
+}
+
 // Offset returns the current scroll offset in lines from the top.
 func (l *List) Offset() int {
 	offset := 0

--- a/internal/ui/list/list_test.go
+++ b/internal/ui/list/list_test.go
@@ -768,3 +768,65 @@ func TestList_F7_ViewportZeroOrNegative(t *testing.T) {
 		})
 	}
 }
+
+// TestList_Prewarm covers incremental cache warming: Prewarm renders a
+// batch of items into the width cache so a later TotalHeight is free, and
+// re-setting the same width afterward must not drop that warmed cache.
+func TestList_Prewarm(t *testing.T) {
+	t.Parallel()
+
+	items := make([]Item, 6)
+	tracked := make([]*trackedItem, 6)
+	for i := range items {
+		it := newTrackedItem(strconv.Itoa(i), "body", true)
+		tracked[i] = it
+		items[i] = it
+	}
+	l := NewList(items...)
+	l.SetSize(40, 3)
+
+	// Warm the first three items; only those render.
+	next := l.Prewarm(0, 3)
+	require.Equal(t, 3, next)
+	for i := 0; i < 3; i++ {
+		require.Equal(t, 1, tracked[i].renderHits, "warmed item %d", i)
+	}
+	for i := 3; i < 6; i++ {
+		require.Equal(t, 0, tracked[i].renderHits, "unwarmed item %d", i)
+	}
+
+	// Warm the rest, then TotalHeight must not render anything again.
+	l.Prewarm(next, 3)
+	before := totalRenderHits(tracked)
+	_ = l.TotalHeight()
+	require.Equal(t, before, totalRenderHits(tracked), "TotalHeight re-rendered after full warm")
+
+	// Re-setting the same width is a no-op and must preserve the cache.
+	l.SetSize(40, 3)
+	_ = l.TotalHeight()
+	require.Equal(t, before, totalRenderHits(tracked), "same-width SetSize dropped the warmed cache")
+}
+
+// TestList_Overflows covers the cheap bounded overflow check: it stops
+// early once the viewport is exceeded and reports overflow correctly.
+func TestList_Overflows(t *testing.T) {
+	t.Parallel()
+
+	items := make([]Item, 10)
+	for i := range items {
+		items[i] = newTrackedItem(strconv.Itoa(i), "body", true) // 1 line each
+	}
+	l := NewList(items...)
+	l.SetSize(40, 4)
+
+	require.True(t, l.Overflows(4), "10 one-line items overflow a height of 4")
+	require.False(t, l.Overflows(20), "10 one-line items fit within a height of 20")
+}
+
+func totalRenderHits(items []*trackedItem) int {
+	n := 0
+	for _, it := range items {
+		n += it.renderHits
+	}
+	return n
+}

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -44,6 +44,33 @@ func scrollbarHideCmd(seq int) tea.Cmd {
 	})
 }
 
+// resizeSettleDuration is how long after the last resize event the chat
+// waits before it starts warming the message cache it skipped mid-drag.
+const resizeSettleDuration = 120 * time.Millisecond
+
+// warmBatchSize is how many messages the chat renders into the width cache
+// per warming step. Kept small so no single step blocks the UI thread for
+// more than a frame or so, even on slow-to-render items.
+const warmBatchSize = 25
+
+// chatWarmMsg drives one incremental cache-warming step. The first one is
+// delayed until the resize settles; the rest fire immediately, one per
+// batch, so warming spreads across frames instead of blocking.
+type chatWarmMsg struct {
+	seq int // guards against stale timers from superseded resizes
+}
+
+// chatWarmCmd schedules the next warming step after delay (zero fires as
+// soon as the runtime delivers it).
+func chatWarmCmd(seq int, delay time.Duration) tea.Cmd {
+	if delay <= 0 {
+		return func() tea.Msg { return chatWarmMsg{seq: seq} }
+	}
+	return tea.Tick(delay, func(_ time.Time) tea.Msg {
+		return chatWarmMsg{seq: seq}
+	})
+}
+
 // Chat represents the chat UI model that handles chat interactions and
 // messages.
 type Chat struct {
@@ -89,6 +116,14 @@ type Chat struct {
 	scrollbarVisible bool
 	scrollbarHideSeq int    // current sequence number for hide timer
 	scrollbarMode    string // "default", "always", or "never"
+
+	// resizing suppresses the O(N) total-height scan while a resize is in
+	// flight (and during the incremental warm afterward), so a drag only
+	// reflows the visible items. resizeSettleSeq guards stale settle/warm
+	// timers; warmNext tracks warming progress through the message list.
+	resizing        bool
+	resizeSettleSeq int
+	warmNext        int
 }
 
 // scrollbarHideDuration is how long the scrollbar remains visible after scroll activity.
@@ -145,10 +180,16 @@ func (m *Chat) Height() int {
 // rendered string and the screen's width method; area / scroll changes do not
 // invalidate it.
 func (m *Chat) Draw(scr uv.Screen, area uv.Rectangle) {
-	// Check if scrollbar should be visible.
+	// Determine scrollbar visibility. Skip it entirely while resizing: the
+	// thumb needs the exact total height (O(N) after a width change), which
+	// is the dominant resize cost. It returns once the resize settles and
+	// the cache has been warmed. The needs-scrollbar test itself uses the
+	// cheap bounded overflow check.
 	listHeight := m.list.Height() - 1
-	listTotalHeight := m.list.TotalHeight() - 1
-	needsScrollbar := listTotalHeight > listHeight
+	needsScrollbar := false
+	if !m.resizing {
+		needsScrollbar = m.list.Overflows(m.list.Height())
+	}
 
 	// Determine visibility based on scrollbar mode.
 	showScrollbar := false
@@ -189,9 +230,11 @@ func (m *Chat) Draw(scr uv.Screen, area uv.Rectangle) {
 		drawCachedBuffer(scr, listArea, m.drawCache.buf)
 	}
 
-	// Draw scrollbar if visible and needed.
+	// Draw scrollbar if visible and needed. Only reached when not resizing
+	// (showScrollbar requires it), so TotalHeight is already computed and
+	// cached above.
 	if scrollbarWidth > 0 {
-		scrollbar := common.Scrollbar(m.com.Styles, listHeight, listTotalHeight, listHeight, m.list.Offset())
+		scrollbar := common.Scrollbar(m.com.Styles, listHeight, m.list.TotalHeight()-1, listHeight, m.list.Offset())
 		if scrollbar != "" {
 			scrollbarArea := image.Rectangle{
 				Min: image.Point{X: area.Max.X - scrollbarWidth, Y: area.Min.Y},
@@ -267,11 +310,44 @@ func drawCachedBuffer(scr uv.Screen, area uv.Rectangle, buf uv.ScreenBuffer) {
 	buf.Draw(scr, area)
 }
 
+// BeginResize marks the chat as actively resizing so the next draws skip
+// the full-height scan (and the scrollbar), reflowing only the visible
+// items. It returns a command that, once resizing settles, starts warming
+// the cache so the scrollbar can recompute without blocking.
+func (m *Chat) BeginResize() tea.Cmd {
+	m.resizing = true
+	m.resizeSettleSeq++
+	m.warmNext = 0
+	return chatWarmCmd(m.resizeSettleSeq, resizeSettleDuration)
+}
+
+// WarmStep renders the next batch of messages into the width cache and
+// returns a command to continue warming plus whether warming finished. On
+// completion the resize suppression is cleared so the next draw recomputes
+// the (now instant) total height and scrollbar. A stale seq — from a resize
+// that has since been superseded — is a no-op returning (nil, false).
+func (m *Chat) WarmStep(seq int) (cmd tea.Cmd, done bool) {
+	if seq != m.resizeSettleSeq {
+		return nil, false
+	}
+	m.warmNext = m.list.Prewarm(m.warmNext, warmBatchSize)
+	if m.warmNext >= m.list.Len() {
+		m.resizing = false
+		return nil, true
+	}
+	return chatWarmCmd(seq, 0), false
+}
+
 // SetSize sets the size of the chat view port.
 func (m *Chat) SetSize(width, height int) {
-	// Reserve space for scrollbar if content exceeds viewport height.
+	// Reserve a column for the scrollbar when content overflows, decided
+	// with a cheap bounded overflow check rather than the O(N) total height.
+	// The final width is applied in a single SetSize so that an unchanged
+	// width is a no-op — critical after warming, where re-setting the same
+	// width would otherwise drop the freshly warmed cache and reintroduce
+	// the blocking full render.
 	listWidth := width
-	if m.list.TotalHeight() > height {
+	if m.list.Overflows(height) {
 		listWidth = max(0, width-1)
 	}
 	m.list.SetSize(listWidth, height)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -837,6 +837,12 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
+		// Suppress the chat's full-height scan during the resize so a drag
+		// only reflows visible items; it settles (and recomputes) shortly
+		// after the last resize event.
+		if m.state == uiChat {
+			cmds = append(cmds, m.chat.BeginResize())
+		}
 		m.updateLayoutAndSize()
 		if m.state == uiChat && m.chat.Follow() {
 			if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
@@ -1032,6 +1038,19 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case scrollbarHideMsg:
 		if m.state == uiChat {
 			m.chat.HideScrollbar(msg.seq)
+		}
+	case chatWarmMsg:
+		// A resize has settled; warm the message cache one batch at a time
+		// so the scrollbar recompute never blocks the UI thread.
+		if m.state == uiChat {
+			cmd, done := m.chat.WarmStep(msg.seq)
+			if cmd != nil {
+				cmds = append(cmds, cmd)
+			} else if done {
+				// Heights are cached now, so the final layout pass (scrollbar
+				// reservation) is cheap.
+				m.updateLayoutAndSize()
+			}
 		}
 	case spinner.TickMsg:
 		if m.dialog.HasDialogs() {

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -923,8 +923,10 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Dialog.TitleGradFromColor = o.primary
 	s.Dialog.TitleGradToColor = o.secondary
 
-	// Dialog.ListItem (commands, reasoning, models)
-	s.Dialog.ListItem.InfoBlurred = lipgloss.NewStyle().Foreground(o.fgBase)
+	// Dialog.ListItem (commands, reasoning, models). The info column holds
+	// secondary hints like keybind shortcuts, so mute it when blurred and
+	// keep it readable on the focused row.
+	s.Dialog.ListItem.InfoBlurred = lipgloss.NewStyle().Foreground(o.fgMostSubtle)
 	s.Dialog.ListItem.InfoFocused = lipgloss.NewStyle().Foreground(o.fgBase)
 
 	// Dialog.Models

--- a/internal/ui/xchroma/chroma.go
+++ b/internal/ui/xchroma/chroma.go
@@ -4,10 +4,44 @@ import (
 	"fmt"
 	"image/color"
 	"io"
+	"sync"
 
 	"charm.land/lipgloss/v2"
 	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
 )
+
+// lexers.Match glob-matches the filename against every registered lexer's
+// patterns, which is surprisingly expensive (hundreds of filepath.Match
+// calls per lookup). The result for a given filename is stable, so we
+// memoize it. This dominated resize cost in large, code-heavy sessions
+// where every diff and code view re-matched on each frame.
+var (
+	lexerCacheMu sync.RWMutex
+	lexerCache   = map[string]chroma.Lexer{}
+)
+
+// MatchLexer returns the chroma lexer for the given filename, coalesced and
+// memoized. It returns nil when no lexer matches (callers can fall back to
+// content analysis). The returned lexer is safe to reuse across calls.
+func MatchLexer(fileName string) chroma.Lexer {
+	lexerCacheMu.RLock()
+	l, ok := lexerCache[fileName]
+	lexerCacheMu.RUnlock()
+	if ok {
+		return l
+	}
+
+	l = lexers.Match(fileName)
+	if l != nil {
+		l = chroma.Coalesce(l)
+	}
+
+	lexerCacheMu.Lock()
+	lexerCache[fileName] = l
+	lexerCacheMu.Unlock()
+	return l
+}
 
 // Formatter is func that returns a custom formatter for Chroma that uses
 // Lip Gloss for foreground styling, while keeping a forced background color.


### PR DESCRIPTION
All the dialogues have been quite fragmented in their resize handling for a bit now and this pr fixes a ton of small bugs with them and just makes the whole experience a bit nicer especially on small screens

Also vastly improved resize speed in large sessions by caching chroma theme and lexer lookups and then the biggest improvement was from fixing the way scroll bar height was calculated instead of having it do a quadratic lookup on message height

fixes CHARM-1687