### PR TITLE
fix(skills): coerce nested metadata maps to strings instead of dropping

### DIFF
--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -49,6 +49,82 @@ type Skill struct {
 	Builtin                bool              `yaml:"-" json:"builtin"`
 }
 
+// UnmarshalYAML decodes a skill's frontmatter. It mirrors the standard Skill
+// field mapping but routes the metadata field through [metadataMap], which
+// tolerates non-string values by coercing them to strings. This matches the
+// reference Agent Skills parser (skills-ref), which stringifies metadata
+// values rather than rejecting nested maps. Popular skill packs (e.g.
+// samber/cc-skills-golang) embed per-client config blocks under metadata;
+// without coercion the entire skill is silently dropped during discovery.
+func (s *Skill) UnmarshalYAML(value *yaml.Node) error {
+	type raw struct {
+		Name                   string      `yaml:"name"`
+		Description            string      `yaml:"description"`
+		UserInvocable          bool        `yaml:"user-invocable"`
+		DisableModelInvocation bool        `yaml:"disable-model-invocation"`
+		License                string      `yaml:"license,omitempty"`
+		Compatibility          string      `yaml:"compatibility,omitempty"`
+		Metadata               metadataMap `yaml:"metadata,omitempty"`
+	}
+	var r raw
+	if err := value.Decode(&r); err != nil {
+		return err
+	}
+	s.Name = r.Name
+	s.Description = r.Description
+	s.UserInvocable = r.UserInvocable
+	s.DisableModelInvocation = r.DisableModelInvocation
+	s.License = r.License
+	s.Compatibility = r.Compatibility
+	s.Metadata = map[string]string(r.Metadata)
+	return nil
+}
+
+// metadataMap is a [map[string]string] that coerces non-string YAML values
+// to their string representation when decoding. The Agent Skills spec types
+// metadata as map[string]string, but real-world skill packs nest maps under
+// it. Stringifying those values preserves the strict contract without
+// discarding an otherwise valid skill. Scalars use their literal text;
+// mappings and sequences are re-encoded as YAML so nothing is lost.
+type metadataMap map[string]string
+
+func (m *metadataMap) UnmarshalYAML(value *yaml.Node) error {
+	// A null or empty value (e.g. "metadata:") leaves the map untouched.
+	if value.Kind == yaml.ScalarNode && value.Value == "" {
+		return nil
+	}
+	var nodes map[string]yaml.Node
+	if err := value.Decode(&nodes); err != nil {
+		return err
+	}
+	*m = make(metadataMap, len(nodes))
+	for k, n := range nodes {
+		coerced, err := nodeToCoercedString(&n)
+		if err != nil {
+			return fmt.Errorf("coercing metadata value %q: %w", k, err)
+		}
+		(*m)[k] = coerced
+	}
+	return nil
+}
+
+// nodeToCoercedString returns the string form of a YAML node. Scalars become
+// their literal text; aliases, mappings, and sequences are re-encoded as
+// YAML and trimmed.
+func nodeToCoercedString(node *yaml.Node) (string, error) {
+	if node.Kind == yaml.AliasNode && node.Alias != nil {
+		node = node.Alias
+	}
+	if node.Kind == yaml.ScalarNode {
+		return node.Value, nil
+	}
+	out, err := yaml.Marshal(node)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // DiscoveryState represents the outcome of discovering a single skill file.
 type DiscoveryState int
 

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -400,6 +400,100 @@ func TestParseContent_NoFrontmatter(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestParseContent_NestedMetadata ensures a skill whose metadata field
+// contains nested maps, sequences, and non-string scalars is still parsed.
+// The reference Agent Skills parser (skills-ref) coerces such values to
+// strings instead of dropping the whole skill. See issue #3331.
+func TestParseContent_NestedMetadata(t *testing.T) {
+	t.Parallel()
+
+	// Modeled on samber/cc-skills-golang/golang-testing/SKILL.md.
+	content := []byte(`---
+name: golang-testing
+description: "Production-ready Golang tests."
+user-invocable: true
+license: MIT
+metadata:
+  author: samber
+  version: "1.2.3"
+  port: 8080
+  enabled: true
+  ratio: 0.5
+  openclaw:
+    emoji: "🧪"
+    homepage: https://github.com/samber/cc-skills-golang
+  aliases:
+    - go-test
+    - gotest
+---
+
+# Golang Testing
+`)
+
+	skill, err := ParseContent(content)
+	require.NoError(t, err)
+	require.Equal(t, "golang-testing", skill.Name)
+
+	require.Equal(t, "samber", skill.Metadata["author"])
+	require.Equal(t, "1.2.3", skill.Metadata["version"])
+
+	// Non-string scalars keep their literal text.
+	require.Equal(t, "8080", skill.Metadata["port"])
+	require.Equal(t, "true", skill.Metadata["enabled"])
+	require.Equal(t, "0.5", skill.Metadata["ratio"])
+
+	// Nested maps and sequences are stringified rather than dropping the skill.
+	require.NotEmpty(t, skill.Metadata["openclaw"])
+	require.Contains(t, skill.Metadata["openclaw"], "emoji")
+	require.Contains(t, skill.Metadata["openclaw"], "homepage")
+	require.Contains(t, skill.Metadata["openclaw"], "https://github.com/samber/cc-skills-golang")
+	require.NotEmpty(t, skill.Metadata["aliases"])
+	require.Contains(t, skill.Metadata["aliases"], "go-test")
+	require.Contains(t, skill.Metadata["aliases"], "gotest")
+}
+
+// TestDiscoverNestedMetadata ensures a skill with nested metadata is
+// discovered and reported as normal rather than silently dropped. See
+// issue #3331.
+func TestDiscoverNestedMetadata(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	skillDir := filepath.Join(dir, "nested-meta")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(`---
+name: nested-meta
+description: Skill with nested metadata.
+metadata:
+  author: someone
+  openclaw:
+    emoji: "🧪"
+    homepage: https://example.com
+---
+
+# Nested Meta
+`), 0o644))
+
+	skills, states := DiscoverWithStates([]string{dir})
+
+	require.Len(t, skills, 1)
+	require.Equal(t, "nested-meta", skills[0].Name)
+	require.NotEmpty(t, skills[0].Metadata["openclaw"])
+	require.Contains(t, skills[0].Metadata["openclaw"], "emoji")
+
+	var normal, errored int
+	for _, state := range states {
+		if state.State == StateNormal {
+			normal++
+		}
+		if state.State == StateError {
+			errored++
+		}
+	}
+	require.Equal(t, 1, normal)
+	require.Zero(t, errored)
+}
+
 func TestDiscoverBuiltin(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #3331

Skills with nested `metadata` maps (e.g. from `samber/cc-skills-golang`) were silently dropped during discovery because `Skill.Metadata` is `map[string]string` and YAML unmarshalling hard-failed on nested map values.

## Fix

Added a custom `UnmarshalYAML` on `*Skill` that routes metadata through a helper type. Non-string values are coerced to their string representation (scalars → literal text, nested maps/sequences → re-encoded YAML), matching the reference `skills-ref` parser behavior.

The public `Skill.Metadata` field type stays `map[string]string` — no API change.

## Test results

- `go test ./internal/skills/...` — PASS
- `go vet` — clean
- `gofmt` / `gofumpt` — clean
- New tests: `TestParseContent_NestedMetadata`, `TestDiscoverNestedMetadata`