### PR TITLE
fix(skills): resolve relative paths from workspace

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -1515,6 +1515,7 @@ func discoverSkills(cfg *config.ConfigStore) (allSkills, activeSkills []*skills.
 	allSkills, activeSkills, states := skills.DiscoverFromConfig(skills.DiscoveryConfig{
 		SkillsPaths:    paths,
 		DisabledSkills: disabled,
+		WorkingDir:     cfg.WorkingDir(),
 		Resolver:       resolver,
 	})
 	logDiscoveryStats(states, paths, allSkills, activeSkills, disabled)

--- a/internal/backend/backend_skills_test.go
+++ b/internal/backend/backend_skills_test.go
@@ -122,9 +122,49 @@ func TestBackend_WorkspaceSkillsIsolation(t *testing.T) {
 		"workspace B's Manager.States() leaked workspace A's republish")
 }
 
+func TestBackend_RelativeSkillsPathUsesWorkspace(t *testing.T) {
+	hostHome := t.TempDir()
+	t.Setenv("HOME", hostHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(hostHome, ".config"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(hostHome, ".local", "share"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(hostHome, ".cache"))
+	t.Setenv("CRUSH_SKILLS_DIR", t.TempDir())
+
+	workingDir := t.TempDir()
+	dataDir := filepath.Join(workingDir, ".crush")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workingDir, "crush.json"),
+		[]byte(`{"options":{"skills_paths":["./team-skills"]}}`),
+		0o644,
+	))
+	writeSkillAt(t, filepath.Join(workingDir, "team-skills"), "relative-config-skill", "Workspace-relative configured skill.")
+
+	srvCfg, err := config.Init(workingDir, "", false)
+	require.NoError(t, err)
+	b := backend.New(t.Context(), srvCfg, nil)
+	clientID := uuid.New().String()
+
+	ws, _, err := b.CreateWorkspace(proto.Workspace{
+		ClientID: clientID,
+		Path:     workingDir,
+		DataDir:  dataDir,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = b.DeleteWorkspace(ws.ID, clientID) })
+
+	require.True(t, containsSkillName(ws.Skills.States(), "relative-config-skill"),
+		"relative skills_paths entry must be resolved from the workspace")
+	require.Contains(t, ws.Skills.ResolvedPaths(), filepath.Join(workingDir, "team-skills"))
+}
+
 func writeSkill(t *testing.T, workingDir, name, desc string) {
 	t.Helper()
-	skillDir := filepath.Join(workingDir, ".agents", "skills", name)
+	writeSkillAt(t, filepath.Join(workingDir, ".agents", "skills"), name, desc)
+}
+
+func writeSkillAt(t *testing.T, root, name, desc string) {
+	t.Helper()
+	skillDir := filepath.Join(root, name)
 	require.NoError(t, os.MkdirAll(skillDir, 0o755))
 	content := fmt.Sprintf("---\nname: %s\ndescription: %s\n---\n%s\n", name, desc, desc)
 	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644))

--- a/internal/skills/manager.go
+++ b/internal/skills/manager.go
@@ -2,6 +2,7 @@ package skills
 
 import (
 	"context"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -205,10 +206,10 @@ type DiscoveryConfig struct {
 	Resolver func(string) (string, error)
 }
 
-// ResolvePaths expands home-directory and $VAR references in
-// SkillsPaths. This is the canonical path-resolution logic used by
-// DiscoverFromConfig; callers that need the resolved list (e.g. for
-// Catalog labels) can call this directly.
+// ResolvePaths expands home-directory and $VAR references in SkillsPaths,
+// then resolves relative paths from WorkingDir. This is the canonical
+// path-resolution logic used by DiscoverFromConfig; callers that need the
+// resolved list (e.g. for Catalog labels) can call this directly.
 func (c DiscoveryConfig) ResolvePaths() []string {
 	if len(c.SkillsPaths) == 0 {
 		return nil
@@ -220,6 +221,12 @@ func (c DiscoveryConfig) ResolvePaths() []string {
 			if resolved, err := c.Resolver(expanded); err == nil {
 				expanded = resolved
 			}
+		}
+		if expanded != "" {
+			if c.WorkingDir != "" && !filepath.IsAbs(expanded) {
+				expanded = filepath.Join(c.WorkingDir, expanded)
+			}
+			expanded = filepath.Clean(expanded)
 		}
 		out = append(out, expanded)
 	}

--- a/internal/skills/manager_test.go
+++ b/internal/skills/manager_test.go
@@ -247,3 +247,61 @@ func TestDiscoverFromConfig_Resolver(t *testing.T) {
 	}
 	require.True(t, found, "DiscoverFromConfig must expand $VAR via Resolver")
 }
+
+func TestDiscoveryConfig_ResolvePathsRelativeToWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	absolutePath := filepath.Join(t.TempDir(), "absolute-skills")
+	cfg := DiscoveryConfig{
+		SkillsPaths: []string{
+			"./skills",
+			"nested/../other-skills",
+			"$RELATIVE_SKILLS_DIR",
+			absolutePath,
+			"",
+		},
+		WorkingDir: workingDir,
+		Resolver: func(s string) (string, error) {
+			if s == "$RELATIVE_SKILLS_DIR" {
+				return "resolved-skills", nil
+			}
+			return s, errors.New("unknown")
+		},
+	}
+
+	require.Equal(t, []string{
+		filepath.Join(workingDir, "skills"),
+		filepath.Join(workingDir, "other-skills"),
+		filepath.Join(workingDir, "resolved-skills"),
+		absolutePath,
+		"",
+	}, cfg.ResolvePaths())
+}
+
+func TestDiscoverFromConfig_RelativePathUsesWorkingDir(t *testing.T) {
+	t.Parallel()
+
+	workingDir := t.TempDir()
+	skillDir := filepath.Join(workingDir, "skills", "relative-skill")
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(skillDir, SkillFileName),
+		[]byte("---\nname: relative-skill\ndescription: Workspace-relative skill.\n---\nx\n"),
+		0o644,
+	))
+
+	allSkills, _, _ := DiscoverFromConfig(DiscoveryConfig{
+		SkillsPaths: []string{"./skills"},
+		WorkingDir:  workingDir,
+	})
+
+	found := false
+	for _, skill := range allSkills {
+		if skill.Name == "relative-skill" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "DiscoverFromConfig must resolve relative paths from WorkingDir")
+}


### PR DESCRIPTION
## Summary

Resolve relative `options.skills_paths` entries from the workspace directory instead of the backend process working directory.

Previously, a client/server workspace configured with `"skills_paths": ["./team-skills"]` searched for `./team-skills` relative to the long-running server process. The configured skills were therefore invisible whenever the server cwd differed from the workspace.

Related to #3366. This addresses the workspace-relative path bug, not the broader Windows/MSYS path report.

## Changes

- resolve relative skill paths from `DiscoveryConfig.WorkingDir` after home and environment expansion
- clean non-empty resolved paths while preserving absolute and empty entries
- pass the working directory through the coordinator fallback discovery path
- add unit coverage for relative, normalized, resolver-produced, absolute, and empty paths
- add a backend integration test using a real workspace `crush.json` with `./team-skills`

## Reproduction

The backend regression test creates a workspace containing:

```json
{"options":{"skills_paths":["./team-skills"]}}
```

and a skill at `<workspace>/team-skills/relative-config-skill/SKILL.md`.

The same test fails on the previous `main` because the skill is not discovered. It passes with this change and verifies that the manager stores `<workspace>/team-skills` as the resolved path.

## Tests

- `go test ./internal/skills ./internal/backend ./internal/agent ./internal/cmd`
- `go test ./...`
- `golangci-lint run --path-mode=abs --config=.golangci.yml --timeout=5m`
- `git diff --check`