### PR TITLE
fix(ui): distinguish paused To-Dos from active execution

### DIFF
--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -313,6 +313,8 @@ func (m *UI) renderPills() {
 	inProgressIcon := t.Tool.TodoInProgressIcon.Render(styles.SpinnerIcon)
 	if m.todoIsSpinning {
 		inProgressIcon = m.todoSpinner.View()
+	} else if !m.isCurrentSessionBusy() {
+		inProgressIcon = t.Tool.TodoInProgressIcon.Render("‖")
 	}
 
 	var pills []string

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -32,19 +32,28 @@ type countingWorkspace struct {
 	agentBusy bool
 	yolo      bool
 	queued    []string
+	// sessionBusy is the per-session busy state behind
+	// AgentIsSessionBusy, keyed by session ID.
+	sessionBusy map[string]bool
 
-	readyCalls      int
-	agentBusyCalls  int
-	queuedCalls     int
-	queueListCalls  int
-	permCalls       int
-	permSetCalls    int
-	clearQueueCalls int
-	cancelCalls     int
+	readyCalls       int
+	agentBusyCalls   int
+	sessionBusyCalls []string
+	queuedCalls      int
+	queueListCalls   int
+	permCalls        int
+	permSetCalls     int
+	clearQueueCalls  int
+	cancelCalls      int
 }
 
 func (w *countingWorkspace) AgentIsReady() bool { w.readyCalls++; return w.ready }
-func (w *countingWorkspace) AgentIsBusy() bool  { w.agentBusyCalls++; return w.agentBusy }
+
+func (w *countingWorkspace) AgentIsSessionBusy(sessionID string) bool {
+	w.sessionBusyCalls = append(w.sessionBusyCalls, sessionID)
+	return w.sessionBusy[sessionID]
+}
+func (w *countingWorkspace) AgentIsBusy() bool { w.agentBusyCalls++; return w.agentBusy }
 
 func (w *countingWorkspace) AgentReadyErr() error {
 	w.readyCalls++
@@ -559,4 +568,48 @@ func TestRemoteYoloToggleUpdatesEditorPrompt(t *testing.T) {
 	require.False(t, m.yoloModeCached())
 	require.Equal(t, normalPrompt, ansi.Strip(m.textarea.View()),
 		"toggling yolo off must restore the normal editor prompt")
+}
+
+// TestIsCurrentSessionBusyIsSessionScoped is the core of this change: the
+// current session's busy state must reflect only its own activity, never
+// another session's, so a paused To-Do is not shown as actively executing.
+func TestIsCurrentSessionBusyIsSessionScoped(t *testing.T) {
+	t.Parallel()
+
+	t.Run("current session busy", func(t *testing.T) {
+		t.Parallel()
+		ws := &countingWorkspace{ready: true, sessionBusy: map[string]bool{"s1": true}}
+		m := newBusyUI(ws)
+		require.True(t, m.isCurrentSessionBusy(),
+			"the viewed session's own activity must read as busy")
+	})
+
+	t.Run("another session busy does not affect current", func(t *testing.T) {
+		t.Parallel()
+		ws := &countingWorkspace{ready: true, sessionBusy: map[string]bool{"other": true}}
+		m := newBusyUI(ws)
+		require.False(t, m.isCurrentSessionBusy(),
+			"another session's activity must not mark the current session busy")
+		for _, id := range ws.sessionBusyCalls {
+			require.Equal(t, "s1", id,
+				"the busy check must be scoped to the current session ID")
+		}
+	})
+
+	t.Run("agent not ready", func(t *testing.T) {
+		t.Parallel()
+		ws := &countingWorkspace{ready: false, sessionBusy: map[string]bool{"s1": true}}
+		m := newBusyUI(ws)
+		require.False(t, m.isCurrentSessionBusy(),
+			"a not-ready agent must not read as busy")
+	})
+
+	t.Run("no active session", func(t *testing.T) {
+		t.Parallel()
+		ws := &countingWorkspace{ready: true, sessionBusy: map[string]bool{"s1": true}}
+		m := newBusyUI(ws)
+		m.session = nil
+		require.False(t, m.isCurrentSessionBusy(),
+			"no active session must not read as busy")
+	})
 }

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -37,21 +37,31 @@ type countingWorkspace struct {
 	lspStates map[string]workspace.LSPClientInfo
 	lspDiags  map[string]lsp.DiagnosticCounts
 
-	readyCalls      int
-	agentBusyCalls  int
-	queuedCalls     int
-	queueListCalls  int
-	permCalls       int
-	permSetCalls    int
-	clearQueueCalls int
-	cancelCalls     int
-	modelCalls      int
-	lspStateCalls   int
-	lspDiagCalls    int
+	// sessionBusy is the per-session busy state behind
+	// AgentIsSessionBusy, keyed by session ID.
+	sessionBusy map[string]bool
+
+	readyCalls       int
+	agentBusyCalls   int
+	sessionBusyCalls []string
+	queuedCalls      int
+	queueListCalls   int
+	permCalls        int
+	permSetCalls     int
+	clearQueueCalls  int
+	cancelCalls      int
+	modelCalls       int
+	lspStateCalls    int
+	lspDiagCalls     int
 }
 
 func (w *countingWorkspace) AgentIsReady() bool { w.readyCalls++; return w.ready }
-func (w *countingWorkspace) AgentIsBusy() bool  { w.agentBusyCalls++; return w.agentBusy }
+
+func (w *countingWorkspace) AgentIsSessionBusy(sessionID string) bool {
+	w.sessionBusyCalls = append(w.sessionBusyCalls, sessionID)
+	return w.sessionBusy[sessionID]
+}
+func (w *countingWorkspace) AgentIsBusy() bool { w.agentBusyCalls++; return w.agentBusy }
 
 func (w *countingWorkspace) AgentReadyErr() error {
 	w.readyCalls++
@@ -777,4 +787,48 @@ func TestRemoteYoloToggleUpdatesEditorPrompt(t *testing.T) {
 	require.False(t, m.yoloModeCached())
 	require.Equal(t, normalPrompt, ansi.Strip(m.textarea.View()),
 		"toggling yolo off must restore the normal editor prompt")
+}
+
+// TestIsCurrentSessionBusyIsSessionScoped is the core of this change: the
+// current session's busy state must reflect only its own activity, never
+// another session's, so a paused To-Do is not shown as actively executing.
+func TestIsCurrentSessionBusyIsSessionScoped(t *testing.T) {
+	t.Parallel()
+
+	t.Run("current session busy", func(t *testing.T) {
+		t.Parallel()
+		ws := &countingWorkspace{ready: true, sessionBusy: map[string]bool{"s1": true}}
+		m := newBusyUI(ws)
+		require.True(t, m.isCurrentSessionBusy(),
+			"the viewed session's own activity must read as busy")
+	})
+
+	t.Run("another session busy does not affect current", func(t *testing.T) {
+		t.Parallel()
+		ws := &countingWorkspace{ready: true, sessionBusy: map[string]bool{"other": true}}
+		m := newBusyUI(ws)
+		require.False(t, m.isCurrentSessionBusy(),
+			"another session's activity must not mark the current session busy")
+		for _, id := range ws.sessionBusyCalls {
+			require.Equal(t, "s1", id,
+				"the busy check must be scoped to the current session ID")
+		}
+	})
+
+	t.Run("agent not ready", func(t *testing.T) {
+		t.Parallel()
+		ws := &countingWorkspace{ready: false, sessionBusy: map[string]bool{"s1": true}}
+		m := newBusyUI(ws)
+		require.False(t, m.isCurrentSessionBusy(),
+			"a not-ready agent must not read as busy")
+	})
+
+	t.Run("no active session", func(t *testing.T) {
+		t.Parallel()
+		ws := &countingWorkspace{ready: true, sessionBusy: map[string]bool{"s1": true}}
+		m := newBusyUI(ws)
+		m.session = nil
+		require.False(t, m.isCurrentSessionBusy(),
+			"no active session must not read as busy")
+	})
 }

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3949,6 +3949,21 @@ func (m *UI) isAgentBusy() bool {
 	return m.agentBusyCache.val
 }
 
+// isCurrentSessionBusy reports whether the agent is actively processing a
+// request for the session the user is currently viewing. Unlike
+// isAgentBusy, activity in another session does not make the current
+// session appear busy.
+func (m *UI) isCurrentSessionBusy() bool {
+	if m.bangCancel != nil {
+		return true
+	}
+	if !m.hasSession() || m.com == nil || m.com.Workspace == nil {
+		return false
+	}
+	return m.com.Workspace.AgentIsReady() &&
+		m.com.Workspace.AgentIsSessionBusy(m.session.ID)
+}
+
 // hasSession returns true if there is an active session with a valid ID.
 func (m *UI) hasSession() bool {
 	return m.session != nil && m.session.ID != ""

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3773,6 +3773,21 @@ func (m *UI) isAgentBusy() bool {
 	return m.agentBusyCache.val
 }
 
+// isCurrentSessionBusy reports whether the agent is actively processing a
+// request for the session the user is currently viewing. Unlike
+// isAgentBusy, activity in another session does not make the current
+// session appear busy.
+func (m *UI) isCurrentSessionBusy() bool {
+	if m.bangCancel != nil {
+		return true
+	}
+	if !m.hasSession() || m.com == nil || m.com.Workspace == nil {
+		return false
+	}
+	return m.com.Workspace.AgentIsReady() &&
+		m.com.Workspace.AgentIsSessionBusy(m.session.ID)
+}
+
 // hasSession returns true if there is an active session with a valid ID.
 func (m *UI) hasSession() bool {
 	return m.session != nil && m.session.ID != ""


### PR DESCRIPTION
Posted by `@joestump-agent` at `@joestump`'s direction.

## Summary

An in-progress To-Do renders identically whether the agent is actively working on it or the session is idle with persisted task state (e.g. you came back to a session later, or the agent is busy in a *different* session). This renders a **pause icon** for in-progress To-Dos when the current session is idle, so paused state is visually distinct from active execution.

Adds a small `isCurrentSessionBusy` helper (busy state scoped to the viewed session, built on the existing `AgentIsSessionBusy`) plus a session-scoped busy-state regression test.

## Heads-up

#3347 (channels 3/3, draft) carries the same helper in its busy-state commit — both PRs are ours; whichever lands second gets rebased to deduplicate. No action needed on your side.

## Test plan

- [x] `internal/ui/model/session_busy_test.go` regression test
- [x] `go test ./internal/ui/model/` passes; `golangci-lint` 0 issues

💘 Generated with Crush

Assisted-by: Claude Fable 5