### PR TITLE
fix(config): prevent data race when reading config during reload

### DIFF
--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -88,8 +88,8 @@ type ConfigStore struct {
 	// build a fresh Config rather than mutating the live one.
 	configMu sync.RWMutex
 
-	mu      sync.Mutex // serialises config file writes
-	writeMu sync.Mutex // serialises in-memory config production (mutators + reload)
+	mu      sync.Mutex   // serialises config file writes
+	writeMu sync.RWMutex // serialises in-memory config production (mutators + reload); RLock for readers
 
 	// refreshSF collapses concurrent in-process OAuth refreshes for the
 	// same provider into a single attempt. Combined with the per-provider
@@ -140,19 +140,26 @@ func (s *ConfigStore) WorkingDir() string {
 
 // Resolver returns the variable resolver.
 func (s *ConfigStore) Resolver() VariableResolver {
+	s.writeMu.RLock()
+	defer s.writeMu.RUnlock()
 	return s.resolver
 }
 
 // Resolve resolves a variable reference using the configured resolver.
 func (s *ConfigStore) Resolve(key string) (string, error) {
-	if s.resolver == nil {
+	s.writeMu.RLock()
+	r := s.resolver
+	s.writeMu.RUnlock()
+	if r == nil {
 		return "", fmt.Errorf("no variable resolver configured")
 	}
-	return s.resolver.ResolveValue(key)
+	return r.ResolveValue(key)
 }
 
 // KnownProviders returns the list of known providers.
 func (s *ConfigStore) KnownProviders() []catwalk.Provider {
+	s.writeMu.RLock()
+	defer s.writeMu.RUnlock()
 	return s.knownProviders
 }
 
@@ -163,11 +170,15 @@ func (s *ConfigStore) SetupAgents() {
 
 // Overrides returns the runtime overrides for this store.
 func (s *ConfigStore) Overrides() *RuntimeOverrides {
+	s.writeMu.RLock()
+	defer s.writeMu.RUnlock()
 	return &s.overrides
 }
 
 // LoadedPaths returns the config file paths that were successfully loaded.
 func (s *ConfigStore) LoadedPaths() []string {
+	s.writeMu.RLock()
+	defer s.writeMu.RUnlock()
 	return slices.Clone(s.loadedPaths)
 }
 


### PR DESCRIPTION
Config reader methods (variable resolver, known providers, runtime overrides, loaded paths) read fields with no lock while a concurrent disk reload could rewrite them. The Go race detector flagged this against `TestDisableDockerMCP_PublishesConfigChanged`.

## What changed
- Guard those reads with the same lock that serializes in-memory reloads, so callers always observe a consistent config snapshot.
- Promote that lock to a read/write mutex so ordinary reads stay concurrent and don't serialize behind each other.

## Verification
- `go test -race ./internal/config/... ./internal/backend/...` passes clean.

💘 Generated with Crush