### PR TITLE
fix(tools): require permission for mutating git queries

### DIFF
--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -206,19 +206,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 			// Determine working directory
 			execWorkingDir := cmp.Or(params.WorkingDir, workingDir)
 
-			isSafeReadOnly := false
-			cmdLower := strings.ToLower(params.Command)
-
-			if !containsCommandChaining(params.Command) {
-				for _, safe := range safeCommands {
-					if strings.HasPrefix(cmdLower, safe) {
-						if len(cmdLower) == len(safe) || cmdLower[len(safe)] == ' ' || cmdLower[len(safe)] == '-' {
-							isSafeReadOnly = true
-							break
-						}
-					}
-				}
-			}
+			isSafeReadOnly := isSafeReadOnlyCommand(params.Command)
 
 			sessionID := GetSessionFromContext(ctx)
 			if sessionID == "" {

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"os/exec"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -164,6 +165,30 @@ func TestBashTool_ChainedCommandsDenied(t *testing.T) {
 		Command:     "ls && rm -rf /",
 	})
 
+	require.Equal(t, 1, perms.requestCount)
+	require.Contains(t, resp.Content, "User denied permission")
+}
+
+func TestBashTool_GitMutationRequiresPermission(t *testing.T) {
+	workingDir := t.TempDir()
+	require.NoError(t, exec.Command("git", "init", workingDir).Run())
+	require.NoError(t, exec.Command(
+		"git", "-C", workingDir,
+		"-c", "user.name=Crush Test",
+		"-c", "user.email=crush@example.com",
+		"commit", "--allow-empty", "-m", "initial",
+	).Run())
+	tool, perms := newBashToolWithRecordingPerms(workingDir, false)
+	ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+
+	resp := runBashTool(t, tool, ctx, BashParams{
+		Description: "create git branch",
+		Command:     "git branch new-branch",
+	})
+
+	branches, err := exec.Command("git", "-C", workingDir, "branch", "--list", "new-branch").Output()
+	require.NoError(t, err)
+	require.Empty(t, branches, "denied command must not create the branch")
 	require.Equal(t, 1, perms.requestCount)
 	require.Contains(t, resp.Content, "User denied permission")
 }

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"charm.land/fantasy"
@@ -171,22 +172,25 @@ func TestBashTool_ChainedCommandsDenied(t *testing.T) {
 
 func TestBashTool_GitMutationRequiresPermission(t *testing.T) {
 	workingDir := t.TempDir()
-	require.NoError(t, exec.Command("git", "init", workingDir).Run())
-	require.NoError(t, exec.Command(
+	testCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, exec.CommandContext(testCtx, "git", "init", workingDir).Run())
+	require.NoError(t, exec.CommandContext(
+		testCtx,
 		"git", "-C", workingDir,
 		"-c", "user.name=Crush Test",
 		"-c", "user.email=crush@example.com",
 		"commit", "--allow-empty", "-m", "initial",
 	).Run())
 	tool, perms := newBashToolWithRecordingPerms(workingDir, false)
-	ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+	ctx := context.WithValue(testCtx, SessionIDContextKey, "test-session")
 
 	resp := runBashTool(t, tool, ctx, BashParams{
 		Description: "create git branch",
 		Command:     "git branch new-branch",
 	})
 
-	branches, err := exec.Command("git", "-C", workingDir, "branch", "--list", "new-branch").Output()
+	branches, err := exec.CommandContext(testCtx, "git", "-C", workingDir, "branch", "--list", "new-branch").Output()
 	require.NoError(t, err)
 	require.Empty(t, branches, "denied command must not create the branch")
 	require.Equal(t, 1, perms.requestCount)

--- a/internal/agent/tools/safe.go
+++ b/internal/agent/tools/safe.go
@@ -41,7 +41,6 @@ var safeCommands = []string{
 
 	// Git
 	"git blame",
-	"git branch",
 	"git config --get",
 	"git config --list",
 	"git describe",
@@ -50,12 +49,34 @@ var safeCommands = []string{
 	"git log",
 	"git ls-files",
 	"git ls-remote",
-	"git remote",
 	"git rev-parse",
 	"git shortlog",
 	"git show",
 	"git status",
+}
+
+var safeGitQueryCommands = []string{
+	"git branch",
+	"git branch --show-current",
+	"git remote",
+	"git remote --verbose",
+	"git remote -v",
 	"git tag",
+}
+
+var safeGitQueryPrefixes = []string{
+	"git branch --all",
+	"git branch --list",
+	"git branch --remotes",
+	"git branch -a",
+	"git branch -l",
+	"git branch -r",
+	"git branch -v",
+	"git branch -vv",
+	"git remote get-url",
+	"git remote show",
+	"git tag --list",
+	"git tag -l",
 }
 
 var chainingMetacharacters = []string{
@@ -72,6 +93,101 @@ func containsCommandChaining(s string) bool {
 	return slices.ContainsFunc(chainingMetacharacters, func(c string) bool {
 		return strings.Contains(s, c)
 	})
+}
+
+func isSafeReadOnlyCommand(command string) bool {
+	if containsCommandChaining(command) {
+		return false
+	}
+
+	command = strings.ToLower(command)
+	for _, safe := range safeCommands {
+		if hasCommandPrefix(command, safe) {
+			return true
+		}
+	}
+
+	if slices.Contains(safeGitQueryCommands, command) {
+		return true
+	}
+
+	for _, safe := range safeGitQueryPrefixes {
+		if (command == safe || strings.HasPrefix(command, safe+" ")) && isSafeGitQuery(command) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isSafeGitQuery(command string) bool {
+	if strings.Contains(command, "$") {
+		return false
+	}
+
+	args := strings.Fields(command)
+	if len(args) < 2 {
+		return false
+	}
+
+	for _, arg := range args[2:] {
+		switch args[1] {
+		case "branch":
+			if isMutatingGitBranchOption(arg) {
+				return false
+			}
+		case "tag":
+			if isMutatingGitTagOption(arg) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func isMutatingGitBranchOption(arg string) bool {
+	if strings.HasPrefix(arg, "--") {
+		option, _, _ := strings.Cut(arg, "=")
+		return slices.Contains([]string{
+			"--copy",
+			"--create-reflog",
+			"--delete",
+			"--edit-description",
+			"--force",
+			"--move",
+			"--no-track",
+			"--recurse-submodules",
+			"--set-upstream-to",
+			"--track",
+			"--unset-upstream",
+		}, option)
+	}
+
+	return strings.HasPrefix(arg, "-") && strings.ContainsAny(arg[1:], "cCdDfmM")
+}
+
+func isMutatingGitTagOption(arg string) bool {
+	if strings.HasPrefix(arg, "--") {
+		option, _, _ := strings.Cut(arg, "=")
+		return slices.Contains([]string{
+			"--annotate",
+			"--delete",
+			"--edit",
+			"--file",
+			"--force",
+			"--local-user",
+			"--message",
+			"--sign",
+		}, option)
+	}
+
+	return strings.HasPrefix(arg, "-") && strings.ContainsAny(arg[1:], "aDefFmsu")
+}
+
+func hasCommandPrefix(command, prefix string) bool {
+	return strings.HasPrefix(command, prefix) &&
+		(len(command) == len(prefix) || command[len(prefix)] == ' ' || command[len(prefix)] == '-')
 }
 
 func init() {

--- a/internal/agent/tools/safe_test.go
+++ b/internal/agent/tools/safe_test.go
@@ -45,3 +45,47 @@ func TestContainsCommandChaining(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSafeReadOnlyCommand_GitQueries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		command string
+		safe    bool
+	}{
+		{command: "git status", safe: true},
+		{command: "git diff --stat", safe: true},
+		{command: "git log --oneline", safe: true},
+		{command: "git branch", safe: true},
+		{command: "git branch --show-current", safe: true},
+		{command: "git branch --list 'feature/*'", safe: true},
+		{command: "git branch -a", safe: true},
+		{command: "git branch new-branch", safe: false},
+		{command: "git branch -D old-branch", safe: false},
+		{command: "git branch -m old new", safe: false},
+		{command: "git branch --all -D old-branch", safe: false},
+		{command: "git branch --list $BRANCH_FLAGS", safe: false},
+		{command: "git tag", safe: true},
+		{command: "git tag --list 'v*'", safe: true},
+		{command: "git tag -l 'v*'", safe: true},
+		{command: "git tag v1.0.0", safe: false},
+		{command: "git tag -d v1.0.0", safe: false},
+		{command: "git tag --list --force v1.0.0", safe: false},
+		{command: "git remote", safe: true},
+		{command: "git remote -v", safe: true},
+		{command: "git remote show origin", safe: true},
+		{command: "git remote get-url origin", safe: true},
+		{command: "git remote add origin https://example.com/repo.git", safe: false},
+		{command: "git remote remove origin", safe: false},
+		{command: "git remote set-url origin https://example.com/repo.git", safe: false},
+		{command: "git remote rename origin upstream", safe: false},
+		{command: "git status && git branch new-branch", safe: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.command, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.safe, isSafeReadOnlyCommand(tt.command))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Prevent mutating `git branch`, `git tag`, and `git remote` commands from being treated as safe read-only shell commands.

Previously, these commands were matched using broad string prefixes. As a result, commands such as the following bypassed the permission prompt:

```sh
git branch new-branch
git branch -D old-branch
git tag v1.0.0
git tag -d v1.0.0
git remote add origin https://example.com/repo.git
git remote set-url origin https://example.com/repo.git
```

This is related to #3274.

## Problem
The Bash tool skips permission requests for commands matching entries in the safe-command list.
Because git branch, git tag, and git remote support both read-only and mutating operations, treating every command with one of those prefixes as safe allowed repository changes to execute without user approval.
The issue was reproduced with a permission service configured to deny every request:
1. Initialize a temporary Git repository.
2. Execute git branch new-branch through the Bash tool.
3. Observe that no permission request is made.
4. Observe that new-branch is created anyway.
On the previous implementation, the regression test reported zero permission requests and confirmed that the denied branch was created.

## Changes
- Move git branch, git tag, and git remote out of the generic safe-prefix list.
- Add dedicated classification for read-only forms of these commands.
- Continue allowing known read-only queries without a permission prompt, including:
> - git branch
> - git branch --show-current
> - git branch --list
> - git tag --list
> - git remote -v
> - git remote show
> - git remote get-url
- Require permission for mutating operations, including:
- branch creation, deletion, copying, and renaming
- tag creation, deletion, signing, editing, and forced updates
- remote addition, removal, renaming, and URL changes
- Reject mixed query/mutation argument combinations from the safe path.
- Conservatively require permission when query arguments contain shell variable expansion.

## Tests
Added table-driven coverage for read-only and mutating Git commands.
Added an end-to-end Bash tool regression test that:
1. Creates a temporary Git repository.
2. Configures the permission service to deny execution.
3. Attempts to run git branch new-branch.
4. Verifies that a permission request was made.
5. Verifies that the branch was not created.
6. Verifies that the tool returned a permission-denied response.

Validation completed:
- go test ./internal/agent/tools
- go test ./...
- go vet ./internal/agent/tools
- git diff --check