### PR TITLE
fix: show thinking blocks for minimax m3 on opencode providers

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -506,6 +506,13 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 			switch providerCfg.ID {
 			case string(catwalk.InferenceProviderIoNet):
 				extraBody["reasoning"] = map[string]string{"effort": reasoningEffort}
+			case string(catwalk.InferenceProviderOpenCodeGo), string(catwalk.InferenceProviderOpenCodeZen):
+				// MiniMax models use the "thinking" parameter instead of
+				// "reasoning_effort". Other models on these providers still
+				// use the standard field.
+				if !strings.HasPrefix(strings.ToLower(model.CatwalkCfg.ID), "minimax") {
+					mergedOptions["reasoning_effort"] = reasoningEffort
+				}
 			default:
 				mergedOptions["reasoning_effort"] = reasoningEffort
 			}
@@ -547,6 +554,19 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 		case string(catwalk.InferenceProviderBaseten):
 			extraBody["chat_template_args"] = map[string]any{
 				"enable_thinking": model.ModelCfg.Think || reasoningEffort != "",
+			}
+
+		case string(catwalk.InferenceProviderOpenCodeGo), string(catwalk.InferenceProviderOpenCodeZen):
+			// MiniMax M3 uses the "thinking" parameter to control reasoning.
+			// "reasoning_split" must be true so thinking content is returned
+			// in the "reasoning_content" field instead of inline in "content".
+			if strings.HasPrefix(strings.ToLower(model.CatwalkCfg.ID), "minimax") {
+				if model.CatwalkCfg.CanReason && (model.ModelCfg.Think || reasoningEffort != "") {
+					extraBody["thinking"] = map[string]any{"type": "adaptive"}
+					extraBody["reasoning_split"] = true
+				} else {
+					extraBody["thinking"] = map[string]any{"type": "disabled"}
+				}
 			}
 
 		case string(catwalk.InferenceProviderAlibabaSingapore), string(catwalk.InferenceProviderAlibabaUS):


### PR DESCRIPTION
MiniMax M3 served via opencode-go/zen (OpenAI-compat API) was not showing thinking blocks because the "thinking" and "reasoning_split" parameters were never sent. Without "thinking: adaptive", reasoning is disabled; without "reasoning_split: true", thinking content is embedded inline in the content field instead of the separate "reasoning_content" field that fantasy can parse.

Also skips setting "reasoning_effort" for MiniMax models on these providers, since MiniMax uses the "thinking" parameter instead.

Fixes https://github.com/charmbracelet/crush/issues/3053

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] ~I have created a discussion that was approved by a maintainer (for new features).~ There is an issue for that
