### PR TITLE
fix(tools): view tool panics on a negative offset for builtin skill files

### DIFF
--- a/internal/agent/tools/view.go
+++ b/internal/agent/tools/view.go
@@ -461,7 +461,9 @@ func readBuiltinFile(params ViewParams, skillTracker *skills.Tracker) (fantasy.T
 	}
 
 	lines := strings.Split(content, "\n")
-	offset := min(params.Offset, len(lines))
+	// Clamp to [0, len(lines)]: a model can pass a negative offset, and a bare
+	// min() would leave it negative, panicking on lines[offset:].
+	offset := max(0, min(params.Offset, len(lines)))
 	lines = lines[offset:]
 
 	hasMore := len(lines) > limit

--- a/internal/agent/tools/view_test.go
+++ b/internal/agent/tools/view_test.go
@@ -321,6 +321,20 @@ func TestReadBuiltinFile(t *testing.T) {
 		require.NoError(t, err)
 		require.NotContains(t, resp.Content, "     1|")
 	})
+
+	t.Run("negative offset does not panic", func(t *testing.T) {
+		t.Parallel()
+
+		// A model can pass any int as offset; a negative value previously
+		// reached lines[offset:] and panicked with "slice bounds out of
+		// range [-1:]". It should clamp to the start of the file instead.
+		resp, err := readBuiltinFile(ViewParams{
+			FilePath: "crush://skills/crush-config/SKILL.md",
+			Offset:   -1,
+		}, nil)
+		require.NoError(t, err)
+		require.Contains(t, resp.Content, "Crush Configuration")
+	})
 }
 
 func TestSniffImageMimeType(t *testing.T) {


### PR DESCRIPTION
Reading a builtin skill file (`crush://skills/...`) with a negative `offset` panics the process. `readBuiltinFile` does `offset := min(params.Offset, len(lines)); lines = lines[offset:]`, and `min(-1, N)` stays `-1`, so `lines[-1:]` panics with `slice bounds out of range [-1:]`. `offset` comes straight from the model-supplied tool-call JSON with no lower-bound check, and the tool-call path has no `recover()`, so it takes the process down rather than returning a tool error.

Clamp to `[0, len(lines)]` at the slice, matching the documented 0-based offset. Added a regression test (`TestReadBuiltinFile/negative_offset_does_not_panic`).