### PR TITLE
fix(commands): scope logout command to oauth providers

### DIFF
--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -131,14 +131,17 @@ func pickLoggedInProvider(c *client.Client, wsID string) (string, error) {
 		name string
 	}
 
+	// Only OAuth-based providers support login/logout. Keep this list in sync
+	// with the switch in RunE and the login command.
+	oauthProviders := map[string]string{
+		"hyper":   "Hyper",
+		"copilot": "GitHub Copilot",
+	}
+
 	var loggedIn []loggedInProvider
-	for p := range cfg.Providers.Seq() {
-		if p.OAuthToken != nil || p.APIKey != "" {
-			name := p.Name
-			if name == "" {
-				name = p.ID
-			}
-			loggedIn = append(loggedIn, loggedInProvider{id: p.ID, name: name})
+	for id, name := range oauthProviders {
+		if p, ok := cfg.Providers.Get(id); ok && p.OAuthToken != nil {
+			loggedIn = append(loggedIn, loggedInProvider{id: id, name: name})
 		}
 	}
 


### PR DESCRIPTION
fixes charmbracelet/crush#3342

previously we just loaded the providers dynamically; this changes it to be symmetric to the login command with just copilot and hyper