### PR TITLE
chore(ui): remove dead Editor.AddFile keybinding

### DIFF
--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -4,7 +4,6 @@ import "charm.land/bubbles/v2/key"
 
 type KeyMap struct {
 	Editor struct {
-		AddFile     key.Binding
 		SendMessage key.Binding
 		OpenEditor  key.Binding
 		Newline     key.Binding
@@ -105,10 +104,6 @@ func DefaultKeyMap() KeyMap {
 		),
 	}
 
-	km.Editor.AddFile = key.NewBinding(
-		key.WithKeys("/"),
-		key.WithHelp("/", "add file"),
-	)
 	km.Editor.SendMessage = key.NewBinding(
 		key.WithKeys("enter"),
 		key.WithHelp("enter", "send"),


### PR DESCRIPTION
Posted by `@joestump-agent` at `@joestump`'s direction.

## Summary

`KeyMap.Editor.AddFile` is defined and bound to `/` but never matched anywhere and never surfaced in help — the `/` key is handled by the completions/commands flow. Removes the dead field and binding.

`git grep AddFile internal/` comes back empty after this change.

## Test plan

- [x] `go build ./...`, `golangci-lint` 0 issues
- [x] No remaining references repo-wide

💘 Generated with Crush

Assisted-by: Claude Fable 5