### PR TITLE
fix(mcp): restore MCP prompts

### DIFF
--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -297,6 +297,37 @@ func (b *Backend) GetMCPPrompt(workspaceID, clientID, promptID string, args map[
 	return commands.GetMCPPrompt(ws.Cfg, clientID, promptID, args)
 }
 
+func (b *Backend) ListMCPPrompts(workspaceID string) ([]proto.MCPPrompt, error) {
+	if _, err := b.GetWorkspace(workspaceID); err != nil {
+		return nil, err
+	}
+	prompts, err := commands.LoadMCPPrompts()
+	if err != nil {
+		return nil, err
+	}
+	result := make([]proto.MCPPrompt, len(prompts))
+	for i, prompt := range prompts {
+		arguments := make([]proto.MCPPromptArgument, len(prompt.Arguments))
+		for j, argument := range prompt.Arguments {
+			arguments[j] = proto.MCPPromptArgument{
+				ID:          argument.ID,
+				Title:       argument.Title,
+				Description: argument.Description,
+				Required:    argument.Required,
+			}
+		}
+		result[i] = proto.MCPPrompt{
+			ID:          prompt.ID,
+			Title:       prompt.Title,
+			Description: prompt.Description,
+			PromptID:    prompt.PromptID,
+			ClientID:    prompt.ClientID,
+			Arguments:   arguments,
+		}
+	}
+	return result, nil
+}
+
 // GetWorkingDir returns the working directory for a workspace.
 func (b *Backend) GetWorkingDir(workspaceID string) (string, error) {
 	ws, err := b.GetWorkspace(workspaceID)

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -321,6 +321,22 @@ func (c *Client) ReadMCPResource(ctx context.Context, id, name, uri string) ([]M
 	return contents, nil
 }
 
+func (c *Client) ListMCPPrompts(ctx context.Context, id string) ([]proto.MCPPrompt, error) {
+	rsp, err := c.get(ctx, fmt.Sprintf("/workspaces/%s/mcp/prompts", id), nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list MCP prompts: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to list MCP prompts: status code %d", rsp.StatusCode)
+	}
+	var prompts []proto.MCPPrompt
+	if err := json.NewDecoder(rsp.Body).Decode(&prompts); err != nil {
+		return nil, fmt.Errorf("failed to decode MCP prompts: %w", err)
+	}
+	return prompts, nil
+}
+
 // GetMCPPrompt retrieves a prompt from a named MCP server.
 func (c *Client) GetMCPPrompt(ctx context.Context, id, clientID, promptID string, args map[string]string) (string, error) {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/mcp/get-prompt", id), nil, jsonBody(struct {

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -126,3 +126,31 @@ func TestListMCPPrompts(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 }
+
+func TestListMCPPromptsNonOKStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := captureClient(t, srv)
+	_, err := c.ListMCPPrompts(t.Context(), "ws1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "status code 500")
+}
+
+func TestListMCPPromptsMalformedBody(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	c := captureClient(t, srv)
+	_, err := c.ListMCPPrompts(t.Context(), "ws1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to decode MCP prompts")
+}

--- a/internal/client/config_test.go
+++ b/internal/client/config_test.go
@@ -99,3 +99,30 @@ func TestSetProviderAPIKeyNilOAuthFailsLocally(t *testing.T) {
 	err := c.SetProviderAPIKey(context.Background(), "ws1", config.ScopeGlobal, "x", tok)
 	require.Error(t, err)
 }
+
+func TestListMCPPrompts(t *testing.T) {
+	t.Parallel()
+
+	want := []proto.MCPPrompt{
+		{
+			ID:          "server:review",
+			Title:       "Review changes",
+			Description: "Review the current changes.",
+			PromptID:    "review",
+			ClientID:    "server",
+			Arguments: []proto.MCPPromptArgument{
+				{ID: "focus", Title: "Focus", Description: "Area to review", Required: true},
+			},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v1/workspaces/ws1/mcp/prompts", r.URL.Path)
+		require.NoError(t, json.NewEncoder(w).Encode(want))
+	}))
+	defer srv.Close()
+
+	got, err := captureClient(t, srv).ListMCPPrompts(t.Context(), "ws1")
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}

--- a/internal/proto/mcp.go
+++ b/internal/proto/mcp.go
@@ -135,6 +135,22 @@ type MCPClientInfo struct {
 	ConnectedAt   time.Time `json:"connected_at"`
 }
 
+type MCPPromptArgument struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+	Required    bool   `json:"required,omitempty"`
+}
+
+type MCPPrompt struct {
+	ID          string              `json:"id"`
+	Title       string              `json:"title,omitempty"`
+	Description string              `json:"description,omitempty"`
+	PromptID    string              `json:"prompt_id"`
+	ClientID    string              `json:"client_id"`
+	Arguments   []MCPPromptArgument `json:"arguments,omitempty"`
+}
+
 // MarshalJSON implements the [json.Marshaler] interface.
 func (i MCPClientInfo) MarshalJSON() ([]byte, error) {
 	type Alias MCPClientInfo

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -413,6 +413,16 @@ func (c *controllerV1) handlePostWorkspaceMCPReadResource(w http.ResponseWriter,
 	jsonEncode(w, contents)
 }
 
+// handleGetWorkspaceMCPPrompts returns the available MCP prompts for a workspace.
+//
+//	@Summary		Get MCP prompts
+//	@Tags			mcp
+//	@Produce		json
+//	@Param			id	path		string			true	"Workspace ID"
+//	@Success		200	{array}		proto.MCPPrompt
+//	@Failure		404	{object}	proto.Error
+//	@Failure		500	{object}	proto.Error
+//	@Router			/workspaces/{id}/mcp/prompts [get]
 func (c *controllerV1) handleGetWorkspaceMCPPrompts(w http.ResponseWriter, r *http.Request) {
 	prompts, err := c.backend.ListMCPPrompts(r.PathValue("id"))
 	if err != nil {

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -413,6 +413,15 @@ func (c *controllerV1) handlePostWorkspaceMCPReadResource(w http.ResponseWriter,
 	jsonEncode(w, contents)
 }
 
+func (c *controllerV1) handleGetWorkspaceMCPPrompts(w http.ResponseWriter, r *http.Request) {
+	prompts, err := c.backend.ListMCPPrompts(r.PathValue("id"))
+	if err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	jsonEncode(w, prompts)
+}
+
 // handlePostWorkspaceMCPGetPrompt retrieves a prompt from an MCP server.
 //
 //	@Summary		Get MCP prompt

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -207,6 +207,7 @@ func (s *Server) installHandler() {
 	mux.HandleFunc("POST /v1/workspaces/{id}/skills/read", c.handlePostWorkspaceSkillRead)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-tools", c.handlePostWorkspaceMCPRefreshTools)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/read-resource", c.handlePostWorkspaceMCPReadResource)
+	mux.HandleFunc("GET /v1/workspaces/{id}/mcp/prompts", c.handleGetWorkspaceMCPPrompts)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/get-prompt", c.handlePostWorkspaceMCPGetPrompt)
 	mux.HandleFunc("GET /v1/workspaces/{id}/mcp/states", c.handleGetWorkspaceMCPStates)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-prompts", c.handlePostWorkspaceMCPRefreshPrompts)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -608,7 +608,7 @@ func (m *UI) loadCustomCommands() tea.Cmd {
 
 // loadMCPrompts loads the MCP prompts asynchronously.
 func (m *UI) loadMCPrompts() tea.Msg {
-	prompts, err := commands.LoadMCPPrompts()
+	prompts, err := m.com.Workspace.ListMCPPrompts(context.Background())
 	if err != nil {
 		slog.Error("Failed to load MCP prompts", "error", err)
 	}

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -427,6 +427,10 @@ func (w *AppWorkspace) ReadMCPResource(ctx context.Context, name, uri string) ([
 	return result, nil
 }
 
+func (w *AppWorkspace) ListMCPPrompts(context.Context) ([]commands.MCPPrompt, error) {
+	return commands.LoadMCPPrompts()
+}
+
 func (w *AppWorkspace) GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error) {
 	return commands.GetMCPPrompt(w.store, clientID, promptID, args)
 }

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -14,6 +14,7 @@ import (
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/client"
+	"github.com/charmbracelet/crush/internal/commands"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/herdr"
 	"github.com/charmbracelet/crush/internal/history"
@@ -629,6 +630,34 @@ func (w *ClientWorkspace) ReadMCPResource(ctx context.Context, name, uri string)
 			MIMEType: c.MIMEType,
 			Text:     c.Text,
 			Blob:     c.Blob,
+		}
+	}
+	return result, nil
+}
+
+func (w *ClientWorkspace) ListMCPPrompts(ctx context.Context) ([]commands.MCPPrompt, error) {
+	prompts, err := w.client.ListMCPPrompts(ctx, w.workspaceID())
+	if err != nil {
+		return nil, err
+	}
+	result := make([]commands.MCPPrompt, len(prompts))
+	for i, prompt := range prompts {
+		arguments := make([]commands.Argument, len(prompt.Arguments))
+		for j, argument := range prompt.Arguments {
+			arguments[j] = commands.Argument{
+				ID:          argument.ID,
+				Title:       argument.Title,
+				Description: argument.Description,
+				Required:    argument.Required,
+			}
+		}
+		result[i] = commands.MCPPrompt{
+			ID:          prompt.ID,
+			Title:       prompt.Title,
+			Description: prompt.Description,
+			PromptID:    prompt.PromptID,
+			ClientID:    prompt.ClientID,
+			Arguments:   arguments,
 		}
 	}
 	return result, nil

--- a/internal/workspace/client_workspace_test.go
+++ b/internal/workspace/client_workspace_test.go
@@ -276,3 +276,22 @@ func TestClientWorkspaceListMCPPrompts(t *testing.T) {
 		},
 	}, got)
 }
+
+func TestClientWorkspaceListMCPPromptsServerError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	c, err := client.NewClient(t.TempDir(), "tcp", u.Host)
+	require.NoError(t, err)
+	workspace := NewClientWorkspace(c, proto.Workspace{ID: "ws-1"})
+
+	_, err = workspace.ListMCPPrompts(t.Context())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "status code 500")
+}

--- a/internal/workspace/client_workspace_test.go
+++ b/internal/workspace/client_workspace_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/client"
+	"github.com/charmbracelet/crush/internal/commands"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/proto"
@@ -236,4 +237,42 @@ func TestTranslateEvent_UpdateAvailable(t *testing.T) {
 	require.Equal(t, "1.0.0", got.CurrentVersion)
 	require.Equal(t, "1.1.0", got.LatestVersion)
 	require.True(t, got.IsDevelopment)
+}
+
+func TestClientWorkspaceListMCPPrompts(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/workspaces/ws-1/mcp/prompts", r.URL.Path)
+		require.NoError(t, json.NewEncoder(w).Encode([]proto.MCPPrompt{
+			{
+				ID:       "server:review",
+				PromptID: "review",
+				ClientID: "server",
+				Arguments: []proto.MCPPromptArgument{
+					{ID: "focus", Title: "Focus", Required: true},
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	c, err := client.NewClient(t.TempDir(), "tcp", u.Host)
+	require.NoError(t, err)
+	workspace := NewClientWorkspace(c, proto.Workspace{ID: "ws-1"})
+
+	got, err := workspace.ListMCPPrompts(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, []commands.MCPPrompt{
+		{
+			ID:       "server:review",
+			PromptID: "review",
+			ClientID: "server",
+			Arguments: []commands.Argument{
+				{ID: "focus", Title: "Focus", Required: true},
+			},
+		},
+	}, got)
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/catwalk/pkg/catwalk"
 	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/commands"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/history"
 	"github.com/charmbracelet/crush/internal/lsp"
@@ -163,6 +164,7 @@ type Workspace interface {
 	MCPRefreshResources(ctx context.Context, name string)
 	RefreshMCPTools(ctx context.Context, name string)
 	ReadMCPResource(ctx context.Context, name, uri string) ([]MCPResourceContents, error)
+	ListMCPPrompts(ctx context.Context) ([]commands.MCPPrompt, error)
 	GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error)
 	EnableDockerMCP(ctx context.Context) error
 	DisableDockerMCP() error


### PR DESCRIPTION
MCP prompts were dropped during client-server mode work. This restores them.