### PR TITLE
feat(ui): framed-square glyph for image attachment icon

### DIFF
--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -42,7 +42,7 @@ const (
 	TodoPendingIcon    string = "•"
 	TodoInProgressIcon string = "→"
 
-	ImageIcon  string = "■"
+	ImageIcon  string = "▣"
 	TextIcon   string = "≡"
 	SkillIcon  string = "▲"
 	RemoveIcon string = "✕"


### PR DESCRIPTION
## What

Replace the plain filled square (`■`) used for image attachment chips with a framed square containing an inner filled square (`▣`), which reads more clearly as "image/picture" at a glance — one const in `internal/ui/styles/styles.go`.

**Before:**

![before](https://raw.githubusercontent.com/joestump-agent/crush/assets/image-icon-before.png)

**After:**

![after](https://raw.githubusercontent.com/joestump-agent/crush/assets/image-icon-after.png)

`▣` (U+25A3, WHITE SQUARE CONTAINING BLACK SMALL SQUARE) sits in the same Geometric Shapes block as the current `■` and the existing scrollbar/border glyphs, so font coverage risk is on par with what's already shipped.

Note: #3338 touches the same `styles.go` const block — whichever merges second needs a trivial one-line rebase. Otherwise independent; merge in any order (or close if the glyph isn't to your taste — zero hard feelings).

💘 Generated with Crush

Assisted-by: Crush:glm-5.2
