### PR TITLE
feat: make crush startup fast and interruptible

### DIFF
--- a/internal/agent/agenttest/coordinator.go
+++ b/internal/agent/agenttest/coordinator.go
@@ -37,7 +37,7 @@ func NewCoordinator(
 	sessions session.Service,
 	messages message.Service,
 ) (agent.Coordinator, error) {
-	cfg, err := config.Init(workingDir, "", false)
+	cfg, err := config.Init(ctx, workingDir, "", false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -136,7 +136,7 @@ func coderAgent(r *vcr.Recorder, env fakeEnv, large, small fantasy.LanguageModel
 	if err != nil {
 		return nil, err
 	}
-	cfg, err := config.Init(env.workingDir, "", false)
+	cfg, err := config.Init(context.Background(), env.workingDir, "", false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/coordinator_readiness_test.go
+++ b/internal/agent/coordinator_readiness_test.go
@@ -49,7 +49,7 @@ func TestBuildAgentReadinessSurvivesCallerCancellation(t *testing.T) {
 }`
 	require.NoError(t, os.WriteFile(filepath.Join(env.workingDir, "crush.json"), []byte(crushJSON), 0o644))
 
-	cfg, err := config.Init(env.workingDir, "", false)
+	cfg, err := config.Init(t.Context(), env.workingDir, "", false)
 	require.NoError(t, err)
 	cfg.SetupAgents()
 

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -50,7 +50,7 @@ func (m *mockSessionAgent) GenerateTitle(context.Context, string, string) {}
 
 // newTestCoordinator creates a minimal coordinator for unit testing runSubAgent.
 func newTestCoordinator(t *testing.T, env fakeEnv, providerID string, providerCfg config.ProviderConfig) *coordinator {
-	cfg, err := config.Init(env.workingDir, "", false)
+	cfg, err := config.Init(t.Context(), env.workingDir, "", false)
 	require.NoError(t, err)
 	cfg.Config().Providers.Set(providerID, providerCfg)
 	return &coordinator{
@@ -382,7 +382,7 @@ func TestRunSubAgent(t *testing.T) {
 func TestUpdateParentSessionCost(t *testing.T) {
 	t.Run("accumulates cost correctly", func(t *testing.T) {
 		env := testEnv(t)
-		cfg, err := config.Init(env.workingDir, "", false)
+		cfg, err := config.Init(t.Context(), env.workingDir, "", false)
 		require.NoError(t, err)
 		coord := &coordinator{cfg: cfg, sessions: env.sessions}
 
@@ -407,7 +407,7 @@ func TestUpdateParentSessionCost(t *testing.T) {
 
 	t.Run("accumulates multiple child costs", func(t *testing.T) {
 		env := testEnv(t)
-		cfg, err := config.Init(env.workingDir, "", false)
+		cfg, err := config.Init(t.Context(), env.workingDir, "", false)
 		require.NoError(t, err)
 		coord := &coordinator{cfg: cfg, sessions: env.sessions}
 
@@ -438,7 +438,7 @@ func TestUpdateParentSessionCost(t *testing.T) {
 
 	t.Run("child session not found", func(t *testing.T) {
 		env := testEnv(t)
-		cfg, err := config.Init(env.workingDir, "", false)
+		cfg, err := config.Init(t.Context(), env.workingDir, "", false)
 		require.NoError(t, err)
 		coord := &coordinator{cfg: cfg, sessions: env.sessions}
 
@@ -452,7 +452,7 @@ func TestUpdateParentSessionCost(t *testing.T) {
 
 	t.Run("parent session not found", func(t *testing.T) {
 		env := testEnv(t)
-		cfg, err := config.Init(env.workingDir, "", false)
+		cfg, err := config.Init(t.Context(), env.workingDir, "", false)
 		require.NoError(t, err)
 		coord := &coordinator{cfg: cfg, sessions: env.sessions}
 
@@ -468,7 +468,7 @@ func TestUpdateParentSessionCost(t *testing.T) {
 
 	t.Run("zero cost handled correctly", func(t *testing.T) {
 		env := testEnv(t)
-		cfg, err := config.Init(env.workingDir, "", false)
+		cfg, err := config.Init(t.Context(), env.workingDir, "", false)
 		require.NoError(t, err)
 		coord := &coordinator{cfg: cfg, sessions: env.sessions}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -509,7 +509,7 @@ func (app *App) GetDefaultSmallModel(providerID string) config.SelectedModel {
 	largeModelCfg := cfg.Models[config.SelectedModelTypeLarge]
 
 	// Find the provider in the known providers list to get its default small model.
-	knownProviders, _ := config.Providers(cfg)
+	knownProviders, _ := config.Providers(context.Background(), cfg)
 	var knownProvider *catwalk.Provider
 	for _, p := range knownProviders {
 		if string(p.ID) == providerID {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -167,13 +167,28 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 	// TODO: remove the concept of agent config, most likely.
 	if !cfg.IsConfigured() {
 		slog.Warn("No agent configuration found")
+		// Background discovery may still turn up a usable provider; when it
+		// does, discoverProviderModels initializes the coder agent.
+		go app.discoverProviderModels(ctx)
 		return app, nil
 	}
 	if err := app.InitCoderAgent(ctx); err != nil {
 		return nil, fmt.Errorf("failed to initialize coder agent: %w", err)
 	}
 
-	// Set up callback for LSP state updates.
+	app.setupLSPTracking(ctx)
+
+	// Discover custom provider models off the startup path so a slow or
+	// unreachable provider never delays the UI.
+	go app.discoverProviderModels(ctx)
+
+	return app, nil
+}
+
+// setupLSPTracking wires the LSP state callback and starts tracking the
+// configured language servers. Shared by New and by the post-discovery
+// coder-agent initialization path.
+func (app *App) setupLSPTracking(ctx context.Context) {
 	app.LSPManager.SetCallback(func(name string, client *lsp.Client) {
 		if client == nil {
 			updateLSPState(name, lsp.StateUnstarted, nil, nil, 0)
@@ -182,12 +197,46 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 		client.SetDiagnosticsCallback(updateLSPDiagnostics)
 		updateLSPState(name, client.GetServerState(), nil, client, 0)
 	})
-
 	// TrackConfigured must run after SetCallback so the callback is already
 	// installed when configured-but-not-yet-started LSPs are announced.
 	go app.LSPManager.TrackConfigured(ctx)
+}
 
-	return app, nil
+// discoverProviderModels probes custom providers for their model lists off
+// the startup path. When it finds new models it reloads the config,
+// refreshes the agent's model set, and (if the app was previously
+// unconfigured) initializes the coder agent.
+func (app *App) discoverProviderModels(ctx context.Context) {
+	defer log.RecoverPanic("app.discoverProviderModels", nil)
+
+	if !app.config.HasPendingModelDiscovery() {
+		return
+	}
+
+	changed, err := app.config.DiscoverModels(ctx)
+	if err != nil {
+		slog.Debug("Background model discovery failed", "error", err)
+	}
+	if !changed {
+		return
+	}
+
+	if app.AgentCoordinator == nil {
+		// The app started unconfigured; discovery may have produced a
+		// usable provider, so bring the coder agent online now.
+		if app.Config().IsConfigured() {
+			if initErr := app.InitCoderAgent(ctx); initErr != nil {
+				slog.Error("Failed to initialize coder agent after discovery", "error", initErr)
+				return
+			}
+			app.setupLSPTracking(ctx)
+		}
+		return
+	}
+
+	if updateErr := app.AgentCoordinator.UpdateModels(ctx); updateErr != nil {
+		slog.Debug("Failed to refresh models after discovery", "error", updateErr)
+	}
 }
 
 // Config returns the pure-data configuration.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -347,7 +347,7 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 	}()
 
 	id := uuid.New().String()
-	cfg, err := config.Init(args.Path, args.DataDir, args.Debug)
+	cfg, err := config.Init(context.Background(), args.Path, args.DataDir, args.Debug)
 	if err != nil {
 		return nil, proto.Workspace{}, fmt.Errorf("failed to initialize config: %w", err)
 	}

--- a/internal/backend/backend_skills_test.go
+++ b/internal/backend/backend_skills_test.go
@@ -42,7 +42,7 @@ func TestBackend_WorkspaceSkillsIsolation(t *testing.T) {
 	writeSkill(t, wdA, "wsa-only-skill", "Workspace A only skill.")
 	writeSkill(t, wdB, "wsb-only-skill", "Workspace B only skill.")
 
-	srvCfg, err := config.Init(wdA, "", false)
+	srvCfg, err := config.Init(t.Context(), wdA, "", false)
 	require.NoError(t, err)
 	b := backend.New(t.Context(), srvCfg, nil)
 

--- a/internal/backend/events.go
+++ b/internal/backend/events.go
@@ -67,7 +67,7 @@ func (b *Backend) GetWorkspaceProviders(workspaceID string) (any, error) {
 		return nil, err
 	}
 
-	providers, _ := config.Providers(ws.Cfg.Config())
+	providers, _ := config.Providers(context.Background(), ws.Cfg.Config())
 	return providers, nil
 }
 

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -45,6 +45,9 @@ crush login -f copilot
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ws, cleanup, err := setupWorkspaceWithProgressBar(cmd)
 		if err != nil {
+			if isStartupInterrupted(cmd, err) {
+				return nil
+			}
 			return err
 		}
 		defer cleanup()

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -51,7 +51,7 @@ var logsCmd = &cobra.Command{
 			log.SetColorProfile(colorprofile.NoTTY)
 		}
 
-		cfg, err := config.Load(cwd, dataDir, false)
+		cfg, err := config.Load(cmd.Context(), cwd, dataDir, false)
 		if err != nil {
 			return fmt.Errorf("failed to load configuration: %v", err)
 		}

--- a/internal/cmd/models.go
+++ b/internal/cmd/models.go
@@ -32,7 +32,7 @@ crush models gpt5`,
 		dataDir, _ := cmd.Flags().GetString("data-dir")
 		debug, _ := cmd.Flags().GetBool("debug")
 
-		cfg, err := config.Init(cwd, dataDir, debug)
+		cfg, err := config.Init(cmd.Context(), cwd, dataDir, debug)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -112,6 +112,9 @@ crush --continue
 
 		ws, cleanup, err := setupWorkspaceWithProgressBar(cmd)
 		if err != nil {
+			if isStartupInterrupted(cmd, err) {
+				return nil
+			}
 			return err
 		}
 		defer cleanup()
@@ -219,6 +222,16 @@ func useClientServer() bool {
 	return v
 }
 
+// isStartupInterrupted reports whether err results from the command
+// context being canceled (for example, the user pressed Ctrl+C during
+// startup). Such interruptions should exit quietly instead of printing a
+// crash-style error, since the cancellation now propagates through config
+// loading, provider discovery, and the database connection.
+func isStartupInterrupted(cmd *cobra.Command, err error) bool {
+	return err != nil &&
+		(errors.Is(err, context.Canceled) || cmd.Context().Err() != nil)
+}
+
 // setupWorkspaceWithProgressBar wraps setupWorkspace with an optional
 // terminal progress bar shown during initialization.
 func setupWorkspaceWithProgressBar(cmd *cobra.Command) (workspace.Workspace, func(), error) {
@@ -261,7 +274,7 @@ func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error
 		return nil, nil, err
 	}
 
-	store, err := config.Init(cwd, dataDir, debug)
+	store, err := config.Init(ctx, cwd, dataDir, debug)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -37,7 +37,7 @@ var serverCmd = &cobra.Command{
 			return fmt.Errorf("failed to get debug flag: %v", err)
 		}
 
-		cfg, err := config.Load(config.GlobalWorkspaceDir(), dataDir, debug)
+		cfg, err := config.Load(cmd.Context(), config.GlobalWorkspaceDir(), dataDir, debug)
 		if err != nil {
 			return fmt.Errorf("failed to load configuration: %v", err)
 		}

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -108,7 +108,7 @@ func sessionSetup(cmd *cobra.Command) (context.Context, *sessionServices, func()
 	dataDir, _ := cmd.Flags().GetString("data-dir")
 	ctx := cmd.Context()
 
-	cfg, err := config.Init("", dataDir, false)
+	cfg, err := config.Init(ctx, "", dataDir, false)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to initialize config: %w", err)
 	}

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -156,7 +156,7 @@ func runStats(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("failed to gather stats from projects: %w", err)
 		}
 	default:
-		cfg, err := config.Init("", dataDir, false)
+		cfg, err := config.Init(ctx, "", dataDir, false)
 		if err != nil {
 			return fmt.Errorf("failed to initialize config: %w", err)
 		}
@@ -216,7 +216,7 @@ func runStats(cmd *cobra.Command, _ []string) error {
 
 	outputDataDir := dataDir
 	if outputDataDir == "" {
-		cfg, err := config.Init("", "", false)
+		cfg, err := config.Init(ctx, "", "", false)
 		if err == nil {
 			outputDataDir = cfg.Config().Options.DataDirectory
 		}

--- a/internal/config/discovery.go
+++ b/internal/config/discovery.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"cmp"
+	"context"
+	"log/slog"
+	"sync"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/discover"
+)
+
+// discoveryJob describes one custom provider whose models should be
+// discovered from its /models endpoint.
+type discoveryJob struct {
+	id           string
+	cfg          discover.Config
+	providerType catwalk.Type
+}
+
+// collectDiscoveryJobs returns the custom providers that need model
+// discovery: enabled, with a base URL, and either opted in via
+// discover_models or lacking an explicit models list. known holds the ids
+// of bundled providers, which never participate in discovery.
+func collectDiscoveryJobs(cfg *Config, known map[string]bool) []discoveryJob {
+	var jobs []discoveryJob
+	for id, pc := range cfg.Providers.Seq2() {
+		if known[id] || pc.Disable || pc.BaseURL == "" {
+			continue
+		}
+		wantsDiscovery := pc.AutoDiscoverModels != nil && *pc.AutoDiscoverModels
+		autoTrigger := len(pc.Models) == 0 && (pc.AutoDiscoverModels == nil || *pc.AutoDiscoverModels)
+		if !wantsDiscovery && !autoTrigger {
+			continue
+		}
+		jobs = append(jobs, discoveryJob{
+			id: id,
+			cfg: discover.Config{
+				ID:             cmp.Or(pc.ID, id),
+				BaseURL:        pc.BaseURL,
+				APIKey:         pc.APIKey,
+				ExtraHeaders:   pc.ExtraHeaders,
+				ExistingModels: pc.Models,
+			},
+			providerType: cmp.Or(pc.Type, catwalk.TypeOpenAICompat),
+		})
+	}
+	return jobs
+}
+
+// setPendingDiscovery records the providers awaiting model discovery.
+// Called from configureProviders while all providers are still present,
+// before empty ones are dropped.
+func (s *ConfigStore) setPendingDiscovery(jobs []discoveryJob) {
+	s.discoveryMu.Lock()
+	defer s.discoveryMu.Unlock()
+	s.pendingDiscovery = jobs
+}
+
+func (s *ConfigStore) pendingDiscoveryJobs() []discoveryJob {
+	s.discoveryMu.Lock()
+	defer s.discoveryMu.Unlock()
+	return s.pendingDiscovery
+}
+
+// isPendingDiscovery reports whether the given provider id is still
+// awaiting background model discovery. Used to avoid persisting a
+// model-selection fallback for a provider whose models simply have not
+// been discovered yet.
+func (s *ConfigStore) isPendingDiscovery(providerID string) bool {
+	if providerID == "" {
+		return false
+	}
+	for _, job := range s.pendingDiscoveryJobs() {
+		if job.id == providerID {
+			return true
+		}
+	}
+	return false
+}
+
+// HasPendingModelDiscovery reports whether any custom provider still needs
+// its models discovered. Callers use this to decide whether to show a
+// discovery indicator before kicking off a background pass.
+func (s *ConfigStore) HasPendingModelDiscovery() bool {
+	return len(s.pendingDiscoveryJobs()) > 0
+}
+
+// DiscoverModels fetches models for every custom provider that needs them,
+// stores the results in the in-memory cache, and reloads the config so the
+// discovered models take effect. It returns whether any new models were
+// found. Intended to run in the background: it makes network calls and
+// respects the caller's context for cancellation.
+func (s *ConfigStore) DiscoverModels(ctx context.Context) (bool, error) {
+	jobs := s.pendingDiscoveryJobs()
+	if len(jobs) == 0 {
+		return false, nil
+	}
+
+	if s.discoveredModels == nil {
+		s.discoveredModels = csync.NewMap[string, []catwalk.Model]()
+	}
+
+	resolver := s.resolver
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	changed := false
+
+	for _, job := range jobs {
+		wg.Go(func() {
+			models, err := discover.DiscoverModels(ctx, job.cfg, resolver)
+			if err != nil {
+				slog.Debug("Background model discovery failed", "provider", job.id, "error", err)
+				return
+			}
+			if len(models) == 0 {
+				return
+			}
+			if enricher := discover.GetEnricher(string(job.providerType)); enricher != nil {
+				models, _ = enricher.EnrichModels(ctx, job.cfg, resolver, models)
+			}
+			mu.Lock()
+			s.discoveredModels.Set(job.id, models)
+			changed = true
+			mu.Unlock()
+			slog.Info("Discovered models for provider", "provider", job.id, "count", len(models))
+		})
+	}
+	wg.Wait()
+
+	if !changed {
+		return false, nil
+	}
+	if err := s.ReloadFromDisk(ctx); err != nil {
+		return true, err
+	}
+	return true, nil
+}

--- a/internal/config/discovery_test.go
+++ b/internal/config/discovery_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigStore_DiscoverModels verifies the background discovery path:
+// a custom provider with no models is dropped on initial load, then
+// reappears with discovered models after DiscoverModels populates the
+// in-memory cache and reloads.
+func TestConfigStore_DiscoverModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": [
+			{"id": "auto-model-a", "object": "model"},
+			{"id": "auto-model-b", "object": "model"}
+		]}`))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	t.Setenv("CRUSH_GLOBAL_CONFIG", dir)
+	t.Setenv("CRUSH_GLOBAL_DATA", dir)
+	t.Setenv("CRUSH_DISABLE_PROVIDER_AUTO_UPDATE", "1")
+	resetProviderState()
+	t.Cleanup(resetProviderState)
+
+	cfgJSON := `{
+		"providers": {
+			"custom": {
+				"type": "openai-compat",
+				"api_key": "test-key",
+				"base_url": "` + server.URL + `/v1"
+			}
+		}
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "crush.json"), []byte(cfgJSON), 0o600))
+
+	store, err := Load(t.Context(), dir, dir, false)
+	require.NoError(t, err)
+
+	// No models yet and nothing cached, so the provider is dropped.
+	_, exists := store.Config().Providers.Get("custom")
+	require.False(t, exists, "provider should be absent before discovery runs")
+
+	// Run discovery: it fetches from the server, caches results, reloads.
+	changed, err := store.DiscoverModels(t.Context())
+	require.NoError(t, err)
+	require.True(t, changed, "discovery should report changes")
+
+	p, exists := store.Config().Providers.Get("custom")
+	require.True(t, exists, "provider should reappear after discovery")
+	require.Len(t, p.Models, 2)
+	require.Equal(t, "auto-model-a", p.Models[0].ID)
+	require.Equal(t, "auto-model-b", p.Models[1].ID)
+}
+
+// TestConfigStore_HasPendingModelDiscovery confirms the pending check
+// tracks whether any custom provider still needs discovery.
+func TestConfigStore_HasPendingModelDiscovery(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CRUSH_GLOBAL_CONFIG", dir)
+	t.Setenv("CRUSH_GLOBAL_DATA", dir)
+	t.Setenv("CRUSH_DISABLE_PROVIDER_AUTO_UPDATE", "1")
+	resetProviderState()
+	t.Cleanup(resetProviderState)
+
+	cfgJSON := `{
+		"providers": {
+			"custom": {
+				"type": "openai-compat",
+				"api_key": "test-key",
+				"base_url": "http://127.0.0.1:1/v1"
+			}
+		}
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "crush.json"), []byte(cfgJSON), 0o600))
+
+	store, err := Load(t.Context(), dir, dir, false)
+	require.NoError(t, err)
+	require.True(t, store.HasPendingModelDiscovery())
+}
+
+// TestConfigStore_DiscoverModels_RestoresSelectedModel guards against the
+// worst regression of deferring discovery: if the user's selected model
+// belongs to a provider that needs discovery, Load must not persist a
+// fallback that would clobber the choice. The selection is served from the
+// fallback in memory until discovery runs, then restored on reload.
+func TestConfigStore_DiscoverModels_RestoresSelectedModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": [{"id": "slow-model", "object": "model"}]}`))
+	}))
+	defer server.Close()
+
+	dir := t.TempDir()
+	t.Setenv("CRUSH_GLOBAL_CONFIG", dir)
+	t.Setenv("CRUSH_GLOBAL_DATA", dir)
+	t.Setenv("CRUSH_DISABLE_PROVIDER_AUTO_UPDATE", "1")
+	resetProviderState()
+	t.Cleanup(resetProviderState)
+
+	configPath := filepath.Join(dir, "crush.json")
+	cfgJSON := `{
+		"models": {"large": {"provider": "slow", "model": "slow-model"}},
+		"providers": {
+			"good": {
+				"type": "openai-compat",
+				"api_key": "test-key",
+				"base_url": "https://api.good.com/v1",
+				"models": [{"id": "good-model", "name": "good-model"}]
+			},
+			"slow": {
+				"type": "openai-compat",
+				"api_key": "test-key",
+				"base_url": "` + server.URL + `/v1"
+			}
+		}
+	}`
+	require.NoError(t, os.WriteFile(configPath, []byte(cfgJSON), 0o600))
+
+	store, err := Load(t.Context(), dir, dir, false)
+	require.NoError(t, err)
+
+	// Before discovery: the slow provider is dropped, so the selection
+	// falls back in memory to the working provider.
+	require.Equal(t, "good", store.Config().Models[SelectedModelTypeLarge].Provider,
+		"selection should fall back in memory while slow provider is pending")
+
+	// The on-disk config must NOT have been rewritten to the fallback.
+	onDisk, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	require.Contains(t, string(onDisk), `"provider": "slow"`,
+		"the user's selection must survive on disk")
+
+	// After discovery the slow provider gains models and the reload
+	// restores the user's original selection.
+	changed, err := store.DiscoverModels(t.Context())
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	require.Equal(t, "slow", store.Config().Models[SelectedModelTypeLarge].Provider,
+		"original selection should be restored after discovery")
+	require.Equal(t, "slow-model", store.Config().Models[SelectedModelTypeLarge].Model)
+}

--- a/internal/config/init.go
+++ b/internal/config/init.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,8 +19,8 @@ type ProjectInitFlag struct {
 	Initialized bool `json:"initialized"`
 }
 
-func Init(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
-	store, err := Load(workingDir, dataDir, debug)
+func Init(ctx context.Context, workingDir, dataDir string, debug bool) (*ConfigStore, error) {
+	store, err := Load(ctx, workingDir, dataDir, debug)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -37,7 +37,9 @@ const defaultCatwalkURL = "https://catwalk.charm.land"
 
 // Load loads the configuration from the default paths and returns a
 // ConfigStore that owns both the pure-data Config and all runtime state.
-func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
+// The context bounds the initial provider fetch so an interrupt during
+// startup cancels it promptly.
+func Load(ctx context.Context, workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 	// Migrate deprecated disable_notifications before loading config.
 	migrateDisableNotifications()
 
@@ -100,7 +102,7 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 	}
 
 	// Load known providers, this loads the config from catwalk
-	providers, err := Providers(cfg)
+	providers, err := Providers(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +118,10 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 	store.writeMu.Lock()
 	defer store.writeMu.Unlock()
 
-	if err := cfg.configureProviders(context.Background(), store, env, valueResolver, store.knownProviders); err != nil {
+	// Pass the caller's context so an interrupt during startup also
+	// cancels model discovery (which reaches out to each provider's
+	// /models endpoint), not just the provider list fetch above.
+	if err := cfg.configureProviders(ctx, store, env, valueResolver, store.knownProviders); err != nil {
 		return nil, fmt.Errorf("failed to configure providers: %w", err)
 	}
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"charm.land/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/agent/hyper"
@@ -34,13 +33,6 @@ import (
 )
 
 const defaultCatwalkURL = "https://catwalk.charm.land"
-
-// modelDiscoveryTimeout bounds how long startup waits for model
-// discovery across all custom providers that need it. Kept short so an
-// unreachable or slow provider (a broken or powered-off endpoint) cannot
-// stall startup: discovery is best-effort, and any provider that does
-// not answer in time simply contributes no discovered models.
-const modelDiscoveryTimeout = 1500 * time.Millisecond
 
 // Load loads the configuration from the default paths and returns a
 // ConfigStore that owns both the pure-data Config and all runtime state.
@@ -60,11 +52,12 @@ func Load(ctx context.Context, workingDir, dataDir string, debug bool) (*ConfigS
 	cfg.setDefaults(workingDir, dataDir)
 
 	store := &ConfigStore{
-		config:         cfg,
-		workingDir:     workingDir,
-		globalDataPath: GlobalConfigData(),
-		workspacePath:  filepath.Join(cfg.Options.DataDirectory, fmt.Sprintf("%s.json", appName)),
-		loadedPaths:    loadedPaths,
+		config:           cfg,
+		workingDir:       workingDir,
+		globalDataPath:   GlobalConfigData(),
+		workspacePath:    filepath.Join(cfg.Options.DataDirectory, fmt.Sprintf("%s.json", appName)),
+		loadedPaths:      loadedPaths,
+		discoveredModels: csync.NewMap[string, []catwalk.Model](),
 	}
 
 	if debug {
@@ -137,6 +130,12 @@ func Load(ctx context.Context, workingDir, dataDir string, debug bool) (*ConfigS
 		return store, nil
 	}
 
+	// Capture the originally-selected providers before overwriting so we
+	// can tell a genuine invalid-selection fallback from one caused by a
+	// provider whose models are still being discovered in the background.
+	origLargeProvider := cfg.Models[SelectedModelTypeLarge].Provider
+	origSmallProvider := cfg.Models[SelectedModelTypeSmall].Provider
+
 	resolved, err := resolveSelectedModels(cfg, store.knownProviders)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure selected models: %w", err)
@@ -144,15 +143,20 @@ func Load(ctx context.Context, workingDir, dataDir string, debug bool) (*ConfigS
 	cfg.Models[SelectedModelTypeLarge] = resolved.Large
 	cfg.Models[SelectedModelTypeSmall] = resolved.Small
 
-	// Persist any fallback corrections while we still hold writeMu.
-	if resolved.LargeFallback {
+	// Persist fallback corrections while we still hold writeMu, but not
+	// when the selected provider is only awaiting background discovery:
+	// persisting would overwrite the user's real choice before discovery
+	// has a chance to make it valid. The in-memory fallback keeps the app
+	// usable until discovery completes and the reload restores the
+	// original selection.
+	if resolved.LargeFallback && !store.isPendingDiscovery(origLargeProvider) {
 		if err := store.updateLocked(ScopeGlobal, func(c *Config) map[string]any {
 			return store.updatePreferredModelFields(c, SelectedModelTypeLarge, resolved.Large)
 		}); err != nil {
 			return nil, fmt.Errorf("failed to update preferred large model: %w", err)
 		}
 	}
-	if resolved.SmallFallback {
+	if resolved.SmallFallback && !store.isPendingDiscovery(origSmallProvider) {
 		if err := store.updateLocked(ScopeGlobal, func(c *Config) map[string]any {
 			return store.updatePreferredModelFields(c, SelectedModelTypeSmall, resolved.Small)
 		}); err != nil {
@@ -205,7 +209,11 @@ func PushPopCrushEnv() func() {
 	return restore
 }
 
-func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env env.Env, resolver VariableResolver, knownProviders []catwalk.Provider) error {
+// configureProviders resolves and validates the provider list. It no
+// longer performs model discovery (that runs in the background via
+// ConfigStore.DiscoverModels), so it takes no context; the parameter is
+// retained for call-site stability across the load and reload paths.
+func (c *Config) configureProviders(_ context.Context, store *ConfigStore, env env.Env, resolver VariableResolver, knownProviders []catwalk.Provider) error {
 	knownProviderNames := make(map[string]bool)
 	restore := PushPopCrushEnv()
 	defer restore()
@@ -374,54 +382,15 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 		c.Providers.Set(string(p.ID), prepared)
 	}
 
-	// Discover models concurrently for custom providers that need it.
-	// A provider needs discovery when discover_models is explicitly true,
-	// or when the models list is empty (auto-trigger, unless opted out).
-	type discoveryResult struct {
-		models []catwalk.Model
-		err    error
+	// Model discovery runs in the background (see ConfigStore.DiscoverModels)
+	// so a slow or unreachable provider never blocks startup. Capture the
+	// providers that need discovery now, while they are all still present;
+	// the validation loop below drops any that still lack models, and they
+	// reappear on the reload a completed discovery triggers. Here we only
+	// apply models a prior discovery pass already cached.
+	if store != nil {
+		store.setPendingDiscovery(collectDiscoveryJobs(c, knownProviderNames))
 	}
-
-	discoveryResults := make(map[string]discoveryResult)
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-
-	discoverCtx, discoverCancel := context.WithTimeout(ctx, modelDiscoveryTimeout)
-	for id, pc := range c.Providers.Seq2() {
-		if knownProviderNames[id] {
-			continue
-		}
-		if pc.Disable || pc.BaseURL == "" {
-			continue
-		}
-		wantsDiscovery := pc.AutoDiscoverModels != nil && *pc.AutoDiscoverModels
-		autoTrigger := len(pc.Models) == 0 && (pc.AutoDiscoverModels == nil || *pc.AutoDiscoverModels)
-		if !wantsDiscovery && !autoTrigger {
-			continue
-		}
-		providerID := cmp.Or(pc.ID, id)
-		cfg := discover.Config{
-			ID:             providerID,
-			BaseURL:        pc.BaseURL,
-			APIKey:         pc.APIKey,
-			ExtraHeaders:   pc.ExtraHeaders,
-			ExistingModels: pc.Models,
-		}
-		providerType := cmp.Or(pc.Type, catwalk.TypeOpenAICompat)
-		wg.Go(func() {
-			models, err := discover.DiscoverModels(discoverCtx, cfg, resolver)
-			if err == nil && len(models) > 0 {
-				if enricher := discover.GetEnricher(string(providerType)); enricher != nil {
-					models, _ = enricher.EnrichModels(discoverCtx, cfg, resolver, models)
-				}
-			}
-			mu.Lock()
-			discoveryResults[id] = discoveryResult{models: models, err: err}
-			mu.Unlock()
-		})
-	}
-	wg.Wait()
-	discoverCancel()
 
 	// Validate the custom providers.
 	for id, providerConfig := range c.Providers.Seq2() {
@@ -456,18 +425,11 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 			continue
 		}
 
-		// Apply discovery results if available.
-		if result, ok := discoveryResults[id]; ok {
-			if result.err != nil {
-				slog.Warn("Model discovery failed", "provider", id, "error", result.err)
-				if len(providerConfig.Models) == 0 {
-					slog.Warn("Skipping provider with no models after failed discovery", "provider", id)
-					c.Providers.Del(id)
-					continue
-				}
-			} else if len(result.models) > 0 {
-				providerConfig.Models = result.models
-				slog.Info("Discovered models for provider", "provider", id, "count", len(result.models))
+		// Apply models found by a previous background discovery pass.
+		if store != nil && store.discoveredModels != nil {
+			if discovered, ok := store.discoveredModels.Get(id); ok && len(discovered) > 0 {
+				providerConfig.Models = discovered
+				slog.Info("Applied discovered models for provider", "provider", id, "count", len(discovered))
 			}
 		}
 

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -35,6 +35,13 @@ import (
 
 const defaultCatwalkURL = "https://catwalk.charm.land"
 
+// modelDiscoveryTimeout bounds how long startup waits for model
+// discovery across all custom providers that need it. Kept short so an
+// unreachable or slow provider (a broken or powered-off endpoint) cannot
+// stall startup: discovery is best-effort, and any provider that does
+// not answer in time simply contributes no discovered models.
+const modelDiscoveryTimeout = 1500 * time.Millisecond
+
 // Load loads the configuration from the default paths and returns a
 // ConfigStore that owns both the pure-data Config and all runtime state.
 // The context bounds the initial provider fetch so an interrupt during
@@ -379,7 +386,7 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
-	discoverCtx, discoverCancel := context.WithTimeout(ctx, 3*time.Second)
+	discoverCtx, discoverCancel := context.WithTimeout(ctx, modelDiscoveryTimeout)
 	for id, pc := range c.Providers.Seq2() {
 		if knownProviderNames[id] {
 			continue

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"io"
 	"log/slog"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -906,22 +904,13 @@ func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {
 		require.False(t, exists)
 	})
 
-	t.Run("custom provider with models and discover_models:true merges discovered models", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"data": [
-				{"id": "existing-model", "object": "model"},
-				{"id": "discovered-model", "object": "model"}
-			]}`))
-		}))
-		defer server.Close()
-
+	t.Run("custom provider applies models found by background discovery", func(t *testing.T) {
 		discoverTrue := true
 		cfg := &Config{
 			Providers: csync.NewMapFrom(map[string]ProviderConfig{
 				"custom": {
 					APIKey:  "test-key",
-					BaseURL: server.URL + "/v1",
+					BaseURL: "https://api.custom.com/v1",
 					Models: []catwalk.Model{
 						{ID: "existing-model", Name: "My Custom Name", ContextWindow: 200000},
 					},
@@ -931,9 +920,18 @@ func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {
 		}
 		cfg.setDefaults("/tmp", "")
 
+		// Simulate a completed background discovery pass by seeding the
+		// store's in-memory cache; configureProviders applies it.
+		store := testStore(cfg)
+		store.discoveredModels = csync.NewMap[string, []catwalk.Model]()
+		store.discoveredModels.Set("custom", []catwalk.Model{
+			{ID: "existing-model", Name: "My Custom Name", ContextWindow: 200000},
+			{ID: "discovered-model", Name: "discovered-model"},
+		})
+
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
+		err := cfg.configureProviders(context.Background(), store, env, resolver, []catwalk.Provider{})
 		require.NoError(t, err)
 
 		require.Equal(t, 1, cfg.Providers.Len())
@@ -946,7 +944,7 @@ func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {
 		require.Equal(t, "My Custom Name", p.Models[0].Name)
 		require.Equal(t, int64(200000), p.Models[0].ContextWindow)
 
-		// Discovered model is appended.
+		// Discovered model is included.
 		require.Equal(t, "discovered-model", p.Models[1].ID)
 	})
 
@@ -976,37 +974,29 @@ func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {
 		require.Equal(t, "my-model", p.Models[0].ID)
 	})
 
-	t.Run("custom provider with no models auto-discovers successfully", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"data": [
-				{"id": "auto-model-a", "object": "model"},
-				{"id": "auto-model-b", "object": "model"}
-			]}`))
-		}))
-		defer server.Close()
-
+	t.Run("custom provider with no models is dropped until background discovery runs", func(t *testing.T) {
 		cfg := &Config{
 			Providers: csync.NewMapFrom(map[string]ProviderConfig{
 				"custom": {
 					APIKey:  "test-key",
-					BaseURL: server.URL + "/v1",
+					BaseURL: "https://api.custom.com/v1",
 				},
 			}),
 		}
 		cfg.setDefaults("/tmp", "")
 
+		// configureProviders no longer performs network discovery; with
+		// nothing in the discovery cache yet, a provider with no models is
+		// dropped. It reappears after DiscoverModels populates the cache
+		// and triggers a reload.
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
 		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
 		require.NoError(t, err)
 
-		require.Equal(t, 1, cfg.Providers.Len())
-		p, exists := cfg.Providers.Get("custom")
-		require.True(t, exists)
-		require.Len(t, p.Models, 2)
-		require.Equal(t, "auto-model-a", p.Models[0].ID)
-		require.Equal(t, "auto-model-b", p.Models[1].ID)
+		require.Equal(t, 0, cfg.Providers.Len())
+		_, exists := cfg.Providers.Get("custom")
+		require.False(t, exists)
 	})
 
 	t.Run("custom provider with unsupported type is removed", func(t *testing.T) {

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -35,8 +35,11 @@ var (
 
 // providerFetchTimeout bounds how long the foreground provider fetch
 // (catwalk + hyper) may run before falling back to cached/embedded
-// providers.
-const providerFetchTimeout = 45 * time.Second
+// providers. Kept short so a slow or unreachable network cannot stall
+// startup: the underlying HTTP clients allow up to 30s on their own, and
+// there is always a usable cached or bundled provider list to fall back
+// to.
+const providerFetchTimeout = 5 * time.Second
 
 // file to cache provider data
 func cachePathFor(name string) string {

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -33,6 +33,11 @@ var (
 	providerErr  error
 )
 
+// providerFetchTimeout bounds how long the foreground provider fetch
+// (catwalk + hyper) may run before falling back to cached/embedded
+// providers.
+const providerFetchTimeout = 45 * time.Second
+
 // file to cache provider data
 func cachePathFor(name string) string {
 	xdgDataHome := os.Getenv("XDG_DATA_HOME")
@@ -136,7 +141,7 @@ var (
 // 2. load the cached providers
 // 3. try to get the fresh list of providers, and return either this new list,
 // the cached list, or the embedded list if all others fail.
-func Providers(cfg *Config) ([]catwalk.Provider, error) {
+func Providers(ctx context.Context, cfg *Config) ([]catwalk.Provider, error) {
 	providerOnce.Do(func() {
 		var wg sync.WaitGroup
 		var errs []error
@@ -144,7 +149,10 @@ func Providers(cfg *Config) ([]catwalk.Provider, error) {
 		autoupdate := !cfg.Options.DisableProviderAutoUpdate
 		customProvidersOnly := cfg.Options.DisableDefaultProviders
 
-		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+		// Derive from the caller's context so an interrupt (Ctrl+C)
+		// during startup cancels the provider fetch instead of
+		// blocking until the timeout fires.
+		ctx, cancel := context.WithTimeout(ctx, providerFetchTimeout)
 		defer cancel()
 
 		var hyperProvider catwalk.Provider

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -46,7 +46,7 @@ func TestProviders_Integration_AutoUpdateDisabled(t *testing.T) {
 		},
 	}
 
-	providers, err := Providers(cfg)
+	providers, err := Providers(t.Context(), cfg)
 	require.NoError(t, err)
 	require.NotNil(t, providers)
 	require.Greater(t, len(providers), 5, "Expected embedded providers")

--- a/internal/config/reload_hooks_test.go
+++ b/internal/config/reload_hooks_test.go
@@ -39,7 +39,7 @@ func TestReloadFromDisk_CompilesHookMatchers(t *testing.T) {
     }`
 	require.NoError(t, os.WriteFile(configPath, []byte(cfgJSON), 0o600))
 
-	store, err := config.Load(workDir, dataDir, false)
+	store, err := config.Load(t.Context(), workDir, dataDir, false)
 	require.NoError(t, err)
 
 	// Sanity: hook filtering works immediately after Load.
@@ -92,7 +92,7 @@ func TestSetConfigField_AutoReload_PreservesHookMatcherFiltering(t *testing.T) {
     }`
 	require.NoError(t, os.WriteFile(configPath, []byte(cfgJSON), 0o600))
 
-	store, err := config.Load(workDir, dataDir, false)
+	store, err := config.Load(t.Context(), workDir, dataDir, false)
 	require.NoError(t, err)
 	assertHookFilters(t, store)
 

--- a/internal/config/scopeb_race_test.go
+++ b/internal/config/scopeb_race_test.go
@@ -34,7 +34,7 @@ func TestScopeB_InPlaceMutationRace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store, err := Load(dir, dir, false)
+	store, err := Load(t.Context(), dir, dir, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -1056,7 +1056,7 @@ func (s *ConfigStore) reloadFromDiskLocked(ctx context.Context) error {
 	// Reconfigure providers
 	env := env.New()
 	resolver := NewShellVariableResolver(env)
-	providers, err := Providers(cfg)
+	providers, err := Providers(ctx, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to load providers during reload: %w", err)
 	}

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -13,6 +13,7 @@ import (
 
 	"charm.land/catwalk/pkg/catwalk"
 	hyperp "github.com/charmbracelet/crush/internal/agent/hyper"
+	"github.com/charmbracelet/crush/internal/csync"
 	"github.com/charmbracelet/crush/internal/env"
 	"github.com/charmbracelet/crush/internal/lock"
 	"github.com/charmbracelet/crush/internal/oauth"
@@ -85,6 +86,20 @@ type ConfigStore struct {
 	overrides          RuntimeOverrides
 	trackedConfigPaths []string                // unique, normalized config file paths
 	snapshots          map[string]fileSnapshot // path -> snapshot at last capture
+
+	// discoveredModels holds models found by background model discovery,
+	// keyed by provider id. configureProviders reads this cache instead
+	// of hitting the network, so startup never blocks on a slow or
+	// unreachable provider; the background DiscoverModels pass populates
+	// it and reloads to apply the results.
+	discoveredModels *csync.Map[string, []catwalk.Model]
+
+	// discoveryMu guards pendingDiscovery, the set of custom providers
+	// that need model discovery. It is captured during configureProviders
+	// (before empty providers are dropped) so the background pass still
+	// knows which providers to probe.
+	discoveryMu      sync.Mutex
+	pendingDiscovery []discoveryJob
 
 	// configMu guards the config pointer field against concurrent
 	// readers (Config) and the writeMu-serialised swap (setConfig). It

--- a/internal/config/store_test.go
+++ b/internal/config/store_test.go
@@ -345,7 +345,7 @@ func TestReloadFromDisk_UsesNewConfigValues(t *testing.T) {
 	require.NoError(t, os.WriteFile(configPath, []byte(initialConfig), 0o600))
 
 	// Load initial config properly
-	store, err := Load(dir, dir, false)
+	store, err := Load(t.Context(), dir, dir, false)
 	require.NoError(t, err)
 
 	// Set globalDataPath for the test (Load doesn't set this directly)
@@ -398,7 +398,7 @@ func TestSetConfigField_AutoReloads(t *testing.T) {
 	require.NoError(t, os.WriteFile(configPath, []byte(initialConfig), 0o600))
 
 	// Load initial config
-	store, err := Load(dir, dir, false)
+	store, err := Load(t.Context(), dir, dir, false)
 	require.NoError(t, err)
 
 	// Verify initial state
@@ -433,7 +433,7 @@ func TestRemoveConfigField_AutoReloads(t *testing.T) {
 	require.NoError(t, os.WriteFile(configPath, []byte(initialConfig), 0o600))
 
 	// Load initial config
-	store, err := Load(dir, dir, false)
+	store, err := Load(t.Context(), dir, dir, false)
 	require.NoError(t, err)
 
 	// Set globalDataPath and capture snapshot
@@ -499,7 +499,7 @@ func TestAutoReloadDisabledDuringReload(t *testing.T) {
 
 	// Load will trigger configureProviders which removes anthropic OAuth config.
 	// This should NOT cause infinite recursion — writeMu prevents re-entrant reloads.
-	store, err := Load(dir, dir, false)
+	store, err := Load(t.Context(), dir, dir, false)
 	require.NoError(t, err)
 
 	// Capture snapshot and verify reload also works without recursion
@@ -528,7 +528,7 @@ func TestSetConfigFields_AutoReloadsAtomically(t *testing.T) {
 	require.NoError(t, os.WriteFile(configPath, []byte(initialConfig), 0o600))
 
 	// Load initial config.
-	store, err := Load(dir, dir, false)
+	store, err := Load(t.Context(), dir, dir, false)
 	require.NoError(t, err)
 
 	// Set globalDataPath and capture snapshot.

--- a/internal/config/update_model_bench_test.go
+++ b/internal/config/update_model_bench_test.go
@@ -47,7 +47,7 @@ func BenchmarkUpdatePreferredModel(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	store, err := Load(dir, dir, false)
+	store, err := Load(b.Context(), dir, dir, false)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func BenchmarkReloadFromDisk(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	store, err := Load(dir, dir, false)
+	store, err := Load(b.Context(), dir, dir, false)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"cmp"
+	"context"
 	"fmt"
 	"slices"
 
@@ -143,7 +144,7 @@ func NewModels(com *common.Common, isOnboarding bool) (*Models, error) {
 	m.keyMap.Close = CloseKey
 
 	var err error
-	m.providers, err = config.Providers(m.com.Config())
+	m.providers, err = config.Providers(context.Background(), m.com.Config())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get providers: %w", err)
 	}
@@ -350,7 +351,7 @@ func (m *Models) setProviderItems() error {
 	addedProviders := make(map[string]bool)
 
 	// Get a list of known providers to compare against
-	knownProviders, err := config.Providers(cfg)
+	knownProviders, err := config.Providers(context.Background(), cfg)
 	if err != nil {
 		return fmt.Errorf("failed to get providers: %w", err)
 	}


### PR DESCRIPTION
Startup could hang for several seconds and Ctrl+C wouldn't properly cancel. The root cause was model fetching happening synchronously before the UI ever appeared and because that work ran on a background context an interrupt wasn't able to cancel it.

The command context now threads through config loading, provider fetching, and model discovery, so an interrupt during startup aborts properly now. Model discovery moved off the startup path entirely. The UI opens immediately using already-known models, and newly discovered models are applied once the background probe finishes.

If your selected model lives on a provider that needs discovery, startup temporarily falls back to a working model but no longer persists that fallback. The correct choice survives on disk and is restored once discovery completes.

Startup with an unreachable custom provider drops from ~3s to ~40ms, and Ctrl+C works properly.