### PR TITLE
fix(ui): keep shell progress output from corrupting the TUI

### DIFF
--- a/internal/ui/chat/shell.go
+++ b/internal/ui/chat/shell.go
@@ -261,6 +261,7 @@ func (s *ShellItem) RawRender(width int) string {
 		}
 	}
 
+	raw = common.StripCursorControl(raw)
 	output := common.RemapANSI16(raw, s.sty.ANSI)
 	lines := strings.Split(output, "\n")
 

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -649,7 +649,9 @@ func toolHeader(sty *styles.Styles, status ToolStatus, name string, width int, o
 
 // toolOutputPlainContent renders plain text with optional expansion support.
 func toolOutputPlainContent(sty *styles.Styles, content string, width int, expanded bool) string {
-	content = common.RemapANSI16(stringext.NormalizeSpace(content), sty.ANSI)
+	content = stringext.NormalizeSpace(content)
+	content = common.StripCursorControl(content)
+	content = common.RemapANSI16(content, sty.ANSI)
 	lines := strings.Split(content, "\n")
 
 	maxLines := responseContextHeight

--- a/internal/ui/common/ansi16.go
+++ b/internal/ui/common/ansi16.go
@@ -110,6 +110,102 @@ func remapSGR(params ansi.Params, palette [16]color.Color, buf *strings.Builder)
 	buf.WriteByte('m')
 }
 
+// StripCursorControl removes ANSI escape sequences that move the cursor,
+// erase regions of the screen, or change terminal modes. These sequences
+// are emitted by programs like git push, cargo build, and npm install to
+// animate progress bars and status lines. When captured as raw text and
+// replayed inside Crush's TUI viewport they corrupt the render state.
+//
+// Preserved: SGR (color/style) sequences, OSC hyperlinks, printable text.
+// Stripped: CSI cursor movement (A-H, f), erase (J, K), scroll (S, T),
+// save/restore cursor (s, u), DEC private modes (?h, ?l), and the ESC
+// save/restore cursor sequences (ESC 7, ESC 8). Bare carriage returns
+// (\r) are also handled by simulating line-overwrite behavior: within
+// each line, text after the last \r wins, matching what a real terminal
+// would display.
+func StripCursorControl(s string) string {
+	if !strings.ContainsRune(s, 0x1b) && !strings.ContainsRune(s, '\r') {
+		return s
+	}
+
+	var buf strings.Builder
+	buf.Grow(len(s))
+
+	parser := ansi.GetParser()
+	defer ansi.PutParser(parser)
+
+	var state byte
+	for len(s) > 0 {
+		parser.Reset()
+		seq, _, n, newState := ansi.DecodeSequence(s, state, parser)
+
+		if ansi.HasCsiPrefix(seq) {
+			cmd := parser.Command()
+			final := cmd & 0xff
+			prefix := (cmd >> 8) & 0xff
+
+			switch final {
+			case 'm':
+				// SGR: keep (colors/styles).
+				buf.WriteString(seq)
+			case 'h', 'l':
+				// DEC private mode set/reset (?h, ?l): strip.
+				// Regular h/l without ? prefix are also non-rendering.
+				_ = prefix
+			case 'A', 'B', 'C', 'D', // cursor up/down/forward/back
+				'E', 'F', // cursor next/prev line
+				'G',      // cursor horizontal absolute
+				'H', 'f', // cursor position
+				'J',      // erase display
+				'K',      // erase line
+				'S', 'T', // scroll up/down
+				's', 'u': // save/restore cursor
+				// Strip all cursor/screen control.
+			default:
+				// Unknown CSI: pass through to avoid data loss.
+				buf.WriteString(seq)
+			}
+		} else if ansi.HasEscPrefix(seq) && len(seq) == 2 {
+			// ESC followed by single byte: check for DEC save/restore.
+			switch seq[1] {
+			case '7', '8':
+				// DEC save/restore cursor: strip.
+			default:
+				buf.WriteString(seq)
+			}
+		} else {
+			buf.WriteString(seq)
+		}
+
+		s = s[n:]
+		state = newState
+	}
+
+	result := buf.String()
+
+	// Handle bare \r by simulating line-overwrite. Split on newlines
+	// first so we only process \r within individual lines.
+	if strings.ContainsRune(result, '\r') {
+		result = simulateCarriageReturns(result)
+	}
+
+	return result
+}
+
+// simulateCarriageReturns processes bare \r characters within each line,
+// keeping only the text after the last \r. This matches terminal behavior
+// where \r moves the cursor to column 0 and subsequent text overwrites
+// what was there before. Progress bars use this pattern extensively.
+func simulateCarriageReturns(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if idx := strings.LastIndex(line, "\r"); idx >= 0 {
+			lines[i] = line[idx+1:]
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
 // writeTruecolor appends "introducer;2;r;g;b" to buf. Nil color emits
 // the bare introducer so the terminal default applies.
 func writeTruecolor(buf *strings.Builder, introducer int, c color.Color) {

--- a/internal/ui/common/ansi16_test.go
+++ b/internal/ui/common/ansi16_test.go
@@ -96,6 +96,109 @@ func TestRemapANSI16(t *testing.T) {
 	}
 }
 
+func TestStripCursorControl(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain text passes through",
+			in:   "hello world",
+			want: "hello world",
+		},
+		{
+			name: "SGR color sequences preserved",
+			in:   "\x1b[31mred\x1b[0m",
+			want: "\x1b[31mred\x1b[0m",
+		},
+		{
+			name: "cursor up stripped",
+			in:   "line1\n\x1b[Aline2",
+			want: "line1\nline2",
+		},
+		{
+			name: "cursor down stripped",
+			in:   "top\x1b[Bbottom",
+			want: "topbottom",
+		},
+		{
+			name: "erase line stripped",
+			in:   "progress\x1b[Kdone",
+			want: "progressdone",
+		},
+		{
+			name: "erase display stripped",
+			in:   "\x1b[2Jcleared",
+			want: "cleared",
+		},
+		{
+			name: "cursor position stripped",
+			in:   "\x1b[Hhome",
+			want: "home",
+		},
+		{
+			name: "DEC private mode hide cursor stripped",
+			in:   "\x1b[?25linvisible\x1b[?25hvisible",
+			want: "invisiblevisible",
+		},
+		{
+			name: "DEC save restore cursor stripped",
+			in:   "\x1b7saved\x1b8restored",
+			want: "savedrestored",
+		},
+		{
+			name: "save restore cursor CSI stripped",
+			in:   "\x1b[spos\x1b[upos",
+			want: "pospos",
+		},
+		{
+			name: "scroll up down stripped",
+			in:   "\x1b[Sscroll\x1b[Tscroll",
+			want: "scrollscroll",
+		},
+		{
+			name: "carriage return simulates overwrite",
+			in:   "loading...\rdone!",
+			want: "done!",
+		},
+		{
+			name: "multiple carriage returns keep last",
+			in:   "step1\rstep2\rstep3",
+			want: "step3",
+		},
+		{
+			name: "carriage return per line",
+			in:   "a\rb\nc\rd",
+			want: "b\nd",
+		},
+		{
+			name: "mixed SGR and cursor control",
+			in:   "\x1b[31mloading\x1b[0m\r\x1b[32mdone\x1b[0m",
+			want: "\x1b[32mdone\x1b[0m",
+		},
+		{
+			name: "git push style progress",
+			in:   "Enumerating objects: 10\rEnumerating objects: 50\rEnumerating objects: 100, done.",
+			want: "Enumerating objects: 100, done.",
+		},
+		{
+			name: "no escapes fast path",
+			in:   "just text no escapes",
+			want: "just text no escapes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, StripCursorControl(tt.in))
+		})
+	}
+}
+
 func TestRemapANSI16NilColorFallsBack(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Programs like git push animate progress with cursor-movement and line-erase escape sequences and bare carriage returns. These were scrambling rendering and now we catch them!