### PR TITLE
fix(client-server): fix hang regression related to MCP server changes

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -627,8 +627,26 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		RunComplete:          c.runComplete,
 	})
 
+	// The readiness goroutines below perform one-time setup — building the
+	// system prompt and the (MCP-gated) tool list — whose results the
+	// coordinator needs for its whole lifetime, so they must survive the
+	// caller's context being canceled. Several entry points build an agent
+	// from a short-lived HTTP request context: the server's
+	// InitAgent/UpdateAgent handlers, and UpdateModels -> buildTools ->
+	// agentTool -> buildAgent for the sub-agent. Because mcp.WaitForInit
+	// blocks until MCP initialization finishes, a slow MCP server keeps one
+	// of these goroutines parked past the request; when the handler returns
+	// and cancels its context, WaitForInit would observe the cancellation,
+	// the errgroup would record context.Canceled, and every later run would
+	// fail at readyWg.Wait() before emitting anything — the client/server
+	// session hangs with no visible response. WithoutCancel drops
+	// cancellation while keeping context values; the work is bounded
+	// (WaitForInit by MCP init timeouts, the rest is local) so it always
+	// completes.
+	initCtx := context.WithoutCancel(ctx)
+
 	c.readyWg.Go(func() error {
-		systemPrompt, err := prompt.Build(ctx, large.Model.Provider(), large.Model.Model(), c.cfg)
+		systemPrompt, err := prompt.Build(initCtx, large.Model.Provider(), large.Model.Model(), c.cfg)
 		if err != nil {
 			return err
 		}
@@ -641,10 +659,10 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		// building the initial tool list. This ensures the first tool set
 		// (used if anything reads it before run() rebuilds) includes all
 		// MCP tools, not just fast-to-init ones.
-		if err := mcp.WaitForInit(ctx); err != nil {
+		if err := mcp.WaitForInit(initCtx); err != nil {
 			return err
 		}
-		tools, err := c.buildTools(ctx, agent, isSubAgent)
+		tools, err := c.buildTools(initCtx, agent, isSubAgent)
 		if err != nil {
 			return err
 		}

--- a/internal/agent/coordinator_readiness_test.go
+++ b/internal/agent/coordinator_readiness_test.go
@@ -1,0 +1,99 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/agent/prompt"
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildAgentReadinessSurvivesCallerCancellation is a regression test for
+// the CRUSH_CLIENT_SERVER=1 "new session hangs" bug.
+//
+// buildAgent starts readiness goroutines that run mcp.WaitForInit before
+// building the tool list. Several server entry points build an agent from a
+// short-lived HTTP request context — the InitAgent/UpdateAgent handlers, and
+// the sub-agent build reached through UpdateModels -> buildTools -> agentTool.
+// When a slow MCP server kept initialization in flight, that request context
+// was canceled the moment the handler returned; WaitForInit then observed the
+// cancellation, the readyWg errgroup recorded context.Canceled, and every
+// later coordinator.run failed at readyWg.Wait() before emitting anything —
+// the session hung with no visible LLM response.
+//
+// The fix detaches the readiness work from the caller context via
+// context.WithoutCancel, so canceling the context that triggered the build no
+// longer poisons readyWg. Here we arm MCP init so WaitForInit blocks, build an
+// agent with a cancelable context, cancel it, and require that readyWg keeps
+// waiting for init instead of failing with context.Canceled.
+func TestBuildAgentReadinessSurvivesCallerCancellation(t *testing.T) {
+	env := testEnv(t)
+
+	// Minimal hermetic config: one openai-typed provider with selected large
+	// and small models so buildAgentModels and the system-prompt build both
+	// succeed. No MCP servers are configured, so initialization would complete
+	// instantly if we let it — we deliberately do not, so WaitForInit stays
+	// blocked for the duration of the assertion.
+	crushJSON := `{
+  "options": {"disable_default_providers": true, "disable_provider_auto_update": true},
+  "providers": {"mock": {"id": "mock", "name": "Mock", "type": "openai",
+    "base_url": "http://127.0.0.1:9/v1", "api_key": "test-key",
+    "models": [{"id": "mock-model", "name": "Mock", "context_window": 8192, "default_max_tokens": 128}]}},
+  "models": {"large": {"provider": "mock", "model": "mock-model"},
+             "small": {"provider": "mock", "model": "mock-model"}}
+}`
+	require.NoError(t, os.WriteFile(filepath.Join(env.workingDir, "crush.json"), []byte(crushJSON), 0o644))
+
+	cfg, err := config.Init(env.workingDir, "", false)
+	require.NoError(t, err)
+	cfg.SetupAgents()
+
+	coord := &coordinator{
+		cfg:         cfg,
+		sessions:    env.sessions,
+		messages:    env.messages,
+		permissions: env.permissions,
+		history:     env.history,
+		filetracker: *env.filetracker,
+	}
+
+	// Arm the MCP init gate so buildAgent's readiness goroutine blocks in
+	// WaitForInit. We never complete init, so the goroutine stays parked; the
+	// agent package's TestMain does not enforce goleak and no other test in it
+	// builds a coordinator, so the parked goroutine is harmless.
+	mcp.ArmInit()
+
+	p, err := coderPrompt(prompt.WithWorkingDir(env.workingDir))
+	require.NoError(t, err)
+	agentCfg := cfg.Config().Agents[config.AgentCoder]
+
+	ctx, cancel := context.WithCancel(context.Background())
+	_, err = coord.buildAgent(ctx, p, agentCfg, false)
+	require.NoError(t, err)
+
+	// The caller goes away, mirroring an HTTP handler returning and canceling
+	// its request context while MCP init is still in flight.
+	cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- coord.readyWg.Wait() }()
+
+	select {
+	case err := <-done:
+		// readyWg finished early. context.Canceled is the regression: the
+		// caller's cancellation leaked into the readiness work and poisoned the
+		// errgroup. Any other early return means this minimal setup failed to
+		// build, which the NoError check surfaces distinctly.
+		require.NotErrorIs(t, err, context.Canceled,
+			"readyWg was poisoned by caller cancellation (client/server new-session hang regression)")
+		require.NoError(t, err, "unexpected buildAgent readiness error")
+	case <-time.After(250 * time.Millisecond):
+		// readyWg is still waiting on MCP init despite the canceled caller
+		// context. This is the fixed behavior.
+	}
+}


### PR DESCRIPTION
This fixes a regression introduced in #3328.

Clients in client-server mode would hang indefinitely after the first message if at least one MCP server was present. This fixes that.