### PR TITLE
feat(ui): Claude Channels TUI — message metadata, status surfaces, dialog, docs (3/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - **Session-Based:** maintain multiple work sessions and contexts per project
 - **LSP-Enhanced:** Crush uses LSPs for additional context, just like you do
 - **Extensible:** add capabilities via MCPs (`http`, `stdio`, and `sse`)
+- **Channel-Ready:** MCP servers can push real-time events into your session via [Claude Channels](https://code.claude.com/docs/en/channels-reference) — CI failures, webhooks, and more, acting on them without you typing a thing
 - **Works Everywhere:** first-class support in every terminal on macOS, Linux, Windows (PowerShell and WSL), Android, FreeBSD, OpenBSD, and NetBSD
 - **Industrial Grade:** built on the Charm ecosystem, powering 25k+ applications, from leading open source projects to business-critical infrastructure
 
@@ -367,6 +368,20 @@ which do expand.
       "headers": {
         "API-Key": "$(echo $API_KEY)"
       }
+    },
+    "signal": {
+      "type": "stdio",
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/path/to/signal-mcp",
+        "python",
+        "signal_mcp/main.py",
+        "--user-id",
+        "+15551234567",
+        "--channel"
+      ]
     }
   }
 }
@@ -415,6 +430,133 @@ When `oauth_client_id` is set, Crush skips dynamic client registration
 and authenticates as the specified client. When omitted, Crush attempts
 dynamic registration automatically (works with Linear, Notion, and other
 servers that support RFC 7591).
+
+#### Channels (experimental)
+
+An MCP server can also act as a **channel**: instead of only exposing tools it
+calls, it *pushes* events straight into your session so Crush reacts to things
+happening outside the terminal — a webhook, a CI failure, a chat message. See
+the [channels reference](https://code.claude.com/docs/en/channels-reference)
+for the protocol.
+
+A server becomes a channel by declaring the `claude/channel` capability in its
+`initialize` result (`capabilities.experimental["claude/channel"] = {}`) and
+emitting `notifications/claude/channel` events with a `content` body and an
+optional `meta` map. Crush injects each event into the active session as a
+`<channel>` element:
+
+```text
+<channel source="webhook" severity="high" run_id="1234">
+build failed on main: https://ci.example.com/run/1234
+</channel>
+```
+
+Listing a channel server in `mcp` is **not** enough to enable it — pushing is
+gated behind an explicit opt-in, so a server present in config stays silent
+until you ask for it. Opt in per launch with the `--channels` flag:
+
+```bash
+# Enable one or more configured MCP servers as channels for this session.
+crush --channels server:webhook
+crush --channels server:webhook --channels server:signal
+```
+
+Or persistently, with `channel_enabled` on the server's `mcp` entry — no CLI
+flag needed on each launch:
+
+```json
+{
+  "mcp": {
+    "webhook": {
+      "type": "http",
+      "url": "https://example.com/mcp",
+      "channel_enabled": true
+    }
+  }
+}
+```
+
+The `source` attribute is always the (trusted) server name. Payloads are
+untrusted, server-initiated input: Crush validates their structure, caps the
+body and attribute sizes, restricts `meta` keys to identifiers
+(`[A-Za-z0-9_]`), escapes all content so a payload cannot break out of the
+`<channel>` element or forge attributes, and drops malformed payloads. A
+server that has not been opted in via `--channels` or `channel_enabled`, or
+that never declared the capability, cannot inject anything.
+
+Channel delivery works in the default in-process `crush` and against a shared
+`crush serve` backend. In-process, an event routes into the session you have
+open, or starts one if none is open, so it is never dropped. Against a
+`crush serve` backend the server routes each event exactly once — into the
+session an attached client is viewing (the most recently updated one when
+clients are viewing different sessions), otherwise into the workspace's most
+recent session, creating one only when none exists. That holds even with no
+clients connected, so a headless server still processes channel pushes;
+attached clients see the injected turn arrive through the normal event
+stream. Servers that are live channels are marked `channel` in the MCP list
+so you can confirm the opt-in took effect.
+
+**Two-way channels.** A channel can also be interactive. Because a channel is a
+regular MCP server, any tool it exposes (a `reply` tool, say) is available to
+the agent through the normal MCP tool path — nothing channel-specific is
+required. Declare `tools` in the server's capabilities, register the tool, and
+use the server's `instructions` string (injected into the system prompt) to
+tell Crush when to call it and which `<channel>` attribute to pass back (like a
+`chat_id`).
+
+For example, [Signal MCP](https://github.com/joestump/signal-mcp) lets Crush
+send and receive Signal messages through a
+[signal-cli](https://github.com/AsamK/signal-cli) daemon:
+
+1. **Start the daemon:** `signal-cli -a +15551234567 daemon --tcp 127.0.0.1:7583 --receive-mode on-start --no-receive-stdout`
+2. **Add to `crush.json`:** Use the example in the [MCPs](#mcps) section above.
+3. **Launch with channel:** `crush --channels server:signal`
+
+Incoming messages arrive as `<channel>` tags; use the `send_message_to_user` tool to reply.
+
+#### Channel reply routing
+
+By default a channel-originated turn only produces terminal output, so a
+person messaging you on Signal never sees the answer unless the model decides
+to call a send tool itself. Adding a `channel_reply` block to a channel
+server's MCP config makes the routing deterministic: when a turn that
+originated from that channel finishes without the model having replied through
+the channel, Crush sends the final assistant response back through the
+configured tool — to the sender for direct messages, or to the group for group
+messages.
+
+```json
+{
+  "mcp": {
+    "signal": {
+      "type": "stdio",
+      "command": "uv",
+      "args": ["run", "signal_mcp/main.py", "--operator", "+15551234567", "--channel"],
+      "channel_reply": {
+        "user": { "tool": "send_message_to_user", "target_param": "user_id" },
+        "group": { "tool": "send_message_to_group", "target_param": "group_id" },
+        "suppress_tools": ["send"]
+      }
+    }
+  }
+}
+```
+
+How it routes:
+
+- **Group pushes** (meta carries `group`) go through the `group` route;
+  **direct pushes** (meta carries `sender`) go through the `user` route.
+  `target_meta` overrides which meta attribute supplies the target;
+  `message_param` (default `message`) names the tool argument that receives
+  the reply text.
+- If the model already called a route tool — or any tool listed in
+  `suppress_tools` — during the turn, the automatic reply is skipped, so
+  richer model-driven replies aren't duplicated.
+- Local (non-channel) turns and channels without a `channel_reply` block are
+  unaffected.
+
+The same shape works for any messaging channel (Discord, Slack, …): point the
+routes at that server's send tools and the matching meta attributes.
 
 ### Hooks
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - **Session-Based:** maintain multiple work sessions and contexts per project
 - **LSP-Enhanced:** Crush uses LSPs for additional context, just like you do
 - **Extensible:** add capabilities via MCPs (`http`, `stdio`, and `sse`)
+- **Channel-Ready:** MCP servers can push real-time events into your session via [Claude Channels](https://code.claude.com/docs/en/channels-reference) — CI failures, webhooks, and more, acting on them without you typing a thing
 - **Works Everywhere:** first-class support in every terminal on macOS, Linux, Windows (PowerShell and WSL), Android, FreeBSD, OpenBSD, and NetBSD
 - **Industrial Grade:** built on the Charm ecosystem, powering 25k+ applications, from leading open source projects to business-critical infrastructure
 
@@ -439,6 +440,147 @@ For other sessionless servers, mark them explicitly with
 `false` to force the default behavior for an auto-detected URL. The
 tradeoff is that a sessionless server won't push live
 tool/prompt/resource list-changed notifications.
+
+#### Channels (experimental)
+
+An MCP server can also act as a **channel**: instead of only exposing tools it
+calls, it *pushes* events straight into your session so Crush reacts to things
+happening outside the terminal — a webhook, a CI failure, a chat message. See
+the [channels reference](https://code.claude.com/docs/en/channels-reference)
+for the protocol.
+
+A server becomes a channel by declaring the `claude/channel` capability in its
+`initialize` result (`capabilities.experimental["claude/channel"] = {}`) and
+emitting `notifications/claude/channel` events with a `content` body and an
+optional `meta` map. Crush injects each event into the active session as a
+`<channel>` element:
+
+```text
+<channel source="webhook" severity="high" run_id="1234">
+build failed on main: https://ci.example.com/run/1234
+</channel>
+```
+
+Listing a channel server in `mcp` is **not** enough to enable it — pushing is
+gated behind an explicit opt-in, so a server present in config stays silent
+until you ask for it. Opt in per launch with the `--channels` flag:
+
+```bash
+# Enable one or more configured MCP servers as channels for this session.
+crush --channels server:webhook
+crush --channels server:webhook --channels server:signal
+```
+
+Or persistently, with `channel_enabled` on the server's `mcp` entry — no CLI
+flag needed on each launch:
+
+```json
+{
+  "mcp": {
+    "webhook": {
+      "type": "http",
+      "url": "https://example.com/mcp",
+      "channel_enabled": true
+    },
+    "signal": {
+      "type": "stdio",
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/path/to/signal-mcp",
+        "python",
+        "signal_mcp/main.py",
+        "--user-id",
+        "+15551234567",
+        "--channel"
+      ]
+    }
+  }
+}
+```
+
+The `source` attribute is always the (trusted) server name. Payloads are
+untrusted, server-initiated input: Crush validates their structure, caps the
+body and attribute sizes, restricts `meta` keys to identifiers
+(`[A-Za-z0-9_]`), escapes all content so a payload cannot break out of the
+`<channel>` element or forge attributes, and drops malformed payloads. A
+server that has not been opted in via `--channels` or `channel_enabled`, or
+that never declared the capability, cannot inject anything.
+
+Channel delivery works in the default in-process `crush` and against a shared
+`crush serve` backend. In-process, an event routes into the session you have
+open, or starts one if none is open, so it is never dropped. Against a
+`crush serve` backend the server routes each event exactly once — into the
+session an attached client is viewing (the most recently updated one when
+clients are viewing different sessions), otherwise into the workspace's most
+recent session, creating one only when none exists. That holds even with no
+clients connected, so a headless server still processes channel pushes;
+attached clients see the injected turn arrive through the normal event
+stream. Servers that are live channels are marked `channel` in the MCP list
+so you can confirm the opt-in took effect.
+
+**Two-way channels.** A channel can also be interactive. Because a channel is a
+regular MCP server, any tool it exposes (a `reply` tool, say) is available to
+the agent through the normal MCP tool path — nothing channel-specific is
+required. Declare `tools` in the server's capabilities, register the tool, and
+use the server's `instructions` string (injected into the system prompt) to
+tell Crush when to call it and which `<channel>` attribute to pass back (like a
+`chat_id`).
+
+For example, [Signal MCP](https://github.com/joestump/signal-mcp) lets Crush
+send and receive Signal messages through a
+[signal-cli](https://github.com/AsamK/signal-cli) daemon:
+
+1. **Start the daemon:** `signal-cli -a +15551234567 daemon --tcp 127.0.0.1:7583 --receive-mode on-start --no-receive-stdout`
+2. **Add to `crush.json`:** Use the example in the [MCPs](#mcps) section above.
+3. **Launch with channel:** `crush --channels server:signal`
+
+Incoming messages arrive as `<channel>` tags; use the `send_message_to_user` tool to reply.
+
+#### Channel reply routing
+
+By default a channel-originated turn only produces terminal output, so a
+person messaging you on Signal never sees the answer unless the model decides
+to call a send tool itself. Adding a `channel_reply` block to a channel
+server's MCP config makes the routing deterministic: when a turn that
+originated from that channel finishes without the model having replied through
+the channel, Crush sends the final assistant response back through the
+configured tool — to the sender for direct messages, or to the group for group
+messages.
+
+```json
+{
+  "mcp": {
+    "signal": {
+      "type": "stdio",
+      "command": "uv",
+      "args": ["run", "signal_mcp/main.py", "--operator", "+15551234567", "--channel"],
+      "channel_reply": {
+        "user": { "tool": "send_message_to_user", "target_param": "user_id" },
+        "group": { "tool": "send_message_to_group", "target_param": "group_id" },
+        "suppress_tools": ["send"]
+      }
+    }
+  }
+}
+```
+
+How it routes:
+
+- **Group pushes** (meta carries `group`) go through the `group` route;
+  **direct pushes** (meta carries `sender`) go through the `user` route.
+  `target_meta` overrides which meta attribute supplies the target;
+  `message_param` (default `message`) names the tool argument that receives
+  the reply text.
+- If the model already called a route tool — or any tool listed in
+  `suppress_tools` — during the turn, the automatic reply is skipped, so
+  richer model-driven replies aren't duplicated.
+- Local (non-channel) turns and channels without a `channel_reply` block are
+  unaffected.
+
+The same shape works for any messaging channel (Discord, Slack, …): point the
+routes at that server's send tools and the matching meta attributes.
 
 ### Hooks
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -84,6 +84,7 @@ type SessionAgentCall struct {
 	// session that may be busy) MUST set it; SessionID alone is
 	// ambiguous when concurrent turns share the same session.
 	RunID            string
+	Channel          string
 	Prompt           string
 	ProviderOptions  fantasy.ProviderOptions
 	Attachments      []message.Attachment
@@ -130,6 +131,22 @@ type SessionAgentCall struct {
 	// fantasy retries the stream transparently. Returning an error
 	// surfaces the original auth error without retry.
 	OnAuthRefresh func(ctx context.Context, err *fantasy.ProviderError) error
+}
+
+func filterToolsForChannel(agentTools []fantasy.AgentTool, channel string, states map[string]mcp.ClientInfo) []fantasy.AgentTool {
+	filtered := make([]fantasy.AgentTool, 0, len(agentTools))
+	for _, agentTool := range agentTools {
+		mcpTool, ok := agentTool.(interface{ MCP() string })
+		if !ok {
+			filtered = append(filtered, agentTool)
+			continue
+		}
+		state, found := states[mcpTool.MCP()]
+		if !found || !state.Channel || channel == mcpTool.MCP() {
+			filtered = append(filtered, agentTool)
+		}
+	}
+	return filtered
 }
 
 type SessionAgent interface {
@@ -657,7 +674,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	defer a.activeRequests.CompareAndDelete(call.SessionID, ac)
 
 	// Copy mutable fields under lock to avoid races with SetTools/SetModels.
-	agentTools := a.tools.Copy()
+	agentTools := filterToolsForChannel(a.tools.Copy(), call.Channel, mcp.GetStates())
 	largeModel := a.largeModel.Get()
 	systemPrompt := a.systemPrompt.Get()
 	promptPrefix := a.systemPromptPrefix.Get()
@@ -813,7 +830,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			}
 
 			// Use latest tools (updated by SetTools when MCP tools change).
-			prepared.Tools = a.tools.Copy()
+			prepared.Tools = filterToolsForChannel(a.tools.Copy(), call.Channel, mcp.GetStates())
 
 			// Drain queued follow-up prompts for this step. Calls covered
 			// by a cancel recorded while they sat in the queue are dropped:
@@ -873,6 +890,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 				return callContext, prepared, err
 			}
 			callContext = context.WithValue(callContext, tools.MessageIDContextKey, assistantMsg.ID)
+			callContext = context.WithValue(callContext, tools.ChannelContextKey, call.Channel)
 			callContext = context.WithValue(callContext, tools.SupportsImagesContextKey, largeModel.CatwalkCfg.SupportsImages)
 			callContext = context.WithValue(callContext, tools.ModelNameContextKey, largeModel.CatwalkCfg.Name)
 			currentAssistant = &assistantMsg

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -131,6 +131,12 @@ type SessionAgentCall struct {
 	// fantasy retries the stream transparently. Returning an error
 	// surfaces the original auth error without retry.
 	OnAuthRefresh func(ctx context.Context, err *fantasy.ProviderError) error
+	// channelMeta holds the attributes of the <channel> element a
+	// channel-originated turn was started with, parsed once at Run
+	// entry. It survives the auto-summarize continuation, whose Prompt
+	// is rewritten and no longer carries the element, so the reply
+	// target is not lost when a long channel turn is summarized.
+	channelMeta map[string]string
 }
 
 func filterToolsForChannel(agentTools []fantasy.AgentTool, channel string, states map[string]mcp.ClientInfo) []fantasy.AgentTool {
@@ -190,9 +196,13 @@ type sessionAgent struct {
 	systemPrompt       *csync.Value[string]
 	tools              *csync.Slice[fantasy.AgentTool]
 
-	isSubAgent           bool
-	sessions             session.Service
-	messages             message.Service
+	isSubAgent bool
+	sessions   session.Service
+	messages   message.Service
+	// cfg backs channel reply routing (config lookup + MCP tool
+	// invocation). Nil in tests and sub-agents that never see channel
+	// turns; sendChannelReply treats nil as "routing disabled".
+	cfg                  *config.ConfigStore
 	disableAutoSummarize bool
 	isYolo               bool
 	notify               pubsub.Publisher[notify.Notification]
@@ -249,6 +259,7 @@ type SessionAgentOptions struct {
 	IsYolo               bool
 	Sessions             session.Service
 	Messages             message.Service
+	Cfg                  *config.ConfigStore
 	Tools                []fantasy.AgentTool
 	Notify               pubsub.Publisher[notify.Notification]
 	RunComplete          pubsub.Publisher[notify.RunComplete]
@@ -265,6 +276,7 @@ func NewSessionAgent(
 		isSubAgent:           opts.IsSubAgent,
 		sessions:             opts.Sessions,
 		messages:             opts.Messages,
+		cfg:                  opts.Cfg,
 		disableAutoSummarize: opts.DisableAutoSummarize,
 		tools:                csync.NewSliceFrom(opts.Tools),
 		isYolo:               opts.IsYolo,
@@ -585,6 +597,10 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		return nil, err
 	}
 
+	if call.Channel != "" && call.channelMeta == nil {
+		call.channelMeta, _ = parseChannelMeta(call.Prompt)
+	}
+
 	// genCtx/cancel are the run context and its cancel func, created under
 	// the per-session dispatch mutex below so a concurrent Cancel can observe
 	// the activeRequests entry before the assistant message exists.
@@ -806,6 +822,11 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	var stepMessages []fantasy.Message
 	var shouldSummarize bool
 	sanitizedToolCalls := make(map[string]bool)
+	// Full names of tool calls that completed without error this turn.
+	// Written only from the streaming callbacks (which run sequentially)
+	// and read after Stream returns, where sendChannelReply uses it to
+	// tell whether the model already replied on the originating channel.
+	completedToolCalls := make(map[string]struct{})
 	// Don't send MaxOutputTokens if 0 — some providers (e.g. LM Studio) reject it
 	var maxOutputTokens *int64
 	if call.MaxOutputTokens > 0 {
@@ -988,6 +1009,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			if sanitizedToolCalls[result.ToolCallID] {
 				toolResult.Content = "Tool call failed: arguments were not valid JSON. Please check your tool call format and try again."
 				toolResult.IsError = true
+			}
+			if !toolResult.IsError && toolResult.Name != "" {
+				completedToolCalls[toolResult.Name] = struct{}{}
 			}
 			// Use parent ctx instead of genCtx to ensure the message is created
 			// even if the request is canceled mid-stream
@@ -1216,6 +1240,16 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			existing = append(existing, call)
 			a.messageQueue.Set(call.SessionID, existing)
 		}
+	}
+
+	// Route the finished turn's response back to the channel it came
+	// from, unless the turn was cut short for summarization with work
+	// still pending — the queued continuation carries the channel and
+	// replies when it actually finishes. Runs before the busy state is
+	// released so a follow-up push queued behind this turn cannot
+	// overtake its reply.
+	if currentAssistant != nil && (!shouldSummarize || len(currentAssistant.ToolCalls()) == 0) {
+		a.sendChannelReply(ctx, call, currentAssistant.Content().String(), completedToolCalls)
 	}
 
 	// Release active request before publishing the notification.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -84,6 +84,7 @@ type SessionAgentCall struct {
 	// session that may be busy) MUST set it; SessionID alone is
 	// ambiguous when concurrent turns share the same session.
 	RunID            string
+	Channel          string
 	Prompt           string
 	ProviderOptions  fantasy.ProviderOptions
 	Attachments      []message.Attachment
@@ -130,6 +131,22 @@ type SessionAgentCall struct {
 	// fantasy retries the stream transparently. Returning an error
 	// surfaces the original auth error without retry.
 	OnAuthRefresh func(ctx context.Context, err *fantasy.ProviderError) error
+}
+
+func filterToolsForChannel(agentTools []fantasy.AgentTool, channel string, states map[string]mcp.ClientInfo) []fantasy.AgentTool {
+	filtered := make([]fantasy.AgentTool, 0, len(agentTools))
+	for _, agentTool := range agentTools {
+		mcpTool, ok := agentTool.(interface{ MCP() string })
+		if !ok {
+			filtered = append(filtered, agentTool)
+			continue
+		}
+		state, found := states[mcpTool.MCP()]
+		if !found || !state.Channel || channel == mcpTool.MCP() {
+			filtered = append(filtered, agentTool)
+		}
+	}
+	return filtered
 }
 
 type SessionAgent interface {
@@ -657,7 +674,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	defer a.activeRequests.CompareAndDelete(call.SessionID, ac)
 
 	// Copy mutable fields under lock to avoid races with SetTools/SetModels.
-	agentTools := a.tools.Copy()
+	agentTools := filterToolsForChannel(a.tools.Copy(), call.Channel, mcp.GetStates())
 	largeModel := a.largeModel.Get()
 	systemPrompt := a.systemPrompt.Get()
 	promptPrefix := a.systemPromptPrefix.Get()
@@ -812,7 +829,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			}
 
 			// Use latest tools (updated by SetTools when MCP tools change).
-			prepared.Tools = a.tools.Copy()
+			prepared.Tools = filterToolsForChannel(a.tools.Copy(), call.Channel, mcp.GetStates())
 
 			// Drain queued follow-up prompts for this step. Calls covered
 			// by a cancel recorded while they sat in the queue are dropped:
@@ -872,6 +889,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 				return callContext, prepared, err
 			}
 			callContext = context.WithValue(callContext, tools.MessageIDContextKey, assistantMsg.ID)
+			callContext = context.WithValue(callContext, tools.ChannelContextKey, call.Channel)
 			callContext = context.WithValue(callContext, tools.SupportsImagesContextKey, largeModel.CatwalkCfg.SupportsImages)
 			callContext = context.WithValue(callContext, tools.ModelNameContextKey, largeModel.CatwalkCfg.Name)
 			currentAssistant = &assistantMsg

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -131,6 +131,12 @@ type SessionAgentCall struct {
 	// fantasy retries the stream transparently. Returning an error
 	// surfaces the original auth error without retry.
 	OnAuthRefresh func(ctx context.Context, err *fantasy.ProviderError) error
+	// channelMeta holds the attributes of the <channel> element a
+	// channel-originated turn was started with, parsed once at Run
+	// entry. It survives the auto-summarize continuation, whose Prompt
+	// is rewritten and no longer carries the element, so the reply
+	// target is not lost when a long channel turn is summarized.
+	channelMeta map[string]string
 }
 
 func filterToolsForChannel(agentTools []fantasy.AgentTool, channel string, states map[string]mcp.ClientInfo) []fantasy.AgentTool {
@@ -190,9 +196,13 @@ type sessionAgent struct {
 	systemPrompt       *csync.Value[string]
 	tools              *csync.Slice[fantasy.AgentTool]
 
-	isSubAgent           bool
-	sessions             session.Service
-	messages             message.Service
+	isSubAgent bool
+	sessions   session.Service
+	messages   message.Service
+	// cfg backs channel reply routing (config lookup + MCP tool
+	// invocation). Nil in tests and sub-agents that never see channel
+	// turns; sendChannelReply treats nil as "routing disabled".
+	cfg                  *config.ConfigStore
 	disableAutoSummarize bool
 	isYolo               bool
 	notify               pubsub.Publisher[notify.Notification]
@@ -249,6 +259,7 @@ type SessionAgentOptions struct {
 	IsYolo               bool
 	Sessions             session.Service
 	Messages             message.Service
+	Cfg                  *config.ConfigStore
 	Tools                []fantasy.AgentTool
 	Notify               pubsub.Publisher[notify.Notification]
 	RunComplete          pubsub.Publisher[notify.RunComplete]
@@ -265,6 +276,7 @@ func NewSessionAgent(
 		isSubAgent:           opts.IsSubAgent,
 		sessions:             opts.Sessions,
 		messages:             opts.Messages,
+		cfg:                  opts.Cfg,
 		disableAutoSummarize: opts.DisableAutoSummarize,
 		tools:                csync.NewSliceFrom(opts.Tools),
 		isYolo:               opts.IsYolo,
@@ -585,6 +597,10 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		return nil, err
 	}
 
+	if call.Channel != "" && call.channelMeta == nil {
+		call.channelMeta, _ = parseChannelMeta(call.Prompt)
+	}
+
 	// genCtx/cancel are the run context and its cancel func, created under
 	// the per-session dispatch mutex below so a concurrent Cancel can observe
 	// the activeRequests entry before the assistant message exists.
@@ -805,6 +821,11 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	var stepMessages []fantasy.Message
 	var shouldSummarize bool
 	sanitizedToolCalls := make(map[string]bool)
+	// Full names of tool calls that completed without error this turn.
+	// Written only from the streaming callbacks (which run sequentially)
+	// and read after Stream returns, where sendChannelReply uses it to
+	// tell whether the model already replied on the originating channel.
+	completedToolCalls := make(map[string]struct{})
 	// Don't send MaxOutputTokens if 0 — some providers (e.g. LM Studio) reject it
 	var maxOutputTokens *int64
 	if call.MaxOutputTokens > 0 {
@@ -987,6 +1008,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			if sanitizedToolCalls[result.ToolCallID] {
 				toolResult.Content = "Tool call failed: arguments were not valid JSON. Please check your tool call format and try again."
 				toolResult.IsError = true
+			}
+			if !toolResult.IsError && toolResult.Name != "" {
+				completedToolCalls[toolResult.Name] = struct{}{}
 			}
 			// Use parent ctx instead of genCtx to ensure the message is created
 			// even if the request is canceled mid-stream
@@ -1222,6 +1246,16 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			existing = append(existing, call)
 			a.messageQueue.Set(call.SessionID, existing)
 		}
+	}
+
+	// Route the finished turn's response back to the channel it came
+	// from, unless the turn was cut short for summarization with work
+	// still pending — the queued continuation carries the channel and
+	// replies when it actually finishes. Runs before the busy state is
+	// released so a follow-up push queued behind this turn cannot
+	// overtake its reply.
+	if currentAssistant != nil && (!shouldSummarize || len(currentAssistant.ToolCalls()) == 0) {
+		a.sendChannelReply(ctx, call, currentAssistant.Content().String(), completedToolCalls)
 	}
 
 	// Release active request before publishing the notification.

--- a/internal/agent/channel.go
+++ b/internal/agent/channel.go
@@ -1,0 +1,18 @@
+package agent
+
+import "context"
+
+type channelContextKey struct{}
+
+// WithChannel returns ctx tagged with the channel that originated the turn.
+func WithChannel(ctx context.Context, channel string) context.Context {
+	return context.WithValue(ctx, channelContextKey{}, channel)
+}
+
+// ChannelFromContext returns the originating channel, or an empty string for local turns.
+func ChannelFromContext(ctx context.Context) string {
+	if channel, ok := ctx.Value(channelContextKey{}).(string); ok {
+		return channel
+	}
+	return ""
+}

--- a/internal/agent/channel_test.go
+++ b/internal/agent/channel_test.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChannelContextIsScopedToTurn(t *testing.T) {
+	t.Parallel()
+	channelContext := WithChannel(context.Background(), "signal")
+	require.Equal(t, "signal", ChannelFromContext(channelContext))
+	require.Empty(t, ChannelFromContext(context.Background()))
+}
+
+func TestFilterToolsForChannel(t *testing.T) {
+	t.Parallel()
+	channelTool := &channelTestTool{name: "send", mcpName: "signal"}
+	plainTool := &fakeTool{name: "plain"}
+	states := map[string]mcp.ClientInfo{"signal": {Channel: true}}
+
+	local := filterToolsForChannel([]fantasy.AgentTool{channelTool, plainTool}, "", states)
+	require.Len(t, local, 1)
+	require.Equal(t, "plain", local[0].Info().Name)
+
+	matching := filterToolsForChannel([]fantasy.AgentTool{channelTool, plainTool}, "signal", states)
+	require.Len(t, matching, 2)
+}
+
+type channelTestTool struct {
+	name    string
+	mcpName string
+}
+
+func (t *channelTestTool) MCP() string {
+	return t.mcpName
+}
+
+func (t *channelTestTool) Info() fantasy.ToolInfo {
+	return fantasy.ToolInfo{Name: t.name}
+}
+
+func (*channelTestTool) Run(context.Context, fantasy.ToolCall) (fantasy.ToolResponse, error) {
+	return fantasy.NewTextResponse("ok"), nil
+}
+
+func (*channelTestTool) ProviderOptions() fantasy.ProviderOptions {
+	return nil
+}
+
+func (*channelTestTool) SetProviderOptions(fantasy.ProviderOptions) {}

--- a/internal/agent/channel_test.go
+++ b/internal/agent/channel_test.go
@@ -6,6 +6,8 @@ import (
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/db"
+	"github.com/charmbracelet/crush/internal/session"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,3 +54,45 @@ func (*channelTestTool) ProviderOptions() fantasy.ProviderOptions {
 }
 
 func (*channelTestTool) SetProviderOptions(fantasy.ProviderOptions) {}
+
+// TestSyncSessionChannelLifecycle covers the full lifecycle of the persisted
+// session-channel binding: a channel turn binds the session, a push from a
+// different channel rebinds it (newest wins), and a local turn clears it —
+// the reaping path for sessions the user takes over.
+func TestSyncSessionChannelLifecycle(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+	t.Cleanup(func() {
+		require.NoError(t, db.Release(dataDir))
+		db.ResetPool()
+	})
+
+	conn, err := db.Connect(t.Context(), dataDir)
+	require.NoError(t, err)
+	sessions := session.NewService(db.New(conn), conn)
+	c := &coordinator{sessions: sessions}
+
+	created, err := sessions.Create(t.Context(), "channel session")
+	require.NoError(t, err)
+
+	// A channel-originated turn binds the session to its channel.
+	c.syncSessionChannel(t.Context(), created.ID, "signal")
+	got, err := sessions.Get(t.Context(), created.ID)
+	require.NoError(t, err)
+	require.Equal(t, "signal", got.Channel)
+
+	// A push from another channel rebinds: the newest push wins.
+	c.syncSessionChannel(t.Context(), created.ID, "switchboard")
+	got, err = sessions.Get(t.Context(), created.ID)
+	require.NoError(t, err)
+	require.Equal(t, "switchboard", got.Channel)
+
+	// A local turn (no originating channel) clears the binding.
+	c.syncSessionChannel(t.Context(), created.ID, "")
+	got, err = sessions.Get(t.Context(), created.ID)
+	require.NoError(t, err)
+	require.Empty(t, got.Channel)
+
+	// A missing session is a no-op, not an error.
+	c.syncSessionChannel(t.Context(), "does-not-exist", "signal")
+}

--- a/internal/agent/channel_test.go
+++ b/internal/agent/channel_test.go
@@ -62,9 +62,10 @@ func (*channelTestTool) SetProviderOptions(fantasy.ProviderOptions) {}
 func TestSyncSessionChannelLifecycle(t *testing.T) {
 	t.Parallel()
 	dataDir := t.TempDir()
+	// Release only this test's pooled connection; a global db.ResetPool()
+	// here would close the databases of tests still running in parallel.
 	t.Cleanup(func() {
 		require.NoError(t, db.Release(dataDir))
-		db.ResetPool()
 	})
 
 	conn, err := db.Connect(t.Context(), dataDir)

--- a/internal/agent/channelreply.go
+++ b/internal/agent/channelreply.go
@@ -1,0 +1,156 @@
+package agent
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/config"
+)
+
+// channelReplyTimeout bounds the auto-reply tool call so a wedged MCP
+// server cannot hold the finished turn (and the session's busy state)
+// open indefinitely.
+const channelReplyTimeout = 30 * time.Second
+
+// Default meta attributes identifying the reply target for each route.
+// They match the channel contract used by messaging servers (e.g. Signal
+// MCP): "sender" carries the author of a direct push, "group" is present
+// only on group pushes.
+const (
+	defaultUserTargetMeta  = "sender"
+	defaultGroupTargetMeta = "group"
+	defaultMessageParam    = "message"
+)
+
+// parseChannelMeta extracts the attributes of the <channel> element a
+// channel-originated turn was started with. The prompt of such a turn is
+// exactly the element rendered by the MCP layer (renderChannel), so this
+// is the inverse of that rendering. Returns ok=false when the prompt does
+// not start with a <channel> element.
+func parseChannelMeta(prompt string) (map[string]string, bool) {
+	dec := xml.NewDecoder(strings.NewReader(prompt))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, false
+		}
+		switch t := tok.(type) {
+		case xml.CharData:
+			if strings.TrimSpace(string(t)) != "" {
+				return nil, false
+			}
+		case xml.StartElement:
+			if t.Name.Local != "channel" {
+				return nil, false
+			}
+			meta := make(map[string]string, len(t.Attr))
+			for _, attr := range t.Attr {
+				meta[attr.Name.Local] = attr.Value
+			}
+			return meta, true
+		default:
+			return nil, false
+		}
+	}
+}
+
+// resolveChannelReply picks the tool call that delivers a reply for a push
+// with the given meta. Group routes win over user routes when the push
+// carries the group target attribute, so a message received in a group is
+// answered in that group rather than as a DM to its author.
+func resolveChannelReply(reply *config.MCPChannelReply, meta map[string]string, text string) (tool string, args map[string]any, ok bool) {
+	msgParam := cmp.Or(reply.MessageParam, defaultMessageParam)
+	route := func(r *config.MCPChannelReplyRoute, defaultMeta string) (string, map[string]any, bool) {
+		if r == nil || r.Tool == "" || r.TargetParam == "" {
+			return "", nil, false
+		}
+		target := meta[cmp.Or(r.TargetMeta, defaultMeta)]
+		if target == "" {
+			return "", nil, false
+		}
+		return r.Tool, map[string]any{r.TargetParam: target, msgParam: text}, true
+	}
+	if tool, args, ok := route(reply.Group, defaultGroupTargetMeta); ok {
+		return tool, args, ok
+	}
+	return route(reply.User, defaultUserTargetMeta)
+}
+
+// channelReplyDelivered reports whether the model already delivered a reply
+// through the channel itself during the turn: completedTools holds the full
+// names (mcp_<server>_<tool>) of tool calls that finished without error, and
+// a call to either route tool or any configured suppress tool counts.
+func channelReplyDelivered(reply *config.MCPChannelReply, channel string, completedTools map[string]struct{}) bool {
+	names := make([]string, 0, 2+len(reply.SuppressTools))
+	if reply.User != nil {
+		names = append(names, reply.User.Tool)
+	}
+	if reply.Group != nil {
+		names = append(names, reply.Group.Tool)
+	}
+	names = append(names, reply.SuppressTools...)
+	for _, name := range names {
+		if name == "" {
+			continue
+		}
+		if _, ok := completedTools[fmt.Sprintf("mcp_%s_%s", channel, name)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// sendChannelReply routes the final assistant text of a channel-originated
+// turn back through the channel's configured reply tool. It is a no-op for
+// local turns, channels without a channel_reply config, empty responses,
+// and turns where the model already replied on the channel itself. Failures
+// are logged and dropped: the turn has finished and there is no caller to
+// return an error to.
+func (a *sessionAgent) sendChannelReply(ctx context.Context, call SessionAgentCall, text string, completedTools map[string]struct{}) {
+	if call.Channel == "" || a.cfg == nil {
+		return
+	}
+	mcpCfg, ok := a.cfg.Config().MCP[call.Channel]
+	if !ok || mcpCfg.ChannelReply == nil {
+		return
+	}
+	reply := mcpCfg.ChannelReply
+	if channelReplyDelivered(reply, call.Channel, completedTools) {
+		slog.Debug("Channel reply already delivered by the model", "channel", call.Channel)
+		return
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	if call.channelMeta == nil {
+		slog.Warn("Channel reply skipped: prompt has no channel metadata", "channel", call.Channel)
+		return
+	}
+	tool, args, ok := resolveChannelReply(reply, call.channelMeta, text)
+	if !ok {
+		slog.Warn("Channel reply skipped: no reply route matches the push metadata", "channel", call.Channel)
+		return
+	}
+	input, err := json.Marshal(args)
+	if err != nil {
+		slog.Error("Channel reply skipped: failed to encode tool arguments", "channel", call.Channel, "tool", tool, "error", err)
+		return
+	}
+	// Detach from the run context: the turn is complete, and a cancel
+	// racing this send must not lose the reply.
+	sendCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), channelReplyTimeout)
+	defer cancel()
+	if _, err := mcp.RunTool(sendCtx, a.cfg, call.Channel, tool, string(input)); err != nil {
+		slog.Error("Channel reply failed", "channel", call.Channel, "tool", tool, "error", err)
+		return
+	}
+	slog.Info("Routed reply to originating channel", "channel", call.Channel, "tool", tool)
+}

--- a/internal/agent/channelreply.go
+++ b/internal/agent/channelreply.go
@@ -29,6 +29,15 @@ const (
 	defaultMessageParam    = "message"
 )
 
+// targetMetaParams maps channel meta attributes to the tool parameter
+// names that typically carry the reply target. During auto-discovery,
+// each candidate tool's InputSchema is checked against these in priority
+// order.
+var targetMetaParams = map[string][]string{
+	"sender": {"user_id", "to", "recipient", "target", "phone", "number"},
+	"group":  {"group_id", "room", "channel", "conversation_id"},
+}
+
 // parseChannelMeta extracts the attributes of the <channel> element a
 // channel-originated turn was started with. The prompt of such a turn is
 // exactly the element rendered by the MCP layer (renderChannel), so this
@@ -107,22 +116,142 @@ func channelReplyDelivered(reply *config.MCPChannelReply, channel string, comple
 	return false
 }
 
+// discoverChannelReply scans the tool list of the MCP server named channel
+// and attempts to find tools that can serve as reply routes. It looks for
+// tools that:
+//   - Accept a "message" (string) parameter
+//   - AND accept a target parameter that matches a channel meta attribute
+//     (e.g. "user_id" for "sender", "group_id" for "group")
+//
+// Returns nil when no suitable tool is found, which is a no-op fallback
+// that preserves the current behaviour when the server has no obvious
+// send-capable tools.
+func discoverChannelReply(channel string) *config.MCPChannelReply {
+	for mcpName, tools := range mcp.Tools() {
+		if mcpName != channel {
+			continue
+		}
+		return discoverReplyFromTools(tools)
+	}
+	return nil
+}
+
+// discoverReplyFromTools scans a slice of MCP tools and builds a reply
+// config from any that look like message-sending tools. It is extracted
+// so tests can call it without setting up global MCP state.
+func discoverReplyFromTools(tools []*mcp.Tool) *config.MCPChannelReply {
+	const msgParam = "message"
+	var userTool, groupTool string
+	var userTargetParam, groupTargetParam string
+
+	for _, tool := range tools {
+		if tool.Name == "" {
+			continue
+		}
+		schema, ok := tool.InputSchema.(map[string]any)
+		if !ok {
+			continue
+		}
+		props, ok := schema["properties"].(map[string]any)
+		if !ok {
+			continue
+		}
+		// Check for a "message" parameter (string type).
+		msgProp, hasMsg := props[msgParam]
+		if !hasMsg {
+			continue
+		}
+		if msgMap, ok := msgProp.(map[string]any); !ok || msgMap["type"] != "string" {
+			continue
+		}
+
+		// Check for a target parameter matching any known meta attribute.
+		for meta, candidates := range targetMetaParams {
+			for _, candidate := range candidates {
+				prop, hasTarget := props[candidate]
+				if !hasTarget {
+					continue
+				}
+				if propMap, ok := prop.(map[string]any); ok && propMap["type"] == "string" {
+					switch meta {
+					case "sender":
+						if userTool == "" {
+							userTool = tool.Name
+							userTargetParam = candidate
+						}
+					case "group":
+						if groupTool == "" {
+							groupTool = tool.Name
+							groupTargetParam = candidate
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Build the reply config from what we found.
+	reply := &config.MCPChannelReply{
+		MessageParam: msgParam,
+	}
+	if userTool != "" {
+		reply.User = &config.MCPChannelReplyRoute{
+			Tool:        userTool,
+			TargetParam: userTargetParam,
+		}
+	}
+	if groupTool != "" {
+		reply.Group = &config.MCPChannelReplyRoute{
+			Tool:        groupTool,
+			TargetParam: groupTargetParam,
+		}
+	}
+	if reply.User == nil && reply.Group == nil {
+		return nil
+	}
+	return reply
+}
+
+// autoReplyDelivered reports whether the model already delivered a reply
+// through a discovered auto-route tool during the turn. It checks the
+// discovered reply's tools plus any additional suppress tools.
+func autoReplyDelivered(reply *config.MCPChannelReply, channel string, completedTools map[string]struct{}) bool {
+	if reply == nil {
+		return false
+	}
+	return channelReplyDelivered(reply, channel, completedTools)
+}
+
 // sendChannelReply routes the final assistant text of a channel-originated
 // turn back through the channel's configured reply tool. It is a no-op for
 // local turns, channels without a channel_reply config, empty responses,
 // and turns where the model already replied on the channel itself. Failures
 // are logged and dropped: the turn has finished and there is no caller to
 // return an error to.
+//
+// When the channel has no explicit channel_reply config, sendChannelReply
+// falls back to auto-discovering the reply tools from the MCP server's tool
+// list. This allows channels like Signal MCP to work without manual
+// channel_reply configuration.
 func (a *sessionAgent) sendChannelReply(ctx context.Context, call SessionAgentCall, text string, completedTools map[string]struct{}) {
 	if call.Channel == "" || a.cfg == nil {
 		return
 	}
 	mcpCfg, ok := a.cfg.Config().MCP[call.Channel]
-	if !ok || mcpCfg.ChannelReply == nil {
+	if !ok {
 		return
 	}
+
+	// Use the explicit config when available, otherwise auto-discover.
 	reply := mcpCfg.ChannelReply
-	if channelReplyDelivered(reply, call.Channel, completedTools) {
+	if reply == nil {
+		reply = discoverChannelReply(call.Channel)
+		if reply == nil {
+			return
+		}
+	}
+
+	if autoReplyDelivered(reply, call.Channel, completedTools) {
 		slog.Debug("Channel reply already delivered by the model", "channel", call.Channel)
 		return
 	}

--- a/internal/agent/channelreply_test.go
+++ b/internal/agent/channelreply_test.go
@@ -1,0 +1,143 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseChannelMeta(t *testing.T) {
+	t.Parallel()
+
+	t.Run("channel element with attributes", func(t *testing.T) {
+		t.Parallel()
+		meta, ok := parseChannelMeta(`<channel source="signal" sender="+15551234567" sender_name="Joe">Hello?</channel>`)
+		require.True(t, ok)
+		require.Equal(t, map[string]string{
+			"source":      "signal",
+			"sender":      "+15551234567",
+			"sender_name": "Joe",
+		}, meta)
+	})
+
+	t.Run("escaped attribute values", func(t *testing.T) {
+		t.Parallel()
+		meta, ok := parseChannelMeta(`<channel source="signal" sender_name="A &amp; B">hi</channel>`)
+		require.True(t, ok)
+		require.Equal(t, "A & B", meta["sender_name"])
+	})
+
+	t.Run("leading whitespace tolerated", func(t *testing.T) {
+		t.Parallel()
+		meta, ok := parseChannelMeta("\n  <channel source=\"signal\" sender=\"+1\">x</channel>")
+		require.True(t, ok)
+		require.Equal(t, "+1", meta["sender"])
+	})
+
+	t.Run("plain prompt is not a channel push", func(t *testing.T) {
+		t.Parallel()
+		_, ok := parseChannelMeta("fix the login flow")
+		require.False(t, ok)
+	})
+
+	t.Run("other element is not a channel push", func(t *testing.T) {
+		t.Parallel()
+		_, ok := parseChannelMeta(`<task source="signal">x</task>`)
+		require.False(t, ok)
+	})
+
+	t.Run("empty prompt", func(t *testing.T) {
+		t.Parallel()
+		_, ok := parseChannelMeta("")
+		require.False(t, ok)
+	})
+}
+
+func signalChannelReply() *config.MCPChannelReply {
+	return &config.MCPChannelReply{
+		User:  &config.MCPChannelReplyRoute{Tool: "send_message_to_user", TargetParam: "user_id"},
+		Group: &config.MCPChannelReplyRoute{Tool: "send_message_to_group", TargetParam: "group_id"},
+	}
+}
+
+func TestResolveChannelReply(t *testing.T) {
+	t.Parallel()
+
+	t.Run("direct message routes to the sender", func(t *testing.T) {
+		t.Parallel()
+		tool, args, ok := resolveChannelReply(signalChannelReply(), map[string]string{"sender": "+15551234567"}, "hi")
+		require.True(t, ok)
+		require.Equal(t, "send_message_to_user", tool)
+		require.Equal(t, map[string]any{"user_id": "+15551234567", "message": "hi"}, args)
+	})
+
+	t.Run("group message routes to the group even with a sender", func(t *testing.T) {
+		t.Parallel()
+		meta := map[string]string{"sender": "+15551234567", "group": "grp=="}
+		tool, args, ok := resolveChannelReply(signalChannelReply(), meta, "hi")
+		require.True(t, ok)
+		require.Equal(t, "send_message_to_group", tool)
+		require.Equal(t, map[string]any{"group_id": "grp==", "message": "hi"}, args)
+	})
+
+	t.Run("custom target meta and message param", func(t *testing.T) {
+		t.Parallel()
+		reply := &config.MCPChannelReply{
+			MessageParam: "text",
+			User:         &config.MCPChannelReplyRoute{Tool: "post", TargetParam: "to", TargetMeta: "author"},
+		}
+		tool, args, ok := resolveChannelReply(reply, map[string]string{"author": "joe"}, "yo")
+		require.True(t, ok)
+		require.Equal(t, "post", tool)
+		require.Equal(t, map[string]any{"to": "joe", "text": "yo"}, args)
+	})
+
+	t.Run("no matching meta yields no route", func(t *testing.T) {
+		t.Parallel()
+		_, _, ok := resolveChannelReply(signalChannelReply(), map[string]string{"source": "signal"}, "hi")
+		require.False(t, ok)
+	})
+
+	t.Run("group push without a group route falls back to user", func(t *testing.T) {
+		t.Parallel()
+		reply := &config.MCPChannelReply{
+			User: &config.MCPChannelReplyRoute{Tool: "send_message_to_user", TargetParam: "user_id"},
+		}
+		meta := map[string]string{"sender": "+15551234567", "group": "grp=="}
+		tool, _, ok := resolveChannelReply(reply, meta, "hi")
+		require.True(t, ok)
+		require.Equal(t, "send_message_to_user", tool)
+	})
+
+	t.Run("incomplete route is skipped", func(t *testing.T) {
+		t.Parallel()
+		reply := &config.MCPChannelReply{
+			User: &config.MCPChannelReplyRoute{Tool: "send_message_to_user"}, // no target_param
+		}
+		_, _, ok := resolveChannelReply(reply, map[string]string{"sender": "+1"}, "hi")
+		require.False(t, ok)
+	})
+}
+
+func TestChannelReplyDelivered(t *testing.T) {
+	t.Parallel()
+	reply := signalChannelReply()
+	reply.SuppressTools = []string{"send"}
+
+	completed := func(names ...string) map[string]struct{} {
+		set := make(map[string]struct{}, len(names))
+		for _, n := range names {
+			set[n] = struct{}{}
+		}
+		return set
+	}
+
+	require.True(t, channelReplyDelivered(reply, "signal", completed("mcp_signal_send_message_to_user")))
+	require.True(t, channelReplyDelivered(reply, "signal", completed("mcp_signal_send_message_to_group")))
+	require.True(t, channelReplyDelivered(reply, "signal", completed("mcp_signal_send")))
+	require.False(t, channelReplyDelivered(reply, "signal", completed("mcp_signal_mark_read", "bash")))
+	// A same-named tool on a different server does not count as a reply.
+	require.False(t, channelReplyDelivered(reply, "signal", completed("mcp_other_send_message_to_user")))
+	require.False(t, channelReplyDelivered(reply, "signal", completed()))
+}

--- a/internal/agent/channelreply_test.go
+++ b/internal/agent/channelreply_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"testing"
 
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/stretchr/testify/require"
 )
@@ -140,4 +141,261 @@ func TestChannelReplyDelivered(t *testing.T) {
 	// A same-named tool on a different server does not count as a reply.
 	require.False(t, channelReplyDelivered(reply, "signal", completed("mcp_other_send_message_to_user")))
 	require.False(t, channelReplyDelivered(reply, "signal", completed()))
+}
+
+// signalTools returns a mock tool list resembling a Signal MCP server.
+func signalTools() []*mcp.Tool {
+	return []*mcp.Tool{
+		{
+			Name: "send_message_to_user",
+			InputSchema: map[string]any{
+				"properties": map[string]any{
+					"message": map[string]any{"type": "string"},
+					"user_id": map[string]any{"type": "string"},
+				},
+			},
+		},
+		{
+			Name: "send_message_to_group",
+			InputSchema: map[string]any{
+				"properties": map[string]any{
+					"message":  map[string]any{"type": "string"},
+					"group_id": map[string]any{"type": "string"},
+				},
+			},
+		},
+		{
+			Name: "mark_read",
+			InputSchema: map[string]any{
+				"properties": map[string]any{
+					"sender":           map[string]any{"type": "string"},
+					"target_timestamp": map[string]any{"type": "integer"},
+				},
+			},
+		},
+	}
+}
+
+func TestDiscoverReplyFromTools(t *testing.T) {
+	t.Parallel()
+
+	t.Run("signal server discovers user and group routes", func(t *testing.T) {
+		t.Parallel()
+		reply := discoverReplyFromTools(signalTools())
+		require.NotNil(t, reply)
+		require.NotNil(t, reply.User)
+		require.Equal(t, "send_message_to_user", reply.User.Tool)
+		require.Equal(t, "user_id", reply.User.TargetParam)
+		require.NotNil(t, reply.Group)
+		require.Equal(t, "send_message_to_group", reply.Group.Tool)
+		require.Equal(t, "group_id", reply.Group.TargetParam)
+		require.Equal(t, "message", reply.MessageParam)
+	})
+
+	t.Run("only user tool available", func(t *testing.T) {
+		t.Parallel()
+		tools := []*mcp.Tool{
+			{
+				Name: "send_message",
+				InputSchema: map[string]any{
+					"properties": map[string]any{
+						"message": map[string]any{"type": "string"},
+						"user_id": map[string]any{"type": "string"},
+					},
+				},
+			},
+		}
+		reply := discoverReplyFromTools(tools)
+		require.NotNil(t, reply)
+		require.NotNil(t, reply.User)
+		require.Equal(t, "send_message", reply.User.Tool)
+		require.Nil(t, reply.Group)
+	})
+
+	t.Run("no message param skips tool", func(t *testing.T) {
+		t.Parallel()
+		tools := []*mcp.Tool{
+			{
+				Name: "echo",
+				InputSchema: map[string]any{
+					"properties": map[string]any{
+						"text": map[string]any{"type": "string"},
+					},
+				},
+			},
+		}
+		reply := discoverReplyFromTools(tools)
+		require.Nil(t, reply)
+	})
+
+	t.Run("no target param skips tool", func(t *testing.T) {
+		t.Parallel()
+		tools := []*mcp.Tool{
+			{
+				Name: "log",
+				InputSchema: map[string]any{
+					"properties": map[string]any{
+						"message": map[string]any{"type": "string"},
+						"level":   map[string]any{"type": "string"},
+					},
+				},
+			},
+		}
+		reply := discoverReplyFromTools(tools)
+		require.Nil(t, reply)
+	})
+
+	t.Run("empty tool list", func(t *testing.T) {
+		t.Parallel()
+		reply := discoverReplyFromTools(nil)
+		require.Nil(t, reply)
+	})
+
+	t.Run("resolves user via 'to' param", func(t *testing.T) {
+		t.Parallel()
+		tools := []*mcp.Tool{
+			{
+				Name: "dm",
+				InputSchema: map[string]any{
+					"properties": map[string]any{
+						"message": map[string]any{"type": "string"},
+						"to":      map[string]any{"type": "string"},
+					},
+				},
+			},
+		}
+		reply := discoverReplyFromTools(tools)
+		require.NotNil(t, reply)
+		require.NotNil(t, reply.User)
+		require.Equal(t, "dm", reply.User.Tool)
+		require.Equal(t, "to", reply.User.TargetParam)
+	})
+
+	t.Run("resolves group via 'room' param", func(t *testing.T) {
+		t.Parallel()
+		tools := []*mcp.Tool{
+			{
+				Name: "room_msg",
+				InputSchema: map[string]any{
+					"properties": map[string]any{
+						"message": map[string]any{"type": "string"},
+						"room":    map[string]any{"type": "string"},
+					},
+				},
+			},
+		}
+		reply := discoverReplyFromTools(tools)
+		require.NotNil(t, reply)
+		require.NotNil(t, reply.Group)
+		require.Equal(t, "room_msg", reply.Group.Tool)
+		require.Equal(t, "room", reply.Group.TargetParam)
+	})
+
+	t.Run("explicit channel_reply config takes precedence", func(t *testing.T) {
+		t.Parallel()
+		// Verify that the auto-discovered reply matches expectations
+		// when an explicit config is also available. The config-driven
+		// path is tested in TestResolveChannelReply.
+		reply := discoverReplyFromTools(signalTools())
+		require.NotNil(t, reply)
+
+		// Resolve a DM push via the auto-discovered route.
+		tool, args, ok := resolveChannelReply(reply, map[string]string{"sender": "+15551234567"}, "hello")
+		require.True(t, ok)
+		require.Equal(t, "send_message_to_user", tool)
+		require.Equal(t, map[string]any{"user_id": "+15551234567", "message": "hello"}, args)
+
+		// Resolve a group push via the auto-discovered route.
+		meta := map[string]string{"sender": "+15551234567", "group": "grp=="}
+		tool, args, ok = resolveChannelReply(reply, meta, "hello group")
+		require.True(t, ok)
+		require.Equal(t, "send_message_to_group", tool)
+		require.Equal(t, map[string]any{"group_id": "grp==", "message": "hello group"}, args)
+	})
+}
+
+func TestDiscoverReplyFromTools_DeliveredCheck(t *testing.T) {
+	t.Parallel()
+	reply := discoverReplyFromTools(signalTools())
+	require.NotNil(t, reply)
+
+	completed := func(names ...string) map[string]struct{} {
+		set := make(map[string]struct{}, len(names))
+		for _, n := range names {
+			set[n] = struct{}{}
+		}
+		return set
+	}
+
+	// The model called the discovered tool — counts as delivered.
+	require.True(t, autoReplyDelivered(reply, "signal", completed("mcp_signal_send_message_to_user")))
+	require.True(t, autoReplyDelivered(reply, "signal", completed("mcp_signal_send_message_to_group")))
+	// A different tool does not count.
+	require.False(t, autoReplyDelivered(reply, "signal", completed("mcp_signal_mark_read")))
+	// Empty set.
+	require.False(t, autoReplyDelivered(reply, "signal", completed()))
+	// Nil reply.
+	require.False(t, autoReplyDelivered(nil, "signal", completed("mcp_signal_send")))
+}
+
+func TestDiscoverReplyFromTools_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil input schema", func(t *testing.T) {
+		t.Parallel()
+		tools := []*mcp.Tool{
+			{
+				Name:        "send",
+				InputSchema: nil,
+			},
+		}
+		reply := discoverReplyFromTools(tools)
+		require.Nil(t, reply)
+	})
+
+	t.Run("empty input schema", func(t *testing.T) {
+		t.Parallel()
+		tools := []*mcp.Tool{
+			{
+				Name:        "send",
+				InputSchema: map[string]any{},
+			},
+		}
+		reply := discoverReplyFromTools(tools)
+		require.Nil(t, reply)
+	})
+
+	t.Run("message param is not string type", func(t *testing.T) {
+		t.Parallel()
+		tools := []*mcp.Tool{
+			{
+				Name: "send",
+				InputSchema: map[string]any{
+					"properties": map[string]any{
+						"message": map[string]any{"type": "integer"},
+						"user_id": map[string]any{"type": "string"},
+					},
+				},
+			},
+		}
+		reply := discoverReplyFromTools(tools)
+		require.Nil(t, reply)
+	})
+
+	t.Run("tool with no name is skipped", func(t *testing.T) {
+		t.Parallel()
+		tools := []*mcp.Tool{
+			{
+				Name: "",
+				InputSchema: map[string]any{
+					"properties": map[string]any{
+						"message": map[string]any{"type": "string"},
+						"user_id": map[string]any{"type": "string"},
+					},
+				},
+			},
+		}
+		reply := discoverReplyFromTools(tools)
+		require.Nil(t, reply)
+	})
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -286,6 +286,7 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 		return c.currentAgent.Run(ctx, SessionAgentCall{
 			SessionID:        sessionID,
 			RunID:            runID,
+			Channel:          ChannelFromContext(ctx),
 			Prompt:           prompt,
 			Attachments:      attachments,
 			MaxOutputTokens:  maxTokens,

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -626,6 +626,7 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		IsYolo:               c.permissions.SkipRequests(),
 		Sessions:             c.sessions,
 		Messages:             c.messages,
+		Cfg:                  c.cfg,
 		Tools:                nil,
 		Notify:               c.notify,
 		RunComplete:          c.runComplete,

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -282,11 +282,13 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 	// the coalesce closure publishes the final outcome under that
 	// same correlator.
 	runID := RunIDFromContext(ctx)
+	channel := ChannelFromContext(ctx)
+	c.syncSessionChannel(ctx, sessionID, channel)
 	run := func() (*fantasy.AgentResult, error) {
 		return c.currentAgent.Run(ctx, SessionAgentCall{
 			SessionID:        sessionID,
 			RunID:            runID,
-			Channel:          ChannelFromContext(ctx),
+			Channel:          channel,
 			Prompt:           prompt,
 			Attachments:      attachments,
 			MaxOutputTokens:  maxTokens,
@@ -323,6 +325,33 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 		MarkRunCompletePublished(ctx)
 	}
 	return result, originalErr
+}
+
+// syncSessionChannel reconciles the session's persisted channel binding with
+// the origin of the turn about to run. A channel-originated turn (re)binds
+// the session to that channel — the newest push wins — and a local turn
+// clears a stale binding, since the session is no longer channel-driven once
+// the user takes it over directly. This is the binding's whole lifecycle:
+// it is only ever a reflection of the most recent turn's origin, and the
+// column is dropped with the session row when the session is deleted, so
+// there is no separate state to reap.
+//
+// Failures are logged and the turn proceeds: the binding is provenance for
+// reply routing, not a precondition for running.
+func (c *coordinator) syncSessionChannel(ctx context.Context, sessionID, channel string) {
+	sess, err := c.sessions.Get(ctx, sessionID)
+	if err != nil {
+		// The session may not exist yet (e.g. it is created later in the
+		// run); there is no binding to reconcile.
+		return
+	}
+	if sess.Channel == channel {
+		return
+	}
+	if _, err := c.sessions.SetChannel(ctx, sessionID, channel); err != nil {
+		slog.Warn("Failed to sync session channel binding",
+			"session", sessionID, "channel", channel, "error", err)
+	}
 }
 
 // effectiveReasoningEffort returns the reasoning effort to apply for provider calls.

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -295,11 +295,13 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 	// the coalesce closure publishes the final outcome under that
 	// same correlator.
 	runID := RunIDFromContext(ctx)
+	channel := ChannelFromContext(ctx)
+	c.syncSessionChannel(ctx, sessionID, channel)
 	run := func() (*fantasy.AgentResult, error) {
 		return c.currentAgent.Run(ctx, SessionAgentCall{
 			SessionID:        sessionID,
 			RunID:            runID,
-			Channel:          ChannelFromContext(ctx),
+			Channel:          channel,
 			Prompt:           prompt,
 			Attachments:      attachments,
 			MaxOutputTokens:  maxTokens,
@@ -338,6 +340,33 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 		MarkRunCompletePublished(ctx)
 	}
 	return result, originalErr
+}
+
+// syncSessionChannel reconciles the session's persisted channel binding with
+// the origin of the turn about to run. A channel-originated turn (re)binds
+// the session to that channel — the newest push wins — and a local turn
+// clears a stale binding, since the session is no longer channel-driven once
+// the user takes it over directly. This is the binding's whole lifecycle:
+// it is only ever a reflection of the most recent turn's origin, and the
+// column is dropped with the session row when the session is deleted, so
+// there is no separate state to reap.
+//
+// Failures are logged and the turn proceeds: the binding is provenance for
+// reply routing, not a precondition for running.
+func (c *coordinator) syncSessionChannel(ctx context.Context, sessionID, channel string) {
+	sess, err := c.sessions.Get(ctx, sessionID)
+	if err != nil {
+		// The session may not exist yet (e.g. it is created later in the
+		// run); there is no binding to reconcile.
+		return
+	}
+	if sess.Channel == channel {
+		return
+	}
+	if _, err := c.sessions.SetChannel(ctx, sessionID, channel); err != nil {
+		slog.Warn("Failed to sync session channel binding",
+			"session", sessionID, "channel", channel, "error", err)
+	}
 }
 
 // effectiveReasoningEffort returns the reasoning effort to apply for provider calls.

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -299,6 +299,7 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 		return c.currentAgent.Run(ctx, SessionAgentCall{
 			SessionID:        sessionID,
 			RunID:            runID,
+			Channel:          ChannelFromContext(ctx),
 			Prompt:           prompt,
 			Attachments:      attachments,
 			MaxOutputTokens:  maxTokens,

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -641,6 +641,7 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		IsYolo:               c.permissions.SkipRequests(),
 		Sessions:             c.sessions,
 		Messages:             c.messages,
+		Cfg:                  c.cfg,
 		Tools:                nil,
 		Notify:               c.notify,
 		RunComplete:          c.runComplete,

--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -101,6 +101,9 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 	if sessionID == "" {
 		return fantasy.ToolResponse{}, fmt.Errorf("session ID is required for creating a new file")
 	}
+	if state, ok := mcp.GetState(m.mcpName); ok && state.Channel && GetChannelFromContext(ctx) != m.mcpName {
+		return fantasy.NewTextErrorResponse("This channel tool is only available for messages from its originating channel."), nil
+	}
 
 	// Skip permission for whitelisted Docker MCP tools.
 	if !slices.Contains(whitelistDockerTools, params.Name) {

--- a/internal/agent/tools/mcp/channel.go
+++ b/internal/agent/tools/mcp/channel.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -175,6 +176,16 @@ func ChannelEnabled(enabled []string, name string) bool {
 		}
 	}
 	return false
+}
+
+// ChannelOptIn reports whether server `name` should be treated as a channel,
+// considering both enablement sources: persistently via crush.json
+// (m.ChannelEnabled) or per-launch via the --channels overrides list. Every
+// site that gates channel behaviour — session creation, session renewal, and
+// message routing — must use this so the two sources are always ORed together
+// and no site drifts out of sync.
+func ChannelOptIn(m config.MCPConfig, enabled []string, name string) bool {
+	return m.ChannelEnabled || ChannelEnabled(enabled, name)
 }
 
 // publishChannelMessage validates and renders a payload, then publishes it as

--- a/internal/agent/tools/mcp/channel.go
+++ b/internal/agent/tools/mcp/channel.go
@@ -158,11 +158,13 @@ func hasChannelCapability(res *mcp.InitializeResult) bool {
 	return ok
 }
 
-// channelEnabled reports whether the given server name was opted in via the
-// --channels flag. A server present in MCP config is not a channel until it is
-// explicitly enabled, matching the "listed is not enabled" model. Entries may
-// be written as "server:<name>" or as a bare "<name>".
-func channelEnabled(enabled []string, name string) bool {
+// ChannelEnabled reports whether the given server name was opted in via the
+// --channels flag. A server present in MCP config is not a channel until it
+// is explicitly enabled, matching the "listed is not enabled" model. Entries
+// may be written as "server:<name>" or as a bare "<name>". Exported for the
+// server backend, which routes channel events per workspace and needs the
+// same opt-in semantics.
+func ChannelEnabled(enabled []string, name string) bool {
 	for _, e := range enabled {
 		e = strings.TrimSpace(e)
 		if e == name {

--- a/internal/agent/tools/mcp/channel.go
+++ b/internal/agent/tools/mcp/channel.go
@@ -191,6 +191,7 @@ func publishChannelMessage(ctx context.Context, name string, raw json.RawMessage
 	broker.PublishMustDeliver(ctx, pubsub.CreatedEvent, Event{
 		Type:           EventChannelMessage,
 		Name:           name,
+		ChannelMeta:    p.Meta,
 		ChannelMessage: renderChannel(name, p),
 	})
 }

--- a/internal/agent/tools/mcp/channel_integration_test.go
+++ b/internal/agent/tools/mcp/channel_integration_test.go
@@ -82,7 +82,7 @@ func TestChannelEndToEnd(t *testing.T) {
 	if !hasChannelCapability(session.InitializeResult()) {
 		t.Fatal("expected claude/channel capability to be detected from the handshake")
 	}
-	if channelEnabled([]string{"chan"}, "chan") && hasChannelCapability(session.InitializeResult()) {
+	if ChannelEnabled([]string{"chan"}, "chan") && hasChannelCapability(session.InitializeResult()) {
 		buffered := gate.resolve(true)
 		for _, raw := range buffered {
 			publishChannelMessage(ctx, "chan", raw)

--- a/internal/agent/tools/mcp/channel_test.go
+++ b/internal/agent/tools/mcp/channel_test.go
@@ -14,6 +14,27 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+func TestPublishChannelMessagePreservesMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	events := SubscribeEvents(ctx)
+	publishChannelMessage("signal", json.RawMessage(`{"content":"hello","meta":{"sender":"123"}}`))
+
+	select {
+	case event := <-events:
+		if event.Payload.Name != "signal" {
+			t.Fatalf("name = %q, want signal", event.Payload.Name)
+		}
+		if event.Payload.ChannelMeta["sender"] != "123" {
+			t.Fatalf("meta = %v", event.Payload.ChannelMeta)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for channel event")
+	}
+}
+
 func TestParseChannelParams(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/tools/mcp/channel_test.go
+++ b/internal/agent/tools/mcp/channel_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -325,6 +326,33 @@ func TestChannelEnabled(t *testing.T) {
 		if got := ChannelEnabled(tt.enabled, tt.name); got != tt.want {
 			t.Errorf("ChannelEnabled(%v, %q) = %v, want %v", tt.enabled, tt.name, got, tt.want)
 		}
+	}
+}
+
+func TestChannelOptIn(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		cfgEnabled bool
+		overrides  []string
+		server     string
+		want       bool
+	}{
+		{"neither source", false, nil, "webhook", false},
+		{"config only", true, nil, "webhook", true},
+		{"override only", false, []string{"webhook"}, "webhook", true},
+		{"both sources", true, []string{"webhook"}, "webhook", true},
+		{"override for a different server", false, []string{"other"}, "webhook", false},
+		{"config-enabled with unrelated override", true, []string{"server:other"}, "webhook", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := config.MCPConfig{ChannelEnabled: tt.cfgEnabled}
+			if got := ChannelOptIn(m, tt.overrides, tt.server); got != tt.want {
+				t.Errorf("ChannelOptIn(%+v, %v, %q) = %v, want %v", m, tt.overrides, tt.server, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/agent/tools/mcp/channel_test.go
+++ b/internal/agent/tools/mcp/channel_test.go
@@ -275,8 +275,8 @@ func TestChannelEnabled(t *testing.T) {
 		{[]string{"SERVER:webhook"}, "webhook", true},
 	}
 	for _, tt := range tests {
-		if got := channelEnabled(tt.enabled, tt.name); got != tt.want {
-			t.Errorf("channelEnabled(%v, %q) = %v, want %v", tt.enabled, tt.name, got, tt.want)
+		if got := ChannelEnabled(tt.enabled, tt.name); got != tt.want {
+			t.Errorf("ChannelEnabled(%v, %q) = %v, want %v", tt.enabled, tt.name, got, tt.want)
 		}
 	}
 }

--- a/internal/agent/tools/mcp/channel_test.go
+++ b/internal/agent/tools/mcp/channel_test.go
@@ -19,8 +19,8 @@ func TestPublishChannelMessagePreservesMetadata(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	events := SubscribeEvents(ctx)
-	publishChannelMessage("signal", json.RawMessage(`{"content":"hello","meta":{"sender":"123"}}`))
+	events := SubscribeChannelEvents(ctx)
+	publishChannelMessage(ctx, "signal", json.RawMessage(`{"content":"hello","meta":{"sender":"123"}}`))
 
 	select {
 	case event := <-events:

--- a/internal/agent/tools/mcp/channel_test.go
+++ b/internal/agent/tools/mcp/channel_test.go
@@ -260,6 +260,32 @@ func TestRenderChannelDeterministicMetaOrder(t *testing.T) {
 	}
 }
 
+func TestUpdateStatePropagatesChannel(t *testing.T) {
+	const name = "test-channel-propagation"
+	t.Cleanup(func() { states.Del(name) })
+
+	updateState(name, StateConnected, nil, &ClientSession{channel: true}, Counts{Tools: 1})
+	info, ok := GetState(name)
+	if !ok {
+		t.Fatal("expected state to be recorded")
+	}
+	if !info.Channel {
+		t.Error("ClientInfo.Channel should reflect the session's channel flag")
+	}
+
+	// A non-channel session must not report as a channel.
+	updateState(name, StateConnected, nil, &ClientSession{channel: false}, Counts{})
+	if info, _ := GetState(name); info.Channel {
+		t.Error("non-channel session must not report Channel=true")
+	}
+
+	// A nil client (e.g. error/disabled state) must not panic or report a channel.
+	updateState(name, StateError, nil, nil, Counts{})
+	if info, _ := GetState(name); info.Channel {
+		t.Error("nil client must not report Channel=true")
+	}
+}
+
 func TestChannelEnabled(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -54,7 +54,8 @@ type ClientSession struct {
 	cancel       context.CancelFunc
 	oauthHandler *mcpoauth.Handler
 	// channel reports whether this server is an active channel (it declared
-	// the claude/channel capability and was opted in via --channels).
+	// the claude/channel capability and was opted in via --channels or
+	// channel_enabled in config).
 	channel bool
 }
 
@@ -185,7 +186,8 @@ type ClientInfo struct {
 	Counts      Counts
 	ConnectedAt time.Time
 	// Channel reports whether this server is an active channel (declared the
-	// claude/channel capability and opted in via --channels).
+	// claude/channel capability and opted in via --channels or
+	// channel_enabled in config).
 	Channel bool
 }
 
@@ -383,7 +385,7 @@ func AuthenticateMCP(ctx context.Context, cfg *config.ConfigStore, name string) 
 
 	// The OAuth handler persists the token automatically as it is
 	// exchanged, so a successful connection has already saved it.
-	_, err := connectAndRegister(ctx, cfg, name, m, cfg.Resolver(), ChannelEnabled(cfg.Overrides().EnabledChannels, name))
+	_, err := connectAndRegister(ctx, cfg, name, m, cfg.Resolver(), ChannelOptIn(m, cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		return err
 	}
@@ -442,7 +444,7 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 	}
 
 	updateState(name, StateStarting, nil, nil, Counts{})
-	_, err := connectAndRegister(ctx, cfg, name, m, resolver, ChannelEnabled(cfg.Overrides().EnabledChannels, name))
+	_, err := connectAndRegister(ctx, cfg, name, m, resolver, ChannelOptIn(m, cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		// If an OAuth MCP fails because the saved token is no longer
 		// valid (e.g. refresh token expired or revoked) or no token
@@ -561,7 +563,7 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	// resources from the registry.
 	updateState(name, StateError, maybeTimeoutErr(pingErr, timeout), nil, state.Counts)
 
-	newSess, err := newSession(ctx, cfg, name, m, cfg.Resolver(), ChannelEnabled(cfg.Overrides().EnabledChannels, name))
+	newSess, err := newSession(ctx, cfg, name, m, cfg.Resolver(), ChannelOptIn(m, cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		clearMCPData(name)
 		// If an OAuth MCP fails to reconnect because the token is no
@@ -745,8 +747,9 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 	slog.Debug("MCP client initialized", "name", name)
 
 	// Resolve the channel gate: open only for a server that both declares
-	// the claude/channel capability and was opted in via --channels.
-	// Otherwise close it (fail closed). Resolving drains buffered messages
+	// the claude/channel capability and was opted in — via --channels or
+	// channel_enabled in config. Merely listing a server under mcp is not
+	// enough. Otherwise close the gate (fail closed). Resolving drains buffered messages
 	// that arrived during negotiation so a fast server does not lose early
 	// events.
 	isChannel := channelOptIn && hasChannelCapability(session.InitializeResult())

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -53,6 +53,9 @@ type ClientSession struct {
 	*mcp.ClientSession
 	cancel       context.CancelFunc
 	oauthHandler *mcpoauth.Handler
+	// channel reports whether this server is an active channel (it declared
+	// the claude/channel capability and was opted in via --channels).
+	channel bool
 }
 
 // Close cancels the session context and then closes the underlying session.
@@ -180,6 +183,9 @@ type ClientInfo struct {
 	Client      *ClientSession
 	Counts      Counts
 	ConnectedAt time.Time
+	// Channel reports whether this server is an active channel (declared the
+	// claude/channel capability and opted in via --channels).
+	Channel bool
 }
 
 // SubscribeEvents returns a channel for MCP events.
@@ -601,11 +607,12 @@ func closeSession(name string, s *ClientSession) {
 // updateState updates the state of an MCP client and publishes an event
 func updateState(name string, state State, err error, client *ClientSession, counts Counts) {
 	info := ClientInfo{
-		Name:   name,
-		State:  state,
-		Error:  err,
-		Client: client,
-		Counts: counts,
+		Name:    name,
+		State:   state,
+		Error:   err,
+		Client:  client,
+		Counts:  counts,
+		Channel: client != nil && client.channel,
 	}
 	switch state {
 	case StateConnected:
@@ -714,7 +721,8 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 	// Otherwise close it (fail closed). Resolving drains buffered messages
 	// that arrived during negotiation so a fast server does not lose early
 	// events.
-	if channelOptIn && hasChannelCapability(session.InitializeResult()) {
+	isChannel := channelOptIn && hasChannelCapability(session.InitializeResult())
+	if isChannel {
 		buffered := channelGate.resolve(true)
 		for _, raw := range buffered {
 			publishChannelMessage(mcpCtx, name, raw)
@@ -728,6 +736,7 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 		ClientSession: session,
 		cancel:        cancel,
 		oauthHandler:  oauthHandler,
+		channel:       isChannel,
 	}, nil
 }
 

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -166,6 +166,7 @@ type Event struct {
 	// ChannelMessage is set only for EventChannelMessage: the fully rendered
 	// and escaped <channel>...</channel> element to inject into the session.
 	ChannelMessage string
+	ChannelMeta    map[string]string
 }
 
 // Counts number of available tools, prompts, etc.

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -349,7 +349,7 @@ func AuthenticateMCP(ctx context.Context, cfg *config.ConfigStore, name string) 
 
 	// The OAuth handler persists the token automatically as it is
 	// exchanged, so a successful connection has already saved it.
-	_, err := connectAndRegister(ctx, cfg, name, m, cfg.Resolver(), channelEnabled(cfg.Overrides().EnabledChannels, name))
+	_, err := connectAndRegister(ctx, cfg, name, m, cfg.Resolver(), ChannelEnabled(cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		return err
 	}
@@ -408,7 +408,7 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 	}
 
 	updateState(name, StateStarting, nil, nil, Counts{})
-	_, err := connectAndRegister(ctx, cfg, name, m, resolver, channelEnabled(cfg.Overrides().EnabledChannels, name))
+	_, err := connectAndRegister(ctx, cfg, name, m, resolver, ChannelEnabled(cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		// If an OAuth MCP fails because the saved token is no longer
 		// valid (e.g. refresh token expired or revoked) or no token
@@ -527,7 +527,7 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	// resources from the registry.
 	updateState(name, StateError, maybeTimeoutErr(pingErr, timeout), nil, state.Counts)
 
-	newSess, err := newSession(ctx, cfg, name, m, cfg.Resolver(), channelEnabled(cfg.Overrides().EnabledChannels, name))
+	newSess, err := newSession(ctx, cfg, name, m, cfg.Resolver(), ChannelEnabled(cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		clearMCPData(name)
 		// If an OAuth MCP fails to reconnect because the token is no

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -194,9 +194,10 @@ type ClientInfo struct {
 // Channel message events (EventChannelMessage) are excluded: they carry no
 // workspace or session identity, and the MCP broker is process-global. Without
 // this filter, every workspace that calls SubscribeEvents would receive every
-// other workspace's channel events — a cross-workspace injection path. Channel
-// delivery requires workspace-scoped routing, which is deferred to a later PR;
-// until then, channel events must not flow through the shared event fan-out.
+// other workspace's channel events — a cross-workspace injection path.
+// Consumers that deliver channel messages use SubscribeChannelEvents and are
+// responsible for scoping each event to the workspaces that declared and
+// opted in the originating server.
 func SubscribeEvents(ctx context.Context) <-chan pubsub.Event[Event] {
 	raw := broker.Subscribe(ctx)
 	filtered := make(chan pubsub.Event[Event], 64)
@@ -214,6 +215,32 @@ func SubscribeEvents(ctx context.Context) <-chan pubsub.Event[Event] {
 		}
 	}()
 	return filtered
+}
+
+// SubscribeChannelEvents returns a channel carrying only channel message
+// events (EventChannelMessage). The MCP broker is process-global, so these
+// events are not scoped to any workspace: every consumer must check that the
+// originating server is declared in the target workspace's MCP config and
+// opted in (ChannelEnabled) before delivering, otherwise one workspace's
+// channel messages leak into another — the injection path SubscribeEvents
+// filters out.
+func SubscribeChannelEvents(ctx context.Context) <-chan pubsub.Event[Event] {
+	raw := broker.Subscribe(ctx)
+	channelOnly := make(chan pubsub.Event[Event], 64)
+	go func() {
+		defer close(channelOnly)
+		for ev := range raw {
+			if ev.Payload.Type != EventChannelMessage {
+				continue
+			}
+			select {
+			case channelOnly <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return channelOnly
 }
 
 // GetStates returns the current state of all MCP clients

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -239,9 +239,10 @@ type ClientInfo struct {
 // Channel message events (EventChannelMessage) are excluded: they carry no
 // workspace or session identity, and the MCP broker is process-global. Without
 // this filter, every workspace that calls SubscribeEvents would receive every
-// other workspace's channel events — a cross-workspace injection path. Channel
-// delivery requires workspace-scoped routing, which is deferred to a later PR;
-// until then, channel events must not flow through the shared event fan-out.
+// other workspace's channel events — a cross-workspace injection path.
+// Consumers that deliver channel messages use SubscribeChannelEvents and are
+// responsible for scoping each event to the workspaces that declared and
+// opted in the originating server.
 func SubscribeEvents(ctx context.Context) <-chan pubsub.Event[Event] {
 	raw := broker.Subscribe(ctx)
 	filtered := make(chan pubsub.Event[Event], 64)
@@ -259,6 +260,32 @@ func SubscribeEvents(ctx context.Context) <-chan pubsub.Event[Event] {
 		}
 	}()
 	return filtered
+}
+
+// SubscribeChannelEvents returns a channel carrying only channel message
+// events (EventChannelMessage). The MCP broker is process-global, so these
+// events are not scoped to any workspace: every consumer must check that the
+// originating server is declared in the target workspace's MCP config and
+// opted in (ChannelEnabled) before delivering, otherwise one workspace's
+// channel messages leak into another — the injection path SubscribeEvents
+// filters out.
+func SubscribeChannelEvents(ctx context.Context) <-chan pubsub.Event[Event] {
+	raw := broker.Subscribe(ctx)
+	channelOnly := make(chan pubsub.Event[Event], 64)
+	go func() {
+		defer close(channelOnly)
+		for ev := range raw {
+			if ev.Payload.Type != EventChannelMessage {
+				continue
+			}
+			select {
+			case channelOnly <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return channelOnly
 }
 
 // GetStates returns the current state of all MCP clients

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -53,6 +53,9 @@ type ClientSession struct {
 	*mcp.ClientSession
 	cancel       context.CancelFunc
 	oauthHandler *mcpoauth.Handler
+	// channel reports whether this server is an active channel (it declared
+	// the claude/channel capability and was opted in via --channels).
+	channel bool
 }
 
 // Close cancels the session context and then closes the underlying session.
@@ -224,6 +227,10 @@ type ClientInfo struct {
 	// progress rather than the last successful one, which would leave the
 	// server skipped as "starting" and never restarted for the new config.
 	PendingConfig *config.MCPConfig
+
+	// Channel reports whether this server is an active channel (declared the
+	// claude/channel capability and opted in via --channels).
+	Channel bool
 }
 
 // SubscribeEvents returns a channel for MCP events.
@@ -511,7 +518,7 @@ func BeginAuth(cfg *config.ConfigStore, name string) (finish func(ctx context.Co
 // suppression enabled on the freshly created handler.
 func runAuthFlow(ctx context.Context, cfg *config.ConfigStore, name string, m config.MCPConfig) error {
 	updateState(name, StateStarting, nil, nil, Counts{}, withPending(m))
-	_, err := connectAndRegister(ctx, cfg, name, m, currentGen(name), cfg.Resolver(), channelEnabled(cfg.Overrides().EnabledChannels, name))
+	_, err := connectAndRegister(ctx, cfg, name, m, currentGen(name), cfg.Resolver(), ChannelEnabled(cfg.Overrides().EnabledChannels, name))
 	return err
 }
 
@@ -835,29 +842,6 @@ func closeSession(name string, s *ClientSession) {
 	}
 }
 
-// stateOpt mutates the ClientInfo a transition is about to publish. Config
-// recording is opt-in: only the sites that actually own a config (the connect
-// and starting paths) pass one, so the many error and count-refresh call sites
-// can't accidentally clobber the recorded config by passing a zero value.
-type stateOpt func(*ClientInfo)
-
-// withConfig records the config now in effect. Used on StateConnected.
-func withConfig(m config.MCPConfig) stateOpt {
-	return func(i *ClientInfo) {
-		i.Config = m
-		i.PendingConfig = nil
-	}
-}
-
-// withPending records the config an in-flight attempt is connecting with.
-// Used on StateStarting.
-func withPending(m config.MCPConfig) stateOpt {
-	return func(i *ClientInfo) {
-		mc := m
-		i.PendingConfig = &mc
-	}
-}
-
 // updateState updates the state of an MCP client and publishes an event.
 //
 // Config bookkeeping is split between the caller and the state machine:
@@ -875,6 +859,7 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 	info.Error = err
 	info.Client = client
 	info.Counts = counts
+	info.Channel = client != nil && client.channel
 	for _, opt := range opts {
 		opt(&info)
 	}
@@ -1021,7 +1006,8 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 	// Otherwise close it (fail closed). Resolving drains buffered messages
 	// that arrived during negotiation so a fast server does not lose early
 	// events.
-	if channelOptIn && hasChannelCapability(session.InitializeResult()) {
+	isChannel := channelOptIn && hasChannelCapability(session.InitializeResult())
+	if isChannel {
 		buffered := channelGate.resolve(true)
 		for _, raw := range buffered {
 			publishChannelMessage(mcpCtx, name, raw)
@@ -1035,6 +1021,7 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 		ClientSession: session,
 		cancel:        cancel,
 		oauthHandler:  oauthHandler,
+		channel:       isChannel,
 	}, nil
 }
 

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -418,7 +418,7 @@ func AuthenticateMCP(ctx context.Context, cfg *config.ConfigStore, name string) 
 
 	// The OAuth handler persists the token automatically as it is
 	// exchanged, so a successful connection has already saved it.
-	_, err := connectAndRegister(ctx, cfg, name, m, currentGen(name), cfg.Resolver(), channelEnabled(cfg.Overrides().EnabledChannels, name))
+	_, err := connectAndRegister(ctx, cfg, name, m, currentGen(name), cfg.Resolver(), ChannelEnabled(cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		return err
 	}
@@ -547,7 +547,7 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 	}
 
 	updateState(name, StateStarting, nil, nil, Counts{}, withPending(m))
-	_, err := connectAndRegister(ctx, cfg, name, m, gen, resolver, channelEnabled(cfg.Overrides().EnabledChannels, name))
+	_, err := connectAndRegister(ctx, cfg, name, m, gen, resolver, ChannelEnabled(cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		// If an OAuth MCP fails because the saved token is no longer
 		// valid (e.g. refresh token expired or revoked) or no token
@@ -748,7 +748,7 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	// Capture the generation so a reconcile teardown that lands mid-renewal
 	// invalidates this rebuild instead of letting it clobber the newer one.
 	gen := currentGen(name)
-	newSess, err := newSession(ctx, cfg, name, m, cfg.Resolver(), channelEnabled(cfg.Overrides().EnabledChannels, name))
+	newSess, err := newSession(ctx, cfg, name, m, cfg.Resolver(), ChannelEnabled(cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		clearMCPData(name)
 		// If an OAuth MCP fails to reconnect because the token is no

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -54,7 +54,8 @@ type ClientSession struct {
 	cancel       context.CancelFunc
 	oauthHandler *mcpoauth.Handler
 	// channel reports whether this server is an active channel (it declared
-	// the claude/channel capability and was opted in via --channels).
+	// the claude/channel capability and was opted in via --channels or
+	// channel_enabled in config).
 	channel bool
 }
 
@@ -230,7 +231,8 @@ type ClientInfo struct {
 	PendingConfig *config.MCPConfig
 
 	// Channel reports whether this server is an active channel (declared the
-	// claude/channel capability and opted in via --channels).
+	// claude/channel capability and opted in via --channels or
+	// channel_enabled in config).
 	Channel bool
 }
 
@@ -453,7 +455,7 @@ func AuthenticateMCP(ctx context.Context, cfg *config.ConfigStore, name string) 
 
 	// The OAuth handler persists the token automatically as it is
 	// exchanged, so a successful connection has already saved it.
-	_, err := connectAndRegister(ctx, cfg, name, m, currentGen(name), cfg.Resolver(), ChannelEnabled(cfg.Overrides().EnabledChannels, name))
+	_, err := connectAndRegister(ctx, cfg, name, m, currentGen(name), cfg.Resolver(), ChannelOptIn(m, cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		return err
 	}
@@ -546,7 +548,7 @@ func BeginAuth(cfg *config.ConfigStore, name string) (finish func(ctx context.Co
 // suppression enabled on the freshly created handler.
 func runAuthFlow(ctx context.Context, cfg *config.ConfigStore, name string, m config.MCPConfig) error {
 	updateState(name, StateStarting, nil, nil, Counts{}, withPending(m))
-	_, err := connectAndRegister(ctx, cfg, name, m, currentGen(name), cfg.Resolver(), ChannelEnabled(cfg.Overrides().EnabledChannels, name))
+	_, err := connectAndRegister(ctx, cfg, name, m, currentGen(name), cfg.Resolver(), ChannelOptIn(m, cfg.Overrides().EnabledChannels, name))
 	return err
 }
 
@@ -582,7 +584,7 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 	}
 
 	updateState(name, StateStarting, nil, nil, Counts{}, withPending(m))
-	_, err := connectAndRegister(ctx, cfg, name, m, gen, resolver, ChannelEnabled(cfg.Overrides().EnabledChannels, name))
+	_, err := connectAndRegister(ctx, cfg, name, m, gen, resolver, ChannelOptIn(m, cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		// If an OAuth MCP fails because the saved token is no longer
 		// valid (e.g. refresh token expired or revoked) or no token
@@ -783,7 +785,7 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	// Capture the generation so a reconcile teardown that lands mid-renewal
 	// invalidates this rebuild instead of letting it clobber the newer one.
 	gen := currentGen(name)
-	newSess, err := newSession(ctx, cfg, name, m, cfg.Resolver(), ChannelEnabled(cfg.Overrides().EnabledChannels, name))
+	newSess, err := newSession(ctx, cfg, name, m, cfg.Resolver(), ChannelOptIn(m, cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		clearMCPData(name)
 		// If an OAuth MCP fails to reconnect because the token is no
@@ -1053,8 +1055,9 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 	slog.Debug("MCP client initialized", "name", name)
 
 	// Resolve the channel gate: open only for a server that both declares
-	// the claude/channel capability and was opted in via --channels.
-	// Otherwise close it (fail closed). Resolving drains buffered messages
+	// the claude/channel capability and was opted in — via --channels or
+	// channel_enabled in config. Merely listing a server under mcp is not
+	// enough. Otherwise close the gate (fail closed). Resolving drains buffered messages
 	// that arrived during negotiation so a fast server does not lose early
 	// events.
 	isChannel := channelOptIn && hasChannelCapability(session.InitializeResult())

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -196,6 +196,7 @@ type Event struct {
 	// ChannelMessage is set only for EventChannelMessage: the fully rendered
 	// and escaped <channel>...</channel> element to inject into the session.
 	ChannelMessage string
+	ChannelMeta    map[string]string
 }
 
 // Counts number of available tools, prompts, etc.
@@ -839,6 +840,29 @@ func closeSession(name string, s *ClientSession) {
 		!errors.Is(err, context.Canceled) &&
 		err.Error() != "signal: killed" {
 		slog.Warn("Error closing MCP session", "name", name, "error", err)
+	}
+}
+
+// stateOpt mutates the ClientInfo a transition is about to publish. Config
+// recording is opt-in: only the sites that actually own a config (the connect
+// and starting paths) pass one, so the many error and count-refresh call sites
+// can't accidentally clobber the recorded config by passing a zero value.
+type stateOpt func(*ClientInfo)
+
+// withConfig records the config now in effect. Used on StateConnected.
+func withConfig(m config.MCPConfig) stateOpt {
+	return func(i *ClientInfo) {
+		i.Config = m
+		i.PendingConfig = nil
+	}
+}
+
+// withPending records the config an in-flight attempt is connecting with.
+// Used on StateStarting.
+func withPending(m config.MCPConfig) stateOpt {
+	return func(i *ClientInfo) {
+		mc := m
+		i.PendingConfig = &mc
 	}
 }
 

--- a/internal/agent/tools/mcp/init_test.go
+++ b/internal/agent/tools/mcp/init_test.go
@@ -731,7 +731,8 @@ func TestMCPConfigEqualExhaustive(t *testing.T) {
 
 	// Fields intentionally excluded from the comparison.
 	excluded := map[string]bool{
-		"OAuthToken": true, // internally managed, refreshed out-of-band.
+		"OAuthToken":   true, // internally managed, refreshed out-of-band.
+		"ChannelReply": true, // read live from config at reply time, not baked into the session.
 	}
 
 	typ := reflect.TypeOf(config.MCPConfig{})

--- a/internal/agent/tools/mcp/lifecycle.go
+++ b/internal/agent/tools/mcp/lifecycle.go
@@ -184,7 +184,8 @@ func mcpConfigEqual(a, b config.MCPConfig) bool {
 		a.OAuth == b.OAuth &&
 		a.OAuthClientID == b.OAuthClientID &&
 		a.OAuthClientSecret == b.OAuthClientSecret &&
-		a.OAuthCallbackPort == b.OAuthCallbackPort
+		a.OAuthCallbackPort == b.OAuthCallbackPort &&
+		a.ChannelEnabled == b.ChannelEnabled
 }
 
 // boolPtrEqual compares two *bool by value, treating two nils as equal.

--- a/internal/agent/tools/tools.go
+++ b/internal/agent/tools/tools.go
@@ -15,6 +15,7 @@ type (
 	messageIDContextKey string
 	supportsImagesKey   string
 	modelNameKey        string
+	channelContextKey   string
 )
 
 const (
@@ -26,6 +27,8 @@ const (
 	SupportsImagesContextKey supportsImagesKey = "supports_images"
 	// ModelNameContextKey is the key for the model name in the context.
 	ModelNameContextKey modelNameKey = "model_name"
+	// ChannelContextKey is the key for the channel that originated the turn.
+	ChannelContextKey channelContextKey = "channel"
 )
 
 // getContextValue is a generic helper that retrieves a typed value from context.
@@ -44,6 +47,11 @@ func getContextValue[T any](ctx context.Context, key any, defaultValue T) T {
 // GetSessionFromContext retrieves the session ID from the context.
 func GetSessionFromContext(ctx context.Context) string {
 	return getContextValue(ctx, SessionIDContextKey, "")
+}
+
+// GetChannelFromContext retrieves the channel that originated the current turn.
+func GetChannelFromContext(ctx context.Context) string {
+	return getContextValue(ctx, ChannelContextKey, "")
 }
 
 // GetMessageFromContext retrieves the message ID from the context.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -580,10 +580,11 @@ func (app *App) subscribeScopedChannelEvents(ctx context.Context) <-chan pubsub.
 	go func() {
 		defer close(scoped)
 		for ev := range raw {
-			if _, declared := app.config.Config().MCP[ev.Payload.Name]; !declared {
+			mcpCfg, declared := app.config.Config().MCP[ev.Payload.Name]
+			if !declared {
 				continue
 			}
-			if !mcp.ChannelEnabled(app.config.Overrides().EnabledChannels, ev.Payload.Name) {
+			if !mcp.ChannelOptIn(mcpCfg, app.config.Overrides().EnabledChannels, ev.Payload.Name) {
 				continue
 			}
 			select {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -553,6 +553,7 @@ func (app *App) setupEvents() {
 	setupSubscriber(ctx, app.serviceEventsWG, "agent-notifications", app.agentNotifications.Subscribe, app.events)
 	setupSubscriberMustDeliver(ctx, app.serviceEventsWG, "run-completions", app.runCompletions.Subscribe, app.events)
 	setupSubscriber(ctx, app.serviceEventsWG, "mcp", mcp.SubscribeEvents, app.events)
+	setupSubscriber(ctx, app.serviceEventsWG, "mcp-channels", app.subscribeScopedChannelEvents, app.events)
 	setupSubscriber(ctx, app.serviceEventsWG, "lsp", SubscribeLSPEvents, app.events)
 	if app.Skills != nil {
 		setupSubscriber(ctx, app.serviceEventsWG, "skills", app.Skills.SubscribeEvents, app.events)
@@ -564,6 +565,35 @@ func (app *App) setupEvents() {
 		return nil
 	}
 	app.cleanupFuncs = append(app.cleanupFuncs, cleanupFunc)
+}
+
+// subscribeScopedChannelEvents forwards channel message events for servers
+// this workspace both declares in its MCP config and opted in via --channels.
+// The MCP broker is process-global and channel events carry no workspace
+// identity, so this per-app scoping is what keeps another workspace's channel
+// messages out of this app's event stream (see mcp.SubscribeChannelEvents).
+// The scoped events feed the TUI's in-process injection and, in server mode,
+// the SSE stream to attached clients.
+func (app *App) subscribeScopedChannelEvents(ctx context.Context) <-chan pubsub.Event[mcp.Event] {
+	raw := mcp.SubscribeChannelEvents(ctx)
+	scoped := make(chan pubsub.Event[mcp.Event], 64)
+	go func() {
+		defer close(scoped)
+		for ev := range raw {
+			if _, declared := app.config.Config().MCP[ev.Payload.Name]; !declared {
+				continue
+			}
+			if !mcp.ChannelEnabled(app.config.Overrides().EnabledChannels, ev.Payload.Name) {
+				continue
+			}
+			select {
+			case scoped <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return scoped
 }
 
 func setupSubscriber[T any](

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -625,10 +625,11 @@ func (app *App) subscribeScopedChannelEvents(ctx context.Context) <-chan pubsub.
 	go func() {
 		defer close(scoped)
 		for ev := range raw {
-			if _, declared := app.config.Config().MCP[ev.Payload.Name]; !declared {
+			mcpCfg, declared := app.config.Config().MCP[ev.Payload.Name]
+			if !declared {
 				continue
 			}
-			if !mcp.ChannelEnabled(app.config.Overrides().EnabledChannels, ev.Payload.Name) {
+			if !mcp.ChannelOptIn(mcpCfg, app.config.Overrides().EnabledChannels, ev.Payload.Name) {
 				continue
 			}
 			select {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -598,6 +598,7 @@ func (app *App) setupEvents() {
 	setupSubscriber(ctx, app.serviceEventsWG, "agent-notifications", app.agentNotifications.Subscribe, app.events)
 	setupSubscriberMustDeliver(ctx, app.serviceEventsWG, "run-completions", app.runCompletions.Subscribe, app.events)
 	setupSubscriber(ctx, app.serviceEventsWG, "mcp", mcp.SubscribeEvents, app.events)
+	setupSubscriber(ctx, app.serviceEventsWG, "mcp-channels", app.subscribeScopedChannelEvents, app.events)
 	setupSubscriber(ctx, app.serviceEventsWG, "lsp", SubscribeLSPEvents, app.events)
 	if app.Skills != nil {
 		setupSubscriber(ctx, app.serviceEventsWG, "skills", app.Skills.SubscribeEvents, app.events)
@@ -609,6 +610,35 @@ func (app *App) setupEvents() {
 		return nil
 	}
 	app.cleanupFuncs = append(app.cleanupFuncs, cleanupFunc)
+}
+
+// subscribeScopedChannelEvents forwards channel message events for servers
+// this workspace both declares in its MCP config and opted in via --channels.
+// The MCP broker is process-global and channel events carry no workspace
+// identity, so this per-app scoping is what keeps another workspace's channel
+// messages out of this app's event stream (see mcp.SubscribeChannelEvents).
+// The scoped events feed the TUI's in-process injection and, in server mode,
+// the SSE stream to attached clients.
+func (app *App) subscribeScopedChannelEvents(ctx context.Context) <-chan pubsub.Event[mcp.Event] {
+	raw := mcp.SubscribeChannelEvents(ctx)
+	scoped := make(chan pubsub.Event[mcp.Event], 64)
+	go func() {
+		defer close(scoped)
+		for ev := range raw {
+			if _, declared := app.config.Config().MCP[ev.Payload.Name]; !declared {
+				continue
+			}
+			if !mcp.ChannelEnabled(app.config.Overrides().EnabledChannels, ev.Payload.Name) {
+				continue
+			}
+			select {
+			case scoped <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return scoped
 }
 
 func setupSubscriber[T any](

--- a/internal/app/resolve_session_test.go
+++ b/internal/app/resolve_session_test.go
@@ -60,6 +60,10 @@ func (m *mockSessionService) Save(_ context.Context, s session.Session) (session
 	return s, nil
 }
 
+func (m *mockSessionService) SetChannel(_ context.Context, sessionID, channel string) (session.Session, error) {
+	return session.Session{ID: sessionID, Channel: channel}, nil
+}
+
 func (m *mockSessionService) UpdateTitleAndUsage(context.Context, string, string, int64, int64, float64) error {
 	return nil
 }

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -94,6 +94,9 @@ func (b *Backend) runAgent(ws *Workspace, msg proto.AgentMessage, accept *agent.
 	}
 	ctx = agent.WithRunCompleteMarker(ctx)
 
+	if msg.Channel != "" {
+		ctx = agent.WithChannel(ctx, msg.Channel)
+	}
 	_, err := ws.AgentCoordinator.RunAccepted(ctx, accept, msg.SessionID, msg.Prompt, proto.AttachmentsToMessage(msg.Attachments)...)
 	if err == nil || errors.Is(err, context.Canceled) {
 		return

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -215,9 +215,11 @@ func (w *Workspace) Shutdown() {
 	}
 }
 
-// New creates a new [Backend].
+// New creates a new [Backend]. The returned backend routes MCP channel
+// events into hosted workspaces for its lifetime (until ctx is
+// canceled); see [Backend.startChannelRouter].
 func New(ctx context.Context, cfg *config.ConfigStore, shutdownFn ShutdownFunc) *Backend {
-	return &Backend{
+	b := &Backend{
 		workspaces:  csync.NewMap[string, *Workspace](),
 		pathIndex:   make(map[string]string),
 		cfg:         cfg,
@@ -226,6 +228,8 @@ func New(ctx context.Context, cfg *config.ConfigStore, shutdownFn ShutdownFunc) 
 		createGrace: DefaultCreateGrace,
 		lingerDelay: idleShutdownDelayFromEnv(),
 	}
+	b.startChannelRouter()
+	return b
 }
 
 // idleShutdownDelayFromEnv returns the idle-shutdown delay, honoring a

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -256,9 +256,11 @@ func (w *Workspace) Shutdown() {
 	}
 }
 
-// New creates a new [Backend].
+// New creates a new [Backend]. The returned backend routes MCP channel
+// events into hosted workspaces for its lifetime (until ctx is
+// canceled); see [Backend.startChannelRouter].
 func New(ctx context.Context, cfg *config.ConfigStore, shutdownFn ShutdownFunc) *Backend {
-	return &Backend{
+	b := &Backend{
 		workspaces:  csync.NewMap[string, *Workspace](),
 		pathIndex:   make(map[string]string),
 		retired:     make(map[string]struct{}),
@@ -269,6 +271,8 @@ func New(ctx context.Context, cfg *config.ConfigStore, shutdownFn ShutdownFunc) 
 		lingerDelay: idleShutdownDelayFromEnv(),
 		detachGrace: durationFromEnv("CRUSH_SERVER_DETACH_GRACE", DefaultDetachGrace),
 	}
+	b.startChannelRouter()
+	return b
 }
 
 // idleShutdownDelayFromEnv returns the idle-shutdown delay, honoring a

--- a/internal/backend/channels.go
+++ b/internal/backend/channels.go
@@ -1,0 +1,164 @@
+package backend
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+
+	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/proto"
+	"github.com/charmbracelet/crush/internal/session"
+)
+
+// channelSessionStore is the slice of session.Service the channel router
+// needs to pick or create a target session. Narrowed so tests can fake it
+// without implementing the full service.
+type channelSessionStore interface {
+	Create(ctx context.Context, title string) (session.Session, error)
+	Get(ctx context.Context, id string) (session.Session, error)
+	List(ctx context.Context) ([]session.Session, error)
+}
+
+// startChannelRouter subscribes to MCP events for the backend's lifetime
+// and injects each channel push into exactly one session per opted-in
+// workspace. In client/server mode the server owns channel routing:
+// frontends do not inject (see workspace.ClientWorkspace.RoutesChannelEvents),
+// so a push is processed once no matter how many clients are attached —
+// including zero, which keeps the "a pushed event is never dropped"
+// contract for a headless `crush serve`.
+//
+// Events are processed sequentially on one goroutine, so pushes keep
+// their arrival order and the init/inject sequence per event does not
+// race with itself.
+func (b *Backend) startChannelRouter() {
+	events := mcptools.SubscribeEvents(b.ctx)
+	go func() {
+		for ev := range events {
+			if ev.Payload.Type != mcptools.EventChannelMessage || ev.Payload.ChannelMessage == "" {
+				continue
+			}
+			b.routeChannelMessage(ev.Payload)
+		}
+	}()
+}
+
+// routeChannelMessage delivers one channel push to every hosted workspace
+// that both declares the originating MCP server in its config and opted it
+// in via --channels. The MCP event broker is process-global, so the
+// config check is what scopes a push to the workspace(s) that actually
+// enabled the channel.
+func (b *Backend) routeChannelMessage(ev mcptools.Event) {
+	for _, ws := range b.workspaces.Seq2() {
+		cfg := ws.Cfg.Config()
+		if _, declared := cfg.MCP[ev.Name]; !declared {
+			continue
+		}
+		if !mcptools.ChannelEnabled(ws.Cfg.Overrides().EnabledChannels, ev.Name) {
+			continue
+		}
+		b.injectChannelMessage(ws, ev.Name, ev.ChannelMessage)
+	}
+}
+
+// injectChannelMessage runs one rendered <channel> element as an agent
+// turn in ws. The coder agent is initialized on demand so a headless
+// server (where no client has called InitCoderAgent yet) can still
+// process pushes. Failures are logged and the push is dropped for this
+// workspace; there is no caller to return an error to.
+func (b *Backend) injectChannelMessage(ws *Workspace, serverName, content string) {
+	if ws.AgentCoordinator == nil {
+		if err := ws.InitCoderAgent(ws.ctx); err != nil {
+			slog.Warn("Channel message dropped: coder agent init failed",
+				"workspace", ws.ID, "server", serverName, "error", err)
+			return
+		}
+	}
+	sessionID, err := channelTargetSession(ws.ctx, ws.viewedSessions(), ws.Sessions)
+	if err != nil {
+		slog.Warn("Channel message dropped: no target session",
+			"workspace", ws.ID, "server", serverName, "error", err)
+		return
+	}
+	if err := b.SendMessage(ws.ID, proto.AgentMessage{
+		SessionID: sessionID,
+		Prompt:    content,
+	}); err != nil {
+		slog.Warn("Channel message dropped: dispatch failed",
+			"workspace", ws.ID, "server", serverName, "session", sessionID, "error", err)
+	}
+}
+
+// channelTargetSession picks the session a channel push should land in,
+// mirroring the in-process TUI semantics ("route into the session you
+// have open; start one if none is open") as closely as a multi-client
+// server can:
+//
+//   - exactly one session is being viewed by attached clients: use it;
+//   - several distinct sessions are viewed: use the most recently
+//     updated of them (ties broken by smallest ID for determinism);
+//   - none viewed (all clients on the landing screen, or no clients):
+//     use the most recently updated top-level session so repeated
+//     pushes coalesce into one conversation, creating a session only
+//     when the workspace has none.
+func channelTargetSession(ctx context.Context, viewed []string, sessions channelSessionStore) (string, error) {
+	switch len(viewed) {
+	case 0:
+		existing, err := sessions.List(ctx)
+		if err != nil {
+			return "", err
+		}
+		if len(existing) > 0 {
+			return existing[0].ID, nil
+		}
+		sess, err := sessions.Create(ctx, "New Session")
+		if err != nil {
+			return "", err
+		}
+		return sess.ID, nil
+	case 1:
+		return viewed[0], nil
+	}
+
+	best := ""
+	var bestUpdated int64 = -1
+	for _, id := range viewed {
+		sess, err := sessions.Get(ctx, id)
+		if err != nil {
+			// A viewed session that cannot be loaded (e.g. deleted
+			// while still selected client-side) is skipped rather
+			// than failing the whole push.
+			continue
+		}
+		if sess.UpdatedAt > bestUpdated || (sess.UpdatedAt == bestUpdated && sess.ID < best) {
+			best = sess.ID
+			bestUpdated = sess.UpdatedAt
+		}
+	}
+	if best != "" {
+		return best, nil
+	}
+	// Every viewed session failed to load; fall back to the no-viewed
+	// path.
+	return channelTargetSession(ctx, nil, sessions)
+}
+
+// viewedSessions returns the distinct sessions currently being viewed by
+// clients with at least one live SSE stream, sorted for determinism.
+// Hold-only clients and clients on the landing screen do not contribute.
+func (w *Workspace) viewedSessions() []string {
+	w.clientsMu.Lock()
+	set := make(map[string]struct{})
+	for _, cs := range w.clients {
+		if cs.streams > 0 && cs.currentSessionID != "" {
+			set[cs.currentSessionID] = struct{}{}
+		}
+	}
+	w.clientsMu.Unlock()
+
+	out := make([]string, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/backend/channels.go
+++ b/internal/backend/channels.go
@@ -81,6 +81,7 @@ func (b *Backend) injectChannelMessage(ws *Workspace, serverName, content string
 	}
 	if err := b.SendMessage(ws.ID, proto.AgentMessage{
 		SessionID: sessionID,
+		Channel:   serverName,
 		Prompt:    content,
 	}); err != nil {
 		slog.Warn("Channel message dropped: dispatch failed",

--- a/internal/backend/channels.go
+++ b/internal/backend/channels.go
@@ -31,10 +31,10 @@ type channelSessionStore interface {
 // their arrival order and the init/inject sequence per event does not
 // race with itself.
 func (b *Backend) startChannelRouter() {
-	events := mcptools.SubscribeEvents(b.ctx)
+	events := mcptools.SubscribeChannelEvents(b.ctx)
 	go func() {
 		for ev := range events {
-			if ev.Payload.Type != mcptools.EventChannelMessage || ev.Payload.ChannelMessage == "" {
+			if ev.Payload.ChannelMessage == "" {
 				continue
 			}
 			b.routeChannelMessage(ev.Payload)

--- a/internal/backend/channels.go
+++ b/internal/backend/channels.go
@@ -49,11 +49,11 @@ func (b *Backend) startChannelRouter() {
 // enabled the channel.
 func (b *Backend) routeChannelMessage(ev mcptools.Event) {
 	for _, ws := range b.workspaces.Seq2() {
-		cfg := ws.Cfg.Config()
-		if _, declared := cfg.MCP[ev.Name]; !declared {
+		mcpCfg, declared := ws.Cfg.Config().MCP[ev.Name]
+		if !declared {
 			continue
 		}
-		if !mcptools.ChannelEnabled(ws.Cfg.Overrides().EnabledChannels, ev.Name) {
+		if !mcptools.ChannelOptIn(mcpCfg, ws.Cfg.Overrides().EnabledChannels, ev.Name) {
 			continue
 		}
 		b.injectChannelMessage(ws, ev.Name, ev.ChannelMessage)

--- a/internal/backend/channels_test.go
+++ b/internal/backend/channels_test.go
@@ -1,0 +1,285 @@
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/agent"
+	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/app"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeChannelSessions is a channelSessionStore backed by in-memory
+// fixtures. created records the titles passed to Create.
+type fakeChannelSessions struct {
+	sessions map[string]session.Session
+	listed   []session.Session
+	created  []string
+	getErr   error
+}
+
+func (f *fakeChannelSessions) Create(_ context.Context, title string) (session.Session, error) {
+	f.created = append(f.created, title)
+	return session.Session{ID: "created-" + title}, nil
+}
+
+func (f *fakeChannelSessions) Get(_ context.Context, id string) (session.Session, error) {
+	if f.getErr != nil {
+		return session.Session{}, f.getErr
+	}
+	s, ok := f.sessions[id]
+	if !ok {
+		return session.Session{}, errors.New("not found")
+	}
+	return s, nil
+}
+
+func (f *fakeChannelSessions) List(context.Context) ([]session.Session, error) {
+	return f.listed, nil
+}
+
+func TestChannelTargetSession(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	t.Run("single viewed session wins", func(t *testing.T) {
+		t.Parallel()
+		got, err := channelTargetSession(ctx, []string{"s1"}, &fakeChannelSessions{})
+		require.NoError(t, err)
+		require.Equal(t, "s1", got)
+	})
+
+	t.Run("multiple viewed picks most recently updated", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeChannelSessions{sessions: map[string]session.Session{
+			"old": {ID: "old", UpdatedAt: 100},
+			"new": {ID: "new", UpdatedAt: 200},
+		}}
+		got, err := channelTargetSession(ctx, []string{"new", "old"}, store)
+		require.NoError(t, err)
+		require.Equal(t, "new", got)
+	})
+
+	t.Run("viewed session ties break on smallest ID", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeChannelSessions{sessions: map[string]session.Session{
+			"b": {ID: "b", UpdatedAt: 100},
+			"a": {ID: "a", UpdatedAt: 100},
+		}}
+		got, err := channelTargetSession(ctx, []string{"b", "a"}, store)
+		require.NoError(t, err)
+		require.Equal(t, "a", got)
+	})
+
+	t.Run("none viewed reuses most recent top-level session", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeChannelSessions{listed: []session.Session{
+			{ID: "recent"}, {ID: "older"},
+		}}
+		got, err := channelTargetSession(ctx, nil, store)
+		require.NoError(t, err)
+		require.Equal(t, "recent", got)
+		require.Empty(t, store.created)
+	})
+
+	t.Run("none viewed and no sessions creates one", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeChannelSessions{}
+		got, err := channelTargetSession(ctx, nil, store)
+		require.NoError(t, err)
+		require.Equal(t, "created-New Session", got)
+		require.Equal(t, []string{"New Session"}, store.created)
+	})
+
+	t.Run("all viewed sessions unloadable falls back", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeChannelSessions{getErr: errors.New("boom")}
+		got, err := channelTargetSession(ctx, []string{"x", "y"}, store)
+		require.NoError(t, err)
+		require.Equal(t, "created-New Session", got)
+	})
+}
+
+func TestWorkspaceViewedSessions(t *testing.T) {
+	t.Parallel()
+	ws := &Workspace{clients: map[string]*clientState{
+		"attached-a":   {streams: 1, currentSessionID: "s2"},
+		"attached-b":   {streams: 2, currentSessionID: "s1"},
+		"attached-c":   {streams: 1, currentSessionID: "s1"}, // duplicate of b
+		"landing":      {streams: 1, currentSessionID: ""},   // landing screen
+		"hold-only":    {streams: 0, currentSessionID: "s3"}, // no live stream
+		"hold-landing": {streams: 0},
+	}}
+	require.Equal(t, []string{"s1", "s2"}, ws.viewedSessions())
+}
+
+// recordingCoordinator is a minimal agent.Coordinator that records the
+// session/prompt of each RunAccepted call.
+type recordingCoordinator struct {
+	runs chan [2]string // {sessionID, prompt}
+}
+
+func newRecordingCoordinator() *recordingCoordinator {
+	return &recordingCoordinator{runs: make(chan [2]string, 8)}
+}
+
+func (c *recordingCoordinator) Run(context.Context, string, string, ...message.Attachment) (*fantasy.AgentResult, error) {
+	return nil, nil
+}
+
+func (c *recordingCoordinator) RunAccepted(_ context.Context, _ *agent.AcceptedRun, sessionID, prompt string, _ ...message.Attachment) (*fantasy.AgentResult, error) {
+	c.runs <- [2]string{sessionID, prompt}
+	return nil, nil
+}
+
+func (c *recordingCoordinator) BeginAccepted(string) *agent.AcceptedRun       { return nil }
+func (c *recordingCoordinator) Cancel(string)                                 {}
+func (c *recordingCoordinator) CancelAll()                                    {}
+func (c *recordingCoordinator) IsBusy() bool                                  { return false }
+func (c *recordingCoordinator) IsSessionBusy(string) bool                     { return false }
+func (c *recordingCoordinator) QueuedPrompts(string) int                      { return 0 }
+func (c *recordingCoordinator) QueuedPromptsList(string) []string             { return nil }
+func (c *recordingCoordinator) ClearQueue(string)                             {}
+func (c *recordingCoordinator) Summarize(context.Context, string) error       { return nil }
+func (c *recordingCoordinator) Model() agent.Model                            { return agent.Model{} }
+func (c *recordingCoordinator) UpdateModels(context.Context) error            { return nil }
+func (c *recordingCoordinator) GenerateTitle(context.Context, string, string) {}
+
+// fullFakeSessions adapts fakeChannelSessions to the full session.Service
+// interface by embedding it; only the channelSessionStore subset is
+// implemented, which is all the channel router touches.
+type fullFakeSessions struct {
+	session.Service
+	*fakeChannelSessions
+}
+
+func (f *fullFakeSessions) Create(ctx context.Context, title string) (session.Session, error) {
+	return f.fakeChannelSessions.Create(ctx, title)
+}
+
+func (f *fullFakeSessions) Get(ctx context.Context, id string) (session.Session, error) {
+	return f.fakeChannelSessions.Get(ctx, id)
+}
+
+func (f *fullFakeSessions) List(ctx context.Context) ([]session.Session, error) {
+	return f.fakeChannelSessions.List(ctx)
+}
+
+// insertChannelWorkspace installs a synthetic workspace whose config
+// declares an MCP server named srvName, opted in as a channel iff
+// enabled is true, mirroring the fields the channel router reads.
+func insertChannelWorkspace(t *testing.T, b *Backend, srvName string, enabled bool, coord agent.Coordinator, sessions session.Service) *Workspace {
+	t.Helper()
+
+	wd := t.TempDir()
+	cfgJSON, err := json.Marshal(map[string]any{
+		"mcp": map[string]any{
+			srvName: map[string]any{"type": "http", "url": "http://127.0.0.1:0/mcp"},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(wd, "crush.json"), cfgJSON, 0o644))
+
+	cfg, err := config.Init(wd, "", false)
+	require.NoError(t, err)
+	if enabled {
+		cfg.Overrides().EnabledChannels = []string{srvName}
+	}
+
+	ws := &Workspace{
+		ID:           uuid.New().String(),
+		Path:         wd,
+		Cfg:          cfg,
+		resolvedPath: wd,
+		clients:      make(map[string]*clientState),
+		shutdownFn:   func() {},
+	}
+	ws.App = &app.App{AgentCoordinator: coord, Sessions: sessions}
+	ws.ctx, ws.cancel = context.WithCancel(b.ctx)
+	b.mu.Lock()
+	b.workspaces.Set(ws.ID, ws)
+	b.pathIndex[ws.resolvedPath] = ws.ID
+	b.mu.Unlock()
+	return ws
+}
+
+// TestRouteChannelMessage_InjectsOncePerOptedInWorkspace is the core
+// exactly-once contract: a channel push is injected into the workspace
+// that declares AND opted in the server (even with zero attached
+// clients), and skipped for workspaces that only declare it or that
+// don't know the server at all.
+func TestRouteChannelMessage_InjectsOncePerOptedInWorkspace(t *testing.T) {
+	xdgIsolated(t)
+	b, _ := newTestBackend(t)
+
+	optedIn := newRecordingCoordinator()
+	declaredOnly := newRecordingCoordinator()
+	unrelated := newRecordingCoordinator()
+
+	wsIn := insertChannelWorkspace(t, b, "webhook", true, optedIn,
+		&fullFakeSessions{fakeChannelSessions: &fakeChannelSessions{listed: []session.Session{{ID: "recent"}}}})
+	insertChannelWorkspace(t, b, "webhook", false, declaredOnly,
+		&fullFakeSessions{fakeChannelSessions: &fakeChannelSessions{}})
+	insertChannelWorkspace(t, b, "other", true, unrelated,
+		&fullFakeSessions{fakeChannelSessions: &fakeChannelSessions{}})
+
+	const content = `<channel source="webhook">build failed</channel>`
+	b.routeChannelMessage(mcptools.Event{
+		Type:           mcptools.EventChannelMessage,
+		Name:           "webhook",
+		ChannelMessage: content,
+	})
+
+	select {
+	case run := <-optedIn.runs:
+		require.Equal(t, "recent", run[0], "should land in the most recent session")
+		require.Equal(t, content, run[1])
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the opted-in workspace to receive the channel push")
+	}
+	wsIn.runWG.Wait()
+
+	require.Empty(t, optedIn.runs, "exactly one injection for the opted-in workspace")
+	require.Empty(t, declaredOnly.runs, "declared-but-not-opted-in workspace must not receive the push")
+	require.Empty(t, unrelated.runs, "workspace without the server must not receive the push")
+}
+
+// TestRouteChannelMessage_PrefersViewedSession verifies the presence map
+// drives targeting: with a client viewing a session, the push lands
+// there instead of the most recently updated session.
+func TestRouteChannelMessage_PrefersViewedSession(t *testing.T) {
+	xdgIsolated(t)
+	b, _ := newTestBackend(t)
+
+	coord := newRecordingCoordinator()
+	ws := insertChannelWorkspace(t, b, "webhook", true, coord,
+		&fullFakeSessions{fakeChannelSessions: &fakeChannelSessions{listed: []session.Session{{ID: "recent"}}}})
+	ws.clientsMu.Lock()
+	ws.clients["client-1"] = &clientState{streams: 1, currentSessionID: "viewed"}
+	ws.clientsMu.Unlock()
+
+	b.routeChannelMessage(mcptools.Event{
+		Type:           mcptools.EventChannelMessage,
+		Name:           "webhook",
+		ChannelMessage: `<channel source="webhook">hi</channel>`,
+	})
+
+	select {
+	case run := <-coord.runs:
+		require.Equal(t, "viewed", run[0])
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected an injection into the viewed session")
+	}
+	ws.runWG.Wait()
+}

--- a/internal/backend/channels_test.go
+++ b/internal/backend/channels_test.go
@@ -125,20 +125,23 @@ func TestWorkspaceViewedSessions(t *testing.T) {
 }
 
 // recordingCoordinator is a minimal agent.Coordinator that records the
-// session/prompt of each RunAccepted call.
+// session/prompt of each RunAccepted call, plus the per-turn channel
+// provenance carried on the context.
 type recordingCoordinator struct {
-	runs chan [2]string // {sessionID, prompt}
+	runs     chan [2]string // {sessionID, prompt}
+	channels chan string    // per-turn channel provenance
 }
 
 func newRecordingCoordinator() *recordingCoordinator {
-	return &recordingCoordinator{runs: make(chan [2]string, 8)}
+	return &recordingCoordinator{runs: make(chan [2]string, 8), channels: make(chan string, 8)}
 }
 
 func (c *recordingCoordinator) Run(context.Context, string, string, ...message.Attachment) (*fantasy.AgentResult, error) {
 	return nil, nil
 }
 
-func (c *recordingCoordinator) RunAccepted(_ context.Context, _ *agent.AcceptedRun, sessionID, prompt string, _ ...message.Attachment) (*fantasy.AgentResult, error) {
+func (c *recordingCoordinator) RunAccepted(ctx context.Context, _ *agent.AcceptedRun, sessionID, prompt string, _ ...message.Attachment) (*fantasy.AgentResult, error) {
+	c.channels <- agent.ChannelFromContext(ctx)
 	c.runs <- [2]string{sessionID, prompt}
 	return nil, nil
 }
@@ -245,6 +248,7 @@ func TestRouteChannelMessage_InjectsOncePerOptedInWorkspace(t *testing.T) {
 	case run := <-optedIn.runs:
 		require.Equal(t, "recent", run[0], "should land in the most recent session")
 		require.Equal(t, content, run[1])
+		require.Equal(t, "webhook", <-optedIn.channels, "the server-routed turn must carry its originating channel")
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected the opted-in workspace to receive the channel push")
 	}

--- a/internal/backend/channels_test.go
+++ b/internal/backend/channels_test.go
@@ -183,13 +183,23 @@ func (f *fullFakeSessions) List(ctx context.Context) ([]session.Session, error) 
 // declares an MCP server named srvName, opted in as a channel iff
 // enabled is true, mirroring the fields the channel router reads.
 func insertChannelWorkspace(t *testing.T, b *Backend, srvName string, enabled bool, coord agent.Coordinator, sessions session.Service) *Workspace {
+	return insertChannelWorkspaceCfg(t, b, srvName, enabled, false, coord, sessions)
+}
+
+// insertChannelWorkspaceCfg is insertChannelWorkspace with control over both
+// enablement sources: `enabled` opts the server in via the --channels
+// override, `configEnabled` writes channel_enabled: true into the workspace's
+// crush.json.
+func insertChannelWorkspaceCfg(t *testing.T, b *Backend, srvName string, enabled, configEnabled bool, coord agent.Coordinator, sessions session.Service) *Workspace {
 	t.Helper()
 
 	wd := t.TempDir()
+	mcpEntry := map[string]any{"type": "http", "url": "http://127.0.0.1:0/mcp"}
+	if configEnabled {
+		mcpEntry["channel_enabled"] = true
+	}
 	cfgJSON, err := json.Marshal(map[string]any{
-		"mcp": map[string]any{
-			srvName: map[string]any{"type": "http", "url": "http://127.0.0.1:0/mcp"},
-		},
+		"mcp": map[string]any{srvName: mcpEntry},
 	})
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(wd, "crush.json"), cfgJSON, 0o644))
@@ -284,6 +294,35 @@ func TestRouteChannelMessage_PrefersViewedSession(t *testing.T) {
 		require.Equal(t, "viewed", run[0])
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected an injection into the viewed session")
+	}
+	ws.runWG.Wait()
+}
+
+// TestRouteChannelMessage_ConfigEnabled verifies that a server with
+// channel_enabled: true in crush.json receives channel pushes without
+// needing --channels on the CLI.
+func TestRouteChannelMessage_ConfigEnabled(t *testing.T) {
+	xdgIsolated(t)
+	b, _ := newTestBackend(t)
+
+	coord := newRecordingCoordinator()
+	sessions := &fullFakeSessions{fakeChannelSessions: &fakeChannelSessions{listed: []session.Session{{ID: "recent"}}}}
+	// channel_enabled in config, deliberately no --channels override.
+	ws := insertChannelWorkspaceCfg(t, b, "webhook", false, true, coord, sessions)
+
+	const content = `<channel source="webhook">config-enabled push</channel>`
+	b.routeChannelMessage(mcptools.Event{
+		Type:           mcptools.EventChannelMessage,
+		Name:           "webhook",
+		ChannelMessage: content,
+	})
+
+	select {
+	case run := <-coord.runs:
+		require.Equal(t, "recent", run[0])
+		require.Equal(t, content, run[1])
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the config-enabled workspace to receive the channel push")
 	}
 	ws.runWG.Wait()
 }

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -430,10 +430,11 @@ func (c *Client) UpdateAgent(ctx context.Context, id string) error {
 // for completion detection. Pass "" when the caller does not need
 // to distinguish its own turn's terminal event from any concurrent
 // turn on the same session (e.g. interactive TUI usage).
-func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID, prompt string, attachments ...message.Attachment) error {
+func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID, channel, prompt string, attachments ...message.Attachment) error {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/agent", id), nil, jsonBody(proto.AgentMessage{
 		SessionID:   sessionID,
 		RunID:       runID,
+		Channel:     channel,
 		Prompt:      prompt,
 		Attachments: proto.AttachmentsFromMessage(attachments),
 	}), http.Header{"Content-Type": []string{"application/json"}})

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -490,10 +490,11 @@ func (c *Client) UpdateAgent(ctx context.Context, id string) error {
 // for completion detection. Pass "" when the caller does not need
 // to distinguish its own turn's terminal event from any concurrent
 // turn on the same session (e.g. interactive TUI usage).
-func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID, prompt string, attachments ...message.Attachment) error {
+func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID, channel, prompt string, attachments ...message.Attachment) error {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/agent", id), nil, jsonBody(proto.AgentMessage{
 		SessionID:   sessionID,
 		RunID:       runID,
+		Channel:     channel,
 		Prompt:      prompt,
 		Attachments: proto.AttachmentsFromMessage(attachments),
 	}), http.Header{"Content-Type": []string{"application/json"}})

--- a/internal/client/proto_test.go
+++ b/internal/client/proto_test.go
@@ -97,7 +97,22 @@ func TestSendMessageAcceptsStatusAccepted(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello"))
+}
+
+func TestSendMessageIncludesChannelOrigin(t *testing.T) {
+	t.Parallel()
+
+	var got proto.AgentMessage
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	c := captureClient(t, srv)
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "signal", "hello"))
+	require.Equal(t, "signal", got.Channel)
 }
 
 func TestSendMessageAcceptsStatusOK(t *testing.T) {
@@ -109,7 +124,7 @@ func TestSendMessageAcceptsStatusOK(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello"))
 }
 
 func TestSendMessageDecodesErrorBody(t *testing.T) {
@@ -122,7 +137,7 @@ func TestSendMessageDecodesErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "", "", "", "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 400")
 	require.Contains(t, err.Error(), "session id is required")
@@ -138,7 +153,7 @@ func TestSendMessageFallsBackOnMalformedErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 500")
 	require.NotContains(t, err.Error(), "not json")
@@ -153,7 +168,7 @@ func TestSendMessageFallsBackOnEmptyErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "", "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 500")
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -257,7 +257,7 @@ func runNonInteractive(
 	// loop would exit on whichever RunComplete arrived first for
 	// the same session and drop the queued prompt's output.
 	runID := uuid.New().String()
-	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, prompt); err != nil {
+	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, "", prompt); err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -261,7 +261,7 @@ func runNonInteractive(
 	// loop would exit on whichever RunComplete arrived first for
 	// the same session and drop the queued prompt's output.
 	runID := uuid.New().String()
-	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, prompt); err != nil {
+	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, "", prompt); err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -233,6 +233,12 @@ type MCPConfig struct {
 	// managed internally and stored in the global data config.
 	OAuthToken *oauth.Token `json:"oauth_token,omitempty" jsonschema:"-"`
 
+	// ChannelEnabled enables an MCP server as a channel directly from config,
+	// equivalent to passing its name via --channels on the CLI. This lets
+	// channels be declared persistently in crush.json without needing a CLI
+	// flag on every launch.
+	ChannelEnabled bool `json:"channel_enabled,omitempty" jsonschema:"description=Enable this MCP server as a channel (equivalent to --channels),default=false"`
+
 	// ChannelReply, when set on a server enabled as a channel, makes Crush
 	// route the final assistant response of every turn that originated from
 	// this channel back through one of the server's own tools, so a message

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -232,6 +232,46 @@ type MCPConfig struct {
 	// OAuthToken is the persisted OAuth token for this server. It is
 	// managed internally and stored in the global data config.
 	OAuthToken *oauth.Token `json:"oauth_token,omitempty" jsonschema:"-"`
+
+	// ChannelReply, when set on a server enabled as a channel, makes Crush
+	// route the final assistant response of every turn that originated from
+	// this channel back through one of the server's own tools, so a message
+	// received on the channel gets a reply on the channel even when the
+	// model only produced terminal output.
+	ChannelReply *MCPChannelReply `json:"channel_reply,omitempty" jsonschema:"description=Automatically route replies for turns originating from this channel back through one of the server's tools"`
+}
+
+// MCPChannelReply configures deterministic reply routing for an MCP server
+// acting as a channel: which of the server's tools deliver a reply for
+// direct and group pushes, and how the reply text and target are mapped
+// onto tool arguments.
+type MCPChannelReply struct {
+	// User routes replies to direct (person-to-person) channel pushes.
+	User *MCPChannelReplyRoute `json:"user,omitempty" jsonschema:"description=Reply route for direct messages"`
+	// Group routes replies to group channel pushes. It is preferred over
+	// User when the push carries the group route's meta attribute.
+	Group *MCPChannelReplyRoute `json:"group,omitempty" jsonschema:"description=Reply route for group messages"`
+	// MessageParam is the tool argument that receives the reply text.
+	MessageParam string `json:"message_param,omitempty" jsonschema:"description=Tool argument name that receives the reply text,default=message"`
+	// SuppressTools lists additional tool names (beyond the two route
+	// tools) that count as the model having already replied on the channel
+	// during the turn, e.g. an operator-shortcut send tool.
+	SuppressTools []string `json:"suppress_tools,omitempty" jsonschema:"description=Additional tool names that suppress the automatic reply when the model already called one of them during the turn,example=send"`
+}
+
+// MCPChannelReplyRoute maps one kind of inbound channel push onto the MCP
+// tool call that delivers a reply to it.
+type MCPChannelReplyRoute struct {
+	// Tool is the MCP tool (bare name, without the mcp_<server>_ prefix)
+	// invoked to deliver the reply.
+	Tool string `json:"tool" jsonschema:"required,description=MCP tool name that sends the reply,example=send_message_to_user"`
+	// TargetParam is the tool argument that receives the reply target
+	// (recipient or group ID).
+	TargetParam string `json:"target_param" jsonschema:"required,description=Tool argument name that receives the reply target,example=user_id"`
+	// TargetMeta is the <channel> meta attribute whose value identifies
+	// the reply target. Defaults to "sender" for the user route and
+	// "group" for the group route.
+	TargetMeta string `json:"target_meta,omitempty" jsonschema:"description=Channel meta attribute carrying the reply target; defaults to sender (user route) or group (group route)"`
 }
 
 type LSPConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -250,6 +250,12 @@ type MCPConfig struct {
 	// managed internally and stored in the global data config.
 	OAuthToken *oauth.Token `json:"oauth_token,omitempty" jsonschema:"-"`
 
+	// ChannelEnabled enables an MCP server as a channel directly from config,
+	// equivalent to passing its name via --channels on the CLI. This lets
+	// channels be declared persistently in crush.json without needing a CLI
+	// flag on every launch.
+	ChannelEnabled bool `json:"channel_enabled,omitempty" jsonschema:"description=Enable this MCP server as a channel (equivalent to --channels),default=false"`
+
 	// ChannelReply, when set on a server enabled as a channel, makes Crush
 	// route the final assistant response of every turn that originated from
 	// this channel back through one of the server's own tools, so a message

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -249,6 +249,46 @@ type MCPConfig struct {
 	// OAuthToken is the persisted OAuth token for this server. It is
 	// managed internally and stored in the global data config.
 	OAuthToken *oauth.Token `json:"oauth_token,omitempty" jsonschema:"-"`
+
+	// ChannelReply, when set on a server enabled as a channel, makes Crush
+	// route the final assistant response of every turn that originated from
+	// this channel back through one of the server's own tools, so a message
+	// received on the channel gets a reply on the channel even when the
+	// model only produced terminal output.
+	ChannelReply *MCPChannelReply `json:"channel_reply,omitempty" jsonschema:"description=Automatically route replies for turns originating from this channel back through one of the server's tools"`
+}
+
+// MCPChannelReply configures deterministic reply routing for an MCP server
+// acting as a channel: which of the server's tools deliver a reply for
+// direct and group pushes, and how the reply text and target are mapped
+// onto tool arguments.
+type MCPChannelReply struct {
+	// User routes replies to direct (person-to-person) channel pushes.
+	User *MCPChannelReplyRoute `json:"user,omitempty" jsonschema:"description=Reply route for direct messages"`
+	// Group routes replies to group channel pushes. It is preferred over
+	// User when the push carries the group route's meta attribute.
+	Group *MCPChannelReplyRoute `json:"group,omitempty" jsonschema:"description=Reply route for group messages"`
+	// MessageParam is the tool argument that receives the reply text.
+	MessageParam string `json:"message_param,omitempty" jsonschema:"description=Tool argument name that receives the reply text,default=message"`
+	// SuppressTools lists additional tool names (beyond the two route
+	// tools) that count as the model having already replied on the channel
+	// during the turn, e.g. an operator-shortcut send tool.
+	SuppressTools []string `json:"suppress_tools,omitempty" jsonschema:"description=Additional tool names that suppress the automatic reply when the model already called one of them during the turn,example=send"`
+}
+
+// MCPChannelReplyRoute maps one kind of inbound channel push onto the MCP
+// tool call that delivers a reply to it.
+type MCPChannelReplyRoute struct {
+	// Tool is the MCP tool (bare name, without the mcp_<server>_ prefix)
+	// invoked to deliver the reply.
+	Tool string `json:"tool" jsonschema:"required,description=MCP tool name that sends the reply,example=send_message_to_user"`
+	// TargetParam is the tool argument that receives the reply target
+	// (recipient or group ID).
+	TargetParam string `json:"target_param" jsonschema:"required,description=Tool argument name that receives the reply target,example=user_id"`
+	// TargetMeta is the <channel> meta attribute whose value identifies
+	// the reply target. Defaults to "sender" for the user route and
+	// "group" for the group route.
+	TargetMeta string `json:"target_meta,omitempty" jsonschema:"description=Channel meta attribute carrying the reply target; defaults to sender (user route) or group (group route)"`
 }
 
 // isOrphanedToken reports whether this entry is a leftover OAuth token

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -11,10 +11,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...any) *sql.Row
+	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -125,6 +125,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.renameSessionStmt, err = db.PrepareContext(ctx, renameSession); err != nil {
 		return nil, fmt.Errorf("error preparing query RenameSession: %w", err)
+	}
+	if q.setSessionChannelStmt, err = db.PrepareContext(ctx, setSessionChannel); err != nil {
+		return nil, fmt.Errorf("error preparing query SetSessionChannel: %w", err)
 	}
 	if q.updateMessageStmt, err = db.PrepareContext(ctx, updateMessage); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateMessage: %w", err)
@@ -310,6 +313,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing renameSessionStmt: %w", cerr)
 		}
 	}
+	if q.setSessionChannelStmt != nil {
+		if cerr := q.setSessionChannelStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing setSessionChannelStmt: %w", cerr)
+		}
+	}
 	if q.updateMessageStmt != nil {
 		if cerr := q.updateMessageStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing updateMessageStmt: %w", cerr)
@@ -398,6 +406,7 @@ type Queries struct {
 	listUserMessagesBySessionStmt  *sql.Stmt
 	recordFileReadStmt             *sql.Stmt
 	renameSessionStmt              *sql.Stmt
+	setSessionChannelStmt          *sql.Stmt
 	updateMessageStmt              *sql.Stmt
 	updateSessionStmt              *sql.Stmt
 	updateSessionTitleAndUsageStmt *sql.Stmt
@@ -441,6 +450,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listUserMessagesBySessionStmt:  q.listUserMessagesBySessionStmt,
 		recordFileReadStmt:             q.recordFileReadStmt,
 		renameSessionStmt:              q.renameSessionStmt,
+		setSessionChannelStmt:          q.setSessionChannelStmt,
 		updateMessageStmt:              q.updateMessageStmt,
 		updateSessionStmt:              q.updateSessionStmt,
 		updateSessionTitleAndUsageStmt: q.updateSessionTitleAndUsageStmt,

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -129,6 +129,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.renameSessionStmt, err = db.PrepareContext(ctx, renameSession); err != nil {
 		return nil, fmt.Errorf("error preparing query RenameSession: %w", err)
 	}
+	if q.setSessionChannelStmt, err = db.PrepareContext(ctx, setSessionChannel); err != nil {
+		return nil, fmt.Errorf("error preparing query SetSessionChannel: %w", err)
+	}
 	if q.updateMessageStmt, err = db.PrepareContext(ctx, updateMessage); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateMessage: %w", err)
 	}
@@ -318,6 +321,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing renameSessionStmt: %w", cerr)
 		}
 	}
+	if q.setSessionChannelStmt != nil {
+		if cerr := q.setSessionChannelStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing setSessionChannelStmt: %w", cerr)
+		}
+	}
 	if q.updateMessageStmt != nil {
 		if cerr := q.updateMessageStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing updateMessageStmt: %w", cerr)
@@ -407,6 +415,7 @@ type Queries struct {
 	listUserMessagesBySessionStmt        *sql.Stmt
 	recordFileReadStmt                   *sql.Stmt
 	renameSessionStmt                    *sql.Stmt
+	setSessionChannelStmt                *sql.Stmt
 	updateMessageStmt                    *sql.Stmt
 	updateSessionStmt                    *sql.Stmt
 	updateSessionTitleAndUsageStmt       *sql.Stmt
@@ -451,6 +460,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listUserMessagesBySessionStmt:        q.listUserMessagesBySessionStmt,
 		recordFileReadStmt:                   q.recordFileReadStmt,
 		renameSessionStmt:                    q.renameSessionStmt,
+		setSessionChannelStmt:                q.setSessionChannelStmt,
 		updateMessageStmt:                    q.updateMessageStmt,
 		updateSessionStmt:                    q.updateSessionStmt,
 		updateSessionTitleAndUsageStmt:       q.updateSessionTitleAndUsageStmt,

--- a/internal/db/migrations/20260713000000_add_channel_to_sessions.sql
+++ b/internal/db/migrations/20260713000000_add_channel_to_sessions.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE sessions ADD COLUMN channel TEXT;
+
+-- +goose Down
+ALTER TABLE sessions DROP COLUMN channel;

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -49,4 +49,5 @@ type Session struct {
 	CreatedAt        int64          `json:"created_at"`
 	SummaryMessageID sql.NullString `json:"summary_message_id"`
 	Todos            sql.NullString `json:"todos"`
+	Channel          sql.NullString `json:"channel"`
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -43,6 +43,7 @@ type Querier interface {
 	ListUserMessagesBySession(ctx context.Context, sessionID string) ([]Message, error)
 	RecordFileRead(ctx context.Context, arg RecordFileReadParams) error
 	RenameSession(ctx context.Context, arg RenameSessionParams) error
+	SetSessionChannel(ctx context.Context, arg SetSessionChannelParams) (Session, error)
 	UpdateMessage(ctx context.Context, arg UpdateMessageParams) error
 	UpdateSession(ctx context.Context, arg UpdateSessionParams) (Session, error)
 	UpdateSessionTitleAndUsage(ctx context.Context, arg UpdateSessionTitleAndUsageParams) error

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -44,6 +44,7 @@ type Querier interface {
 	ListUserMessagesBySession(ctx context.Context, sessionID string) ([]Message, error)
 	RecordFileRead(ctx context.Context, arg RecordFileReadParams) error
 	RenameSession(ctx context.Context, arg RenameSessionParams) error
+	SetSessionChannel(ctx context.Context, arg SetSessionChannelParams) (Session, error)
 	UpdateMessage(ctx context.Context, arg UpdateMessageParams) error
 	UpdateSession(ctx context.Context, arg UpdateSessionParams) (Session, error)
 	UpdateSessionTitleAndUsage(ctx context.Context, arg UpdateSessionTitleAndUsageParams) error

--- a/internal/db/sessions.sql.go
+++ b/internal/db/sessions.sql.go
@@ -33,7 +33,7 @@ INSERT INTO sessions (
     null,
     strftime('%s', 'now'),
     strftime('%s', 'now')
-) RETURNING id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos
+) RETURNING id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos, channel
 `
 
 type CreateSessionParams struct {
@@ -69,6 +69,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 		&i.CreatedAt,
 		&i.SummaryMessageID,
 		&i.Todos,
+		&i.Channel,
 	)
 	return i, err
 }
@@ -84,7 +85,7 @@ func (q *Queries) DeleteSession(ctx context.Context, id string) error {
 }
 
 const getLastSession = `-- name: GetLastSession :one
-SELECT id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos
+SELECT id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos, channel
 FROM sessions
 ORDER BY updated_at DESC
 LIMIT 1
@@ -105,12 +106,13 @@ func (q *Queries) GetLastSession(ctx context.Context) (Session, error) {
 		&i.CreatedAt,
 		&i.SummaryMessageID,
 		&i.Todos,
+		&i.Channel,
 	)
 	return i, err
 }
 
 const getSessionByID = `-- name: GetSessionByID :one
-SELECT id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos
+SELECT id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos, channel
 FROM sessions
 WHERE id = ? LIMIT 1
 `
@@ -130,12 +132,13 @@ func (q *Queries) GetSessionByID(ctx context.Context, id string) (Session, error
 		&i.CreatedAt,
 		&i.SummaryMessageID,
 		&i.Todos,
+		&i.Channel,
 	)
 	return i, err
 }
 
 const listSessions = `-- name: ListSessions :many
-SELECT id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos
+SELECT id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos, channel
 FROM sessions
 WHERE parent_session_id is NULL
 ORDER BY updated_at DESC
@@ -162,6 +165,7 @@ func (q *Queries) ListSessions(ctx context.Context) ([]Session, error) {
 			&i.CreatedAt,
 			&i.SummaryMessageID,
 			&i.Todos,
+			&i.Channel,
 		); err != nil {
 			return nil, err
 		}
@@ -193,6 +197,38 @@ func (q *Queries) RenameSession(ctx context.Context, arg RenameSessionParams) er
 	return err
 }
 
+const setSessionChannel = `-- name: SetSessionChannel :one
+UPDATE sessions
+SET channel = ?
+WHERE id = ?
+RETURNING id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos, channel
+`
+
+type SetSessionChannelParams struct {
+	Channel sql.NullString `json:"channel"`
+	ID      string         `json:"id"`
+}
+
+func (q *Queries) SetSessionChannel(ctx context.Context, arg SetSessionChannelParams) (Session, error) {
+	row := q.queryRow(ctx, q.setSessionChannelStmt, setSessionChannel, arg.Channel, arg.ID)
+	var i Session
+	err := row.Scan(
+		&i.ID,
+		&i.ParentSessionID,
+		&i.Title,
+		&i.MessageCount,
+		&i.PromptTokens,
+		&i.CompletionTokens,
+		&i.Cost,
+		&i.UpdatedAt,
+		&i.CreatedAt,
+		&i.SummaryMessageID,
+		&i.Todos,
+		&i.Channel,
+	)
+	return i, err
+}
+
 const updateSession = `-- name: UpdateSession :one
 UPDATE sessions
 SET
@@ -201,9 +237,10 @@ SET
     completion_tokens = ?,
     summary_message_id = ?,
     cost = ?,
-    todos = ?
+    todos = ?,
+    channel = ?
 WHERE id = ?
-RETURNING id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos
+RETURNING id, parent_session_id, title, message_count, prompt_tokens, completion_tokens, cost, updated_at, created_at, summary_message_id, todos, channel
 `
 
 type UpdateSessionParams struct {
@@ -213,6 +250,7 @@ type UpdateSessionParams struct {
 	SummaryMessageID sql.NullString `json:"summary_message_id"`
 	Cost             float64        `json:"cost"`
 	Todos            sql.NullString `json:"todos"`
+	Channel          sql.NullString `json:"channel"`
 	ID               string         `json:"id"`
 }
 
@@ -224,6 +262,7 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) (S
 		arg.SummaryMessageID,
 		arg.Cost,
 		arg.Todos,
+		arg.Channel,
 		arg.ID,
 	)
 	var i Session
@@ -239,6 +278,7 @@ func (q *Queries) UpdateSession(ctx context.Context, arg UpdateSessionParams) (S
 		&i.CreatedAt,
 		&i.SummaryMessageID,
 		&i.Todos,
+		&i.Channel,
 	)
 	return i, err
 }

--- a/internal/db/sql/sessions.sql
+++ b/internal/db/sql/sessions.sql
@@ -48,7 +48,14 @@ SET
     completion_tokens = ?,
     summary_message_id = ?,
     cost = ?,
-    todos = ?
+    todos = ?,
+    channel = ?
+WHERE id = ?
+RETURNING *;
+
+-- name: SetSessionChannel :one
+UPDATE sessions
+SET channel = ?
 WHERE id = ?
 RETURNING *;
 

--- a/internal/proto/mcp.go
+++ b/internal/proto/mcp.go
@@ -143,6 +143,8 @@ type MCPClientInfo struct {
 	PromptCount   int       `json:"prompt_count,omitempty"`
 	ResourceCount int       `json:"resource_count,omitempty"`
 	ConnectedAt   time.Time `json:"connected_at"`
+	// Channel reports whether this server is an active channel.
+	Channel bool `json:"channel,omitempty"`
 }
 
 type MCPPromptArgument struct {

--- a/internal/proto/mcp.go
+++ b/internal/proto/mcp.go
@@ -68,6 +68,7 @@ const (
 	MCPEventToolsListChanged     MCPEventType = "tools_list_changed"
 	MCPEventPromptsListChanged   MCPEventType = "prompts_list_changed"
 	MCPEventResourcesListChanged MCPEventType = "resources_list_changed"
+	MCPEventChannelMessage       MCPEventType = "channel_message"
 )
 
 // MarshalText implements the [encoding.TextMarshaler] interface.
@@ -90,6 +91,10 @@ type MCPEvent struct {
 	ToolCount     int          `json:"tool_count,omitempty"`
 	PromptCount   int          `json:"prompt_count,omitempty"`
 	ResourceCount int          `json:"resource_count,omitempty"`
+	// ChannelMessage carries the rendered <channel> element for
+	// MCPEventChannelMessage events so channel pushes reach client/server
+	// sessions over the wire.
+	ChannelMessage string `json:"channel_message,omitempty"`
 }
 
 // MarshalJSON implements the [json.Marshaler] interface.

--- a/internal/proto/mcp_test.go
+++ b/internal/proto/mcp_test.go
@@ -1,0 +1,50 @@
+package proto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestMCPClientInfo_ChannelRoundTrip verifies the channel flag survives the
+// JSON wire format so client/server sessions can show which servers are active
+// channels.
+func TestMCPClientInfo_ChannelRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	src := MCPClientInfo{
+		Name:      "webhook",
+		State:     MCPStateConnected,
+		ToolCount: 1,
+		Channel:   true,
+	}
+
+	data, err := json.Marshal(src)
+	require.NoError(t, err)
+
+	var got MCPClientInfo
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.True(t, got.Channel, "channel flag must survive the wire")
+	require.Equal(t, "webhook", got.Name)
+}
+
+// TestMCPEvent_ChannelMessageRoundTrip verifies the rendered <channel> body
+// survives the JSON wire format.
+func TestMCPEvent_ChannelMessageRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	src := MCPEvent{
+		Type:           MCPEventChannelMessage,
+		Name:           "webhook",
+		ChannelMessage: `<channel source="webhook">hi</channel>`,
+	}
+
+	data, err := json.Marshal(src)
+	require.NoError(t, err)
+
+	var got MCPEvent
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, MCPEventChannelMessage, got.Type)
+	require.Equal(t, `<channel source="webhook">hi</channel>`, got.ChannelMessage)
+}

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -144,6 +144,7 @@ func (a AgentInfo) IsZero() bool {
 type AgentMessage struct {
 	SessionID   string       `json:"session_id"`
 	RunID       string       `json:"run_id,omitempty"`
+	Channel     string       `json:"channel,omitempty"`
 	Prompt      string       `json:"prompt"`
 	Attachments []Attachment `json:"attachments,omitempty"`
 }

--- a/internal/proto/session.go
+++ b/internal/proto/session.go
@@ -23,6 +23,7 @@ type Session struct {
 	SummaryMessageID string  `json:"summary_message_id"`
 	Cost             float64 `json:"cost"`
 	Todos            []Todo  `json:"todos,omitempty"`
+	Channel          string  `json:"channel,omitempty"`
 	CreatedAt        int64   `json:"created_at"`
 	UpdatedAt        int64   `json:"updated_at"`
 	IsBusy           bool    `json:"is_busy"`

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -486,6 +486,7 @@ func (c *controllerV1) handleGetWorkspaceMCPStates(w http.ResponseWriter, r *htt
 			PromptCount:   v.Counts.Prompts,
 			ResourceCount: v.Counts.Resources,
 			ConnectedAt:   v.ConnectedAt,
+			Channel:       v.Channel,
 		}
 	}
 	jsonEncode(w, result)

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -206,6 +206,7 @@ func sessionToProto(s session.Session) proto.Session {
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
 		Todos:            todosToProto(s.Todos),
+		Channel:          s.Channel,
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -40,20 +40,20 @@ func wrapEvent(ev any) *pubsub.Payload {
 	case pubsub.Event[mcp.Event]:
 		pt := mcpEventTypeToProto(e.Payload.Type)
 		if pt == "" {
-			// Unsupported MCP event type (e.g. EventChannelMessage, which
-			// has no proto representation until session delivery is wired
-			// up). Drop it instead of fabricating a state_changed event.
+			// Unsupported MCP event type. Drop it instead of fabricating
+			// a state_changed event.
 			slog.Debug("Dropping unsupported MCP event type for SSE", "type", e.Payload.Type)
 			return nil
 		}
 		return envelope(pubsub.PayloadTypeMCPEvent, pubsub.Event[proto.MCPEvent]{
 			Type: e.Type,
 			Payload: proto.MCPEvent{
-				Type:      pt,
-				Name:      e.Payload.Name,
-				State:     proto.MCPState(e.Payload.State),
-				Error:     e.Payload.Error,
-				ToolCount: e.Payload.Counts.Tools,
+				Type:           pt,
+				Name:           e.Payload.Name,
+				State:          proto.MCPState(e.Payload.State),
+				Error:          e.Payload.Error,
+				ToolCount:      e.Payload.Counts.Tools,
+				ChannelMessage: e.Payload.ChannelMessage,
 			},
 		})
 	case pubsub.Event[permission.PermissionRequest]:
@@ -186,9 +186,11 @@ func mcpEventTypeToProto(t mcp.EventType) proto.MCPEventType {
 		return proto.MCPEventPromptsListChanged
 	case mcp.EventResourcesListChanged:
 		return proto.MCPEventResourcesListChanged
+	case mcp.EventChannelMessage:
+		return proto.MCPEventChannelMessage
 	default:
-		// Unsupported type (e.g. EventChannelMessage). Return empty so
-		// callers can drop it rather than coercing to state_changed.
+		// Unsupported type. Return empty so callers can drop it rather
+		// than coercing to state_changed.
 		return ""
 	}
 }

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -40,20 +40,20 @@ func wrapEvent(ev any) *pubsub.Payload {
 	case pubsub.Event[mcp.Event]:
 		pt := mcpEventTypeToProto(e.Payload.Type)
 		if pt == "" {
-			// Unsupported MCP event type (e.g. EventChannelMessage, which
-			// has no proto representation until session delivery is wired
-			// up). Drop it instead of fabricating a state_changed event.
+			// Unsupported MCP event type. Drop it instead of fabricating
+			// a state_changed event.
 			slog.Debug("Dropping unsupported MCP event type for SSE", "type", e.Payload.Type)
 			return nil
 		}
 		return envelope(pubsub.PayloadTypeMCPEvent, pubsub.Event[proto.MCPEvent]{
 			Type: e.Type,
 			Payload: proto.MCPEvent{
-				Type:      pt,
-				Name:      e.Payload.Name,
-				State:     proto.MCPState(e.Payload.State),
-				Error:     e.Payload.Error,
-				ToolCount: e.Payload.Counts.Tools,
+				Type:           pt,
+				Name:           e.Payload.Name,
+				State:          proto.MCPState(e.Payload.State),
+				Error:          e.Payload.Error,
+				ToolCount:      e.Payload.Counts.Tools,
+				ChannelMessage: e.Payload.ChannelMessage,
 			},
 		})
 	case pubsub.Event[permission.PermissionRequest]:
@@ -192,9 +192,11 @@ func mcpEventTypeToProto(t mcp.EventType) proto.MCPEventType {
 		return proto.MCPEventPromptsListChanged
 	case mcp.EventResourcesListChanged:
 		return proto.MCPEventResourcesListChanged
+	case mcp.EventChannelMessage:
+		return proto.MCPEventChannelMessage
 	default:
-		// Unsupported type (e.g. EventChannelMessage). Return empty so
-		// callers can drop it rather than coercing to state_changed.
+		// Unsupported type. Return empty so callers can drop it rather
+		// than coercing to state_changed.
 		return ""
 	}
 }

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -212,6 +212,7 @@ func sessionToProto(s session.Session) proto.Session {
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
 		Todos:            todosToProto(s.Todos),
+		Channel:          s.Channel,
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -52,9 +52,6 @@ func TestMessageToProtoToolResult(t *testing.T) {
 	require.False(t, tr.IsError)
 }
 
-// TestSkillsEventToProto_RoundTrip verifies that a pubsub.Event[skills.Event]
-// can be wrapped, marshaled, and unmarshaled back through the SSE
-// envelope without losing state values or error messages.
 // TestMCPChannelEventToProto_RoundTrip verifies that a channel push survives
 // the SSE envelope conversion with its type and rendered <channel> body intact,
 // so client/server sessions receive channel events rather than dropping the
@@ -82,6 +79,9 @@ func TestMCPChannelEventToProto_RoundTrip(t *testing.T) {
 	require.Equal(t, `<channel source="webhook">build failed</channel>`, decoded.Payload.ChannelMessage)
 }
 
+// TestSkillsEventToProto_RoundTrip verifies that a pubsub.Event[skills.Event]
+// can be wrapped, marshaled, and unmarshaled back through the SSE
+// envelope without losing state values or error messages.
 func TestSkillsEventToProto_RoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -55,6 +55,33 @@ func TestMessageToProtoToolResult(t *testing.T) {
 // TestSkillsEventToProto_RoundTrip verifies that a pubsub.Event[skills.Event]
 // can be wrapped, marshaled, and unmarshaled back through the SSE
 // envelope without losing state values or error messages.
+// TestMCPChannelEventToProto_RoundTrip verifies that a channel push survives
+// the SSE envelope conversion with its type and rendered <channel> body intact,
+// so client/server sessions receive channel events rather than dropping the
+// payload at the wire.
+func TestMCPChannelEventToProto_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	src := pubsub.Event[mcp.Event]{
+		Type: pubsub.CreatedEvent,
+		Payload: mcp.Event{
+			Type:           mcp.EventChannelMessage,
+			Name:           "webhook",
+			ChannelMessage: `<channel source="webhook">build failed</channel>`,
+		},
+	}
+
+	env := wrapEvent(src)
+	require.NotNil(t, env)
+	require.Equal(t, pubsub.PayloadTypeMCPEvent, env.Type)
+
+	var decoded pubsub.Event[proto.MCPEvent]
+	require.NoError(t, json.Unmarshal(env.Payload, &decoded))
+	require.Equal(t, proto.MCPEventChannelMessage, decoded.Payload.Type)
+	require.Equal(t, "webhook", decoded.Payload.Name)
+	require.Equal(t, `<channel source="webhook">build failed</channel>`, decoded.Payload.ChannelMessage)
+}
+
 func TestSkillsEventToProto_RoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/events_test.go
+++ b/internal/server/events_test.go
@@ -236,29 +236,6 @@ func TestUpdateAvailableMsgToProto_RoundTrip(t *testing.T) {
 	require.False(t, decoded.Payload.IsDevelopment)
 }
 
-// TestMCPChannelMessageNotWrappedAsStateChange verifies that an
-// EventChannelMessage — which has no proto representation until session
-// delivery is wired up in a later PR — is NOT wrapped as a spurious
-// state_changed MCP event by the SSE event pipeline. Before the fix,
-// mcpEventTypeToProto's default branch mapped every unknown event type to
-// MCPEventStateChanged, so a channel notification looked like a state
-// change to every SSE client.
-func TestMCPChannelMessageNotWrappedAsStateChange(t *testing.T) {
-	t.Parallel()
-
-	src := pubsub.Event[mcp.Event]{
-		Type: pubsub.CreatedEvent,
-		Payload: mcp.Event{
-			Type:           mcp.EventChannelMessage,
-			Name:           "webhook",
-			ChannelMessage: `<channel source="webhook">build failed</channel>`,
-		},
-	}
-
-	env := wrapEvent(src)
-	require.Nil(t, env, "EventChannelMessage must not be wrapped as an SSE event (no proto representation yet)")
-}
-
 // TestMCPUnknownEventTypeNotMappedToStateChange verifies that any
 // unrecognized MCP event type is not silently coerced to state_changed —
 // the mapping must return ok=false so wrapEvent can drop it instead of

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -58,6 +58,7 @@ type Session struct {
 	SummaryMessageID string
 	Cost             float64
 	Todos            []Todo
+	Channel          string
 	CreatedAt        int64
 	UpdatedAt        int64
 }
@@ -71,6 +72,7 @@ type Service interface {
 	GetLast(ctx context.Context) (Session, error)
 	List(ctx context.Context) ([]Session, error)
 	Save(ctx context.Context, session Session) (Session, error)
+	SetChannel(ctx context.Context, sessionID, channel string) (Session, error)
 	UpdateTitleAndUsage(ctx context.Context, sessionID, title string, promptTokens, completionTokens int64, cost float64) error
 	Rename(ctx context.Context, id string, title string) error
 	Delete(ctx context.Context, id string) error
@@ -208,6 +210,10 @@ func (s *service) Save(ctx context.Context, session Session) (Session, error) {
 			String: todosJSON,
 			Valid:  todosJSON != "",
 		},
+		Channel: sql.NullString{
+			String: session.Channel,
+			Valid:  session.Channel != "",
+		},
 	})
 	if err != nil {
 		return Session{}, err
@@ -216,6 +222,23 @@ func (s *service) Save(ctx context.Context, session Session) (Session, error) {
 	s.setEstimatedUsageState(session.ID, estimatedUsage)
 	session = s.fromDBItem(dbSession)
 	session.EstimatedUsage = estimatedUsage
+	s.Publish(pubsub.UpdatedEvent, session)
+	return session, nil
+}
+
+func (s *service) SetChannel(ctx context.Context, sessionID, channel string) (Session, error) {
+	dbSession, err := s.q.SetSessionChannel(ctx, db.SetSessionChannelParams{
+		ID: sessionID,
+		Channel: sql.NullString{
+			String: channel,
+			Valid:  channel != "",
+		},
+	})
+	if err != nil {
+		return Session{}, err
+	}
+	session := s.fromDBItem(dbSession)
+	s.applyEstimatedUsageState(&session)
 	s.Publish(pubsub.UpdatedEvent, session)
 	return session, nil
 }
@@ -310,6 +333,7 @@ func (s *service) fromDBItem(item db.Session) Session {
 		SummaryMessageID: item.SummaryMessageID.String,
 		Cost:             item.Cost,
 		Todos:            todos,
+		Channel:          item.Channel.String,
 		CreatedAt:        item.CreatedAt,
 		UpdatedAt:        item.UpdatedAt,
 	}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -48,6 +48,29 @@ func TestEstimatedUsageStateSurvivesFetchModifySave(t *testing.T) {
 	require.True(t, refetched.EstimatedUsage)
 }
 
+func TestSessionChannelPersists(t *testing.T) {
+	t.Parallel()
+	dataDir := t.TempDir()
+	t.Cleanup(func() {
+		require.NoError(t, db.Release(dataDir))
+		db.ResetPool()
+	})
+
+	conn, err := db.Connect(t.Context(), dataDir)
+	require.NoError(t, err)
+	sessions := NewService(db.New(conn), conn)
+
+	created, err := sessions.Create(t.Context(), "channel")
+	require.NoError(t, err)
+	updated, err := sessions.SetChannel(t.Context(), created.ID, "signal")
+	require.NoError(t, err)
+	require.Equal(t, "signal", updated.Channel)
+
+	fetched, err := sessions.Get(t.Context(), created.ID)
+	require.NoError(t, err)
+	require.Equal(t, "signal", fetched.Channel)
+}
+
 func TestEstimatedUsageStateCanBeClearedByExplicitSave(t *testing.T) {
 	dataDir := t.TempDir()
 	t.Cleanup(func() {

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"encoding/xml"
 	"fmt"
 	"image"
 	"strings"
@@ -354,6 +355,117 @@ func (a *AssistantInfoItem) renderContent(width int) string {
 	return common.Section(a.sty, assistant, width)
 }
 
+// ChannelInfoID returns a stable ID for channel-info items.
+func ChannelInfoID(messageID string) string {
+	return fmt.Sprintf("%s:channel-info", messageID)
+}
+
+// ChannelInfoItem renders sender/channel/timestamp metadata for a
+// channel-originated user message. It is emitted as a separate list item
+// below the message body, mirroring how AssistantInfoItem appears below
+// assistant messages.
+type ChannelInfoItem struct {
+	*list.Versioned
+	*cachedMessageItem
+
+	id      string
+	message *message.Message
+	sty     *styles.Styles
+}
+
+// NewChannelInfoItem creates a new ChannelInfoItem.
+func NewChannelInfoItem(sty *styles.Styles, msg *message.Message) MessageItem {
+	return &ChannelInfoItem{
+		Versioned:         list.NewVersioned(),
+		cachedMessageItem: &cachedMessageItem{},
+		id:                ChannelInfoID(msg.ID),
+		message:           msg,
+		sty:               sty,
+	}
+}
+
+// Finished implements list.Item. Channel metadata is immutable once
+// rendered, so the entry is always safe to freeze.
+func (c *ChannelInfoItem) Finished() bool {
+	return true
+}
+
+// ID implements MessageItem.
+func (c *ChannelInfoItem) ID() string {
+	return c.id
+}
+
+// RawRender implements MessageItem.
+func (c *ChannelInfoItem) RawRender(width int) string {
+	innerWidth := max(0, width-MessageLeftPaddingTotal)
+	content, _, ok := c.getCachedRender(innerWidth)
+	if !ok {
+		content = c.renderContent(innerWidth)
+		height := lipgloss.Height(content)
+		c.setCachedRender(content, innerWidth, height)
+	}
+	return content
+}
+
+// Render implements MessageItem.
+func (c *ChannelInfoItem) Render(width int) string {
+	if cached, ok := c.getCachedPrefixedRender(width, 0); ok {
+		return cached
+	}
+	prefix := c.sty.Messages.SectionHeader.Render()
+	lines := strings.Split(c.RawRender(width), "\n")
+	for i, line := range lines {
+		lines[i] = prefix + line
+	}
+	out := strings.Join(lines, "\n")
+	c.setCachedPrefixedRender(out, width, 0)
+	return out
+}
+
+func (c *ChannelInfoItem) renderContent(width int) string {
+	raw := strings.TrimSpace(c.message.Content().Text)
+	var ch channelMessage
+	if err := xml.Unmarshal([]byte(raw), &ch); err != nil {
+		return ""
+	}
+
+	parts := make([]string, 0, 3)
+
+	sender := ch.SenderName
+	if sender == "" {
+		sender = ch.Sender
+	}
+	if sender != "" {
+		parts = append(parts, c.sty.Messages.ChannelInfoSender.Render(sender))
+	}
+
+	if ch.Source != "" {
+		parts = append(parts, c.sty.Messages.ChannelInfoProvider.Render(fmt.Sprintf("via %s", ch.Source)))
+	}
+
+	ts := ch.Time
+	if ts == "" && c.message.CreatedAt > 0 {
+		ts = time.Unix(c.message.CreatedAt, 0).Format(time.TimeOnly)
+	}
+	if ts != "" {
+		parts = append(parts, c.sty.Messages.ChannelInfoTimestamp.Render(fmt.Sprintf("at %s", ts)))
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	icon := c.sty.Messages.ChannelInfoIcon.Render(styles.ChannelIcon)
+	metaStr := fmt.Sprintf("%s %s", icon, strings.Join(parts, " "))
+	return common.Section(c.sty, metaStr, width)
+}
+
+// IsChannelMessage reports whether the given message content is a
+// channel-originated message (i.e. starts with the <channel XML tag).
+func IsChannelMessage(msg *message.Message) bool {
+	return strings.HasPrefix(strings.TrimSpace(msg.Content().Text), "<channel")
+}
+
 // cappedMessageWidth returns the maximum width for message content for readability.
 func cappedMessageWidth(availableWidth int) int {
 	return min(availableWidth-MessageLeftPaddingTotal, maxTextWidth)
@@ -385,7 +497,11 @@ func ExtractMessageItems(sty *styles.Styles, msg *message.Message, toolResults m
 			sty.Attachments.Skill,
 			sty.Attachments.Remove,
 		)
-		return []MessageItem{NewUserMessageItem(sty, msg, r)}
+		items = []MessageItem{NewUserMessageItem(sty, msg, r)}
+		if IsChannelMessage(msg) {
+			items = append(items, NewChannelInfoItem(sty, msg))
+		}
+		return items
 	case message.Assistant:
 		var items []MessageItem
 		if ShouldRenderAssistantMessage(msg) {

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -21,6 +21,17 @@ type skillInvocation struct {
 	Instructions string `xml:"instructions"`
 }
 
+// channelMessage represents the XML structure for a channel-originated
+// message pushed by an MCP channel server.
+type channelMessage struct {
+	XMLName    xml.Name `xml:"channel"`
+	Source     string   `xml:"source,attr"`
+	Sender     string   `xml:"sender,attr"`
+	SenderName string   `xml:"sender_name,attr"`
+	Time       string   `xml:"time,attr"`
+	Content    string   `xml:",chardata"`
+}
+
 // UserMessageItem represents a user message in the chat UI.
 type UserMessageItem struct {
 	*list.Versioned
@@ -73,6 +84,14 @@ func (m *UserMessageItem) RawRender(width int) string {
 		return m.renderHighlighted(content, cappedWidth, height)
 	}
 
+	// Check if this is a channel-originated message.
+	if strings.HasPrefix(msgContent, "<channel") {
+		content = m.renderChannelMessage(msgContent, cappedWidth)
+		height = lipgloss.Height(content)
+		m.setCachedRender(content, cappedWidth, height)
+		return m.renderHighlighted(content, cappedWidth, height)
+	}
+
 	renderer := common.MarkdownRenderer(m.sty, cappedWidth)
 	mu := common.LockMarkdownRenderer(renderer)
 
@@ -119,6 +138,46 @@ func (m *UserMessageItem) renderSkillInvocation(content string, width int) strin
 	}
 
 	return toolOutputSkillContent(m.sty, skill.Name, skill.Description)
+}
+
+// renderChannelMessage parses a <channel source="..." ...>body</channel>
+// element and renders only the body as markdown. The metadata
+// (sender, channel source, timestamp) is rendered separately by
+// ChannelInfoItem so it appears outside the message body, mirroring
+// the assistant info line.
+func (m *UserMessageItem) renderChannelMessage(raw string, width int) string {
+	var ch channelMessage
+	if err := xml.Unmarshal([]byte(raw), &ch); err != nil {
+		return m.fallbackRender(raw, width)
+	}
+
+	body := strings.TrimSpace(ch.Content)
+	if body == "" {
+		return ""
+	}
+
+	renderer := common.MarkdownRenderer(m.sty, width)
+	mu := common.LockMarkdownRenderer(renderer)
+	mu.Lock()
+	result, err := renderer.Render(body)
+	mu.Unlock()
+	if err != nil {
+		return body
+	}
+	return strings.TrimSuffix(result, "\n")
+}
+
+// fallbackRender renders text as plain markdown when XML parsing fails.
+func (m *UserMessageItem) fallbackRender(content string, width int) string {
+	renderer := common.MarkdownRenderer(m.sty, width)
+	mu := common.LockMarkdownRenderer(renderer)
+	mu.Lock()
+	result, err := renderer.Render(content)
+	mu.Unlock()
+	if err != nil {
+		return content
+	}
+	return strings.TrimSuffix(result, "\n")
 }
 
 // Render implements MessageItem.

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -21,6 +21,17 @@ type skillInvocation struct {
 	Instructions string `xml:"instructions"`
 }
 
+// channelMessage represents the XML structure for a channel-originated
+// message pushed by an MCP channel server.
+type channelMessage struct {
+	XMLName    xml.Name `xml:"channel"`
+	Source     string   `xml:"source,attr"`
+	Sender     string   `xml:"sender,attr"`
+	SenderName string   `xml:"sender_name,attr"`
+	Time       string   `xml:"time,attr"`
+	Content    string   `xml:",chardata"`
+}
+
 // UserMessageItem represents a user message in the chat UI.
 type UserMessageItem struct {
 	*list.Versioned
@@ -73,6 +84,14 @@ func (m *UserMessageItem) RawRender(width int) string {
 		return m.renderHighlighted(content, cappedWidth, height)
 	}
 
+	// Check if this is a channel-originated message.
+	if strings.HasPrefix(msgContent, "<channel") {
+		content = m.renderChannelMessage(msgContent, cappedWidth)
+		height = lipgloss.Height(content)
+		m.setCachedRender(content, cappedWidth, height)
+		return m.renderHighlighted(content, cappedWidth, height)
+	}
+
 	renderer := common.UserMarkdownRenderer(m.sty, cappedWidth)
 	mu := common.LockMarkdownRenderer(renderer)
 
@@ -119,6 +138,46 @@ func (m *UserMessageItem) renderSkillInvocation(content string, width int) strin
 	}
 
 	return toolOutputSkillContent(m.sty, skill.Name, skill.Description)
+}
+
+// renderChannelMessage parses a <channel source="..." ...>body</channel>
+// element and renders only the body as markdown. The metadata
+// (sender, channel source, timestamp) is rendered separately by
+// ChannelInfoItem so it appears outside the message body, mirroring
+// the assistant info line.
+func (m *UserMessageItem) renderChannelMessage(raw string, width int) string {
+	var ch channelMessage
+	if err := xml.Unmarshal([]byte(raw), &ch); err != nil {
+		return m.fallbackRender(raw, width)
+	}
+
+	body := strings.TrimSpace(ch.Content)
+	if body == "" {
+		return ""
+	}
+
+	renderer := common.MarkdownRenderer(m.sty, width)
+	mu := common.LockMarkdownRenderer(renderer)
+	mu.Lock()
+	result, err := renderer.Render(body)
+	mu.Unlock()
+	if err != nil {
+		return body
+	}
+	return strings.TrimSuffix(result, "\n")
+}
+
+// fallbackRender renders text as plain markdown when XML parsing fails.
+func (m *UserMessageItem) fallbackRender(content string, width int) string {
+	renderer := common.MarkdownRenderer(m.sty, width)
+	mu := common.LockMarkdownRenderer(renderer)
+	mu.Lock()
+	result, err := renderer.Render(content)
+	mu.Unlock()
+	if err != nil {
+		return content
+	}
+	return strings.TrimSuffix(result, "\n")
 }
 
 // Render implements MessageItem.

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -156,7 +156,7 @@ func (m *UserMessageItem) renderChannelMessage(raw string, width int) string {
 		return ""
 	}
 
-	renderer := common.MarkdownRenderer(m.sty, width)
+	renderer := common.UserMarkdownRenderer(m.sty, width)
 	mu := common.LockMarkdownRenderer(renderer)
 	mu.Lock()
 	result, err := renderer.Render(body)
@@ -169,7 +169,7 @@ func (m *UserMessageItem) renderChannelMessage(raw string, width int) string {
 
 // fallbackRender renders text as plain markdown when XML parsing fails.
 func (m *UserMessageItem) fallbackRender(content string, width int) string {
-	renderer := common.MarkdownRenderer(m.sty, width)
+	renderer := common.UserMarkdownRenderer(m.sty, width)
 	mu := common.LockMarkdownRenderer(renderer)
 	mu.Lock()
 	result, err := renderer.Render(content)

--- a/internal/ui/chat/user_test.go
+++ b/internal/ui/chat/user_test.go
@@ -1,0 +1,254 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestUserItem(text string, createdAt int64) *UserMessageItem {
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:        "test-id",
+		Role:      message.User,
+		CreatedAt: createdAt,
+		Parts:     []message.ContentPart{message.TextContent{Text: text}},
+	}
+	r := attachments.NewRenderer(
+		sty.Attachments.Normal,
+		sty.Attachments.Deleting,
+		sty.Attachments.Image,
+		sty.Attachments.Text,
+		sty.Attachments.Skill,
+		sty.Attachments.Remove,
+	)
+	return NewUserMessageItem(&sty, msg, r).(*UserMessageItem)
+}
+
+func newTestChannelInfoItem(text string, createdAt int64) *ChannelInfoItem {
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:        "test-id",
+		Role:      message.User,
+		CreatedAt: createdAt,
+		Parts:     []message.ContentPart{message.TextContent{Text: text}},
+	}
+	return NewChannelInfoItem(&sty, msg).(*ChannelInfoItem)
+}
+
+// --- UserMessageItem body tests (body only, no metadata) ---
+
+// TestRawRender_ChannelMessageBody verifies that the UserMessageItem for a
+// channel message renders only the body content, not the metadata line.
+func TestRawRender_ChannelMessageBody(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender="+15551234567" sender_name="Alice" time="14:30">Hello from Signal!</channel>`
+
+	item := newTestUserItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	// Body should be rendered as markdown, not raw XML.
+	require.Contains(t, out, "Hello from Signal!")
+
+	// Raw XML tags must not be visible.
+	require.NotContains(t, out, "<channel")
+	require.NotContains(t, out, "</channel>")
+
+	// Metadata must NOT appear in the body — it is rendered by ChannelInfoItem.
+	require.NotContains(t, out, "via signal")
+	require.NotContains(t, out, "at 14:30")
+}
+
+// TestRawRender_ChannelMessageSourceOnlyBody verifies that a message with
+// only a source renders just the body in UserMessageItem.
+func TestRawRender_ChannelMessageSourceOnlyBody(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal">Just the source, no sender or time.</channel>`
+
+	item := newTestUserItem(text, 1752456000)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "Just the source")
+	require.NotContains(t, out, "<channel")
+	require.NotContains(t, out, "</channel>")
+	require.NotContains(t, out, "via signal")
+}
+
+// TestRawRender_ChannelMessageMalformed verifies that truncated/invalid XML
+// does not panic and falls back to plain markdown rendering.
+func TestRawRender_ChannelMessageMalformed(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender="broken`
+
+	item := newTestUserItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.NotEmpty(t, out)
+	require.Contains(t, out, "<channel")
+}
+
+// TestRawRender_NormalMessage verifies that non-channel messages are not
+// affected by channel rendering logic.
+func TestRawRender_NormalMessage(t *testing.T) {
+	t.Parallel()
+
+	text := `This is a normal user message.`
+
+	item := newTestUserItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "This is a normal user message.")
+	require.NotContains(t, out, "signal")
+	require.NotContains(t, out, "via")
+	require.NotContains(t, out, "<channel")
+}
+
+// TestRawRender_ChannelMessageEmptyBody verifies that a channel message with
+// no body renders an empty string in UserMessageItem.
+func TestRawRender_ChannelMessageEmptyBody(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender="+15551234567" sender_name="Bob" time="09:15"></channel>`
+
+	item := newTestUserItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.NotContains(t, out, "<channel")
+	require.NotContains(t, out, "</channel>")
+	require.NotContains(t, out, "via signal")
+}
+
+// TestRawRender_ChannelMessageSenderFallbackBody verifies that the body
+// renders correctly when sender is provided but sender_name is not.
+func TestRawRender_ChannelMessageSenderFallbackBody(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender="+15559876543">Fallback sender</channel>`
+
+	item := newTestUserItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "Fallback sender")
+	require.NotContains(t, out, "<channel")
+}
+
+// --- ChannelInfoItem metadata tests ---
+
+// TestChannelInfo_Full verifies that the ChannelInfoItem renders the full
+// metadata line: "[icon] [sender] via [channel] at [timestamp]".
+func TestChannelInfo_Full(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender="+15551234567" sender_name="Alice" time="14:30">Hello!</channel>`
+
+	item := newTestChannelInfoItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	// Must contain sender, channel source, and timestamp.
+	require.Contains(t, out, "Alice")
+	require.Contains(t, out, "via signal")
+	require.Contains(t, out, "at 14:30")
+
+	// Must contain the chat-bubble glyph icon.
+	require.Contains(t, out, styles.ChannelIcon)
+
+	// Must NOT contain the body content — that's in UserMessageItem.
+	require.NotContains(t, out, "Hello!")
+
+	// Must NOT contain raw XML.
+	require.NotContains(t, out, "<channel")
+	require.NotContains(t, out, "</channel>")
+}
+
+// TestChannelInfo_SenderFallback verifies that when sender is provided but
+// sender_name is not, the raw sender value is shown.
+func TestChannelInfo_SenderFallback(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender="+15559876543">Body text</channel>`
+
+	item := newTestChannelInfoItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "+15559876543")
+	require.Contains(t, out, "via signal")
+}
+
+// TestChannelInfo_CreatedAtFallback verifies that when no time attribute is
+// present, the message's CreatedAt timestamp is used.
+func TestChannelInfo_CreatedAtFallback(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal">Uses CreatedAt</channel>`
+
+	item := newTestChannelInfoItem(text, 1752456000)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "via signal")
+	require.Contains(t, out, "at ")
+}
+
+// TestChannelInfo_NoSource verifies that when no source attribute is present,
+// the "via" clause is omitted but metadata still renders without panicking.
+func TestChannelInfo_NoSource(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel sender="+1234" sender_name="Eve" time="08:00">No source</channel>`
+
+	item := newTestChannelInfoItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	require.Contains(t, out, "Eve")
+	require.Contains(t, out, "at 08:00")
+	require.NotContains(t, out, "via")
+}
+
+// TestChannelInfo_NoMetadata verifies that when only the body is present with
+// no metadata attributes, the ChannelInfoItem renders an empty string.
+func TestChannelInfo_NoMetadata(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel>Just a body, nothing else.</channel>`
+
+	item := newTestChannelInfoItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	// With no metadata, the info item should be empty.
+	require.Empty(t, out)
+}
+
+// TestChannelInfo_MalformedXML verifies that malformed XML does not panic.
+func TestChannelInfo_MalformedXML(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender="broken`
+
+	item := newTestChannelInfoItem(text, 0)
+	out := ansi.Strip(item.RawRender(80))
+
+	// Should not panic and should be empty (XML parse fails).
+	require.Empty(t, out)
+}
+
+// TestChannelInfo_RenderHasSectionHeader verifies that the Render method
+// applies the SectionHeader padding ( paddingLeft(2) ), confirming the
+// metadata appears as a separate item outside the message body.
+func TestChannelInfo_RenderHasSectionHeader(t *testing.T) {
+	t.Parallel()
+
+	text := `<channel source="signal" sender_name="Alice" time="14:30">Hi</channel>`
+
+	item := newTestChannelInfoItem(text, 0)
+	out := ansi.Strip(item.Render(80))
+
+	// The rendered output should start with at least 2 spaces (paddingLeft(2)).
+	require.True(t, strings.HasPrefix(out, "  "), "ChannelInfoItem.Render must apply SectionHeader padding")
+}

--- a/internal/ui/chat/user_test.go
+++ b/internal/ui/chat/user_test.go
@@ -11,7 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestUserItem(text string, createdAt int64) *UserMessageItem {
+// newTestChannelUserItem builds a UserMessageItem carrying text and a creation
+// timestamp, with a real attachments renderer, for the channel render tests.
+func newTestChannelUserItem(text string, createdAt int64) *UserMessageItem {
 	sty := styles.CharmtonePantera()
 	msg := &message.Message{
 		ID:        "test-id",
@@ -50,7 +52,7 @@ func TestRawRender_ChannelMessageBody(t *testing.T) {
 
 	text := `<channel source="signal" sender="+15551234567" sender_name="Alice" time="14:30">Hello from Signal!</channel>`
 
-	item := newTestUserItem(text, 0)
+	item := newTestChannelUserItem(text, 0)
 	out := ansi.Strip(item.RawRender(80))
 
 	// Body should be rendered as markdown, not raw XML.
@@ -72,7 +74,7 @@ func TestRawRender_ChannelMessageSourceOnlyBody(t *testing.T) {
 
 	text := `<channel source="signal">Just the source, no sender or time.</channel>`
 
-	item := newTestUserItem(text, 1752456000)
+	item := newTestChannelUserItem(text, 1752456000)
 	out := ansi.Strip(item.RawRender(80))
 
 	require.Contains(t, out, "Just the source")
@@ -88,7 +90,7 @@ func TestRawRender_ChannelMessageMalformed(t *testing.T) {
 
 	text := `<channel source="signal" sender="broken`
 
-	item := newTestUserItem(text, 0)
+	item := newTestChannelUserItem(text, 0)
 	out := ansi.Strip(item.RawRender(80))
 
 	require.NotEmpty(t, out)
@@ -102,7 +104,7 @@ func TestRawRender_NormalMessage(t *testing.T) {
 
 	text := `This is a normal user message.`
 
-	item := newTestUserItem(text, 0)
+	item := newTestChannelUserItem(text, 0)
 	out := ansi.Strip(item.RawRender(80))
 
 	require.Contains(t, out, "This is a normal user message.")
@@ -118,7 +120,7 @@ func TestRawRender_ChannelMessageEmptyBody(t *testing.T) {
 
 	text := `<channel source="signal" sender="+15551234567" sender_name="Bob" time="09:15"></channel>`
 
-	item := newTestUserItem(text, 0)
+	item := newTestChannelUserItem(text, 0)
 	out := ansi.Strip(item.RawRender(80))
 
 	require.NotContains(t, out, "<channel")
@@ -133,7 +135,7 @@ func TestRawRender_ChannelMessageSenderFallbackBody(t *testing.T) {
 
 	text := `<channel source="signal" sender="+15559876543">Fallback sender</channel>`
 
-	item := newTestUserItem(text, 0)
+	item := newTestChannelUserItem(text, 0)
 	out := ansi.Strip(item.RawRender(80))
 
 	require.Contains(t, out, "Fallback sender")

--- a/internal/ui/dialog/channels.go
+++ b/internal/ui/dialog/channels.go
@@ -1,0 +1,283 @@
+package dialog
+
+import (
+	"fmt"
+	"sort"
+
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/list"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/sahilm/fuzzy"
+)
+
+// ChannelsID is the identifier for the channels dialog.
+const ChannelsID = "channels"
+
+// ChannelItem wraps a channel server's ClientInfo as a filterable list item.
+type ChannelItem struct {
+	*list.Versioned
+	info    mcp.ClientInfo
+	t       *styles.Styles
+	m       fuzzy.Match
+	cache   map[int]string
+	focused bool
+}
+
+var _ ListItem = &ChannelItem{Versioned: list.NewVersioned()}
+
+// NewChannelItem creates a new ChannelItem.
+func NewChannelItem(t *styles.Styles, info mcp.ClientInfo) *ChannelItem {
+	return &ChannelItem{
+		Versioned: list.NewVersioned(),
+		t:         t,
+		info:      info,
+	}
+}
+
+// Finished implements list.Item.
+func (c *ChannelItem) Finished() bool { return true }
+
+// Filter implements ListItem.
+func (c *ChannelItem) Filter() string {
+	return c.info.Name
+}
+
+// ID implements ListItem.
+func (c *ChannelItem) ID() string {
+	return c.info.Name
+}
+
+// SetFocused implements ListItem.
+func (c *ChannelItem) SetFocused(focused bool) {
+	if c.focused == focused {
+		return
+	}
+	c.cache = nil
+	c.focused = focused
+	if c.Versioned != nil {
+		c.Bump()
+	}
+}
+
+// SetMatch implements ListItem.
+func (c *ChannelItem) SetMatch(match fuzzy.Match) {
+	if sameFuzzyMatch(c.m, match) {
+		return
+	}
+	c.cache = nil
+	c.m = match
+	if c.Versioned != nil {
+		c.Bump()
+	}
+}
+
+// Render implements ListItem.
+func (c *ChannelItem) Render(width int) string {
+	itemStyles := ListItemStyles{
+		ItemBlurred:     c.t.Dialog.NormalItem,
+		ItemFocused:     c.t.Dialog.SelectedItem,
+		InfoTextBlurred: c.t.Dialog.ListItem.InfoBlurred,
+		InfoTextFocused: c.t.Dialog.ListItem.InfoFocused,
+	}
+
+	info := fmt.Sprintf("%s  %dt", c.info.State.String(), c.info.Counts.Tools)
+
+	return renderItem(itemStyles, c.info.Name, info, c.focused, width, c.cache, &c.m)
+}
+
+// Channels is a dialog that lists channel-capable MCP servers and their
+// connection state.
+type Channels struct {
+	com    *common.Common
+	help   help.Model
+	list   *list.FilterableList
+	input  textinput.Model
+	ws     workspace.Workspace
+	keyMap struct {
+		Next,
+		Previous,
+		UpDown,
+		Close key.Binding
+	}
+}
+
+var _ Dialog = (*Channels)(nil)
+
+// NewChannels creates a new channels dialog.
+func NewChannels(com *common.Common, ws workspace.Workspace) *Channels {
+	d := &Channels{
+		com: com,
+		ws:  ws,
+	}
+
+	help := help.New()
+	help.Styles = com.Styles.DialogHelpStyles()
+	d.help = help
+
+	d.list = list.NewFilterableList(d.channelItems()...)
+	d.list.Focus()
+	d.list.SetSelected(0)
+
+	d.input = textinput.New()
+	d.input.SetVirtualCursor(false)
+	d.input.Placeholder = "Type to filter"
+	d.input.SetStyles(com.Styles.TextInput)
+	d.input.Focus()
+
+	d.keyMap.UpDown = key.NewBinding(
+		key.WithKeys("up", "down"),
+		key.WithHelp("↑/↓", "choose"),
+	)
+	d.keyMap.Next = key.NewBinding(
+		key.WithKeys("down"),
+		key.WithHelp("↓", "next"),
+	)
+	d.keyMap.Previous = key.NewBinding(
+		key.WithKeys("up"),
+		key.WithHelp("↑", "previous"),
+	)
+	closeKey := CloseKey
+	closeKey.SetHelp("esc", "close")
+	d.keyMap.Close = closeKey
+
+	return d
+}
+
+// channelItems builds the list items from current MCP server states, filtered
+// to only show channel-capable servers, sorted by name.
+func (d *Channels) channelItems() []list.FilterableItem {
+	states := d.ws.MCPGetStates()
+	names := make([]string, 0, len(states))
+	for name, info := range states {
+		if info.Channel {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	items := make([]list.FilterableItem, 0, len(names))
+	for _, name := range names {
+		info := states[name]
+		info.Name = name
+		items = append(items, NewChannelItem(d.com.Styles, info))
+	}
+	return items
+}
+
+// ID implements Dialog.
+func (d *Channels) ID() string { return ChannelsID }
+
+// HandleMsg implements Dialog.
+func (d *Channels) HandleMsg(msg tea.Msg) Action {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, d.keyMap.Close):
+			return ActionClose{}
+		case key.Matches(msg, d.keyMap.Previous):
+			d.list.Focus()
+			if d.list.IsSelectedFirst() {
+				d.list.SelectLast()
+			} else {
+				d.list.SelectPrev()
+			}
+			d.list.ScrollToSelected()
+		case key.Matches(msg, d.keyMap.Next):
+			d.list.Focus()
+			if d.list.IsSelectedLast() {
+				d.list.SelectFirst()
+			} else {
+				d.list.SelectNext()
+			}
+			d.list.ScrollToSelected()
+		case msg.Code == tea.KeyEnter:
+			// Channels have no per-item action yet; swallow Enter so it does
+			// not fall through into the filter input.
+			return nil
+		default:
+			var cmd tea.Cmd
+			d.input, cmd = d.input.Update(msg)
+			value := d.input.Value()
+			d.list.SetFilter(value)
+			d.list.ScrollToTop()
+			d.list.SetSelected(0)
+			return ActionCmd{cmd}
+		}
+	}
+	return nil
+}
+
+// selectedChannel returns the currently selected ChannelItem, or nil.
+func (d *Channels) selectedChannel() *ChannelItem {
+	item := d.list.SelectedItem()
+	if item == nil {
+		return nil
+	}
+	if ci, ok := item.(*ChannelItem); ok {
+		return ci
+	}
+	return nil
+}
+
+// Cursor returns the cursor position relative to the dialog.
+func (d *Channels) Cursor() *tea.Cursor {
+	return InputCursor(d.com.Styles, d.input.Cursor())
+}
+
+// Draw implements Dialog.
+func (d *Channels) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	t := d.com.Styles
+	width := max(0, min(defaultDialogMaxWidth, area.Dx()-t.Dialog.View.GetHorizontalBorderSize()))
+	height := max(0, min(defaultDialogHeight, area.Dy()-t.Dialog.View.GetVerticalBorderSize()))
+	innerWidth := width - t.Dialog.View.GetHorizontalFrameSize()
+	heightOffset := t.Dialog.Title.GetVerticalFrameSize() + titleContentHeight +
+		t.Dialog.InputPrompt.GetVerticalFrameSize() + inputContentHeight +
+		t.Dialog.HelpView.GetVerticalFrameSize() +
+		t.Dialog.View.GetVerticalFrameSize()
+
+	d.input.SetWidth(max(0, innerWidth-t.Dialog.InputPrompt.GetHorizontalFrameSize()-1))
+
+	listHeight := height - heightOffset
+	listWidth := max(0, innerWidth-3)
+	d.list.SetSize(listWidth, listHeight)
+	d.help.SetWidth(innerWidth)
+
+	rc := NewRenderContext(t, width)
+	rc.Title = "Channels"
+	inputView := t.Dialog.InputPrompt.Render(d.input.View())
+	rc.AddPart(inputView)
+	listView := t.Dialog.List.Height(d.list.Height()).Render(d.list.Render())
+	scrollbar := common.Scrollbar(t, listHeight, d.list.TotalHeight(), listHeight, d.list.Offset())
+	if scrollbar != "" {
+		listView = lipgloss.JoinHorizontal(lipgloss.Top, listView, scrollbar)
+	}
+	rc.AddPart(listView)
+	rc.Help = d.help.View(d)
+
+	view := rc.Render()
+	cur := d.Cursor()
+	DrawCenterCursor(scr, area, view, cur)
+	return cur
+}
+
+// ShortHelp implements help.KeyMap.
+func (d *Channels) ShortHelp() []key.Binding {
+	return []key.Binding{
+		d.keyMap.UpDown,
+		d.keyMap.Close,
+	}
+}
+
+// FullHelp implements help.KeyMap.
+func (d *Channels) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{d.keyMap.UpDown, d.keyMap.Close},
+	}
+}

--- a/internal/ui/dialog/channels_test.go
+++ b/internal/ui/dialog/channels_test.go
@@ -1,0 +1,162 @@
+package dialog
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+type stubChannelsWorkspace struct {
+	workspace.Workspace
+	states map[string]mcp.ClientInfo
+}
+
+func (w *stubChannelsWorkspace) MCPGetStates() map[string]mcp.ClientInfo {
+	return w.states
+}
+
+func newTestChannels(t *testing.T, states map[string]mcp.ClientInfo) *Channels {
+	t.Helper()
+	s := styles.CharmtonePantera()
+	com := &common.Common{Styles: &s}
+	ws := &stubChannelsWorkspace{states: states}
+	return NewChannels(com, ws)
+}
+
+func TestChannels_EscClosesDialog(t *testing.T) {
+	t.Parallel()
+
+	d := newTestChannels(t, map[string]mcp.ClientInfo{
+		"signal": {Name: "signal", State: mcp.StateConnected, Channel: true},
+	})
+
+	action := d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEscape})
+	_, ok := action.(ActionClose)
+	require.True(t, ok, "Esc should close the dialog")
+}
+
+func TestChannels_FilterNarrowsList(t *testing.T) {
+	t.Parallel()
+
+	d := newTestChannels(t, map[string]mcp.ClientInfo{
+		"signal": {Name: "signal", State: mcp.StateConnected, Channel: true},
+		"slack":  {Name: "slack", State: mcp.StateError, Channel: true},
+	})
+
+	d.HandleMsg(keyMsg('s'))
+	d.HandleMsg(keyMsg('i'))
+	d.HandleMsg(keyMsg('g'))
+
+	filtered := d.list.FilteredItems()
+	require.Len(t, filtered, 1)
+	item := filtered[0].(*ChannelItem)
+	require.Equal(t, "signal", item.info.Name)
+}
+
+func TestChannels_OnlyShowsChannelServers(t *testing.T) {
+	t.Parallel()
+
+	d := newTestChannels(t, map[string]mcp.ClientInfo{
+		"signal":     {Name: "signal", State: mcp.StateConnected, Channel: true},
+		"nonchannel": {Name: "nonchannel", State: mcp.StateConnected, Channel: false},
+	})
+
+	items := d.list.FilteredItems()
+	require.Len(t, items, 1, "only channel-capable servers should appear")
+	require.Equal(t, "signal", items[0].(*ChannelItem).info.Name)
+}
+
+func TestChannels_ChannelsSortedByName(t *testing.T) {
+	t.Parallel()
+
+	d := newTestChannels(t, map[string]mcp.ClientInfo{
+		"zeta":  {Name: "zeta", State: mcp.StateConnected, Channel: true},
+		"alpha": {Name: "alpha", State: mcp.StateConnected, Channel: true},
+		"mid":   {Name: "mid", State: mcp.StateConnected, Channel: true},
+	})
+
+	items := d.list.FilteredItems()
+	require.Len(t, items, 3)
+	names := make([]string, 0, len(items))
+	for _, it := range items {
+		names = append(names, it.(*ChannelItem).info.Name)
+	}
+	require.Equal(t, []string{"alpha", "mid", "zeta"}, names,
+		"channels should be listed in a stable alphabetical order")
+}
+
+func TestChannels_NavigationWraps(t *testing.T) {
+	t.Parallel()
+
+	d := newTestChannels(t, map[string]mcp.ClientInfo{
+		"alpha": {Name: "alpha", State: mcp.StateConnected, Channel: true},
+		"beta":  {Name: "beta", State: mcp.StateConnected, Channel: true},
+	})
+
+	first := d.selectedChannel()
+	require.NotNil(t, first)
+
+	d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyDown})
+	second := d.selectedChannel()
+	require.NotNil(t, second)
+	require.NotEqual(t, first.info.Name, second.info.Name, "Down should move to a different channel")
+
+	d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyDown})
+	wrapped := d.selectedChannel()
+	require.NotNil(t, wrapped)
+	require.Equal(t, first.info.Name, wrapped.info.Name, "Down at end should wrap to first")
+
+	d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyUp})
+	upWrapped := d.selectedChannel()
+	require.NotNil(t, upWrapped)
+	require.Equal(t, second.info.Name, upWrapped.info.Name, "Up at start should wrap to last")
+}
+
+func TestChannels_EmptyStatesNoPanic(t *testing.T) {
+	t.Parallel()
+
+	d := newTestChannels(t, map[string]mcp.ClientInfo{})
+
+	action := d.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.Nil(t, action, "no action when no channel selected")
+}
+
+func TestChannels_NoChannelsOnlyNonChannelServers(t *testing.T) {
+	t.Parallel()
+
+	d := newTestChannels(t, map[string]mcp.ClientInfo{
+		"mcp1": {Name: "mcp1", State: mcp.StateConnected, Channel: false},
+		"mcp2": {Name: "mcp2", State: mcp.StateConnected, Channel: false},
+	})
+
+	items := d.list.FilteredItems()
+	require.Empty(t, items, "no channels should appear when all servers are non-channel")
+}
+
+func TestChannelItem_RenderDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	s := styles.CharmtonePantera()
+	info := mcp.ClientInfo{
+		Name:    "test",
+		State:   mcp.StateConnected,
+		Channel: true,
+		Counts:  mcp.Counts{Tools: 5},
+	}
+	item := NewChannelItem(&s, info)
+	rendered := item.Render(60)
+	require.NotEmpty(t, rendered)
+}
+
+func TestChannelItem_FilterMatchesName(t *testing.T) {
+	t.Parallel()
+
+	s := styles.CharmtonePantera()
+	item := NewChannelItem(&s, mcp.ClientInfo{Name: "signal-channel"})
+	require.Equal(t, "signal-channel", item.Filter())
+}

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -531,6 +531,9 @@ func (c *Commands) defaultCommands() []*CommandItem {
 	}
 	commands = append(commands, NewCommandItem(c.com.Styles, "toggle_transparent", transparentLabel, "", ActionToggleTransparentBackground{}))
 
+	// Add Channels command — opens the channels management dialog.
+	commands = append(commands, NewCommandItem(c.com.Styles, "channels", "Channels", "", ActionOpenDialog{DialogID: ChannelsID}))
+
 	commands = append(
 		commands,
 		NewCommandItem(c.com.Styles, "quit", "Quit", "ctrl+c", tea.QuitMsg{}).WithAliases("exit"),

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -548,6 +548,9 @@ func (c *Commands) defaultCommands() []*CommandItem {
 	}
 	commands = append(commands, NewCommandItem(c.com.Styles, "toggle_transparent", transparentLabel, "", ActionToggleTransparentBackground{}))
 
+	// Add Channels command — opens the channels management dialog.
+	commands = append(commands, NewCommandItem(c.com.Styles, "channels", "Channels", "", ActionOpenDialog{DialogID: ChannelsID}))
+
 	commands = append(
 		commands,
 		NewCommandItem(c.com.Styles, "quit", "Quit", "ctrl+c", tea.QuitMsg{}).WithAliases("exit"),

--- a/internal/ui/model/channel_test.go
+++ b/internal/ui/model/channel_test.go
@@ -20,12 +20,13 @@ import (
 // stub honest about what the code under test depends on.
 type channelWorkspace struct {
 	workspace.Workspace
-	ready       bool
-	createErr   error
-	newSession  session.Session
-	createCalls int
-	runCalls    []channelRun
-	runErr      error
+	ready        bool
+	routesRemote bool
+	createErr    error
+	newSession   session.Session
+	createCalls  int
+	runCalls     []channelRun
+	runErr       error
 }
 
 type channelRun struct {
@@ -33,7 +34,8 @@ type channelRun struct {
 	prompt    string
 }
 
-func (w *channelWorkspace) AgentIsReady() bool { return w.ready }
+func (w *channelWorkspace) AgentIsReady() bool        { return w.ready }
+func (w *channelWorkspace) RoutesChannelEvents() bool { return w.routesRemote }
 
 func (w *channelWorkspace) CreateSession(context.Context, string) (session.Session, error) {
 	w.createCalls++
@@ -108,6 +110,24 @@ func TestHandleChannelMessageCreatesSessionWhenNoneActive(t *testing.T) {
 	}
 	if !m.hasSession() || m.session.ID != "new-sess" {
 		t.Fatalf("expected active session new-sess, got %+v", m.session)
+	}
+}
+
+// TestHandleChannelMessageSkipsWhenServerRoutes verifies the client/server
+// split: when the workspace routes channel events itself (ClientWorkspace),
+// the TUI must not inject — the server injects exactly once and per-client
+// injection would duplicate the turn.
+func TestHandleChannelMessageSkipsWhenServerRoutes(t *testing.T) {
+	t.Parallel()
+	ws := &channelWorkspace{ready: true, routesRemote: true}
+	m := newChannelUI(ws)
+	m.session = &session.Session{ID: "sess-1"}
+
+	if cmd := m.handleChannelMessage(mcp.Event{ChannelMessage: "<channel source=\"s\">hi</channel>"}); cmd != nil {
+		t.Error("expected no command when the server owns channel routing")
+	}
+	if ws.createCalls != 0 || len(ws.runCalls) != 0 {
+		t.Errorf("server-routed event must not create sessions or run the agent locally; got %d creates, %d runs", ws.createCalls, len(ws.runCalls))
 	}
 }
 

--- a/internal/ui/model/channel_test.go
+++ b/internal/ui/model/channel_test.go
@@ -1,0 +1,140 @@
+package model
+
+import (
+	"context"
+	"testing"
+
+	"charm.land/bubbles/v2/textarea"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/workspace"
+)
+
+// channelWorkspace is a workspace.Workspace stub that records the calls
+// handleChannelMessage makes. Only the methods that path touches are
+// implemented; the embedded interface panics on anything else, which keeps the
+// stub honest about what the code under test depends on.
+type channelWorkspace struct {
+	workspace.Workspace
+	ready       bool
+	createErr   error
+	newSession  session.Session
+	createCalls int
+	runCalls    []channelRun
+	runErr      error
+}
+
+type channelRun struct {
+	sessionID string
+	prompt    string
+}
+
+func (w *channelWorkspace) AgentIsReady() bool { return w.ready }
+
+func (w *channelWorkspace) CreateSession(context.Context, string) (session.Session, error) {
+	w.createCalls++
+	if w.createErr != nil {
+		return session.Session{}, w.createErr
+	}
+	return w.newSession, nil
+}
+
+func (w *channelWorkspace) AgentRun(_ context.Context, sessionID, prompt string, _ ...message.Attachment) error {
+	w.runCalls = append(w.runCalls, channelRun{sessionID: sessionID, prompt: prompt})
+	return w.runErr
+}
+
+func (w *channelWorkspace) Config() *config.Config { return nil }
+
+// newChannelUI builds a UI initialized enough that ensureSession's setState /
+// layout path is safe to exercise.
+func newChannelUI(ws *channelWorkspace) *UI {
+	com := common.DefaultCommon(ws)
+	return &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusEditor,
+		width:    140,
+		height:   45,
+	}
+}
+
+func TestHandleChannelMessageExistingSession(t *testing.T) {
+	t.Parallel()
+	ws := &channelWorkspace{ready: true}
+	m := newChannelUI(ws)
+	m.session = &session.Session{ID: "sess-1"}
+
+	cmd := m.handleChannelMessage(mcp.Event{ChannelMessage: "<channel source=\"s\">hi</channel>"})
+	if cmd == nil {
+		t.Fatal("expected a command for an active-session channel event")
+	}
+	// No session creation when one is already active.
+	if ws.createCalls != 0 {
+		t.Errorf("CreateSession calls = %d, want 0", ws.createCalls)
+	}
+	// Running the command drives the AgentRun injection.
+	cmd()
+	if len(ws.runCalls) != 1 {
+		t.Fatalf("AgentRun calls = %d, want 1", len(ws.runCalls))
+	}
+	if ws.runCalls[0].sessionID != "sess-1" {
+		t.Errorf("AgentRun sessionID = %q, want sess-1", ws.runCalls[0].sessionID)
+	}
+	if ws.runCalls[0].prompt != "<channel source=\"s\">hi</channel>" {
+		t.Errorf("AgentRun prompt = %q", ws.runCalls[0].prompt)
+	}
+}
+
+func TestHandleChannelMessageCreatesSessionWhenNoneActive(t *testing.T) {
+	t.Parallel()
+	ws := &channelWorkspace{ready: true, newSession: session.Session{ID: "new-sess"}}
+	m := newChannelUI(ws)
+	// No active session: a pushed event must not be dropped.
+
+	cmd := m.handleChannelMessage(mcp.Event{ChannelMessage: "<channel source=\"s\">hi</channel>"})
+	if cmd == nil {
+		t.Fatal("expected a command when auto-creating a session")
+	}
+	if ws.createCalls != 1 {
+		t.Errorf("CreateSession calls = %d, want 1", ws.createCalls)
+	}
+	if !m.hasSession() || m.session.ID != "new-sess" {
+		t.Fatalf("expected active session new-sess, got %+v", m.session)
+	}
+}
+
+func TestHandleChannelMessageDropsWhenNotReadyOrEmpty(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty content", func(t *testing.T) {
+		t.Parallel()
+		ws := &channelWorkspace{ready: true}
+		m := newChannelUI(ws)
+		if cmd := m.handleChannelMessage(mcp.Event{ChannelMessage: ""}); cmd != nil {
+			t.Error("empty channel message should be a no-op")
+		}
+		if ws.createCalls != 0 {
+			t.Error("empty message should not create a session")
+		}
+	})
+
+	t.Run("agent not ready", func(t *testing.T) {
+		t.Parallel()
+		ws := &channelWorkspace{ready: false}
+		m := newChannelUI(ws)
+		if cmd := m.handleChannelMessage(mcp.Event{ChannelMessage: "<channel source=\"s\">hi</channel>"}); cmd != nil {
+			t.Error("event should be dropped when the agent is not ready")
+		}
+		if ws.createCalls != 0 {
+			t.Error("not-ready event should not create a session")
+		}
+	})
+}

--- a/internal/ui/model/channel_test.go
+++ b/internal/ui/model/channel_test.go
@@ -27,9 +27,11 @@ type channelWorkspace struct {
 	createCalls  int
 	runCalls     []channelRun
 	runErr       error
+	channels     []string
 }
 
 type channelRun struct {
+	channel   string
 	sessionID string
 	prompt    string
 }
@@ -48,6 +50,16 @@ func (w *channelWorkspace) CreateSession(context.Context, string) (session.Sessi
 func (w *channelWorkspace) AgentRun(_ context.Context, sessionID, prompt string, _ ...message.Attachment) error {
 	w.runCalls = append(w.runCalls, channelRun{sessionID: sessionID, prompt: prompt})
 	return w.runErr
+}
+
+func (w *channelWorkspace) AgentRunChannel(_ context.Context, channel, sessionID, prompt string, _ ...message.Attachment) error {
+	w.runCalls = append(w.runCalls, channelRun{channel: channel, sessionID: sessionID, prompt: prompt})
+	return w.runErr
+}
+
+func (w *channelWorkspace) SetSessionChannel(_ context.Context, sessionID, channel string) (session.Session, error) {
+	w.channels = append(w.channels, channel)
+	return session.Session{ID: sessionID, Channel: channel}, nil
 }
 
 func (w *channelWorkspace) Config() *config.Config { return nil }
@@ -74,7 +86,7 @@ func TestHandleChannelMessageExistingSession(t *testing.T) {
 	m := newChannelUI(ws)
 	m.session = &session.Session{ID: "sess-1"}
 
-	cmd := m.handleChannelMessage(mcp.Event{ChannelMessage: "<channel source=\"s\">hi</channel>"})
+	cmd := m.handleChannelMessage(mcp.Event{Name: "s", ChannelMessage: "<channel source=\"s\">hi</channel>"})
 	if cmd == nil {
 		t.Fatal("expected a command for an active-session channel event")
 	}
@@ -86,6 +98,12 @@ func TestHandleChannelMessageExistingSession(t *testing.T) {
 	cmd()
 	if len(ws.runCalls) != 1 {
 		t.Fatalf("AgentRun calls = %d, want 1", len(ws.runCalls))
+	}
+	if ws.runCalls[0].channel != "s" {
+		t.Errorf("AgentRun channel = %q, want s", ws.runCalls[0].channel)
+	}
+	if len(ws.channels) != 1 || ws.channels[0] != "s" {
+		t.Errorf("session channels = %v, want [s]", ws.channels)
 	}
 	if ws.runCalls[0].sessionID != "sess-1" {
 		t.Errorf("AgentRun sessionID = %q, want sess-1", ws.runCalls[0].sessionID)
@@ -101,7 +119,7 @@ func TestHandleChannelMessageCreatesSessionWhenNoneActive(t *testing.T) {
 	m := newChannelUI(ws)
 	// No active session: a pushed event must not be dropped.
 
-	cmd := m.handleChannelMessage(mcp.Event{ChannelMessage: "<channel source=\"s\">hi</channel>"})
+	cmd := m.handleChannelMessage(mcp.Event{Name: "s", ChannelMessage: "<channel source=\"s\">hi</channel>"})
 	if cmd == nil {
 		t.Fatal("expected a command when auto-creating a session")
 	}

--- a/internal/ui/model/channels.go
+++ b/internal/ui/model/channels.go
@@ -1,0 +1,114 @@
+package model
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+)
+
+// channelsInfo renders the channel status section showing MCP servers that are
+// connected as channels (via the claude/channel capability + --channels opt-in).
+func (m *UI) channelsInfo(width, maxItems int, isSection bool) string {
+	t := m.com.Styles
+
+	title := t.Resource.Heading.Render("Channels")
+	if isSection {
+		title = common.Section(t, title, width)
+	}
+
+	channels := m.channelStatusItems()
+	if len(channels) == 0 {
+		list := t.Resource.AdditionalText.Render("None")
+		return lipgloss.NewStyle().Width(width).Render(fmt.Sprintf("%s\n\n%s", title, list))
+	}
+
+	list := channelList(t, channels, width, maxItems)
+	return lipgloss.NewStyle().Width(width).Render(fmt.Sprintf("%s\n\n%s", title, list))
+}
+
+// channelStatusItem holds the display data for a single channel entry.
+type channelStatusItem struct {
+	name        string
+	icon        string
+	title       string
+	description string
+}
+
+// channelStatusItems collects all MCP servers that are active channels and
+// returns them sorted by name.
+func (m *UI) channelStatusItems() []channelStatusItem {
+	t := m.com.Styles
+	var items []channelStatusItem
+
+	for _, mcpCfg := range m.com.Config().MCP.Sorted() {
+		state, ok := m.mcpStates[mcpCfg.Name]
+		if !ok || !state.Channel {
+			continue
+		}
+
+		var icon string
+		var description string
+		switch state.State {
+		case mcp.StateStarting:
+			icon = t.Resource.BusyIcon.String()
+			description = t.Resource.StatusText.Render("starting...")
+		case mcp.StateConnected:
+			icon = t.Resource.OnlineIcon.String()
+			description = t.Resource.StatusText.Render("connected")
+		case mcp.StateError:
+			icon = t.Resource.ErrorIcon.String()
+			description = t.Resource.StatusText.Render("error")
+			if state.Error != nil {
+				description = t.Resource.StatusText.Render(fmt.Sprintf("error: %s", state.Error.Error()))
+			}
+		case mcp.StateDisabled:
+			icon = t.Resource.DisabledIcon.String()
+			description = t.Resource.StatusText.Render("disabled")
+		default:
+			icon = t.Resource.OfflineIcon.String()
+			description = t.Resource.StatusText.Render("offline")
+		}
+
+		items = append(items, channelStatusItem{
+			name:        mcpCfg.Name,
+			icon:        icon,
+			title:       t.Resource.Name.Render(mcpCfg.Name),
+			description: description,
+		})
+	}
+
+	slices.SortStableFunc(items, func(a, b channelStatusItem) int {
+		return strings.Compare(a.name, b.name)
+	})
+
+	return items
+}
+
+func channelList(t *styles.Styles, items []channelStatusItem, width, maxItems int) string {
+	if maxItems <= 0 {
+		return ""
+	}
+
+	if len(items) > maxItems {
+		visibleItems := items[:maxItems-1]
+		remaining := len(items) - (maxItems - 1)
+		items = append(visibleItems, channelStatusItem{
+			title: t.Resource.AdditionalText.Render(fmt.Sprintf("…and %d more", remaining)),
+		})
+	}
+
+	renderedItems := make([]string, 0, len(items))
+	for _, item := range items {
+		renderedItems = append(renderedItems, common.Status(t, common.StatusOpts{
+			Icon:        item.icon,
+			Title:       item.title,
+			Description: item.description,
+		}, width))
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, renderedItems...)
+}

--- a/internal/ui/model/channels_test.go
+++ b/internal/ui/model/channels_test.go
@@ -1,0 +1,120 @@
+package model
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/workspace"
+)
+
+type channelsTestWorkspace struct {
+	workspace.Workspace
+	cfg *config.Config
+}
+
+func (w *channelsTestWorkspace) Config() *config.Config { return w.cfg }
+
+// newChannelsTestUI builds a UI whose Config lists the given MCP names and
+// whose mcpStates map holds the given per-server ClientInfo.
+func newChannelsTestUI(t *testing.T, mcpNames []string, states map[string]mcp.ClientInfo) *UI {
+	t.Helper()
+	mcps := config.MCPs{}
+	for _, n := range mcpNames {
+		mcps[n] = config.MCPConfig{}
+	}
+	com := &common.Common{
+		Workspace: &channelsTestWorkspace{cfg: &config.Config{MCP: mcps}},
+		Styles:    common.DefaultCommon(nil).Styles,
+	}
+	return &UI{com: com, mcpStates: states}
+}
+
+// TestChannelStatusItems_FiltersSortsAndMapsState covers the core logic: only
+// MCP servers that are active channels (Channel==true) with a known state are
+// listed, they are sorted by name, and each connection state maps to the
+// expected status text (including the error message).
+func TestChannelStatusItems_FiltersSortsAndMapsState(t *testing.T) {
+	t.Parallel()
+
+	states := map[string]mcp.ClientInfo{
+		"zeta-chan":  {Name: "zeta-chan", State: mcp.StateConnected, Channel: true},
+		"alpha-chan": {Name: "alpha-chan", State: mcp.StateError, Channel: true, Error: errors.New("boom")},
+		"plain-mcp":  {Name: "plain-mcp", State: mcp.StateConnected, Channel: false}, // not a channel
+		// "orphan" has an MCP config but no entry in mcpStates → excluded.
+	}
+	m := newChannelsTestUI(t, []string{"zeta-chan", "alpha-chan", "plain-mcp", "orphan"}, states)
+
+	items := m.channelStatusItems()
+
+	// Only the two Channel==true servers that have a state, sorted by name.
+	require.Len(t, items, 2, "only active channels with a known state are listed")
+	require.Equal(t, "alpha-chan", items[0].name)
+	require.Equal(t, "zeta-chan", items[1].name)
+
+	// Error channel surfaces its error text; connected channel shows "connected".
+	require.Contains(t, ansi.Strip(items[0].description), "error: boom")
+	require.Contains(t, ansi.Strip(items[1].description), "connected")
+}
+
+// TestChannelStatusItems_StateVariants exercises the remaining state → text
+// mappings (starting, disabled, and an unknown state → offline).
+func TestChannelStatusItems_StateVariants(t *testing.T) {
+	t.Parallel()
+
+	states := map[string]mcp.ClientInfo{
+		"starting":  {Name: "starting", State: mcp.StateStarting, Channel: true},
+		"disabled":  {Name: "disabled", State: mcp.StateDisabled, Channel: true},
+		"errorless": {Name: "errorless", State: mcp.StateError, Channel: true}, // error state, nil Error
+		"unknown":   {Name: "unknown", State: mcp.State(99), Channel: true},    // out-of-range → offline
+	}
+	m := newChannelsTestUI(t, []string{"starting", "disabled", "errorless", "unknown"}, states)
+
+	got := map[string]string{}
+	for _, it := range m.channelStatusItems() {
+		got[it.name] = ansi.Strip(it.description)
+	}
+	require.Contains(t, got["starting"], "starting")
+	require.Contains(t, got["disabled"], "disabled")
+	require.Equal(t, "error", got["errorless"], "error state with no Error shows bare 'error'")
+	require.Contains(t, got["unknown"], "offline", "unknown state falls back to offline")
+}
+
+// TestChannelsInfo_EmptyShowsNone verifies the empty state renders the section
+// title plus "None" when no channels are configured.
+func TestChannelsInfo_EmptyShowsNone(t *testing.T) {
+	t.Parallel()
+
+	m := newChannelsTestUI(t, []string{"plain"}, map[string]mcp.ClientInfo{
+		"plain": {Name: "plain", State: mcp.StateConnected, Channel: false},
+	})
+
+	out := ansi.Strip(m.channelsInfo(40, 10, false))
+	require.Contains(t, out, "Channels")
+	require.Contains(t, out, "None")
+}
+
+// TestChannelList_Truncation covers the "…and N more" overflow behavior and the
+// maxItems<=0 guard.
+func TestChannelList_Truncation(t *testing.T) {
+	t.Parallel()
+
+	styles := common.DefaultCommon(nil).Styles
+	items := []channelStatusItem{
+		{name: "a", title: "a"},
+		{name: "b", title: "b"},
+		{name: "c", title: "c"},
+	}
+
+	// maxItems=2 with 3 items → one item shown plus a "…and 2 more" line.
+	out := ansi.Strip(channelList(styles, items, 80, 2))
+	require.Contains(t, out, "and 2 more")
+
+	// Non-positive budget renders nothing.
+	require.Empty(t, channelList(styles, items, 80, 0))
+}

--- a/internal/ui/model/landing.go
+++ b/internal/ui/model/landing.go
@@ -39,13 +39,14 @@ func (m *UI) landingView() string {
 		layout.Fill(1),
 	).Split(m.layout.main).Assign(new(image.Rectangle), &remainingHeightArea)
 
-	mcpLspSectionWidth := min(30, (width-2)/3)
+	mcpLspSectionWidth := min(30, (width-3)/4)
 
 	lspSection := m.lspInfo(mcpLspSectionWidth, max(1, remainingHeightArea.Dy()), false)
 	mcpSection := m.mcpInfo(mcpLspSectionWidth, max(1, remainingHeightArea.Dy()), false)
 	skillsSection := m.skillsInfo(mcpLspSectionWidth, max(1, remainingHeightArea.Dy()), false)
+	channelsSection := m.channelsInfo(mcpLspSectionWidth, max(1, remainingHeightArea.Dy()), false)
 
-	content := lipgloss.JoinHorizontal(lipgloss.Left, lspSection, " ", mcpSection, " ", skillsSection)
+	content := lipgloss.JoinHorizontal(lipgloss.Left, lspSection, " ", mcpSection, " ", skillsSection, " ", channelsSection)
 
 	return lipgloss.NewStyle().
 		Width(width).

--- a/internal/ui/model/landing.go
+++ b/internal/ui/model/landing.go
@@ -42,13 +42,14 @@ func (m *UI) landingView() string {
 		layout.Fill(1),
 	).Split(m.layout.main).Assign(new(image.Rectangle), &remainingHeightArea)
 
-	mcpLspSectionWidth := min(30, (width-2)/3)
+	mcpLspSectionWidth := min(30, (width-3)/4)
 
 	lspSection := m.lspInfo(mcpLspSectionWidth, max(1, remainingHeightArea.Dy()), false)
 	mcpSection := m.mcpInfo(mcpLspSectionWidth, max(1, remainingHeightArea.Dy()), false)
 	skillsSection := m.skillsInfo(mcpLspSectionWidth, max(1, remainingHeightArea.Dy()), false)
+	channelsSection := m.channelsInfo(mcpLspSectionWidth, max(1, remainingHeightArea.Dy()), false)
 
-	content := lipgloss.JoinHorizontal(lipgloss.Left, lspSection, " ", mcpSection, " ", skillsSection)
+	content := lipgloss.JoinHorizontal(lipgloss.Left, lspSection, " ", mcpSection, " ", skillsSection, " ", channelsSection)
 
 	return lipgloss.NewStyle().
 		Width(width).

--- a/internal/ui/model/mcp.go
+++ b/internal/ui/model/mcp.go
@@ -76,6 +76,14 @@ func mcpList(t *styles.Styles, mcps []mcp.ClientInfo, width, maxItems int) strin
 		case mcp.StateConnected:
 			icon = t.Resource.OnlineIcon.String()
 			extraContent = mcpCounts(t, m.Counts)
+			if m.Channel {
+				badge := t.Resource.StatusText.Render("channel")
+				if extraContent != "" {
+					extraContent += " " + badge
+				} else {
+					extraContent = badge
+				}
+			}
 		case mcp.StateError:
 			icon = t.Resource.ErrorIcon.String()
 			description = t.Resource.StatusText.Render("error")

--- a/internal/ui/model/mcp_test.go
+++ b/internal/ui/model/mcp_test.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/ui/common"
+)
+
+func TestMCPList_ChannelBadge(t *testing.T) {
+	t.Parallel()
+	styles := common.DefaultCommon(nil).Styles
+
+	channelSrv := []mcp.ClientInfo{
+		{Name: "webhook", State: mcp.StateConnected, Channel: true},
+	}
+	if out := mcpList(styles, channelSrv, 80, 10); !strings.Contains(out, "channel") {
+		t.Errorf("expected a channel badge for an active channel server, got:\n%s", out)
+	}
+
+	plainSrv := []mcp.ClientInfo{
+		{Name: "webhook", State: mcp.StateConnected, Channel: false},
+	}
+	if out := mcpList(styles, plainSrv, 80, 10); strings.Contains(out, "channel") {
+		t.Errorf("non-channel server must not show a channel badge, got:\n%s", out)
+	}
+}

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -46,6 +46,13 @@ type countingWorkspace struct {
 func (w *countingWorkspace) AgentIsReady() bool { w.readyCalls++; return w.ready }
 func (w *countingWorkspace) AgentIsBusy() bool  { w.agentBusyCalls++; return w.agentBusy }
 
+// AgentIsSessionBusy mirrors AgentIsBusy for the fake: the busy probe is
+// scoped to the viewed session, and the tests model a single session.
+func (w *countingWorkspace) AgentIsSessionBusy(string) bool {
+	w.agentBusyCalls++
+	return w.agentBusy
+}
+
 func (w *countingWorkspace) AgentReadyErr() error {
 	w.readyCalls++
 	if w.ready {

--- a/internal/ui/model/sidebar.go
+++ b/internal/ui/model/sidebar.go
@@ -97,6 +97,7 @@ func (m *UI) updateSidebarScrollState() {
 	lspSection := m.lspInfo(contentWidth, len(m.lspStates), true)
 	mcpSection := m.mcpInfo(contentWidth, mcpCount(m.com.Config().MCP.Sorted(), m.mcpStates), true)
 	skillsSection := m.skillsInfo(contentWidth, len(m.skillStatusItems()), true)
+	channelsSection := m.channelsInfo(contentWidth, len(m.channelStatusItems()), true)
 	filesSection := m.filesInfo(m.com.Workspace.WorkingDir(), contentWidth, fileChangeCount(m.sessionFiles), true)
 
 	// Build the scrollable content.
@@ -115,6 +116,8 @@ func (m *UI) updateSidebarScrollState() {
 		mcpSection,
 		"",
 		skillsSection,
+		"",
+		channelsSection,
 	)
 
 	totalLines := strings.Count(content, "\n") + 1

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4205,6 +4205,8 @@ func (m *UI) openDialog(id string) tea.Cmd {
 		if cmd := m.openFilesDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+	case dialog.ChannelsID:
+		m.openChannelsDialog()
 	case dialog.QuitID:
 		if cmd := m.openQuitDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -4300,6 +4302,16 @@ func (m *UI) openNotificationsDialog() tea.Cmd {
 	notificationsDialog := dialog.NewNotifications(m.com)
 	m.dialog.OpenDialog(notificationsDialog)
 	return nil
+}
+
+// openChannelsDialog opens the channels management dialog.
+func (m *UI) openChannelsDialog() {
+	if m.dialog.ContainsDialog(dialog.ChannelsID) {
+		m.dialog.BringToFront(dialog.ChannelsID)
+		return
+	}
+	channelsDialog := dialog.NewChannels(m.com, m.com.Workspace)
+	m.dialog.OpenDialog(channelsDialog)
 }
 
 // openSessionsDialog opens the sessions dialog. If the dialog is already open,

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -890,6 +890,8 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, handleMCPToolsEvent(m.com.Workspace, msg.Payload.Name)
 		case mcp.EventResourcesListChanged:
 			return m, handleMCPResourcesEvent(m.com.Workspace, msg.Payload.Name)
+		case mcp.EventChannelMessage:
+			return m, m.handleChannelMessage(msg.Payload)
 		}
 	case pubsub.Event[permission.PermissionRequest]:
 		if cmd := m.openPermissionsDialog(msg.Payload); cmd != nil {
@@ -3896,6 +3898,30 @@ func (m *UI) attachSkill(skillID, name string) tea.Cmd {
 	}
 }
 
+// ensureSession makes sure a session is active, creating one if none is. It
+// returns a command that loads the freshly created session (nil when a session
+// already existed) and an error if creation failed. It mutates UI state, so
+// callers must run on the Update goroutine.
+func (m *UI) ensureSession() (tea.Cmd, error) {
+	if m.hasSession() {
+		return nil, nil
+	}
+	newSession, err := m.com.Workspace.CreateSession(context.Background(), "New Session")
+	if err != nil {
+		return nil, err
+	}
+	if m.forceCompactMode {
+		m.isCompact = true
+	}
+	var cmd tea.Cmd
+	if newSession.ID != "" {
+		m.session = &newSession
+		cmd = m.loadSession(newSession.ID)
+	}
+	m.setState(uiChat, m.focus)
+	return cmd, nil
+}
+
 // sendMessage sends a message with the given content and attachments.
 func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.Cmd {
 	if err := m.com.Workspace.AgentReadyErr(); err != nil {
@@ -3906,19 +3932,12 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 	common.StartTurn()
 
 	var cmds []tea.Cmd
-	if !m.hasSession() {
-		newSession, err := m.com.Workspace.CreateSession(context.Background(), "New Session")
-		if err != nil {
-			return util.ReportError(err)
-		}
-		if m.forceCompactMode {
-			m.isCompact = true
-		}
-		if newSession.ID != "" {
-			m.session = &newSession
-			cmds = append(cmds, m.loadSession(newSession.ID))
-		}
-		m.setState(uiChat, m.focus)
+	loadCmd, err := m.ensureSession()
+	if err != nil {
+		return util.ReportError(err)
+	}
+	if loadCmd != nil {
+		cmds = append(cmds, loadCmd)
 	}
 
 	ctx := context.Background()
@@ -3956,6 +3975,38 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 		return agentRunSubmittedMsg{}
 	})
 	return tea.Batch(cmds...)
+}
+
+// handleChannelMessage injects a channel event pushed by an MCP server into a
+// session so the agent reacts to it on its next turn. The rendered <channel>
+// element is already validated and escaped by the mcp package. If no session is
+// active yet, one is created so a pushed event is never silently dropped; if the
+// agent is busy, AgentRun enqueues the message and it is picked up on the next
+// step.
+func (m *UI) handleChannelMessage(ev mcp.Event) tea.Cmd {
+	if ev.ChannelMessage == "" || !m.com.Workspace.AgentIsReady() {
+		return nil
+	}
+	loadCmd, err := m.ensureSession()
+	if err != nil {
+		slog.Debug("Failed to create session for channel message", "error", err)
+		return nil
+	}
+	if !m.hasSession() {
+		return loadCmd
+	}
+	sessionID := m.session.ID
+	content := ev.ChannelMessage
+	runCmd := func() tea.Msg {
+		if err := m.com.Workspace.AgentRun(context.Background(), sessionID, content); err != nil {
+			slog.Debug("Failed to inject channel message", "error", err, "session", sessionID)
+		}
+		return nil
+	}
+	if loadCmd != nil {
+		return tea.Batch(loadCmd, runCmd)
+	}
+	return runCmd
 }
 
 // runShellCommand executes a shell command server-side without triggering

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4004,10 +4004,17 @@ func (m *UI) handleChannelMessage(ev mcp.Event) tea.Cmd {
 	if !m.hasSession() {
 		return loadCmd
 	}
+	updatedSession, err := m.com.Workspace.SetSessionChannel(context.Background(), m.session.ID, ev.Name)
+	if err != nil {
+		slog.Debug("Failed to set session channel", "error", err, "session", m.session.ID, "channel", ev.Name)
+		return loadCmd
+	}
+	m.session = &updatedSession
 	sessionID := m.session.ID
+	channel := ev.Name
 	content := ev.ChannelMessage
 	runCmd := func() tea.Msg {
-		if err := m.com.Workspace.AgentRun(context.Background(), sessionID, content); err != nil {
+		if err := m.com.Workspace.AgentRunChannel(context.Background(), channel, sessionID, content); err != nil {
 			slog.Debug("Failed to inject channel message", "error", err, "session", sessionID)
 		}
 		return nil

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3983,7 +3983,16 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 // active yet, one is created so a pushed event is never silently dropped; if the
 // agent is busy, AgentRun enqueues the message and it is picked up on the next
 // step.
+//
+// Injection is skipped entirely when the workspace routes channel events
+// itself (client/server mode): the server injects each event exactly once,
+// and injecting here as well would duplicate the turn once per attached
+// client. The injected turn still reaches this client through the normal
+// session/message event stream.
 func (m *UI) handleChannelMessage(ev mcp.Event) tea.Cmd {
+	if m.com.Workspace.RoutesChannelEvents() {
+		return nil
+	}
 	if ev.ChannelMessage == "" || !m.com.Workspace.AgentIsReady() {
 		return nil
 	}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4510,6 +4510,8 @@ func (m *UI) openDialog(id string) tea.Cmd {
 		if cmd := m.openFilesDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+	case dialog.ChannelsID:
+		m.openChannelsDialog()
 	case dialog.QuitID:
 		if cmd := m.openQuitDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -4605,6 +4607,16 @@ func (m *UI) openNotificationsDialog() tea.Cmd {
 	notificationsDialog := dialog.NewNotifications(m.com)
 	m.dialog.OpenDialog(notificationsDialog)
 	return nil
+}
+
+// openChannelsDialog opens the channels management dialog.
+func (m *UI) openChannelsDialog() {
+	if m.dialog.ContainsDialog(dialog.ChannelsID) {
+		m.dialog.BringToFront(dialog.ChannelsID)
+		return
+	}
+	channelsDialog := dialog.NewChannels(m.com, m.com.Workspace)
+	m.dialog.OpenDialog(channelsDialog)
 }
 
 // openSessionsDialog opens the sessions dialog. If the dialog is already open,

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4286,7 +4286,16 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 // active yet, one is created so a pushed event is never silently dropped; if the
 // agent is busy, AgentRun enqueues the message and it is picked up on the next
 // step.
+//
+// Injection is skipped entirely when the workspace routes channel events
+// itself (client/server mode): the server injects each event exactly once,
+// and injecting here as well would duplicate the turn once per attached
+// client. The injected turn still reaches this client through the normal
+// session/message event stream.
 func (m *UI) handleChannelMessage(ev mcp.Event) tea.Cmd {
+	if m.com.Workspace.RoutesChannelEvents() {
+		return nil
+	}
 	if ev.ChannelMessage == "" || !m.com.Workspace.AgentIsReady() {
 		return nil
 	}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -963,6 +963,8 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, handleMCPToolsEvent(m.com.Workspace, msg.Payload.Name)
 		case mcp.EventResourcesListChanged:
 			return m, handleMCPResourcesEvent(m.com.Workspace, msg.Payload.Name)
+		case mcp.EventChannelMessage:
+			return m, m.handleChannelMessage(msg.Payload)
 		}
 	case pubsub.Event[permission.PermissionRequest]:
 		if cmd := m.openPermissionsDialog(msg.Payload); cmd != nil {
@@ -4199,6 +4201,30 @@ func (m *UI) attachSkill(skillID, name string) tea.Cmd {
 	}
 }
 
+// ensureSession makes sure a session is active, creating one if none is. It
+// returns a command that loads the freshly created session (nil when a session
+// already existed) and an error if creation failed. It mutates UI state, so
+// callers must run on the Update goroutine.
+func (m *UI) ensureSession() (tea.Cmd, error) {
+	if m.hasSession() {
+		return nil, nil
+	}
+	newSession, err := m.com.Workspace.CreateSession(context.Background(), "New Session")
+	if err != nil {
+		return nil, err
+	}
+	if m.forceCompactMode {
+		m.isCompact = true
+	}
+	var cmd tea.Cmd
+	if newSession.ID != "" {
+		m.session = &newSession
+		cmd = m.loadSession(newSession.ID)
+	}
+	m.setState(uiChat, m.focus)
+	return cmd, nil
+}
+
 // sendMessage sends a message with the given content and attachments.
 func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.Cmd {
 	if err := m.com.Workspace.AgentReadyErr(); err != nil {
@@ -4209,19 +4235,12 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 	common.StartTurn()
 
 	var cmds []tea.Cmd
-	if !m.hasSession() {
-		newSession, err := m.com.Workspace.CreateSession(context.Background(), "New Session")
-		if err != nil {
-			return util.ReportError(err)
-		}
-		if m.forceCompactMode {
-			m.isCompact = true
-		}
-		if newSession.ID != "" {
-			m.session = &newSession
-			cmds = append(cmds, m.loadSession(newSession.ID))
-		}
-		m.setState(uiChat, m.focus)
+	loadCmd, err := m.ensureSession()
+	if err != nil {
+		return util.ReportError(err)
+	}
+	if loadCmd != nil {
+		cmds = append(cmds, loadCmd)
 	}
 
 	ctx := context.Background()
@@ -4259,6 +4278,38 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 		return agentRunSubmittedMsg{}
 	})
 	return tea.Batch(cmds...)
+}
+
+// handleChannelMessage injects a channel event pushed by an MCP server into a
+// session so the agent reacts to it on its next turn. The rendered <channel>
+// element is already validated and escaped by the mcp package. If no session is
+// active yet, one is created so a pushed event is never silently dropped; if the
+// agent is busy, AgentRun enqueues the message and it is picked up on the next
+// step.
+func (m *UI) handleChannelMessage(ev mcp.Event) tea.Cmd {
+	if ev.ChannelMessage == "" || !m.com.Workspace.AgentIsReady() {
+		return nil
+	}
+	loadCmd, err := m.ensureSession()
+	if err != nil {
+		slog.Debug("Failed to create session for channel message", "error", err)
+		return nil
+	}
+	if !m.hasSession() {
+		return loadCmd
+	}
+	sessionID := m.session.ID
+	content := ev.ChannelMessage
+	runCmd := func() tea.Msg {
+		if err := m.com.Workspace.AgentRun(context.Background(), sessionID, content); err != nil {
+			slog.Debug("Failed to inject channel message", "error", err, "session", sessionID)
+		}
+		return nil
+	}
+	if loadCmd != nil {
+		return tea.Batch(loadCmd, runCmd)
+	}
+	return runCmd
 }
 
 // runShellCommand executes a shell command server-side without triggering

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4307,10 +4307,17 @@ func (m *UI) handleChannelMessage(ev mcp.Event) tea.Cmd {
 	if !m.hasSession() {
 		return loadCmd
 	}
+	updatedSession, err := m.com.Workspace.SetSessionChannel(context.Background(), m.session.ID, ev.Name)
+	if err != nil {
+		slog.Debug("Failed to set session channel", "error", err, "session", m.session.ID, "channel", ev.Name)
+		return loadCmd
+	}
+	m.session = &updatedSession
 	sessionID := m.session.ID
+	channel := ev.Name
 	content := ev.ChannelMessage
 	runCmd := func() tea.Msg {
-		if err := m.com.Workspace.AgentRun(context.Background(), sessionID, content); err != nil {
+		if err := m.com.Workspace.AgentRunChannel(context.Background(), channel, sessionID, content); err != nil {
 			slog.Debug("Failed to inject channel message", "error", err, "session", sessionID)
 		}
 		return nil

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -124,10 +124,21 @@ func (m *UI) dispatchBusyRefresh() tea.Cmd {
 	m.busyFetchInFlight = true
 	ws := m.com.Workspace
 	gen := m.busyFetchGen
+	sessionID := m.currentSessionID()
 	return func() tea.Msg {
 		st := busyStateMsg{gen: gen}
 		if ws.AgentIsReady() {
-			st.agentBusy = ws.AgentIsBusy()
+			// Scope the probe to the viewed session when there is one:
+			// with channels dispatching work into background sessions,
+			// global busy state would make the current view look busy
+			// (spinner, cancel hints) for activity happening elsewhere.
+			// Session switches bump gen, so a probe scoped to a departed
+			// session is discarded rather than applied.
+			if sessionID != "" {
+				st.agentBusy = ws.AgentIsSessionBusy(sessionID)
+			} else {
+				st.agentBusy = ws.AgentIsBusy()
+			}
 		}
 		st.yolo = ws.PermissionSkipRequests()
 		return st

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -906,6 +906,12 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Messages.AssistantInfoDuration = subtle
 	s.Messages.AssistantCanceled = lipgloss.NewStyle().Foreground(o.fgSubtle).Italic(true)
 
+	// Channel message metadata styles.
+	s.Messages.ChannelInfoIcon = subtle
+	s.Messages.ChannelInfoSender = muted
+	s.Messages.ChannelInfoProvider = subtle
+	s.Messages.ChannelInfoTimestamp = subtle
+
 	// Thinking section styles
 	s.Messages.ThinkingBox = subtle.Background(o.bgLeastVisible)
 	s.Messages.ThinkingTruncationHint = muted

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -919,6 +919,12 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Messages.AssistantInfoDuration = subtle
 	s.Messages.AssistantCanceled = lipgloss.NewStyle().Foreground(o.fgSubtle).Italic(true)
 
+	// Channel message metadata styles.
+	s.Messages.ChannelInfoIcon = subtle
+	s.Messages.ChannelInfoSender = muted
+	s.Messages.ChannelInfoProvider = subtle
+	s.Messages.ChannelInfoTimestamp = subtle
+
 	// Thinking section styles
 	s.Messages.ThinkingBox = subtle.Background(o.bgLeastVisible)
 	s.Messages.ThinkingTruncationHint = muted

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -50,6 +50,8 @@ const (
 	ScrollbarThumb string = "┃"
 	ScrollbarTrack string = "│"
 
+	ChannelIcon string = "󰍩"
+
 	LSPErrorIcon   string = "E"
 	LSPWarningIcon string = "W"
 	LSPInfoIcon    string = "I"
@@ -311,6 +313,12 @@ type Styles struct {
 		AssistantInfoProvider  lipgloss.Style
 		AssistantInfoDuration  lipgloss.Style
 		AssistantCanceled      lipgloss.Style // Italic "Canceled" footer
+
+		// Channel message metadata line styles.
+		ChannelInfoIcon      lipgloss.Style // Chat-bubble glyph prefix
+		ChannelInfoSender    lipgloss.Style // Sender name in channel metadata line
+		ChannelInfoProvider  lipgloss.Style // "via <channel>" text
+		ChannelInfoTimestamp lipgloss.Style // "at <timestamp>" text
 	}
 
 	// Tool - styles for tool call rendering

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -63,6 +63,8 @@ const (
 	ScrollbarThumb string = "┃"
 	ScrollbarTrack string = "│"
 
+	ChannelIcon string = "󰍩"
+
 	LSPErrorIcon   string = "E"
 	LSPWarningIcon string = "W"
 	LSPInfoIcon    string = "I"
@@ -325,6 +327,12 @@ type Styles struct {
 		AssistantInfoProvider  lipgloss.Style
 		AssistantInfoDuration  lipgloss.Style
 		AssistantCanceled      lipgloss.Style // Italic "Canceled" footer
+
+		// Channel message metadata line styles.
+		ChannelInfoIcon      lipgloss.Style // Chat-bubble glyph prefix
+		ChannelInfoSender    lipgloss.Style // Sender name in channel metadata line
+		ChannelInfoProvider  lipgloss.Style // "via <channel>" text
+		ChannelInfoTimestamp lipgloss.Style // "at <timestamp>" text
 	}
 
 	// Tool - styles for tool call rendering

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -81,6 +81,10 @@ func (w *AppWorkspace) SetCurrentSession(ctx context.Context, sessionID string) 
 	return nil
 }
 
+// RoutesChannelEvents reports false: in-process mode has no server to
+// route channel events, so the frontend injects them itself.
+func (w *AppWorkspace) RoutesChannelEvents() bool { return false }
+
 // -- Messages --
 
 func (w *AppWorkspace) ListMessages(ctx context.Context, sessionID string) ([]message.Message, error) {

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -60,6 +60,10 @@ func (w *AppWorkspace) SaveSession(ctx context.Context, sess session.Session) (s
 	return w.app.Sessions.Save(ctx, sess)
 }
 
+func (w *AppWorkspace) SetSessionChannel(ctx context.Context, sessionID, channel string) (session.Session, error) {
+	return w.app.Sessions.SetChannel(ctx, sessionID, channel)
+}
+
 func (w *AppWorkspace) DeleteSession(ctx context.Context, sessionID string) error {
 	return w.app.Sessions.Delete(ctx, sessionID)
 }
@@ -112,6 +116,14 @@ func (w *AppWorkspace) AgentRun(ctx context.Context, sessionID, prompt string, a
 		return errors.New("agent coordinator not initialized")
 	}
 	_, err := w.app.AgentCoordinator.Run(ctx, sessionID, prompt, attachments...)
+	return err
+}
+
+func (w *AppWorkspace) AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error {
+	if w.app.AgentCoordinator == nil {
+		return errors.New("agent coordinator not initialized")
+	}
+	_, err := w.app.AgentCoordinator.Run(agent.WithChannel(ctx, channel), sessionID, prompt, attachments...)
 	return err
 }
 

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -151,6 +151,15 @@ func (w *ClientWorkspace) SaveSession(ctx context.Context, sess session.Session)
 	return protoToSession(*saved), nil
 }
 
+func (w *ClientWorkspace) SetSessionChannel(ctx context.Context, sessionID, channel string) (session.Session, error) {
+	sess, err := w.GetSession(ctx, sessionID)
+	if err != nil {
+		return session.Session{}, err
+	}
+	sess.Channel = channel
+	return w.SaveSession(ctx, sess)
+}
+
 func (w *ClientWorkspace) DeleteSession(ctx context.Context, sessionID string) error {
 	return w.client.DeleteSession(ctx, w.workspaceID(), sessionID)
 }
@@ -216,7 +225,11 @@ func (w *ClientWorkspace) AgentRun(ctx context.Context, sessionID, prompt string
 	// completion detection (it observes message events directly),
 	// so passing an empty RunID is correct here: it skips the
 	// correlator stamping path without functional consequences.
-	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", prompt, attachments...)
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", "", prompt, attachments...)
+}
+
+func (w *ClientWorkspace) AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error {
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", channel, prompt, attachments...)
 }
 
 func (w *ClientWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, _ func(string), _ bool) (proto.ShellCommandResponse, error) {
@@ -1006,6 +1019,7 @@ func protoToSession(s proto.Session) session.Session {
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
 		Todos:            protoToTodos(s.Todos),
+		Channel:          s.Channel,
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}
@@ -1127,6 +1141,7 @@ func sessionToProto(s session.Session) proto.Session {
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
 		Todos:            todosToProto(s.Todos),
+		Channel:          s.Channel,
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -634,6 +634,7 @@ func (w *ClientWorkspace) MCPGetStates() map[string]mcp.ClientInfo {
 				Resources: v.ResourceCount,
 			},
 			ConnectedAt: v.ConnectedAt,
+			Channel:     v.Channel,
 		}
 	}
 	return result

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -176,6 +176,13 @@ func (w *ClientWorkspace) SetCurrentSession(ctx context.Context, sessionID strin
 	return w.client.SetCurrentSession(ctx, w.workspaceID(), sessionID)
 }
 
+// RoutesChannelEvents reports true: the server backend injects each
+// channel event exactly once (see backend.startChannelRouter), so this
+// client must not inject on EventChannelMessage — with several clients
+// attached, per-client injection would run the same event multiple
+// times, and it would never run with zero clients attached.
+func (w *ClientWorkspace) RoutesChannelEvents() bool { return true }
+
 // -- Messages --
 
 func (w *ClientWorkspace) ListMessages(ctx context.Context, sessionID string) ([]message.Message, error) {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -850,6 +850,7 @@ func (w *ClientWorkspace) translateEvent(ev any) tea.Msg {
 					Prompts:   e.Payload.PromptCount,
 					Resources: e.Payload.ResourceCount,
 				},
+				ChannelMessage: e.Payload.ChannelMessage,
 			},
 		}
 	case pubsub.Event[proto.PermissionRequest]:
@@ -972,6 +973,8 @@ func protoToMCPEventType(t proto.MCPEventType) mcp.EventType {
 		return mcp.EventPromptsListChanged
 	case proto.MCPEventResourcesListChanged:
 		return mcp.EventResourcesListChanged
+	case proto.MCPEventChannelMessage:
+		return mcp.EventChannelMessage
 	default:
 		return mcp.EventStateChanged
 	}

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -1097,6 +1097,7 @@ func (w *ClientWorkspace) translateEvent(ev any) tea.Msg {
 					Prompts:   e.Payload.PromptCount,
 					Resources: e.Payload.ResourceCount,
 				},
+				ChannelMessage: e.Payload.ChannelMessage,
 			},
 		}
 	case pubsub.Event[proto.PermissionRequest]:
@@ -1221,6 +1222,8 @@ func protoToMCPEventType(t proto.MCPEventType) mcp.EventType {
 		return mcp.EventPromptsListChanged
 	case proto.MCPEventResourcesListChanged:
 		return mcp.EventResourcesListChanged
+	case proto.MCPEventChannelMessage:
+		return mcp.EventChannelMessage
 	default:
 		return mcp.EventStateChanged
 	}

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -197,6 +197,13 @@ func (w *ClientWorkspace) SetCurrentSession(ctx context.Context, sessionID strin
 	return w.client.SetCurrentSession(ctx, w.workspaceID(), sessionID)
 }
 
+// RoutesChannelEvents reports true: the server backend injects each
+// channel event exactly once (see backend.startChannelRouter), so this
+// client must not inject on EventChannelMessage — with several clients
+// attached, per-client injection would run the same event multiple
+// times, and it would never run with zero clients attached.
+func (w *ClientWorkspace) RoutesChannelEvents() bool { return true }
+
 // -- Messages --
 
 func (w *ClientWorkspace) ListMessages(ctx context.Context, sessionID string) ([]message.Message, error) {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -661,6 +661,7 @@ func (w *ClientWorkspace) MCPGetStates() map[string]mcp.ClientInfo {
 				Resources: v.ResourceCount,
 			},
 			ConnectedAt: v.ConnectedAt,
+			Channel:     v.Channel,
 		}
 	}
 	return result

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -169,6 +169,15 @@ func (w *ClientWorkspace) SaveSession(ctx context.Context, sess session.Session)
 	return protoToSession(*saved), nil
 }
 
+func (w *ClientWorkspace) SetSessionChannel(ctx context.Context, sessionID, channel string) (session.Session, error) {
+	sess, err := w.GetSession(ctx, sessionID)
+	if err != nil {
+		return session.Session{}, err
+	}
+	sess.Channel = channel
+	return w.SaveSession(ctx, sess)
+}
+
 func (w *ClientWorkspace) DeleteSession(ctx context.Context, sessionID string) error {
 	return w.client.DeleteSession(ctx, w.workspaceID(), sessionID)
 }
@@ -237,7 +246,11 @@ func (w *ClientWorkspace) AgentRun(ctx context.Context, sessionID, prompt string
 	// completion detection (it observes message events directly),
 	// so passing an empty RunID is correct here: it skips the
 	// correlator stamping path without functional consequences.
-	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", prompt, attachments...)
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", "", prompt, attachments...)
+}
+
+func (w *ClientWorkspace) AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error {
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", channel, prompt, attachments...)
 }
 
 func (w *ClientWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, _ func(string), _ bool) (proto.ShellCommandResponse, error) {
@@ -1255,6 +1268,7 @@ func protoToSession(s proto.Session) session.Session {
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
 		Todos:            protoToTodos(s.Todos),
+		Channel:          s.Channel,
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}
@@ -1377,6 +1391,7 @@ func sessionToProto(s session.Session) proto.Session {
 		CompletionTokens: s.CompletionTokens,
 		Cost:             s.Cost,
 		Todos:            todosToProto(s.Todos),
+		Channel:          s.Channel,
 		CreatedAt:        s.CreatedAt,
 		UpdatedAt:        s.UpdatedAt,
 	}

--- a/internal/workspace/client_workspace_test.go
+++ b/internal/workspace/client_workspace_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/client"
 	"github.com/charmbracelet/crush/internal/commands"
@@ -194,6 +195,30 @@ func TestTranslateEvent_Skills(t *testing.T) {
 	cached := skills.GetLatestStates()
 	require.Len(t, cached, 1)
 	require.Equal(t, "from-server", cached[0].Name)
+}
+
+// TestTranslateEvent_MCPChannel verifies the client reconstructs a channel
+// push from the wire with its type and rendered <channel> body intact, so the
+// TUI's channel handler fires in client/server mode.
+func TestTranslateEvent_MCPChannel(t *testing.T) {
+	t.Parallel()
+
+	w := NewClientWorkspace(nil, proto.Workspace{})
+	ev := pubsub.Event[proto.MCPEvent]{
+		Type: pubsub.CreatedEvent,
+		Payload: proto.MCPEvent{
+			Type:           proto.MCPEventChannelMessage,
+			Name:           "webhook",
+			ChannelMessage: `<channel source="webhook">build failed</channel>`,
+		},
+	}
+
+	out := w.translateEvent(ev)
+	got, ok := out.(pubsub.Event[mcp.Event])
+	require.True(t, ok, "expected pubsub.Event[mcp.Event], got %T", out)
+	require.Equal(t, mcp.EventChannelMessage, got.Payload.Type)
+	require.Equal(t, "webhook", got.Payload.Name)
+	require.Equal(t, `<channel source="webhook">build failed</channel>`, got.Payload.ChannelMessage)
 }
 
 // TestNewClientWorkspace_SeedsSkillsCache verifies that the snapshot in

--- a/internal/workspace/client_workspace_test.go
+++ b/internal/workspace/client_workspace_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/client"
 	"github.com/charmbracelet/crush/internal/commands"
@@ -195,6 +196,30 @@ func TestTranslateEvent_Skills(t *testing.T) {
 	cached := skills.GetLatestStates()
 	require.Len(t, cached, 1)
 	require.Equal(t, "from-server", cached[0].Name)
+}
+
+// TestTranslateEvent_MCPChannel verifies the client reconstructs a channel
+// push from the wire with its type and rendered <channel> body intact, so the
+// TUI's channel handler fires in client/server mode.
+func TestTranslateEvent_MCPChannel(t *testing.T) {
+	t.Parallel()
+
+	w := NewClientWorkspace(nil, proto.Workspace{})
+	ev := pubsub.Event[proto.MCPEvent]{
+		Type: pubsub.CreatedEvent,
+		Payload: proto.MCPEvent{
+			Type:           proto.MCPEventChannelMessage,
+			Name:           "webhook",
+			ChannelMessage: `<channel source="webhook">build failed</channel>`,
+		},
+	}
+
+	out := w.translateEvent(ev)
+	got, ok := out.(pubsub.Event[mcp.Event])
+	require.True(t, ok, "expected pubsub.Event[mcp.Event], got %T", out)
+	require.Equal(t, mcp.EventChannelMessage, got.Payload.Type)
+	require.Equal(t, "webhook", got.Payload.Name)
+	require.Equal(t, `<channel source="webhook">build failed</channel>`, got.Payload.ChannelMessage)
 }
 
 // TestNewClientWorkspace_SeedsSkillsCache verifies that the snapshot in

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -82,6 +82,7 @@ type Workspace interface {
 	GetSession(ctx context.Context, sessionID string) (session.Session, error)
 	ListSessions(ctx context.Context) ([]session.Session, error)
 	SaveSession(ctx context.Context, sess session.Session) (session.Session, error)
+	SetSessionChannel(ctx context.Context, sessionID, channel string) (session.Session, error)
 	DeleteSession(ctx context.Context, sessionID string) error
 	CreateAgentToolSessionID(messageID, toolCallID string) string
 	ParseAgentToolSessionID(sessionID string) (messageID string, toolCallID string, ok bool)
@@ -108,6 +109,7 @@ type Workspace interface {
 
 	// Agent
 	AgentRun(ctx context.Context, sessionID, prompt string, attachments ...message.Attachment) error
+	AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error
 	AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, onProgress func(string), isFirstMessage bool) (proto.ShellCommandResponse, error)
 	AgentCancel(sessionID string)
 	AgentIsBusy() bool

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -97,6 +97,15 @@ type Workspace interface {
 	ListUserMessages(ctx context.Context, sessionID string) ([]message.Message, error)
 	ListAllUserMessages(ctx context.Context) ([]message.Message, error)
 
+	// RoutesChannelEvents reports whether the workspace's backing
+	// process routes MCP channel events into sessions itself. When
+	// true (client/server mode), frontends must not inject channel
+	// messages on EventChannelMessage — the server injects each event
+	// exactly once and the resulting turn arrives through the normal
+	// session/message event stream. When false (in-process mode), the
+	// frontend owns injection.
+	RoutesChannelEvents() bool
+
 	// Agent
 	AgentRun(ctx context.Context, sessionID, prompt string, attachments ...message.Attachment) error
 	AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, onProgress func(string), isFirstMessage bool) (proto.ShellCommandResponse, error)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -135,6 +135,15 @@ type Workspace interface {
 	ListUserMessages(ctx context.Context, sessionID string) ([]message.Message, error)
 	ListAllUserMessages(ctx context.Context) ([]message.Message, error)
 
+	// RoutesChannelEvents reports whether the workspace's backing
+	// process routes MCP channel events into sessions itself. When
+	// true (client/server mode), frontends must not inject channel
+	// messages on EventChannelMessage — the server injects each event
+	// exactly once and the resulting turn arrives through the normal
+	// session/message event stream. When false (in-process mode), the
+	// frontend owns injection.
+	RoutesChannelEvents() bool
+
 	// Agent
 	AgentRun(ctx context.Context, sessionID, prompt string, attachments ...message.Attachment) error
 	AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, onProgress func(string), isFirstMessage bool) (proto.ShellCommandResponse, error)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -120,6 +120,7 @@ type Workspace interface {
 	GetSession(ctx context.Context, sessionID string) (session.Session, error)
 	ListSessions(ctx context.Context) ([]session.Session, error)
 	SaveSession(ctx context.Context, sess session.Session) (session.Session, error)
+	SetSessionChannel(ctx context.Context, sessionID, channel string) (session.Session, error)
 	DeleteSession(ctx context.Context, sessionID string) error
 	CreateAgentToolSessionID(messageID, toolCallID string) string
 	ParseAgentToolSessionID(sessionID string) (messageID string, toolCallID string, ok bool)
@@ -146,6 +147,7 @@ type Workspace interface {
 
 	// Agent
 	AgentRun(ctx context.Context, sessionID, prompt string, attachments ...message.Attachment) error
+	AgentRunChannel(ctx context.Context, channel, sessionID, prompt string, attachments ...message.Attachment) error
 	AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, onProgress func(string), isFirstMessage bool) (proto.ShellCommandResponse, error)
 	AgentCancel(sessionID string)
 	AgentIsBusy() bool

--- a/schema.json
+++ b/schema.json
@@ -212,6 +212,63 @@
       },
       "type": "object"
     },
+    "MCPChannelReply": {
+      "properties": {
+        "user": {
+          "$ref": "#/$defs/MCPChannelReplyRoute",
+          "description": "Reply route for direct messages"
+        },
+        "group": {
+          "$ref": "#/$defs/MCPChannelReplyRoute",
+          "description": "Reply route for group messages"
+        },
+        "message_param": {
+          "type": "string",
+          "description": "Tool argument name that receives the reply text",
+          "default": "message"
+        },
+        "suppress_tools": {
+          "items": {
+            "type": "string",
+            "examples": [
+              "send"
+            ]
+          },
+          "type": "array",
+          "description": "Additional tool names that suppress the automatic reply when the model already called one of them during the turn"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MCPChannelReplyRoute": {
+      "properties": {
+        "tool": {
+          "type": "string",
+          "description": "MCP tool name that sends the reply",
+          "examples": [
+            "send_message_to_user"
+          ]
+        },
+        "target_param": {
+          "type": "string",
+          "description": "Tool argument name that receives the reply target",
+          "examples": [
+            "user_id"
+          ]
+        },
+        "target_meta": {
+          "type": "string",
+          "description": "Channel meta attribute carrying the reply target; defaults to sender (user route) or group (group route)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "tool",
+        "target_param"
+      ]
+    },
     "MCPConfig": {
       "properties": {
         "command": {
@@ -311,6 +368,10 @@
         "oauth_callback_port": {
           "type": "integer",
           "description": "Fixed localhost port for the OAuth callback"
+        },
+        "channel_reply": {
+          "$ref": "#/$defs/MCPChannelReply",
+          "description": "Automatically route replies for turns originating from this channel back through one of the server's tools"
         }
       },
       "additionalProperties": false,

--- a/schema.json
+++ b/schema.json
@@ -369,6 +369,11 @@
           "type": "integer",
           "description": "Fixed localhost port for the OAuth callback"
         },
+        "channel_enabled": {
+          "type": "boolean",
+          "description": "Enable this MCP server as a channel (equivalent to --channels)",
+          "default": false
+        },
         "channel_reply": {
           "$ref": "#/$defs/MCPChannelReply",
           "description": "Automatically route replies for turns originating from this channel back through one of the server's tools"

--- a/schema.json
+++ b/schema.json
@@ -219,6 +219,63 @@
       },
       "type": "object"
     },
+    "MCPChannelReply": {
+      "properties": {
+        "user": {
+          "$ref": "#/$defs/MCPChannelReplyRoute",
+          "description": "Reply route for direct messages"
+        },
+        "group": {
+          "$ref": "#/$defs/MCPChannelReplyRoute",
+          "description": "Reply route for group messages"
+        },
+        "message_param": {
+          "type": "string",
+          "description": "Tool argument name that receives the reply text",
+          "default": "message"
+        },
+        "suppress_tools": {
+          "items": {
+            "type": "string",
+            "examples": [
+              "send"
+            ]
+          },
+          "type": "array",
+          "description": "Additional tool names that suppress the automatic reply when the model already called one of them during the turn"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MCPChannelReplyRoute": {
+      "properties": {
+        "tool": {
+          "type": "string",
+          "description": "MCP tool name that sends the reply",
+          "examples": [
+            "send_message_to_user"
+          ]
+        },
+        "target_param": {
+          "type": "string",
+          "description": "Tool argument name that receives the reply target",
+          "examples": [
+            "user_id"
+          ]
+        },
+        "target_meta": {
+          "type": "string",
+          "description": "Channel meta attribute carrying the reply target; defaults to sender (user route) or group (group route)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "tool",
+        "target_param"
+      ]
+    },
     "MCPConfig": {
       "properties": {
         "command": {
@@ -323,6 +380,10 @@
         "oauth_callback_port": {
           "type": "integer",
           "description": "Fixed localhost port for the OAuth callback"
+        },
+        "channel_reply": {
+          "$ref": "#/$defs/MCPChannelReply",
+          "description": "Automatically route replies for turns originating from this channel back through one of the server's tools"
         }
       },
       "additionalProperties": false,

--- a/schema.json
+++ b/schema.json
@@ -381,6 +381,11 @@
           "type": "integer",
           "description": "Fixed localhost port for the OAuth callback"
         },
+        "channel_enabled": {
+          "type": "boolean",
+          "description": "Enable this MCP server as a channel (equivalent to --channels)",
+          "default": false
+        },
         "channel_reply": {
           "$ref": "#/$defs/MCPChannelReply",
           "description": "Automatically route replies for turns originating from this channel back through one of the server's tools"


### PR DESCRIPTION
Part **3/3** of the Claude Channels series (#3298, #3304). Posted by `@joestump-agent` at `@joestump`'s direction.

> [!NOTE]
> **Stacked on #3346.** Rebased on 2026-09-21 onto #3346's current head (`98a16cd5`, on `main` v0.96.0). The first 18 commits belong to #3346; please review **commits 19–28** (`98a16cd5..db6d533a`). Once #3346 merges, this rebases down to just its own commits.

## Summary

The TUI layer for channels, plus docs:

- **Message metadata** — user messages that arrived via a channel render a `sender / via channel / at time` metadata line as a separate list item below the body, so channel traffic is distinguishable from typed input.
- **Status surfaces** — a Channels section on the landing page and sidebar (alongside LSPs/MCPs/Skills) showing each opted-in channel server in whatever state it's in (connected, starting, error, needs auth, or connected without the channel capability). The column and section only appear once a server is opted in, so users who never touch channels see no change.
- **Channels dialog** — a filterable dialog (via the command palette) listing active channels, opted-in servers in any state, and channel-capable servers that aren't enabled yet. It refreshes live as MCP state changes.
- **Channel state in MCP** — `ClientInfo` gains `ChannelOptIn` (opted in via `--channels` or `channel_enabled`, whatever the connection state) and `ChannelCapable` (declared `claude/channel`), carried over the wire for client/server mode. These drive both surfaces above.
- **README** — documents the capability, the `--channels` and `channel_enabled` opt-ins, payload security posture, delivery semantics, two-way channels, `channel_reply` routing, and a Signal MCP walkthrough ([signal-mcp](https://github.com/joestump/signal-mcp)).

## Screenshots

Channels status on first boot:

<img width="1624" alt="Channels status on the landing page" src="https://github.com/user-attachments/assets/80444c7b-bc46-46a9-ad0d-b864e5d7f933" />

Channel-originated message with the metadata line, and the sidebar section:

<img width="1624" alt="Channel message metadata and sidebar section" src="https://github.com/user-attachments/assets/cd22ac23-3880-49a5-85d5-6f54399116cf" />

## Notes

- The dialog intentionally ships **without** a reconnect action for now — that plumbing belongs to a separate MCP-management series brewing in the fork; it'll come as a tiny follow-up.
- No prompt or fixture changes; upstream's recorded agent cassettes remain valid.

## Test plan

- [x] Metadata rendering tests (`internal/ui/chat/user_test.go`)
- [x] Metadata line only added when there's something to show; server time reformatting (`TestExtractMessageItems_ChannelInfoOnlyWithMetadata`, `TestFormatChannelTime`)
- [x] Status section tests: opted-in channels in every state, name order, capable-only servers excluded (`internal/ui/model/channels_test.go`)
- [x] Dialog tests: listing rules, info labels, live refresh keeping filter + selection, filtering, navigation wrap, empty states (`internal/ui/dialog/channels_test.go`)
- [x] State-change wiring: a real `mcpStateChangedMsg` through `UI.Update` refreshes an open dialog (`TestMCPStateChangeRefreshesOpenChannelsDialog`)
- [x] MCP state: opt-in survives failed attempts, capability persists, disable clears both (`TestUpdateStateTracksChannelOptInAndCapability`)
- [x] `go test ./...` and `go test -race` on touched packages pass; golangci-lint 0 issues

💘 Generated with Crush

Assisted-by: Claude Fable 5

