### PR TITLE
feat: add keybinding and logic to copy verification URL in OAuth dialog #3323

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -92,11 +92,11 @@ func loginHyper(ws workspace.Workspace, force bool) error {
 	fmt.Println("The following code should be on clipboard already:")
 
 	fmt.Println()
-	fmt.Println(lipgloss.NewStyle().Bold(true).Render(resp.UserCode))
+	lipgloss.Println(lipgloss.NewStyle().Bold(true).Render(resp.UserCode))
 	fmt.Println()
 	fmt.Println("Press enter to open this URL, and then paste it there:")
 	fmt.Println()
-	fmt.Println(lipgloss.NewStyle().Hyperlink(resp.VerificationURL, "id=hyper").Render(resp.VerificationURL))
+	lipgloss.Println(lipgloss.NewStyle().Hyperlink(resp.VerificationURL, "id=hyper").Render(resp.VerificationURL))
 	fmt.Println()
 	waitEnter()
 	if err := browser.OpenURL(resp.VerificationURL); err != nil {
@@ -169,13 +169,21 @@ func loginCopilot(ws workspace.Workspace, force bool) error {
 			return err
 		}
 
+		clipboard.WriteText(dc.UserCode)
 		fmt.Println()
-		fmt.Println("Open the following URL and follow the instructions to authenticate with GitHub Copilot:")
+		fmt.Println("The following code should be on clipboard already:")
 		fmt.Println()
-		fmt.Println(lipgloss.NewStyle().Hyperlink(dc.VerificationURI, "id=copilot").Render(dc.VerificationURI))
+		lipgloss.Println(lipgloss.NewStyle().Bold(true).Render(dc.UserCode))
 		fmt.Println()
-		fmt.Println("Code:", lipgloss.NewStyle().Bold(true).Render(dc.UserCode))
+		fmt.Println("Press enter to open this URL and authenticate with GitHub Copilot:")
 		fmt.Println()
+		lipgloss.Println(lipgloss.NewStyle().Hyperlink(dc.VerificationURI, "id=copilot").Render(dc.VerificationURI))
+		fmt.Println()
+		waitEnter()
+		if err := browser.OpenURL(dc.VerificationURI); err != nil {
+			fmt.Println("Could not open the URL. You'll need to manually open the URL in your browser.")
+		}
+
 		fmt.Println("Waiting for authorization...")
 
 		t, err := copilot.PollForToken(loginCtx, dc)
@@ -183,11 +191,11 @@ func loginCopilot(ws workspace.Workspace, force bool) error {
 			fmt.Println()
 			fmt.Println("GitHub Copilot is unavailable for this account. To signup, go to the following page:")
 			fmt.Println()
-			fmt.Println(lipgloss.NewStyle().Hyperlink(copilot.SignupURL, "id=copilot-signup").Render(copilot.SignupURL))
+			lipgloss.Println(lipgloss.NewStyle().Hyperlink(copilot.SignupURL, "id=copilot-signup").Render(copilot.SignupURL))
 			fmt.Println()
 			fmt.Println("You may be able to request free access if eligible. For more information, see:")
 			fmt.Println()
-			fmt.Println(lipgloss.NewStyle().Hyperlink(copilot.FreeURL, "id=copilot-free").Render(copilot.FreeURL))
+			lipgloss.Println(lipgloss.NewStyle().Hyperlink(copilot.FreeURL, "id=copilot-free").Render(copilot.FreeURL))
 		}
 		if err != nil {
 			return err

--- a/internal/ui/dialog/oauth.go
+++ b/internal/ui/dialog/oauth.go
@@ -55,9 +55,10 @@ type OAuth struct {
 	spinner spinner.Model
 	help    help.Model
 	keyMap  struct {
-		Copy   key.Binding
-		Submit key.Binding
-		Close  key.Binding
+		Copy    key.Binding
+		CopyURL key.Binding
+		Submit  key.Binding
+		Close   key.Binding
 	}
 
 	width           int
@@ -105,6 +106,10 @@ func newOAuth(
 		key.WithKeys("c"),
 		key.WithHelp("c", "copy code"),
 	)
+	m.keyMap.CopyURL = key.NewBinding(
+		key.WithKeys("u"),
+		key.WithHelp("u", "copy url"),
+	)
 	m.keyMap.Submit = key.NewBinding(
 		key.WithKeys("enter", "ctrl+y"),
 		key.WithHelp("enter", "copy & open"),
@@ -136,6 +141,10 @@ func (m *OAuth) HandleMsg(msg tea.Msg) Action {
 		switch {
 		case key.Matches(msg, m.keyMap.Copy):
 			cmd := m.copyCode()
+			return ActionCmd{cmd}
+
+		case key.Matches(msg, m.keyMap.CopyURL):
+			cmd := m.copyURL()
 			return ActionCmd{cmd}
 
 		case key.Matches(msg, m.keyMap.Submit):
@@ -398,6 +407,7 @@ func (m *OAuth) ShortHelp() []key.Binding {
 	default:
 		return []key.Binding{
 			m.keyMap.Copy,
+			m.keyMap.CopyURL,
 			m.keyMap.Submit,
 			m.keyMap.Close,
 		}
@@ -409,6 +419,13 @@ func (d *OAuth) copyCode() tea.Cmd {
 		return nil
 	}
 	return common.CopyToClipboard(d.userCode, "Code copied to clipboard")
+}
+
+func (d *OAuth) copyURL() tea.Cmd {
+	if d.State != OAuthStateDisplay {
+		return nil
+	}
+	return common.CopyToClipboard(d.verificationURL, "URL copied to clipboard")
 }
 
 func (d *OAuth) copyCodeAndOpenURL() tea.Cmd {


### PR DESCRIPTION
- [X] I have read [`CONTRIBUTING.md`](<https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md>).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Closes charmbracelet/crush#3323

Adds a u keybinding to the OAuth dialog to copy the raw verification URL to the clipboard.<br>Useful for remote environments (like SSH) where the browser doesn't open automatically and the terminal's hyperlink rendering makes it annoying to copy the URL manually.