### PR TITLE
fix(agent): reject tool calls with empty names

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -789,6 +789,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	var stepMessages []fantasy.Message
 	var shouldSummarize bool
 	sanitizedToolCalls := make(map[string]bool)
+	malformedToolCalls := make(map[string]bool)
 	// Don't send MaxOutputTokens if 0 — some providers (e.g. LM Studio) reject it
 	var maxOutputTokens *int64
 	if call.MaxOutputTokens > 0 {
@@ -918,6 +919,10 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			return a.messages.Update(genCtx, *currentAssistant)
 		},
 		OnToolInputStart: func(id string, toolName string) error {
+			if strings.TrimSpace(toolName) == "" {
+				malformedToolCalls[id] = true
+				return nil
+			}
 			toolCall := message.ToolCall{
 				ID:               id,
 				Name:             toolName,
@@ -949,6 +954,20 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			return m.Model
 		},
 		OnToolCall: func(tc fantasy.ToolCallContent) error {
+			if strings.TrimSpace(tc.ToolName) == "" {
+				malformedToolCalls[tc.ToolCallID] = true
+				toolCalls := currentAssistant.ToolCalls()
+				validToolCalls := make([]message.ToolCall, 0, len(toolCalls))
+				for _, toolCall := range toolCalls {
+					if toolCall.ID != tc.ToolCallID {
+						validToolCalls = append(validToolCalls, toolCall)
+					}
+				}
+				currentAssistant.SetToolCalls(validToolCalls)
+				slog.Warn("Ignoring tool call with empty name", "tool_call_id", tc.ToolCallID)
+				return a.messages.Update(ctx, *currentAssistant)
+			}
+			delete(malformedToolCalls, tc.ToolCallID)
 			input, wasSanitized := sanitizeToolInput(tc.ToolName, tc.ToolCallID, tc.Input)
 			if wasSanitized {
 				sanitizedToolCalls[tc.ToolCallID] = true
@@ -966,6 +985,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			return a.messages.Update(ctx, *currentAssistant)
 		},
 		OnToolResult: func(result fantasy.ToolResultContent) error {
+			if malformedToolCalls[result.ToolCallID] {
+				return nil
+			}
 			toolResult := a.convertToToolResult(result)
 			if sanitizedToolCalls[result.ToolCallID] {
 				toolResult.Content = "Tool call failed: arguments were not valid JSON. Please check your tool call format and try again."
@@ -1006,7 +1028,15 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 					}
 				}
 			}
-			currentAssistant.AddFinish(finishReason, "", "")
+			if len(malformedToolCalls) > 0 {
+				currentAssistant.AddFinish(
+					message.FinishReasonError,
+					"Invalid tool call",
+					"The model returned a tool call without a name. Please try again.",
+				)
+			} else {
+				currentAssistant.AddFinish(finishReason, "", "")
+			}
 			sessionLock.Lock()
 			defer sessionLock.Unlock()
 
@@ -1025,6 +1055,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			return a.messages.Update(genCtx, *currentAssistant)
 		},
 		StopWhen: []fantasy.StopCondition{
+			func(_ []fantasy.StepResult) bool {
+				return len(malformedToolCalls) > 0
+			},
 			func(_ []fantasy.StepResult) bool {
 				cw := int64(largeModel.CatwalkCfg.ContextWindow)
 				// If context window is unknown (0), skip auto-summarize

--- a/internal/agent/empty_tool_name_test.go
+++ b/internal/agent/empty_tool_name_test.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/stretchr/testify/require"
+)
+
+type emptyToolNameStreamModel struct {
+	calls atomic.Int64
+}
+
+func (m *emptyToolNameStreamModel) Provider() string { return "fake" }
+func (m *emptyToolNameStreamModel) Model() string    { return "fake-model" }
+
+func (m *emptyToolNameStreamModel) Generate(context.Context, fantasy.Call) (*fantasy.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *emptyToolNameStreamModel) Stream(context.Context, fantasy.Call) (fantasy.StreamResponse, error) {
+	if m.calls.Add(1) > 1 {
+		return func(yield func(fantasy.StreamPart) bool) {
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop})
+		}, nil
+	}
+
+	return func(yield func(fantasy.StreamPart) bool) {
+		if !yield(fantasy.StreamPart{
+			Type:         fantasy.StreamPartTypeToolInputStart,
+			ID:           "call-empty-name",
+			ToolCallName: "",
+		}) {
+			return
+		}
+		if !yield(fantasy.StreamPart{
+			Type:          fantasy.StreamPartTypeToolCall,
+			ID:            "call-empty-name",
+			ToolCallName:  "",
+			ToolCallInput: "{}",
+		}) {
+			return
+		}
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonToolCalls})
+	}, nil
+}
+
+func (m *emptyToolNameStreamModel) GenerateObject(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *emptyToolNameStreamModel) StreamObject(context.Context, fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestRun_EmptyToolNameDoesNotCorruptSession(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	large := &emptyToolNameStreamModel{}
+	small := &finishStreamModel{text: "title"}
+	agent := testSessionAgent(env, large, small, "system").(*sessionAgent)
+
+	sess, err := env.sessions.Create(t.Context(), "session")
+	require.NoError(t, err)
+
+	_, err = agent.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		Prompt:    "Use a tool",
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), large.calls.Load(), "malformed call must not be replayed to the provider")
+
+	msgs, err := env.messages.List(t.Context(), sess.ID)
+	require.NoError(t, err)
+	for _, msg := range msgs {
+		for _, toolCall := range msg.ToolCalls() {
+			require.NotEmpty(t, toolCall.Name, "empty tool name must not be persisted")
+		}
+		for _, toolResult := range msg.ToolResults() {
+			require.NotEqual(t, "call-empty-name", toolResult.ToolCallID, "result for malformed call must not be persisted")
+		}
+	}
+
+	require.Equal(t, message.FinishReasonError, msgs[len(msgs)-1].FinishReason())
+	require.Contains(t, msgs[len(msgs)-1].FinishPart().Details, "without a name")
+
+	_, err = agent.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		Prompt:    "Continue after the malformed call",
+	})
+	require.NoError(t, err, "the next turn must remain usable")
+	require.Equal(t, int64(2), large.calls.Load())
+}


### PR DESCRIPTION
Fixes #3070.

## What I looked at

I traced empty tool names through the streaming callbacks and session persistence path. Crush wrote the call when tool input started, replaced it when the call completed, wrote the matching error result, and then allowed the agent loop to make another provider request with that malformed history.

That explains why affected sessions can become unusable: providers that validate tool history reject the saved empty name on every later turn.

## What changed

- Ignore empty and whitespace-only tool names during streaming.
- Remove any partial copy of the malformed call before the assistant message is saved.
- Skip the matching tool result so the database never contains an orphaned malformed pair.
- Stop the turn before another provider request can replay the bad history.
- Save a clear, recoverable `Invalid tool call` error and keep the session usable for the next prompt.

Valid tool calls in the same streaming path keep their existing behavior.

## Before / after

The regression test uses a deterministic mock model that streams `call-empty-name` with an empty name and `{}` input.

| Behavior | Before | After |
| --- | ---: | ---: |
| Provider requests during malformed turn | 2 | 1 |
| Empty-name call saved to session | Yes | No |
| Matching malformed result saved | Yes | No |
| Next user turn remains usable | Not guaranteed | Yes |

This is a correctness and session-integrity fix, so the useful measurement is bounded provider requests and persisted state rather than a CPU benchmark.

## Tests

- `go test ./internal/agent -count=1`
- `go test -race ./internal/agent -count=1`
- `go test -race -failfast ./...`
- `go build -race ./...`
- `golangci-lint run --path-mode=abs --config=.golangci.yml --timeout=5m`
- `go mod tidy` with no diff
- `git diff --check`