### PR TITLE
fix(agent): enforce context-window admission and recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,20 @@ it creates. You can customize this behavior with the `attribution` option:
 Crush supports custom provider configurations for both OpenAI-compatible and
 Anthropic-compatible APIs.
 
+Crush uses each model's `context_window` as a client-side admission limit. It
+conservatively estimates the complete request, including conversation history,
+tool definitions, tool results, message framing, and a reserved response. The
+estimate intentionally fails closed near the limit, but it is not an exact
+provider tokenizer result; provider-specific chat serialization and vision
+token accounting can differ.
+
+For models with a known context window, every request also carries an explicit
+response limit. Crush uses the selected model's `max_tokens` override first,
+then the provider model's `default_max_tokens`. If neither is configured, it
+uses the context safety reserve (20% for contexts up to 200,000 tokens, or
+20,000 tokens for larger contexts). Models with an unknown context window keep
+the provider's existing default when no response limit is configured.
+
 > [!NOTE]
 > Note that we support two "types" for OpenAI. Make sure to choose the right one
 > to ensure the best experience!

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -646,6 +646,35 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		return nil, nil
 	}
 
+	// Install the terminal-event contract before any database lookup,
+	// pre-dispatch compaction, or provider call. Automatic compaction can
+	// fail or be cancelled before an assistant message exists; RunID callers
+	// still require exactly one terminal RunComplete.
+	var skipRunComplete bool
+	var currentAssistant *message.Message
+	defer func() {
+		flushCtx, flushCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer flushCancel()
+		if flushErr := a.messages.FlushAll(flushCtx); flushErr != nil {
+			slog.Error("Failed to flush pending message updates after run", "error", flushErr)
+		}
+		if skipRunComplete {
+			return
+		}
+		complete := notify.RunComplete{SessionID: call.SessionID, RunID: call.RunID}
+		if currentAssistant != nil {
+			complete.MessageID = currentAssistant.ID
+			complete.Text = currentAssistant.Content().String()
+		}
+		if retErr != nil {
+			complete.Error = retErr.Error()
+			complete.Cancelled = errors.Is(retErr, context.Canceled)
+		} else if ctx.Err() != nil {
+			complete.Cancelled = true
+		}
+		a.publishRunComplete(ctx, call, complete)
+	}()
+
 	// Copy mutable fields under lock to avoid races with SetTools/SetModels.
 	agentTools := a.tools.Copy()
 	largeModel := a.largeModel.Get()
@@ -673,7 +702,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	}
 
 	agent := fantasy.NewAgent(
-		largeModel.Model,
+		withContextWindowLimit(largeModel.Model, largeModel.CatwalkCfg.ContextWindow),
 		fantasy.WithSystemPrompt(systemPrompt),
 		fantasy.WithTools(agentTools...),
 		fantasy.WithUserAgent(userAgent),
@@ -688,6 +717,46 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	msgs, err := a.getSessionMessages(ctx, currentSession)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get session messages: %w", err)
+	}
+	history, files := a.preparePrompt(msgs, largeModel.CatwalkCfg.SupportsImages, call.Attachments...)
+
+	contextWindow := largeModel.CatwalkCfg.ContextWindow
+	maxOutputTokens := resolveMaxOutputTokens(
+		contextWindow,
+		largeModel.CatwalkCfg.DefaultMaxTokens,
+		call.MaxOutputTokens,
+	)
+	initialInputTokens := estimateInitialCallInputTokens(
+		systemPrompt,
+		promptPrefix,
+		history,
+		message.PromptWithTextAttachments(call.Prompt, call.Attachments),
+		files,
+		agentTools,
+	)
+	if contextWindow > 0 &&
+		initialInputTokens+contextWindowOutputReserve(contextWindow, maxOutputTokens) >= contextWindow &&
+		!a.disableAutoSummarize && len(msgs) > 0 {
+		if !activeRegistered {
+			runCtx := context.WithValue(ctx, tools.SessionIDContextKey, call.SessionID)
+			genCtx, cancel = context.WithCancel(runCtx)
+			a.activeRequests.Set(call.SessionID, cancel)
+			activeRegistered = true
+			defer cancel()
+			defer a.activeRequests.Del(call.SessionID)
+		}
+		if err := a.compactSession(genCtx, call.SessionID, call.ProviderOptions); err != nil {
+			return nil, fmt.Errorf("compact session before model dispatch: %w", err)
+		}
+		currentSession, err = a.sessions.Get(ctx, call.SessionID)
+		if err != nil {
+			return nil, fmt.Errorf("reload compacted session: %w", err)
+		}
+		msgs, err = a.getSessionMessages(ctx, currentSession)
+		if err != nil {
+			return nil, fmt.Errorf("reload compacted session messages: %w", err)
+		}
+		history, files = a.preparePrompt(msgs, largeModel.CatwalkCfg.SupportsImages, call.Attachments...)
 	}
 
 	var wg sync.WaitGroup
@@ -721,79 +790,12 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		defer cancel()
 		defer a.activeRequests.Del(call.SessionID)
 	}
-	// skipRunComplete is set just before the queued-recursion path so
-	// the outer Run doesn't publish a RunComplete that would race
-	// with — and be superseded by — the recursive call's own
-	// RunComplete (each queued user prompt is its own turn and
-	// publishes exactly one terminal event).
-	var skipRunComplete bool
-	// currentAssistant is declared here so the deferred RunComplete
-	// publish below can capture the pointer that PrepareStep will
-	// later (re)assign for each streaming step. The final assistant
-	// message of the turn is the value reachable through this
-	// pointer when the defer runs.
-	var currentAssistant *message.Message
-	// Drain any debounced message updates before returning. message.Service
-	// already flushes synchronously on terminal updates, but a defer here
-	// guarantees the contract at every Run exit (success, error, panic
-	// recovery upstream) without callers needing to know.
-	//
-	// After the flush completes — meaning all per-message
-	// Publish(UpdatedEvent) calls have fired and been buffered into
-	// every subscriber's channel — publish the authoritative
-	// RunComplete event for this turn. The flush-then-publish order
-	// gives well-behaved clients the best chance of seeing the final
-	// message event before RunComplete; the embedded Text field
-	// reconciles for clients that observe the events out of order
-	// (the pubsub broker fan-in does not serialize publishes from
-	// different upstream brokers).
-	defer func() {
-		// Use a context detached from the run context: workspace
-		// shutdown cancels ctx before this goroutine returns, but the
-		// buffered streaming deltas must still land before the DB is
-		// closed. A short timeout bounds the flush.
-		flushCtx, flushCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
-		defer flushCancel()
-		if flushErr := a.messages.FlushAll(flushCtx); flushErr != nil {
-			slog.Error("Failed to flush pending message updates after run", "error", flushErr)
-		}
-		if skipRunComplete {
-			return
-		}
-		complete := notify.RunComplete{SessionID: call.SessionID, RunID: call.RunID}
-		if currentAssistant != nil {
-			complete.MessageID = currentAssistant.ID
-			complete.Text = currentAssistant.Content().String()
-		}
-		if retErr != nil {
-			complete.Error = retErr.Error()
-			complete.Cancelled = errors.Is(retErr, context.Canceled)
-		} else if ctx.Err() != nil {
-			complete.Cancelled = true
-		}
-		// Prefer the per-call hook when supplied so the coordinator
-		// can coalesce retries (e.g. unauthorized → re-auth → retry)
-		// into a single user-visible terminal event. The fallback
-		// must-deliver publish applies bounded-blocking semantics to
-		// the authoritative terminal event so a momentarily-full
-		// subscriber channel can't silently drop it and hang
-		// non-interactive clients waiting on RunComplete.
-		a.publishRunComplete(ctx, call, complete)
-	}()
-
-	history, files := a.preparePrompt(msgs, largeModel.CatwalkCfg.SupportsImages, call.Attachments...)
-
 	startTime := time.Now()
 	a.eventPromptSent(call.SessionID)
 
 	var stepMessages []fantasy.Message
 	var shouldSummarize bool
 	sanitizedToolCalls := make(map[string]bool)
-	// Don't send MaxOutputTokens if 0 — some providers (e.g. LM Studio) reject it
-	var maxOutputTokens *int64
-	if call.MaxOutputTokens > 0 {
-		maxOutputTokens = &call.MaxOutputTokens
-	}
 	result, err = agent.Stream(genCtx, fantasy.AgentStreamCall{
 		Prompt:           message.PromptWithTextAttachments(call.Prompt, call.Attachments),
 		Files:            files,
@@ -946,7 +948,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			slog.Info("ModelProvider called",
 				"provider", m.ModelCfg.Provider,
 				"model", m.ModelCfg.Model)
-			return m.Model
+			return withContextWindowLimit(m.Model, m.CatwalkCfg.ContextWindow)
 		},
 		OnToolCall: func(tc fantasy.ToolCallContent) error {
 			input, wasSanitized := sanitizeToolInput(tc.ToolName, tc.ToolCallID, tc.Input)
@@ -1025,22 +1027,24 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			return a.messages.Update(genCtx, *currentAssistant)
 		},
 		StopWhen: []fantasy.StopCondition{
-			func(_ []fantasy.StepResult) bool {
+			func(steps []fantasy.StepResult) bool {
 				cw := int64(largeModel.CatwalkCfg.ContextWindow)
 				// If context window is unknown (0), skip auto-summarize
 				// to avoid immediately truncating custom/local models.
 				if cw == 0 {
 					return false
 				}
+				if !a.disableAutoSummarize && len(steps) > 0 {
+					nextInputTokens := estimateNextStepInputTokens(stepMessages, steps[len(steps)-1], a.tools.Copy())
+					if nextInputTokens+contextWindowOutputReserve(cw, maxOutputTokens) >= cw {
+						shouldSummarize = true
+						return true
+					}
+				}
+
 				tokens := currentSession.CompletionTokens + currentSession.PromptTokens
 				remaining := cw - tokens
-				var threshold int64
-				if cw > largeContextWindowThreshold {
-					threshold = largeContextWindowBuffer
-				} else {
-					threshold = int64(float64(cw) * smallContextWindowRatio)
-				}
-				if (remaining <= threshold) && !a.disableAutoSummarize {
+				if remaining <= contextWindowReserve(cw) && !a.disableAutoSummarize {
 					shouldSummarize = true
 					return true
 				}
@@ -1325,128 +1329,19 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		return ErrSessionBusy
 	}
 
-	// Copy mutable fields under lock to avoid races with SetModels.
-	largeModel := a.largeModel.Get()
-	systemPromptPrefix := a.systemPromptPrefix.Get()
-
-	currentSession, err := a.sessions.Get(ctx, sessionID)
-	if err != nil {
-		return fmt.Errorf("failed to get session: %w", err)
-	}
-	msgs, err := a.getSessionMessages(ctx, currentSession)
-	if err != nil {
-		return err
-	}
-	if len(msgs) == 0 {
-		// Nothing to summarize.
-		return nil
-	}
-
-	aiMsgs, _ := a.preparePrompt(msgs, largeModel.CatwalkCfg.SupportsImages)
-
 	genCtx, cancel := context.WithCancel(ctx)
 	a.activeRequests.Set(sessionID, cancel)
 	defer a.activeRequests.Del(sessionID)
 	defer cancel()
 	defer func() {
-		if flushErr := a.messages.FlushAll(ctx); flushErr != nil {
+		flushCtx, flushCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer flushCancel()
+		if flushErr := a.messages.FlushAll(flushCtx); flushErr != nil {
 			slog.Error("Failed to flush pending message updates after summarize", "error", flushErr)
 		}
 	}()
 
-	agent := fantasy.NewAgent(
-		largeModel.Model,
-		fantasy.WithSystemPrompt(string(summaryPrompt)),
-		fantasy.WithUserAgent(userAgent),
-	)
-	summaryMessage, err := a.messages.Create(ctx, sessionID, message.CreateMessageParams{
-		Role:             message.Assistant,
-		Model:            largeModel.ModelCfg.Model,
-		Provider:         largeModel.ModelCfg.Provider,
-		IsSummaryMessage: true,
-	})
-	if err != nil {
-		return err
-	}
-
-	summaryPromptText := buildSummaryPrompt(currentSession.Todos)
-
-	resp, err := agent.Stream(genCtx, fantasy.AgentStreamCall{
-		Prompt:          summaryPromptText,
-		Messages:        aiMsgs,
-		Headers:         sessionHeaders(sessionID),
-		ProviderOptions: opts,
-		PrepareStep: func(callContext context.Context, options fantasy.PrepareStepFunctionOptions) (_ context.Context, prepared fantasy.PrepareStepResult, err error) {
-			prepared.Messages = options.Messages
-			if systemPromptPrefix != "" {
-				prepared.Messages = append([]fantasy.Message{fantasy.NewSystemMessage(systemPromptPrefix)}, prepared.Messages...)
-			}
-			return callContext, prepared, nil
-		},
-		OnReasoningDelta: func(id string, text string) error {
-			summaryMessage.AppendReasoningContent(text)
-			return a.messages.Update(genCtx, summaryMessage)
-		},
-		OnReasoningEnd: func(id string, reasoning fantasy.ReasoningContent) error {
-			// Handle anthropic signature.
-			if anthropicData, ok := reasoning.ProviderMetadata["anthropic"]; ok {
-				if signature, ok := anthropicData.(*anthropic.ReasoningOptionMetadata); ok && signature.Signature != "" {
-					summaryMessage.AppendReasoningSignature(signature.Signature)
-				}
-			}
-			summaryMessage.FinishThinking()
-			return a.messages.Update(genCtx, summaryMessage)
-		},
-		OnTextDelta: func(id, text string) error {
-			summaryMessage.AppendContent(text)
-			return a.messages.Update(genCtx, summaryMessage)
-		},
-	})
-	if err != nil {
-		isCancelErr := errors.Is(err, context.Canceled)
-		if isCancelErr {
-			// User cancelled summarize we need to remove the summary message.
-			deleteErr := a.messages.Delete(ctx, summaryMessage.ID)
-			return deleteErr
-		}
-		// Mark the summary message as finished with an error so the UI
-		// stops spinning.
-		summaryMessage.AddFinish(message.FinishReasonError, "Summarization Error", err.Error())
-		if updateErr := a.messages.Update(ctx, summaryMessage); updateErr != nil {
-			return updateErr
-		}
-		return err
-	}
-
-	summaryMessage.AddFinish(message.FinishReasonEndTurn, "", "")
-	err = a.messages.Update(genCtx, summaryMessage)
-	if err != nil {
-		return err
-	}
-
-	var openrouterCost *float64
-	for _, step := range resp.Steps {
-		stepCost := a.openrouterCost(step.ProviderMetadata)
-		if stepCost != nil {
-			newCost := *stepCost
-			if openrouterCost != nil {
-				newCost += *openrouterCost
-			}
-			openrouterCost = &newCost
-		}
-		extractHyperCredits(step.ProviderMetadata)
-	}
-
-	a.updateSessionUsage(largeModel, &currentSession, resp.TotalUsage, openrouterCost, false)
-
-	// Just in case, get just the last usage info.
-	usage := resp.Response.Usage
-	currentSession.SummaryMessageID = summaryMessage.ID
-	currentSession.CompletionTokens = summaryCompletionTokens(usage, summaryMessage)
-	currentSession.PromptTokens = 0
-	currentSession.EstimatedUsage = usageIsZero(usage)
-	_, err = a.sessions.Save(genCtx, currentSession)
-	if err != nil {
+	if err := a.compactSession(genCtx, sessionID, opts); err != nil {
 		return err
 	}
 
@@ -1464,6 +1359,90 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	a.messageQueue.Set(sessionID, queuedMessages[1:])
 	_, qErr := a.Run(ctx, firstQueuedMessage)
 	return qErr
+}
+
+func (a *sessionAgent) compactSession(ctx context.Context, sessionID string, opts fantasy.ProviderOptions) error {
+	// Copy mutable fields under lock to avoid races with SetModels.
+	largeModel := a.largeModel.Get()
+	systemPromptPrefix := a.systemPromptPrefix.Get()
+
+	currentSession, err := a.sessions.Get(ctx, sessionID)
+	if err != nil {
+		return fmt.Errorf("failed to get session: %w", err)
+	}
+	msgs, err := a.getSessionMessages(ctx, currentSession)
+	if err != nil {
+		return err
+	}
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	aiMsgs, _ := a.preparePrompt(msgs, largeModel.CatwalkCfg.SupportsImages)
+	summaryMessage, err := a.messages.Create(ctx, sessionID, message.CreateMessageParams{
+		Role:             message.Assistant,
+		Model:            largeModel.ModelCfg.Model,
+		Provider:         largeModel.ModelCfg.Provider,
+		IsSummaryMessage: true,
+	})
+	if err != nil {
+		return err
+	}
+
+	compacted, err := a.compactMessages(
+		ctx,
+		largeModel,
+		aiMsgs,
+		currentSession.Todos,
+		opts,
+		systemPromptPrefix,
+		sessionID,
+	)
+	if err != nil {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cleanupCancel()
+		compactionErr := err
+		if !usageIsZero(compacted.totalUsage) || compacted.openrouterCost != nil {
+			a.updateSessionUsage(largeModel, &currentSession, compacted.totalUsage, compacted.openrouterCost, false)
+			if _, saveErr := a.sessions.Save(cleanupCtx, currentSession); saveErr != nil {
+				compactionErr = errors.Join(compactionErr, fmt.Errorf("save partial compaction usage: %w", saveErr))
+			}
+		}
+		isCancelErr := errors.Is(err, context.Canceled)
+		if isCancelErr {
+			// User cancelled summarize we need to remove the summary message.
+			if deleteErr := a.messages.Delete(cleanupCtx, summaryMessage.ID); deleteErr != nil {
+				return errors.Join(compactionErr, fmt.Errorf("delete cancelled summary message: %w", deleteErr))
+			}
+			return compactionErr
+		}
+		// Mark the summary message as finished with an error so the UI
+		// stops spinning.
+		summaryMessage.AddFinish(message.FinishReasonError, "Summarization Error", compactionErr.Error())
+		if updateErr := a.messages.Update(cleanupCtx, summaryMessage); updateErr != nil {
+			return errors.Join(compactionErr, updateErr)
+		}
+		return compactionErr
+	}
+
+	summaryMessage.AppendContent(compacted.summary)
+	summaryMessage.AddFinish(message.FinishReasonEndTurn, "", "")
+	err = a.messages.Update(ctx, summaryMessage)
+	if err != nil {
+		return err
+	}
+
+	a.updateSessionUsage(largeModel, &currentSession, compacted.totalUsage, compacted.openrouterCost, false)
+
+	currentSession.SummaryMessageID = summaryMessage.ID
+	currentSession.CompletionTokens = summaryCompletionTokens(compacted.finalUsage, summaryMessage)
+	currentSession.PromptTokens = 0
+	currentSession.EstimatedUsage = usageIsZero(compacted.finalUsage)
+	_, err = a.sessions.Save(ctx, currentSession)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (a *sessionAgent) getCacheControlOptions() fantasy.ProviderOptions {
@@ -1733,9 +1712,9 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 	largeModel := a.largeModel.Get()
 	systemPromptPrefix := a.systemPromptPrefix.Get()
 
-	newAgent := func(m fantasy.LanguageModel, p []byte, tok int64) fantasy.Agent {
+	newAgent := func(model Model, p []byte, tok int64) fantasy.Agent {
 		return fantasy.NewAgent(
-			m,
+			withContextWindowLimit(model.Model, model.CatwalkCfg.ContextWindow),
 			fantasy.WithSystemPrompt(string(p)+"\n /no_think"),
 			fantasy.WithMaxOutputTokens(tok),
 			fantasy.WithUserAgent(userAgent),
@@ -1774,7 +1753,7 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 		if attempt.model.CatwalkCfg.CanReason {
 			tok = attempt.model.CatwalkCfg.DefaultMaxTokens
 		}
-		agent := newAgent(attempt.model.Model, titlePrompt, tok)
+		agent := newAgent(attempt.model, titlePrompt, tok)
 		resp, err = agent.Stream(ctx, streamCall)
 		if err == nil && resp.Response.FinishReason != fantasy.FinishReasonLength {
 			model = attempt.model

--- a/internal/agent/compaction.go
+++ b/internal/agent/compaction.go
@@ -1,0 +1,420 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/session"
+)
+
+const (
+	compactionSafetyMarginTokens = 1_024
+	maxCompactionPasses          = 32
+	// Bound automatic paid work independently of provider pricing. The call
+	// limit caps request count; the token multiplier allows the source pass,
+	// reserved outputs, and merge passes without unbounded amplification.
+	maxCompactionCalls        = 64
+	compactionTokenMultiplier = 3
+)
+
+type compactionResult struct {
+	summary        string
+	totalUsage     fantasy.Usage
+	finalUsage     fantasy.Usage
+	openrouterCost *float64
+	calls          int
+	passes         int
+	estimatedSpend int64
+}
+
+func (a *sessionAgent) compactMessages(
+	ctx context.Context,
+	model Model,
+	messages []fantasy.Message,
+	todos []session.Todo,
+	providerOptions fantasy.ProviderOptions,
+	systemPromptPrefix string,
+	sessionID string,
+) (result compactionResult, retErr error) {
+	transcript := renderCompactionTranscript(messages)
+	if strings.TrimSpace(transcript) == "" {
+		return compactionResult{}, fmt.Errorf("cannot compact an empty conversation")
+	}
+
+	outputTokens := compactionOutputTokens(model.CatwalkCfg.ContextWindow, model.CatwalkCfg.DefaultMaxTokens)
+	inputBudget, err := compactionInputBudget(
+		model.CatwalkCfg.ContextWindow,
+		outputTokens,
+		systemPromptPrefix,
+		buildCompactionChunkPrompt("", 0, 1, 1, todos),
+	)
+	if err != nil {
+		return compactionResult{}, err
+	}
+	sourceTokens := approxTokenCount(transcript)
+	tokenBudget := compactionTokenBudget(sourceTokens, model.CatwalkCfg.ContextWindow)
+	startedAt := time.Now()
+	slog.Info("Conversation compaction started",
+		"session_id", sessionID,
+		"estimated_source_tokens", sourceTokens,
+		"context_window", model.CatwalkCfg.ContextWindow,
+		"chunk_input_budget", inputBudget,
+		"chunk_output_limit", outputTokens,
+		"max_calls", maxCompactionCalls,
+		"estimated_token_budget", tokenBudget,
+	)
+
+	input := transcript
+	defer func() {
+		fields := []any{
+			"session_id", sessionID,
+			"passes", result.passes,
+			"calls", result.calls,
+			"estimated_token_spend", result.estimatedSpend,
+			"input_tokens", result.totalUsage.InputTokens,
+			"output_tokens", result.totalUsage.OutputTokens,
+			"summary_tokens", approxTokenCount(result.summary),
+			"duration", time.Since(startedAt).Round(time.Millisecond),
+		}
+		if retErr != nil {
+			fields = append(fields, "error", retErr)
+			slog.Warn("Conversation compaction failed", fields...)
+			return
+		}
+		slog.Info("Conversation compaction completed", fields...)
+	}()
+	for pass := range maxCompactionPasses {
+		chunks := splitTextByApproxTokens(input, inputBudget)
+		if len(chunks) == 0 {
+			return result, fmt.Errorf("cannot compact an empty conversation")
+		}
+		if len(chunks) > maxCompactionCalls-result.calls {
+			return result, fmt.Errorf(
+				"conversation compaction exceeds the %d-call safety limit: %d calls already used and the next pass requires %d",
+				maxCompactionCalls,
+				result.calls,
+				len(chunks),
+			)
+		}
+
+		type plannedCall struct {
+			prompt         string
+			estimatedSpend int64
+		}
+		planned := make([]plannedCall, 0, len(chunks))
+		var passSpend int64
+		for i, chunk := range chunks {
+			prompt := buildCompactionChunkPrompt(chunk, pass, i+1, len(chunks), todos)
+			spend := estimateCompactionCallSpend(prompt, systemPromptPrefix, outputTokens)
+			passSpend = saturatingAdd(passSpend, spend)
+			planned = append(planned, plannedCall{prompt: prompt, estimatedSpend: spend})
+		}
+		if passSpend > tokenBudget-result.estimatedSpend {
+			return result, fmt.Errorf(
+				"conversation compaction exceeds its estimated token-spend safety budget: %d tokens already reserved, next pass requires %d, limit is %d",
+				result.estimatedSpend,
+				passSpend,
+				tokenBudget,
+			)
+		}
+		result.passes = pass + 1
+		slog.Debug("Conversation compaction pass planned",
+			"session_id", sessionID,
+			"pass", result.passes,
+			"chunks", len(planned),
+			"estimated_token_spend", passSpend,
+		)
+
+		summaries := make([]string, 0, len(chunks))
+		for i, plannedCall := range planned {
+			result.calls++
+			result.estimatedSpend = saturatingAdd(result.estimatedSpend, plannedCall.estimatedSpend)
+			callResult, err := a.summarizeCompactionChunk(
+				ctx,
+				model,
+				plannedCall.prompt,
+				outputTokens,
+				providerOptions,
+				systemPromptPrefix,
+				sessionID,
+			)
+			if err != nil {
+				return result, fmt.Errorf("compact conversation chunk %d of %d: %w", i+1, len(chunks), err)
+			}
+			result.totalUsage = addTokenUsage(result.totalUsage, callResult.totalUsage)
+			result.finalUsage = callResult.finalUsage
+			result.openrouterCost = addOptionalCost(result.openrouterCost, callResult.openrouterCost)
+			if strings.TrimSpace(callResult.summary) == "" {
+				return result, fmt.Errorf("compact conversation chunk %d of %d: model returned an empty summary", i+1, len(chunks))
+			}
+			summaries = append(summaries, callResult.summary)
+		}
+
+		if len(summaries) == 1 {
+			result.summary = summaries[0]
+			return result, nil
+		}
+		input = joinCompactionSummaries(summaries)
+	}
+
+	return result, fmt.Errorf("conversation compaction did not converge after %d passes", maxCompactionPasses)
+}
+
+func compactionTokenBudget(sourceTokens, contextWindow int64) int64 {
+	baseline := max(sourceTokens, contextWindow)
+	if baseline > math.MaxInt64/compactionTokenMultiplier {
+		return math.MaxInt64
+	}
+	return baseline * compactionTokenMultiplier
+}
+
+func estimateCompactionCallSpend(prompt, systemPromptPrefix string, outputTokens int64) int64 {
+	messages := []fantasy.Message{fantasy.NewSystemMessage(string(summaryPrompt))}
+	if systemPromptPrefix != "" {
+		messages = append([]fantasy.Message{fantasy.NewSystemMessage(systemPromptPrefix)}, messages...)
+	}
+	messages = append(messages, fantasy.NewUserMessage(prompt))
+	return saturatingAdd(estimateMessageTokens(messages), outputTokens)
+}
+
+func saturatingAdd(left, right int64) int64 {
+	if right > 0 && left > math.MaxInt64-right {
+		return math.MaxInt64
+	}
+	return left + right
+}
+
+func (a *sessionAgent) summarizeCompactionChunk(
+	ctx context.Context,
+	model Model,
+	prompt string,
+	maxOutputTokens int64,
+	providerOptions fantasy.ProviderOptions,
+	systemPromptPrefix string,
+	sessionID string,
+) (compactionResult, error) {
+	agent := fantasy.NewAgent(
+		withContextWindowLimit(model.Model, model.CatwalkCfg.ContextWindow),
+		fantasy.WithSystemPrompt(string(summaryPrompt)),
+		fantasy.WithUserAgent(userAgent),
+	)
+
+	call := fantasy.AgentStreamCall{
+		Prompt:          prompt,
+		Headers:         sessionHeaders(sessionID),
+		ProviderOptions: providerOptions,
+		PrepareStep: func(callContext context.Context, options fantasy.PrepareStepFunctionOptions) (context.Context, fantasy.PrepareStepResult, error) {
+			messages := options.Messages
+			if systemPromptPrefix != "" {
+				messages = append([]fantasy.Message{fantasy.NewSystemMessage(systemPromptPrefix)}, messages...)
+			}
+			return callContext, fantasy.PrepareStepResult{Messages: messages}, nil
+		},
+	}
+	if maxOutputTokens > 0 {
+		call.MaxOutputTokens = &maxOutputTokens
+	}
+
+	var summary strings.Builder
+	call.OnTextDelta = func(_, text string) error {
+		summary.WriteString(text)
+		return nil
+	}
+
+	response, err := agent.Stream(ctx, call)
+	if err != nil {
+		return compactionResult{}, err
+	}
+	if summary.Len() == 0 {
+		summary.WriteString(response.Response.Content.Text())
+	}
+
+	var cost *float64
+	for _, step := range response.Steps {
+		cost = addOptionalCost(cost, a.openrouterCost(step.ProviderMetadata))
+		extractHyperCredits(step.ProviderMetadata)
+	}
+
+	return compactionResult{
+		summary:        summary.String(),
+		totalUsage:     response.TotalUsage,
+		finalUsage:     response.Response.Usage,
+		openrouterCost: cost,
+	}, nil
+}
+
+func compactionOutputTokens(contextWindow, defaultMaxTokens int64) int64 {
+	if contextWindow <= 0 {
+		return defaultMaxTokens
+	}
+	reserve := contextWindowReserve(contextWindow)
+	if defaultMaxTokens > 0 {
+		return min(reserve, defaultMaxTokens)
+	}
+	return reserve
+}
+
+func compactionInputBudget(contextWindow, outputTokens int64, systemPromptPrefix, promptWrapper string) (int64, error) {
+	if contextWindow <= 0 {
+		return 1<<62 - 1, nil
+	}
+	overhead := approxTokenCount(string(summaryPrompt)) +
+		approxTokenCount(systemPromptPrefix) +
+		approxTokenCount(promptWrapper) +
+		compactionSafetyMarginTokens
+	budget := contextWindow - outputTokens - overhead
+	if budget <= 0 {
+		return 0, fmt.Errorf(
+			"context window is too small for compaction: %d tokens available, %d required for output and prompt overhead",
+			contextWindow,
+			outputTokens+overhead,
+		)
+	}
+	return budget, nil
+}
+
+func splitTextByApproxTokens(text string, maxTokens int64) []string {
+	if text == "" || maxTokens <= 0 {
+		return nil
+	}
+
+	var chunks []string
+	var chunk strings.Builder
+	var counter approxTokenCounter
+	flush := func() {
+		if chunk.Len() == 0 {
+			return
+		}
+		chunks = append(chunks, chunk.String())
+		chunk.Reset()
+		counter = approxTokenCounter{}
+	}
+
+	for len(text) > 0 {
+		r, size := utf8.DecodeRuneInString(text)
+		piece := text[:size]
+		next := counter
+		next.add(r)
+		if chunk.Len() > 0 && next.total() > maxTokens {
+			flush()
+			next = approxTokenCounter{}
+			next.add(r)
+		}
+		// Write the original bytes rather than encoding r again. This keeps
+		// malformed UTF-8 from tool output byte-for-byte intact while still
+		// avoiding splits inside valid multi-byte runes.
+		chunk.WriteString(piece)
+		counter = next
+		text = text[size:]
+	}
+	flush()
+	return chunks
+}
+
+func renderCompactionTranscript(messages []fantasy.Message) string {
+	var transcript strings.Builder
+	for _, msg := range messages {
+		fmt.Fprintf(&transcript, "\n<message role=%q>\n", msg.Role)
+		for _, part := range msg.Content {
+			renderCompactionPart(&transcript, part)
+		}
+		transcript.WriteString("\n</message>\n")
+	}
+	return transcript.String()
+}
+
+func renderCompactionPart(transcript *strings.Builder, part fantasy.MessagePart) {
+	if text, ok := fantasy.AsMessagePart[fantasy.TextPart](part); ok {
+		transcript.WriteString(text.Text)
+		return
+	}
+	if reasoning, ok := fantasy.AsMessagePart[fantasy.ReasoningPart](part); ok {
+		transcript.WriteString("\n[reasoning]\n")
+		transcript.WriteString(reasoning.Text)
+		return
+	}
+	if toolCall, ok := fantasy.AsMessagePart[fantasy.ToolCallPart](part); ok {
+		fmt.Fprintf(transcript, "\n[tool call %s id=%s]\n%s", toolCall.ToolName, toolCall.ToolCallID, toolCall.Input)
+		return
+	}
+	if toolResult, ok := fantasy.AsMessagePart[fantasy.ToolResultPart](part); ok {
+		fmt.Fprintf(transcript, "\n[tool result id=%s]\n", toolResult.ToolCallID)
+		renderCompactionToolResult(transcript, toolResult.Output)
+		return
+	}
+	if file, ok := fantasy.AsMessagePart[fantasy.FilePart](part); ok {
+		fmt.Fprintf(transcript, "\n[file %q media_type=%q bytes=%d]\n", file.Filename, file.MediaType, len(file.Data))
+		return
+	}
+	if encoded, err := json.Marshal(part); err == nil {
+		transcript.Write(encoded)
+	}
+}
+
+func renderCompactionToolResult(transcript *strings.Builder, output fantasy.ToolResultOutputContent) {
+	if text, ok := fantasy.AsToolResultOutputType[fantasy.ToolResultOutputContentText](output); ok {
+		transcript.WriteString(text.Text)
+		return
+	}
+	if resultErr, ok := fantasy.AsToolResultOutputType[fantasy.ToolResultOutputContentError](output); ok {
+		if resultErr.Error != nil {
+			transcript.WriteString(resultErr.Error.Error())
+		}
+		return
+	}
+	if media, ok := fantasy.AsToolResultOutputType[fantasy.ToolResultOutputContentMedia](output); ok {
+		fmt.Fprintf(transcript, "[media media_type=%q bytes=%d] %s", media.MediaType, len(media.Data), media.Text)
+	}
+}
+
+func buildCompactionChunkPrompt(chunk string, pass, index, total int, todos []session.Todo) string {
+	var prompt strings.Builder
+	if pass == 0 {
+		fmt.Fprintf(&prompt, "Summarize conversation segment %d of %d faithfully. Preserve decisions, file paths, commands, errors, completed work, and exact next steps.\n\n", index, total)
+	} else {
+		fmt.Fprintf(&prompt, "Merge partial continuation summaries %d of %d into a single faithful continuation summary. Remove duplication without dropping decisions, file paths, commands, errors, completed work, or exact next steps.\n\n", index, total)
+	}
+	prompt.WriteString(buildSummaryPrompt(todos))
+	prompt.WriteString("\n\n<conversation_segment>\n")
+	prompt.WriteString(chunk)
+	prompt.WriteString("\n</conversation_segment>")
+	return prompt.String()
+}
+
+func joinCompactionSummaries(summaries []string) string {
+	var joined strings.Builder
+	for i, summary := range summaries {
+		fmt.Fprintf(&joined, "\n<partial_summary index=%d>\n%s\n</partial_summary>\n", i+1, summary)
+	}
+	return joined.String()
+}
+
+func addTokenUsage(a, b fantasy.Usage) fantasy.Usage {
+	return fantasy.Usage{
+		InputTokens:         a.InputTokens + b.InputTokens,
+		OutputTokens:        a.OutputTokens + b.OutputTokens,
+		TotalTokens:         a.TotalTokens + b.TotalTokens,
+		ReasoningTokens:     a.ReasoningTokens + b.ReasoningTokens,
+		CacheCreationTokens: a.CacheCreationTokens + b.CacheCreationTokens,
+		CacheReadTokens:     a.CacheReadTokens + b.CacheReadTokens,
+	}
+}
+
+func addOptionalCost(a, b *float64) *float64 {
+	if b == nil {
+		return a
+	}
+	if a == nil {
+		value := *b
+		return &value
+	}
+	value := *a + *b
+	return &value
+}

--- a/internal/agent/compaction_test.go
+++ b/internal/agent/compaction_test.go
@@ -1,0 +1,993 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"math"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/agent/notify"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/stretchr/testify/require"
+)
+
+type compactionTestModel struct {
+	mu    sync.Mutex
+	calls []fantasy.Call
+}
+
+type toolLoopCompactionTestModel struct {
+	mu              sync.Mutex
+	calls           []fantasy.Call
+	mainCalls       int
+	compactionCalls int
+}
+
+type compactionFaultModel struct {
+	mu        sync.Mutex
+	calls     []fantasy.Call
+	failAt    int
+	failErr   error
+	empty     bool
+	block     bool
+	blockAt   int
+	entered   chan struct{}
+	release   chan struct{}
+	enterOnce sync.Once
+}
+
+func (m *compactionFaultModel) Provider() string { return "test" }
+func (m *compactionFaultModel) Model() string    { return "fault-model" }
+
+func (m *compactionFaultModel) Generate(context.Context, fantasy.Call) (*fantasy.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *compactionFaultModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+	m.mu.Lock()
+	m.calls = append(m.calls, call)
+	callNumber := len(m.calls)
+	m.mu.Unlock()
+
+	if m.block && (m.blockAt == 0 || m.blockAt == callNumber) {
+		m.enterOnce.Do(func() { close(m.entered) })
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-m.release:
+		}
+	}
+	if m.failAt == callNumber {
+		return nil, m.failErr
+	}
+	if m.empty {
+		return textStream(""), nil
+	}
+	return textStream("bounded summary"), nil
+}
+
+func (m *compactionFaultModel) GenerateObject(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *compactionFaultModel) StreamObject(context.Context, fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *compactionFaultModel) recordedCalls() []fantasy.Call {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]fantasy.Call(nil), m.calls...)
+}
+
+func (m *compactionTestModel) Provider() string { return "test" }
+func (m *compactionTestModel) Model() string    { return "test-model" }
+
+func (m *compactionTestModel) Generate(context.Context, fantasy.Call) (*fantasy.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *compactionTestModel) Stream(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+	m.mu.Lock()
+	m.calls = append(m.calls, call)
+	callNumber := len(m.calls)
+	m.mu.Unlock()
+
+	text := "summary for bounded chunk " + strings.Repeat("x", callNumber)
+	usage := fantasy.Usage{InputTokens: 100, OutputTokens: 10, TotalTokens: 110}
+	return func(yield func(fantasy.StreamPart) bool) {
+		if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "summary"}) {
+			return
+		}
+		if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "summary", Delta: text}) {
+			return
+		}
+		if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "summary"}) {
+			return
+		}
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop, Usage: usage})
+	}, nil
+}
+
+func (m *compactionTestModel) GenerateObject(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *compactionTestModel) StreamObject(context.Context, fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *compactionTestModel) recordedCalls() []fantasy.Call {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]fantasy.Call(nil), m.calls...)
+}
+
+func (m *toolLoopCompactionTestModel) Provider() string { return "test" }
+func (m *toolLoopCompactionTestModel) Model() string    { return "test-model" }
+
+func (m *toolLoopCompactionTestModel) Generate(context.Context, fantasy.Call) (*fantasy.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *toolLoopCompactionTestModel) Stream(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+	m.mu.Lock()
+	m.calls = append(m.calls, call)
+	isCompaction := callContainsText(call, "You are summarizing a conversation")
+	if isCompaction {
+		m.compactionCalls++
+	} else {
+		m.mainCalls++
+	}
+	mainCall := m.mainCalls
+	m.mu.Unlock()
+
+	if isCompaction {
+		return textStream("bounded compacted context"), nil
+	}
+	if mainCall == 1 {
+		return toolCallStream("large-output", "tool-1", `{}`), nil
+	}
+	return textStream("continued after compaction"), nil
+}
+
+func (m *toolLoopCompactionTestModel) GenerateObject(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *toolLoopCompactionTestModel) StreamObject(context.Context, fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *toolLoopCompactionTestModel) state() (calls []fantasy.Call, mainCalls, compactionCalls int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]fantasy.Call(nil), m.calls...), m.mainCalls, m.compactionCalls
+}
+
+func callContainsText(call fantasy.Call, text string) bool {
+	for _, msg := range call.Prompt {
+		for _, part := range msg.Content {
+			if content, ok := fantasy.AsMessagePart[fantasy.TextPart](part); ok && strings.Contains(content.Text, text) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func textStream(text string) fantasy.StreamResponse {
+	return func(yield func(fantasy.StreamPart) bool) {
+		if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "text"}) {
+			return
+		}
+		if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "text", Delta: text}) {
+			return
+		}
+		if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "text"}) {
+			return
+		}
+		yield(fantasy.StreamPart{
+			Type:         fantasy.StreamPartTypeFinish,
+			FinishReason: fantasy.FinishReasonStop,
+			Usage:        fantasy.Usage{InputTokens: 100, OutputTokens: 10, TotalTokens: 110},
+		})
+	}
+}
+
+func toolCallStream(toolName, toolCallID, input string) fantasy.StreamResponse {
+	return func(yield func(fantasy.StreamPart) bool) {
+		if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeToolInputStart, ID: toolCallID, ToolCallName: toolName}) {
+			return
+		}
+		if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeToolInputDelta, ID: toolCallID, Delta: input}) {
+			return
+		}
+		if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeToolInputEnd, ID: toolCallID}) {
+			return
+		}
+		if !yield(fantasy.StreamPart{
+			Type:          fantasy.StreamPartTypeToolCall,
+			ID:            toolCallID,
+			ToolCallName:  toolName,
+			ToolCallInput: input,
+		}) {
+			return
+		}
+		yield(fantasy.StreamPart{
+			Type:         fantasy.StreamPartTypeFinish,
+			FinishReason: fantasy.FinishReasonToolCalls,
+			Usage:        fantasy.Usage{InputTokens: 100, OutputTokens: 10, TotalTokens: 110},
+		})
+	}
+}
+
+func TestCompactMessagesRecoversHistoryLargerThanContextWindow(t *testing.T) {
+	t.Parallel()
+
+	provider := &compactionTestModel{}
+	model := Model{
+		Model: provider,
+		CatwalkCfg: catwalk.Model{
+			ContextWindow:    4_096,
+			DefaultMaxTokens: 512,
+		},
+	}
+	messages := []fantasy.Message{
+		fantasy.NewUserMessage(strings.Repeat("large historical context ", 1_000)),
+	}
+
+	result, err := (&sessionAgent{}).compactMessages(
+		t.Context(),
+		model,
+		messages,
+		nil,
+		nil,
+		"",
+		"session-id",
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, result.summary)
+
+	calls := provider.recordedCalls()
+	require.Equal(t, len(calls), result.calls)
+	require.Positive(t, result.passes)
+	require.Positive(t, result.estimatedSpend)
+	require.Greater(t, len(calls), 1, "oversized history must be summarized in multiple bounded calls")
+	for _, call := range calls {
+		inputTokens, estimateErr := estimateCallInputTokens(call)
+		require.NoError(t, estimateErr)
+		require.LessOrEqual(t, inputTokens+contextWindowOutputReserve(model.CatwalkCfg.ContextWindow, call.MaxOutputTokens), model.CatwalkCfg.ContextWindow)
+	}
+}
+
+func TestCompactMessagesRejectsEmptyConversationWithoutProviderCall(t *testing.T) {
+	t.Parallel()
+
+	provider := &compactionFaultModel{}
+	_, err := (&sessionAgent{}).compactMessages(t.Context(), Model{
+		Model:      provider,
+		CatwalkCfg: catwalk.Model{ContextWindow: 4_096, DefaultMaxTokens: 512},
+	}, nil, nil, nil, "", "session-id")
+
+	require.ErrorContains(t, err, "cannot compact an empty conversation")
+	require.Empty(t, provider.recordedCalls())
+}
+
+func TestCompactionOutputTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		contextWindow    int64
+		defaultMaxTokens int64
+		expected         int64
+	}{
+		{name: "unknown context preserves default", defaultMaxTokens: 1_024, expected: 1_024},
+		{name: "default below reserve", contextWindow: 4_096, defaultMaxTokens: 512, expected: 512},
+		{name: "default above reserve", contextWindow: 4_096, defaultMaxTokens: 2_000, expected: 819},
+		{name: "missing default uses reserve", contextWindow: 204_800, expected: 20_000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, compactionOutputTokens(tt.contextWindow, tt.defaultMaxTokens))
+		})
+	}
+}
+
+func TestCompactionTokenBudget(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, int64(600_000), compactionTokenBudget(200_000, 100_000))
+	require.Equal(t, int64(600_000), compactionTokenBudget(100_000, 200_000))
+	require.Equal(t, int64(0), compactionTokenBudget(0, 0))
+	require.Equal(t, int64(math.MaxInt64), compactionTokenBudget(math.MaxInt64, 1))
+	require.Equal(t, int64(math.MaxInt64), saturatingAdd(math.MaxInt64-1, 10))
+	require.Equal(t, int64(30), saturatingAdd(10, 20))
+	require.Greater(
+		t,
+		estimateCompactionCallSpend("prompt", "prefix", 512),
+		estimateCompactionCallSpend("prompt", "", 512),
+	)
+}
+
+func TestCompactMessagesRejectsCallBudgetBeforeProviderDispatch(t *testing.T) {
+	t.Parallel()
+
+	provider := &compactionFaultModel{}
+	_, err := (&sessionAgent{}).compactMessages(t.Context(), Model{
+		Model:      provider,
+		CatwalkCfg: catwalk.Model{ContextWindow: 4_096, DefaultMaxTokens: 512},
+	}, []fantasy.Message{
+		fantasy.NewUserMessage(strings.Repeat("history ", 50_000)),
+	}, nil, nil, "", "session-id")
+
+	require.ErrorContains(t, err, "64-call safety limit")
+	require.Empty(t, provider.recordedCalls(), "unsafe compaction must be rejected before incurring provider cost")
+}
+
+func TestCompactMessagesRejectsTokenSpendBudgetBeforeProviderDispatch(t *testing.T) {
+	t.Parallel()
+
+	provider := &compactionFaultModel{}
+	_, err := (&sessionAgent{}).compactMessages(t.Context(), Model{
+		Model:      provider,
+		CatwalkCfg: catwalk.Model{ContextWindow: 4_096, DefaultMaxTokens: 512},
+	}, []fantasy.Message{
+		fantasy.NewUserMessage(strings.Repeat("history ", 1_000)),
+	}, nil, nil, strings.Repeat("prefix ", 400), "session-id")
+
+	require.ErrorContains(t, err, "estimated token-spend safety budget")
+	require.Empty(t, provider.recordedCalls(), "over-budget pass must be rejected atomically")
+}
+
+func TestCompactMessagesRejectsContextTooSmallForPromptOverhead(t *testing.T) {
+	t.Parallel()
+
+	provider := &compactionFaultModel{}
+	_, err := (&sessionAgent{}).compactMessages(t.Context(), Model{
+		Model:      provider,
+		CatwalkCfg: catwalk.Model{ContextWindow: 512, DefaultMaxTokens: 128},
+	}, []fantasy.Message{fantasy.NewUserMessage("history")}, nil, nil, "", "session-id")
+
+	require.ErrorContains(t, err, "context window is too small for compaction")
+	require.Empty(t, provider.recordedCalls())
+}
+
+func TestCompactMessagesRejectsEmptyModelSummary(t *testing.T) {
+	t.Parallel()
+
+	provider := &compactionFaultModel{empty: true}
+	result, err := (&sessionAgent{}).compactMessages(t.Context(), Model{
+		Model:      provider,
+		CatwalkCfg: catwalk.Model{ContextWindow: 4_096, DefaultMaxTokens: 512},
+	}, []fantasy.Message{fantasy.NewUserMessage("history")}, nil, nil, "", "session-id")
+
+	require.ErrorContains(t, err, "model returned an empty summary")
+	require.Len(t, provider.recordedCalls(), 1)
+	require.Equal(t, int64(100), result.totalUsage.InputTokens)
+	require.Equal(t, int64(10), result.totalUsage.OutputTokens)
+}
+
+func TestSummarizeChunkFailureDoesNotAdvanceSessionCutoff(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	provider := &compactionFaultModel{failAt: 2, failErr: errors.New("chunk failed")}
+	model := Model{
+		Model: provider,
+		CatwalkCfg: catwalk.Model{
+			ContextWindow:    4_096,
+			DefaultMaxTokens: 512,
+			CostPer1MIn:      10,
+			CostPer1MOut:     20,
+		},
+	}
+	agent := testSessionAgent(env, provider, provider, "system prompt").(*sessionAgent)
+	agent.SetModels(model, model)
+
+	sess, err := env.sessions.Create(t.Context(), "failure atomicity")
+	require.NoError(t, err)
+	original, err := env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: strings.Repeat("large historical context ", 1_000)},
+		},
+	})
+	require.NoError(t, err)
+
+	err = agent.Summarize(t.Context(), sess.ID, nil)
+	require.ErrorContains(t, err, "chunk failed")
+	require.GreaterOrEqual(t, len(provider.recordedCalls()), 2)
+
+	sess, err = env.sessions.Get(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.Empty(t, sess.SummaryMessageID, "failed compaction must not hide the original history")
+	require.Equal(t, int64(100), sess.PromptTokens)
+	require.Equal(t, int64(10), sess.CompletionTokens)
+	require.InDelta(t, 0.0012, sess.Cost, 0.0000001)
+	stored, err := env.messages.List(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(stored), 2)
+	require.Equal(t, original.ID, stored[0].ID)
+	require.True(t, stored[len(stored)-1].IsSummaryMessage, "failed placeholder should be terminally marked for the UI")
+}
+
+func TestSummarizeCancellationDeletesPlaceholderAndClearsBusyState(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	provider := &compactionFaultModel{block: true, blockAt: 2, entered: make(chan struct{})}
+	model := Model{
+		Model:      provider,
+		CatwalkCfg: catwalk.Model{ContextWindow: 4_096, DefaultMaxTokens: 512},
+	}
+	agent := testSessionAgent(env, provider, provider, "system prompt").(*sessionAgent)
+	agent.SetModels(model, model)
+
+	sess, err := env.sessions.Create(t.Context(), "cancel compaction")
+	require.NoError(t, err)
+	_, err = env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: strings.Repeat("large historical context ", 1_000)},
+		},
+	})
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() { done <- agent.Summarize(t.Context(), sess.ID, nil) }()
+	select {
+	case <-provider.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("compaction never reached provider")
+	}
+	require.True(t, agent.IsSessionBusy(sess.ID))
+	agent.Cancel(sess.ID)
+
+	select {
+	case err = <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled compaction did not return")
+	}
+	require.False(t, agent.IsSessionBusy(sess.ID))
+	sess, err = env.sessions.Get(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.Empty(t, sess.SummaryMessageID)
+	require.Equal(t, int64(100), sess.PromptTokens, "completed chunks before cancellation must remain accounted")
+	require.Equal(t, int64(10), sess.CompletionTokens)
+	stored, err := env.messages.List(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.Len(t, stored, 1, "cancelled summary placeholder must be deleted")
+}
+
+func TestSummarizeCallerCancellationPersistsCompletedChunkUsage(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	provider := &compactionFaultModel{block: true, blockAt: 2, entered: make(chan struct{})}
+	model := Model{
+		Model: provider,
+		CatwalkCfg: catwalk.Model{
+			ContextWindow:    4_096,
+			DefaultMaxTokens: 512,
+			CostPer1MIn:      10,
+			CostPer1MOut:     20,
+		},
+	}
+	agent := testSessionAgent(env, provider, provider, "system prompt").(*sessionAgent)
+	agent.SetModels(model, model)
+
+	sess, err := env.sessions.Create(t.Context(), "caller cancel compaction")
+	require.NoError(t, err)
+	_, err = env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: strings.Repeat("large historical context ", 1_000)},
+		},
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- agent.Summarize(ctx, sess.ID, nil) }()
+	select {
+	case <-provider.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("compaction never reached its second provider call")
+	}
+	cancel()
+
+	select {
+	case err = <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("caller-cancelled compaction did not return")
+	}
+
+	sess, err = env.sessions.Get(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.Empty(t, sess.SummaryMessageID)
+	require.Equal(t, int64(100), sess.PromptTokens)
+	require.Equal(t, int64(10), sess.CompletionTokens)
+	require.InDelta(t, 0.0012, sess.Cost, 0.0000001)
+	stored, err := env.messages.List(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.Len(t, stored, 1, "caller-cancelled summary placeholder must be deleted")
+}
+
+func TestSummarizeRejectsAlreadyBusySessionWithoutProviderCall(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	provider := &compactionFaultModel{}
+	agent := testSessionAgent(env, provider, provider, "system prompt").(*sessionAgent)
+	sess, err := env.sessions.Create(t.Context(), "busy summary")
+	require.NoError(t, err)
+	agent.activeRequests.Set(sess.ID, func() {})
+	t.Cleanup(func() { agent.activeRequests.Del(sess.ID) })
+
+	err = agent.Summarize(t.Context(), sess.ID, nil)
+	require.ErrorIs(t, err, ErrSessionBusy)
+	require.Empty(t, provider.recordedCalls())
+}
+
+func TestSummarizeProcessesPromptQueuedDuringCompactionExactlyOnce(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	provider := &compactionFaultModel{
+		block:   true,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	model := Model{
+		Model:      provider,
+		CatwalkCfg: catwalk.Model{ContextWindow: 4_096, DefaultMaxTokens: 512},
+	}
+	agent := testSessionAgent(env, provider, provider, "system prompt").(*sessionAgent)
+	agent.SetModels(model, model)
+
+	sess, err := env.sessions.Create(t.Context(), "queued during summary")
+	require.NoError(t, err)
+	_, err = env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: strings.Repeat("large historical context ", 1_000)},
+		},
+	})
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() { done <- agent.Summarize(t.Context(), sess.ID, nil) }()
+	select {
+	case <-provider.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("compaction never reached provider")
+	}
+	result, err := agent.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		Prompt:    "queued follow-up",
+	})
+	require.NoError(t, err)
+	require.Nil(t, result, "run submitted during compaction must queue")
+	queued, ok := agent.messageQueue.Get(sess.ID)
+	require.True(t, ok)
+	require.Len(t, queued, 1)
+
+	close(provider.release)
+	select {
+	case err = <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("summary did not process queued prompt")
+	}
+	require.False(t, agent.IsSessionBusy(sess.ID))
+	queued, ok = agent.messageQueue.Get(sess.ID)
+	require.True(t, !ok || len(queued) == 0)
+
+	stored, err := env.messages.List(t.Context(), sess.ID)
+	require.NoError(t, err)
+	var followUps int
+	for _, msg := range stored {
+		if msg.Role == message.User && msg.Content().Text == "queued follow-up" {
+			followUps++
+		}
+	}
+	require.Equal(t, 1, followUps, "queued prompt must be persisted and executed exactly once")
+}
+
+func TestSummarizePersistsHierarchicalCompactionAsSessionCutoff(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	provider := &compactionTestModel{}
+	model := Model{
+		Model: provider,
+		CatwalkCfg: catwalk.Model{
+			ContextWindow:    4_096,
+			DefaultMaxTokens: 512,
+		},
+	}
+	agent := testSessionAgent(env, provider, provider, "system prompt").(*sessionAgent)
+	agent.SetModels(model, model)
+
+	sess, err := env.sessions.Create(t.Context(), "oversized session")
+	require.NoError(t, err)
+	_, err = env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: strings.Repeat("historical tool-driven work ", 1_000)},
+		},
+	})
+	require.NoError(t, err)
+
+	err = agent.Summarize(t.Context(), sess.ID, nil)
+	require.NoError(t, err)
+
+	sess, err = env.sessions.Get(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, sess.SummaryMessageID)
+
+	activeMessages, err := agent.getSessionMessages(t.Context(), sess)
+	require.NoError(t, err)
+	require.Len(t, activeMessages, 1)
+	require.Equal(t, sess.SummaryMessageID, activeMessages[0].ID)
+	require.True(t, activeMessages[0].IsSummaryMessage)
+	require.Equal(t, message.User, activeMessages[0].Role)
+	require.NotEmpty(t, activeMessages[0].Content().Text)
+	require.Greater(t, len(provider.recordedCalls()), 1)
+}
+
+func TestRunAutomaticallyCompactsOversizedExistingSessionBeforeDispatch(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	provider := &compactionTestModel{}
+	model := Model{
+		Model: provider,
+		CatwalkCfg: catwalk.Model{
+			ContextWindow:    4_096,
+			DefaultMaxTokens: 512,
+		},
+	}
+	agent := testSessionAgent(env, provider, provider, "system prompt").(*sessionAgent)
+	agent.SetModels(model, model)
+
+	sess, err := env.sessions.Create(t.Context(), "oversized session")
+	require.NoError(t, err)
+	_, err = env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: strings.Repeat("historical tool-driven work ", 1_000)},
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := agent.Run(t.Context(), SessionAgentCall{
+		SessionID:       sess.ID,
+		Prompt:          "continue the work",
+		MaxOutputTokens: 512,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	sess, err = env.sessions.Get(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, sess.SummaryMessageID)
+
+	calls := provider.recordedCalls()
+	require.Greater(t, len(calls), 2, "pre-dispatch recovery should compact in bounded calls before the requested inference")
+	for _, call := range calls {
+		inputTokens, estimateErr := estimateCallInputTokens(call)
+		require.NoError(t, estimateErr)
+		require.LessOrEqual(t, inputTokens+contextWindowOutputReserve(model.CatwalkCfg.ContextWindow, call.MaxOutputTokens), model.CatwalkCfg.ContextWindow)
+	}
+}
+
+func TestRunPreDispatchCompactionFailurePublishesOneTerminalEvent(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	provider := &compactionFaultModel{failAt: 1, failErr: errors.New("compaction unavailable")}
+	model := Model{
+		Model:      provider,
+		CatwalkCfg: catwalk.Model{ContextWindow: 4_096, DefaultMaxTokens: 512},
+	}
+	agent := testSessionAgent(env, provider, provider, "system prompt").(*sessionAgent)
+	agent.SetModels(model, model)
+
+	sess, err := env.sessions.Create(t.Context(), "pre-dispatch failure")
+	require.NoError(t, err)
+	_, err = env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: strings.Repeat("large historical context ", 1_000)},
+		},
+	})
+	require.NoError(t, err)
+
+	var completions []notify.RunComplete
+	_, err = agent.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		RunID:     "pre-dispatch-failure",
+		Prompt:    "continue",
+		Accepted:  agent.BeginAccepted(sess.ID),
+		OnComplete: func(complete notify.RunComplete) {
+			completions = append(completions, complete)
+		},
+	})
+	require.ErrorContains(t, err, "compaction unavailable")
+	require.Len(t, completions, 1)
+	require.Equal(t, "pre-dispatch-failure", completions[0].RunID)
+	require.Contains(t, completions[0].Error, "compaction unavailable")
+	require.False(t, completions[0].Cancelled)
+	require.False(t, agent.IsSessionBusy(sess.ID))
+
+	sess, err = env.sessions.Get(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.Empty(t, sess.SummaryMessageID)
+}
+
+func TestRunPreDispatchCompactionCancellationPublishesOneCancelledTerminalEvent(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	provider := &compactionFaultModel{block: true, entered: make(chan struct{})}
+	model := Model{
+		Model:      provider,
+		CatwalkCfg: catwalk.Model{ContextWindow: 4_096, DefaultMaxTokens: 512},
+	}
+	agent := testSessionAgent(env, provider, provider, "system prompt").(*sessionAgent)
+	agent.SetModels(model, model)
+
+	sess, err := env.sessions.Create(t.Context(), "pre-dispatch cancellation")
+	require.NoError(t, err)
+	_, err = env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: strings.Repeat("large historical context ", 1_000)},
+		},
+	})
+	require.NoError(t, err)
+
+	completion := make(chan notify.RunComplete, 1)
+	done := make(chan error, 1)
+	go func() {
+		_, runErr := agent.Run(t.Context(), SessionAgentCall{
+			SessionID: sess.ID,
+			RunID:     "pre-dispatch-cancel",
+			Prompt:    "continue",
+			OnComplete: func(complete notify.RunComplete) {
+				completion <- complete
+			},
+		})
+		done <- runErr
+	}()
+	select {
+	case <-provider.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pre-dispatch compaction never reached provider")
+	}
+	agent.Cancel(sess.ID)
+
+	select {
+	case err = <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled run did not return")
+	}
+	select {
+	case got := <-completion:
+		require.Equal(t, "pre-dispatch-cancel", got.RunID)
+		require.True(t, got.Cancelled)
+		require.Contains(t, got.Error, "context canceled")
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelled run did not publish RunComplete")
+	}
+	select {
+	case extra := <-completion:
+		t.Fatalf("expected one RunComplete, got extra: %+v", extra)
+	default:
+	}
+	require.False(t, agent.IsSessionBusy(sess.ID))
+}
+
+func TestRunCompactsLargeToolResultBeforeContinuing(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	provider := &toolLoopCompactionTestModel{}
+	model := Model{
+		Model: provider,
+		CatwalkCfg: catwalk.Model{
+			ContextWindow:    4_096,
+			DefaultMaxTokens: 512,
+		},
+	}
+	largeOutputTool := fantasy.NewAgentTool[struct{}](
+		"large-output",
+		"Return a large result",
+		func(context.Context, struct{}, fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			return fantasy.NewTextResponse(strings.Repeat("large tool output ", 2_000)), nil
+		},
+	)
+	agent := testSessionAgent(env, provider, provider, "system prompt", largeOutputTool).(*sessionAgent)
+	agent.SetModels(model, model)
+
+	sess, err := env.sessions.Create(t.Context(), "tool loop session")
+	require.NoError(t, err)
+	_, err = env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role:  message.User,
+		Parts: []message.ContentPart{message.TextContent{Text: "prior context"}},
+	})
+	require.NoError(t, err)
+	var completions []notify.RunComplete
+	result, err := agent.Run(t.Context(), SessionAgentCall{
+		SessionID:       sess.ID,
+		RunID:           "tool-loop-compaction",
+		Prompt:          "run the large output tool and continue",
+		MaxOutputTokens: 512,
+		OnComplete: func(complete notify.RunComplete) {
+			completions = append(completions, complete)
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	sess, err = env.sessions.Get(t.Context(), sess.ID)
+	require.NoError(t, err)
+	calls, mainCalls, compactionCalls := provider.state()
+	require.NotEmpty(t, sess.SummaryMessageID)
+	require.Equal(t, 2, mainCalls)
+	require.Positive(t, compactionCalls)
+	require.Len(t, completions, 1, "summarize-and-resume must complete the originating run exactly once")
+	require.Equal(t, "tool-loop-compaction", completions[0].RunID)
+	require.False(t, callContainsText(calls[0], "You are summarizing a conversation"))
+	require.False(t, callContainsText(calls[len(calls)-1], "You are summarizing a conversation"))
+	for _, call := range calls[1 : len(calls)-1] {
+		require.True(t, callContainsText(call, "You are summarizing a conversation"), "only bounded compaction calls may occur between main attempts")
+	}
+	for _, call := range calls {
+		inputTokens, estimateErr := estimateCallInputTokens(call)
+		require.NoError(t, estimateErr)
+		require.LessOrEqual(t, inputTokens+contextWindowOutputReserve(model.CatwalkCfg.ContextWindow, call.MaxOutputTokens), model.CatwalkCfg.ContextWindow)
+	}
+}
+
+func TestSplitTextByApproxTokensPreservesUnicode(t *testing.T) {
+	t.Parallel()
+
+	text := strings.Repeat("English 中文 ", 100)
+	chunks := splitTextByApproxTokens(text, 25)
+
+	require.Greater(t, len(chunks), 1)
+	require.Equal(t, text, strings.Join(chunks, ""))
+	for _, chunk := range chunks {
+		require.LessOrEqual(t, approxTokenCount(chunk), int64(25))
+	}
+}
+
+func FuzzSplitTextByApproxTokensPreservesInputAndBudget(f *testing.F) {
+	f.Add("English 中文 😀 paths/and_json:{}", int64(25))
+	f.Add(strings.Repeat("x", 1_000), int64(64))
+	f.Add("", int64(10))
+	f.Add(string([]byte{0xd3}), int64(3))
+
+	f.Fuzz(func(t *testing.T, text string, budget int64) {
+		// A valid Unicode rune or malformed byte can conservatively cost up
+		// to four estimated tokens and must remain indivisible.
+		if budget < 4 || budget > 4_096 || len(text) > 64*1024 {
+			t.Skip()
+		}
+		chunks := splitTextByApproxTokens(text, budget)
+		require.Equal(t, text, strings.Join(chunks, ""))
+		for _, chunk := range chunks {
+			require.LessOrEqual(t, approxTokenCount(chunk), budget)
+		}
+	})
+}
+
+func TestRenderCompactionTranscriptOmitsMediaPayload(t *testing.T) {
+	t.Parallel()
+
+	mediaData := strings.Repeat("base64-payload", 1_000)
+	messages := []fantasy.Message{
+		{
+			Role: fantasy.MessageRoleTool,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolResultPart{
+					ToolCallID: "call-1",
+					Output: fantasy.ToolResultOutputContentMedia{
+						Data:      mediaData,
+						MediaType: "image/png",
+						Text:      "screenshot",
+					},
+				},
+			},
+		},
+	}
+
+	transcript := renderCompactionTranscript(messages)
+	require.NotContains(t, transcript, mediaData)
+	require.Contains(t, transcript, "image/png")
+	require.Contains(t, transcript, "screenshot")
+}
+
+func TestRenderCompactionTranscriptPreservesSemanticPartsInOrder(t *testing.T) {
+	t.Parallel()
+
+	filePayload := strings.Repeat("binary-file-payload", 100)
+	messages := []fantasy.Message{
+		{
+			Role: fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{
+				fantasy.TextPart{Text: "assistant text"},
+				fantasy.ReasoningPart{Text: "reasoning trace"},
+				fantasy.ToolCallPart{ToolName: "view", ToolCallID: "call-1", Input: `{"path":"agent.go"}`},
+			},
+		},
+		{
+			Role: fantasy.MessageRoleTool,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolResultPart{
+					ToolCallID: "call-1",
+					Output:     fantasy.ToolResultOutputContentText{Text: "tool output"},
+				},
+				fantasy.ToolResultPart{
+					ToolCallID: "call-2",
+					Output:     fantasy.ToolResultOutputContentError{Error: errors.New("tool failed")},
+				},
+			},
+		},
+		{
+			Role: fantasy.MessageRoleUser,
+			Content: []fantasy.MessagePart{
+				fantasy.FilePart{Filename: "screen.png", MediaType: "image/png", Data: []byte(filePayload)},
+			},
+		},
+	}
+
+	transcript := renderCompactionTranscript(messages)
+	require.NotContains(t, transcript, filePayload)
+	ordered := []string{
+		"assistant text",
+		"reasoning trace",
+		"[tool call view id=call-1]",
+		`{"path":"agent.go"}`,
+		"[tool result id=call-1]",
+		"tool output",
+		"[tool result id=call-2]",
+		"tool failed",
+		`[file "screen.png" media_type="image/png"`,
+	}
+	cursor := 0
+	for _, expected := range ordered {
+		next := strings.Index(transcript[cursor:], expected)
+		require.NotEqualf(t, -1, next, "missing %q", expected)
+		cursor += next + len(expected)
+	}
+}
+
+func TestAddOptionalCost(t *testing.T) {
+	t.Parallel()
+
+	one := 1.25
+	two := 2.75
+	require.Nil(t, addOptionalCost(nil, nil))
+	first := addOptionalCost(nil, &one)
+	require.NotNil(t, first)
+	require.Equal(t, 1.25, *first)
+	require.NotSame(t, &one, first, "cost accumulator must not alias provider metadata")
+	total := addOptionalCost(first, &two)
+	require.NotNil(t, total)
+	require.Equal(t, 4.0, *total)
+	require.Equal(t, first, addOptionalCost(first, nil))
+}

--- a/internal/agent/context_window.go
+++ b/internal/agent/context_window.go
@@ -1,0 +1,161 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"charm.land/fantasy"
+)
+
+type contextWindowModel struct {
+	fantasy.LanguageModel
+	contextWindow int64
+}
+
+// contextWindowModel enforces Crush's provider-independent admission policy at
+// the final LanguageModel boundary. The count is deliberately conservative,
+// not a claim of provider-exact tokenization; the output reserve covers normal
+// tokenizer and serialization differences while the wrapper prevents known
+// oversized calls from reaching any provider implementation.
+
+type contextWindowExceededError struct {
+	inputTokens   int64
+	outputReserve int64
+	contextWindow int64
+}
+
+func (e *contextWindowExceededError) Error() string {
+	return fmt.Sprintf(
+		"model request exceeds context window: estimated %d input tokens plus %d reserved output tokens exceeds the %d token limit",
+		e.inputTokens,
+		e.outputReserve,
+		e.contextWindow,
+	)
+}
+
+func withContextWindowLimit(model fantasy.LanguageModel, contextWindow int64) fantasy.LanguageModel {
+	if model == nil || contextWindow <= 0 {
+		return model
+	}
+	return &contextWindowModel{
+		LanguageModel: model,
+		contextWindow: contextWindow,
+	}
+}
+
+func (m *contextWindowModel) Generate(ctx context.Context, call fantasy.Call) (*fantasy.Response, error) {
+	if err := validateContextWindow(call, m.contextWindow); err != nil {
+		return nil, err
+	}
+	return m.LanguageModel.Generate(ctx, call)
+}
+
+func (m *contextWindowModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+	if err := validateContextWindow(call, m.contextWindow); err != nil {
+		return nil, err
+	}
+	return m.LanguageModel.Stream(ctx, call)
+}
+
+func validateContextWindow(call fantasy.Call, contextWindow int64) error {
+	inputTokens, err := estimateCallInputTokens(call)
+	if err != nil {
+		return fmt.Errorf("estimate model request size: %w", err)
+	}
+
+	reserve := contextWindowOutputReserve(contextWindow, call.MaxOutputTokens)
+	if inputTokens+reserve <= contextWindow {
+		return nil
+	}
+
+	return &contextWindowExceededError{
+		inputTokens:   inputTokens,
+		outputReserve: reserve,
+		contextWindow: contextWindow,
+	}
+}
+
+func contextWindowOutputReserve(contextWindow int64, maxOutputTokens *int64) int64 {
+	reserve := contextWindowReserve(contextWindow)
+	if maxOutputTokens != nil {
+		reserve = max(reserve, *maxOutputTokens)
+	}
+	return reserve
+}
+
+// resolveMaxOutputTokens applies one cross-provider policy: a call-specific
+// limit wins, then the model default, then the context reserve. The final
+// fallback turns every known-context request into a bounded generation so
+// admission and provider execution share the same maximum total size. An
+// unknown-context model with no configured limit preserves provider behavior.
+func resolveMaxOutputTokens(contextWindow, defaultMaxTokens, requested int64) *int64 {
+	value := requested
+	if value <= 0 {
+		value = defaultMaxTokens
+	}
+	if value <= 0 && contextWindow > 0 {
+		value = contextWindowReserve(contextWindow)
+	}
+	if value <= 0 {
+		return nil
+	}
+	return &value
+}
+
+func estimateNextStepInputTokens(currentMessages []fantasy.Message, step fantasy.StepResult, tools []fantasy.AgentTool) int64 {
+	tokens := estimateMessageTokens(currentMessages) + estimateMessageTokens(step.Messages)
+	toolsJSON, err := json.Marshal(agentToolInfo(tools))
+	if err == nil {
+		tokens += approxTokenCount(string(toolsJSON))
+	}
+	return tokens
+}
+
+func estimateInitialCallInputTokens(
+	systemPrompt string,
+	systemPromptPrefix string,
+	history []fantasy.Message,
+	prompt string,
+	files []fantasy.FilePart,
+	tools []fantasy.AgentTool,
+) int64 {
+	messages := make([]fantasy.Message, 0, len(history)+3)
+	if systemPromptPrefix != "" {
+		messages = append(messages, fantasy.NewSystemMessage(systemPromptPrefix))
+	}
+	if systemPrompt != "" {
+		messages = append(messages, fantasy.NewSystemMessage(systemPrompt))
+	}
+	messages = append(messages, history...)
+	messages = append(messages, fantasy.NewUserMessage(prompt, files...))
+	return estimateNextStepInputTokens(messages, fantasy.StepResult{}, tools)
+}
+
+func agentToolInfo(tools []fantasy.AgentTool) []fantasy.ToolInfo {
+	info := make([]fantasy.ToolInfo, len(tools))
+	for i, tool := range tools {
+		info[i] = tool.Info()
+	}
+	return info
+}
+
+func estimateCallInputTokens(call fantasy.Call) (int64, error) {
+	tokens := estimateMessageTokens(call.Prompt)
+	if len(call.Tools) == 0 {
+		return tokens, nil
+	}
+
+	toolsJSON, err := json.Marshal(call.Tools)
+	if err != nil {
+		return 0, err
+	}
+	return tokens + approxTokenCount(string(toolsJSON)), nil
+}
+
+func contextWindowReserve(contextWindow int64) int64 {
+	if contextWindow > largeContextWindowThreshold {
+		return largeContextWindowBuffer
+	}
+	return int64(float64(contextWindow) * smallContextWindowRatio)
+}

--- a/internal/agent/context_window_integration_test.go
+++ b/internal/agent/context_window_integration_test.go
@@ -1,0 +1,220 @@
+package agent
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/agent/notify"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunOversizedFirstPromptDispatchesNeitherMainNorTitleRequest(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	provider := &contextWindowTestModel{}
+	model := Model{
+		Model: provider,
+		CatwalkCfg: catwalk.Model{
+			ContextWindow:    4_096,
+			DefaultMaxTokens: 512,
+		},
+	}
+	agent := testSessionAgent(env, provider, provider, "system prompt").(*sessionAgent)
+	agent.SetModels(model, model)
+
+	sess, err := env.sessions.Create(t.Context(), "new session")
+	require.NoError(t, err)
+	var completions []string
+	_, err = agent.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		RunID:     "oversized-first-prompt",
+		Prompt:    strings.Repeat("large first prompt ", 2_000),
+		OnComplete: func(complete notify.RunComplete) {
+			completions = append(completions, complete.Error)
+		},
+	})
+
+	require.ErrorContains(t, err, "model request exceeds context window")
+	require.Zero(t, provider.streamCalls.Load(), "neither title nor main request may reach the provider")
+	require.Len(t, completions, 1, "rejected run must still have exactly one terminal event")
+	require.Contains(t, completions[0], "model request exceeds context window")
+}
+
+func TestRunOversizedTextAttachmentFailsBeforeProviderDispatch(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	provider := &contextWindowTestModel{}
+	model := Model{
+		Model: provider,
+		CatwalkCfg: catwalk.Model{
+			ContextWindow:    4_096,
+			DefaultMaxTokens: 512,
+		},
+	}
+	agent := testSessionAgent(env, provider, provider, "system prompt").(*sessionAgent)
+	agent.SetModels(model, model)
+
+	sess, err := env.sessions.Create(t.Context(), "large attachment")
+	require.NoError(t, err)
+	_, err = agent.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		Attachments: []message.Attachment{
+			{
+				FileName: "large.txt",
+				MimeType: "text/plain",
+				Content:  []byte(strings.Repeat("attachment content ", 2_000)),
+			},
+		},
+	})
+	require.ErrorContains(t, err, "model request exceeds context window")
+	require.Zero(t, provider.streamCalls.Load())
+}
+
+func TestRunAlwaysSendsKnownOutputBound(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		modelDefault int64
+		requested    int64
+		expected     int64
+	}{
+		{name: "model default", modelDefault: 512, expected: 512},
+		{name: "context reserve fallback", expected: 819},
+		{name: "call-specific limit", modelDefault: 512, requested: 256, expected: 256},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := testEnv(t)
+			provider := &compactionTestModel{}
+			model := Model{
+				Model: provider,
+				CatwalkCfg: catwalk.Model{
+					ContextWindow:    4_096,
+					DefaultMaxTokens: tt.modelDefault,
+				},
+			}
+			agent := testSessionAgent(env, provider, provider, "system prompt").(*sessionAgent)
+			agent.SetModels(model, model)
+
+			sess, err := env.sessions.Create(t.Context(), "bounded output")
+			require.NoError(t, err)
+			_, err = env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+				Role:  message.User,
+				Parts: []message.ContentPart{message.TextContent{Text: "existing history suppresses title generation"}},
+			})
+			require.NoError(t, err)
+
+			_, err = agent.Run(t.Context(), SessionAgentCall{
+				SessionID:       sess.ID,
+				Prompt:          "continue",
+				MaxOutputTokens: tt.requested,
+			})
+			require.NoError(t, err)
+
+			calls := provider.recordedCalls()
+			require.Len(t, calls, 1)
+			require.NotNil(t, calls[0].MaxOutputTokens)
+			require.Equal(t, tt.expected, *calls[0].MaxOutputTokens)
+		})
+	}
+}
+
+func TestRunWithAutoCompactionDisabledFailsClosedWithoutProviderDispatch(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	provider := &compactionTestModel{}
+	model := Model{
+		Model: provider,
+		CatwalkCfg: catwalk.Model{
+			ContextWindow:    4_096,
+			DefaultMaxTokens: 512,
+		},
+	}
+	agent := testSessionAgent(env, provider, provider, "system prompt").(*sessionAgent)
+	agent.SetModels(model, model)
+	agent.disableAutoSummarize = true
+
+	sess, err := env.sessions.Create(t.Context(), "disabled compaction")
+	require.NoError(t, err)
+	_, err = env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: strings.Repeat("oversized history ", 1_000)},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = agent.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		Prompt:    "continue",
+	})
+	require.ErrorContains(t, err, "model request exceeds context window")
+	require.Empty(t, provider.recordedCalls(), "disabled compaction must fail before provider dispatch")
+	sess, err = env.sessions.Get(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.Empty(t, sess.SummaryMessageID)
+}
+
+func TestRunRetryUsesReplacementModelsSmallerContextGuard(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	initial := &contextWindowTestModel{streamErr: &fantasy.ProviderError{
+		Message:    "expired credentials",
+		StatusCode: http.StatusUnauthorized,
+	}}
+	replacement := &contextWindowTestModel{}
+	initialModel := Model{
+		Model: initial,
+		CatwalkCfg: catwalk.Model{
+			ContextWindow:    4_096,
+			DefaultMaxTokens: 512,
+		},
+	}
+	replacementModel := Model{
+		Model: replacement,
+		CatwalkCfg: catwalk.Model{
+			ContextWindow:    2_048,
+			DefaultMaxTokens: 512,
+		},
+	}
+	agent := testSessionAgent(env, initial, initial, "system prompt").(*sessionAgent)
+	agent.SetModels(initialModel, initialModel)
+
+	sess, err := env.sessions.Create(t.Context(), "retry context")
+	require.NoError(t, err)
+	_, err = env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: strings.Repeat("word ", 700)},
+		},
+	})
+	require.NoError(t, err)
+
+	refreshCalls := 0
+	_, err = agent.Run(t.Context(), SessionAgentCall{
+		SessionID:       sess.ID,
+		Prompt:          "continue",
+		MaxOutputTokens: 512,
+		OnAuthRefresh: func(context.Context, *fantasy.ProviderError) error {
+			refreshCalls++
+			agent.SetModels(replacementModel, replacementModel)
+			return nil
+		},
+	})
+	require.ErrorContains(t, err, "model request exceeds context window")
+	require.Equal(t, 1, refreshCalls)
+	require.Equal(t, int64(1), initial.streamCalls.Load())
+	require.Zero(t, replacement.streamCalls.Load(), "replacement provider must be guarded by its own smaller context")
+}

--- a/internal/agent/context_window_test.go
+++ b/internal/agent/context_window_test.go
@@ -1,0 +1,274 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/require"
+)
+
+type contextWindowTestModel struct {
+	generateCalls atomic.Int64
+	streamCalls   atomic.Int64
+	streamErr     error
+}
+
+type contextWindowTestTool struct {
+	info fantasy.ToolInfo
+}
+
+func (t *contextWindowTestTool) Info() fantasy.ToolInfo { return t.info }
+func (t *contextWindowTestTool) Run(context.Context, fantasy.ToolCall) (fantasy.ToolResponse, error) {
+	return fantasy.ToolResponse{}, nil
+}
+func (t *contextWindowTestTool) ProviderOptions() fantasy.ProviderOptions   { return nil }
+func (t *contextWindowTestTool) SetProviderOptions(fantasy.ProviderOptions) {}
+
+func (m *contextWindowTestModel) Provider() string { return "test" }
+func (m *contextWindowTestModel) Model() string    { return "test-model" }
+
+func (m *contextWindowTestModel) Generate(context.Context, fantasy.Call) (*fantasy.Response, error) {
+	m.generateCalls.Add(1)
+	return &fantasy.Response{}, nil
+}
+
+func (m *contextWindowTestModel) Stream(context.Context, fantasy.Call) (fantasy.StreamResponse, error) {
+	m.streamCalls.Add(1)
+	if m.streamErr != nil {
+		return nil, m.streamErr
+	}
+	return func(func(fantasy.StreamPart) bool) {}, nil
+}
+
+func (m *contextWindowTestModel) GenerateObject(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *contextWindowTestModel) StreamObject(context.Context, fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestContextWindowModelRejectsOversizedCallBeforeDispatch(t *testing.T) {
+	t.Parallel()
+
+	provider := &contextWindowTestModel{}
+	model := withContextWindowLimit(provider, 204_800)
+	// Reproduce the shape of the captured LM Studio incident: one system,
+	// 33 user, 571 assistant, and 775 tool messages (1,380 total). A single
+	// giant string would miss regressions that omit accumulated tool results.
+	prompt := make(fantasy.Prompt, 0, 1_380)
+	prompt = append(prompt, fantasy.NewSystemMessage("system prompt"))
+	for range 33 {
+		prompt = append(prompt, fantasy.NewUserMessage("continue the translation"))
+	}
+	for range 571 {
+		prompt = append(prompt, fantasy.Message{
+			Role:    fantasy.MessageRoleAssistant,
+			Content: []fantasy.MessagePart{fantasy.TextPart{Text: "working"}},
+		})
+	}
+	toolPayload := strings.Repeat("large tool output ", 400)
+	for i := range 775 {
+		prompt = append(prompt, fantasy.Message{
+			Role: fantasy.MessageRoleTool,
+			Content: []fantasy.MessagePart{
+				fantasy.ToolResultPart{
+					ToolCallID: fmt.Sprintf("call-%d", i),
+					Output:     fantasy.ToolResultOutputContentText{Text: toolPayload},
+				},
+			},
+		})
+	}
+	require.Len(t, prompt, 1_380)
+	call := fantasy.Call{Prompt: prompt}
+
+	_, err := model.Stream(t.Context(), call)
+	require.ErrorContains(t, err, "model request exceeds context window")
+	require.Zero(t, provider.streamCalls.Load())
+}
+
+func TestContextWindowModelRejectsOversizedGenerateBeforeDispatch(t *testing.T) {
+	t.Parallel()
+
+	provider := &contextWindowTestModel{}
+	model := withContextWindowLimit(provider, 1_000)
+	_, err := model.Generate(t.Context(), fantasy.Call{
+		Prompt: fantasy.Prompt{fantasy.NewUserMessage(strings.Repeat("x", 3_000))},
+	})
+
+	var exceeded *contextWindowExceededError
+	require.ErrorAs(t, err, &exceeded)
+	require.Zero(t, provider.generateCalls.Load())
+	require.Equal(t, int64(1_000), exceeded.contextWindow)
+}
+
+func TestContextWindowModelDispatchesGenerateWithinLimit(t *testing.T) {
+	t.Parallel()
+
+	provider := &contextWindowTestModel{}
+	model := withContextWindowLimit(provider, 4_096)
+	_, err := model.Generate(t.Context(), fantasy.Call{
+		Prompt: fantasy.Prompt{fantasy.NewUserMessage("small request")},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int64(1), provider.generateCalls.Load())
+}
+
+func TestContextWindowModelBoundaryIsInclusive(t *testing.T) {
+	t.Parallel()
+
+	provider := &contextWindowTestModel{}
+	model := withContextWindowLimit(provider, 1_000)
+	// Message framing plus "user" contributes six estimated tokens and 397
+	// short word/space pairs contribute 794, leaving exactly the 200-token
+	// output reserve.
+	exact := fantasy.Call{Prompt: fantasy.Prompt{
+		fantasy.NewUserMessage(strings.Repeat("xxx ", 397)),
+	}}
+	_, err := model.Stream(t.Context(), exact)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), provider.streamCalls.Load())
+
+	over := fantasy.Call{Prompt: fantasy.Prompt{
+		fantasy.NewUserMessage(strings.Repeat("xxx ", 397) + "!"),
+	}}
+	_, err = model.Stream(t.Context(), over)
+	require.ErrorAs(t, err, new(*contextWindowExceededError))
+	require.Equal(t, int64(1), provider.streamCalls.Load(), "one-token-over call must not reach the provider")
+}
+
+func TestContextWindowModelDispatchesCallWithinLimit(t *testing.T) {
+	t.Parallel()
+
+	provider := &contextWindowTestModel{}
+	model := withContextWindowLimit(provider, 204_800)
+	maxOutputTokens := int64(8_192)
+	call := fantasy.Call{
+		Prompt: fantasy.Prompt{
+			fantasy.NewUserMessage(strings.Repeat("word ", 30_000)),
+		},
+		MaxOutputTokens: &maxOutputTokens,
+	}
+
+	_, err := model.Stream(t.Context(), call)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), provider.streamCalls.Load())
+}
+
+func TestContextWindowModelIncludesToolsInBudget(t *testing.T) {
+	t.Parallel()
+
+	provider := &contextWindowTestModel{}
+	model := withContextWindowLimit(provider, 204_800)
+	call := fantasy.Call{
+		Prompt: fantasy.Prompt{
+			fantasy.NewUserMessage(strings.Repeat("x", 180_000*4)),
+		},
+		Tools: []fantasy.Tool{
+			fantasy.FunctionTool{
+				Name:        "large-tool",
+				Description: strings.Repeat("x", 20_000*4),
+			},
+		},
+	}
+
+	_, err := model.Stream(t.Context(), call)
+	require.ErrorContains(t, err, "model request exceeds context window")
+	require.Zero(t, provider.streamCalls.Load())
+}
+
+func TestContextWindowModelReservesConfiguredOutputTokens(t *testing.T) {
+	t.Parallel()
+
+	provider := &contextWindowTestModel{}
+	model := withContextWindowLimit(provider, 1_000)
+	maxOutputTokens := int64(300)
+	call := fantasy.Call{
+		Prompt: fantasy.Prompt{
+			fantasy.NewUserMessage(strings.Repeat("x", 750*4)),
+		},
+		MaxOutputTokens: &maxOutputTokens,
+	}
+
+	_, err := model.Stream(t.Context(), call)
+	require.ErrorContains(t, err, "plus 300 reserved output tokens")
+	require.Zero(t, provider.streamCalls.Load())
+}
+
+func TestContextWindowModelSkipsUnknownLimit(t *testing.T) {
+	t.Parallel()
+
+	provider := &contextWindowTestModel{}
+	model := withContextWindowLimit(provider, 0)
+
+	require.Same(t, provider, model)
+}
+
+func TestResolveMaxOutputTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		contextWindow int64
+		modelDefault  int64
+		requested     int64
+		expected      int64
+		expectedIsNil bool
+	}{
+		{name: "request wins", contextWindow: 204_800, modelDefault: 8_192, requested: 4_096, expected: 4_096},
+		{name: "model default", contextWindow: 204_800, modelDefault: 8_192, expected: 8_192},
+		{name: "known context reserve", contextWindow: 204_800, expected: 20_000},
+		{name: "small context reserve", contextWindow: 4_096, expected: 819},
+		{name: "unknown remains unbounded", expectedIsNil: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveMaxOutputTokens(tt.contextWindow, tt.modelDefault, tt.requested)
+			if tt.expectedIsNil {
+				require.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			require.Equal(t, tt.expected, *got)
+		})
+	}
+}
+
+func TestEstimateNextStepIncludesToolResultsAndDefinitions(t *testing.T) {
+	t.Parallel()
+
+	currentMessages := []fantasy.Message{
+		fantasy.NewUserMessage(strings.Repeat("x", 100*4)),
+	}
+	step := fantasy.StepResult{
+		Messages: []fantasy.Message{
+			{
+				Role: fantasy.MessageRoleTool,
+				Content: []fantasy.MessagePart{
+					fantasy.ToolResultPart{
+						ToolCallID: "call-1",
+						Output: fantasy.ToolResultOutputContentText{
+							Text: strings.Repeat("x", 200*4),
+						},
+					},
+				},
+			},
+		},
+	}
+	tools := []fantasy.AgentTool{
+		&contextWindowTestTool{info: fantasy.ToolInfo{
+			Name:        "large-tool",
+			Description: strings.Repeat("x", 300*4),
+		}},
+	}
+
+	estimated := estimateNextStepInputTokens(currentMessages, step, tools)
+	require.GreaterOrEqual(t, estimated, int64(600))
+}

--- a/internal/agent/usage_fallback.go
+++ b/internal/agent/usage_fallback.go
@@ -2,9 +2,13 @@ package agent
 
 import (
 	"fmt"
+	"unicode"
+	"unicode/utf8"
 
 	"charm.land/fantasy"
 )
+
+const messageFramingTokens = 4
 
 func usageIsZero(usage fantasy.Usage) bool {
 	return usage.InputTokens == 0 &&
@@ -45,7 +49,10 @@ func cloneFantasyMessages(messages []fantasy.Message) []fantasy.Message {
 func estimateMessageTokens(messages []fantasy.Message) int64 {
 	var tokens int64
 	for _, msg := range messages {
-		tokens += approxTokenCount(string(msg.Role))
+		// Chat templates add fixed start/end/newline markers around every
+		// message. Four tokens covers the Qwen ChatML framing and prevents
+		// long histories of tiny tool messages from being underestimated.
+		tokens += messageFramingTokens + approxTokenCount(string(msg.Role))
 		for _, part := range msg.Content {
 			tokens += estimateMessagePartTokens(part)
 		}
@@ -172,5 +179,84 @@ func approxTokenCount(s string) int64 {
 	if s == "" {
 		return 0
 	}
-	return int64((len(s) + 3) / 4)
+	var counter approxTokenCounter
+	for _, r := range s {
+		counter.add(r)
+	}
+	return counter.total()
+}
+
+type approxTokenCounter struct {
+	tokens    int64
+	runLength int64
+	runKind   uint8
+}
+
+func (c *approxTokenCounter) add(r rune) {
+	const (
+		runAlphaNumeric uint8 = iota + 1
+		runWhitespace
+	)
+
+	var kind uint8
+	if r < utf8.RuneSelf {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			kind = runAlphaNumeric
+		case unicode.IsSpace(r):
+			kind = runWhitespace
+		}
+	}
+	if kind != 0 {
+		if c.runKind != kind {
+			c.flushRun()
+			c.runKind = kind
+		}
+		c.runLength++
+		return
+	}
+
+	c.flushRun()
+	if r < utf8.RuneSelf {
+		// ASCII punctuation and separators are frequently individual tokens
+		// in code, paths, JSON, and tool output. Counting each byte prevents
+		// the old bytes/4 heuristic from systematically underestimating them.
+		c.tokens++
+		return
+	}
+	if unicode.IsLetter(r) || unicode.IsNumber(r) {
+		// CJK tokenizers commonly encode one or more characters per token;
+		// one token per rune is intentionally conservative for prose.
+		c.tokens++
+		return
+	}
+	// Emoji and other symbols often decompose into multiple byte-level BPE
+	// tokens. UTF-8 width is a portable upper estimate for that decomposition.
+	c.tokens += int64(utf8.RuneLen(r))
+}
+
+func (c *approxTokenCounter) flushRun() {
+	if c.runLength == 0 {
+		return
+	}
+	if c.runKind == 1 {
+		if c.runLength <= 16 {
+			c.tokens += (c.runLength + 2) / 3
+		} else {
+			// Long unbroken alphanumeric runs are commonly hashes, minified
+			// data, random identifiers, or base64. They tokenize far more
+			// densely than natural-language words; Qwen3.6 is approximately
+			// 0.72 tokens/byte for representative base64 and random data.
+			c.tokens += (c.runLength*3 + 3) / 4
+		}
+	} else {
+		c.tokens += (c.runLength + 3) / 4
+	}
+	c.runLength = 0
+	c.runKind = 0
+}
+
+func (c approxTokenCounter) total() int64 {
+	c.flushRun()
+	return c.tokens
 }

--- a/internal/agent/usage_fallback_test.go
+++ b/internal/agent/usage_fallback_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"charm.land/catwalk/pkg/catwalk"
@@ -21,6 +22,54 @@ func TestUsageIsZero(t *testing.T) {
 	require.False(t, usageIsZero(fantasy.Usage{ReasoningTokens: 1}))
 	require.False(t, usageIsZero(fantasy.Usage{CacheCreationTokens: 1}))
 	require.False(t, usageIsZero(fantasy.Usage{CacheReadTokens: 1}))
+}
+
+func TestApproxTokenCountDoesNotUndercountCJKAsUTF8Bytes(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, int64(4), approxTokenCount("翻译中文"))
+	require.Equal(t, int64(2), approxTokenCount("text"))
+}
+
+func TestApproxTokenCountCoversQwen36GoldenCorpus(t *testing.T) {
+	t.Parallel()
+
+	// Expected counts were generated with the Qwen3.6-27B tokenizer.json
+	// shipped with LM Studio. These are an independent oracle: changing the
+	// estimator cannot silently change the expected values with it.
+	tests := []struct {
+		text       string
+		qwenTokens int64
+	}{
+		{text: "text", qwenTokens: 1},
+		{text: "翻译中文", qwenTokens: 2},
+		{text: "Hello, world!", qwenTokens: 4},
+		{text: `func main() { fmt.Println("hello") }`, qwenTokens: 10},
+		{text: "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", qwenTokens: 4},
+		{text: "😀🧪🚀🫠", qwenTokens: 10},
+		{text: "snake_case_identifier_with_many_parts", qwenTokens: 6},
+		{text: "    ", qwenTokens: 1},
+		{text: "https://github.com/charmbracelet/crush/pull/3280", qwenTokens: 17},
+		{text: `{"path":"internal/agent/agent.go","line":698}`, qwenTokens: 16},
+		{text: strings.Repeat("deadbeef", 125), qwenTokens: 375},
+		{text: strings.Repeat("QWxhZGRpbjpvcGVuIHNlc2FtZQ==", 36), qwenTokens: 720},
+	}
+	for _, tt := range tests {
+		estimated := approxTokenCount(tt.text)
+		require.GreaterOrEqualf(t, estimated, tt.qwenTokens, "underestimated %q", tt.text)
+	}
+}
+
+func TestEstimateMessageTokensIncludesPerMessageFraming(t *testing.T) {
+	t.Parallel()
+
+	messages := []fantasy.Message{
+		{Role: fantasy.MessageRoleUser},
+		{Role: fantasy.MessageRoleAssistant},
+		{Role: fantasy.MessageRoleTool},
+	}
+	roles := approxTokenCount("user") + approxTokenCount("assistant") + approxTokenCount("tool")
+	require.Equal(t, roles+3*messageFramingTokens, estimateMessageTokens(messages))
 }
 
 func TestFallbackStepUsageKeepsProviderUsage(t *testing.T) {

--- a/internal/discover/lmstudio.go
+++ b/internal/discover/lmstudio.go
@@ -79,15 +79,15 @@ func (e *lmstudioEnricher) EnrichModels(ctx context.Context, cfg Config, resolve
 			continue
 		}
 
-		// Context window: prefer loaded instance config, fall back
-		// to the model-level max.
-		if models[i].ContextWindow == 0 {
-			if len(meta.LoadedInstances) > 0 && meta.LoadedInstances[0].Config.ContextLength > 0 {
-				models[i].ContextWindow = meta.LoadedInstances[0].Config.ContextLength
-			} else if meta.MaxContextLength > 0 {
-				models[i].ContextWindow = meta.MaxContextLength
-			}
+		// Use the smallest known limit. A configured value may intentionally
+		// restrict the model, but it cannot expand the loaded instance or the
+		// model's maximum context length.
+		contextWindow := models[i].ContextWindow
+		contextWindow = minPositive(contextWindow, meta.MaxContextLength)
+		for _, instance := range meta.LoadedInstances {
+			contextWindow = minPositive(contextWindow, instance.Config.ContextLength)
 		}
+		models[i].ContextWindow = contextWindow
 
 		// Display name if not already set by user.
 		if models[i].Name == models[i].ID && meta.DisplayName != "" {
@@ -99,4 +99,14 @@ func (e *lmstudioEnricher) EnrichModels(ctx context.Context, cfg Config, resolve
 	}
 
 	return models, nil
+}
+
+func minPositive(values ...int64) int64 {
+	var result int64
+	for _, value := range values {
+		if value > 0 && (result == 0 || value < result) {
+			result = value
+		}
+	}
+	return result
 }

--- a/internal/discover/lmstudio_test.go
+++ b/internal/discover/lmstudio_test.go
@@ -86,6 +86,67 @@ func TestLmstudioEnricher(t *testing.T) {
 		require.Equal(t, int64(8192), result[0].ContextWindow)
 	})
 
+	t.Run("loaded instance caps configured context length", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(lmstudioModelsResponse{
+				Models: []lmstudioModelEntry{
+					{
+						Key:              "qwen/qwen3.6-27b",
+						MaxContextLength: 262144,
+						LoadedInstances: []lmstudioInstance{
+							{Config: lmstudioInstanceConfig{ContextLength: 204800}},
+						},
+					},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-lmstudio", BaseURL: srv.URL}
+		models := []catwalk.Model{{
+			ID:            "qwen/qwen3.6-27b",
+			Name:          "Qwen 3.6 27B",
+			ContextWindow: 262144,
+		}}
+
+		e := &lmstudioEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.Equal(t, int64(204800), result[0].ContextWindow)
+	})
+
+	t.Run("uses the smallest context across loaded instances", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(lmstudioModelsResponse{
+				Models: []lmstudioModelEntry{
+					{
+						Key:              "m1",
+						MaxContextLength: 262144,
+						LoadedInstances: []lmstudioInstance{
+							{Config: lmstudioInstanceConfig{ContextLength: 204800}},
+							{Config: lmstudioInstanceConfig{ContextLength: 131072}},
+							{Config: lmstudioInstanceConfig{ContextLength: 0}},
+						},
+					},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		result, err := (&lmstudioEnricher{}).EnrichModels(
+			context.Background(),
+			Config{ID: "test-lmstudio", BaseURL: srv.URL},
+			&mockResolver{},
+			[]catwalk.Model{{ID: "m1", ContextWindow: 230000}},
+		)
+		require.NoError(t, err)
+		require.Equal(t, int64(131072), result[0].ContextWindow)
+	})
+
 	t.Run("preserves existing non-zero values", func(t *testing.T) {
 		t.Parallel()
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -194,4 +255,26 @@ func TestLmstudioEnricher(t *testing.T) {
 		require.False(t, result[1].SupportsImages, "text-only model should have SupportsImages=false")
 		require.False(t, result[2].SupportsImages, "model without capabilities should default to false")
 	})
+}
+
+func TestMinPositive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		values   []int64
+		expected int64
+	}{
+		{name: "empty", expected: 0},
+		{name: "ignores non-positive", values: []int64{0, -1, -100}, expected: 0},
+		{name: "single", values: []int64{204800}, expected: 204800},
+		{name: "smallest independent of order", values: []int64{262144, 131072, 204800}, expected: 131072},
+		{name: "mixed", values: []int64{0, 204800, -1, 262144}, expected: 204800},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, minPositive(tt.values...))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

- discover the effective LM Studio runtime context window, including loaded-instance limits
- reject oversized requests at the final model boundary before provider dispatch
- automatically compact oversized history and tool-loop state using bounded hierarchical summaries
- preserve partial compaction usage and cost on failure or cancellation
- apply and document one cross-provider output-token policy

## Motivation

LM Studio was observed receiving a 989,844-token prompt from Crush while the loaded Qwen model had a 204,800-token runtime context. LM Studio then removed 892,563 tokens from the middle before inference. Client-side admission and recovery prevent that silent, expensive loss of conversation state.

Admission uses a conservative provider-independent estimate covering message framing, tools, tool results, attachments, and reserved output. It intentionally fails closed near the configured limit, but does not claim exact provider tokenizer or vision accounting.

Automatic hierarchical compaction is bounded by 32 passes, 64 provider calls, and a three-times estimated-token budget. Each pass is budgeted before dispatch, and structured logs expose calls, passes, estimated spend, actual usage, output size, duration, and failures.

## Testing

- go test ./...
- go test -race ./internal/agent ./internal/discover -count=1
- go test ./internal/agent ./internal/discover -count=20
- fuzzed the Unicode-safe compaction splitter for 51,044 executions
- golangci-lint run --path-mode=abs --config=.golangci.yml --timeout=5m
- scripts/check_log_capitalization.sh
- git diff --check

Focused coverage is 96.4% for compactMessages, 95.5% for Summarize and summarizeCompactionChunk, and 100% for the final Generate and Stream admission wrappers.