### PR TITLE
feat(ui): interactive Skills dialog with live enable/disable toggle

### DIFF
--- a/internal/agent/agentic_fetch_tool.go
+++ b/internal/agent/agentic_fetch_tool.go
@@ -140,6 +140,7 @@ func (c *coordinator) agenticFetchTool(_ context.Context, client *http.Client) (
 
 			promptOpts := []prompt.Option{
 				prompt.WithWorkingDir(tmpDir),
+				prompt.WithSkills(c.activeSkills),
 			}
 
 			promptTemplate, err := prompt.NewPrompt("agentic_fetch", string(agenticFetchPromptTmpl), promptOpts...)

--- a/internal/agent/agenttest/coordinator.go
+++ b/internal/agent/agenttest/coordinator.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/skills"
 )
 
 // NewCoordinator builds a real agent.Coordinator through the production
@@ -69,5 +70,6 @@ func NewCoordinator(
 		Sessions:    sessions,
 		Messages:    messages,
 		Permissions: permission.NewPermissionService(workingDir, true, nil),
+		Skills:      skills.NewManager(nil, nil, nil),
 	})
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -152,8 +152,7 @@ type CoordinatorOptions struct {
 }
 
 func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, error) {
-	allSkills := opts.Skills.AllSkills()
-	activeSkills := opts.Skills.ActiveSkills()
+	allSkills, activeSkills := opts.Skills.SkillSnapshot()
 	skillTracker := skills.NewTracker(activeSkills)
 
 	c := &coordinator{
@@ -1177,12 +1176,12 @@ func (c *coordinator) ReloadSkills(ctx context.Context) error {
 		return errors.New("skill reload requires a skills manager")
 	}
 
-	activeSkills, err := c.skillsMgr.Reload(ctx)
+	allSkills, activeSkills, err := c.skillsMgr.Reload(ctx)
 	if err != nil {
 		return err
 	}
 
-	c.allSkills = c.skillsMgr.AllSkills()
+	c.allSkills = allSkills
 	c.activeSkills = activeSkills
 	c.skillTracker = skills.NewTracker(activeSkills)
 	logPromptSkillStats(activeSkills)

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -184,6 +184,8 @@ func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, 
 		interactive:  opts.Interactive,
 	}
 
+	logPromptSkillStats(activeSkills)
+
 	agentCfg, ok := opts.Config.Config().Agents[config.AgentCoder]
 	if !ok {
 		return nil, errCoderAgentNotConfigured
@@ -1189,6 +1191,7 @@ func (c *coordinator) ReloadSkills(ctx context.Context) error {
 	c.allSkills = c.skillsMgr.AllSkills()
 	c.activeSkills = activeSkills
 	c.skillTracker = skills.NewTracker(activeSkills)
+	logPromptSkillStats(activeSkills)
 
 	// Rebuild the system prompt so <available_skills> reflects the new set.
 	p, err := coderPrompt(
@@ -1512,12 +1515,11 @@ func discoverSkills(cfg *config.ConfigStore) (allSkills, activeSkills []*skills.
 	if r := cfg.Resolver(); r != nil {
 		resolver = r.ResolveValue
 	}
-	allSkills, activeSkills, states := skills.DiscoverFromConfig(skills.DiscoveryConfig{
+	allSkills, activeSkills, _ = skills.DiscoverFromConfig(skills.DiscoveryConfig{
 		SkillsPaths:    paths,
 		DisabledSkills: disabled,
 		Resolver:       resolver,
 	})
-	logDiscoveryStats(states, paths, allSkills, activeSkills, disabled)
 	return allSkills, activeSkills
 }
 
@@ -1563,51 +1565,15 @@ func logTurnSkillUsage(
 	)
 }
 
-// logDiscoveryStats emits a single structured log line summarising skill
-// discovery for the current session. It is intentionally low-volume: one
-// line per session start. Builtin vs user counts are derived from the
-// SkillState.Path — builtin states use the "builtin/" embed prefix.
-func logDiscoveryStats(
-	states []*skills.SkillState,
-	userPaths []string,
-	allSkills, activeSkills []*skills.Skill,
-	disabled []string,
-) {
-	var builtinOK, builtinErr, userOK, userErr int
-	for _, s := range states {
-		isBuiltin := strings.HasPrefix(s.Path, "builtin/")
-		switch {
-		case isBuiltin && s.State == skills.StateNormal:
-			builtinOK++
-		case isBuiltin && s.State == skills.StateError:
-			builtinErr++
-		case !isBuiltin && s.State == skills.StateNormal:
-			userOK++
-		case !isBuiltin && s.State == skills.StateError:
-			userErr++
-		}
-	}
-
-	activeNames := make([]string, 0, len(activeSkills))
-	for _, s := range activeSkills {
-		activeNames = append(activeNames, s.Name)
-	}
-
+// logPromptSkillStats logs the prompt-injection size of the active
+// skills XML — the only discovery metric that is coordinator-specific
+// (depends on the active set AND the XML encoder).
+func logPromptSkillStats(activeSkills []*skills.Skill) {
 	xml := skills.ToPromptXML(activeSkills)
-
-	slog.Info(
-		"Skill discovery complete",
+	slog.Info("Skill prompt stats",
 		"component", "skills",
-		"builtin_ok", builtinOK,
-		"builtin_errors", builtinErr,
-		"user_ok", userOK,
-		"user_errors", userErr,
-		"user_paths", len(userPaths),
-		"deduped_total", len(allSkills),
 		"active", len(activeSkills),
-		"disabled", len(disabled),
 		"prompt_bytes", len(xml),
 		"prompt_tok_est", skills.ApproxTokenCount(xml),
-		"active_names", activeNames,
 	)
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -1186,7 +1186,10 @@ func (c *coordinator) ReloadSkills(ctx context.Context) error {
 		return errors.New("skill reload requires a skills manager")
 	}
 
-	activeSkills := c.skillsMgr.Reload()
+	activeSkills, err := c.skillsMgr.Reload(ctx)
+	if err != nil {
+		return err
+	}
 
 	c.allSkills = c.skillsMgr.AllSkills()
 	c.activeSkills = activeSkills

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -187,7 +187,10 @@ func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, 
 	}
 
 	// TODO: make this dynamic when we support multiple agents
-	prompt, err := coderPrompt(prompt.WithWorkingDir(c.cfg.WorkingDir()))
+	prompt, err := coderPrompt(
+		prompt.WithWorkingDir(c.cfg.WorkingDir()),
+		prompt.WithSkills(c.activeSkills),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -128,7 +128,7 @@ type coordinator struct {
 	allSkills    []*skills.Skill // Pre-filter: all discovered after dedup.
 	activeSkills []*skills.Skill // Post-filter: active skills only.
 	skillTracker *skills.Tracker
-	skillsMgr    *skills.Manager // required for ReloadSkills; nil only if caller bypassed normal setup
+	skillsMgr    *skills.Manager
 
 	readyWg errgroup.Group
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -152,17 +152,8 @@ type CoordinatorOptions struct {
 }
 
 func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, error) {
-	// Skills are pre-discovered by the caller (see app.New /
-	// backend.CreateWorkspace) and passed in via the manager. If no
-	// manager was provided (legacy callers), fall back to an in-line
-	// discovery so the coordinator still works.
-	var allSkills, activeSkills []*skills.Skill
-	if opts.Skills != nil {
-		allSkills = opts.Skills.AllSkills()
-		activeSkills = opts.Skills.ActiveSkills()
-	} else {
-		allSkills, activeSkills = discoverSkills(opts.Config)
-	}
+	allSkills := opts.Skills.AllSkills()
+	activeSkills := opts.Skills.ActiveSkills()
 	skillTracker := skills.NewTracker(activeSkills)
 
 	c := &coordinator{
@@ -1497,33 +1488,6 @@ func (c *coordinator) updateParentSessionCost(ctx context.Context, childSessionI
 	}
 
 	return nil
-}
-
-// discoverSkills is a thin fallback wrapper used only when no
-// skills.Manager has been threaded through to the coordinator. All
-// production call sites (backend.CreateWorkspace, setupLocalWorkspace)
-// run discovery in advance and pass the results via the manager;
-// reaching this path means a caller bypassed both. It deliberately does
-// NOT publish to the package-level broker — there are no subscribers in
-// that case, so doing so would be misleading without delivering the
-// snapshot anywhere useful.
-func discoverSkills(cfg *config.ConfigStore) (allSkills, activeSkills []*skills.Skill) {
-	opts := cfg.Config().Options
-	var paths, disabled []string
-	if opts != nil {
-		paths = opts.SkillsPaths
-		disabled = opts.DisabledSkills
-	}
-	var resolver func(string) (string, error)
-	if r := cfg.Resolver(); r != nil {
-		resolver = r.ResolveValue
-	}
-	allSkills, activeSkills, _ = skills.DiscoverFromConfig(skills.DiscoveryConfig{
-		SkillsPaths:    paths,
-		DisabledSkills: disabled,
-		Resolver:       resolver,
-	})
-	return allSkills, activeSkills
 }
 
 // logTurnSkillUsage emits a per-turn diagnostic line showing which skills

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -1181,21 +1181,17 @@ func (c *coordinator) ReloadSkills(ctx context.Context) error {
 		return err
 	}
 
-	c.allSkills = allSkills
-	c.activeSkills = activeSkills
-	c.skillTracker = skills.NewTracker(activeSkills)
-	logPromptSkillStats(activeSkills)
-
-	// Rebuild the system prompt so <available_skills> reflects the new set.
-	p, err := coderPrompt(
-		prompt.WithWorkingDir(c.cfg.WorkingDir()),
-		prompt.WithSkills(c.activeSkills),
-	)
+	// Build everything that can fail BEFORE swapping coordinator state,
+	// so a mid-reload error leaves the agent on the old skills.
+	large, _, err := c.buildAgentModels(ctx, false)
 	if err != nil {
 		return err
 	}
 
-	large, _, err := c.buildAgentModels(ctx, false)
+	p, err := coderPrompt(
+		prompt.WithWorkingDir(c.cfg.WorkingDir()),
+		prompt.WithSkills(activeSkills),
+	)
 	if err != nil {
 		return err
 	}
@@ -1203,9 +1199,15 @@ func (c *coordinator) ReloadSkills(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// All builds succeeded — commit the new skill state, then rebuild
+	// tools (which capture the slices by value at construction time).
+	c.allSkills = allSkills
+	c.activeSkills = activeSkills
+	c.skillTracker = skills.NewTracker(activeSkills)
+	logPromptSkillStats(activeSkills)
 	c.currentAgent.SetSystemPrompt(systemPrompt)
 
-	// Rebuild tools — they capture skill slices and the tracker by reference.
 	agentCfg, ok := c.cfg.Config().Agents[config.AgentCoder]
 	if !ok {
 		return errCoderAgentNotConfigured

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -1573,9 +1573,14 @@ func logTurnSkillUsage(
 // (depends on the active set AND the XML encoder).
 func logPromptSkillStats(activeSkills []*skills.Skill) {
 	xml := skills.ToPromptXML(activeSkills)
+	activeNames := make([]string, len(activeSkills))
+	for i, s := range activeSkills {
+		activeNames[i] = s.Name
+	}
 	slog.Info("Skill prompt stats",
 		"component", "skills",
 		"active", len(activeSkills),
+		"active_names", activeNames,
 		"prompt_bytes", len(xml),
 		"prompt_tok_est", skills.ApproxTokenCount(xml),
 	)

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -128,7 +128,7 @@ type coordinator struct {
 	allSkills    []*skills.Skill // Pre-filter: all discovered after dedup.
 	activeSkills []*skills.Skill // Post-filter: active skills only.
 	skillTracker *skills.Tracker
-	skillsMgr    *skills.Manager // nil in legacy fallback mode
+	skillsMgr    *skills.Manager // required for ReloadSkills; nil only if caller bypassed normal setup
 
 	readyWg errgroup.Group
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -104,6 +104,7 @@ type Coordinator interface {
 	Summarize(context.Context, string) error
 	Model() Model
 	UpdateModels(ctx context.Context) error
+	ReloadSkills(ctx context.Context) error
 	GenerateTitle(ctx context.Context, sessionID, prompt string)
 }
 
@@ -127,6 +128,7 @@ type coordinator struct {
 	allSkills    []*skills.Skill // Pre-filter: all discovered after dedup.
 	activeSkills []*skills.Skill // Post-filter: active skills only.
 	skillTracker *skills.Tracker
+	skillsMgr    *skills.Manager // nil in legacy fallback mode
 
 	readyWg errgroup.Group
 }
@@ -178,6 +180,7 @@ func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, 
 		allSkills:    allSkills,
 		activeSkills: activeSkills,
 		skillTracker: skillTracker,
+		skillsMgr:    opts.Skills,
 		interactive:  opts.Interactive,
 	}
 
@@ -1164,6 +1167,53 @@ func (c *coordinator) UpdateModels(ctx context.Context) error {
 		return errCoderAgentNotConfigured
 	}
 
+	tools, err := c.buildTools(ctx, agentCfg, false)
+	if err != nil {
+		return err
+	}
+	c.currentAgent.SetTools(tools)
+	return nil
+}
+
+// ReloadSkills re-runs skill discovery and propagates the updated
+// skills to the system prompt, tools, and tracker. This lets users
+// pick up skill changes (new files, edits, deletions) without
+// restarting the session.
+func (c *coordinator) ReloadSkills(ctx context.Context) error {
+	if c.skillsMgr == nil {
+		return errors.New("skill reload requires a skills manager")
+	}
+
+	activeSkills := c.skillsMgr.Reload()
+
+	c.allSkills = c.skillsMgr.AllSkills()
+	c.activeSkills = activeSkills
+	c.skillTracker = skills.NewTracker(activeSkills)
+
+	// Rebuild the system prompt so <available_skills> reflects the new set.
+	p, err := coderPrompt(
+		prompt.WithWorkingDir(c.cfg.WorkingDir()),
+		prompt.WithSkills(c.activeSkills),
+	)
+	if err != nil {
+		return err
+	}
+
+	large, _, err := c.buildAgentModels(ctx, false)
+	if err != nil {
+		return err
+	}
+	systemPrompt, err := p.Build(ctx, large.Model.Provider(), large.Model.Model(), c.cfg)
+	if err != nil {
+		return err
+	}
+	c.currentAgent.SetSystemPrompt(systemPrompt)
+
+	// Rebuild tools — they capture skill slices and the tracker by reference.
+	agentCfg, ok := c.cfg.Config().Agents[config.AgentCoder]
+	if !ok {
+		return errCoderAgentNotConfigured
+	}
 	tools, err := c.buildTools(ctx, agentCfg, false)
 	if err != nil {
 		return err

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -1633,9 +1633,14 @@ func logTurnSkillUsage(
 // (depends on the active set AND the XML encoder).
 func logPromptSkillStats(activeSkills []*skills.Skill) {
 	xml := skills.ToPromptXML(activeSkills)
+	activeNames := make([]string, len(activeSkills))
+	for i, s := range activeSkills {
+		activeNames[i] = s.Name
+	}
 	slog.Info("Skill prompt stats",
 		"component", "skills",
 		"active", len(activeSkills),
+		"active_names", activeNames,
 		"prompt_bytes", len(xml),
 		"prompt_tok_est", skills.ApproxTokenCount(xml),
 	)

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -1243,7 +1243,10 @@ func (c *coordinator) ReloadSkills(ctx context.Context) error {
 		return errors.New("skill reload requires a skills manager")
 	}
 
-	activeSkills := c.skillsMgr.Reload()
+	activeSkills, err := c.skillsMgr.Reload(ctx)
+	if err != nil {
+		return err
+	}
 
 	c.allSkills = c.skillsMgr.AllSkills()
 	c.activeSkills = activeSkills

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -191,7 +191,10 @@ func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, 
 	}
 
 	// TODO: make this dynamic when we support multiple agents
-	prompt, err := coderPrompt(prompt.WithWorkingDir(c.cfg.WorkingDir()))
+	prompt, err := coderPrompt(
+		prompt.WithWorkingDir(c.cfg.WorkingDir()),
+		prompt.WithSkills(c.activeSkills),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -156,17 +156,8 @@ type CoordinatorOptions struct {
 }
 
 func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, error) {
-	// Skills are pre-discovered by the caller (see app.New /
-	// backend.CreateWorkspace) and passed in via the manager. If no
-	// manager was provided (legacy callers), fall back to an in-line
-	// discovery so the coordinator still works.
-	var allSkills, activeSkills []*skills.Skill
-	if opts.Skills != nil {
-		allSkills = opts.Skills.AllSkills()
-		activeSkills = opts.Skills.ActiveSkills()
-	} else {
-		allSkills, activeSkills = discoverSkills(opts.Config)
-	}
+	allSkills := opts.Skills.AllSkills()
+	activeSkills := opts.Skills.ActiveSkills()
 	skillTracker := skills.NewTracker(activeSkills)
 
 	c := &coordinator{
@@ -1557,33 +1548,6 @@ func (c *coordinator) updateParentSessionCost(ctx context.Context, childSessionI
 	}
 
 	return nil
-}
-
-// discoverSkills is a thin fallback wrapper used only when no
-// skills.Manager has been threaded through to the coordinator. All
-// production call sites (backend.CreateWorkspace, setupLocalWorkspace)
-// run discovery in advance and pass the results via the manager;
-// reaching this path means a caller bypassed both. It deliberately does
-// NOT publish to the package-level broker — there are no subscribers in
-// that case, so doing so would be misleading without delivering the
-// snapshot anywhere useful.
-func discoverSkills(cfg *config.ConfigStore) (allSkills, activeSkills []*skills.Skill) {
-	opts := cfg.Config().Options
-	var paths, disabled []string
-	if opts != nil {
-		paths = opts.SkillsPaths
-		disabled = opts.DisabledSkills
-	}
-	var resolver func(string) (string, error)
-	if r := cfg.Resolver(); r != nil {
-		resolver = r.ResolveValue
-	}
-	allSkills, activeSkills, _ = skills.DiscoverFromConfig(skills.DiscoveryConfig{
-		SkillsPaths:    paths,
-		DisabledSkills: disabled,
-		Resolver:       resolver,
-	})
-	return allSkills, activeSkills
 }
 
 // logTurnSkillUsage emits a per-turn diagnostic line showing which skills

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -1238,21 +1238,17 @@ func (c *coordinator) ReloadSkills(ctx context.Context) error {
 		return err
 	}
 
-	c.allSkills = allSkills
-	c.activeSkills = activeSkills
-	c.skillTracker = skills.NewTracker(activeSkills)
-	logPromptSkillStats(activeSkills)
-
-	// Rebuild the system prompt so <available_skills> reflects the new set.
-	p, err := coderPrompt(
-		prompt.WithWorkingDir(c.cfg.WorkingDir()),
-		prompt.WithSkills(c.activeSkills),
-	)
+	// Build everything that can fail BEFORE swapping coordinator state,
+	// so a mid-reload error leaves the agent on the old skills.
+	large, _, err := c.buildAgentModels(ctx, false)
 	if err != nil {
 		return err
 	}
 
-	large, _, err := c.buildAgentModels(ctx, false)
+	p, err := coderPrompt(
+		prompt.WithWorkingDir(c.cfg.WorkingDir()),
+		prompt.WithSkills(activeSkills),
+	)
 	if err != nil {
 		return err
 	}
@@ -1260,9 +1256,15 @@ func (c *coordinator) ReloadSkills(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// All builds succeeded — commit the new skill state, then rebuild
+	// tools (which capture the slices by value at construction time).
+	c.allSkills = allSkills
+	c.activeSkills = activeSkills
+	c.skillTracker = skills.NewTracker(activeSkills)
+	logPromptSkillStats(activeSkills)
 	c.currentAgent.SetSystemPrompt(systemPrompt)
 
-	// Rebuild tools — they capture skill slices and the tracker by reference.
 	agentCfg, ok := c.cfg.Config().Agents[config.AgentCoder]
 	if !ok {
 		return errCoderAgentNotConfigured

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -156,8 +156,7 @@ type CoordinatorOptions struct {
 }
 
 func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, error) {
-	allSkills := opts.Skills.AllSkills()
-	activeSkills := opts.Skills.ActiveSkills()
+	allSkills, activeSkills := opts.Skills.SkillSnapshot()
 	skillTracker := skills.NewTracker(activeSkills)
 
 	c := &coordinator{
@@ -1234,12 +1233,12 @@ func (c *coordinator) ReloadSkills(ctx context.Context) error {
 		return errors.New("skill reload requires a skills manager")
 	}
 
-	activeSkills, err := c.skillsMgr.Reload(ctx)
+	allSkills, activeSkills, err := c.skillsMgr.Reload(ctx)
 	if err != nil {
 		return err
 	}
 
-	c.allSkills = c.skillsMgr.AllSkills()
+	c.allSkills = allSkills
 	c.activeSkills = activeSkills
 	c.skillTracker = skills.NewTracker(activeSkills)
 	logPromptSkillStats(activeSkills)

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -108,6 +108,7 @@ type Coordinator interface {
 	Summarize(context.Context, string) error
 	Model() Model
 	UpdateModels(ctx context.Context) error
+	ReloadSkills(ctx context.Context) error
 	GenerateTitle(ctx context.Context, sessionID, prompt string)
 }
 
@@ -131,6 +132,7 @@ type coordinator struct {
 	allSkills    []*skills.Skill // Pre-filter: all discovered after dedup.
 	activeSkills []*skills.Skill // Post-filter: active skills only.
 	skillTracker *skills.Tracker
+	skillsMgr    *skills.Manager // nil in legacy fallback mode
 
 	readyWg errgroup.Group
 }
@@ -182,6 +184,7 @@ func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, 
 		allSkills:    allSkills,
 		activeSkills: activeSkills,
 		skillTracker: skillTracker,
+		skillsMgr:    opts.Skills,
 		interactive:  opts.Interactive,
 	}
 
@@ -1221,6 +1224,53 @@ func (c *coordinator) UpdateModels(ctx context.Context) error {
 		return errCoderAgentNotConfigured
 	}
 
+	tools, err := c.buildTools(ctx, agentCfg, false)
+	if err != nil {
+		return err
+	}
+	c.currentAgent.SetTools(tools)
+	return nil
+}
+
+// ReloadSkills re-runs skill discovery and propagates the updated
+// skills to the system prompt, tools, and tracker. This lets users
+// pick up skill changes (new files, edits, deletions) without
+// restarting the session.
+func (c *coordinator) ReloadSkills(ctx context.Context) error {
+	if c.skillsMgr == nil {
+		return errors.New("skill reload requires a skills manager")
+	}
+
+	activeSkills := c.skillsMgr.Reload()
+
+	c.allSkills = c.skillsMgr.AllSkills()
+	c.activeSkills = activeSkills
+	c.skillTracker = skills.NewTracker(activeSkills)
+
+	// Rebuild the system prompt so <available_skills> reflects the new set.
+	p, err := coderPrompt(
+		prompt.WithWorkingDir(c.cfg.WorkingDir()),
+		prompt.WithSkills(c.activeSkills),
+	)
+	if err != nil {
+		return err
+	}
+
+	large, _, err := c.buildAgentModels(ctx, false)
+	if err != nil {
+		return err
+	}
+	systemPrompt, err := p.Build(ctx, large.Model.Provider(), large.Model.Model(), c.cfg)
+	if err != nil {
+		return err
+	}
+	c.currentAgent.SetSystemPrompt(systemPrompt)
+
+	// Rebuild tools — they capture skill slices and the tracker by reference.
+	agentCfg, ok := c.cfg.Config().Agents[config.AgentCoder]
+	if !ok {
+		return errCoderAgentNotConfigured
+	}
 	tools, err := c.buildTools(ctx, agentCfg, false)
 	if err != nil {
 		return err

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -132,7 +132,7 @@ type coordinator struct {
 	allSkills    []*skills.Skill // Pre-filter: all discovered after dedup.
 	activeSkills []*skills.Skill // Post-filter: active skills only.
 	skillTracker *skills.Tracker
-	skillsMgr    *skills.Manager // nil in legacy fallback mode
+	skillsMgr    *skills.Manager // required for ReloadSkills; nil only if caller bypassed normal setup
 
 	readyWg errgroup.Group
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -132,7 +132,7 @@ type coordinator struct {
 	allSkills    []*skills.Skill // Pre-filter: all discovered after dedup.
 	activeSkills []*skills.Skill // Post-filter: active skills only.
 	skillTracker *skills.Tracker
-	skillsMgr    *skills.Manager // required for ReloadSkills; nil only if caller bypassed normal setup
+	skillsMgr    *skills.Manager
 
 	readyWg errgroup.Group
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -188,6 +188,8 @@ func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, 
 		interactive:  opts.Interactive,
 	}
 
+	logPromptSkillStats(activeSkills)
+
 	agentCfg, ok := opts.Config.Config().Agents[config.AgentCoder]
 	if !ok {
 		return nil, errCoderAgentNotConfigured
@@ -1246,6 +1248,7 @@ func (c *coordinator) ReloadSkills(ctx context.Context) error {
 	c.allSkills = c.skillsMgr.AllSkills()
 	c.activeSkills = activeSkills
 	c.skillTracker = skills.NewTracker(activeSkills)
+	logPromptSkillStats(activeSkills)
 
 	// Rebuild the system prompt so <available_skills> reflects the new set.
 	p, err := coderPrompt(
@@ -1572,12 +1575,11 @@ func discoverSkills(cfg *config.ConfigStore) (allSkills, activeSkills []*skills.
 	if r := cfg.Resolver(); r != nil {
 		resolver = r.ResolveValue
 	}
-	allSkills, activeSkills, states := skills.DiscoverFromConfig(skills.DiscoveryConfig{
+	allSkills, activeSkills, _ = skills.DiscoverFromConfig(skills.DiscoveryConfig{
 		SkillsPaths:    paths,
 		DisabledSkills: disabled,
 		Resolver:       resolver,
 	})
-	logDiscoveryStats(states, paths, allSkills, activeSkills, disabled)
 	return allSkills, activeSkills
 }
 
@@ -1623,51 +1625,15 @@ func logTurnSkillUsage(
 	)
 }
 
-// logDiscoveryStats emits a single structured log line summarising skill
-// discovery for the current session. It is intentionally low-volume: one
-// line per session start. Builtin vs user counts are derived from the
-// SkillState.Path — builtin states use the "builtin/" embed prefix.
-func logDiscoveryStats(
-	states []*skills.SkillState,
-	userPaths []string,
-	allSkills, activeSkills []*skills.Skill,
-	disabled []string,
-) {
-	var builtinOK, builtinErr, userOK, userErr int
-	for _, s := range states {
-		isBuiltin := strings.HasPrefix(s.Path, "builtin/")
-		switch {
-		case isBuiltin && s.State == skills.StateNormal:
-			builtinOK++
-		case isBuiltin && s.State == skills.StateError:
-			builtinErr++
-		case !isBuiltin && s.State == skills.StateNormal:
-			userOK++
-		case !isBuiltin && s.State == skills.StateError:
-			userErr++
-		}
-	}
-
-	activeNames := make([]string, 0, len(activeSkills))
-	for _, s := range activeSkills {
-		activeNames = append(activeNames, s.Name)
-	}
-
+// logPromptSkillStats logs the prompt-injection size of the active
+// skills XML — the only discovery metric that is coordinator-specific
+// (depends on the active set AND the XML encoder).
+func logPromptSkillStats(activeSkills []*skills.Skill) {
 	xml := skills.ToPromptXML(activeSkills)
-
-	slog.Info(
-		"Skill discovery complete",
+	slog.Info("Skill prompt stats",
 		"component", "skills",
-		"builtin_ok", builtinOK,
-		"builtin_errors", builtinErr,
-		"user_ok", userOK,
-		"user_errors", userErr,
-		"user_paths", len(userPaths),
-		"deduped_total", len(allSkills),
 		"active", len(activeSkills),
-		"disabled", len(disabled),
 		"prompt_bytes", len(xml),
 		"prompt_tok_est", skills.ApproxTokenCount(xml),
-		"active_names", activeNames,
 	)
 }

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -60,6 +60,15 @@ func newTestCoordinator(t *testing.T, env fakeEnv, providerID string, providerCf
 	}
 }
 
+func TestCoordinator_ReloadSkills_NilManager(t *testing.T) {
+	t.Parallel()
+
+	c := &coordinator{}
+	err := c.ReloadSkills(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "skills manager")
+}
+
 // newMockAgent creates a mockSessionAgent with the given provider and run function.
 func newMockAgent(providerID string, maxTokens int64, runFunc func(context.Context, SessionAgentCall) (*fantasy.AgentResult, error)) *mockSessionAgent {
 	return &mockSessionAgent{

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -62,6 +62,15 @@ func newTestCoordinator(t *testing.T, env fakeEnv, providerID string, providerCf
 	}
 }
 
+func TestCoordinator_ReloadSkills_NilManager(t *testing.T) {
+	t.Parallel()
+
+	c := &coordinator{}
+	err := c.ReloadSkills(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "skills manager")
+}
+
 // newMockAgent creates a mockSessionAgent with the given provider and run function.
 func newMockAgent(providerID string, maxTokens int64, runFunc func(context.Context, SessionAgentCall) (*fantasy.AgentResult, error)) *mockSessionAgent {
 	return &mockSessionAgent{

--- a/internal/agent/prompt/prompt.go
+++ b/internal/agent/prompt/prompt.go
@@ -26,6 +26,7 @@ type Prompt struct {
 	now        func() time.Time
 	platform   string
 	workingDir string
+	skills     []*skills.Skill // pre-discovered; nil means discover at build time
 }
 
 type PromptDat struct {
@@ -64,6 +65,15 @@ func WithPlatform(platform string) Option {
 func WithWorkingDir(workingDir string) Option {
 	return func(p *Prompt) {
 		p.workingDir = workingDir
+	}
+}
+
+// WithSkills supplies pre-discovered skills so that promptData does not
+// re-walk the filesystem on every Build call. When nil (the default),
+// promptData falls back to discovering skills from config paths.
+func WithSkills(skills []*skills.Skill) Option {
+	return func(p *Prompt) {
+		p.skills = skills
 	}
 }
 
@@ -170,35 +180,39 @@ func (p *Prompt) promptData(ctx context.Context, provider, model string, store *
 	contextFiles := loadContextFiles(cfg.Options.ContextPaths, store)
 	globalContextFiles := loadContextFiles(cfg.Options.GlobalContextPaths, store)
 
-	// Discover and load skills metadata.
+	// Use pre-discovered skills if provided; otherwise discover from config.
 	var availSkillXML string
-
-	// Start with builtin skills.
-	allSkills := skills.DiscoverBuiltin()
-	builtinNames := make(map[string]bool, len(allSkills))
-	for _, s := range allSkills {
-		builtinNames[s.Name] = true
-	}
-
-	// Discover user skills from configured paths.
-	if len(cfg.Options.SkillsPaths) > 0 {
-		expandedPaths := make([]string, 0, len(cfg.Options.SkillsPaths))
-		for _, pth := range cfg.Options.SkillsPaths {
-			expandedPaths = append(expandedPaths, expandPath(pth, store))
+	var allSkills []*skills.Skill
+	if p.skills != nil {
+		allSkills = append(allSkills, p.skills...)
+	} else {
+		// Start with builtin skills.
+		allSkills = skills.DiscoverBuiltin()
+		builtinNames := make(map[string]bool, len(allSkills))
+		for _, s := range allSkills {
+			builtinNames[s.Name] = true
 		}
-		for _, userSkill := range skills.Discover(expandedPaths) {
-			if builtinNames[userSkill.Name] {
-				slog.Warn("User skill overrides builtin skill", "name", userSkill.Name)
+
+		// Discover user skills from configured paths.
+		if len(cfg.Options.SkillsPaths) > 0 {
+			expandedPaths := make([]string, 0, len(cfg.Options.SkillsPaths))
+			for _, pth := range cfg.Options.SkillsPaths {
+				expandedPaths = append(expandedPaths, expandPath(pth, store))
 			}
-			allSkills = append(allSkills, userSkill)
+			for _, userSkill := range skills.Discover(expandedPaths) {
+				if builtinNames[userSkill.Name] {
+					slog.Warn("User skill overrides builtin skill", "name", userSkill.Name)
+				}
+				allSkills = append(allSkills, userSkill)
+			}
 		}
+
+		// Deduplicate: user skills override builtins with the same name.
+		allSkills = skills.Deduplicate(allSkills)
+
+		// Filter out disabled skills.
+		allSkills = skills.Filter(allSkills, cfg.Options.DisabledSkills)
 	}
-
-	// Deduplicate: user skills override builtins with the same name.
-	allSkills = skills.Deduplicate(allSkills)
-
-	// Filter out disabled skills.
-	allSkills = skills.Filter(allSkills, cfg.Options.DisabledSkills)
 
 	if len(allSkills) > 0 {
 		availSkillXML = skills.ToPromptXML(allSkills)

--- a/internal/agent/prompt/prompt_test.go
+++ b/internal/agent/prompt/prompt_test.go
@@ -1,0 +1,32 @@
+package prompt
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithSkills_StoresProvidedSkills(t *testing.T) {
+	t.Parallel()
+
+	provided := []*skills.Skill{
+		{Name: "my-skill", Description: "A test skill.", SkillFilePath: "/skills/my-skill/SKILL.md"},
+	}
+
+	p, err := NewPrompt("test", "Test template", WithSkills(provided))
+	require.NoError(t, err)
+
+	require.Equal(t, provided, p.skills,
+		"WithSkills must store the slice on the Prompt")
+}
+
+func TestWithoutSkills_LeavesNil(t *testing.T) {
+	t.Parallel()
+
+	p, err := NewPrompt("test", "Test template")
+	require.NoError(t, err)
+
+	require.Nil(t, p.skills,
+		"Without WithSkills, p.skills must be nil so promptData falls back to discovery")
+}

--- a/internal/agent/prompts.go
+++ b/internal/agent/prompts.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/crush/internal/agent/prompt"
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/skills"
 )
 
 //go:embed templates/coder.md.tpl
@@ -33,8 +34,10 @@ func taskPrompt(opts ...prompt.Option) (*prompt.Prompt, error) {
 	return systemPrompt, nil
 }
 
-func InitializePrompt(cfg *config.ConfigStore) (string, error) {
-	systemPrompt, err := prompt.NewPrompt("initialize", string(initializePromptTmpl))
+func InitializePrompt(cfg *config.ConfigStore, activeSkills []*skills.Skill) (string, error) {
+	systemPrompt, err := prompt.NewPrompt("initialize", string(initializePromptTmpl),
+		prompt.WithSkills(activeSkills),
+	)
 	if err != nil {
 		return "", err
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -443,6 +443,13 @@ func (app *App) UpdateAgentModel(ctx context.Context) error {
 	return app.AgentCoordinator.UpdateModels(ctx)
 }
 
+func (app *App) ReloadSkills(ctx context.Context) error {
+	if app.AgentCoordinator == nil {
+		return fmt.Errorf("agent configuration is missing")
+	}
+	return app.AgentCoordinator.ReloadSkills(ctx)
+}
+
 // overrideModelsForNonInteractive parses the model strings and temporarily
 // overrides the model configurations, then rebuilds the agent.
 // Format: "model-name" (searches all providers) or "provider/model-name".

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -492,6 +492,13 @@ func (app *App) restoreModelFromSession(ctx context.Context, sessionID string) e
 	return nil
 }
 
+func (app *App) ReloadSkills(ctx context.Context) error {
+	if app.AgentCoordinator == nil {
+		return fmt.Errorf("agent configuration is missing")
+	}
+	return app.AgentCoordinator.ReloadSkills(ctx)
+}
+
 // overrideModelsForNonInteractive parses the model strings and temporarily
 // overrides the model configurations, then rebuilds the agent.
 // Format: "model-name" (searches all providers) or "provider/model-name".

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -164,6 +164,16 @@ func (b *Backend) UpdateAgent(ctx context.Context, workspaceID string) error {
 	return ws.UpdateAgentModel(ctx)
 }
 
+// ReloadSkills re-discovers skills and propagates them to the agent.
+func (b *Backend) ReloadSkills(ctx context.Context, workspaceID string) error {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return err
+	}
+
+	return ws.ReloadSkills(ctx)
+}
+
 // CancelSession cancels an ongoing agent operation for the given
 // session.
 func (b *Backend) CancelSession(workspaceID, sessionID string) error {

--- a/internal/backend/agent_runcomplete_test.go
+++ b/internal/backend/agent_runcomplete_test.go
@@ -47,6 +47,7 @@ func (c *errorCoordinator) ClearQueue(string)                                 {}
 func (c *errorCoordinator) Summarize(context.Context, string) error           { return nil }
 func (c *errorCoordinator) Model() agent.Model                                { return agent.Model{} }
 func (c *errorCoordinator) UpdateModels(context.Context) error                { return nil }
+func (c *errorCoordinator) ReloadSkills(context.Context) error               { return nil }
 func (c *errorCoordinator) GenerateTitle(context.Context, string, string)     {}
 
 // insertRunCompleteWorkspace installs a workspace backed by a real

--- a/internal/backend/agent_runcomplete_test.go
+++ b/internal/backend/agent_runcomplete_test.go
@@ -47,7 +47,7 @@ func (c *errorCoordinator) ClearQueue(string)                                 {}
 func (c *errorCoordinator) Summarize(context.Context, string) error           { return nil }
 func (c *errorCoordinator) Model() agent.Model                                { return agent.Model{} }
 func (c *errorCoordinator) UpdateModels(context.Context) error                { return nil }
-func (c *errorCoordinator) ReloadSkills(context.Context) error               { return nil }
+func (c *errorCoordinator) ReloadSkills(context.Context) error                { return nil }
 func (c *errorCoordinator) GenerateTitle(context.Context, string, string)     {}
 
 // insertRunCompleteWorkspace installs a workspace backed by a real

--- a/internal/backend/agent_test.go
+++ b/internal/backend/agent_test.go
@@ -57,6 +57,7 @@ func (c *blockingCoordinator) ClearQueue(string)                                
 func (c *blockingCoordinator) Summarize(context.Context, string) error           { return nil }
 func (c *blockingCoordinator) Model() agent.Model                                { return agent.Model{} }
 func (c *blockingCoordinator) UpdateModels(context.Context) error                { return nil }
+func (c *blockingCoordinator) ReloadSkills(context.Context) error               { return nil }
 func (c *blockingCoordinator) GenerateTitle(context.Context, string, string)     {}
 
 // insertAgentWorkspace installs a synthetic workspace with the given

--- a/internal/backend/agent_test.go
+++ b/internal/backend/agent_test.go
@@ -57,7 +57,7 @@ func (c *blockingCoordinator) ClearQueue(string)                                
 func (c *blockingCoordinator) Summarize(context.Context, string) error           { return nil }
 func (c *blockingCoordinator) Model() agent.Model                                { return agent.Model{} }
 func (c *blockingCoordinator) UpdateModels(context.Context) error                { return nil }
-func (c *blockingCoordinator) ReloadSkills(context.Context) error               { return nil }
+func (c *blockingCoordinator) ReloadSkills(context.Context) error                { return nil }
 func (c *blockingCoordinator) GenerateTitle(context.Context, string, string)     {}
 
 // insertAgentWorkspace installs a synthetic workspace with the given

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -290,6 +290,7 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 	allSkills, activeSkills, skillStates := skills.DiscoverFromConfig(discoveryCfg)
 	skillsMgr := skills.NewManager(
 		allSkills, activeSkills, skillStates,
+		skills.WithDiscoveryConfig(discoveryCfg),
 		skills.WithResolvedPaths(discoveryCfg.ResolvePaths()),
 		skills.WithWorkingDir(discoveryCfg.WorkingDir),
 	)

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -436,6 +436,7 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 	allSkills, activeSkills, skillStates := skills.DiscoverFromConfig(discoveryCfg)
 	skillsMgr := skills.NewManager(
 		allSkills, activeSkills, skillStates,
+		skills.WithDiscoveryConfig(discoveryCfg),
 		skills.WithResolvedPaths(discoveryCfg.ResolvePaths()),
 		skills.WithWorkingDir(discoveryCfg.WorkingDir),
 	)

--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -160,7 +160,11 @@ func (b *Backend) InitializePrompt(workspaceID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return agent.InitializePrompt(ws.Cfg)
+	var active []*skills.Skill
+	if ws.Skills != nil {
+		active = ws.Skills.ActiveSkills()
+	}
+	return agent.InitializePrompt(ws.Cfg, active)
 }
 
 // ReadSkill reads a skill's content by ID.

--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -169,7 +169,11 @@ func (b *Backend) InitializePrompt(workspaceID string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return agent.InitializePrompt(ws.Cfg)
+	var active []*skills.Skill
+	if ws.Skills != nil {
+		active = ws.Skills.ActiveSkills()
+	}
+	return agent.InitializePrompt(ws.Cfg, active)
 }
 
 // ReadSkill reads a skill's content by ID.

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -423,6 +423,19 @@ func (c *Client) UpdateAgent(ctx context.Context, id string) error {
 	return nil
 }
 
+// ReloadSkills triggers a skill reload on the server.
+func (c *Client) ReloadSkills(ctx context.Context, id string) error {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/skills/reload", id), nil, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to reload skills: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to reload skills: status code %d", rsp.StatusCode)
+	}
+	return nil
+}
+
 // SendMessage sends a message to the agent for a workspace.
 //
 // When runID is non-empty it is echoed back on the resulting

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -483,6 +483,19 @@ func (c *Client) UpdateAgent(ctx context.Context, id string) error {
 	return nil
 }
 
+// ReloadSkills triggers a skill reload on the server.
+func (c *Client) ReloadSkills(ctx context.Context, id string) error {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/skills/reload", id), nil, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to reload skills: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to reload skills: status code %d", rsp.StatusCode)
+	}
+	return nil
+}
+
 // SendMessage sends a message to the agent for a workspace.
 //
 // When runID is non-empty it is echoed back on the resulting

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -298,6 +298,7 @@ func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error
 	skillsMgr := skills.NewManager(
 		allSkills, activeSkills, skillStates,
 		skills.WithGlobalMirror(),
+		skills.WithDiscoveryConfig(discoveryCfg),
 		skills.WithResolvedPaths(discoveryCfg.ResolvePaths()),
 		skills.WithWorkingDir(discoveryCfg.WorkingDir),
 	)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -381,6 +381,7 @@ func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error
 	skillsMgr := skills.NewManager(
 		allSkills, activeSkills, skillStates,
 		skills.WithGlobalMirror(),
+		skills.WithDiscoveryConfig(discoveryCfg),
 		skills.WithResolvedPaths(discoveryCfg.ResolvePaths()),
 		skills.WithWorkingDir(discoveryCfg.WorkingDir),
 	)

--- a/internal/commands/commands_test.go
+++ b/internal/commands/commands_test.go
@@ -107,8 +107,44 @@ func TestFromSkillCatalog_UsesDiscoveredSymlinkedSkills(t *testing.T) {
 	entries := skills.Catalog(activeSkills, []string{root}, "")
 	cmds := FromSkillCatalog(entries)
 
+	require.GreaterOrEqual(t, len(cmds), 1)
+	var found bool
+	for _, cmd := range cmds {
+		if cmd.ID == "user:linked-skill" {
+			found = true
+			require.Equal(t, "linked-skill", cmd.Skill.Name)
+			require.Equal(t, filepath.Join(link, skills.SkillFileName), cmd.Skill.SkillFilePath)
+		}
+	}
+	require.True(t, found, "linked-skill should be in the palette")
+}
+
+func TestFromSkillCatalog_BuiltinSkillsAreUserInvocable(t *testing.T) {
+	t.Parallel()
+
+	_, activeSkills, _ := skills.DiscoverFromConfig(skills.DiscoveryConfig{})
+	entries := skills.Catalog(activeSkills, nil, "")
+	cmds := FromSkillCatalog(entries)
+
+	names := make(map[string]bool, len(cmds))
+	for _, cmd := range cmds {
+		names[cmd.Skill.Name] = true
+	}
+	for _, expected := range []string{"crush-config", "crush-hooks", "jq"} {
+		require.True(t, names[expected], "%s should be user-invocable in the palette", expected)
+	}
+}
+
+func TestFromSkillCatalog_UserInvocableFilter(t *testing.T) {
+	t.Parallel()
+
+	entries := []skills.CatalogEntry{
+		{Name: "invocable", Description: "Yes.", UserInvocable: true},
+		{Name: "hidden", Description: "No.", UserInvocable: false},
+	}
+	cmds := FromSkillCatalog(entries)
+
 	require.Len(t, cmds, 1)
-	require.Equal(t, "user:linked-skill", cmds[0].ID)
-	require.Equal(t, "linked-skill", cmds[0].Skill.Name)
-	require.Equal(t, filepath.Join(link, skills.SkillFileName), cmds[0].Skill.SkillFilePath)
+	require.Equal(t, "user:invocable", cmds[0].ID)
+	require.Equal(t, "invocable", cmds[0].Skill.Name)
 }

--- a/internal/server/agent_cancel_test.go
+++ b/internal/server/agent_cancel_test.go
@@ -81,6 +81,7 @@ func (s *runCoordinator) Summarize(context.Context, string) error {
 }
 func (s *runCoordinator) Model() agent.Model                            { return agent.Model{} }
 func (s *runCoordinator) UpdateModels(context.Context) error            { return nil }
+func (s *runCoordinator) ReloadSkills(context.Context) error           { return nil }
 func (s *runCoordinator) GenerateTitle(context.Context, string, string) {}
 
 func (s *runCoordinator) capturedCtx() context.Context {

--- a/internal/server/agent_cancel_test.go
+++ b/internal/server/agent_cancel_test.go
@@ -81,7 +81,7 @@ func (s *runCoordinator) Summarize(context.Context, string) error {
 }
 func (s *runCoordinator) Model() agent.Model                            { return agent.Model{} }
 func (s *runCoordinator) UpdateModels(context.Context) error            { return nil }
-func (s *runCoordinator) ReloadSkills(context.Context) error           { return nil }
+func (s *runCoordinator) ReloadSkills(context.Context) error            { return nil }
 func (s *runCoordinator) GenerateTitle(context.Context, string, string) {}
 
 func (s *runCoordinator) capturedCtx() context.Context {

--- a/internal/server/e2e_agent_test.go
+++ b/internal/server/e2e_agent_test.go
@@ -220,6 +220,7 @@ func (c *scriptedCoordinator) ClearQueue(string)                             {}
 func (c *scriptedCoordinator) Summarize(context.Context, string) error       { return nil }
 func (c *scriptedCoordinator) Model() agent.Model                            { return agent.Model{} }
 func (c *scriptedCoordinator) UpdateModels(context.Context) error            { return nil }
+func (c *scriptedCoordinator) ReloadSkills(context.Context) error           { return nil }
 func (c *scriptedCoordinator) GenerateTitle(context.Context, string, string) {}
 
 // agentE2EHarness extends the SSE harness with a scripted coordinator

--- a/internal/server/e2e_agent_test.go
+++ b/internal/server/e2e_agent_test.go
@@ -220,7 +220,7 @@ func (c *scriptedCoordinator) ClearQueue(string)                             {}
 func (c *scriptedCoordinator) Summarize(context.Context, string) error       { return nil }
 func (c *scriptedCoordinator) Model() agent.Model                            { return agent.Model{} }
 func (c *scriptedCoordinator) UpdateModels(context.Context) error            { return nil }
-func (c *scriptedCoordinator) ReloadSkills(context.Context) error           { return nil }
+func (c *scriptedCoordinator) ReloadSkills(context.Context) error            { return nil }
 func (c *scriptedCoordinator) GenerateTitle(context.Context, string, string) {}
 
 // agentE2EHarness extends the SSE harness with a scripted coordinator

--- a/internal/server/proto.go
+++ b/internal/server/proto.go
@@ -821,6 +821,16 @@ func (c *controllerV1) handlePostWorkspaceAgentUpdate(w http.ResponseWriter, r *
 	w.WriteHeader(http.StatusOK)
 }
 
+// handlePostWorkspaceSkillsReload reloads skills for a workspace.
+func (c *controllerV1) handlePostWorkspaceSkillsReload(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if err := c.backend.ReloadSkills(r.Context(), id); err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
 // handleGetWorkspaceAgentSession returns a specific agent session.
 //
 //	@Summary		Get agent session

--- a/internal/server/proto.go
+++ b/internal/server/proto.go
@@ -822,6 +822,14 @@ func (c *controllerV1) handlePostWorkspaceAgentUpdate(w http.ResponseWriter, r *
 }
 
 // handlePostWorkspaceSkillsReload reloads skills for a workspace.
+//
+//	@Summary		Reload skills
+//	@Tags			skills
+//	@Param			id	path		string	true	"Workspace ID"
+//	@Success		200
+//	@Failure		404	{object}	proto.Error
+//	@Failure		500	{object}	proto.Error
+//	@Router			/workspaces/{id}/skills/reload [post]
 func (c *controllerV1) handlePostWorkspaceSkillsReload(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if err := c.backend.ReloadSkills(r.Context(), id); err != nil {

--- a/internal/server/proto.go
+++ b/internal/server/proto.go
@@ -846,6 +846,14 @@ func (c *controllerV1) handlePostWorkspaceAgentUpdate(w http.ResponseWriter, r *
 }
 
 // handlePostWorkspaceSkillsReload reloads skills for a workspace.
+//
+//	@Summary		Reload skills
+//	@Tags			skills
+//	@Param			id	path		string	true	"Workspace ID"
+//	@Success		200
+//	@Failure		404	{object}	proto.Error
+//	@Failure		500	{object}	proto.Error
+//	@Router			/workspaces/{id}/skills/reload [post]
 func (c *controllerV1) handlePostWorkspaceSkillsReload(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if err := c.backend.ReloadSkills(r.Context(), id); err != nil {

--- a/internal/server/proto.go
+++ b/internal/server/proto.go
@@ -845,6 +845,16 @@ func (c *controllerV1) handlePostWorkspaceAgentUpdate(w http.ResponseWriter, r *
 	w.WriteHeader(http.StatusOK)
 }
 
+// handlePostWorkspaceSkillsReload reloads skills for a workspace.
+func (c *controllerV1) handlePostWorkspaceSkillsReload(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if err := c.backend.ReloadSkills(r.Context(), id); err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
 // handleGetWorkspaceAgentSession returns a specific agent session.
 //
 //	@Summary		Get agent session

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -185,6 +185,7 @@ func (s *Server) installHandler() {
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent", c.handlePostWorkspaceAgent)
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent/init", c.handlePostWorkspaceAgentInit)
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent/update", c.handlePostWorkspaceAgentUpdate)
+	mux.HandleFunc("POST /v1/workspaces/{id}/skills/reload", c.handlePostWorkspaceSkillsReload)
 	mux.HandleFunc("GET /v1/workspaces/{id}/agent/sessions/{sid}", c.handleGetWorkspaceAgentSession)
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent/sessions/{sid}/cancel", c.handlePostWorkspaceAgentSessionCancel)
 	mux.HandleFunc("GET /v1/workspaces/{id}/agent/sessions/{sid}/prompts/queued", c.handleGetWorkspaceAgentSessionPromptQueued)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -193,6 +193,7 @@ func (s *Server) installHandler() {
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent", c.handlePostWorkspaceAgent)
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent/init", c.handlePostWorkspaceAgentInit)
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent/update", c.handlePostWorkspaceAgentUpdate)
+	mux.HandleFunc("POST /v1/workspaces/{id}/skills/reload", c.handlePostWorkspaceSkillsReload)
 	mux.HandleFunc("GET /v1/workspaces/{id}/agent/sessions/{sid}", c.handleGetWorkspaceAgentSession)
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent/sessions/{sid}/cancel", c.handlePostWorkspaceAgentSessionCancel)
 	mux.HandleFunc("GET /v1/workspaces/{id}/agent/sessions/{sid}/prompts/queued", c.handleGetWorkspaceAgentSessionPromptQueued)

--- a/internal/server/sessions_isbusy_test.go
+++ b/internal/server/sessions_isbusy_test.go
@@ -52,7 +52,7 @@ func (s *stubCoordinator) Summarize(context.Context, string) error {
 }
 func (s *stubCoordinator) Model() agent.Model                            { return agent.Model{} }
 func (s *stubCoordinator) UpdateModels(context.Context) error            { return nil }
-func (s *stubCoordinator) ReloadSkills(context.Context) error           { return nil }
+func (s *stubCoordinator) ReloadSkills(context.Context) error            { return nil }
 func (s *stubCoordinator) GenerateTitle(context.Context, string, string) {}
 
 // stubSessions is a minimal session.Service that returns a fixed list

--- a/internal/server/sessions_isbusy_test.go
+++ b/internal/server/sessions_isbusy_test.go
@@ -52,6 +52,7 @@ func (s *stubCoordinator) Summarize(context.Context, string) error {
 }
 func (s *stubCoordinator) Model() agent.Model                            { return agent.Model{} }
 func (s *stubCoordinator) UpdateModels(context.Context) error            { return nil }
+func (s *stubCoordinator) ReloadSkills(context.Context) error           { return nil }
 func (s *stubCoordinator) GenerateTitle(context.Context, string, string) {}
 
 // stubSessions is a minimal session.Service that returns a fixed list

--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: crush-config
 description: Use when the user needs help configuring Crush — working with crush.json, setting up providers, configuring LSPs, adding MCP servers, managing skills or permissions, or changing Crush behavior.
+user-invocable: true
 ---
 
 # Crush Configuration

--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: crush-config
 description: Use when the user needs help configuring Crush — writing crushrc (the Bash config format) or crush.json, setting up providers, models, LSPs, MCP servers, hooks, skills, permissions, or changing Crush behavior.
+user-invocable: true
 ---
 
 # Crush Configuration

--- a/internal/skills/builtin/crush-hooks/SKILL.md
+++ b/internal/skills/builtin/crush-hooks/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: crush-hooks
 description: Use when the user wants to add, write, debug, or configure a Crush hook — gating or blocking tool calls, approving or rewriting tool input before execution, injecting context into tool results, or troubleshooting hook behavior in crush.json.
+user-invocable: true
 ---
 
 # Crush Hooks

--- a/internal/skills/builtin/jq/SKILL.md
+++ b/internal/skills/builtin/jq/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: jq
 description: Use when the user needs to query, filter, reshape, extract, create, or construct JSON data — including API responses, config files, log output, or any structured data — or when helping the user write or debug JSON transformations.
+user-invocable: true
 ---
 
 # jq — Built-in JSON Processor

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"slices"
 	"strings"
@@ -173,10 +174,15 @@ func (m *Manager) SubscribeEvents(ctx context.Context) <-chan pubsub.Event[Event
 // replacing allSkills, activeSkills, states, and resolvedPaths. It also
 // publishes a discovery event so subscribers (TUI sidebar, etc.) update.
 // Returns the new active skills so callers (e.g. the coordinator) can
-// propagate them to the system prompt and tools.
-func (m *Manager) Reload() []*Skill {
+// propagate them to the system prompt and tools. The context is checked
+// for cancellation after discovery completes but before swapping state.
+func (m *Manager) Reload(ctx context.Context) ([]*Skill, error) {
 	allSkills, activeSkills, states := DiscoverFromConfig(m.discoveryCfg)
 	resolved := m.discoveryCfg.ResolvePaths()
+
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("skill reload cancelled: %w", err)
+	}
 
 	m.mu.Lock()
 	m.allSkills = allSkills
@@ -186,7 +192,7 @@ func (m *Manager) Reload() []*Skill {
 	m.mu.Unlock()
 
 	m.PublishStates(states)
-	return activeSkills
+	return activeSkills, nil
 }
 
 // Shutdown releases broker resources.

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -116,6 +116,14 @@ func (m *Manager) ActiveSkills() []*Skill {
 	return m.activeSkills
 }
 
+// SkillSnapshot returns allSkills and activeSkills in a single lock
+// acquisition, preventing torn reads across a concurrent Reload.
+func (m *Manager) SkillSnapshot() (all, active []*Skill) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.allSkills, m.activeSkills
+}
+
 // ResolvedPaths returns the expanded skills directory paths stored at
 // construction time.
 func (m *Manager) ResolvedPaths() []string {
@@ -176,12 +184,12 @@ func (m *Manager) SubscribeEvents(ctx context.Context) <-chan pubsub.Event[Event
 // Returns the new active skills so callers (e.g. the coordinator) can
 // propagate them to the system prompt and tools. The context is checked
 // for cancellation after discovery completes but before swapping state.
-func (m *Manager) Reload(ctx context.Context) ([]*Skill, error) {
+func (m *Manager) Reload(ctx context.Context) (all, active []*Skill, err error) {
 	allSkills, activeSkills, states := DiscoverFromConfig(m.discoveryCfg)
 	resolved := m.discoveryCfg.ResolvePaths()
 
 	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("skill reload cancelled: %w", err)
+		return nil, nil, fmt.Errorf("skill reload cancelled: %w", err)
 	}
 
 	m.mu.Lock()
@@ -192,7 +200,7 @@ func (m *Manager) Reload(ctx context.Context) ([]*Skill, error) {
 	m.mu.Unlock()
 
 	m.PublishStates(states)
-	return activeSkills, nil
+	return allSkills, activeSkills, nil
 }
 
 // Shutdown releases broker resources.

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -33,6 +33,10 @@ type Manager struct {
 	resolvedPaths []string
 	workingDir    string
 
+	// discoveryCfg caches the config used at construction so Reload
+	// can re-run discovery without callers needing to pass it again.
+	discoveryCfg DiscoveryConfig
+
 	broker       *pubsub.Broker[Event]
 	globalMirror bool
 }
@@ -56,6 +60,15 @@ func WithGlobalMirror() ManagerOption {
 func WithResolvedPaths(paths []string) ManagerOption {
 	return func(m *Manager) {
 		m.resolvedPaths = paths
+	}
+}
+
+// WithDiscoveryConfig stores the config used during discovery so the
+// manager can re-run discovery later via Reload without callers needing
+// to pass it again.
+func WithDiscoveryConfig(cfg DiscoveryConfig) ManagerOption {
+	return func(m *Manager) {
+		m.discoveryCfg = cfg
 	}
 }
 
@@ -153,6 +166,26 @@ func (m *Manager) PublishStates(states []*SkillState) {
 // manager's workspace.
 func (m *Manager) SubscribeEvents(ctx context.Context) <-chan pubsub.Event[Event] {
 	return m.broker.Subscribe(ctx)
+}
+
+// Reload re-runs discovery from scratch using the stored DiscoveryConfig,
+// replacing allSkills, activeSkills, states, and resolvedPaths. It also
+// publishes a discovery event so subscribers (TUI sidebar, etc.) update.
+// Returns the new active skills so callers (e.g. the coordinator) can
+// propagate them to the system prompt and tools.
+func (m *Manager) Reload() []*Skill {
+	allSkills, activeSkills, states := DiscoverFromConfig(m.discoveryCfg)
+	resolved := m.discoveryCfg.ResolvePaths()
+
+	m.mu.Lock()
+	m.allSkills = allSkills
+	m.activeSkills = activeSkills
+	m.states = states
+	m.resolvedPaths = resolved
+	m.mu.Unlock()
+
+	m.PublishStates(states)
+	return activeSkills
 }
 
 // Shutdown releases broker resources.

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"context"
+	"log/slog"
 	"slices"
 	"strings"
 	"sync"
@@ -224,7 +225,41 @@ func DiscoverFromConfig(cfg DiscoveryConfig) (allSkills, activeSkills []*Skill, 
 	slices.SortStableFunc(allStates, func(a, b *SkillState) int {
 		return strings.Compare(strings.ToLower(a.Path), strings.ToLower(b.Path))
 	})
+
+	logDiscovery(allSkills, activeSkills, allStates, userPaths, cfg.DisabledSkills)
+
 	return allSkills, activeSkills, allStates
+}
+
+// logDiscovery emits a single structured INFO line summarising a
+// discovery pass. Called from DiscoverFromConfig so every discovery —
+// initial startup AND reloads — is logged.
+func logDiscovery(all, active []*Skill, states []*SkillState, userPaths []string, disabled []string) {
+	var builtinOK, builtinErr, userOK, userErr int
+	for _, s := range states {
+		isBuiltin := strings.HasPrefix(s.Path, "builtin/")
+		switch {
+		case isBuiltin && s.State == StateNormal:
+			builtinOK++
+		case isBuiltin && s.State == StateError:
+			builtinErr++
+		case !isBuiltin && s.State == StateNormal:
+			userOK++
+		case !isBuiltin && s.State == StateError:
+			userErr++
+		}
+	}
+	slog.Info("Skill discovery complete",
+		"component", "skills",
+		"builtin_ok", builtinOK,
+		"builtin_errors", builtinErr,
+		"user_ok", userOK,
+		"user_errors", userErr,
+		"user_paths", len(userPaths),
+		"deduped_total", len(all),
+		"active", len(active),
+		"disabled", len(disabled),
+	)
 }
 
 // DiscoveryConfig contains the inputs DiscoverFromConfig needs. Using a

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -195,7 +195,6 @@ func (m *Manager) Reload(ctx context.Context) (all, active []*Skill, err error) 
 	m.mu.Lock()
 	m.allSkills = allSkills
 	m.activeSkills = activeSkills
-	m.states = states
 	m.resolvedPaths = resolved
 	m.mu.Unlock()
 

--- a/internal/skills/manager_test.go
+++ b/internal/skills/manager_test.go
@@ -312,3 +312,63 @@ func TestManager_ReloadCancelled(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cancelled")
 }
+
+func TestManager_SkillSnapshot(t *testing.T) {
+	t.Parallel()
+
+	all := []*Skill{{Name: "a", Description: "desc-a"}, {Name: "b", Description: "desc-b"}}
+	active := []*Skill{{Name: "a", Description: "desc-a"}}
+	mgr := NewManager(all, active, nil)
+	t.Cleanup(mgr.Shutdown)
+
+	gotAll, gotActive := mgr.SkillSnapshot()
+	require.Equal(t, all, gotAll, "snapshot must return the all-skills slice")
+	require.Equal(t, active, gotActive, "snapshot must return the active-skills slice")
+}
+
+func TestManager_SkillSnapshot_AfterReload(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfg := DiscoveryConfig{SkillsPaths: []string{tmp}}
+	mgr := NewManager(nil, nil, nil, WithDiscoveryConfig(cfg))
+	t.Cleanup(mgr.Shutdown)
+
+	// Snapshot before: no user skills.
+	allBefore, activeBefore := mgr.SkillSnapshot()
+
+	// Add a skill.
+	skillDir := filepath.Join(tmp, "snap-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skillDir, SkillFileName),
+		[]byte("---\nname: snap-skill\ndescription: snapshot test.\n---\nBody.\n"),
+		0o644,
+	))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, _, err := mgr.Reload(ctx)
+	require.NoError(t, err)
+
+	// Snapshot after: both slices must reflect the reload atomically.
+	allAfter, activeAfter := mgr.SkillSnapshot()
+	require.Greater(t, len(allAfter), len(allBefore),
+		"allSkills must grow after reload")
+	require.Greater(t, len(activeAfter), len(activeBefore),
+		"activeSkills must grow after reload")
+
+	// Both slices must agree — every active skill is in allSkills.
+	activeSet := make(map[string]bool, len(activeAfter))
+	for _, s := range activeAfter {
+		activeSet[s.Name] = true
+	}
+	for _, s := range allAfter {
+		if activeSet[s.Name] {
+			activeSet[s.Name] = false // mark as seen
+		}
+	}
+	for name, unseen := range activeSet {
+		require.False(t, unseen, "active skill %q must appear in allSkills", name)
+	}
+}

--- a/internal/skills/manager_test.go
+++ b/internal/skills/manager_test.go
@@ -277,7 +277,7 @@ func TestManager_Reload(t *testing.T) {
 	))
 
 	// Reload should pick up the new skill.
-	activeAfter, err := mgr.Reload(ctx)
+	_, activeAfter, err := mgr.Reload(ctx)
 	require.NoError(t, err)
 
 	var found bool
@@ -308,7 +308,7 @@ func TestManager_ReloadCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before calling
 
-	_, err := mgr.Reload(ctx)
+	_, _, err := mgr.Reload(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cancelled")
 }

--- a/internal/skills/manager_test.go
+++ b/internal/skills/manager_test.go
@@ -247,3 +247,68 @@ func TestDiscoverFromConfig_Resolver(t *testing.T) {
 	}
 	require.True(t, found, "DiscoverFromConfig must expand $VAR via Resolver")
 }
+
+func TestManager_Reload(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	// Start with no skills.
+	cfg := DiscoveryConfig{
+		SkillsPaths: []string{tmp},
+	}
+	mgr := NewManager(nil, nil, nil, WithDiscoveryConfig(cfg))
+	t.Cleanup(mgr.Shutdown)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Initial state: no user skills (only builtins).
+	activeBefore := mgr.ActiveSkills()
+	statesBefore := mgr.States()
+
+	// Add a skill file after construction.
+	skillDir := filepath.Join(tmp, "late-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skillDir, SkillFileName),
+		[]byte("---\nname: late-skill\ndescription: Added after startup.\n---\nDo a thing.\n"),
+		0o644,
+	))
+
+	// Reload should pick up the new skill.
+	activeAfter, err := mgr.Reload(ctx)
+	require.NoError(t, err)
+
+	var found bool
+	for _, s := range activeAfter {
+		if s.Name == "late-skill" {
+			found = true
+		}
+	}
+	require.True(t, found, "Reload must discover skills added after construction")
+
+	// Manager slices must reflect the new state.
+	require.Greater(t, len(mgr.ActiveSkills()), len(activeBefore),
+		"ActiveSkills must reflect reload")
+	require.Greater(t, len(mgr.States()), len(statesBefore),
+		"States must reflect reload")
+	require.Equal(t, mgr.ActiveSkills(), activeAfter,
+		"ActiveSkills must match the returned slice")
+}
+
+func TestManager_ReloadCancelled(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	cfg := DiscoveryConfig{SkillsPaths: []string{tmp}}
+	mgr := NewManager(nil, nil, nil, WithDiscoveryConfig(cfg))
+	t.Cleanup(mgr.Shutdown)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before calling
+
+	_, err := mgr.Reload(ctx)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cancelled")
+}

--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -252,12 +252,19 @@ func DiscoverWithStates(paths []string) ([]*Skill, []*SkillState) {
 			if d.IsDir() || d.Name() != SkillFileName {
 				return nil
 			}
+			// Resolve symlinks so the same file reached via different paths
+			// (e.g. a global dir symlinked into a project) is only parsed,
+			// validated, and warned about once.
+			realPath := path
+			if resolved, err := filepath.EvalSymlinks(path); err == nil {
+				realPath = resolved
+			}
 			mu.Lock()
-			if seen[path] {
+			if seen[realPath] {
 				mu.Unlock()
 				return nil
 			}
-			seen[path] = true
+			seen[realPath] = true
 			mu.Unlock()
 			skill, err := Parse(path)
 			if err != nil {

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -400,6 +400,45 @@ func TestParseContent_NoFrontmatter(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestDiscoverSymlinkDedup(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Create a valid skill.
+	skillDir := filepath.Join(tmpDir, "real-skills", "my-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: my-skill
+description: Skill reachable via symlink.
+---
+# My Skill
+`), 0o644))
+
+	// Create a symlink directory pointing at the real skills dir.
+	linkDir := filepath.Join(tmpDir, "linked-skills")
+	require.NoError(t, os.Symlink(filepath.Join(tmpDir, "real-skills"), linkDir))
+
+	// Discover from both the real and symlinked paths.
+	discovered, states := DiscoverWithStates([]string{
+		filepath.Join(tmpDir, "real-skills"),
+		linkDir,
+	})
+
+	// Should find exactly one skill (not two).
+	require.Len(t, discovered, 1, "symlinked duplicate should be deduped")
+	require.Equal(t, "my-skill", discovered[0].Name)
+
+	// Should have exactly one normal state.
+	var normalCount int
+	for _, s := range states {
+		if s.State == StateNormal {
+			normalCount++
+		}
+	}
+	require.Equal(t, 1, normalCount, "symlinked duplicate should produce one state")
+}
+
 func TestDiscoverBuiltin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -59,7 +59,11 @@ type (
 	ActionToggleTransparentBackground struct{}
 	ActionInitializeProject           struct{}
 	ActionReloadSkills                struct{}
-	ActionSummarize                   struct {
+	// ActionSkillToggle toggles a skill's enabled/disabled state.
+	ActionSkillToggle struct {
+		SkillName string
+	}
+	ActionSummarize struct {
 		SessionID string
 	}
 	// ActionSelectReasoningEffort is a message indicating a reasoning effort

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -58,6 +58,7 @@ type (
 	}
 	ActionToggleTransparentBackground struct{}
 	ActionInitializeProject           struct{}
+	ActionReloadSkills                struct{}
 	ActionSummarize                   struct {
 		SessionID string
 	}

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -59,6 +59,7 @@ type (
 	}
 	ActionToggleTransparentBackground struct{}
 	ActionInitializeProject           struct{}
+	ActionReloadSkills                struct{}
 	ActionSummarize                   struct {
 		SessionID string
 	}

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -60,7 +60,11 @@ type (
 	ActionToggleTransparentBackground struct{}
 	ActionInitializeProject           struct{}
 	ActionReloadSkills                struct{}
-	ActionSummarize                   struct {
+	// ActionSkillToggle toggles a skill's enabled/disabled state.
+	ActionSkillToggle struct {
+		SkillName string
+	}
+	ActionSummarize struct {
 		SessionID string
 	}
 	// ActionSelectReasoningEffort is a message indicating a reasoning effort

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -434,6 +434,7 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		NewCommandItem(c.com.Styles, "new_session", "New Session", "ctrl+n", ActionNewSession{}),
 		NewCommandItem(c.com.Styles, "switch_session", "Sessions", "ctrl+s", ActionOpenDialog{SessionsID}),
 		NewCommandItem(c.com.Styles, "switch_model", "Switch Model", "ctrl+l", ActionOpenDialog{ModelsID}),
+		NewCommandItem(c.com.Styles, "skills", "Skills", "", ActionOpenDialog{SkillsID}),
 		NewCommandItem(c.com.Styles, "reload_skills", "Reload Skills", "", ActionReloadSkills{}),
 	}
 

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -434,6 +434,7 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		NewCommandItem(c.com.Styles, "new_session", "New Session", "ctrl+n", ActionNewSession{}),
 		NewCommandItem(c.com.Styles, "switch_session", "Sessions", "ctrl+s", ActionOpenDialog{SessionsID}),
 		NewCommandItem(c.com.Styles, "switch_model", "Switch Model", "ctrl+l", ActionOpenDialog{ModelsID}),
+		NewCommandItem(c.com.Styles, "reload_skills", "Reload Skills", "", ActionReloadSkills{}),
 	}
 
 	// Only show compact command if there's an active session

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -448,6 +448,7 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		NewCommandItem(c.com.Styles, "new_session", "New Session", "ctrl+n", ActionNewSession{}).WithAliases("clear"),
 		NewCommandItem(c.com.Styles, "switch_session", "Sessions", "ctrl+s", ActionOpenDialog{SessionsID}),
 		NewCommandItem(c.com.Styles, "switch_model", "Switch Model", "ctrl+l", ActionOpenDialog{ModelsID}),
+		NewCommandItem(c.com.Styles, "reload_skills", "Reload Skills", "", ActionReloadSkills{}),
 	}
 
 	// Only show compact command if there's an active session

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -448,6 +448,7 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		NewCommandItem(c.com.Styles, "new_session", "New Session", "ctrl+n", ActionNewSession{}).WithAliases("clear"),
 		NewCommandItem(c.com.Styles, "switch_session", "Sessions", "ctrl+s", ActionOpenDialog{SessionsID}),
 		NewCommandItem(c.com.Styles, "switch_model", "Switch Model", "ctrl+l", ActionOpenDialog{ModelsID}),
+		NewCommandItem(c.com.Styles, "skills", "Skills", "", ActionOpenDialog{SkillsID}),
 		NewCommandItem(c.com.Styles, "reload_skills", "Reload Skills", "", ActionReloadSkills{}),
 	}
 

--- a/internal/ui/dialog/skills.go
+++ b/internal/ui/dialog/skills.go
@@ -1,0 +1,353 @@
+package dialog
+
+import (
+	"context"
+	"strings"
+
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/list"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/sahilm/fuzzy"
+)
+
+// SkillsID is the identifier for the skills dialog.
+const SkillsID = "skills"
+
+// SkillItem wraps a skill catalog entry and its state as a list item.
+type SkillItem struct {
+	*list.Versioned
+	entry    skills.CatalogEntry
+	state    *skills.SkillState
+	disabled bool
+	t        *styles.Styles
+	m        fuzzy.Match
+	cache    map[int]string
+	focused  bool
+}
+
+var _ ListItem = &SkillItem{Versioned: list.NewVersioned()}
+
+// NewSkillItem creates a new SkillItem.
+func NewSkillItem(t *styles.Styles, entry skills.CatalogEntry, state *skills.SkillState, disabled bool) *SkillItem {
+	return &SkillItem{
+		Versioned: list.NewVersioned(),
+		t:         t,
+		entry:     entry,
+		state:     state,
+		disabled:  disabled,
+	}
+}
+
+// Finished implements list.Item.
+func (s *SkillItem) Finished() bool { return true }
+
+// Filter implements ListItem.
+func (s *SkillItem) Filter() string {
+	return s.entry.Name + " " + s.entry.Description
+}
+
+// ID implements ListItem.
+func (s *SkillItem) ID() string {
+	return s.entry.ID
+}
+
+// SetFocused implements ListItem.
+func (s *SkillItem) SetFocused(focused bool) {
+	if s.focused == focused {
+		return
+	}
+	s.cache = nil
+	s.focused = focused
+	if s.Versioned != nil {
+		s.Bump()
+	}
+}
+
+// SetMatch implements ListItem.
+func (s *SkillItem) SetMatch(match fuzzy.Match) {
+	if sameFuzzyMatch(s.m, match) {
+		return
+	}
+	s.cache = nil
+	s.m = match
+	if s.Versioned != nil {
+		s.Bump()
+	}
+}
+
+// Render implements ListItem.
+func (s *SkillItem) Render(width int) string {
+	itemStyles := ListItemStyles{
+		ItemBlurred:     s.t.Dialog.NormalItem,
+		ItemFocused:     s.t.Dialog.SelectedItem,
+		InfoTextBlurred: s.t.Dialog.ListItem.InfoBlurred,
+		InfoTextFocused: s.t.Dialog.ListItem.InfoFocused,
+	}
+
+	var parts []string
+	parts = append(parts, string(s.entry.Source))
+
+	if s.disabled {
+		parts = append(parts, "off")
+	} else if s.state != nil && s.state.State == skills.StateError {
+		parts = append(parts, "error")
+	} else {
+		parts = append(parts, "on")
+	}
+
+	if s.entry.UserInvocable {
+		parts = append(parts, "user")
+	}
+
+	info := strings.Join(parts, " ")
+	return renderItem(itemStyles, s.entry.Name, info, s.focused, width, s.cache, &s.m)
+}
+
+// Skills is a dialog that lists discovered skills and provides reload/toggle actions.
+type Skills struct {
+	com    *common.Common
+	help   help.Model
+	list   *list.FilterableList
+	input  textinput.Model
+	ws     workspace.Workspace
+	keyMap struct {
+		Reload,
+		Toggle,
+		Next,
+		Previous,
+		UpDown,
+		Close key.Binding
+	}
+}
+
+var _ Dialog = (*Skills)(nil)
+
+// NewSkills creates a new skills dialog.
+func NewSkills(com *common.Common, ws workspace.Workspace) *Skills {
+	d := &Skills{
+		com: com,
+		ws:  ws,
+	}
+
+	help := help.New()
+	help.Styles = com.Styles.DialogHelpStyles()
+	d.help = help
+
+	d.list = list.NewFilterableList(d.skillItems()...)
+	d.list.Focus()
+	d.list.SetSelected(0)
+
+	d.input = textinput.New()
+	d.input.SetVirtualCursor(false)
+	d.input.Placeholder = "Type to filter"
+	d.input.SetStyles(com.Styles.TextInput)
+	d.input.Focus()
+
+	d.keyMap.Reload = key.NewBinding(
+		key.WithKeys("ctrl+r"),
+		key.WithHelp("ctrl+r", "reload"),
+	)
+	d.keyMap.Toggle = key.NewBinding(
+		key.WithKeys("enter", "ctrl+d"),
+		key.WithHelp("enter", "toggle"),
+	)
+	d.keyMap.UpDown = key.NewBinding(
+		key.WithKeys("up", "down"),
+		key.WithHelp("↑/↓", "choose"),
+	)
+	d.keyMap.Next = key.NewBinding(
+		key.WithKeys("down"),
+		key.WithHelp("↓", "next"),
+	)
+	d.keyMap.Previous = key.NewBinding(
+		key.WithKeys("up"),
+		key.WithHelp("↑", "previous"),
+	)
+	closeKey := CloseKey
+	closeKey.SetHelp("esc", "close")
+	d.keyMap.Close = closeKey
+
+	return d
+}
+
+// skillItems builds the list items from current skill catalog entries and states.
+func (d *Skills) skillItems() []list.FilterableItem {
+	entries, err := d.ws.ListSkills(context.Background())
+	if err != nil || len(entries) == 0 {
+		return nil
+	}
+
+	states := d.ws.GetSkillStates()
+	stateMap := make(map[string]*skills.SkillState, len(states))
+	for i := range states {
+		stateMap[states[i].Name] = states[i]
+	}
+
+	disabledSet := make(map[string]bool)
+	if cfg := d.com.Config(); cfg != nil && cfg.Options != nil {
+		for _, name := range cfg.Options.DisabledSkills {
+			disabledSet[name] = true
+		}
+	}
+
+	// Track which skills are already listed by NAME. CatalogEntry.ID is the
+	// skill's file path, not its name, whereas SkillState.Name is the name —
+	// so the disabled-skill dedup below must key on name, or every active
+	// skill would be re-appended as "off".
+	seenNames := make(map[string]bool, len(entries))
+	items := make([]list.FilterableItem, 0, len(entries))
+	for _, entry := range entries {
+		seenNames[entry.Name] = true
+		state := stateMap[entry.Name]
+		items = append(items, NewSkillItem(d.com.Styles, entry, state, disabledSet[entry.Name]))
+	}
+
+	// Add skills that are discovered but disabled (not in the active catalog).
+	for _, st := range states {
+		if seenNames[st.Name] {
+			continue
+		}
+		entry := skills.CatalogEntry{
+			ID:          st.Name,
+			Name:        st.Name,
+			Description: "",
+			Source:      skills.SourceProject,
+		}
+		items = append(items, NewSkillItem(d.com.Styles, entry, st, true))
+	}
+
+	return items
+}
+
+// ID implements Dialog.
+func (d *Skills) ID() string { return SkillsID }
+
+// HandleMsg implements Dialog.
+func (d *Skills) HandleMsg(msg tea.Msg) Action {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, d.keyMap.Close):
+			return ActionClose{}
+		case key.Matches(msg, d.keyMap.Previous):
+			d.list.Focus()
+			if d.list.IsSelectedFirst() {
+				d.list.SelectLast()
+			} else {
+				d.list.SelectPrev()
+			}
+			d.list.ScrollToSelected()
+		case key.Matches(msg, d.keyMap.Next):
+			d.list.Focus()
+			if d.list.IsSelectedLast() {
+				d.list.SelectFirst()
+			} else {
+				d.list.SelectNext()
+			}
+			d.list.ScrollToSelected()
+		case key.Matches(msg, d.keyMap.Reload):
+			return ActionReloadSkills{}
+		case key.Matches(msg, d.keyMap.Toggle):
+			if item := d.selectedSkill(); item != nil {
+				return ActionSkillToggle{SkillName: item.entry.Name}
+			}
+		default:
+			var cmd tea.Cmd
+			d.input, cmd = d.input.Update(msg)
+			value := d.input.Value()
+			d.list.SetFilter(value)
+			d.list.ScrollToTop()
+			d.list.SetSelected(0)
+			return ActionCmd{cmd}
+		}
+	}
+	return nil
+}
+
+// selectedSkill returns the currently selected SkillItem, or nil.
+func (d *Skills) selectedSkill() *SkillItem {
+	item := d.list.SelectedItem()
+	if item == nil {
+		return nil
+	}
+	if si, ok := item.(*SkillItem); ok {
+		return si
+	}
+	return nil
+}
+
+// Cursor returns the cursor position relative to the dialog.
+func (d *Skills) Cursor() *tea.Cursor {
+	return InputCursor(d.com.Styles, d.input.Cursor())
+}
+
+// Draw implements Dialog.
+func (d *Skills) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	t := d.com.Styles
+	width := max(0, min(defaultDialogMaxWidth, area.Dx()-t.Dialog.View.GetHorizontalBorderSize()))
+	height := max(0, min(defaultDialogHeight, area.Dy()-t.Dialog.View.GetVerticalBorderSize()))
+	innerWidth := width - t.Dialog.View.GetHorizontalFrameSize()
+	heightOffset := t.Dialog.Title.GetVerticalFrameSize() + titleContentHeight +
+		t.Dialog.InputPrompt.GetVerticalFrameSize() + inputContentHeight +
+		t.Dialog.HelpView.GetVerticalFrameSize() +
+		t.Dialog.View.GetVerticalFrameSize()
+
+	d.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1))
+
+	listHeight := height - heightOffset
+	listWidth := max(0, innerWidth-3)
+	d.list.SetSize(listWidth, listHeight)
+	d.help.SetWidth(innerWidth)
+
+	rc := NewRenderContext(t, width)
+	rc.Title = "Skills"
+	inputView := t.Dialog.InputPrompt.Render(d.input.View())
+	rc.AddPart(inputView)
+	listView := t.Dialog.List.Height(d.list.Height()).Render(d.list.Render())
+	scrollbar := common.Scrollbar(t, listHeight, d.list.TotalHeight(), listHeight, d.list.Offset())
+	if scrollbar != "" {
+		listView = lipgloss.JoinHorizontal(lipgloss.Top, listView, scrollbar)
+	}
+	rc.AddPart(listView)
+	rc.Help = d.help.View(d)
+
+	view := rc.Render()
+	cur := d.Cursor()
+	DrawCenterCursor(scr, area, view, cur)
+	return cur
+}
+
+// ShortHelp implements help.KeyMap.
+func (d *Skills) ShortHelp() []key.Binding {
+	return []key.Binding{
+		d.keyMap.UpDown,
+		d.keyMap.Toggle,
+		d.keyMap.Reload,
+		d.keyMap.Close,
+	}
+}
+
+// FullHelp implements help.KeyMap.
+func (d *Skills) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{d.keyMap.Toggle, d.keyMap.Reload, d.keyMap.UpDown, d.keyMap.Close},
+	}
+}
+
+// Refresh reloads the skill items from the workspace. Call after a reload
+// or toggle action to update the list.
+func (d *Skills) Refresh() {
+	d.list.SetItems(d.skillItems()...)
+	d.list.SetFilter("")
+	d.list.ScrollToTop()
+	d.list.SetSelected(0)
+	d.input.SetValue("")
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1762,6 +1762,15 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		cmds = append(cmds, m.initializeProject())
 		m.dialog.CloseDialog(dialog.CommandsID)
 
+	case dialog.ActionReloadSkills:
+		cmds = append(cmds, func() tea.Msg {
+			if err := m.com.Workspace.ReloadSkills(context.TODO()); err != nil {
+				return util.NewErrorMsg(fmt.Errorf("failed to reload skills: %w", err))
+			}
+			return util.NewInfoMsg("Skills reloaded")
+		})
+		m.dialog.CloseDialog(dialog.CommandsID)
+
 	case dialog.ActionSelectModel:
 		if cmd := m.handleSelectModel(msg); cmd != nil {
 			cmds = append(cmds, cmd)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1764,7 +1764,9 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 
 	case dialog.ActionReloadSkills:
 		cmds = append(cmds, func() tea.Msg {
-			if err := m.com.Workspace.ReloadSkills(context.TODO()); err != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			if err := m.com.Workspace.ReloadSkills(ctx); err != nil {
 				return util.NewErrorMsg(fmt.Errorf("failed to reload skills: %w", err))
 			}
 			return util.NewInfoMsg("Skills reloaded")

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1761,6 +1761,9 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		}
 		cmds = append(cmds, m.initializeProject())
 		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionSkillToggle:
+		cmds = append(cmds, m.toggleSkill(msg.SkillName))
+		m.dialog.CloseDialog(dialog.SkillsID)
 
 	case dialog.ActionReloadSkills:
 		cmds = append(cmds, func() tea.Msg {
@@ -1772,6 +1775,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			return util.NewInfoMsg("Skills reloaded")
 		})
 		m.dialog.CloseDialog(dialog.CommandsID)
+		m.dialog.CloseDialog(dialog.SkillsID)
 
 	case dialog.ActionSelectModel:
 		if cmd := m.handleSelectModel(msg); cmd != nil {
@@ -3932,6 +3936,10 @@ func (m *UI) openDialog(id string) tea.Cmd {
 		if cmd := m.openQuitDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+	case dialog.SkillsID:
+		if cmd := m.openSkillsDialog(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	default:
 		// Unknown dialog
 		break
@@ -3949,6 +3957,18 @@ func (m *UI) openQuitDialog() tea.Cmd {
 
 	quitDialog := dialog.NewQuit(m.com)
 	m.dialog.OpenDialog(quitDialog)
+	return nil
+}
+
+// openSkillsDialog opens the skills management dialog.
+func (m *UI) openSkillsDialog() tea.Cmd {
+	if m.dialog.ContainsDialog(dialog.SkillsID) {
+		m.dialog.BringToFront(dialog.SkillsID)
+		return nil
+	}
+
+	skillsDialog := dialog.NewSkills(m.com, m.com.Workspace)
+	m.dialog.OpenDialog(skillsDialog)
 	return nil
 }
 
@@ -4597,6 +4617,47 @@ func (m *UI) disableDockerMCP() tea.Msg {
 	}
 
 	return util.NewInfoMsg("Docker MCP disabled successfully")
+}
+
+// toggleSkill toggles a skill's enabled/disabled state by updating
+// options.disabled_skills in the config and reloading skills so the
+// change takes effect immediately.
+func (m *UI) toggleSkill(skillName string) tea.Cmd {
+	return func() tea.Msg {
+		cfg := m.com.Config()
+		if cfg == nil || cfg.Options == nil {
+			return util.NewErrorMsg(fmt.Errorf("no config available"))
+		}
+
+		disabled := cfg.Options.DisabledSkills
+		found := false
+		var newList []string
+		for _, name := range disabled {
+			if name == skillName {
+				found = true
+				continue
+			}
+			newList = append(newList, name)
+		}
+
+		action := "enabled"
+		if !found {
+			newList = append(newList, skillName)
+			action = "disabled"
+		}
+
+		if err := m.com.Workspace.SetConfigField(config.ScopeGlobal, "options.disabled_skills", newList); err != nil {
+			return util.ReportError(err)()
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		if err := m.com.Workspace.ReloadSkills(ctx); err != nil {
+			return util.ReportError(err)()
+		}
+
+		return util.NewInfoMsg(fmt.Sprintf("Skill %q %s", skillName, action))
+	}
 }
 
 // renderLogo renders the Crush logo with the given styles and dimensions.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1996,6 +1996,9 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		}
 		cmds = append(cmds, m.initializeProject())
 		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionSkillToggle:
+		cmds = append(cmds, m.toggleSkill(msg.SkillName))
+		m.dialog.CloseDialog(dialog.SkillsID)
 
 	case dialog.ActionReloadSkills:
 		cmds = append(cmds, func() tea.Msg {
@@ -2007,6 +2010,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			return util.NewInfoMsg("Skills reloaded")
 		})
 		m.dialog.CloseDialog(dialog.CommandsID)
+		m.dialog.CloseDialog(dialog.SkillsID)
 
 	case dialog.ActionSelectModel:
 		if cmd := m.handleSelectModel(msg); cmd != nil {
@@ -4337,6 +4341,10 @@ func (m *UI) openDialog(id string) tea.Cmd {
 		if cmd := m.openQuitDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+	case dialog.SkillsID:
+		if cmd := m.openSkillsDialog(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	default:
 		// Unknown dialog
 		break
@@ -4354,6 +4362,18 @@ func (m *UI) openQuitDialog() tea.Cmd {
 
 	quitDialog := dialog.NewQuit(m.com)
 	m.dialog.OpenDialog(quitDialog)
+	return nil
+}
+
+// openSkillsDialog opens the skills management dialog.
+func (m *UI) openSkillsDialog() tea.Cmd {
+	if m.dialog.ContainsDialog(dialog.SkillsID) {
+		m.dialog.BringToFront(dialog.SkillsID)
+		return nil
+	}
+
+	skillsDialog := dialog.NewSkills(m.com, m.com.Workspace)
+	m.dialog.OpenDialog(skillsDialog)
 	return nil
 }
 
@@ -5068,6 +5088,47 @@ func (m *UI) disableDockerMCP() tea.Msg {
 	}
 
 	return util.NewInfoMsg("Docker MCP disabled successfully")
+}
+
+// toggleSkill toggles a skill's enabled/disabled state by updating
+// options.disabled_skills in the config and reloading skills so the
+// change takes effect immediately.
+func (m *UI) toggleSkill(skillName string) tea.Cmd {
+	return func() tea.Msg {
+		cfg := m.com.Config()
+		if cfg == nil || cfg.Options == nil {
+			return util.NewErrorMsg(fmt.Errorf("no config available"))
+		}
+
+		disabled := cfg.Options.DisabledSkills
+		found := false
+		var newList []string
+		for _, name := range disabled {
+			if name == skillName {
+				found = true
+				continue
+			}
+			newList = append(newList, name)
+		}
+
+		action := "enabled"
+		if !found {
+			newList = append(newList, skillName)
+			action = "disabled"
+		}
+
+		if err := m.com.Workspace.SetConfigField(config.ScopeGlobal, "options.disabled_skills", newList); err != nil {
+			return util.ReportError(err)()
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		if err := m.com.Workspace.ReloadSkills(ctx); err != nil {
+			return util.ReportError(err)()
+		}
+
+		return util.NewInfoMsg(fmt.Sprintf("Skill %q %s", skillName, action))
+	}
 }
 
 // renderLogo renders the Crush logo with the given styles and dimensions.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1997,6 +1997,15 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		cmds = append(cmds, m.initializeProject())
 		m.dialog.CloseDialog(dialog.CommandsID)
 
+	case dialog.ActionReloadSkills:
+		cmds = append(cmds, func() tea.Msg {
+			if err := m.com.Workspace.ReloadSkills(context.TODO()); err != nil {
+				return util.NewErrorMsg(fmt.Errorf("failed to reload skills: %w", err))
+			}
+			return util.NewInfoMsg("Skills reloaded")
+		})
+		m.dialog.CloseDialog(dialog.CommandsID)
+
 	case dialog.ActionSelectModel:
 		if cmd := m.handleSelectModel(msg); cmd != nil {
 			cmds = append(cmds, cmd)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1999,7 +1999,9 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 
 	case dialog.ActionReloadSkills:
 		cmds = append(cmds, func() tea.Msg {
-			if err := m.com.Workspace.ReloadSkills(context.TODO()); err != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			if err := m.com.Workspace.ReloadSkills(ctx); err != nil {
 				return util.NewErrorMsg(fmt.Errorf("failed to reload skills: %w", err))
 			}
 			return util.NewInfoMsg("Skills reloaded")

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -223,6 +223,10 @@ func (w *AppWorkspace) UpdateAgentModel(ctx context.Context) error {
 	return w.app.UpdateAgentModel(ctx)
 }
 
+func (w *AppWorkspace) ReloadSkills(ctx context.Context) error {
+	return w.app.ReloadSkills(ctx)
+}
+
 func (w *AppWorkspace) InitCoderAgent(ctx context.Context) error {
 	return w.app.InitCoderAgent(ctx)
 }

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -400,6 +400,13 @@ func (w *AppWorkspace) ReadSkill(_ context.Context, skillID string) ([]byte, ski
 	return skills.ReadContent(mgr.ActiveSkills(), mgr.ResolvedPaths(), mgr.WorkingDir(), skillID)
 }
 
+func (w *AppWorkspace) GetSkillStates() []*skills.SkillState {
+	if w.app.Skills == nil {
+		return nil
+	}
+	return w.app.Skills.States()
+}
+
 // -- MCP operations --
 
 func (w *AppWorkspace) MCPGetStates() map[string]mcptools.ClientInfo {

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -383,7 +383,11 @@ func (w *AppWorkspace) MarkProjectInitialized() error {
 }
 
 func (w *AppWorkspace) InitializePrompt() (string, error) {
-	return agent.InitializePrompt(w.store)
+	var active []*skills.Skill
+	if w.app.Skills != nil {
+		active = w.app.Skills.ActiveSkills()
+	}
+	return agent.InitializePrompt(w.store, active)
 }
 
 func (w *AppWorkspace) ListSkills(_ context.Context) ([]skills.CatalogEntry, error) {

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -230,6 +230,10 @@ func (w *AppWorkspace) UpdateAgentModel(ctx context.Context) error {
 	return w.app.UpdateAgentModel(ctx)
 }
 
+func (w *AppWorkspace) ReloadSkills(ctx context.Context) error {
+	return w.app.ReloadSkills(ctx)
+}
+
 func (w *AppWorkspace) InitCoderAgent(ctx context.Context) error {
 	return w.app.InitCoderAgent(ctx)
 }

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -390,7 +390,11 @@ func (w *AppWorkspace) MarkProjectInitialized() error {
 }
 
 func (w *AppWorkspace) InitializePrompt() (string, error) {
-	return agent.InitializePrompt(w.store)
+	var active []*skills.Skill
+	if w.app.Skills != nil {
+		active = w.app.Skills.ActiveSkills()
+	}
+	return agent.InitializePrompt(w.store, active)
 }
 
 func (w *AppWorkspace) ListSkills(_ context.Context) ([]skills.CatalogEntry, error) {

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -407,6 +407,13 @@ func (w *AppWorkspace) ReadSkill(_ context.Context, skillID string) ([]byte, ski
 	return skills.ReadContent(mgr.ActiveSkills(), mgr.ResolvedPaths(), mgr.WorkingDir(), skillID)
 }
 
+func (w *AppWorkspace) GetSkillStates() []*skills.SkillState {
+	if w.app.Skills == nil {
+		return nil
+	}
+	return w.app.Skills.States()
+}
+
 // -- MCP operations --
 
 func (w *AppWorkspace) MCPGetStates() map[string]mcptools.ClientInfo {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -266,6 +266,10 @@ func (w *ClientWorkspace) UpdateAgentModel(ctx context.Context) error {
 	return w.client.UpdateAgent(ctx, w.workspaceID())
 }
 
+func (w *ClientWorkspace) ReloadSkills(ctx context.Context) error {
+	return w.client.ReloadSkills(ctx, w.workspaceID())
+}
+
 func (w *ClientWorkspace) InitCoderAgent(ctx context.Context) error {
 	return w.client.InitiateAgentProcessing(ctx, w.workspaceID(), true)
 }

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -585,6 +585,13 @@ func (w *ClientWorkspace) ReadSkill(ctx context.Context, skillID string) ([]byte
 	}, nil
 }
 
+func (w *ClientWorkspace) GetSkillStates() []*skills.SkillState {
+	if w.skills == nil {
+		return nil
+	}
+	return w.skills.States()
+}
+
 // -- MCP operations --
 
 func (w *ClientWorkspace) MCPGetStates() map[string]mcp.ClientInfo {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -318,6 +318,10 @@ func (w *ClientWorkspace) UpdateAgentModel(ctx context.Context) error {
 	return w.client.UpdateAgent(ctx, w.workspaceID())
 }
 
+func (w *ClientWorkspace) ReloadSkills(ctx context.Context) error {
+	return w.client.ReloadSkills(ctx, w.workspaceID())
+}
+
 func (w *ClientWorkspace) InitCoderAgent(ctx context.Context) error {
 	return w.client.InitiateAgentProcessing(ctx, w.workspaceID(), true)
 }

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -637,6 +637,13 @@ func (w *ClientWorkspace) ReadSkill(ctx context.Context, skillID string) ([]byte
 	}, nil
 }
 
+func (w *ClientWorkspace) GetSkillStates() []*skills.SkillState {
+	if w.skills == nil {
+		return nil
+	}
+	return w.skills.States()
+}
+
 // -- MCP operations --
 
 func (w *ClientWorkspace) MCPGetStates() map[string]mcp.ClientInfo {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -157,6 +157,10 @@ type Workspace interface {
 	InitializePrompt() (string, error)
 	ListSkills(ctx context.Context) ([]skills.CatalogEntry, error)
 	ReadSkill(ctx context.Context, skillID string) ([]byte, skills.SkillReadResult, error)
+	// GetSkillStates returns the current per-skill discovery states (including
+	// disabled and errored skills), used by the skills dialog to show all
+	// skills — not just the active catalog.
+	GetSkillStates() []*skills.SkillState
 
 	// MCP operations (server-side in client mode)
 	MCPGetStates() map[string]mcptools.ClientInfo

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -95,6 +95,7 @@ type Workspace interface {
 	AgentClearQueue(sessionID string)
 	AgentSummarize(ctx context.Context, sessionID string) error
 	UpdateAgentModel(ctx context.Context) error
+	ReloadSkills(ctx context.Context) error
 	InitCoderAgent(ctx context.Context) error
 	InitCoderAgentNonInteractive(ctx context.Context) error
 	GetDefaultSmallModel(providerID string) config.SelectedModel

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -217,6 +217,10 @@ type Workspace interface {
 	InitializePrompt() (string, error)
 	ListSkills(ctx context.Context) ([]skills.CatalogEntry, error)
 	ReadSkill(ctx context.Context, skillID string) ([]byte, skills.SkillReadResult, error)
+	// GetSkillStates returns the current per-skill discovery states (including
+	// disabled and errored skills), used by the skills dialog to show all
+	// skills — not just the active catalog.
+	GetSkillStates() []*skills.SkillState
 
 	// MCP operations (server-side in client mode)
 	MCPGetStates() map[string]mcptools.ClientInfo

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -155,6 +155,7 @@ type Workspace interface {
 	AgentClearQueue(sessionID string)
 	AgentSummarize(ctx context.Context, sessionID string) error
 	UpdateAgentModel(ctx context.Context) error
+	ReloadSkills(ctx context.Context) error
 	InitCoderAgent(ctx context.Context) error
 	InitCoderAgentNonInteractive(ctx context.Context) error
 	GetDefaultSmallModel(providerID string) config.SelectedModel


### PR DESCRIPTION
## Summary

Adds an interactive Skills management dialog that lets users browse all discovered skills and toggle individual skills on/off live — no config-file editing, no restart.

Builds on the `ReloadSkills` / `SkillSnapshot` infrastructure from #3319.

## What it does

- **New "Skills" command** in the command palette opens a full-screen dialog
- Lists **all** skills — active, disabled, and errored — with their source (builtin/user/project), state indicator (`on`/`off`/`error`), and user-invocable flag
- **`enter` / `ctrl+d`**: toggle the selected skill's enabled state by updating `options.disabled_skills` in config, then triggers an immediate `ReloadSkills` so the change takes effect instantly
- **`ctrl+r`**: reload skills from disk (picks up new/edited/deleted skill files)
- Type to filter, `↑`/`↓` to navigate

## Why

Currently the only way to disable a skill is to hand-edit `options.disabled_skills` in the config file and restart the session. A live, per-skill toggle in a browsable dialog is a significant UX improvement — users can experiment with skills without leaving the TUI.

## Changes

| File | What |
|------|------|
| `internal/ui/dialog/skills.go` | **New.** The dialog: filterable list of all skills with toggle/reload keybindings |
| `internal/ui/dialog/actions.go` | Add `ActionSkillToggle` action type |
| `internal/ui/dialog/commands.go` | Add "Skills" command palette entry that opens the dialog |
| `internal/ui/model/ui.go` | `openSkillsDialog()` + `toggleSkill()` handler + `ActionReloadSkills` also closes Skills dialog |
| `internal/workspace/workspace.go` | Add `GetSkillStates()` to the `Workspace` interface |
| `internal/workspace/app_workspace.go` | Implement `GetSkillStates()` via `Manager.States()` |
| `internal/workspace/client_workspace.go` | Implement `GetSkillStates()` via local `Manager.States()` |

## Dependencies

- **#3319** — This PR builds on the `ReloadSkills(ctx)`, `Manager.Reload()`, and `Manager.SkillSnapshot()` APIs introduced there. The branch includes #3319's commits so CI passes; once #3319 merges, this can rebase cleanly onto `main`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/ui/dialog/... ./internal/workspace/... ./internal/skills/...` passes
- [x] `go vet` clean
- [ ] Manual: open Skills dialog, toggle a builtin skill off, verify it disappears from `<available_skills>`, toggle it back on
- [ ] Manual: add a skill file to disk, `ctrl+r` in the dialog, verify it appears

💘 Generated with Crush