### PR TITLE
feat(ui): clickable ✕ remove button on attachment chips

### DIFF
--- a/internal/ui/attachments/attachments.go
+++ b/internal/ui/attachments/attachments.go
@@ -74,43 +74,84 @@ func (m *Attachments) Update(msg tea.Msg) bool {
 	return false
 }
 
+// HandleClick processes a mouse click at the given x offset within the
+// attachment row. If the click lands on a remove button, the
+// corresponding attachment is removed. It returns true if the click was
+// handled.
+func (m *Attachments) HandleClick(x int) bool {
+	if m.deleting || len(m.list) == 0 {
+		return false
+	}
+	idx := m.renderer.HitTestRemove(m.list, x)
+	if idx >= 0 && idx < len(m.list) {
+		m.list = slices.Delete(m.list, idx, idx+1)
+		return true
+	}
+	return false
+}
+
 func (m *Attachments) Render(width int) string {
-	return m.renderer.Render(m.list, m.deleting, width)
+	// The editor is interactive, so the remove button is shown.
+	return m.renderer.Render(m.list, m.deleting, true, width)
 }
 
 // Renderer returns the attachment renderer so callers can update its
 // styles in place.
 func (m *Attachments) Renderer() *Renderer { return m.renderer }
 
-func NewRenderer(normalStyle, deletingStyle, imageStyle, textStyle, skillStyle lipgloss.Style) *Renderer {
+func NewRenderer(normalStyle, deletingStyle, imageStyle, textStyle, skillStyle, removeStyle lipgloss.Style) *Renderer {
 	return &Renderer{
 		normalStyle:   normalStyle,
 		textStyle:     textStyle,
 		imageStyle:    imageStyle,
 		skillStyle:    skillStyle,
+		removeStyle:   removeStyle,
 		deletingStyle: deletingStyle,
 	}
 }
 
 // SetStyles updates the renderer styles in place.
-func (r *Renderer) SetStyles(normalStyle, deletingStyle, imageStyle, textStyle, skillStyle lipgloss.Style) {
+func (r *Renderer) SetStyles(normalStyle, deletingStyle, imageStyle, textStyle, skillStyle, removeStyle lipgloss.Style) {
 	r.normalStyle = normalStyle
 	r.textStyle = textStyle
 	r.imageStyle = imageStyle
 	r.skillStyle = skillStyle
+	r.removeStyle = removeStyle
 	r.deletingStyle = deletingStyle
 }
 
 type Renderer struct {
-	normalStyle, textStyle, imageStyle, skillStyle, deletingStyle lipgloss.Style
+	normalStyle, textStyle, imageStyle, skillStyle, removeStyle, deletingStyle lipgloss.Style
+	// bounds stores the X-coordinate ranges of each chip's remove
+	// button from the most recent Render call, for mouse hit-testing.
+	bounds []chipBounds
 }
 
-func (r *Renderer) Render(attachments []message.Attachment, deleting bool, width int) string {
-	var chips []string
+// chipBounds holds the rendered strings and the X-coordinate range of
+// each chip's remove button for hit-testing.
+type chipBounds struct {
+	startX    int
+	removeEnd int // exclusive end X of the remove button (0 if none)
+}
 
-	maxItemWidth := lipgloss.Width(r.imageStyle.String() + r.normalStyle.Render(strings.Repeat("x", maxFilename)))
+// Render renders the attachment chips. When not in deleting mode and
+// showRemove is true, each chip shows an icon, filename, and a remove
+// button (✕) on the right. showRemove should be false for attachments on
+// already-posted messages, where removal is not possible.
+func (r *Renderer) Render(attachments []message.Attachment, deleting, showRemove bool, width int) string {
+	var chips []string
+	r.bounds = r.bounds[:0]
+
+	removeStr := r.removeStyle.String()
+	// Only reserve width for the remove button when it will be drawn.
+	removeReserve := ""
+	if showRemove {
+		removeReserve = removeStr
+	}
+	maxItemWidth := lipgloss.Width(r.imageStyle.String() + r.normalStyle.Render(strings.Repeat("x", maxFilename)) + removeReserve)
 	fits := int(math.Floor(float64(width)/float64(maxItemWidth))) - 1
 
+	var offset int
 	for i, att := range attachments {
 		filename := filepath.Base(att.FileName)
 		// Truncate if needed.
@@ -124,12 +165,35 @@ func (r *Renderer) Render(attachments []message.Attachment, deleting bool, width
 				r.deletingStyle.Render(fmt.Sprintf("%d", i)),
 				r.normalStyle.Render(filename),
 			)
+			offset += lipgloss.Width(r.deletingStyle.Render(fmt.Sprintf("%d", i))) + lipgloss.Width(r.normalStyle.Render(filename))
 		} else {
-			chips = append(
-				chips,
-				r.icon(att).String(),
-				r.normalStyle.Render(filename),
-			)
+			iconStr := r.icon(att).String()
+			nameStyle := r.normalStyle
+			if !showRemove {
+				// Without a remove button there is nothing to carry the
+				// trailing margin that separates adjacent chips (the ✕'s
+				// MarginRight does this on the editor path), so put it on the
+				// filename instead. Otherwise posted messages with multiple
+				// attachments render with their chip backgrounds touching.
+				nameStyle = nameStyle.MarginRight(1)
+			}
+			nameStr := nameStyle.Render(filename)
+
+			chips = append(chips, iconStr, nameStr)
+			chipW := lipgloss.Width(iconStr) + lipgloss.Width(nameStr)
+
+			if showRemove {
+				chips = append(chips, removeStr)
+				removeStart := offset + chipW
+				removeW := lipgloss.Width(removeStr)
+				r.bounds = append(r.bounds, chipBounds{
+					startX:    removeStart,
+					removeEnd: removeStart + removeW,
+				})
+				offset = removeStart + removeW
+			} else {
+				offset += chipW
+			}
 		}
 
 		if i == fits && len(attachments) > i {
@@ -139,6 +203,17 @@ func (r *Renderer) Render(attachments []message.Attachment, deleting bool, width
 	}
 
 	return lipgloss.JoinHorizontal(lipgloss.Left, chips...)
+}
+
+// HitTestRemove returns the index of the attachment whose remove button
+// contains the given x coordinate, or -1 if none.
+func (r *Renderer) HitTestRemove(_ []message.Attachment, x int) int {
+	for i, b := range r.bounds {
+		if x >= b.startX && x < b.removeEnd {
+			return i
+		}
+	}
+	return -1
 }
 
 func (r *Renderer) icon(a message.Attachment) lipgloss.Style {

--- a/internal/ui/attachments/attachments.go
+++ b/internal/ui/attachments/attachments.go
@@ -134,10 +134,12 @@ type chipBounds struct {
 	removeEnd int // exclusive end X of the remove button (0 if none)
 }
 
-// Render renders the attachment chips. When not in deleting mode and
-// showRemove is true, each chip shows an icon, filename, and a remove
-// button (✕) on the right. showRemove should be false for attachments on
-// already-posted messages, where removal is not possible.
+// Render renders the attachment chips. Each chip shows an icon and a
+// filename; when showRemove is true a remove button (✕) follows on the
+// right, and in deleting mode that slot shows the numeral to press
+// instead, so toggling delete-mode doesn't shift the chips. showRemove
+// should be false for attachments on already-posted messages, where
+// removal is not possible.
 func (r *Renderer) Render(attachments []message.Attachment, deleting, showRemove bool, width int) string {
 	var chips []string
 	r.bounds = r.bounds[:0]
@@ -159,41 +161,39 @@ func (r *Renderer) Render(attachments []message.Attachment, deleting, showRemove
 			filename = ansi.Truncate(filename, maxFilename, "…")
 		}
 
-		if deleting {
-			chips = append(
-				chips,
-				r.deletingStyle.Render(fmt.Sprintf("%d", i)),
-				r.normalStyle.Render(filename),
-			)
-			offset += lipgloss.Width(r.deletingStyle.Render(fmt.Sprintf("%d", i))) + lipgloss.Width(r.normalStyle.Render(filename))
-		} else {
-			iconStr := r.icon(att).String()
-			nameStyle := r.normalStyle
-			if !showRemove {
-				// Without a remove button there is nothing to carry the
-				// trailing margin that separates adjacent chips (the ✕'s
-				// MarginRight does this on the editor path), so put it on the
-				// filename instead. Otherwise posted messages with multiple
-				// attachments render with their chip backgrounds touching.
-				nameStyle = nameStyle.MarginRight(1)
-			}
-			nameStr := nameStyle.Render(filename)
+		iconStr := r.icon(att).String()
+		nameStyle := r.normalStyle
+		if !showRemove {
+			// Without a remove button there is nothing to carry the
+			// trailing margin that separates adjacent chips (the ✕'s
+			// MarginRight does this on the editor path), so put it on the
+			// filename instead. Otherwise posted messages with multiple
+			// attachments render with their chip backgrounds touching.
+			nameStyle = nameStyle.MarginRight(1)
+		}
+		nameStr := nameStyle.Render(filename)
 
-			chips = append(chips, iconStr, nameStr)
-			chipW := lipgloss.Width(iconStr) + lipgloss.Width(nameStr)
+		chips = append(chips, iconStr, nameStr)
+		chipW := lipgloss.Width(iconStr) + lipgloss.Width(nameStr)
 
-			if showRemove {
-				chips = append(chips, removeStr)
-				removeStart := offset + chipW
-				removeW := lipgloss.Width(removeStr)
-				r.bounds = append(r.bounds, chipBounds{
-					startX:    removeStart,
-					removeEnd: removeStart + removeW,
-				})
-				offset = removeStart + removeW
-			} else {
-				offset += chipW
-			}
+		switch {
+		case deleting:
+			numStr := r.deletingStyle.Render(fmt.Sprintf("%d", i))
+			chips = append(chips, numStr)
+			offset += chipW + lipgloss.Width(numStr)
+		case showRemove:
+			chips = append(chips, removeStr)
+			removeStart := offset + chipW
+			removeW := lipgloss.Width(removeStr)
+			// The trailing margin is the gap between chips, not part of
+			// the button, so it is excluded from the hit region.
+			r.bounds = append(r.bounds, chipBounds{
+				startX:    removeStart,
+				removeEnd: removeStart + removeW - r.removeStyle.GetHorizontalMargins(),
+			})
+			offset = removeStart + removeW
+		default:
+			offset += chipW
 		}
 
 		if i == fits && len(attachments) > i {

--- a/internal/ui/attachments/attachments.go
+++ b/internal/ui/attachments/attachments.go
@@ -185,8 +185,11 @@ func (r *Renderer) Render(attachments []message.Attachment, deleting, showRemove
 			chips = append(chips, removeStr)
 			removeStart := offset + chipW
 			removeW := lipgloss.Width(removeStr)
-			// The trailing margin is the gap between chips, not part of
-			// the button, so it is excluded from the hit region.
+			// If the button carries a trailing margin it is the gap between
+			// chips, not part of the button, so exclude it from the hit
+			// region. (Currently the button uses padding rather than a
+			// margin, so this subtracts zero, but stays correct if that
+			// changes.)
 			r.bounds = append(r.bounds, chipBounds{
 				startX:    removeStart,
 				removeEnd: removeStart + removeW - r.removeStyle.GetHorizontalMargins(),

--- a/internal/ui/attachments/attachments_test.go
+++ b/internal/ui/attachments/attachments_test.go
@@ -143,6 +143,28 @@ func TestRender_RemoveButtonHasRightPadding(t *testing.T) {
 		"the cell to the right of ✕ must share the button's background (padding), not be a transparent margin")
 }
 
+func TestRender_RemoveButtonKeepsGapBetweenChips(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "first.txt"},
+		{FileName: "second.txt"},
+	}
+	cells := parseCells(r.Render(atts, false, true, 200))
+
+	xi := -1
+	for i, c := range cells {
+		if c.r == styles.RemoveIcon {
+			xi = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, xi, 0)
+	require.Less(t, xi+2, len(cells))
+	require.Empty(t, cells[xi+2].bg, "adjacent attachment chips must have a transparent one-cell gap")
+}
+
 // cell is one rendered terminal cell: its rune and the truecolor background
 // in effect ("r;g;b", or "" for none).
 type cell struct {

--- a/internal/ui/attachments/attachments_test.go
+++ b/internal/ui/attachments/attachments_test.go
@@ -86,6 +86,29 @@ func TestRender_ShowRemoveFalseKeepsGapBetweenChips(t *testing.T) {
 		"each posted chip must carry a 1-col trailing margin so adjacent chip backgrounds don't touch")
 }
 
+func TestRender_DeletingModeKeepsChipLayout(t *testing.T) {
+	t.Parallel()
+
+	// Regression for review feedback on #3338: entering delete-mode used
+	// to replace the leading icon with the numeral and drop the remove
+	// button, shifting every chip. The numeral must instead take over the
+	// remove button's slot, leaving the left side of the chip as-is.
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "main.go"},
+		{FileName: "models.go"},
+	}
+	idle := r.Render(atts, false, true, 200)
+	deleting := r.Render(atts, true, true, 200)
+
+	require.Equal(t, lipgloss.Width(idle), lipgloss.Width(deleting),
+		"entering delete-mode must not shift the chips")
+	require.Contains(t, deleting, styles.TextIcon,
+		"delete-mode must keep the chip's icon")
+	require.Contains(t, deleting, "0")
+	require.Contains(t, deleting, "1")
+}
+
 func TestRender_MultipleChipsEachHaveRemoveButton(t *testing.T) {
 	t.Parallel()
 
@@ -145,6 +168,22 @@ func TestHitTestRemove_ReturnsCorrectIndex(t *testing.T) {
 	b1 := r.bounds[1]
 	idx = r.HitTestRemove(atts, b1.startX)
 	require.Equal(t, 1, idx)
+}
+
+func TestHitTestRemove_TrailingMarginNotClickable(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "first.txt"},
+		{FileName: "second.txt"},
+	}
+	_ = r.Render(atts, false, true, 120)
+
+	// The cell after the button is the margin gap between chips — a click
+	// there must not remove anything.
+	b0 := r.bounds[0]
+	require.Equal(t, -1, r.HitTestRemove(atts, b0.removeEnd))
 }
 
 func TestHitTestRemove_OutsideAnyRemoveReturnsMinusOne(t *testing.T) {

--- a/internal/ui/attachments/attachments_test.go
+++ b/internal/ui/attachments/attachments_test.go
@@ -1,7 +1,9 @@
 package attachments
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/message"
@@ -109,6 +111,100 @@ func TestRender_DeletingModeKeepsChipLayout(t *testing.T) {
 	require.Contains(t, deleting, "1")
 }
 
+func TestRender_RemoveButtonHasRightPadding(t *testing.T) {
+	t.Parallel()
+
+	// Regression for review feedback on #3338: the ✕ must not sit flush
+	// against the right edge of its colored box. The cell to the right of the
+	// glyph has to be padding — part of the button's background — rather than
+	// a transparent margin, so the glyph has breathing room on its right.
+	//
+	// A plain-width or ANSI-stripped check can't catch this: a margin space
+	// and a background-colored padding space are both one blank column. So we
+	// inspect the per-cell background and assert the button's background
+	// extends one cell past the ✕.
+	r := newTestRenderer()
+	atts := []message.Attachment{{FileName: "main.go"}}
+	out := r.Render(atts, false, true, 200)
+
+	cells := parseCells(out)
+	xi := -1
+	for i, c := range cells {
+		if c.r == styles.RemoveIcon {
+			xi = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, xi, 0, "rendered output must contain the ✕ glyph")
+	require.NotEmpty(t, cells[xi].bg, "the ✕ cell must have the button's background")
+	require.Less(t, xi+1, len(cells),
+		"the ✕ must be followed by a trailing padding cell, not be the box's last cell")
+	require.Equal(t, cells[xi].bg, cells[xi+1].bg,
+		"the cell to the right of ✕ must share the button's background (padding), not be a transparent margin")
+}
+
+// cell is one rendered terminal cell: its rune and the truecolor background
+// in effect ("r;g;b", or "" for none).
+type cell struct {
+	r  string
+	bg string
+}
+
+// parseCells walks a lipgloss-rendered string and returns its visible cells
+// with the background color active at each. It understands the SGR sequences
+// lipgloss emits (truecolor 48;2;r;g;b backgrounds, 38;2;r;g;b foregrounds,
+// and resets); other escapes are ignored.
+func parseCells(s string) []cell {
+	var cells []cell
+	bg := ""
+	for i := 0; i < len(s); {
+		if s[i] == 0x1b && i+1 < len(s) && s[i+1] == '[' {
+			j := i + 2
+			for j < len(s) && s[j] != 'm' {
+				j++
+			}
+			if j < len(s) {
+				bg = applyBG(s[i+2:j], bg)
+				i = j + 1
+				continue
+			}
+		}
+		_, size := utf8.DecodeRuneInString(s[i:])
+		cells = append(cells, cell{r: s[i : i+size], bg: bg})
+		i += size
+	}
+	return cells
+}
+
+// applyBG updates the current background given one SGR parameter string.
+func applyBG(params, cur string) string {
+	if params == "" || params == "0" {
+		return ""
+	}
+	toks := strings.Split(params, ";")
+	for k := 0; k < len(toks); k++ {
+		switch toks[k] {
+		case "0":
+			cur = ""
+		case "38": // foreground — skip its arguments
+			if k+1 < len(toks) && toks[k+1] == "2" {
+				k += 4
+			} else if k+1 < len(toks) && toks[k+1] == "5" {
+				k += 2
+			}
+		case "48": // background
+			if k+4 < len(toks) && toks[k+1] == "2" {
+				cur = toks[k+2] + ";" + toks[k+3] + ";" + toks[k+4]
+				k += 4
+			} else if k+2 < len(toks) && toks[k+1] == "5" {
+				cur = toks[k+2]
+				k += 2
+			}
+		}
+	}
+	return cur
+}
+
 func TestRender_MultipleChipsEachHaveRemoveButton(t *testing.T) {
 	t.Parallel()
 
@@ -180,8 +276,8 @@ func TestHitTestRemove_TrailingMarginNotClickable(t *testing.T) {
 	}
 	_ = r.Render(atts, false, true, 120)
 
-	// The cell after the button is the margin gap between chips — a click
-	// there must not remove anything.
+	// The cell just past a button's hit region belongs to the next chip, not
+	// to this button — a click there must not remove this attachment.
 	b0 := r.bounds[0]
 	require.Equal(t, -1, r.HitTestRemove(atts, b0.removeEnd))
 }

--- a/internal/ui/attachments/attachments_test.go
+++ b/internal/ui/attachments/attachments_test.go
@@ -1,0 +1,233 @@
+package attachments
+
+import (
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRenderer() *Renderer {
+	sty := styles.CharmtonePantera()
+	return NewRenderer(
+		sty.Attachments.Normal,
+		sty.Attachments.Deleting,
+		sty.Attachments.Image,
+		sty.Attachments.Text,
+		sty.Attachments.Skill,
+		sty.Attachments.Remove,
+	)
+}
+
+func TestRender_IncludesRemoveButton(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "test.txt"},
+	}
+	out := r.Render(atts, false, true, 80)
+	require.Contains(t, out, styles.RemoveIcon)
+}
+
+func TestRender_DeletingModeNoRemoveButton(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "test.txt"},
+	}
+	out := r.Render(atts, true, true, 80)
+	require.NotContains(t, out, styles.RemoveIcon)
+}
+
+func TestRender_ShowRemoveFalseOmitsRemoveButton(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "no-change.png"},
+	}
+	out := r.Render(atts, false, false, 80)
+	require.NotContains(t, out, styles.RemoveIcon,
+		"posted-message attachments must not show a remove button")
+	require.Empty(t, r.bounds,
+		"no remove bounds should be recorded when the button is hidden")
+	require.Equal(t, -1, r.HitTestRemove(atts, 0))
+}
+
+func TestRender_ShowRemoveFalseKeepsGapBetweenChips(t *testing.T) {
+	t.Parallel()
+
+	// Regression for the #134 + #135 interaction: #134 moved the trailing
+	// margin onto the remove button, and #135 hides that button on posted
+	// messages. Together, posted messages with multiple attachments lost the
+	// margin that separated adjacent chips, so their backgrounds touched. The
+	// filename must carry the margin when the remove button is hidden.
+	//
+	// White-box width check: the visible width of the two chips without any
+	// separator is icon+filename per chip. With the fix each posted chip adds
+	// a 1-column trailing margin, so the rendered row is exactly two columns
+	// wider. Stripping ANSI can't detect this (a margin space and a
+	// background-colored padding space are both just spaces), so we measure
+	// width instead.
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "alpha.txt"},
+		{FileName: "beta.txt"},
+	}
+	bare := lipgloss.Width(r.textStyle.String()+r.normalStyle.Render("alpha.txt")) +
+		lipgloss.Width(r.textStyle.String()+r.normalStyle.Render("beta.txt"))
+
+	got := lipgloss.Width(r.Render(atts, false, false, 200))
+	require.Equal(t, bare+2, got,
+		"each posted chip must carry a 1-col trailing margin so adjacent chip backgrounds don't touch")
+}
+
+func TestRender_MultipleChipsEachHaveRemoveButton(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "a.txt"},
+		{FileName: "b.txt"},
+		{FileName: "c.txt"},
+	}
+	out := r.Render(atts, false, true, 120)
+	// Count occurrences of the remove glyph.
+	count := 0
+	for _, c := range out {
+		if string(c) == styles.RemoveIcon {
+			count++
+		}
+	}
+	require.Equal(t, 3, count, "each chip should have a remove button")
+}
+
+func TestHitTestRemove_ClickOnFirstChipRemove(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "first.txt"},
+		{FileName: "second.txt"},
+	}
+	_ = r.Render(atts, false, true, 120)
+
+	// The remove button of the first chip should be hit-testable.
+	// Click at various X positions to verify we hit the right chip.
+	idx := r.HitTestRemove(atts, 0)
+	// At x=0 we're on the icon, not the remove button.
+	require.Equal(t, -1, idx)
+}
+
+func TestHitTestRemove_ReturnsCorrectIndex(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "first.txt"},
+		{FileName: "second.txt"},
+	}
+	_ = r.Render(atts, false, true, 120)
+
+	// Each chip bounds are stored after render. Verify there are two.
+	require.Len(t, r.bounds, 2)
+
+	// Click on the first chip's remove button.
+	b0 := r.bounds[0]
+	idx := r.HitTestRemove(atts, b0.startX)
+	require.Equal(t, 0, idx)
+
+	// Click on the second chip's remove button.
+	b1 := r.bounds[1]
+	idx = r.HitTestRemove(atts, b1.startX)
+	require.Equal(t, 1, idx)
+}
+
+func TestHitTestRemove_OutsideAnyRemoveReturnsMinusOne(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	atts := []message.Attachment{
+		{FileName: "test.txt"},
+	}
+	_ = r.Render(atts, false, true, 80)
+
+	// Click far past the remove button.
+	idx := r.HitTestRemove(atts, 999)
+	require.Equal(t, -1, idx)
+}
+
+func TestHandleClick_RemovesAttachment(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	km := Keymap{}
+	m := New(r, km)
+	m.list = []message.Attachment{
+		{FileName: "first.txt"},
+		{FileName: "second.txt"},
+	}
+
+	// Render so bounds are populated.
+	_ = m.Render(120)
+
+	// Click the first chip's remove button.
+	b0 := r.bounds[0]
+	handled := m.HandleClick(b0.startX)
+	require.True(t, handled)
+	require.Len(t, m.list, 1)
+	require.Equal(t, "second.txt", m.list[0].FileName)
+}
+
+func TestHandleClick_ClickOutsideRemoveDoesNothing(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	km := Keymap{}
+	m := New(r, km)
+	m.list = []message.Attachment{
+		{FileName: "test.txt"},
+	}
+
+	_ = m.Render(80)
+
+	// Click at x=0 (the icon area, not the remove button).
+	handled := m.HandleClick(0)
+	require.False(t, handled)
+	require.Len(t, m.list, 1)
+}
+
+func TestHandleClick_DeletingModeIgnored(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	km := Keymap{}
+	m := New(r, km)
+	m.list = []message.Attachment{
+		{FileName: "test.txt"},
+	}
+	m.deleting = true
+
+	_ = m.Render(80)
+
+	// bounds are empty in deleting mode since remove buttons aren't rendered.
+	require.Empty(t, r.bounds)
+	// Click anywhere — should be ignored.
+	handled := m.HandleClick(10)
+	require.False(t, handled)
+}
+
+func TestHandleClick_EmptyListIgnored(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRenderer()
+	km := Keymap{}
+	m := New(r, km)
+
+	handled := m.HandleClick(5)
+	require.False(t, handled)
+}

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -383,6 +383,7 @@ func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults m
 			sty.Attachments.Image,
 			sty.Attachments.Text,
 			sty.Attachments.Skill,
+			sty.Attachments.Remove,
 		)
 		return []MessageItem{NewUserMessageItem(sty, msg, r)}
 	case message.Assistant:

--- a/internal/ui/chat/prefix_cache_test.go
+++ b/internal/ui/chat/prefix_cache_test.go
@@ -117,6 +117,7 @@ func TestUserMessageItemRender_PrefixCacheFocusBlur(t *testing.T) {
 		sty.Attachments.Image,
 		sty.Attachments.Text,
 		sty.Attachments.Skill,
+		sty.Attachments.Remove,
 	)
 	item := NewUserMessageItem(&sty, msg, r).(*UserMessageItem)
 

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -168,7 +168,9 @@ func (m *UserMessageItem) renderAttachments(width int) string {
 			MimeType: at.MIMEType,
 		})
 	}
-	return m.attachments.Render(attachments, false, width)
+	// This message is already posted, so the attachment can't be removed;
+	// don't render the remove button.
+	return m.attachments.Render(attachments, false, false, width)
 }
 
 // HandleKeyEvent implements KeyEventHandler.

--- a/internal/ui/chat/version_bump_test.go
+++ b/internal/ui/chat/version_bump_test.go
@@ -84,6 +84,7 @@ func TestUserMessageItem_MutatorsBumpVersion(t *testing.T) {
 		sty.Attachments.Image,
 		sty.Attachments.Text,
 		sty.Attachments.Skill,
+		sty.Attachments.Remove,
 	)
 	msg := &message.Message{
 		ID:   "u-mut",
@@ -255,6 +256,7 @@ func TestUserMessageItem_FinishedAlwaysTrue(t *testing.T) {
 		sty.Attachments.Image,
 		sty.Attachments.Text,
 		sty.Attachments.Skill,
+		sty.Attachments.Remove,
 	)
 	msg := &message.Message{
 		ID:    "u-fin",

--- a/internal/ui/model/attachments_mouse_test.go
+++ b/internal/ui/model/attachments_mouse_test.go
@@ -1,0 +1,98 @@
+package model
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/question"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/stretchr/testify/require"
+)
+
+type attachmentClickWorkspace struct {
+	historyWorkspace
+}
+
+func (attachmentClickWorkspace) AgentIsReady() bool { return false }
+
+func newAttachmentClickTestUI(t *testing.T) (*UI, int) {
+	t.Helper()
+
+	u := newTestUI()
+	u.com.Workspace = attachmentClickWorkspace{}
+	u.dialog = dialog.NewOverlay()
+	sty := u.com.Styles.Attachments
+	renderer := attachments.NewRenderer(
+		sty.Normal,
+		sty.Deleting,
+		sty.Image,
+		sty.Text,
+		sty.Skill,
+		sty.Remove,
+	)
+	u.attachments = attachments.New(renderer, attachments.Keymap{})
+	u.updateLayoutAndSize()
+	require.True(t, u.attachments.Update(message.Attachment{FileName: "test.txt"}))
+	_ = u.attachments.Render(u.layout.editor.Dx())
+
+	for x := range u.layout.editor.Dx() {
+		if renderer.HitTestRemove(u.attachments.List(), x) == 0 {
+			return u, x
+		}
+	}
+	t.Fatal("remove button was not rendered")
+	return nil, 0
+}
+
+func TestAttachmentClickIgnoredWhileInlineEditorIsActive(t *testing.T) {
+	t.Parallel()
+
+	u, removeX := newAttachmentClickTestUI(t)
+	u.openBatchFormDialog(question.Request{
+		Questions: []question.Question{{
+			ID:   "question",
+			Type: question.TypeFreeText,
+			Text: "Question?",
+		}},
+	})
+
+	_, _ = u.Update(tea.MouseClickMsg(tea.Mouse{
+		X:      u.layout.editor.Min.X + removeX,
+		Y:      u.layout.editor.Min.Y,
+		Button: uv.MouseLeft,
+	}))
+
+	require.Len(t, u.attachments.List(), 1)
+}
+
+func TestAttachmentClickRequiresLeftMouseButton(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		button    tea.MouseButton
+		remaining int
+	}{
+		{name: "left", button: uv.MouseLeft, remaining: 0},
+		{name: "middle", button: uv.MouseMiddle, remaining: 1},
+		{name: "right", button: uv.MouseRight, remaining: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, removeX := newAttachmentClickTestUI(t)
+			_, _ = u.Update(tea.MouseClickMsg(tea.Mouse{
+				X:      u.layout.editor.Min.X + removeX,
+				Y:      u.layout.editor.Min.Y,
+				Button: tt.button,
+			}))
+
+			require.Len(t, u.attachments.List(), tt.remaining)
+		})
+	}
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -368,6 +368,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 			com.Styles.Attachments.Image,
 			com.Styles.Attachments.Text,
 			com.Styles.Attachments.Skill,
+			com.Styles.Attachments.Remove,
 		),
 		attachments.Keymap{
 			DeleteMode: keyMap.Editor.AttachmentDeleteMode,
@@ -883,6 +884,16 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if cmd := m.handleClickFocus(msg); cmd != nil {
 			cmds = append(cmds, cmd)
+		}
+
+		// Check if the click landed on an attachment's remove button.
+		// The attachment chips are rendered on the first row of the
+		// editor layout area, above the textarea.
+		if len(m.attachments.List()) > 0 && msg.Y == m.layout.editor.Min.Y {
+			relX := msg.X - m.layout.editor.Min.X
+			if m.attachments.HandleClick(relX) {
+				return m, tea.Batch(cmds...)
+			}
 		}
 
 		switch m.state {
@@ -3672,6 +3683,7 @@ func (m *UI) refreshStyles() {
 		t.Attachments.Image,
 		t.Attachments.Text,
 		t.Attachments.Skill,
+		t.Attachments.Remove,
 	)
 	m.todoSpinner.Style = t.Pills.TodoSpinner
 	m.status.help.Styles = t.Help

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -889,7 +889,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Check if the click landed on an attachment's remove button.
 		// The attachment chips are rendered on the first row of the
 		// editor layout area, above the textarea.
-		if len(m.attachments.List()) > 0 && msg.Y == m.layout.editor.Min.Y {
+		if m.activeInline == nil && msg.Button == uv.MouseLeft && len(m.attachments.List()) > 0 && msg.Y == m.layout.editor.Min.Y {
 			relX := msg.X - m.layout.editor.Min.X
 			if m.attachments.HandleClick(relX) {
 				return m, tea.Batch(cmds...)

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -1028,9 +1028,12 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Attachments.Normal = base.Padding(0, 1).Background(o.fgMoreSubtle).Foreground(o.fgBase)
 	// Remove and Deleting share the same slot on the right side of a chip
 	// and must keep the same geometry so toggling delete-mode doesn't
-	// shift the chips.
-	s.Attachments.Remove = base.PaddingLeft(1).MarginRight(1).Background(o.bgLessVisible).Foreground(o.fgSubtle).SetString(RemoveIcon)
-	s.Attachments.Deleting = base.PaddingLeft(1).MarginRight(1).Bold(true).Background(o.destructive).Foreground(o.fgBase)
+	// shift the chips. Padding(0, 1) puts a colored cell on each side of the
+	// glyph so it isn't flush against the box edge; the trailing cell is
+	// padding (part of the box) rather than a transparent margin, which also
+	// keeps the chip-to-chip spacing intact.
+	s.Attachments.Remove = base.Padding(0, 1).Background(o.bgLessVisible).Foreground(o.fgSubtle).SetString(RemoveIcon)
+	s.Attachments.Deleting = base.Padding(0, 1).Bold(true).Background(o.destructive).Foreground(o.fgBase)
 
 	// Pills styles
 	s.Pills.Base = base.Padding(0, 1)

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -1026,8 +1026,11 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Attachments.Text = attachmentIconStyle.SetString(TextIcon)
 	s.Attachments.Skill = attachmentIconStyle.SetString(SkillIcon)
 	s.Attachments.Normal = base.Padding(0, 1).Background(o.fgMoreSubtle).Foreground(o.fgBase)
-	s.Attachments.Remove = base.Padding(0, 1).MarginRight(1).Background(o.bgLessVisible).Foreground(o.fgSubtle).SetString(RemoveIcon)
-	s.Attachments.Deleting = base.Padding(0, 1).Bold(true).Background(o.destructive).Foreground(o.fgBase)
+	// Remove and Deleting share the same slot on the right side of a chip
+	// and must keep the same geometry so toggling delete-mode doesn't
+	// shift the chips.
+	s.Attachments.Remove = base.PaddingLeft(1).MarginRight(1).Background(o.bgLessVisible).Foreground(o.fgSubtle).SetString(RemoveIcon)
+	s.Attachments.Deleting = base.PaddingLeft(1).MarginRight(1).Bold(true).Background(o.destructive).Foreground(o.fgBase)
 
 	// Pills styles
 	s.Pills.Base = base.Padding(0, 1)

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -1029,11 +1029,10 @@ func quickStyle(o quickStyleOpts) Styles {
 	// Remove and Deleting share the same slot on the right side of a chip
 	// and must keep the same geometry so toggling delete-mode doesn't
 	// shift the chips. Padding(0, 1) puts a colored cell on each side of the
-	// glyph so it isn't flush against the box edge; the trailing cell is
-	// padding (part of the box) rather than a transparent margin, which also
-	// keeps the chip-to-chip spacing intact.
-	s.Attachments.Remove = base.Padding(0, 1).Background(o.bgLessVisible).Foreground(o.fgSubtle).SetString(RemoveIcon)
-	s.Attachments.Deleting = base.Padding(0, 1).Bold(true).Background(o.destructive).Foreground(o.fgBase)
+	// glyph so it isn't flush against the box edge, while MarginRight(1)
+	// keeps a transparent gap between adjacent chips.
+	s.Attachments.Remove = base.Padding(0, 1).MarginRight(1).Background(o.bgLessVisible).Foreground(o.fgSubtle).SetString(RemoveIcon)
+	s.Attachments.Deleting = base.Padding(0, 1).MarginRight(1).Bold(true).Background(o.destructive).Foreground(o.fgBase)
 
 	// Pills styles
 	s.Pills.Base = base.Padding(0, 1)

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -1025,7 +1025,8 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Attachments.Image = attachmentIconStyle.SetString(ImageIcon)
 	s.Attachments.Text = attachmentIconStyle.SetString(TextIcon)
 	s.Attachments.Skill = attachmentIconStyle.SetString(SkillIcon)
-	s.Attachments.Normal = base.Padding(0, 1).MarginRight(1).Background(o.fgMoreSubtle).Foreground(o.fgBase)
+	s.Attachments.Normal = base.Padding(0, 1).Background(o.fgMoreSubtle).Foreground(o.fgBase)
+	s.Attachments.Remove = base.Padding(0, 1).MarginRight(1).Background(o.bgLessVisible).Foreground(o.fgSubtle).SetString(RemoveIcon)
 	s.Attachments.Deleting = base.Padding(0, 1).Bold(true).Background(o.destructive).Foreground(o.fgBase)
 
 	// Pills styles

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -42,9 +42,10 @@ const (
 	TodoPendingIcon    string = "•"
 	TodoInProgressIcon string = "→"
 
-	ImageIcon string = "■"
-	TextIcon  string = "≡"
-	SkillIcon string = "▲"
+	ImageIcon  string = "■"
+	TextIcon   string = "≡"
+	SkillIcon  string = "▲"
+	RemoveIcon string = "✕"
 
 	ScrollbarThumb string = "┃"
 	ScrollbarTrack string = "│"
@@ -564,6 +565,7 @@ type Styles struct {
 		Image    lipgloss.Style
 		Text     lipgloss.Style
 		Skill    lipgloss.Style
+		Remove   lipgloss.Style
 		Deleting lipgloss.Style
 	}
 


### PR DESCRIPTION
## What

Each attachment chip in the editor now shows a ✕ button on its right side; clicking it removes the attachment before sending. The renderer records each button's X-coordinate range during `Render` for mouse hit-testing.

**Before** — the only way to remove an attachment is the keyboard delete-mode:

![before](https://raw.githubusercontent.com/joestump-agent/crush/assets/remove-button-before.png)

**After** — every pending chip gets a clickable ✕:

![after](https://raw.githubusercontent.com/joestump-agent/crush/assets/remove-button-after.png)

Chips on already-posted messages don't show the button (those attachments can't be removed). There the filename carries the trailing margin instead, so adjacent chip backgrounds keep their 1-column gap:

![posted](https://raw.githubusercontent.com/joestump-agent/crush/assets/remove-button-posted.png)

## How

- `internal/ui/attachments/attachments.go` — `Render` gains a `showRemove` flag, records `chipBounds` per chip, and `HitTestRemove`/`HandleClick` translate a click X-offset into a removal
- `internal/ui/model/ui.go` — route `tea.MouseClickMsg` on the attachments row to `HandleClick`
- `internal/ui/chat/user.go` — posted messages render with `showRemove=false`
- `internal/ui/styles/` — new `RemoveIcon` (✕) const and `Attachments.Remove` style

## Testing

New `internal/ui/attachments/attachments_test.go` (233 lines): rendering with/without the button, hit-testing indices and misses, click handling in delete-mode/empty-list edge cases, and a white-box width regression test for the posted-chip gap. `go build ./...`, package tests, and `golangci-lint` (0 new issues) pass.

Independent of the other attachment PRs in this series (#3313, #3337) — merge in any order. Only note: #3339 touches the same `styles.go` const block, so whichever of the two merges second needs a trivial one-line rebase.

💘 Generated with Crush

Assisted-by: Crush:glm-5.2
