### PR TITLE
fix(ui): resolve timer display conflicts in thinking animation and tool spinners

### DIFF
--- a/internal/ui/anim/anim.go
+++ b/internal/ui/anim/anim.go
@@ -83,8 +83,8 @@ var animCacheMap = csync.NewMap[string, *animCache]()
 // settingsHash creates a hash key for the settings to use for caching
 func settingsHash(opts Settings) string {
 	h := xxh3.New()
-	fmt.Fprintf(h, "%d-%s-%v-%v-%v-%t",
-		opts.Size, opts.Label, opts.LabelColor, opts.GradColorA, opts.GradColorB, opts.CycleColors)
+	fmt.Fprintf(h, "%d-%s-%v-%v-%v-%t-%v",
+		opts.Size, opts.Label, opts.LabelColor, opts.GradColorA, opts.GradColorB, opts.CycleColors, opts.SuffixColor)
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
@@ -110,6 +110,10 @@ type Settings struct {
 	// Suffix is an optional function that returns a dynamic suffix string
 	// to render after the label and ellipsis. Called on every Render().
 	Suffix func() string
+
+	// SuffixColor is the color used to render the suffix text.
+	// Falls back to LabelColor if unset.
+	SuffixColor color.Color
 }
 
 // Default settings.
@@ -132,6 +136,7 @@ type Anim struct {
 	ellipsisFrames   *csync.Slice[string] // ellipsis animation frames
 	id               string
 	suffix           func() string
+	suffixColor      color.Color
 }
 
 // New creates a new Anim instance with the specified width and label.
@@ -166,6 +171,11 @@ func New(opts Settings) *Anim {
 	// Store the suffix function if provided.
 	if opts.Suffix != nil {
 		a.suffix = opts.Suffix
+	}
+	if opts.SuffixColor != nil {
+		a.suffixColor = opts.SuffixColor
+	} else {
+		a.suffixColor = opts.LabelColor
 	}
 
 	// NoScramble means no cycling chars and no birth animation. Mark as
@@ -427,11 +437,20 @@ func (a *Anim) Render() string {
 		}
 	}
 	// Render animated ellipsis at the end of the label if all characters
-	// have been initialized.
+	// have been initialized. Skip when a suffix is active to avoid visual
+	// competition between the animated dots and the timer.
 	if a.initialized.Load() && a.labelWidth > 0 {
-		ellipsisStep := int(a.ellipsisStep.Load())
-		if ellipsisFrame, ok := a.ellipsisFrames.Get(ellipsisStep / ellipsisAnimSpeed); ok {
-			b.WriteString(ellipsisFrame)
+		showEllipsis := true
+		if a.suffix != nil {
+			if s := a.suffix(); s != "" {
+				showEllipsis = false
+			}
+		}
+		if showEllipsis {
+			ellipsisStep := int(a.ellipsisStep.Load())
+			if ellipsisFrame, ok := a.ellipsisFrames.Get(ellipsisStep / ellipsisAnimSpeed); ok {
+				b.WriteString(ellipsisFrame)
+			}
 		}
 	}
 
@@ -440,7 +459,7 @@ func (a *Anim) Render() string {
 		suffixStr := a.suffix()
 		if suffixStr != "" {
 			b.WriteString(" ")
-			b.WriteString(lipgloss.NewStyle().Foreground(a.labelColor).Render(suffixStr))
+			b.WriteString(lipgloss.NewStyle().Foreground(a.suffixColor).Render(suffixStr))
 		}
 	}
 

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -177,6 +177,7 @@ func NewAssistantMessageItem(sty *styles.Styles, message *message.Message) Messa
 		Suffix: func() string {
 			return common.Elapsed()
 		},
+		SuffixColor: sty.WorkingTimerColor,
 	})
 	return a
 }

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -338,7 +338,7 @@ func (a *AssistantInfoItem) renderContent(width int) string {
 	}
 	finishTime := time.Unix(finishData.Time, 0)
 	duration := finishTime.Sub(a.lastUserMessageTime)
-	infoMsg := a.sty.Messages.AssistantInfoDuration.Render(duration.String())
+	infoMsg := a.sty.Messages.AssistantInfoDuration.Render(fmt.Sprintf("in %s", duration))
 	icon := a.sty.Messages.AssistantInfoIcon.Render(styles.ModelIcon)
 	model := a.cfg.GetModel(a.message.Provider, a.message.Model)
 	if model == nil {

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -198,9 +198,6 @@ func newBaseToolMessageItem(
 		GradColorB:  sty.WorkingGradToColor,
 		LabelColor:  sty.WorkingLabelColor,
 		CycleColors: true,
-		Suffix: func() string {
-			return common.Elapsed()
-		},
 	})
 
 	return t

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -99,6 +99,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.WorkingGradFromColor = o.primary
 	s.WorkingGradToColor = o.secondary
 	s.WorkingLabelColor = o.fgMostSubtle
+	s.WorkingTimerColor = o.fgMostSubtle
 
 	s.TextInput = textinput.Styles{
 		Focused: textinput.StyleState{

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -200,6 +200,7 @@ type Styles struct {
 	WorkingGradFromColor color.Color
 	WorkingGradToColor   color.Color
 	WorkingLabelColor    color.Color // Label text color next to the indicator
+	WorkingTimerColor    color.Color // Elapsed timer suffix color
 
 	// Section Title
 	Section struct {


### PR DESCRIPTION
Fixes CHARM-1716.

The elapsed timer added in #3223 had a few color issues and this pr fixes them. Also adds `in` between the model provider and the time as it looked better to me

<img width="365" height="129" alt="image" src="https://github.com/user-attachments/assets/561723c8-7fc7-4e99-8d60-c7807a2fd7d0" />
