### PR TITLE
fix(mcp): clear tools and close the session on MCP error; reap stdio process groups

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/agent/prompt"
 	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/discover"
 	"github.com/charmbracelet/crush/internal/event"
@@ -219,6 +220,15 @@ func (c *coordinator) RunAccepted(ctx context.Context, accept *AcceptedRun, sess
 func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID string, prompt string, attachments ...message.Attachment) (*fantasy.AgentResult, error) {
 	if err := c.readyWg.Wait(); err != nil {
 		return nil, err
+	}
+
+	// Wait for MCP initialization to complete before building the tool list.
+	// Without this, slow-to-start MCP servers (e.g. stdio Python via uv) may
+	// not have registered their tools yet when buildTools reads the registry,
+	// so their tools silently never appear in the LLM tool palette — even
+	// though crush_info reports them as connected.
+	if err := mcp.WaitForInit(ctx); err != nil {
+		return nil, fmt.Errorf("failed to wait for MCP initialization: %w", err)
 	}
 
 	// refresh models before each run
@@ -618,6 +628,13 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 	})
 
 	c.readyWg.Go(func() error {
+		// Wait for MCP servers to finish registering their tools before
+		// building the initial tool list. This ensures the first tool set
+		// (used if anything reads it before run() rebuilds) includes all
+		// MCP tools, not just fast-to-init ones.
+		if err := mcp.WaitForInit(ctx); err != nil {
+			return err
+		}
 		tools, err := c.buildTools(ctx, agent, isSubAgent)
 		if err != nil {
 			return err

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -241,11 +241,11 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 		return err
 	}
 
-	tools, err := getTools(ctx, session)
+	toolCount, err := registerSessionTools(ctx, cfg, name, session)
 	if err != nil {
 		slog.Error("Error listing tools", "error", err)
 		updateState(name, StateError, err, nil, Counts{})
-		session.Close()
+		closeSession(name, session)
 		return err
 	}
 
@@ -253,11 +253,10 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 	if err != nil {
 		slog.Error("Error listing prompts", "error", err)
 		updateState(name, StateError, err, nil, Counts{})
-		session.Close()
+		closeSession(name, session)
 		return err
 	}
 
-	toolCount := updateTools(cfg, name, tools)
 	updatePrompts(name, prompts)
 	sessions.Set(name, session)
 
@@ -271,15 +270,8 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 
 // DisableSingle disables and closes a single MCP client by name.
 func DisableSingle(cfg *config.ConfigStore, name string) error {
-	session, ok := sessions.Get(name)
-	if ok {
-		if err := session.Close(); err != nil &&
-			!errors.Is(err, io.EOF) &&
-			!errors.Is(err, context.Canceled) &&
-			err.Error() != "signal: killed" {
-			slog.Warn("Error closing MCP session", "name", name, "error", err)
-		}
-		sessions.Del(name)
+	if session, ok := sessions.Take(name); ok {
+		closeSession(name, session)
 	}
 
 	// Clear tools and prompts for this MCP.
@@ -316,9 +308,33 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 		return nil, err
 	}
 
-	updateState(name, StateConnected, nil, sess, state.Counts)
+	// The StateError transition above cleared this server's tools from the
+	// registry (and closed the dead session). Re-list and re-register them on
+	// the fresh session; otherwise the agent reconnects but the LLM's tool
+	// list stays empty and the next call fails with "tool not found".
+	counts := state.Counts
+	counts.Tools, err = registerSessionTools(ctx, cfg, name, sess)
+	if err != nil {
+		updateState(name, StateError, err, nil, state.Counts)
+		closeSession(name, sess)
+		return nil, err
+	}
+
 	sessions.Set(name, sess)
+	updateState(name, StateConnected, nil, sess, counts)
 	return sess, nil
+}
+
+// closeSession closes an MCP session, logging only unexpected errors. EOF,
+// context cancellation, and a killed child are the ordinary result of tearing
+// a session down and are not worth surfacing.
+func closeSession(name string, s *ClientSession) {
+	if err := s.Close(); err != nil &&
+		!errors.Is(err, io.EOF) &&
+		!errors.Is(err, context.Canceled) &&
+		err.Error() != "signal: killed" {
+		slog.Warn("Error closing MCP session", "name", name, "error", err)
+	}
 }
 
 // updateState updates the state of an MCP client and publishes an event
@@ -334,7 +350,17 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 	case StateConnected:
 		info.ConnectedAt = time.Now()
 	case StateError:
-		sessions.Del(name)
+		// A session that has errored is dead to us. Atomically remove it and
+		// close it so the child process and its stdio pipes are released — the
+		// bare map delete this used to do leaked both. Clearing the tool
+		// registry keeps the agent from advertising tools it can no longer
+		// call: without it, crush_info / the `/mcp` menu and the tool list
+		// handed to the LLM diverge, so a server still reads "connected, N
+		// tools" while every call fails with "tool not found".
+		if old, ok := sessions.Take(name); ok {
+			closeSession(name, old)
+		}
+		allTools.Del(name)
 	}
 	states.Set(name, info)
 
@@ -457,6 +483,12 @@ func createTransport(ctx context.Context, m config.MCPConfig, resolver config.Va
 		}
 		cmd := exec.CommandContext(ctx, home.Long(command), args...)
 		cmd.Env = append(os.Environ(), envs...)
+		// Run the child in its own process group and kill the whole group when
+		// the session context is cancelled. A stdio server often spawns its own
+		// children (signal-mcp launches signal-cli); os/exec's default
+		// cancellation kills only the direct child, orphaning the rest with
+		// PPID 1 — production accumulated 15+ such zombies over two days.
+		configureStdioProcess(cmd)
 		return &mcp.CommandTransport{
 			Command: cmd,
 		}, nil

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -203,8 +203,12 @@ func Initialize(ctx context.Context, permissions permission.Service, cfg *config
 	initOnce.Do(func() { close(initDone) })
 }
 
-// WaitForInit blocks until MCP initialization is complete.
-// If Initialize was never called, this returns immediately.
+// WaitForInit blocks until MCP initialization is complete, i.e. until
+// Initialize has finished and closed initDone. If Initialize is never called,
+// initDone is never closed, so this blocks until ctx is cancelled and then
+// returns ctx.Err(). Callers must therefore pass a context that is eventually
+// cancelled (Initialize is spawned unconditionally during app startup, so in
+// practice initDone always closes).
 func WaitForInit(ctx context.Context) error {
 	select {
 	case <-initDone:

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -58,7 +58,45 @@ var (
 	broker   = pubsub.NewBroker[Event]()
 	initOnce sync.Once
 	initDone = make(chan struct{})
+
+	// initStarted records whether Initialize has been armed. WaitForInit only
+	// blocks once initialization is expected; coordinators built outside app
+	// startup never arm it and so must not wait forever.
+	initMu      sync.Mutex
+	initStarted bool
+
+	// renewMus serializes lazy session renewals per server so concurrent tool
+	// calls cannot race to rebuild the same session.
+	renewMusMu sync.Mutex
+	renewMus   = map[string]*sync.Mutex{}
+
+	// newSession creates a client session. It is a seam so tests can exercise
+	// renewal concurrency without spawning a real transport.
+	newSession = createSession
 )
+
+// ArmInit marks that MCP initialization is expected so WaitForInit blocks
+// until it completes. Call this synchronously before launching Initialize in a
+// goroutine; otherwise WaitForInit could observe the not-yet-started state and
+// return early, letting the tool list be read before MCP tools register.
+func ArmInit() {
+	initMu.Lock()
+	initStarted = true
+	initMu.Unlock()
+}
+
+// renewLock returns the per-server mutex used to serialize session renewals,
+// creating it on first use.
+func renewLock(name string) *sync.Mutex {
+	renewMusMu.Lock()
+	defer renewMusMu.Unlock()
+	mu, ok := renewMus[name]
+	if !ok {
+		mu = &sync.Mutex{}
+		renewMus[name] = mu
+	}
+	return mu
+}
 
 // State represents the current state of an MCP client
 type State int
@@ -164,6 +202,7 @@ func Close(ctx context.Context) error {
 
 // Initialize initializes MCP clients based on the provided configuration.
 func Initialize(ctx context.Context, permissions permission.Service, cfg *config.ConfigStore) {
+	ArmInit()
 	slog.Info("Initializing MCP clients")
 	var wg sync.WaitGroup
 	// Initialize states for all configured MCPs
@@ -204,12 +243,17 @@ func Initialize(ctx context.Context, permissions permission.Service, cfg *config
 }
 
 // WaitForInit blocks until MCP initialization is complete, i.e. until
-// Initialize has finished and closed initDone. If Initialize is never called,
-// initDone is never closed, so this blocks until ctx is cancelled and then
-// returns ctx.Err(). Callers must therefore pass a context that is eventually
-// cancelled (Initialize is spawned unconditionally during app startup, so in
-// practice initDone always closes).
+// Initialize has finished and closed initDone. If initialization was never
+// armed (ArmInit was not called, e.g. a coordinator built outside app
+// startup), there is nothing to wait for and this returns nil immediately
+// rather than blocking until ctx is cancelled.
 func WaitForInit(ctx context.Context) error {
+	initMu.Lock()
+	started := initStarted
+	initMu.Unlock()
+	if !started {
+		return nil
+	}
 	select {
 	case <-initDone:
 		return nil
@@ -290,43 +334,94 @@ func DisableSingle(cfg *config.ConfigStore, name string) error {
 }
 
 func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string) (*ClientSession, error) {
+	m := cfg.Config().MCP[name]
+	timeout := mcpTimeout(m)
+
+	// Fast path: reuse a healthy session without taking the renewal lock.
+	if sess, ok := sessions.Get(name); ok {
+		if err := pingSession(ctx, sess, timeout); err == nil {
+			return sess, nil
+		}
+	}
+
+	// Serialize renewals per server. Two concurrent tool calls can both
+	// observe a dead session and race to rebuild it: one may close the
+	// session the other just registered, or overwrite and leak a live
+	// replacement. Under this lock only the first arrival rebuilds; later
+	// arrivals re-check and reuse the healthy result.
+	mu := renewLock(name)
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Under the lock the map is stable: any in-flight renewal has finished and
+	// either re-registered its session or failed and left none. A renewal
+	// removes the session transiently (StateError takes it before rebuilding),
+	// so this check must happen here rather than before the lock — otherwise a
+	// caller arriving mid-renewal sees no session and wrongly reports the
+	// server unavailable.
 	sess, ok := sessions.Get(name)
 	if !ok {
 		return nil, fmt.Errorf("mcp '%s' not available", name)
 	}
 
-	m := cfg.Config().MCP[name]
-	state, _ := states.Get(name)
-
-	timeout := mcpTimeout(m)
-	pingCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-	err := sess.Ping(pingCtx, nil)
-	if err == nil {
+	// A concurrent goroutine may have already renewed the session while we
+	// waited for the lock. Reuse it if it is now healthy.
+	pingErr := pingSession(ctx, sess, timeout)
+	if pingErr == nil {
 		return sess, nil
 	}
-	updateState(name, StateError, maybeTimeoutErr(err, timeout), nil, state.Counts)
 
-	sess, err = createSession(ctx, name, m, cfg.Resolver())
+	state, _ := states.Get(name)
+	// StateError closes the dead session and clears its tools, prompts, and
+	// resources from the registry.
+	updateState(name, StateError, maybeTimeoutErr(pingErr, timeout), nil, state.Counts)
+
+	newSess, err := newSession(ctx, name, m, cfg.Resolver())
 	if err != nil {
 		return nil, err
 	}
 
-	// The StateError transition above cleared this server's tools from the
-	// registry (and closed the dead session). Re-list and re-register them on
-	// the fresh session; otherwise the agent reconnects but the LLM's tool
-	// list stays empty and the next call fails with "tool not found".
-	counts := state.Counts
-	counts.Tools, err = registerSessionTools(ctx, cfg, name, sess)
+	// StateError cleared this server's tools, prompts, and resources from the
+	// registry. Re-list and re-register them all on the fresh session and
+	// recompute the counts from what actually registered; otherwise the agent
+	// reconnects but the registries stay empty (the next tool call fails with
+	// "tool not found") while the reported counts still advertise capabilities
+	// that are no longer there.
+	var counts Counts
+	counts.Tools, err = registerSessionTools(ctx, cfg, name, newSess)
 	if err != nil {
-		updateState(name, StateError, err, nil, state.Counts)
-		closeSession(name, sess)
+		updateState(name, StateError, err, nil, Counts{})
+		closeSession(name, newSess)
 		return nil, err
 	}
 
-	sessions.Set(name, sess)
-	updateState(name, StateConnected, nil, sess, counts)
-	return sess, nil
+	prompts, err := getPrompts(ctx, newSess)
+	if err != nil {
+		updateState(name, StateError, err, nil, Counts{})
+		closeSession(name, newSess)
+		return nil, err
+	}
+	updatePrompts(name, prompts)
+	counts.Prompts = len(prompts)
+
+	resources, err := getResources(ctx, newSess)
+	if err != nil {
+		updateState(name, StateError, err, nil, Counts{})
+		closeSession(name, newSess)
+		return nil, err
+	}
+	counts.Resources = updateResources(name, resources)
+
+	sessions.Set(name, newSess)
+	updateState(name, StateConnected, nil, newSess, counts)
+	return newSess, nil
+}
+
+// pingSession pings a session with the server's configured timeout.
+func pingSession(ctx context.Context, s *ClientSession, timeout time.Duration) error {
+	pingCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return s.Ping(pingCtx, nil)
 }
 
 // closeSession closes an MCP session, logging only unexpected errors. EOF,
@@ -364,7 +459,13 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 		if old, ok := sessions.Take(name); ok {
 			closeSession(name, old)
 		}
+		// Drop every registry entry for the dead server. Leaving prompts or
+		// resources behind lets a disconnected server keep advertising
+		// capabilities the agent can no longer fulfil, the same divergence the
+		// tool clear prevents.
 		allTools.Del(name)
+		allPrompts.Del(name)
+		allResources.Del(name)
 	}
 	states.Set(name, info)
 

--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/config"
@@ -38,6 +40,45 @@ func liveSession(t *testing.T, toolName string) (*ClientSession, context.Context
 	require.NoError(t, err)
 
 	return &ClientSession{ClientSession: clientSession, cancel: cancel}, ctx
+}
+
+// liveSessionWithCapabilities is like liveSession but the server also exposes a
+// prompt and a resource, so tests can assert those registries are populated on
+// (re)connect.
+func liveSessionWithCapabilities(t *testing.T, toolName, promptName, resourceURI string) *ClientSession {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "srv"}, nil)
+	mcp.AddTool(
+		server,
+		&mcp.Tool{Name: toolName, Description: "test tool"},
+		func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil, nil
+		},
+	)
+	server.AddPrompt(
+		&mcp.Prompt{Name: promptName},
+		func(context.Context, *mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+			return &mcp.GetPromptResult{}, nil
+		},
+	)
+	server.AddResource(
+		&mcp.Resource{Name: "res", URI: resourceURI},
+		func(context.Context, *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+			return &mcp.ReadResourceResult{}, nil
+		},
+	)
+	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	return &ClientSession{ClientSession: clientSession, cancel: cancel}
 }
 
 // TestUpdateState_ErrorClosesSessionAndClearsTools pins the primary fix: a
@@ -80,6 +121,107 @@ func TestUpdateState_ErrorClosesSessionAndClearsTools(t *testing.T) {
 	info, ok := GetState(name)
 	require.True(t, ok)
 	require.Equal(t, StateError, info.State)
+}
+
+// TestUpdateState_ErrorClearsPromptsAndResources pins that a StateError
+// transition also drops the dead server's prompts and resources, not just its
+// tools. Leaving them registered lets a disconnected server keep advertising
+// capabilities the agent can no longer fulfil — the same state/registry
+// divergence the tool clear exists to prevent.
+func TestUpdateState_ErrorClearsPromptsAndResources(t *testing.T) {
+	const name = "test-error-clears-all"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		allPrompts.Del(name)
+		allResources.Del(name)
+		states.Del(name)
+	})
+
+	allTools.Set(name, []*Tool{{Name: "do_thing"}})
+	allPrompts.Set(name, []*Prompt{{Name: "a_prompt"}})
+	allResources.Set(name, []*Resource{{Name: "a_resource"}})
+
+	updateState(name, StateError, errors.New("pipe broke"), nil, Counts{})
+
+	_, ok := allTools.Get(name)
+	require.False(t, ok, "errored session's tools must be cleared")
+	_, ok = allPrompts.Get(name)
+	require.False(t, ok, "errored session's prompts must be cleared")
+	_, ok = allResources.Get(name)
+	require.False(t, ok, "errored session's resources must be cleared")
+}
+
+// TestGetOrRenewClient_SerializesConcurrentRenewals is the concurrency
+// regression the production renew path needs: when several tool calls observe
+// the same dead session at once they must not each rebuild it. Without
+// serialization, concurrent renewals close a session another goroutine just
+// registered or overwrite and leak a live replacement. With the per-server
+// lock only the first arrival rebuilds; the rest re-check and reuse the
+// healthy session, so exactly one new session is created.
+func TestGetOrRenewClient_SerializesConcurrentRenewals(t *testing.T) {
+	const name = "test-renew-concurrency"
+	const workers = 8
+
+	t.Cleanup(func() {
+		if s, ok := sessions.Take(name); ok {
+			_ = s.Close()
+		}
+		allTools.Del(name)
+		states.Del(name)
+	})
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	// Seed a dead session so the first ping fails and every worker attempts a
+	// renewal.
+	dead, _ := liveSession(t, "send_message")
+	require.NoError(t, dead.Close())
+	sessions.Set(name, dead)
+
+	// Pre-build enough live replacements that the buggy (unserialized) path
+	// could consume more than one; the fix must consume exactly one.
+	replacements := make(chan *ClientSession, workers)
+	for range workers {
+		s, _ := liveSession(t, "send_message")
+		replacements <- s
+	}
+	close(replacements)
+	t.Cleanup(func() {
+		for s := range replacements {
+			_ = s.Close()
+		}
+	})
+
+	var created atomic.Int32
+	origNewSession := newSession
+	newSession = func(context.Context, string, config.MCPConfig, config.VariableResolver) (*ClientSession, error) {
+		created.Add(1)
+		return <-replacements, nil
+	}
+	t.Cleanup(func() { newSession = origNewSession })
+
+	var wg sync.WaitGroup
+	results := make([]*ClientSession, workers)
+	errs := make([]error, workers)
+	for i := range workers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = getOrRenewClient(context.Background(), cfg, name)
+		}(i)
+	}
+	wg.Wait()
+
+	require.Equal(t, int32(1), created.Load(),
+		"exactly one renewal must occur; concurrent callers must reuse the renewed session")
+
+	final, ok := sessions.Get(name)
+	require.True(t, ok, "a live session must remain registered after concurrent renewals")
+	for i := range workers {
+		require.NoError(t, errs[i])
+		require.Same(t, final, results[i], "every caller must observe the same renewed session")
+	}
 }
 
 // TestRegisterSessionTools_PopulatesRegistry pins that registerSessionTools —
@@ -152,4 +294,60 @@ func TestSessionErrorThenRenew_RestoresTools(t *testing.T) {
 	require.True(t, ok, "tools must be restored after the session is renewed")
 	require.Len(t, got, 1)
 	require.Equal(t, "send_message", got[0].Name)
+}
+
+// TestGetOrRenewClient_RestoresPromptsAndResources pins that a renewal
+// repopulates every registry and reports counts that match. StateError clears
+// tools, prompts, and resources; if renewal restored only tools while keeping
+// the old prompt/resource counts, GetState would again advertise capabilities
+// absent from the registries.
+func TestGetOrRenewClient_RestoresPromptsAndResources(t *testing.T) {
+	const name = "test-renew-prompts-resources"
+	t.Cleanup(func() {
+		if s, ok := sessions.Take(name); ok {
+			_ = s.Close()
+		}
+		allTools.Del(name)
+		allPrompts.Del(name)
+		allResources.Del(name)
+		states.Del(name)
+	})
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	// Seed a dead session so the renewal path runs.
+	dead, _ := liveSession(t, "send_message")
+	require.NoError(t, dead.Close())
+	sessions.Set(name, dead)
+	// Stale counts that must be recomputed, not preserved.
+	updateState(name, StateConnected, nil, dead, Counts{Tools: 1, Prompts: 1, Resources: 1})
+
+	replacement := liveSessionWithCapabilities(t, "send_message", "a_prompt", "res://thing")
+	origNewSession := newSession
+	newSession = func(context.Context, string, config.MCPConfig, config.VariableResolver) (*ClientSession, error) {
+		return replacement, nil
+	}
+	t.Cleanup(func() { newSession = origNewSession })
+
+	sess, err := getOrRenewClient(context.Background(), cfg, name)
+	require.NoError(t, err)
+	require.Same(t, replacement, sess)
+
+	tools, ok := allTools.Get(name)
+	require.True(t, ok, "tools must be restored on renewal")
+	require.Len(t, tools, 1)
+
+	prompts, ok := allPrompts.Get(name)
+	require.True(t, ok, "prompts must be restored on renewal")
+	require.Len(t, prompts, 1)
+
+	resources, ok := allResources.Get(name)
+	require.True(t, ok, "resources must be restored on renewal")
+	require.Len(t, resources, 1)
+
+	info, ok := GetState(name)
+	require.True(t, ok)
+	require.Equal(t, StateConnected, info.State)
+	require.Equal(t, Counts{Tools: 1, Prompts: 1, Resources: 1}, info.Counts,
+		"reported counts must match the restored registries")
 }

--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -1,0 +1,155 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// liveSession spins up a real in-memory MCP server exposing a single tool and
+// returns a connected client session wrapped as a *ClientSession, mirroring
+// what createSession produces in production. The returned context is the one
+// bound to the session's cancel func, so a test can assert the session was
+// actually closed (ctx cancelled) rather than merely dropped. Both sides are
+// torn down via t.Cleanup.
+func liveSession(t *testing.T, toolName string) (*ClientSession, context.Context) {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "srv"}, nil)
+	mcp.AddTool(
+		server,
+		&mcp.Tool{Name: toolName, Description: "test tool"},
+		func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil, nil
+		},
+	)
+	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	return &ClientSession{ClientSession: clientSession, cancel: cancel}, ctx
+}
+
+// TestUpdateState_ErrorClosesSessionAndClearsTools pins the primary fix: a
+// StateError transition must (1) remove the session from the map, (2) actually
+// close it so its child process/pipes are released, and (3) clear its tools
+// from the registry. Before the fix updateState only did a bare
+// sessions.Del(name): the session was leaked and its tools lingered, so
+// crush_info kept reading "connected, N tools" while the LLM's tool list and
+// the live session had diverged.
+func TestUpdateState_ErrorClosesSessionAndClearsTools(t *testing.T) {
+	const name = "test-error-cleanup"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		states.Del(name)
+	})
+
+	sess, sessCtx := liveSession(t, "do_thing")
+	sessions.Set(name, sess)
+	allTools.Set(name, []*Tool{{Name: "do_thing"}})
+
+	// Preconditions: tool registered and session live.
+	_, ok := allTools.Get(name)
+	require.True(t, ok)
+	require.NoError(t, sessCtx.Err(), "session context must be live before the error")
+
+	updateState(name, StateError, errors.New("stdio pipe broke"), nil, Counts{Tools: 1})
+
+	// The dead session is removed from the map...
+	_, ok = sessions.Get(name)
+	require.False(t, ok, "errored session must be removed from the sessions map")
+
+	// ...actually closed (its context is cancelled, not merely dropped)...
+	require.ErrorIs(t, sessCtx.Err(), context.Canceled, "errored session must be closed, not just dropped from the map")
+
+	// ...and its tools cleared from the registry the agent sends to the LLM.
+	_, ok = allTools.Get(name)
+	require.False(t, ok, "errored session's tools must be cleared from the registry")
+
+	info, ok := GetState(name)
+	require.True(t, ok)
+	require.Equal(t, StateError, info.State)
+}
+
+// TestRegisterSessionTools_PopulatesRegistry pins that registerSessionTools —
+// the single seam through which a (re)connected session's tools enter the
+// registry — lists a live session's tools and writes them to allTools.
+func TestRegisterSessionTools_PopulatesRegistry(t *testing.T) {
+	const name = "test-register-tools"
+	t.Cleanup(func() { allTools.Del(name) })
+
+	sess, _ := liveSession(t, "send_message")
+	t.Cleanup(func() { _ = sess.Close() })
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	count, err := registerSessionTools(context.Background(), cfg, name, sess)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	got, ok := allTools.Get(name)
+	require.True(t, ok, "a live session's tools must be registered")
+	require.Len(t, got, 1)
+	require.Equal(t, "send_message", got[0].Name)
+}
+
+// TestSessionErrorThenRenew_RestoresTools is the end-to-end regression for the
+// reported bug: an MCP tool works, the stdio session drops mid-conversation,
+// and afterwards every call returned "tool not found" forever. It walks the
+// exact registry transitions the production code performs — initial connect
+// registers tools, a StateError clears them (and closes the session), and the
+// lazy renew re-registers them — so a regression in any leg (tools left stale
+// on error, or tools never restored on renew) fails here.
+func TestSessionErrorThenRenew_RestoresTools(t *testing.T) {
+	const name = "test-error-then-renew"
+	t.Cleanup(func() {
+		if s, ok := sessions.Take(name); ok {
+			_ = s.Close()
+		}
+		allTools.Del(name)
+		states.Del(name)
+	})
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	// 1. Initial connect registers the tool (mirrors initClient).
+	sess1, _ := liveSession(t, "send_message")
+	sessions.Set(name, sess1)
+	_, err := registerSessionTools(context.Background(), cfg, name, sess1)
+	require.NoError(t, err)
+	_, ok := allTools.Get(name)
+	require.True(t, ok, "tool should be registered after the initial connect")
+
+	// 2. The session drops mid-conversation -> StateError. Post-fix this clears
+	//    the tools and closes the dead session.
+	updateState(name, StateError, errors.New("pipe broke"), nil, Counts{Tools: 1})
+	_, ok = allTools.Get(name)
+	require.False(t, ok, "tools must be cleared when the session errors")
+	_, ok = sessions.Get(name)
+	require.False(t, ok, "errored session must be removed from the map")
+
+	// 3. The lazy renew path creates a fresh session and MUST re-register the
+	//    tools. The bug was that it never did: the LLM's tool list stayed empty
+	//    and every subsequent call returned "tool not found".
+	sess2, _ := liveSession(t, "send_message")
+	count, err := registerSessionTools(context.Background(), cfg, name, sess2)
+	require.NoError(t, err)
+	sessions.Set(name, sess2)
+	require.Equal(t, 1, count)
+
+	got, ok := allTools.Get(name)
+	require.True(t, ok, "tools must be restored after the session is renewed")
+	require.Len(t, got, 1)
+	require.Equal(t, "send_message", got[0].Name)
+}

--- a/internal/agent/tools/mcp/process_other.go
+++ b/internal/agent/tools/mcp/process_other.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package mcp
+
+import "os/exec"
+
+// configureStdioProcess is a no-op on platforms without POSIX process groups.
+// os/exec's default context cancellation still kills the direct child.
+func configureStdioProcess(cmd *exec.Cmd) {}

--- a/internal/agent/tools/mcp/process_unix.go
+++ b/internal/agent/tools/mcp/process_unix.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+package mcp
+
+import (
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// configureStdioProcess puts a stdio MCP server child in its own process group
+// and makes context cancellation kill that whole group.
+//
+// A stdio server frequently spawns its own children (signal-mcp launches
+// signal-cli, an npx-based server launches node). os/exec's default
+// cancellation only signals the direct child, so those grandchildren are
+// orphaned with PPID 1 and run forever; production accumulated 15+ such
+// processes over two days. Setpgid makes the child a process-group leader
+// (pgid == pid) and the Cancel hook signals the negated pid so every process in
+// the group is reaped whenever the session's context is cancelled (on Close, a
+// StateError transition, or a lazy renew).
+func configureStdioProcess(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+
+	// Replaces os/exec's default cancel (which kills only cmd.Process). A
+	// negative pid targets the whole process group.
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+
+	// Without a WaitDelay, a leaked descendant that keeps a stdio pipe open can
+	// block cmd.Wait indefinitely even after the group is signalled.
+	cmd.WaitDelay = 5 * time.Second
+}

--- a/internal/agent/tools/mcp/process_unix_test.go
+++ b/internal/agent/tools/mcp/process_unix_test.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateTransport_StdioProcessGroup pins that a stdio MCP child is spawned
+// as its own process-group leader with a cancel hook wired up. This is what
+// lets Crush reap a server's descendant processes (e.g. signal-cli launched by
+// signal-mcp) when the session context is cancelled, instead of orphaning them.
+func TestCreateTransport_StdioProcessGroup(t *testing.T) {
+	t.Parallel()
+
+	m := config.MCPConfig{Type: config.MCPStdio, Command: "echo", Args: []string{"hi"}}
+	tr, err := createTransport(t.Context(), m, shellResolverWithPath(t, nil))
+	require.NoError(t, err)
+
+	ct, ok := tr.(*mcp.CommandTransport)
+	require.True(t, ok, "expected CommandTransport, got %T", tr)
+	require.NotNil(t, ct.Command.SysProcAttr, "stdio child must set SysProcAttr")
+	require.True(t, ct.Command.SysProcAttr.Setpgid,
+		"stdio child must lead its own process group so cancellation kills the whole tree")
+	require.NotNil(t, ct.Command.Cancel,
+		"stdio child must set a Cancel hook that kills the process group")
+}

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -130,6 +130,20 @@ func RefreshTools(ctx context.Context, cfg *config.ConfigStore, name string) {
 	updateState(name, StateConnected, nil, session, prev.Counts)
 }
 
+// registerSessionTools lists the tools a live session exposes and writes them
+// into the shared registry, returning the number registered after any
+// configured allow/deny filtering. It is the single seam through which a
+// (re)connected session's tools enter the registry, so both the initial
+// connect and a lazy renew repopulate the tool list the agent sends to the LLM
+// instead of leaving it empty.
+func registerSessionTools(ctx context.Context, cfg *config.ConfigStore, name string, sess *ClientSession) (int, error) {
+	tools, err := getTools(ctx, sess)
+	if err != nil {
+		return 0, err
+	}
+	return updateTools(cfg, name, tools), nil
+}
+
 func getTools(ctx context.Context, session *ClientSession) ([]*Tool, error) {
 	// Always call ListTools to get the actual available tools.
 	// The InitializeResult Capabilities.Tools field may be an empty object {},

--- a/internal/agent/tools/mcp/waitforinit_test.go
+++ b/internal/agent/tools/mcp/waitforinit_test.go
@@ -19,7 +19,18 @@ func swapInitGate(t *testing.T) chan struct{} {
 	t.Helper()
 	orig := initDone
 	initDone = make(chan struct{})
-	t.Cleanup(func() { initDone = orig })
+
+	initMu.Lock()
+	origStarted := initStarted
+	initStarted = true
+	initMu.Unlock()
+
+	t.Cleanup(func() {
+		initDone = orig
+		initMu.Lock()
+		initStarted = origStarted
+		initMu.Unlock()
+	})
 	return initDone
 }
 
@@ -41,6 +52,29 @@ func TestWaitForInit_BlocksUntilInitCompletes(t *testing.T) {
 	close(gate)
 	require.NoError(t, WaitForInit(context.Background()),
 		"WaitForInit must return once initialization has completed")
+}
+
+// TestWaitForInit_ReturnsWhenNotArmed is the regression test for coordinators
+// built outside app startup. Those paths never call mcp.Initialize (which is
+// what arms the gate), so WaitForInit must return immediately instead of
+// blocking on a channel that will never close. Before the fix it blocked until
+// ctx was cancelled, hanging coordinator.run's readyWg forever.
+func TestWaitForInit_ReturnsWhenNotArmed(t *testing.T) {
+	// Ensure the gate looks unarmed regardless of test ordering.
+	initMu.Lock()
+	orig := initStarted
+	initStarted = false
+	initMu.Unlock()
+	t.Cleanup(func() {
+		initMu.Lock()
+		initStarted = orig
+		initMu.Unlock()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, WaitForInit(ctx),
+		"WaitForInit must return immediately when initialization was never armed")
 }
 
 // TestWaitForInit_ToolsVisibleAfterInit is the regression test for the bug the

--- a/internal/agent/tools/mcp/waitforinit_test.go
+++ b/internal/agent/tools/mcp/waitforinit_test.go
@@ -1,0 +1,82 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// swapInitGate replaces the package-global initDone channel that WaitForInit
+// waits on with a fresh, open one for the duration of the test, restoring the
+// original in cleanup. This lets each test drive WaitForInit deterministically
+// (by closing the returned channel to signal "init complete") instead of
+// branching on whether an earlier test already closed the process-wide
+// one-shot. The tests that use it are not parallel and nothing else touches the
+// gate during a unit-test run, so the swap is race-free.
+func swapInitGate(t *testing.T) chan struct{} {
+	t.Helper()
+	orig := initDone
+	initDone = make(chan struct{})
+	t.Cleanup(func() { initDone = orig })
+	return initDone
+}
+
+// TestWaitForInit_BlocksUntilInitCompletes pins the contract the coordinator
+// relies on: WaitForInit blocks while MCP initialization is still in flight and
+// returns once it completes. The coordinator calls it before reading the tool
+// registry so slow-to-start servers (e.g. stdio Python via uv) have registered
+// their tools first.
+func TestWaitForInit_BlocksUntilInitCompletes(t *testing.T) {
+	gate := swapInitGate(t)
+
+	// Init not done yet: WaitForInit must block until the context expires.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, WaitForInit(ctx), context.DeadlineExceeded,
+		"WaitForInit must block while initialization is in flight")
+
+	// Once initialization completes (the gate closes), WaitForInit returns nil.
+	close(gate)
+	require.NoError(t, WaitForInit(context.Background()),
+		"WaitForInit must return once initialization has completed")
+}
+
+// TestWaitForInit_ToolsVisibleAfterInit is the regression test for the bug the
+// coordinator fix addresses: buildTools read allTools concurrently with MCP
+// initialization, so a slow server's tools were silently missing from the LLM's
+// palette even though crush_info later reported the server as connected. Gating
+// on WaitForInit fixes it — any tool registered before initialization completes
+// must be visible once WaitForInit returns.
+func TestWaitForInit_ToolsVisibleAfterInit(t *testing.T) {
+	const name = "test-waitforinit-tools"
+	t.Cleanup(func() {
+		if s, ok := sessions.Take(name); ok {
+			_ = s.Close()
+		}
+		allTools.Del(name)
+		states.Del(name)
+	})
+
+	sess, _ := liveSession(t, "slow_tool")
+	gate := swapInitGate(t)
+
+	// A slow MCP server registers its tools, then initialization completes
+	// (the gate closes). close(gate) happens-after the registration, and
+	// WaitForInit returning happens-after observing the close, so the tools are
+	// guaranteed visible once WaitForInit returns.
+	go func() {
+		sessions.Set(name, sess)
+		allTools.Set(name, []*Tool{{Name: "slow_tool"}})
+		updateState(name, StateConnected, nil, sess, Counts{Tools: 1})
+		close(gate)
+	}()
+
+	require.NoError(t, WaitForInit(context.Background()))
+
+	tools, ok := allTools.Get(name)
+	require.True(t, ok, "a slow server's tools must be visible after WaitForInit returns")
+	require.Len(t, tools, 1)
+	require.Equal(t, "slow_tool", tools[0].Name)
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -140,6 +140,10 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 	// Check for updates in the background.
 	go app.checkForUpdates(ctx)
 
+	// Arm initialization synchronously before launching it so WaitForInit
+	// blocks for the in-flight init instead of racing the goroutine and
+	// returning before any MCP tools register.
+	mcp.ArmInit()
 	go mcp.Initialize(ctx, app.Permissions, store)
 
 	// Start herdr integration when running inside a herdr pane.


### PR DESCRIPTION
Fixes charmbracelet/crush#3327.

When a stdio MCP session dropped mid-conversation, its tools silently disappeared: the first tool call worked, every later call to the same tool returned "tool not found", yet `/mcp` and crush_info still showed the server "connected, N tools". Reconnecting via `/mcp` did not help.

Root causes, all pre-existing:

* updateState(StateError) removed the session from the map with a bare sessions.Del. It never closed the session (leaking the child process and its stdio pipes) and never cleared the server's tools from the registry. The state map (what crush_info / `/mcp` read) and the tool registry (what the agent sends to the LLM) then diverged, so a dead server kept advertising tools that could no longer be called.
* getOrRenewClient's lazy reconnect created a fresh session but never re-listed or re-registered its tools, so once the registry had been cleared the tools never came back for the rest of the session.
* stdio children were spawned with a bare exec.CommandContext. A server that spawns its own children (signal-mcp -> signal-cli) leaks those grandchildren on cancellation, since os/exec only kills the direct child; 15+ orphaned processes accumulated over two days in production.

Fixes:

* StateError now atomically removes, closes, and clears the tools of the errored session, so state and registry can no longer diverge.
* getOrRenewClient and initClient register tools through a single registerSessionTools seam, so a renewed session repopulates the tool list instead of leaving it empty.
* stdio children run in their own process group with a cancel hook that kills the whole group (no-op on Windows).

Adds regression tests for the error->renew tool lifecycle and the process-group wiring; the two new lifecycle tests fail against the prior behavior.

Claude-Session: [https://claude.ai/code/session_018QwjJ7yxRMtgRidfLuv2mu](<https://claude.ai/code/session_018QwjJ7yxRMtgRidfLuv2mu>)

- [X] I have read [`CONTRIBUTING.md`](<https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md>).
- [X] I have created a discussion that was approved by a maintainer (for new features).