### PR TITLE
fix(config): resolve provider base URL before custom validation

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -435,11 +435,13 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 			c.Providers.Del(id)
 			continue
 		}
-		if providerConfig.APIKey == "" {
+		apiKey, err := resolver.ResolveValue(providerConfig.APIKey)
+		if apiKey == "" || err != nil {
 			slog.Warn("Provider is missing API key, this might be OK for local providers", "provider", id)
 		}
-		if providerConfig.BaseURL == "" {
-			slog.Warn("Skipping custom provider due to missing API endpoint", "provider", id)
+		baseURL, err := resolver.ResolveValue(providerConfig.BaseURL)
+		if baseURL == "" || err != nil {
+			slog.Warn("Skipping custom provider due to missing API endpoint", "provider", id, "error", err)
 			c.Providers.Del(id)
 			continue
 		}
@@ -461,17 +463,6 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 
 		if len(providerConfig.Models) == 0 {
 			slog.Warn("Skipping custom provider because the provider has no models", "provider", id)
-			c.Providers.Del(id)
-			continue
-		}
-
-		apiKey, err := resolver.ResolveValue(providerConfig.APIKey)
-		if apiKey == "" || err != nil {
-			slog.Warn("Provider is missing API key, this might be OK for local providers", "provider", id)
-		}
-		baseURL, err := resolver.ResolveValue(providerConfig.BaseURL)
-		if baseURL == "" || err != nil {
-			slog.Warn("Skipping custom provider due to missing API endpoint", "provider", id, "error", err)
 			c.Providers.Del(id)
 			continue
 		}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -824,6 +824,101 @@ func TestConfig_configureProvidersCustomProviderValidation(t *testing.T) {
 		require.False(t, exists)
 	})
 
+	t.Run("custom provider with shell-expanded BaseURL is kept", func(t *testing.T) {
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"custom": {
+					APIKey:  "test-key",
+					BaseURL: "$(echo https://api.custom.com/v1)",
+					Models: []catwalk.Model{{
+						ID: "test-model",
+					}},
+				},
+			}),
+		}
+		cfg.setDefaults("/tmp", "")
+
+		env := env.NewFromMap(map[string]string{})
+		resolver := NewShellVariableResolver(env)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
+		require.NoError(t, err)
+
+		require.Equal(t, 1, cfg.Providers.Len())
+		_, exists := cfg.Providers.Get("custom")
+		require.True(t, exists, "a BaseURL supplied via shell expansion must pass endpoint validation")
+	})
+
+	t.Run("custom provider with env var BaseURL is kept", func(t *testing.T) {
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"custom": {
+					APIKey:  "test-key",
+					BaseURL: "$CUSTOM_API_URL",
+					Models: []catwalk.Model{{
+						ID: "test-model",
+					}},
+				},
+			}),
+		}
+		cfg.setDefaults("/tmp", "")
+
+		env := env.NewFromMap(map[string]string{
+			"CUSTOM_API_URL": "https://api.custom.com/v1",
+		})
+		resolver := NewShellVariableResolver(env)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
+		require.NoError(t, err)
+
+		require.Equal(t, 1, cfg.Providers.Len())
+		_, exists := cfg.Providers.Get("custom")
+		require.True(t, exists, "a BaseURL supplied via an env variable must pass endpoint validation")
+	})
+
+	t.Run("custom provider whose BaseURL resolves to empty is removed", func(t *testing.T) {
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"custom": {
+					APIKey:  "test-key",
+					BaseURL: "$MISSING_API_URL",
+					Models: []catwalk.Model{{
+						ID: "test-model",
+					}},
+				},
+			}),
+		}
+		cfg.setDefaults("/tmp", "")
+
+		env := env.NewFromMap(map[string]string{})
+		resolver := NewShellVariableResolver(env)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
+		require.NoError(t, err)
+
+		require.Equal(t, 0, cfg.Providers.Len())
+		_, exists := cfg.Providers.Get("custom")
+		require.False(t, exists, "a raw-non-empty BaseURL that resolves to empty must be rejected")
+	})
+
+	t.Run("BaseURL resolving to empty with disable_default_providers returns an error", func(t *testing.T) {
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"custom": {
+					APIKey:  "test-key",
+					BaseURL: "$MISSING_API_URL",
+					Models: []catwalk.Model{{
+						ID: "test-model",
+					}},
+				},
+			}),
+		}
+		cfg.setDefaults("/tmp", "")
+		cfg.Options.DisableDefaultProviders = true
+
+		env := env.NewFromMap(map[string]string{})
+		resolver := NewShellVariableResolver(env)
+		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{})
+		require.Error(t, err, "the sole custom provider is invalid after resolution, so configuration must fail")
+	})
+
 	t.Run("custom provider with no models attempts discovery and is removed on failure", func(t *testing.T) {
 		cfg := &Config{
 			Providers: csync.NewMapFrom(map[string]ProviderConfig{


### PR DESCRIPTION
Posted by `@joestump-agent` at `@joestump`'s direction.

## Summary

Custom provider validation checked the **raw** config values (`providerConfig.BaseURL == ""`) at the top of the loop, and only consulted the **resolved** values in a duplicated check at the bottom — after model discovery had already run and been applied. This PR resolves `api_key`/`base_url` once, up front, and validates with the resolved values:

- A provider whose endpoint doesn't resolve is now skipped immediately with the accurate reason ("missing API endpoint" + the resolver error) instead of surviving until after discovery and sometimes being reported as "no models after failed discovery".
- The missing-API-key warning now fires for keys that fail to *resolve*, not only for keys that are literally empty in the config.
- The duplicated late resolution block is removed.

Keep/remove outcomes for well-formed configs are unchanged — this makes the validation order and diagnostics consistent with the resolved values, and removes the duplication.

## Regression tests

Added to `TestConfig_configureProvidersCustomProviderValidation`, pinning the resolved-value contract:

- shell-expanded `base_url` (`$(echo …)`) passes endpoint validation
- env-var `base_url` (`$CUSTOM_API_URL`) passes endpoint validation
- a raw-non-empty `base_url` that resolves to empty is rejected
- with `disable_default_providers`, a sole provider whose endpoint fails to resolve fails configuration with an error

## Test plan

- [x] `go test ./internal/config/ -run TestConfig_configureProvidersCustomProviderValidation` — all subtests pass
- [x] `golangci-lint run internal/config/` — 0 issues

💘 Generated with Crush

Assisted-by: Claude Fable 5