### PR TITLE
perf(tui): keep synchronous workspace probes off the per-message Update path

### DIFF
--- a/internal/ui/model/history.go
+++ b/internal/ui/model/history.go
@@ -131,8 +131,7 @@ func (m *UI) syncBangModeFromTextarea() {
 		m.bangMode = false
 		m.bangWasEmpty = false
 	}
-	yolo := m.com.Workspace.PermissionSkipRequests()
-	m.setEditorPrompt(yolo)
+	m.setEditorPrompt(m.yoloModeCached())
 }
 
 // historyPrev changes the text area content to the previous message in the history

--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -328,9 +328,11 @@ func (m *UI) renderPills() {
 		if todosFocused && hasIncomplete {
 			expandedList = todoList(m.session.Todos, inProgressIcon, t, contentWidth)
 		} else if queueFocused && hasQueue {
-			if m.com != nil && m.com.Workspace != nil && m.com.Workspace.AgentIsReady() {
-				queueItems := m.com.Workspace.AgentQueuedPromptsList(m.session.ID)
-				expandedList = queueList(queueItems, t)
+			// Render from the memoized queue (fetched off-thread, see
+			// workspace_cache.go): renderPills runs on the Update/View
+			// path and must never block on a workspace round-trip.
+			if len(m.promptQueueItems) > 0 {
+				expandedList = queueList(m.promptQueueItems, t)
 			}
 		}
 	}

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 
 	"github.com/charmbracelet/crush/internal/agent/notify"
@@ -319,6 +320,35 @@ func TestToggleYoloWritesThroughCache(t *testing.T) {
 	require.False(t, m.yoloModeCached())
 }
 
+// TestLocalYoloToggleSupersedesInFlightProbe pins the generation bump in
+// toggleYoloMode: a busy/yolo probe dispatched before the toggle carries the
+// old generation. Without advancing busyFetchGen its stale result would land
+// with a still-matching generation and clobber the just-toggled value.
+func TestLocalYoloToggleSupersedesInFlightProbe(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, yolo: false}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+
+	// A busy/yolo probe carrying the pre-toggle generation is in flight.
+	m.busyFetchInFlight = true
+	staleGen := m.busyFetchGen
+
+	require.True(t, m.toggleYoloMode())
+	require.NotEqual(t, staleGen, m.busyFetchGen,
+		"toggle must advance the busy generation to supersede in-flight probes")
+	require.True(t, m.yoloModeCached(), "toggle must write the new value through the cache")
+
+	// The stale probe (old generation, old yolo=false) lands.
+	m.busyFetchInFlight = true
+	cmds := m.applyBusyState(busyStateMsg{gen: staleGen, yolo: false})
+	require.True(t, m.yoloModeCached(),
+		"stale probe must not overwrite the freshly toggled value")
+	require.NotEmpty(t, cmds, "stale probe must re-dispatch an authoritative refresh")
+	require.True(t, m.busyFetchInFlight, "re-dispatched refresh must be in flight")
+}
+
 // TestSendMessageSetsOptimisticBusy pins the esc-after-enter behavior:
 // submitting a prompt optimistically marks the agent busy so an immediate
 // esc routes to cancelAgent instead of reading a stale idle value and doing
@@ -398,4 +428,127 @@ func TestBackstopRefreshesStaleCaches(t *testing.T) {
 	// Freshly refreshed caches must not re-dispatch.
 	m.Update(plainMsg{})
 	require.False(t, m.busyFetchInFlight, "fresh caches must not re-dispatch the backstop")
+}
+
+// TestStaleBusyRefreshDiscardedAndReDispatched pins the generation guard for
+// busy/permission state: a probe started before a newer state transition
+// (here an optimistic busy write) must not overwrite the newer value when it
+// lands, and the authoritative refresh must not be lost merely because the
+// older probe was in flight — the stale result re-dispatches it.
+func TestStaleBusyRefreshDiscardedAndReDispatched(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+
+	// A busy probe is in flight; capture the generation it was dispatched
+	// with, then a newer transition (optimistic send) supersedes it.
+	m.busyFetchInFlight = true
+	staleGen := m.busyFetchGen
+	m.agentBusyCache.set(true) // optimistic busy
+	m.busyFetchGen++           // newer state transition
+
+	// The stale probe (agent reported idle) lands with the old generation.
+	cmds := m.applyBusyState(busyStateMsg{gen: staleGen, agentBusy: false})
+	require.True(t, m.isAgentBusy(),
+		"a stale busy result must not overwrite the newer optimistic busy state")
+	require.NotEmpty(t, cmds,
+		"a stale busy result must re-dispatch the authoritative refresh")
+	require.True(t, m.busyFetchInFlight, "the re-dispatched probe must be in flight")
+
+	// The fresh probe (matching generation) is applied normally.
+	freshGen := m.busyFetchGen
+	m.applyBusyState(busyStateMsg{gen: freshGen, agentBusy: false})
+	require.False(t, m.isAgentBusy(), "a current-generation result must land in the cache")
+}
+
+// TestStalePromptQueueDiscardedAndReDispatched pins the generation guard for
+// the queue: a fetch started before a newer transition (here a queue clear)
+// must not repopulate the cleared queue, and it must re-dispatch the
+// authoritative fetch instead of being applied.
+func TestStalePromptQueueDiscardedAndReDispatched(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, queued: []string{"real"}}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"real"}
+
+	// A fetch is in flight; capture its generation, then a newer transition
+	// (esc clears the queue) supersedes it.
+	m.promptQueueInFlight = true
+	staleGen := m.promptQueueGen
+	m.invalidatePromptQueue()
+	m.promptQueue = 0
+	m.promptQueueItems = nil
+
+	// The stale fetch (still saw one prompt) lands for the same session.
+	cmds := m.applyPromptQueue(promptQueueMsg{
+		forSession: "s1",
+		gen:        staleGen,
+		prompts:    []string{"stale"},
+	})
+	require.Zero(t, m.promptQueue,
+		"a stale queue result must not repopulate the cleared queue")
+	require.Empty(t, m.promptQueueItems)
+	require.NotEmpty(t, cmds,
+		"a stale queue result must re-dispatch the authoritative fetch")
+	require.True(t, m.promptQueueInFlight, "the re-dispatched fetch must be in flight")
+}
+
+// TestStalePromptQueuePreservesSessionScoping pins that the generation guard
+// does not weaken session scoping: a fetch scoped to a different session is
+// still discarded and re-fetched even when its generation would otherwise
+// match.
+func TestStalePromptQueuePreservesSessionScoping(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws) // active session "s1"
+	warmCaches(m, false)
+	m.promptQueueInFlight = true
+	gen := m.promptQueueGen
+
+	cmds := m.applyPromptQueue(promptQueueMsg{
+		forSession: "other",
+		gen:        gen,
+		prompts:    []string{"from other session"},
+	})
+	require.Zero(t, m.promptQueue,
+		"a result from a different session must never populate the queue")
+	require.NotEmpty(t, cmds, "a session-mismatched result must re-fetch for the current session")
+}
+
+// TestRemoteYoloToggleUpdatesEditorPrompt pins the second fix: when an
+// asynchronous busy-state refresh reports a yolo mode different from the
+// cached one (a remote toggle), applyBusyState must update the textarea
+// prompt function too, not just the cache — otherwise the prompt icon/style
+// keeps rendering the old mode.
+func TestRemoteYoloToggleUpdatesEditorPrompt(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
+	m.textarea.Focus()
+	m.textarea.SetWidth(40)
+	m.yoloCache.set(false)
+	m.setEditorPrompt(false)
+	normalPrompt := ansi.Strip(m.textarea.View())
+
+	// A remote toggle flips yolo on; delivered via an off-thread refresh.
+	m.applyBusyState(busyStateMsg{gen: m.busyFetchGen, yolo: true})
+	require.True(t, m.yoloModeCached(), "the refresh must write the new yolo value through the cache")
+	yoloPrompt := ansi.Strip(m.textarea.View())
+	require.NotEqual(t, normalPrompt, yoloPrompt,
+		"a remote yolo toggle must change the rendered editor prompt")
+	require.Contains(t, yoloPrompt, "Y",
+		"the yolo prompt icon must render after a remote toggle")
+
+	// Flipping back off must restore the normal prompt.
+	m.applyBusyState(busyStateMsg{gen: m.busyFetchGen, yolo: false})
+	require.False(t, m.yoloModeCached())
+	require.Equal(t, normalPrompt, ansi.Strip(m.textarea.View()),
+		"toggling yolo off must restore the normal editor prompt")
 }

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -1,0 +1,401 @@
+package model
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/charmbracelet/crush/internal/agent/notify"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/pubsub"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
+	"github.com/charmbracelet/crush/internal/workspace"
+)
+
+// countingWorkspace is a workspace.Workspace stub that counts every probe
+// that is a synchronous HTTP round-trip in client/server mode, split per
+// method so tests can pin exactly which probes ran. The embedded interface
+// panics on anything unimplemented.
+type countingWorkspace struct {
+	workspace.Workspace
+
+	ready     bool
+	agentBusy bool
+	yolo      bool
+	queued    []string
+
+	readyCalls      int
+	agentBusyCalls  int
+	queuedCalls     int
+	queueListCalls  int
+	permCalls       int
+	permSetCalls    int
+	clearQueueCalls int
+	cancelCalls     int
+}
+
+func (w *countingWorkspace) AgentIsReady() bool { w.readyCalls++; return w.ready }
+func (w *countingWorkspace) AgentIsBusy() bool  { w.agentBusyCalls++; return w.agentBusy }
+
+func (w *countingWorkspace) AgentQueuedPrompts(string) int {
+	w.queuedCalls++
+	return len(w.queued)
+}
+
+func (w *countingWorkspace) AgentQueuedPromptsList(string) []string {
+	w.queueListCalls++
+	return w.queued
+}
+
+func (w *countingWorkspace) PermissionSkipRequests() bool { w.permCalls++; return w.yolo }
+
+func (w *countingWorkspace) PermissionSetSkipRequests(skip bool) {
+	w.permSetCalls++
+	w.yolo = skip
+}
+
+func (w *countingWorkspace) AgentClearQueue(string) { w.clearQueueCalls++; w.queued = nil }
+func (w *countingWorkspace) AgentCancel(string)     { w.cancelCalls++ }
+
+func (w *countingWorkspace) ListMessages(context.Context, string) ([]message.Message, error) {
+	return nil, nil
+}
+
+func (w *countingWorkspace) ListUserMessages(context.Context, string) ([]message.Message, error) {
+	return nil, nil
+}
+
+func (w *countingWorkspace) LSPStart(context.Context, string) {}
+
+func (w *countingWorkspace) Config() *config.Config { return nil }
+
+// syncProbes sums every synchronous counter; Update/View must keep this at
+// zero — the busy/queue invariant is that no workspace call ever happens on
+// the Update goroutine.
+func (w *countingWorkspace) syncProbes() int {
+	return w.readyCalls + w.agentBusyCalls +
+		w.queuedCalls + w.queueListCalls + w.permCalls
+}
+
+func (w *countingWorkspace) resetCounters() {
+	w.readyCalls, w.agentBusyCalls = 0, 0
+	w.queuedCalls, w.queueListCalls, w.permCalls = 0, 0, 0
+	w.permSetCalls, w.clearQueueCalls, w.cancelCalls = 0, 0, 0
+}
+
+// newBusyUI builds a UI wired to the stub workspace with an active session
+// "s1", enough state for Update to run end to end.
+func newBusyUI(ws *countingWorkspace) *UI {
+	com := common.DefaultCommon(ws)
+	return &UI{
+		com:         com,
+		status:      NewStatus(com, nil),
+		chat:        NewChat(com, config.ScrollbarDefault),
+		textarea:    textarea.New(),
+		state:       uiChat,
+		focus:       uiFocusEditor,
+		width:       140,
+		height:      45,
+		session:     &session.Session{ID: "s1"},
+		keyMap:      DefaultKeyMap(),
+		dialog:      dialog.NewOverlay(),
+		attachments: attachments.New(nil, attachments.Keymap{}),
+	}
+}
+
+// pinTTLs makes the TTL backstop inert for the duration of the test so
+// assertions about event-driven refreshes cannot flake by straddling a TTL
+// boundary (the tests using it must not call t.Parallel).
+func pinTTLs(t *testing.T) {
+	t.Helper()
+	oldBusy, oldQueue := busyCacheTTL, promptQueueTTL
+	busyCacheTTL = time.Hour
+	promptQueueTTL = time.Hour
+	t.Cleanup(func() { busyCacheTTL, promptQueueTTL = oldBusy, oldQueue })
+}
+
+// warmCaches marks all memoized workspace state fresh so only explicit
+// invalidation (not startup staleness) can trigger refresh dispatches.
+func warmCaches(m *UI, busy bool) {
+	m.agentBusyCache.set(busy)
+	m.yoloCache.set(false)
+	m.promptQueueCheckedAt = time.Now()
+}
+
+// runCmds executes a command tree the way the Bubble Tea runtime would,
+// feeding cache-refresh messages back into Update. Other leaf commands are
+// executed (for their side effects on the stub) but their messages dropped.
+func runCmds(m *UI, cmd tea.Cmd) {
+	if cmd == nil {
+		return
+	}
+	switch msg := cmd().(type) {
+	case tea.BatchMsg:
+		for _, c := range msg {
+			runCmds(m, c)
+		}
+	case busyStateMsg, promptQueueMsg, agentRunSubmittedMsg:
+		_, next := m.Update(msg)
+		runCmds(m, next)
+	}
+}
+
+// plainMsg is an arbitrary tea.Msg standing in for keystroke/mouse/tick
+// traffic through Update.
+type plainMsg struct{}
+
+// TestUpdateDoesNotProbeWorkspacePerMessage pins the hot-path fix: Update
+// used to call AgentQueuedPrompts (a synchronous HTTP GET in client/server
+// mode) at the top of every message while the agent was busy, and the
+// placeholder path probed AgentIsReady/AgentIsBusy/PermissionSkipRequests —
+// every keystroke blocked the single Update goroutine on network round-
+// trips. Now Update performs no synchronous workspace call at all; refreshes
+// are dispatched as commands.
+func TestUpdateDoesNotProbeWorkspacePerMessage(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
+
+	for range 25 {
+		m.Update(plainMsg{})
+	}
+	require.Zero(t, ws.queuedCalls,
+		"Update must not call AgentQueuedPrompts per message (HTTP per keystroke in client mode)")
+	require.Zero(t, ws.syncProbes(),
+		"Update must not make any synchronous workspace call")
+}
+
+// TestReadsNeverProbeWorkspace pins the read side of the invariant: the
+// busy/yolo getters used by render paths serve the memoized value and never
+// probe, so View can never block on HTTP.
+func TestReadsNeverProbeWorkspace(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, agentBusy: true}
+	m := newBusyUI(ws)
+
+	for range 10 {
+		m.isAgentBusy()
+		m.yoloModeCached()
+	}
+	require.Zero(t, ws.syncProbes(), "cache reads must never probe the workspace")
+}
+
+// TestStreamingUpdatedEventsDoNotProbe pins the streaming path: per-chunk
+// message UpdatedEvents arrive once per streamed token and must neither
+// probe the workspace synchronously nor schedule busy/queue refreshes —
+// only CreatedEvents (run boundaries) do.
+func TestStreamingUpdatedEventsDoNotProbe(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	ws.resetCounters()
+
+	for range 25 {
+		m.Update(pubsub.Event[message.Message]{
+			Type:    pubsub.UpdatedEvent,
+			Payload: message.Message{ID: "m1", SessionID: "s1", Role: message.Assistant},
+		})
+	}
+	require.Zero(t, ws.syncProbes(),
+		"per-chunk UpdatedEvents must not probe the workspace")
+	require.False(t, m.busyFetchInFlight,
+		"per-chunk UpdatedEvents must not schedule a busy refresh")
+	require.False(t, m.promptQueueInFlight,
+		"per-chunk UpdatedEvents must not schedule a queue refresh")
+}
+
+// TestMessageCreatedEventRefreshesBusyAndQueue: a CreatedEvent is a run
+// boundary and must invalidate the memoized busy state and fetch fresh
+// busy/queue values off-thread.
+func TestMessageCreatedEventRefreshesBusyAndQueue(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, agentBusy: true, queued: []string{"queued prompt"}}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	ws.resetCounters()
+
+	_, cmd := m.Update(pubsub.Event[message.Message]{
+		Type:    pubsub.CreatedEvent,
+		Payload: message.Message{ID: "m1", SessionID: "s1", Role: message.User},
+	})
+	require.Zero(t, ws.syncProbes(), "the event handler itself must not probe synchronously")
+	require.True(t, m.busyFetchInFlight, "CreatedEvent must schedule a busy refresh")
+	require.True(t, m.promptQueueInFlight, "CreatedEvent must schedule a queue refresh")
+
+	runCmds(m, cmd)
+	require.True(t, m.isAgentBusy(), "refreshed busy state must land in the cache")
+	require.Equal(t, 1, m.promptQueue, "refreshed queue count must land in the cache")
+	require.False(t, m.busyFetchInFlight)
+	require.False(t, m.promptQueueInFlight)
+}
+
+// TestAgentTerminalNotificationsRefreshBusy pins the busy→idle edge: the
+// agent clears its active request before publishing TypeAgentFinished (and
+// TypeAgentError) precisely so observers can re-probe. The handler must
+// invalidate the memoized busy state and re-fetch busy + queue.
+func TestAgentTerminalNotificationsRefreshBusy(t *testing.T) {
+	pinTTLs(t)
+
+	for _, typ := range []notify.Type{notify.TypeAgentFinished, notify.TypeAgentError} {
+		t.Run(string(typ), func(t *testing.T) {
+			ws := &countingWorkspace{ready: true} // agent now idle
+			m := newBusyUI(ws)
+			warmCaches(m, true) // stale: still busy
+			ws.resetCounters()
+			require.True(t, m.isAgentBusy())
+
+			_, cmd := m.Update(pubsub.Event[notify.Notification]{
+				Type:    pubsub.CreatedEvent,
+				Payload: notify.Notification{Type: typ, SessionID: "s1"},
+			})
+			require.True(t, m.busyFetchInFlight, "terminal notification must schedule a busy refresh")
+			require.True(t, m.promptQueueInFlight, "terminal notification must schedule a queue refresh")
+
+			runCmds(m, cmd)
+			require.False(t, m.isAgentBusy(),
+				"busy→idle edge must reach the cache without waiting for the TTL")
+		})
+	}
+}
+
+// TestSessionSwitchRefreshesQueueAndBusy: switching sessions must drop the
+// previous session's queue pill and memoized busy state and fetch the new
+// session's, so esc never offers to clear the wrong queue.
+func TestSessionSwitchRefreshesQueueAndBusy(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, queued: []string{"a", "b"}}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 5 // stale queue pill from the previous session
+	m.promptQueueItems = []string{"x", "y", "z", "w", "v"}
+	ws.resetCounters()
+
+	_, cmd := m.Update(loadSessionMsg{session: &session.Session{ID: "s2"}})
+	require.Zero(t, m.promptQueue, "switching sessions must drop the old session's queue pill")
+	require.True(t, m.promptQueueInFlight, "session switch must schedule a queue refresh")
+	require.True(t, m.busyFetchInFlight, "session switch must schedule a busy refresh")
+
+	runCmds(m, cmd)
+	require.Equal(t, 2, m.promptQueue, "the new session's queue must be fetched")
+	require.Equal(t, []string{"a", "b"}, m.promptQueueItems)
+}
+
+// TestToggleYoloWritesThroughCache: both yolo toggle paths share
+// toggleYoloMode, which must write the known new value through the cache —
+// no invalidation, no re-probe.
+func TestToggleYoloWritesThroughCache(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, yolo: false}
+	m := newBusyUI(ws)
+
+	got := m.toggleYoloMode()
+	require.True(t, got)
+	require.Equal(t, 1, ws.permSetCalls)
+	readsAfterToggle := ws.permCalls
+	require.Equal(t, 1, readsAfterToggle, "toggle reads the authoritative value exactly once")
+
+	require.True(t, m.yoloModeCached(), "the new value must be served from the cache")
+	require.True(t, m.yoloCache.fresh(busyCacheTTL), "write-through must stamp the cache fresh")
+	m.yoloModeCached()
+	require.Equal(t, readsAfterToggle, ws.permCalls, "reads after the toggle must not re-probe")
+
+	got = m.toggleYoloMode()
+	require.False(t, got)
+	require.False(t, m.yoloModeCached())
+}
+
+// TestSendMessageSetsOptimisticBusy pins the esc-after-enter behavior:
+// submitting a prompt optimistically marks the agent busy so an immediate
+// esc routes to cancelAgent instead of reading a stale idle value and doing
+// nothing.
+func TestSendMessageSetsOptimisticBusy(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true} // workspace still reports idle
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+
+	require.False(t, m.isAgentBusy())
+	cmd := m.sendMessage("hello") // returned cmds (AgentRun etc.) deliberately not run
+	require.NotNil(t, cmd)
+	require.True(t, m.isAgentBusy(),
+		"sendMessage must optimistically mark the agent busy")
+
+	// esc right after enter: isAgentBusy gates cancelAgent, first press
+	// arms the double-press cancel.
+	require.Zero(t, m.promptQueue)
+	m.cancelAgent()
+	require.True(t, m.isCanceling, "first esc press must arm cancellation")
+
+	// Second press must actually cancel.
+	m.cancelAgent()
+	require.Equal(t, 1, ws.cancelCalls, "second esc press must cancel the agent")
+}
+
+// TestCancelAgentClearsQueueFromCachedCount: the queue-clear decision must
+// come from the memoized count — no synchronous AgentQueuedPrompts probe —
+// and clearing must zero the cached count immediately.
+func TestCancelAgentClearsQueueFromCachedCount(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, queued: []string{"a"}}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"a"}
+	ws.resetCounters()
+
+	cmd := m.cancelAgent()
+	require.Nil(t, cmd)
+	require.Equal(t, 1, ws.clearQueueCalls, "esc with a queue must clear it")
+	require.Zero(t, ws.queuedCalls, "the decision must use the cached count, not a probe")
+	require.Zero(t, ws.queueListCalls, "the decision must use the cached count, not a probe")
+	require.Zero(t, m.promptQueue, "the cached count must be zeroed immediately")
+	require.Empty(t, m.promptQueueItems)
+	require.False(t, m.isCanceling, "clearing the queue must not arm cancellation")
+}
+
+// TestBackstopRefreshesStaleCaches: when the memoized state outlives its TTL
+// with no event edge, the Update tail schedules exactly one off-thread
+// refresh (deduplicated while in flight) and the result lands as a message.
+func TestBackstopRefreshesStaleCaches(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, agentBusy: true}
+	m := newBusyUI(ws)
+	// Caches start at their zero value: stale by definition.
+
+	_, cmd := m.Update(plainMsg{})
+	require.True(t, m.busyFetchInFlight, "stale caches must trigger a backstop refresh")
+	require.Zero(t, ws.syncProbes(), "the backstop itself must not probe synchronously")
+
+	// A second Update while the fetch is in flight must not stack another.
+	before := m.busyFetchInFlight
+	m.Update(plainMsg{})
+	require.Equal(t, before, m.busyFetchInFlight)
+	require.Zero(t, ws.syncProbes())
+
+	runCmds(m, cmd)
+	require.False(t, m.busyFetchInFlight)
+	require.True(t, m.isAgentBusy(), "the backstop result must land in the cache")
+	require.Equal(t, 1, ws.agentBusyCalls, "exactly one probe per backstop refresh")
+
+	// Freshly refreshed caches must not re-dispatch.
+	m.Update(plainMsg{})
+	require.False(t, m.busyFetchInFlight, "fresh caches must not re-dispatch the backstop")
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -325,13 +325,21 @@ type UI struct {
 	promptQueueItems     []string
 	promptQueueCheckedAt time.Time
 	promptQueueInFlight  bool
+	// promptQueueGen is bumped by every queue state transition; an
+	// in-flight fetch captures it at dispatch and its result is discarded
+	// if the generation has moved on (see workspace_cache.go).
+	promptQueueGen uint64
 	// agentBusyCache / yoloCache memoize the workspace busy and permission
 	// probes (synchronous HTTP round-trips in client/server mode). Reads
 	// never probe; refreshes happen off-thread (see workspace_cache.go).
 	agentBusyCache    ttlCache
 	yoloCache         ttlCache
 	busyFetchInFlight bool
-	pillsView         string
+	// busyFetchGen is bumped by every busy/permission state transition;
+	// like promptQueueGen it lets a stale in-flight probe result be
+	// discarded and re-fetched instead of clobbering newer state.
+	busyFetchGen uint64
+	pillsView    string
 
 	// Todo spinner
 	todoSpinner    spinner.Model
@@ -673,6 +681,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// authoritative busy/queue state to confirm the optimistic values
 		// sendMessage wrote.
 		m.invalidateBusyCaches()
+		m.invalidatePromptQueue()
 		if cmd := m.dispatchBusyRefresh(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
@@ -692,6 +701,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// off-thread so the queue pill and esc behavior track the new
 		// session instead of a stale one.
 		m.invalidateBusyCaches()
+		m.invalidatePromptQueue()
 		m.promptQueue = 0
 		m.promptQueueItems = nil
 		m.promptQueueCheckedAt = time.Time{}
@@ -830,6 +840,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// trigger this: during streaming that would put workspace
 			// probes on every token.
 			m.invalidateBusyCaches()
+			m.invalidatePromptQueue()
 			if cmd := m.dispatchBusyRefresh(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
@@ -3900,7 +3911,11 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 	// either starts a run or is enqueued behind one. This keeps esc pressed
 	// right after enter routing to cancelAgent instead of reading a stale
 	// idle value; the authoritative state arrives via agentRunSubmittedMsg.
+	// Bump the busy/queue generations so any probe started before this
+	// optimistic write is discarded rather than reverting us to idle.
 	m.agentBusyCache.set(true)
+	m.busyFetchGen++
+	m.invalidatePromptQueue()
 	cmds = append(cmds, func() tea.Msg {
 		// AgentRun is fire-and-forget: it returns once the prompt has
 		// been accepted (HTTP 202) or synchronously with a validation
@@ -4058,6 +4073,9 @@ func (m *UI) cancelAgent() tea.Cmd {
 		m.promptQueue = 0
 		m.promptQueueItems = nil
 		m.promptQueueCheckedAt = time.Now()
+		// Bump the queue generation so a fetch started before this clear
+		// cannot land and repopulate the pill we just emptied.
+		m.invalidatePromptQueue()
 		m.updateLayoutAndSize()
 		return nil
 	}
@@ -4355,6 +4373,7 @@ func (m *UI) handleAgentNotification(n notify.Notification) tea.Cmd {
 	// can re-probe. Drop the memoized busy state and re-fetch it and the
 	// prompt queue off-thread.
 	m.invalidateBusyCaches()
+	m.invalidatePromptQueue()
 	if cmd := m.dispatchBusyRefresh(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
@@ -4402,6 +4421,7 @@ func (m *UI) newSession() tea.Cmd {
 	m.promptQueueItems = nil
 	m.promptQueueCheckedAt = time.Now()
 	m.invalidateBusyCaches()
+	m.invalidatePromptQueue()
 	m.pillsView = ""
 	m.historyReset()
 	agenttools.ResetCache()

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -317,8 +317,21 @@ type UI struct {
 	pillsExpanded      bool
 	pillsAutoExpanded  bool
 	focusedPillSection pillSection
-	promptQueue        int
-	pillsView          string
+	// promptQueue / promptQueueItems mirror the session's queued prompts.
+	// They are event-driven with a TTL backstop, fetched off-thread by
+	// dispatchPromptQueueRefresh (see workspace_cache.go); promptQueue is
+	// always len(promptQueueItems).
+	promptQueue          int
+	promptQueueItems     []string
+	promptQueueCheckedAt time.Time
+	promptQueueInFlight  bool
+	// agentBusyCache / yoloCache memoize the workspace busy and permission
+	// probes (synchronous HTTP round-trips in client/server mode). Reads
+	// never probe; refreshes happen off-thread (see workspace_cache.go).
+	agentBusyCache    ttlCache
+	yoloCache         ttlCache
+	busyFetchInFlight bool
+	pillsView         string
 
 	// Todo spinner
 	todoSpinner    spinner.Model
@@ -418,7 +431,12 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 		ui.themeKey = styles.ThemeKeyForProvider(cfg.Models[config.SelectedModelTypeLarge].Provider)
 	}
 
-	ui.setEditorPrompt(com.Workspace.PermissionSkipRequests())
+	// Seed the yolo cache once at construction; afterwards it is kept
+	// fresh by write-through toggles and off-thread refreshes so Update
+	// and View never probe the workspace synchronously.
+	yolo := com.Workspace.PermissionSkipRequests()
+	ui.yoloCache.set(yolo)
+	ui.setEditorPrompt(yolo)
 	ui.randomizePlaceholders()
 	ui.textarea.Placeholder = ui.readyPlaceholder
 	ui.status = status
@@ -470,6 +488,10 @@ func (m *UI) Init() tea.Cmd {
 	}
 	if m.com.IsHyper() {
 		cmds = append(cmds, m.fetchHyperCredits())
+	}
+	// Prime the memoized busy/permission state off-thread.
+	if cmd := m.dispatchBusyRefresh(); cmd != nil {
+		cmds = append(cmds, cmd)
 	}
 	return tea.Batch(cmds...)
 }
@@ -621,13 +643,6 @@ func (m *UI) loadMCPrompts() tea.Msg {
 // Update handles updates to the UI model.
 func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
-	if m.hasSession() && m.isAgentBusy() {
-		queueSize := m.com.Workspace.AgentQueuedPrompts(m.session.ID)
-		if queueSize != m.promptQueue {
-			m.promptQueue = queueSize
-			m.updateLayoutAndSize()
-		}
-	}
 	// Update terminal capabilities
 	m.caps.Update(msg)
 	switch msg := msg.(type) {
@@ -649,6 +664,21 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if cmd := m.handleAgentNotification(msg.Payload); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+	case busyStateMsg:
+		cmds = append(cmds, m.applyBusyState(msg)...)
+	case promptQueueMsg:
+		cmds = append(cmds, m.applyPromptQueue(msg)...)
+	case agentRunSubmittedMsg:
+		// A prompt was just accepted (run started or enqueued): fetch the
+		// authoritative busy/queue state to confirm the optimistic values
+		// sendMessage wrote.
+		m.invalidateBusyCaches()
+		if cmd := m.dispatchBusyRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case loadSessionMsg:
 		if m.forceCompactMode {
 			m.isCompact = true
@@ -657,6 +687,20 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.session = msg.session
 		m.sidebarOffset = 0
 		m.sessionFiles = msg.files
+		// Session switch: the memoized busy state and queued prompts
+		// belong to the previous session. Drop them and re-fetch
+		// off-thread so the queue pill and esc behavior track the new
+		// session instead of a stale one.
+		m.invalidateBusyCaches()
+		m.promptQueue = 0
+		m.promptQueueItems = nil
+		m.promptQueueCheckedAt = time.Time{}
+		if cmd := m.dispatchBusyRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 		cmds = append(cmds, m.startLSPs(msg.lspFilePaths()))
 		msgs, err := m.com.Workspace.ListMessages(context.Background(), m.session.ID)
 		if err != nil {
@@ -779,6 +823,19 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.Type {
 		case pubsub.CreatedEvent:
 			cmds = append(cmds, m.appendSessionMessage(msg.Payload))
+			// A new message is a run boundary — a user prompt starting
+			// a turn or the agent replying/dequeueing. Drop the
+			// memoized busy state and re-fetch it and the queue
+			// off-thread. Per-chunk UpdatedEvents deliberately do NOT
+			// trigger this: during streaming that would put workspace
+			// probes on every token.
+			m.invalidateBusyCaches()
+			if cmd := m.dispatchBusyRefresh(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
 		case pubsub.UpdatedEvent:
 			cmds = append(cmds, m.updateSessionMessage(msg.Payload))
 		case pubsub.DeletedEvent:
@@ -1229,10 +1286,15 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.textarea.Placeholder = m.readyPlaceholder
 		}
-		if !m.bangMode && m.com.Workspace.PermissionSkipRequests() {
+		if !m.bangMode && m.yoloModeCached() {
 			m.textarea.Placeholder = "Yolo mode!"
 		}
 	}
+
+	// TTL backstop: schedule an off-thread re-probe for any memoized
+	// workspace state that has gone stale. Never does IO on this
+	// goroutine.
+	cmds = append(cmds, m.staleWorkspaceRefreshCmds()...)
 
 	// at this point this can only handle [message.Attachment] message, and we
 	// should return all cmds anyway.
@@ -1681,9 +1743,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 
 	// Command dialog messages.
 	case dialog.ActionToggleYoloMode:
-		yolo := !m.com.Workspace.PermissionSkipRequests()
-		m.com.Workspace.PermissionSetSkipRequests(yolo)
-		m.setEditorPrompt(yolo)
+		m.toggleYoloMode()
 		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionSelectNotificationStyle:
 		cfg := m.com.Config()
@@ -2161,9 +2221,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			cmds = append(cmds, tea.Suspend)
 			return true
 		case key.Matches(msg, m.keyMap.ToggleYolo):
-			yolo := !m.com.Workspace.PermissionSkipRequests()
-			m.com.Workspace.PermissionSetSkipRequests(yolo)
-			m.setEditorPrompt(yolo)
+			yolo := m.toggleYoloMode()
 			status := "disabled"
 			if yolo {
 				status = "enabled"
@@ -2307,8 +2365,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 
 				if m.bangMode && value != "" {
 					m.bangMode = false
-					yolo := m.com.Workspace.PermissionSkipRequests()
-					m.setEditorPrompt(yolo)
+					m.setEditorPrompt(m.yoloModeCached())
 					m.randomizePlaceholders()
 					m.historyReset()
 					return tea.Batch(m.runShellCommand(value))
@@ -2386,8 +2443,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				if m.bangMode && m.bangWasEmpty && msg.Code == tea.KeyBackspace {
 					m.bangMode = false
 					m.bangWasEmpty = false
-					yolo := m.com.Workspace.PermissionSkipRequests()
-					m.setEditorPrompt(yolo)
+					m.setEditorPrompt(m.yoloModeCached())
 					break
 				}
 
@@ -2436,8 +2492,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					m.textarea.SetValue(stripped)
 					m.textarea.SetCursorColumn(max(0, col-(len(newVal)-len(stripped))))
 					_ = line // cursor line doesn't change; prefix removed
-					yolo := m.com.Workspace.PermissionSkipRequests()
-					m.setEditorPrompt(yolo)
+					m.setEditorPrompt(m.yoloModeCached())
 				} else if m.bangMode && newVal == "" && curValue != "" {
 					// Just cleared last character; mark empty, stay in bang mode.
 					m.bangWasEmpty = true
@@ -2850,7 +2905,7 @@ func (m *UI) ShortHelp() []key.Binding {
 			cancelBinding := k.Chat.Cancel
 			if m.isCanceling {
 				cancelBinding.SetHelp("esc", "press again to cancel")
-			} else if m.com.Workspace.AgentQueuedPrompts(m.session.ID) > 0 {
+			} else if m.promptQueue > 0 {
 				cancelBinding.SetHelp("esc", "clear queue")
 			}
 			binds = append(binds, cancelBinding)
@@ -2946,7 +3001,7 @@ func (m *UI) FullHelp() [][]key.Binding {
 			cancelBinding := k.Chat.Cancel
 			if m.isCanceling {
 				cancelBinding.SetHelp("esc", "press again to cancel")
-			} else if m.com.Workspace.AgentQueuedPrompts(m.session.ID) > 0 {
+			} else if m.promptQueue > 0 {
 				cancelBinding.SetHelp("esc", "clear queue")
 			}
 			binds = append(binds, []key.Binding{cancelBinding})
@@ -3672,13 +3727,15 @@ func isWhitespace(b byte) bool {
 }
 
 // isAgentBusy returns true if the agent coordinator exists and is currently
-// busy processing a request.
+// busy processing a request. It only reads the memoized state (it runs in
+// per-message paths like the textarea placeholder, where a workspace probe
+// would be an HTTP round-trip per keystroke in client/server mode); the
+// value is refreshed off-thread, see workspace_cache.go.
 func (m *UI) isAgentBusy() bool {
 	if m.bangCancel != nil {
 		return true
 	}
-	return m.com.Workspace.AgentIsReady() &&
-		m.com.Workspace.AgentIsBusy()
+	return m.agentBusyCache.val
 }
 
 // hasSession returns true if there is an active session with a valid ID.
@@ -3839,6 +3896,11 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 
 	// Capture session ID to avoid race with main goroutine updating m.session.
 	sessionID := m.session.ID
+	// Optimistically mark the agent busy: the prompt we are about to submit
+	// either starts a run or is enqueued behind one. This keeps esc pressed
+	// right after enter routing to cancelAgent instead of reading a stale
+	// idle value; the authoritative state arrives via agentRunSubmittedMsg.
+	m.agentBusyCache.set(true)
 	cmds = append(cmds, func() tea.Msg {
 		// AgentRun is fire-and-forget: it returns once the prompt has
 		// been accepted (HTTP 202) or synchronously with a validation
@@ -3851,7 +3913,7 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 				Msg:  fmt.Sprintf("%v", err),
 			}
 		}
-		return nil
+		return agentRunSubmittedMsg{}
 	})
 	return tea.Batch(cmds...)
 }
@@ -3979,15 +4041,24 @@ func (m *UI) cancelAgent() tea.Cmd {
 		}
 
 		m.com.Workspace.AgentCancel(m.session.ID)
-		// Stop the spinning todo indicator.
+		// Stop the spinning todo indicator and drop the memoized busy
+		// state the cancel just changed; the pill re-renders now from
+		// last-known state and again when the off-thread refresh (and
+		// the agent's own events) land.
 		m.todoIsSpinning = false
+		m.invalidateBusyCaches()
 		m.renderPills()
-		return nil
+		return m.dispatchBusyRefresh()
 	}
 
-	// Check if there are queued prompts - if so, clear the queue.
-	if m.com.Workspace.AgentQueuedPrompts(m.session.ID) > 0 {
+	// Queued prompts pending: esc clears the queue. Decide from the cached
+	// count (event-driven) instead of a synchronous workspace probe.
+	if m.promptQueue > 0 {
 		m.com.Workspace.AgentClearQueue(m.session.ID)
+		m.promptQueue = 0
+		m.promptQueueItems = nil
+		m.promptQueueCheckedAt = time.Now()
+		m.updateLayoutAndSize()
 		return nil
 	}
 
@@ -4260,10 +4331,10 @@ func (m *UI) handlePermissionNotification(notification permission.PermissionNoti
 // handleAgentNotification translates domain agent events into desktop
 // notifications using the UI notification backend.
 func (m *UI) handleAgentNotification(n notify.Notification) tea.Cmd {
+	var cmds []tea.Cmd
 	switch n.Type {
 	case notify.TypeAgentFinished:
 		common.StopTurn()
-		var cmds []tea.Cmd
 		cmds = append(cmds, m.sendNotification(notification.Notification{
 			Title:   "Crush is waiting...",
 			Message: fmt.Sprintf("Agent's turn completed in \"%s\"", n.SessionTitle),
@@ -4271,12 +4342,26 @@ func (m *UI) handleAgentNotification(n notify.Notification) tea.Cmd {
 		if m.com.IsHyper() {
 			cmds = append(cmds, m.fetchHyperCredits())
 		}
-		return tea.Batch(cmds...)
+	case notify.TypeAgentError:
+		// Terminal edge like TypeAgentFinished; fall through to the
+		// busy/queue refresh below.
 	case notify.TypeReAuthenticate:
 		return m.handleReAuthenticate(n.ProviderID)
 	default:
 		return nil
 	}
+	// TypeAgentFinished / TypeAgentError are the busy→idle edge: the agent
+	// clears its active request before publishing precisely so observers
+	// can re-probe. Drop the memoized busy state and re-fetch it and the
+	// prompt queue off-thread.
+	m.invalidateBusyCaches()
+	if cmd := m.dispatchBusyRefresh(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	return tea.Batch(cmds...)
 }
 
 func (m *UI) handleReAuthenticate(providerID string) tea.Cmd {
@@ -4314,6 +4399,9 @@ func (m *UI) newSession() tea.Cmd {
 	m.pillsExpanded = false
 	m.pillsAutoExpanded = false
 	m.promptQueue = 0
+	m.promptQueueItems = nil
+	m.promptQueueCheckedAt = time.Now()
+	m.invalidateBusyCaches()
 	m.pillsView = ""
 	m.historyReset()
 	agenttools.ResetCache()
@@ -4345,8 +4433,7 @@ func (m *UI) checkBangModeAfterPaste() {
 	m.textarea.SetValue(stripped)
 	col := m.textarea.Column()
 	m.textarea.SetCursorColumn(max(0, col-(len(val)-len(stripped))))
-	yolo := m.com.Workspace.PermissionSkipRequests()
-	m.setEditorPrompt(yolo)
+	m.setEditorPrompt(m.yoloModeCached())
 }
 
 // handlePasteMsg handles a paste message.

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -60,6 +60,12 @@ func (c *ttlCache) invalidate() {
 
 // busyStateMsg delivers the result of an off-thread busy/permission probe.
 type busyStateMsg struct {
+	// gen is the busy generation captured when the probe was dispatched.
+	// A result whose generation no longer matches m.busyFetchGen started
+	// before a newer state transition (optimistic send, invalidation,
+	// session switch, ...) and is discarded, then re-fetched, so the
+	// authoritative refresh is never lost to an older in-flight request.
+	gen       uint64
 	agentBusy bool
 	yolo      bool
 }
@@ -69,7 +75,11 @@ type promptQueueMsg struct {
 	// forSession is the session the fetch was scoped to; a result that
 	// raced a session switch is discarded and re-fetched.
 	forSession string
-	prompts    []string
+	// gen is the queue generation captured at dispatch; like
+	// busyStateMsg.gen it guards against a stale in-flight result
+	// overwriting newer optimistic or invalidated queue state.
+	gen     uint64
+	prompts []string
 }
 
 // agentRunSubmittedMsg reports that AgentRun accepted a prompt (it either
@@ -85,11 +95,21 @@ func (m *UI) currentSessionID() string {
 	return m.session.ID
 }
 
-// invalidateBusyCaches marks all memoized workspace probe state stale.
-// Called by handlers for events that change agent or permission state.
+// invalidateBusyCaches marks all memoized workspace probe state stale and
+// bumps the busy generation so any in-flight probe result is discarded when
+// it lands. Called by handlers for events that change agent or permission
+// state.
 func (m *UI) invalidateBusyCaches() {
 	m.agentBusyCache.invalidate()
 	m.yoloCache.invalidate()
+	m.busyFetchGen++
+}
+
+// invalidatePromptQueue bumps the prompt-queue generation so any in-flight
+// queue fetch result is discarded when it lands (and re-fetched) instead of
+// overwriting newer optimistic or cleared queue state.
+func (m *UI) invalidatePromptQueue() {
+	m.promptQueueGen++
 }
 
 // dispatchBusyRefresh returns a command that probes the workspace busy and
@@ -103,8 +123,9 @@ func (m *UI) dispatchBusyRefresh() tea.Cmd {
 	}
 	m.busyFetchInFlight = true
 	ws := m.com.Workspace
+	gen := m.busyFetchGen
 	return func() tea.Msg {
-		var st busyStateMsg
+		st := busyStateMsg{gen: gen}
 		if ws.AgentIsReady() {
 			st.agentBusy = ws.AgentIsBusy()
 		}
@@ -117,9 +138,27 @@ func (m *UI) dispatchBusyRefresh() tea.Cmd {
 // edges (todo spinner, pills). Runs on the Update goroutine.
 func (m *UI) applyBusyState(msg busyStateMsg) []tea.Cmd {
 	m.busyFetchInFlight = false
+	if msg.gen != m.busyFetchGen {
+		// This probe started before a newer state transition (optimistic
+		// send, invalidation, session switch, ...). Discard its result and
+		// re-dispatch so the required authoritative refresh is not lost
+		// merely because this older request was in flight.
+		if cmd := m.dispatchBusyRefresh(); cmd != nil {
+			return []tea.Cmd{cmd}
+		}
+		return nil
+	}
 	prevBusy := m.isAgentBusy()
+	prevYolo := m.yoloModeCached()
 	m.agentBusyCache.set(msg.agentBusy)
 	m.yoloCache.set(msg.yolo)
+	if prevYolo != msg.yolo {
+		// A remote/async toggle changed yolo mode: update the editor
+		// prompt function so the prompt icon/style tracks the new mode.
+		// The cache is written above and the placeholder is refreshed by
+		// the Update tail.
+		m.setEditorPrompt(msg.yolo)
+	}
 
 	var cmds []tea.Cmd
 	busy := m.isAgentBusy()
@@ -147,6 +186,10 @@ func (m *UI) dispatchPromptQueueRefresh() tea.Cmd {
 	if !m.hasSession() {
 		m.promptQueueItems = nil
 		m.promptQueueCheckedAt = time.Now()
+		// Bump the generation so any in-flight fetch scoped to the
+		// now-departed session is discarded rather than repopulating the
+		// queue.
+		m.invalidatePromptQueue()
 		if m.promptQueue != 0 {
 			m.promptQueue = 0
 			m.updateLayoutAndSize()
@@ -156,8 +199,9 @@ func (m *UI) dispatchPromptQueueRefresh() tea.Cmd {
 	m.promptQueueInFlight = true
 	ws := m.com.Workspace
 	sessionID := m.session.ID
+	gen := m.promptQueueGen
 	return func() tea.Msg {
-		msg := promptQueueMsg{forSession: sessionID}
+		msg := promptQueueMsg{forSession: sessionID, gen: gen}
 		if ws.AgentIsReady() {
 			msg.prompts = ws.AgentQueuedPromptsList(sessionID)
 		}
@@ -169,7 +213,11 @@ func (m *UI) dispatchPromptQueueRefresh() tea.Cmd {
 // count changed. Runs on the Update goroutine.
 func (m *UI) applyPromptQueue(msg promptQueueMsg) []tea.Cmd {
 	m.promptQueueInFlight = false
-	if msg.forSession != m.currentSessionID() {
+	if msg.forSession != m.currentSessionID() || msg.gen != m.promptQueueGen {
+		// The fetch raced a session switch or a newer queue transition
+		// (submit, clear, invalidation). Discard the stale result and
+		// re-fetch so newer state is not clobbered and the authoritative
+		// refresh is not lost to this older in-flight request.
 		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
 			return []tea.Cmd{cmd}
 		}
@@ -218,6 +266,12 @@ func (m *UI) toggleYoloMode() bool {
 	yolo := !m.com.Workspace.PermissionSkipRequests()
 	m.com.Workspace.PermissionSetSkipRequests(yolo)
 	m.yoloCache.set(yolo)
+	// Supersede any in-flight busy/yolo probe: its result carries the old
+	// generation and would otherwise overwrite the value we just wrote.
+	// Bump the generation (rather than invalidateBusyCaches, which would
+	// clear the fresh value) so applyBusyState's guard discards and
+	// re-dispatches the stale probe.
+	m.busyFetchGen++
 	m.setEditorPrompt(yolo)
 	return yolo
 }

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -1,0 +1,230 @@
+package model
+
+// Memoized workspace state.
+//
+// In client/server mode every workspace probe (busy checks, permission mode,
+// queued prompts) is a synchronous HTTP round-trip, and the Update goroutine
+// is the render loop — blocking it freezes typing. The UI therefore never
+// probes the workspace synchronously from Update or View:
+//
+//   - Reads (isAgentBusy, yoloModeCached, promptQueue) always return the
+//     memoized value, stale or not.
+//   - State edges (message created, agent finished/errored, prompt
+//     submitted, cancel, session switch, yolo toggle) invalidate or
+//     write through the caches and dispatch an off-thread refresh cmd.
+//   - A TTL backstop at the end of Update re-dispatches a refresh whenever
+//     the memoized state has gone stale, so unrelated churn (typing,
+//     resize storms, spinner ticks) only ever schedules async work.
+//
+// Fresh values arrive as busyStateMsg / promptQueueMsg and are applied on
+// the Update goroutine, per the UI guidelines (no IO in Update, no model
+// mutation inside commands).
+
+import (
+	"slices"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// busyCacheTTL bounds how long the memoized busy/permission state may go
+// without a re-probe being scheduled. Package var so tests can pin it.
+var busyCacheTTL = 500 * time.Millisecond
+
+// promptQueueTTL is the backstop refresh interval for the queued-prompt
+// state; the queue is otherwise refreshed on event edges.
+var promptQueueTTL = 2 * time.Second
+
+// ttlCache memoizes one boolean workspace probe result.
+type ttlCache struct {
+	val bool
+	at  time.Time
+}
+
+// fresh reports whether the cached value is within its TTL.
+func (c *ttlCache) fresh(ttl time.Duration) bool {
+	return !c.at.IsZero() && time.Since(c.at) < ttl
+}
+
+// set writes a known-good value through the cache.
+func (c *ttlCache) set(val bool) {
+	c.val = val
+	c.at = time.Now()
+}
+
+// invalidate marks the value stale so the next Update-tail backstop
+// re-probes; the last value keeps being served in the meantime.
+func (c *ttlCache) invalidate() {
+	c.at = time.Time{}
+}
+
+// busyStateMsg delivers the result of an off-thread busy/permission probe.
+type busyStateMsg struct {
+	agentBusy bool
+	yolo      bool
+}
+
+// promptQueueMsg delivers the queued prompts fetched off-thread.
+type promptQueueMsg struct {
+	// forSession is the session the fetch was scoped to; a result that
+	// raced a session switch is discarded and re-fetched.
+	forSession string
+	prompts    []string
+}
+
+// agentRunSubmittedMsg reports that AgentRun accepted a prompt (it either
+// started a run or was enqueued behind one), so busy and queue state should
+// be re-fetched.
+type agentRunSubmittedMsg struct{}
+
+// currentSessionID returns the active session's ID, or "" when none.
+func (m *UI) currentSessionID() string {
+	if m.session == nil {
+		return ""
+	}
+	return m.session.ID
+}
+
+// invalidateBusyCaches marks all memoized workspace probe state stale.
+// Called by handlers for events that change agent or permission state.
+func (m *UI) invalidateBusyCaches() {
+	m.agentBusyCache.invalidate()
+	m.yoloCache.invalidate()
+}
+
+// dispatchBusyRefresh returns a command that probes the workspace busy and
+// permission state off the Update goroutine, delivering a busyStateMsg. It
+// returns nil while a probe is already in flight. The closure captures only
+// locals (never m) so it is safe off-thread; state is applied by
+// applyBusyState on the Update goroutine.
+func (m *UI) dispatchBusyRefresh() tea.Cmd {
+	if m.busyFetchInFlight || m.com == nil || m.com.Workspace == nil {
+		return nil
+	}
+	m.busyFetchInFlight = true
+	ws := m.com.Workspace
+	return func() tea.Msg {
+		var st busyStateMsg
+		if ws.AgentIsReady() {
+			st.agentBusy = ws.AgentIsBusy()
+		}
+		st.yolo = ws.PermissionSkipRequests()
+		return st
+	}
+}
+
+// applyBusyState stores an off-thread probe result and reacts to busy
+// edges (todo spinner, pills). Runs on the Update goroutine.
+func (m *UI) applyBusyState(msg busyStateMsg) []tea.Cmd {
+	m.busyFetchInFlight = false
+	prevBusy := m.isAgentBusy()
+	m.agentBusyCache.set(msg.agentBusy)
+	m.yoloCache.set(msg.yolo)
+
+	var cmds []tea.Cmd
+	busy := m.isAgentBusy()
+	if m.hasSession() && hasInProgressTodo(m.session.Todos) && busy && !m.todoIsSpinning {
+		m.todoIsSpinning = true
+		cmds = append(cmds, m.todoSpinner.Tick)
+	}
+	if m.todoIsSpinning && !busy {
+		m.todoIsSpinning = false
+	}
+	if prevBusy != busy {
+		m.renderPills()
+	}
+	return cmds
+}
+
+// dispatchPromptQueueRefresh returns a command that fetches the queued
+// prompts off the Update goroutine, delivering a promptQueueMsg. It returns
+// nil while a fetch is already in flight. With no active session the queue
+// is simply cleared.
+func (m *UI) dispatchPromptQueueRefresh() tea.Cmd {
+	if m.promptQueueInFlight || m.com == nil || m.com.Workspace == nil {
+		return nil
+	}
+	if !m.hasSession() {
+		m.promptQueueItems = nil
+		m.promptQueueCheckedAt = time.Now()
+		if m.promptQueue != 0 {
+			m.promptQueue = 0
+			m.updateLayoutAndSize()
+		}
+		return nil
+	}
+	m.promptQueueInFlight = true
+	ws := m.com.Workspace
+	sessionID := m.session.ID
+	return func() tea.Msg {
+		msg := promptQueueMsg{forSession: sessionID}
+		if ws.AgentIsReady() {
+			msg.prompts = ws.AgentQueuedPromptsList(sessionID)
+		}
+		return msg
+	}
+}
+
+// applyPromptQueue stores an off-thread queue fetch and re-layouts when the
+// count changed. Runs on the Update goroutine.
+func (m *UI) applyPromptQueue(msg promptQueueMsg) []tea.Cmd {
+	m.promptQueueInFlight = false
+	if msg.forSession != m.currentSessionID() {
+		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+			return []tea.Cmd{cmd}
+		}
+		return nil
+	}
+	m.promptQueueCheckedAt = time.Now()
+	itemsChanged := !slices.Equal(m.promptQueueItems, msg.prompts)
+	countChanged := len(msg.prompts) != m.promptQueue
+	m.promptQueueItems = msg.prompts
+	m.promptQueue = len(msg.prompts)
+	if countChanged {
+		m.updateLayoutAndSize()
+	} else if itemsChanged {
+		m.renderPills()
+	}
+	return nil
+}
+
+// staleWorkspaceRefreshCmds is the TTL backstop, called at the tail of
+// Update: when any memoized workspace state has outlived its TTL (and no
+// event edge refreshed it), schedule an off-thread re-probe. It never does
+// IO itself — a couple of time comparisons per message at most.
+func (m *UI) staleWorkspaceRefreshCmds() []tea.Cmd {
+	if m.com == nil || m.com.Workspace == nil {
+		return nil
+	}
+	var cmds []tea.Cmd
+	if !m.agentBusyCache.fresh(busyCacheTTL) || !m.yoloCache.fresh(busyCacheTTL) {
+		if cmd := m.dispatchBusyRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	if m.hasSession() && time.Since(m.promptQueueCheckedAt) >= promptQueueTTL {
+		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	return cmds
+}
+
+// toggleYoloMode flips permission auto-approval and writes the new value
+// through the yolo cache (no re-probe needed) and the editor prompt. Shared
+// by the direct keybinding and the commands-dialog action so both stay
+// write-through. Returns the new mode.
+func (m *UI) toggleYoloMode() bool {
+	yolo := !m.com.Workspace.PermissionSkipRequests()
+	m.com.Workspace.PermissionSetSkipRequests(yolo)
+	m.yoloCache.set(yolo)
+	m.setEditorPrompt(yolo)
+	return yolo
+}
+
+// yoloModeCached reports the memoized permission-skip ("yolo") mode. Toggles
+// write through the cache; the Update-tail backstop keeps it bounded-stale
+// otherwise.
+func (m *UI) yoloModeCached() bool {
+	return m.yoloCache.val
+}


### PR DESCRIPTION
## The problem

`UI.Update` issues synchronous workspace calls on the per-message hot path:

- At the top of `Update` (`internal/ui/model/ui.go:624`), **every** `tea.Msg` — every keystroke, mouse event, and tick — evaluates `isAgentBusy()` (= `AgentIsReady()` + `AgentIsBusy()`), and while the agent is busy also calls `AgentQueuedPrompts`.
- The textarea-placeholder path probes `isAgentBusy()` + `PermissionSkipRequests()` per message, under the existing comment that already asks: *“This logic gets triggered on any message type, but should it?”*
- `ShortHelp`/`FullHelp`, the progress bar, and the expanded queue pill probe again per render, and several keystroke-edge paths (bang-mode enter/exit, paste, history navigation) read `PermissionSkipRequests()` directly.

In local mode these are cheap in-memory reads. In **client mode** (`crush` connected to `crush serve`), each is an HTTP round-trip (`client_workspace.go` → `GetAgentInfo` etc.) — so typing blocks the single `Update` goroutine on the network, per keystroke, precisely while the agent (and therefore the server) is busiest. A slow or hiccuping server freezes input entirely.

`internal/ui/AGENTS.md` states the rule this violates: *“Never do IO or expensive work in `Update`; always use a `tea.Cmd`.”*

## The fix

- **Reads are pure cache reads; probes never run in `Update` or `View`.** A small `ttlCache` (new `internal/ui/model/workspace_cache.go`) memoizes agent-busy and permission-skip state; refreshes run in `tea.Cmd`s that deliver `busyStateMsg` / `promptQueueMsg`, applied in `Update`.
- **The queued-prompt count is event-driven** rather than polled: refreshed on message `CreatedEvent`s (deliberately *not* per-chunk `UpdatedEvent`s), on `TypeAgentFinished`/`TypeAgentError` notifications (the agent clears `activeRequests` before publishing exactly for this), on session load/clear, and after prompt submission. Local mutations (esc-to-clear) update the cached count directly with zero probes.
- **Freshness edges:** sending a prompt sets the busy cache optimistically (so esc immediately after enter still cancels); yolo toggles write through the cache; a ~500ms TTL backstop (pure time comparison at the end of `Update`, refresh delivered as a message) bounds staleness from out-of-band changes, e.g. another client attached to the same server session.

## Tests

New `internal/ui/model/session_busy_test.go` with a counting workspace stub: zero probes across 25 `Update` messages (the regression test), reads-never-probe, streaming chunks don’t probe, created-event/terminal-notification/session-switch refreshes, yolo write-through, optimistic busy on send, cancel-from-cached-count, and TTL backstop. TTLs are package vars pinned in tests to avoid timing flakes.

`go build ./...`, `gofmt`, `go test ./internal/ui/... [-race]`, and `golangci-lint run` (repo config) are all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsciXLNzYReyZce1uAggjN