### PR TITLE
feat(models): reload model discovery from the /models dialog

### DIFF
--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -207,6 +207,17 @@ func (b *Backend) ListSkills(workspaceID string) ([]proto.SkillInfo, error) {
 	return result, nil
 }
 
+// ReloadModelDiscovery re-runs model discovery for a workspace's custom
+// providers and merges any newly found models into the in-memory config. It
+// returns the number of models added across all providers.
+func (b *Backend) ReloadModelDiscovery(ctx context.Context, workspaceID string) (int, error) {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return 0, err
+	}
+	return ws.Cfg.ReloadModelDiscovery(ctx)
+}
+
 // EnableDockerMCP validates Docker MCP availability, stages the
 // configuration, starts the MCP client, and persists the config.
 func (b *Backend) EnableDockerMCP(ctx context.Context, workspaceID string) error {

--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -216,6 +216,17 @@ func (b *Backend) ListSkills(workspaceID string) ([]proto.SkillInfo, error) {
 	return result, nil
 }
 
+// ReloadModelDiscovery re-runs model discovery for a workspace's custom
+// providers and merges any newly found models into the in-memory config. It
+// returns the number of models added across all providers.
+func (b *Backend) ReloadModelDiscovery(ctx context.Context, workspaceID string) (int, error) {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return 0, err
+	}
+	return ws.Cfg.ReloadModelDiscovery(ctx)
+}
+
 // EnableDockerMCP validates Docker MCP availability, stages the
 // configuration, starts the MCP client, and persists the config.
 func (b *Backend) EnableDockerMCP(ctx context.Context, workspaceID string) error {

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -252,6 +252,24 @@ func (c *Client) ReadSkill(ctx context.Context, id, skillID string) (*proto.Read
 	return &result, nil
 }
 
+// ReloadModelDiscovery triggers model re-discovery on the server and returns
+// the number of newly discovered models.
+func (c *Client) ReloadModelDiscovery(ctx context.Context, id string) (int, error) {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/config/reload-discovery", id), nil, nil, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to reload model discovery: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("failed to reload model discovery: status code %d", rsp.StatusCode)
+	}
+	var result proto.ReloadModelDiscoveryResponse
+	if err := json.NewDecoder(rsp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("failed to decode reload discovery response: %w", err)
+	}
+	return result.Added, nil
+}
+
 // MCPResourceContents holds the contents of an MCP resource.
 type MCPResourceContents struct {
 	URI      string `json:"uri"`

--- a/internal/config/discovery.go
+++ b/internal/config/discovery.go
@@ -1,0 +1,236 @@
+package config
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"log/slog"
+	"maps"
+	"sync"
+	"time"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/discover"
+)
+
+// loadModelDiscoveryTimeout bounds the model-discovery pass that runs
+// during config load. It is deliberately tight because it blocks startup;
+// providers whose endpoints miss it are recorded on the store and can be
+// retried later via ReloadModelDiscovery.
+const loadModelDiscoveryTimeout = 3 * time.Second
+
+// modelDiscoveryTimeout bounds an interactive model-discovery reload. It
+// is more generous than loadModelDiscoveryTimeout because the user
+// explicitly asked for it and local model servers (Ollama, LM Studio, …)
+// can be slow to answer.
+const modelDiscoveryTimeout = 10 * time.Second
+
+// providerWantsDiscovery reports whether a custom provider consents to
+// model discovery. userModels is the provider's user-configured model
+// list: at load time that is pc.Models itself; on reload it is the list
+// the store recorded before load-time discovery merged endpoint models
+// into pc.Models.
+//
+// The consent model: a provider with a curated, non-empty models list is
+// never discovered unless it explicitly sets discover_models: true, and
+// an empty list implies consent unless discover_models: false opts out.
+// An interactive reload re-probes eligible providers but never widens
+// this consent.
+func providerWantsDiscovery(pc ProviderConfig, userModels []catwalk.Model) bool {
+	if pc.AutoDiscoverModels != nil {
+		return *pc.AutoDiscoverModels
+	}
+	return len(userModels) == 0
+}
+
+// knownProviderNameSet returns the set of provider IDs treated as known
+// (non-custom) for discovery purposes. When disableDefaults is set every
+// provider is custom — matching configureProviders, which skips all
+// default providers under that option — so the set is empty.
+func knownProviderNameSet(known []catwalk.Provider, disableDefaults bool) map[string]bool {
+	names := make(map[string]bool, len(known))
+	if disableDefaults {
+		return names
+	}
+	for _, p := range known {
+		names[string(p.ID)] = true
+	}
+	return names
+}
+
+// discoverProviderModels runs model discovery concurrently for the custom
+// (non-known) candidates that are eligible for it (see
+// providerWantsDiscovery). Each candidate's Models field must hold only
+// its user-configured models; those are passed to discovery as the
+// existing set, so they always survive and take precedence over endpoint
+// models. It returns the discovered model lists and the per-provider
+// discovery errors, both keyed by provider ID. A provider that succeeds
+// but reports no models gets a results entry with an empty list.
+//
+// The caller owns the context deadline; both load and reload set one so a
+// slow or unreachable provider endpoint cannot block indefinitely.
+func discoverProviderModels(
+	ctx context.Context,
+	candidates map[string]ProviderConfig,
+	knownProviderNames map[string]bool,
+	resolver VariableResolver,
+) (map[string][]catwalk.Model, map[string]error) {
+	results := make(map[string][]catwalk.Model)
+	errs := make(map[string]error)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	for id, pc := range candidates {
+		if knownProviderNames[id] {
+			continue
+		}
+		if pc.Disable || pc.BaseURL == "" {
+			continue
+		}
+		if !providerWantsDiscovery(pc, pc.Models) {
+			continue
+		}
+
+		providerID := cmp.Or(pc.ID, id)
+		cfg := discover.Config{
+			ID:             providerID,
+			BaseURL:        pc.BaseURL,
+			APIKey:         pc.APIKey,
+			ExtraHeaders:   pc.ExtraHeaders,
+			ExistingModels: pc.Models,
+		}
+		providerType := cmp.Or(pc.Type, catwalk.TypeOpenAICompat)
+		wg.Go(func() {
+			models, err := discover.DiscoverModels(ctx, cfg, resolver)
+			if err != nil {
+				slog.Warn("Model discovery failed", "provider", id, "error", err)
+				mu.Lock()
+				errs[id] = err
+				mu.Unlock()
+				return
+			}
+			if len(models) > 0 {
+				if enricher := discover.GetEnricher(string(providerType)); enricher != nil {
+					models, _ = enricher.EnrichModels(ctx, cfg, resolver, models)
+				}
+			}
+			mu.Lock()
+			results[id] = models
+			mu.Unlock()
+		})
+	}
+	wg.Wait()
+	return results, errs
+}
+
+// ReloadModelDiscovery re-runs model discovery for every custom provider
+// eligible for it and merges the results into the in-memory config. It
+// returns the number of models added across all providers.
+//
+// Eligibility matches load exactly (see providerWantsDiscovery): a reload
+// never widens consent, it only re-probes providers load would have
+// probed — including providers load dropped because discovery failed and
+// they had no user-specified models (e.g. Crush started before Ollama),
+// which are resurrected here when their endpoint comes back.
+//
+// Discovered models are intentionally not persisted to disk: like the
+// discovery that runs during load, they are recomputed from the live
+// provider endpoints each time. This lets a running Crush pick up models
+// that appeared after startup (e.g. an `ollama pull`) without a restart.
+//
+// The network I/O runs without holding writeMu so config mutators (e.g.
+// model selection) are never blocked behind slow provider endpoints. The
+// merge goes through mutateInMemory and re-reads each provider fresh, so
+// concurrent changes to other provider fields (e.g. an OAuth token
+// refresh) are preserved.
+//
+// It returns an error when every eligible provider failed discovery so
+// total failure is distinguishable from "no new models".
+func (s *ConfigStore) ReloadModelDiscovery(ctx context.Context) (int, error) {
+	cfg := s.Config()
+
+	// Snapshot the discovery bookkeeping under a brief lock.
+	s.writeMu.Lock()
+	userModels := maps.Clone(s.userConfiguredModels)
+	failed := maps.Clone(s.failedDiscoveryProviders)
+	s.writeMu.Unlock()
+
+	var disableDefaults bool
+	if cfg.Options != nil {
+		disableDefaults = cfg.Options.DisableDefaultProviders
+	}
+	known := knownProviderNameSet(s.knownProviders, disableDefaults)
+
+	// Build the candidate set from the live providers plus the ones load
+	// dropped after failed discovery. Models is seeded with the recorded
+	// user-configured list (not the current, possibly discovery-merged
+	// one) so re-discovery prunes endpoint-removed models while keeping
+	// user-specified ones.
+	candidates := make(map[string]ProviderConfig)
+	for id, pc := range cfg.Providers.Seq2() {
+		if um, ok := userModels[id]; ok {
+			pc.Models = um
+		}
+		candidates[id] = pc
+	}
+	for id, pc := range failed {
+		if _, ok := candidates[id]; !ok {
+			candidates[id] = pc
+		}
+	}
+
+	discoverCtx, cancel := context.WithTimeout(ctx, modelDiscoveryTimeout)
+	defer cancel()
+
+	results, errs := discoverProviderModels(discoverCtx, candidates, known, s.resolver)
+	if len(errs) > 0 && len(results) == 0 {
+		return 0, fmt.Errorf("model discovery failed for all %d eligible providers", len(errs))
+	}
+
+	added := 0
+	s.mutateInMemory(func(c *Config) {
+		for id, models := range results {
+			if len(models) == 0 {
+				continue
+			}
+			// Re-read the provider fresh under writeMu and write only
+			// the merged Models onto it, so concurrent changes to other
+			// fields (OAuth tokens, header edits, …) are not clobbered.
+			pc, ok := c.Providers.Get(id)
+			if !ok {
+				// Resurrect a provider dropped at load. writeMu is
+				// held by mutateInMemory, so touching the failed map
+				// here is safe.
+				fp, wasFailed := s.failedDiscoveryProviders[id]
+				if !wasFailed {
+					continue
+				}
+				fp.Models = models
+				c.Providers.Set(id, fp)
+				delete(s.failedDiscoveryProviders, id)
+				added += len(models)
+				slog.Info("Recovered provider via model discovery",
+					"provider", id, "count", len(models))
+				continue
+			}
+			newCount := 0
+			have := make(map[string]bool, len(pc.Models))
+			for _, m := range pc.Models {
+				have[m.ID] = true
+			}
+			for _, m := range models {
+				if !have[m.ID] {
+					newCount++
+				}
+			}
+			pc.Models = models
+			c.Providers.Set(id, pc)
+			if newCount > 0 {
+				added += newCount
+				slog.Info("Reloaded models for provider",
+					"provider", id, "added", newCount, "count", len(models))
+			}
+		}
+	})
+	return added, nil
+}

--- a/internal/config/discovery_test.go
+++ b/internal/config/discovery_test.go
@@ -1,0 +1,453 @@
+package config
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/env"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderWantsDiscovery(t *testing.T) {
+	t.Parallel()
+
+	discoverTrue := true
+	discoverFalse := false
+
+	tests := []struct {
+		name       string
+		pc         ProviderConfig
+		userModels []catwalk.Model
+		want       bool
+	}{
+		{
+			name: "empty user models auto-triggers",
+			pc:   ProviderConfig{},
+			want: true,
+		},
+		{
+			name:       "curated user models do not trigger",
+			pc:         ProviderConfig{},
+			userModels: []catwalk.Model{{ID: "a"}},
+			want:       false,
+		},
+		{
+			name:       "explicit discover_models:true triggers even with models",
+			pc:         ProviderConfig{AutoDiscoverModels: &discoverTrue},
+			userModels: []catwalk.Model{{ID: "a"}},
+			want:       true,
+		},
+		{
+			name: "discover_models:false never triggers",
+			pc:   ProviderConfig{AutoDiscoverModels: &discoverFalse},
+			want: false,
+		},
+		{
+			name: "reload: discovery-merged models do not widen consent",
+			// pc.Models holds load-discovered models, but the recorded
+			// user-configured list is empty, so it stays eligible.
+			pc:         ProviderConfig{Models: []catwalk.Model{{ID: "found"}}},
+			userModels: nil,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, providerWantsDiscovery(tt.pc, tt.userModels))
+		})
+	}
+}
+
+func TestReloadModelDiscovery(t *testing.T) {
+	t.Parallel()
+
+	// modelsBody is swapped out to simulate a provider that gains a model
+	// between the first and second discovery pass (e.g. an `ollama pull`).
+	var modelsBody atomic.Value
+	modelsBody.Store(`{"data": [{"id": "existing-model", "object": "model"}]}`)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(modelsBody.Load().(string)))
+	}))
+	defer server.Close()
+
+	discoverTrue := true
+	cfg := &Config{
+		Providers: csync.NewMapFrom(map[string]ProviderConfig{
+			"custom": {
+				ID:      "custom",
+				APIKey:  "test-key",
+				BaseURL: server.URL + "/v1",
+				Models: []catwalk.Model{
+					{ID: "existing-model", Name: "Existing"},
+				},
+				AutoDiscoverModels: &discoverTrue,
+			},
+		}),
+	}
+	cfg.setDefaults(t.TempDir(), "")
+
+	store := testStore(cfg)
+	store.resolver = NewShellVariableResolver(env.NewFromMap(map[string]string{}))
+	store.userConfiguredModels = map[string][]catwalk.Model{
+		"custom": {{ID: "existing-model", Name: "Existing"}},
+	}
+
+	// First reload: the server only reports the model we already have, so
+	// nothing new is discovered.
+	added, err := store.ReloadModelDiscovery(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, added)
+
+	p, ok := cfg.Providers.Get("custom")
+	require.True(t, ok)
+	require.Len(t, p.Models, 1)
+
+	// A new model appears on the provider; a reload should pick it up.
+	modelsBody.Store(`{"data": [
+		{"id": "existing-model", "object": "model"},
+		{"id": "fresh-model", "object": "model"}
+	]}`)
+
+	added, err = store.ReloadModelDiscovery(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, added)
+
+	p, ok = cfg.Providers.Get("custom")
+	require.True(t, ok)
+	require.Len(t, p.Models, 2)
+	require.Equal(t, "existing-model", p.Models[0].ID)
+	require.Equal(t, "Existing", p.Models[0].Name, "user-specified model keeps its name")
+	require.Equal(t, "fresh-model", p.Models[1].ID)
+}
+
+func TestReloadModelDiscovery_RespectsOptOut(t *testing.T) {
+	t.Parallel()
+
+	var called atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": [{"id": "should-not-appear", "object": "model"}]}`))
+	}))
+	defer server.Close()
+
+	discoverFalse := false
+	cfg := &Config{
+		Providers: csync.NewMapFrom(map[string]ProviderConfig{
+			"custom": {
+				ID:                 "custom",
+				APIKey:             "test-key",
+				BaseURL:            server.URL + "/v1",
+				Models:             []catwalk.Model{{ID: "listed-model"}},
+				AutoDiscoverModels: &discoverFalse,
+			},
+		}),
+	}
+	cfg.setDefaults(t.TempDir(), "")
+
+	store := testStore(cfg)
+	store.resolver = NewShellVariableResolver(env.NewFromMap(map[string]string{}))
+
+	added, err := store.ReloadModelDiscovery(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, added)
+	require.False(t, called.Load(), "provider opted out of discovery should not be queried")
+
+	p, ok := cfg.Providers.Get("custom")
+	require.True(t, ok)
+	require.Len(t, p.Models, 1)
+	require.Equal(t, "listed-model", p.Models[0].ID)
+}
+
+func TestReloadModelDiscovery_SkipsCuratedProviders(t *testing.T) {
+	t.Parallel()
+
+	var called atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": [{"id": "should-not-appear", "object": "model"}]}`))
+	}))
+	defer server.Close()
+
+	// A curated, non-empty models list without discover_models: true is
+	// never discovered at load; reload must respect the same consent.
+	cfg := &Config{
+		Providers: csync.NewMapFrom(map[string]ProviderConfig{
+			"curated": {
+				ID:      "curated",
+				APIKey:  "test-key",
+				BaseURL: server.URL + "/v1",
+				Models:  []catwalk.Model{{ID: "hand-picked"}},
+			},
+		}),
+	}
+	cfg.setDefaults(t.TempDir(), "")
+
+	store := testStore(cfg)
+	store.resolver = NewShellVariableResolver(env.NewFromMap(map[string]string{}))
+	store.userConfiguredModels = map[string][]catwalk.Model{
+		"curated": {{ID: "hand-picked"}},
+	}
+
+	added, err := store.ReloadModelDiscovery(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 0, added)
+	require.False(t, called.Load(), "curated provider must not be re-discovered on reload")
+
+	p, ok := cfg.Providers.Get("curated")
+	require.True(t, ok)
+	require.Len(t, p.Models, 1)
+	require.Equal(t, "hand-picked", p.Models[0].ID)
+}
+
+func TestReloadModelDiscovery_ResurrectsFailedProvider(t *testing.T) {
+	t.Parallel()
+
+	// The server is "down" (500) while configureProviders runs, then comes
+	// up before the reload — the feature's headline case (Crush started
+	// before Ollama).
+	var healthy atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !healthy.Load() {
+			http.Error(w, "not ready", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": [
+			{"id": "model-a", "object": "model"},
+			{"id": "model-b", "object": "model"}
+		]}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		Providers: csync.NewMapFrom(map[string]ProviderConfig{
+			"flaky": {
+				APIKey:  "test-key",
+				BaseURL: server.URL + "/v1",
+			},
+		}),
+	}
+	cfg.setDefaults(t.TempDir(), "")
+
+	store := testStore(cfg)
+	testEnv := env.NewFromMap(map[string]string{})
+	resolver := NewShellVariableResolver(testEnv)
+	store.resolver = resolver
+
+	require.NoError(t, cfg.configureProviders(context.Background(), store, testEnv, resolver, nil))
+
+	_, ok := cfg.Providers.Get("flaky")
+	require.False(t, ok, "provider with failed discovery and no models is dropped at load")
+	require.Contains(t, store.failedDiscoveryProviders, "flaky")
+
+	// Endpoint comes up; the reload should resurrect the provider.
+	healthy.Store(true)
+
+	added, err := store.ReloadModelDiscovery(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 2, added, "resurrected provider's models count as added")
+
+	p, ok := cfg.Providers.Get("flaky")
+	require.True(t, ok, "provider is resurrected once its endpoint answers")
+	require.Len(t, p.Models, 2)
+	require.NotContains(t, store.failedDiscoveryProviders, "flaky")
+}
+
+func TestReloadModelDiscovery_PrunesRemovedModels(t *testing.T) {
+	t.Parallel()
+
+	t.Run("auto-discovered provider", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data": [
+				{"id": "fresh-a", "object": "model"},
+				{"id": "fresh-b", "object": "model"}
+			]}`))
+		}))
+		defer server.Close()
+
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"custom": {
+					ID:      "custom",
+					APIKey:  "test-key",
+					BaseURL: server.URL + "/v1",
+					// Discovered at load; gone from the endpoint now.
+					Models: []catwalk.Model{{ID: "stale-model"}},
+				},
+			}),
+		}
+		cfg.setDefaults(t.TempDir(), "")
+
+		store := testStore(cfg)
+		store.resolver = NewShellVariableResolver(env.NewFromMap(map[string]string{}))
+		store.userConfiguredModels = map[string][]catwalk.Model{"custom": nil}
+
+		added, err := store.ReloadModelDiscovery(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, 2, added, "added is the set difference, not a length delta")
+
+		p, ok := cfg.Providers.Get("custom")
+		require.True(t, ok)
+		require.Len(t, p.Models, 2)
+		require.Equal(t, "fresh-a", p.Models[0].ID)
+		require.Equal(t, "fresh-b", p.Models[1].ID)
+	})
+
+	t.Run("user models survive alongside pruning", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data": [{"id": "new-model", "object": "model"}]}`))
+		}))
+		defer server.Close()
+
+		discoverTrue := true
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"custom": {
+					ID:      "custom",
+					APIKey:  "test-key",
+					BaseURL: server.URL + "/v1",
+					Models: []catwalk.Model{
+						{ID: "user-model", Name: "User"},
+						{ID: "stale-model"},
+					},
+					AutoDiscoverModels: &discoverTrue,
+				},
+			}),
+		}
+		cfg.setDefaults(t.TempDir(), "")
+
+		store := testStore(cfg)
+		store.resolver = NewShellVariableResolver(env.NewFromMap(map[string]string{}))
+		store.userConfiguredModels = map[string][]catwalk.Model{
+			"custom": {{ID: "user-model", Name: "User"}},
+		}
+
+		// Simultaneous add (new-model) + remove (stale-model): added must
+		// count only genuinely new IDs.
+		added, err := store.ReloadModelDiscovery(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, 1, added)
+
+		p, ok := cfg.Providers.Get("custom")
+		require.True(t, ok)
+		require.Len(t, p.Models, 2)
+		require.Equal(t, "user-model", p.Models[0].ID)
+		require.Equal(t, "User", p.Models[0].Name, "user-specified model is preserved")
+		require.Equal(t, "new-model", p.Models[1].ID)
+	})
+}
+
+func TestReloadModelDiscovery_AllProvidersFail(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cfg := &Config{
+		Providers: csync.NewMapFrom(map[string]ProviderConfig{
+			"custom": {
+				ID:      "custom",
+				APIKey:  "test-key",
+				BaseURL: server.URL + "/v1",
+			},
+		}),
+	}
+	cfg.setDefaults(t.TempDir(), "")
+
+	store := testStore(cfg)
+	store.resolver = NewShellVariableResolver(env.NewFromMap(map[string]string{}))
+
+	added, err := store.ReloadModelDiscovery(context.Background())
+	require.Error(t, err, "total discovery failure must not look like 'no new models'")
+	require.Contains(t, err.Error(), "all 1")
+	require.Equal(t, 0, added)
+}
+
+func TestReloadModelDiscovery_DisableDefaultProviders(t *testing.T) {
+	t.Parallel()
+
+	newServer := func(called *atomic.Bool) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called.Store(true)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data": [{"id": "found-model", "object": "model"}]}`))
+		}))
+	}
+
+	newConfig := func(baseURL string) *Config {
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"myprov": {
+					ID:      "myprov",
+					APIKey:  "test-key",
+					BaseURL: baseURL + "/v1",
+				},
+			}),
+		}
+		cfg.setDefaults(t.TempDir(), "")
+		return cfg
+	}
+
+	knownProviders := []catwalk.Provider{{ID: "myprov"}}
+
+	t.Run("known-ID provider skipped by default", func(t *testing.T) {
+		t.Parallel()
+
+		var called atomic.Bool
+		server := newServer(&called)
+		defer server.Close()
+
+		cfg := newConfig(server.URL)
+		store := testStore(cfg)
+		store.resolver = NewShellVariableResolver(env.NewFromMap(map[string]string{}))
+		store.knownProviders = knownProviders
+
+		added, err := store.ReloadModelDiscovery(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, 0, added)
+		require.False(t, called.Load(), "known providers are not custom-discovered")
+	})
+
+	t.Run("known-ID provider reloaded when defaults disabled", func(t *testing.T) {
+		t.Parallel()
+
+		var called atomic.Bool
+		server := newServer(&called)
+		defer server.Close()
+
+		cfg := newConfig(server.URL)
+		cfg.Options.DisableDefaultProviders = true
+		store := testStore(cfg)
+		store.resolver = NewShellVariableResolver(env.NewFromMap(map[string]string{}))
+		store.knownProviders = knownProviders
+
+		added, err := store.ReloadModelDiscovery(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, 1, added)
+		require.True(t, called.Load(), "with disable_default_providers every provider is custom")
+
+		p, ok := cfg.Providers.Get("myprov")
+		require.True(t, ok)
+		require.Len(t, p.Models, 1)
+		require.Equal(t, "found-model", p.Models[0].ID)
+	})
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"charm.land/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/agent/hyper"
@@ -194,20 +193,21 @@ func PushPopCrushEnv() func() {
 }
 
 func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env env.Env, resolver VariableResolver, knownProviders []catwalk.Provider) error {
-	knownProviderNames := make(map[string]bool)
 	restore := PushPopCrushEnv()
 	defer restore()
 
 	// When disable_default_providers is enabled, skip all default/embedded
 	// providers entirely. Users must fully specify any providers they want.
 	// We skip to the custom provider validation loop which handles all
-	// user-configured providers uniformly.
+	// user-configured providers uniformly. knownProviderNameSet mirrors
+	// this policy so the interactive discovery reload agrees with load on
+	// which providers count as custom.
+	knownProviderNames := knownProviderNameSet(knownProviders, c.Options.DisableDefaultProviders)
 	if c.Options.DisableDefaultProviders {
 		knownProviders = nil
 	}
 
 	for _, p := range knownProviders {
-		knownProviderNames[string(p.ID)] = true
 		config, configExists := c.Providers.Get(string(p.ID))
 		// if the user configured a known provider we need to allow it to override a couple of parameters
 		if configExists {
@@ -365,50 +365,27 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 	// Discover models concurrently for custom providers that need it.
 	// A provider needs discovery when discover_models is explicitly true,
 	// or when the models list is empty (auto-trigger, unless opted out).
-	type discoveryResult struct {
-		models []catwalk.Model
-		err    error
-	}
-
-	discoveryResults := make(map[string]discoveryResult)
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-
-	discoverCtx, discoverCancel := context.WithTimeout(ctx, 3*time.Second)
-	for id, pc := range c.Providers.Seq2() {
+	// The same helper backs the interactive reload; see discovery.go.
+	//
+	// Record each custom provider's user-configured models first, before
+	// discovery merges endpoint models into the live config: the reload
+	// seeds re-discovery from this set so endpoint-removed models get
+	// pruned while user-specified ones survive.
+	store.userConfiguredModels = make(map[string][]catwalk.Model)
+	store.failedDiscoveryProviders = make(map[string]ProviderConfig)
+	candidates := maps.Collect(c.Providers.Seq2())
+	for id, pc := range candidates {
 		if knownProviderNames[id] {
 			continue
 		}
-		if pc.Disable || pc.BaseURL == "" {
-			continue
-		}
-		wantsDiscovery := pc.AutoDiscoverModels != nil && *pc.AutoDiscoverModels
-		autoTrigger := len(pc.Models) == 0 && (pc.AutoDiscoverModels == nil || *pc.AutoDiscoverModels)
-		if !wantsDiscovery && !autoTrigger {
-			continue
-		}
-		providerID := cmp.Or(pc.ID, id)
-		cfg := discover.Config{
-			ID:             providerID,
-			BaseURL:        pc.BaseURL,
-			APIKey:         pc.APIKey,
-			ExtraHeaders:   pc.ExtraHeaders,
-			ExistingModels: pc.Models,
-		}
-		providerType := cmp.Or(pc.Type, catwalk.TypeOpenAICompat)
-		wg.Go(func() {
-			models, err := discover.DiscoverModels(discoverCtx, cfg, resolver)
-			if err == nil && len(models) > 0 {
-				if enricher := discover.GetEnricher(string(providerType)); enricher != nil {
-					models, _ = enricher.EnrichModels(discoverCtx, cfg, resolver, models)
-				}
-			}
-			mu.Lock()
-			discoveryResults[id] = discoveryResult{models: models, err: err}
-			mu.Unlock()
-		})
+		store.userConfiguredModels[id] = slices.Clone(pc.Models)
 	}
-	wg.Wait()
+
+	// Per-provider errors are logged by the helper; providers that fail
+	// with no user models to fall back on are recorded below so the
+	// interactive reload can retry them.
+	discoverCtx, discoverCancel := context.WithTimeout(ctx, loadModelDiscoveryTimeout)
+	discoveryResults, _ := discoverProviderModels(discoverCtx, candidates, knownProviderNames, resolver)
 	discoverCancel()
 
 	// Validate the custom providers.
@@ -444,22 +421,23 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 			continue
 		}
 
-		// Apply discovery results if available.
-		if result, ok := discoveryResults[id]; ok {
-			if result.err != nil {
-				slog.Warn("Model discovery failed", "provider", id, "error", result.err)
-				if len(providerConfig.Models) == 0 {
-					slog.Warn("Skipping provider with no models after failed discovery", "provider", id)
-					c.Providers.Del(id)
-					continue
-				}
-			} else if len(result.models) > 0 {
-				providerConfig.Models = result.models
-				slog.Info("Discovered models for provider", "provider", id, "count", len(result.models))
-			}
+		// Apply discovery results if available. discoverProviderModels
+		// returns entries only for providers whose discovery succeeded;
+		// failures (and empty results) fall through to the no-models
+		// check below, which drops the provider when it has no
+		// user-specified models to fall back on.
+		if models, ok := discoveryResults[id]; ok && len(models) > 0 {
+			providerConfig.Models = models
+			slog.Info("Discovered models for provider", "provider", id, "count", len(models))
 		}
 
 		if len(providerConfig.Models) == 0 {
+			// Remember discovery-eligible providers dropped here so an
+			// interactive reload can resurrect them once their endpoint
+			// comes up (e.g. Crush started before Ollama was running).
+			if providerWantsDiscovery(providerConfig, store.userConfiguredModels[id]) {
+				store.failedDiscoveryProviders[id] = providerConfig
+			}
 			slog.Warn("Skipping custom provider because the provider has no models", "provider", id)
 			c.Providers.Del(id)
 			continue

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"charm.land/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/agent/hyper"
@@ -211,20 +210,21 @@ func PushPopCrushEnv() func() {
 }
 
 func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env env.Env, resolver VariableResolver, knownProviders []catwalk.Provider) error {
-	knownProviderNames := make(map[string]bool)
 	restore := PushPopCrushEnv()
 	defer restore()
 
 	// When disable_default_providers is enabled, skip all default/embedded
 	// providers entirely. Users must fully specify any providers they want.
 	// We skip to the custom provider validation loop which handles all
-	// user-configured providers uniformly.
+	// user-configured providers uniformly. knownProviderNameSet mirrors
+	// this policy so the interactive discovery reload agrees with load on
+	// which providers count as custom.
+	knownProviderNames := knownProviderNameSet(knownProviders, c.Options.DisableDefaultProviders)
 	if c.Options.DisableDefaultProviders {
 		knownProviders = nil
 	}
 
 	for _, p := range knownProviders {
-		knownProviderNames[string(p.ID)] = true
 		config, configExists := c.Providers.Get(string(p.ID))
 		// if the user configured a known provider we need to allow it to override a couple of parameters
 		if configExists {
@@ -382,50 +382,27 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 	// Discover models concurrently for custom providers that need it.
 	// A provider needs discovery when discover_models is explicitly true,
 	// or when the models list is empty (auto-trigger, unless opted out).
-	type discoveryResult struct {
-		models []catwalk.Model
-		err    error
-	}
-
-	discoveryResults := make(map[string]discoveryResult)
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-
-	discoverCtx, discoverCancel := context.WithTimeout(ctx, 3*time.Second)
-	for id, pc := range c.Providers.Seq2() {
+	// The same helper backs the interactive reload; see discovery.go.
+	//
+	// Record each custom provider's user-configured models first, before
+	// discovery merges endpoint models into the live config: the reload
+	// seeds re-discovery from this set so endpoint-removed models get
+	// pruned while user-specified ones survive.
+	store.userConfiguredModels = make(map[string][]catwalk.Model)
+	store.failedDiscoveryProviders = make(map[string]ProviderConfig)
+	candidates := maps.Collect(c.Providers.Seq2())
+	for id, pc := range candidates {
 		if knownProviderNames[id] {
 			continue
 		}
-		if pc.Disable || pc.BaseURL == "" {
-			continue
-		}
-		wantsDiscovery := pc.AutoDiscoverModels != nil && *pc.AutoDiscoverModels
-		autoTrigger := len(pc.Models) == 0 && (pc.AutoDiscoverModels == nil || *pc.AutoDiscoverModels)
-		if !wantsDiscovery && !autoTrigger {
-			continue
-		}
-		providerID := cmp.Or(pc.ID, id)
-		cfg := discover.Config{
-			ID:             providerID,
-			BaseURL:        pc.BaseURL,
-			APIKey:         pc.APIKey,
-			ExtraHeaders:   pc.ExtraHeaders,
-			ExistingModels: pc.Models,
-		}
-		providerType := cmp.Or(pc.Type, catwalk.TypeOpenAICompat)
-		wg.Go(func() {
-			models, err := discover.DiscoverModels(discoverCtx, cfg, resolver)
-			if err == nil && len(models) > 0 {
-				if enricher := discover.GetEnricher(string(providerType)); enricher != nil {
-					models, _ = enricher.EnrichModels(discoverCtx, cfg, resolver, models)
-				}
-			}
-			mu.Lock()
-			discoveryResults[id] = discoveryResult{models: models, err: err}
-			mu.Unlock()
-		})
+		store.userConfiguredModels[id] = slices.Clone(pc.Models)
 	}
-	wg.Wait()
+
+	// Per-provider errors are logged by the helper; providers that fail
+	// with no user models to fall back on are recorded below so the
+	// interactive reload can retry them.
+	discoverCtx, discoverCancel := context.WithTimeout(ctx, loadModelDiscoveryTimeout)
+	discoveryResults, _ := discoverProviderModels(discoverCtx, candidates, knownProviderNames, resolver)
 	discoverCancel()
 
 	// Validate the custom providers.
@@ -461,22 +438,23 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 			continue
 		}
 
-		// Apply discovery results if available.
-		if result, ok := discoveryResults[id]; ok {
-			if result.err != nil {
-				slog.Warn("Model discovery failed", "provider", id, "error", result.err)
-				if len(providerConfig.Models) == 0 {
-					slog.Warn("Skipping provider with no models after failed discovery", "provider", id)
-					c.Providers.Del(id)
-					continue
-				}
-			} else if len(result.models) > 0 {
-				providerConfig.Models = result.models
-				slog.Info("Discovered models for provider", "provider", id, "count", len(result.models))
-			}
+		// Apply discovery results if available. discoverProviderModels
+		// returns entries only for providers whose discovery succeeded;
+		// failures (and empty results) fall through to the no-models
+		// check below, which drops the provider when it has no
+		// user-specified models to fall back on.
+		if models, ok := discoveryResults[id]; ok && len(models) > 0 {
+			providerConfig.Models = models
+			slog.Info("Discovered models for provider", "provider", id, "count", len(models))
 		}
 
 		if len(providerConfig.Models) == 0 {
+			// Remember discovery-eligible providers dropped here so an
+			// interactive reload can resurrect them once their endpoint
+			// comes up (e.g. Crush started before Ollama was running).
+			if providerWantsDiscovery(providerConfig, store.userConfiguredModels[id]) {
+				store.failedDiscoveryProviders[id] = providerConfig
+			}
 			slog.Warn("Skipping custom provider because the provider has no models", "provider", id)
 			c.Providers.Del(id)
 			continue

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -81,6 +81,21 @@ type ConfigStore struct {
 	trackedConfigPaths []string                // unique, normalized config file paths
 	snapshots          map[string]fileSnapshot // path -> snapshot at last capture
 
+	// userConfiguredModels records, per custom provider, the models the
+	// user explicitly listed in config, captured by configureProviders
+	// before load-time discovery merges endpoint models into the live
+	// provider config. ReloadModelDiscovery seeds re-discovery from this
+	// set so endpoint-removed models get pruned while user-specified
+	// models survive. Guarded by writeMu.
+	userConfiguredModels map[string][]catwalk.Model
+
+	// failedDiscoveryProviders records custom providers dropped during
+	// configureProviders because model discovery failed (or found
+	// nothing) and they had no user-specified models to fall back on.
+	// ReloadModelDiscovery retries them and resurrects any that succeed.
+	// Guarded by writeMu.
+	failedDiscoveryProviders map[string]ProviderConfig
+
 	// configMu guards the config pointer field against concurrent
 	// readers (Config) and the writeMu-serialised swap (setConfig). It
 	// protects the pointer word only; the pointed-to Config is treated

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -99,6 +99,21 @@ type ConfigStore struct {
 	trackedConfigPaths []string                // unique, normalized config file paths
 	snapshots          map[string]fileSnapshot // path -> snapshot at last capture
 
+	// userConfiguredModels records, per custom provider, the models the
+	// user explicitly listed in config, captured by configureProviders
+	// before load-time discovery merges endpoint models into the live
+	// provider config. ReloadModelDiscovery seeds re-discovery from this
+	// set so endpoint-removed models get pruned while user-specified
+	// models survive. Guarded by writeMu.
+	userConfiguredModels map[string][]catwalk.Model
+
+	// failedDiscoveryProviders records custom providers dropped during
+	// configureProviders because model discovery failed (or found
+	// nothing) and they had no user-specified models to fall back on.
+	// ReloadModelDiscovery retries them and resurrects any that succeed.
+	// Guarded by writeMu.
+	failedDiscoveryProviders map[string]ProviderConfig
+
 	// configMu guards the config pointer field against concurrent
 	// readers (Config) and the writeMu-serialised swap (setConfig). It
 	// protects the pointer word only; the pointed-to Config is treated

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -102,6 +102,13 @@ type ReadSkillResponse struct {
 	Result  SkillReadResult `json:"result"`
 }
 
+// ReloadModelDiscoveryResponse is the response for re-running model
+// discovery. Added reports how many models were newly discovered across all
+// providers.
+type ReloadModelDiscoveryResponse struct {
+	Added int `json:"added"`
+}
+
 // SkillReadResult holds metadata about a skill returned alongside its
 // content.
 type SkillReadResult struct {

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -105,6 +105,13 @@ type ReadSkillResponse struct {
 	Result  SkillReadResult `json:"result"`
 }
 
+// ReloadModelDiscoveryResponse is the response for re-running model
+// discovery. Added reports how many models were newly discovered across all
+// providers.
+type ReloadModelDiscoveryResponse struct {
+	Added int `json:"added"`
+}
+
 // SkillReadResult holds metadata about a skill returned alongside its
 // content.
 type SkillReadResult struct {

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -317,6 +317,25 @@ func (c *controllerV1) handlePostWorkspaceSkillRead(w http.ResponseWriter, r *ht
 	jsonEncode(w, proto.ReadSkillResponse{Content: content, Result: result})
 }
 
+// handlePostWorkspaceConfigReloadDiscovery re-runs model discovery.
+//
+//	@Summary		Reload model discovery
+//	@Tags			config
+//	@Param			id	path		string	true	"Workspace ID"
+//	@Success		200	{object}	proto.ReloadModelDiscoveryResponse
+//	@Failure		404	{object}	proto.Error
+//	@Failure		500	{object}	proto.Error
+//	@Router			/workspaces/{id}/config/reload-discovery [post]
+func (c *controllerV1) handlePostWorkspaceConfigReloadDiscovery(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	added, err := c.backend.ReloadModelDiscovery(r.Context(), id)
+	if err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	jsonEncode(w, proto.ReloadModelDiscoveryResponse{Added: added})
+}
+
 // handlePostWorkspaceMCPEnableDocker enables the Docker MCP server.
 //
 //	@Summary		Enable Docker MCP

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -205,6 +205,7 @@ func (s *Server) installHandler() {
 	mux.HandleFunc("GET /v1/workspaces/{id}/project/init-prompt", c.handleGetWorkspaceProjectInitPrompt)
 	mux.HandleFunc("GET /v1/workspaces/{id}/skills", c.handleGetWorkspaceSkills)
 	mux.HandleFunc("POST /v1/workspaces/{id}/skills/read", c.handlePostWorkspaceSkillRead)
+	mux.HandleFunc("POST /v1/workspaces/{id}/config/reload-discovery", c.handlePostWorkspaceConfigReloadDiscovery)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-tools", c.handlePostWorkspaceMCPRefreshTools)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/read-resource", c.handlePostWorkspaceMCPReadResource)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/get-prompt", c.handlePostWorkspaceMCPGetPrompt)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -213,6 +213,7 @@ func (s *Server) installHandler() {
 	mux.HandleFunc("GET /v1/workspaces/{id}/project/init-prompt", c.handleGetWorkspaceProjectInitPrompt)
 	mux.HandleFunc("GET /v1/workspaces/{id}/skills", c.handleGetWorkspaceSkills)
 	mux.HandleFunc("POST /v1/workspaces/{id}/skills/read", c.handlePostWorkspaceSkillRead)
+	mux.HandleFunc("POST /v1/workspaces/{id}/config/reload-discovery", c.handlePostWorkspaceConfigReloadDiscovery)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-tools", c.handlePostWorkspaceMCPRefreshTools)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/read-resource", c.handlePostWorkspaceMCPReadResource)
 	mux.HandleFunc("GET /v1/workspaces/{id}/mcp/prompts", c.handleGetWorkspaceMCPPrompts)

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -96,6 +96,10 @@ type (
 	ActionEnableDockerMCP struct{}
 	// ActionDisableDockerMCP is a message to disable Docker MCP.
 	ActionDisableDockerMCP struct{}
+	// ActionReloadModelDiscovery triggers model re-discovery for custom
+	// providers from the model selection dialog, picking up models that
+	// appeared after startup (e.g. an `ollama pull`) without a restart.
+	ActionReloadModelDiscovery struct{}
 )
 
 // Messages for API key input dialog.

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -97,6 +97,10 @@ type (
 	ActionEnableDockerMCP struct{}
 	// ActionDisableDockerMCP is a message to disable Docker MCP.
 	ActionDisableDockerMCP struct{}
+	// ActionReloadModelDiscovery triggers model re-discovery for custom
+	// providers from the model selection dialog, picking up models that
+	// appeared after startup (e.g. an `ollama pull`) without a restart.
+	ActionReloadModelDiscovery struct{}
 )
 
 // Messages for MCP OAuth authentication dialog.

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -84,6 +84,7 @@ type Models struct {
 		UpDown   key.Binding
 		Select   key.Binding
 		Edit     key.Binding
+		Reload   key.Binding
 		Next     key.Binding
 		Previous key.Binding
 		Close    key.Binding
@@ -127,6 +128,10 @@ func NewModels(com *common.Common, isOnboarding bool) (*Models, error) {
 	m.keyMap.Edit = key.NewBinding(
 		key.WithKeys("ctrl+e"),
 		key.WithHelp("ctrl+e", "edit"),
+	)
+	m.keyMap.Reload = key.NewBinding(
+		key.WithKeys("ctrl+r"),
+		key.WithHelp("ctrl+r", "reload"),
 	)
 	m.keyMap.UpDown = key.NewBinding(
 		key.WithKeys("up", "down"),
@@ -202,6 +207,8 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 				ModelType:      modelItem.SelectedModelType(),
 				ReAuthenticate: isEdit,
 			}
+		case key.Matches(msg, m.keyMap.Reload):
+			return ActionReloadModelDiscovery{}
 		case key.Matches(msg, m.keyMap.Tab):
 			if m.isOnboarding {
 				break
@@ -313,7 +320,7 @@ func (m *Models) ShortHelp() []key.Binding {
 	if m.isSelectedConfigured() {
 		h = append(h, m.keyMap.Edit)
 	}
-	h = append(h, m.keyMap.Close)
+	h = append(h, m.keyMap.Reload, m.keyMap.Close)
 	return h
 }
 
@@ -493,6 +500,26 @@ func (m *Models) setProviderItems() error {
 		m.input.Placeholder = m.modelType.Placeholder()
 	}
 
+	return nil
+}
+
+// ReloadItems rebuilds the model list from the current config, preserving the
+// active filter query. It is called after a model-discovery reload so newly
+// discovered models appear without closing the dialog.
+func (m *Models) ReloadItems() error {
+	if err := m.setProviderItems(); err != nil {
+		return err
+	}
+	// setProviderItems repopulates the full item set; re-apply the filter
+	// the user had typed so the view doesn't jump back to the full list.
+	// Mirror the typing path: filtering invalidates the previous
+	// selection, so select the first match rather than leaving the cursor
+	// on an arbitrary (possibly hidden) item.
+	if query := m.input.Value(); query != "" {
+		m.list.SetFilter(query)
+		m.list.SelectFirst()
+		m.list.ScrollToTop()
+	}
 	return nil
 }
 

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -85,6 +85,7 @@ type Models struct {
 		UpDown   key.Binding
 		Select   key.Binding
 		Edit     key.Binding
+		Reload   key.Binding
 		Next     key.Binding
 		Previous key.Binding
 		Close    key.Binding
@@ -128,6 +129,10 @@ func NewModels(com *common.Common, isOnboarding bool) (*Models, error) {
 	m.keyMap.Edit = key.NewBinding(
 		key.WithKeys("ctrl+e"),
 		key.WithHelp("ctrl+e", "edit"),
+	)
+	m.keyMap.Reload = key.NewBinding(
+		key.WithKeys("ctrl+r"),
+		key.WithHelp("ctrl+r", "reload"),
 	)
 	m.keyMap.UpDown = key.NewBinding(
 		key.WithKeys("up", "down"),
@@ -208,6 +213,8 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 				ModelType:      modelItem.SelectedModelType(),
 				ReAuthenticate: isEdit,
 			}
+		case key.Matches(msg, m.keyMap.Reload):
+			return ActionReloadModelDiscovery{}
 		case key.Matches(msg, m.keyMap.Tab):
 			if m.isOnboarding {
 				break
@@ -319,7 +326,7 @@ func (m *Models) ShortHelp() []key.Binding {
 	if m.isSelectedConfigured() {
 		h = append(h, m.keyMap.Edit)
 	}
-	h = append(h, m.keyMap.Close)
+	h = append(h, m.keyMap.Reload, m.keyMap.Close)
 	return h
 }
 
@@ -499,6 +506,26 @@ func (m *Models) setProviderItems() error {
 		m.input.Placeholder = m.modelType.Placeholder()
 	}
 
+	return nil
+}
+
+// ReloadItems rebuilds the model list from the current config, preserving the
+// active filter query. It is called after a model-discovery reload so newly
+// discovered models appear without closing the dialog.
+func (m *Models) ReloadItems() error {
+	if err := m.setProviderItems(); err != nil {
+		return err
+	}
+	// setProviderItems repopulates the full item set; re-apply the filter
+	// the user had typed so the view doesn't jump back to the full list.
+	// Mirror the typing path: filtering invalidates the previous
+	// selection, so select the first match rather than leaving the cursor
+	// on an arbitrary (possibly hidden) item.
+	if query := m.input.Value(); query != "" {
+		m.list.SetFilter(query)
+		m.list.SelectFirst()
+		m.list.ScrollToTop()
+	}
 	return nil
 }
 

--- a/internal/ui/dialog/models_test.go
+++ b/internal/ui/dialog/models_test.go
@@ -1,0 +1,79 @@
+package dialog
+
+import (
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+type stubModelsWorkspace struct {
+	workspace.Workspace
+	cfg *config.Config
+}
+
+func (w *stubModelsWorkspace) Config() *config.Config {
+	return w.cfg
+}
+
+func newTestModelsDialog(t *testing.T) *Models {
+	t.Helper()
+	s := styles.CharmtonePantera()
+	cfg := &config.Config{
+		// Keep config.Providers offline and deterministic in tests.
+		Options: &config.Options{DisableDefaultProviders: true},
+		Models: map[config.SelectedModelType]config.SelectedModel{
+			config.SelectedModelTypeLarge: {Provider: "custom", Model: "beta-model"},
+		},
+		Providers: csync.NewMapFrom(map[string]config.ProviderConfig{
+			"custom": {
+				ID:      "custom",
+				Name:    "Custom",
+				BaseURL: "http://localhost:0/v1",
+				Models: []catwalk.Model{
+					{ID: "alpha-model", Name: "Alpha"},
+					{ID: "beta-model", Name: "Beta"},
+				},
+			},
+		}),
+	}
+	com := &common.Common{
+		Workspace: &stubModelsWorkspace{cfg: cfg},
+		Styles:    &s,
+	}
+	d, err := NewModels(com, false)
+	require.NoError(t, err)
+	return d
+}
+
+func TestModelsDialog_ReloadItemsFilteredSelectsFirstMatch(t *testing.T) {
+	d := newTestModelsDialog(t)
+
+	// The current model (beta-model) is selected when the dialog opens;
+	// the user then types a filter that hides it.
+	d.input.SetValue("alpha")
+	d.list.SetFilter("alpha")
+
+	require.NoError(t, d.ReloadItems())
+
+	item, ok := d.list.SelectedItem().(*ModelItem)
+	require.True(t, ok, "a model item should be selected after a filtered reload")
+	require.Equal(t, "alpha-model", item.SelectedModel().Model,
+		"filtered reload must select the first visible match, not a hidden item")
+}
+
+func TestModelsDialog_ReloadItemsNoFilterKeepsCurrentModel(t *testing.T) {
+	d := newTestModelsDialog(t)
+
+	require.NoError(t, d.ReloadItems())
+
+	item, ok := d.list.SelectedItem().(*ModelItem)
+	require.True(t, ok)
+	require.Equal(t, "beta-model", item.SelectedModel().Model,
+		"without a filter the current model stays selected")
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -174,6 +174,15 @@ type (
 	creditsUpdatedMsg struct {
 		credits int
 	}
+
+	// modelsDiscoveryReloadedMsg is sent after a model-discovery reload
+	// triggered from the /models dialog completes. It carries the number of
+	// newly discovered models (or an error) so the dialog can refresh its
+	// list and the user can be told what happened.
+	modelsDiscoveryReloadedMsg struct {
+		added int
+		err   error
+	}
 )
 
 // UI represents the main user interface model.
@@ -1186,6 +1195,32 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case creditsUpdatedMsg:
 		m.hyperCredits = &msg.credits
+	case modelsDiscoveryReloadedMsg:
+		if msg.err != nil {
+			cmds = append(cmds, util.ReportError(msg.err))
+			break
+		}
+		if msg.added == 0 {
+			// Nothing was added, so skip the list rebuild. (Enrichment
+			// could in theory tweak metadata on existing models, but that
+			// is not worth resetting the dialog's list state for.)
+			cmds = append(cmds, util.ReportInfo("No new models found"))
+			break
+		}
+		// Refresh the models dialog in place if it's still open.
+		if d := m.dialog.Dialog(dialog.ModelsID); d != nil {
+			if md, ok := d.(*dialog.Models); ok {
+				if err := md.ReloadItems(); err != nil {
+					cmds = append(cmds, util.ReportError(err))
+					break
+				}
+			}
+		}
+		label := "models"
+		if msg.added == 1 {
+			label = "model"
+		}
+		cmds = append(cmds, util.ReportInfo(fmt.Sprintf("Discovered %d new %s", msg.added, label)))
 	case util.InfoMsg:
 		if msg.Type == util.InfoTypeError {
 			slog.Error("Error reported", "error", msg.Msg)
@@ -1814,6 +1849,11 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		}
 		cmds = append(cmds, m.initializeProject())
 		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionReloadModelDiscovery:
+		// Keep the dialog open; run discovery in the background and refresh
+		// the list when the result arrives (modelsDiscoveryReloadedMsg).
+		cmds = append(cmds, util.ReportInfo("Reloading models…"))
+		cmds = append(cmds, m.reloadModelDiscovery)
 
 	case dialog.ActionSelectModel:
 		if cmd := m.handleSelectModel(msg); cmd != nil {
@@ -1944,6 +1984,14 @@ func (m *UI) refreshHyperAndRetrySelect(msg dialog.ActionSelectModel) tea.Cmd {
 		}
 		return hyperRefreshDoneMsg{action: msg}
 	}
+}
+
+// reloadModelDiscovery re-runs provider model discovery and reports the
+// outcome back to the update loop as a modelsDiscoveryReloadedMsg. It is
+// used as a tea.Cmd.
+func (m *UI) reloadModelDiscovery() tea.Msg {
+	added, err := m.com.Workspace.ReloadModelDiscovery(context.Background())
+	return modelsDiscoveryReloadedMsg{added: added, err: err}
 }
 
 // fetchHyperCredits returns a command that asynchronously fetches the

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -176,6 +176,15 @@ type (
 	creditsUpdatedMsg struct {
 		credits *int
 	}
+
+	// modelsDiscoveryReloadedMsg is sent after a model-discovery reload
+	// triggered from the /models dialog completes. It carries the number of
+	// newly discovered models (or an error) so the dialog can refresh its
+	// list and the user can be told what happened.
+	modelsDiscoveryReloadedMsg struct {
+		added int
+		err   error
+	}
 )
 
 // UI represents the main user interface model.
@@ -1317,6 +1326,32 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	case creditsUpdatedMsg:
 		m.hyperCredits = msg.credits
+	case modelsDiscoveryReloadedMsg:
+		if msg.err != nil {
+			cmds = append(cmds, util.ReportError(msg.err))
+			break
+		}
+		if msg.added == 0 {
+			// Nothing was added, so skip the list rebuild. (Enrichment
+			// could in theory tweak metadata on existing models, but that
+			// is not worth resetting the dialog's list state for.)
+			cmds = append(cmds, util.ReportInfo("No new models found"))
+			break
+		}
+		// Refresh the models dialog in place if it's still open.
+		if d := m.dialog.Dialog(dialog.ModelsID); d != nil {
+			if md, ok := d.(*dialog.Models); ok {
+				if err := md.ReloadItems(); err != nil {
+					cmds = append(cmds, util.ReportError(err))
+					break
+				}
+			}
+		}
+		label := "models"
+		if msg.added == 1 {
+			label = "model"
+		}
+		cmds = append(cmds, util.ReportInfo(fmt.Sprintf("Discovered %d new %s", msg.added, label)))
 	case util.InfoMsg:
 		if msg.Type == util.InfoTypeError {
 			slog.Error("Error reported", "error", msg.Msg)
@@ -1996,6 +2031,11 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		}
 		cmds = append(cmds, m.initializeProject())
 		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionReloadModelDiscovery:
+		// Keep the dialog open; run discovery in the background and refresh
+		// the list when the result arrives (modelsDiscoveryReloadedMsg).
+		cmds = append(cmds, util.ReportInfo("Reloading models…"))
+		cmds = append(cmds, m.reloadModelDiscovery)
 
 	case dialog.ActionSelectModel:
 		if cmd := m.handleSelectModel(msg); cmd != nil {
@@ -2126,6 +2166,14 @@ func (m *UI) refreshHyperAndRetrySelect(msg dialog.ActionSelectModel) tea.Cmd {
 		}
 		return hyperRefreshDoneMsg{action: msg}
 	}
+}
+
+// reloadModelDiscovery re-runs provider model discovery and reports the
+// outcome back to the update loop as a modelsDiscoveryReloadedMsg. It is
+// used as a tea.Cmd.
+func (m *UI) reloadModelDiscovery() tea.Msg {
+	added, err := m.com.Workspace.ReloadModelDiscovery(context.Background())
+	return modelsDiscoveryReloadedMsg{added: added, err: err}
 }
 
 // fetchHyperCredits returns a command that asynchronously fetches the

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -392,6 +392,10 @@ func (w *AppWorkspace) ReadSkill(_ context.Context, skillID string) ([]byte, ski
 	return skills.ReadContent(mgr.ActiveSkills(), mgr.ResolvedPaths(), mgr.WorkingDir(), skillID)
 }
 
+func (w *AppWorkspace) ReloadModelDiscovery(ctx context.Context) (int, error) {
+	return w.store.ReloadModelDiscovery(ctx)
+}
+
 // -- MCP operations --
 
 func (w *AppWorkspace) MCPGetStates() map[string]mcptools.ClientInfo {

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -399,6 +399,10 @@ func (w *AppWorkspace) ReadSkill(_ context.Context, skillID string) ([]byte, ski
 	return skills.ReadContent(mgr.ActiveSkills(), mgr.ResolvedPaths(), mgr.WorkingDir(), skillID)
 }
 
+func (w *AppWorkspace) ReloadModelDiscovery(ctx context.Context) (int, error) {
+	return w.store.ReloadModelDiscovery(ctx)
+}
+
 // -- MCP operations --
 
 func (w *AppWorkspace) MCPGetStates() map[string]mcptools.ClientInfo {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -69,12 +69,21 @@ func NewClientWorkspace(c *client.Client, ws proto.Workspace) *ClientWorkspace {
 }
 
 // refreshWorkspace re-fetches the workspace from the server, updating
-// the cached snapshot. Called after config-mutating operations.
+// the cached snapshot. Called after config-mutating operations. Failures
+// are logged only; callers that must surface them use
+// refreshWorkspaceErr instead.
 func (w *ClientWorkspace) refreshWorkspace() {
+	if err := w.refreshWorkspaceErr(); err != nil {
+		slog.Error("Failed to refresh workspace", "error", err)
+	}
+}
+
+// refreshWorkspaceErr re-fetches the workspace from the server, updating
+// the cached snapshot, and returns any fetch error to the caller.
+func (w *ClientWorkspace) refreshWorkspaceErr() error {
 	updated, err := w.client.GetWorkspace(context.Background(), w.workspaceID())
 	if err != nil {
-		slog.Error("Failed to refresh workspace", "error", err)
-		return
+		return err
 	}
 	if updated.Config != nil {
 		updated.Config.SetupAgents()
@@ -82,6 +91,7 @@ func (w *ClientWorkspace) refreshWorkspace() {
 	w.mu.Lock()
 	w.ws = *updated
 	w.mu.Unlock()
+	return nil
 }
 
 // cached returns a snapshot of the cached workspace.
@@ -579,6 +589,25 @@ func (w *ClientWorkspace) ReadSkill(ctx context.Context, skillID string) ([]byte
 		Source:      skills.SourceType(resp.Result.Source),
 		Builtin:     resp.Result.Builtin,
 	}, nil
+}
+
+func (w *ClientWorkspace) ReloadModelDiscovery(ctx context.Context) (int, error) {
+	added, err := w.client.ReloadModelDiscovery(ctx, w.workspaceID())
+	if err != nil {
+		return added, err
+	}
+	if added == 0 {
+		// Nothing changed server-side, so the cached snapshot is
+		// already current.
+		return 0, nil
+	}
+	// Pull the server's updated config so the newly discovered models are
+	// visible in this client's cached view (e.g. the /models dialog). A
+	// stale snapshot must not masquerade as success.
+	if err := w.refreshWorkspaceErr(); err != nil {
+		return added, fmt.Errorf("reload succeeded but refreshing workspace failed: %w", err)
+	}
+	return added, nil
 }
 
 // -- MCP operations --

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -102,12 +102,21 @@ func NewClientWorkspace(c *client.Client, ws proto.Workspace) *ClientWorkspace {
 }
 
 // refreshWorkspace re-fetches the workspace from the server, updating
-// the cached snapshot. Called after config-mutating operations.
+// the cached snapshot. Called after config-mutating operations. Failures
+// are logged only; callers that must surface them use
+// refreshWorkspaceErr instead.
 func (w *ClientWorkspace) refreshWorkspace() {
+	if err := w.refreshWorkspaceErr(); err != nil {
+		slog.Error("Failed to refresh workspace", "error", err)
+	}
+}
+
+// refreshWorkspaceErr re-fetches the workspace from the server, updating
+// the cached snapshot, and returns any fetch error to the caller.
+func (w *ClientWorkspace) refreshWorkspaceErr() error {
 	updated, err := w.client.GetWorkspace(context.Background(), w.workspaceID())
 	if err != nil {
-		slog.Error("Failed to refresh workspace", "error", err)
-		return
+		return err
 	}
 	if updated.Config != nil {
 		updated.Config.SetupAgents()
@@ -115,6 +124,7 @@ func (w *ClientWorkspace) refreshWorkspace() {
 	w.mu.Lock()
 	w.ws = *updated
 	w.mu.Unlock()
+	return nil
 }
 
 // cached returns a snapshot of the cached workspace.
@@ -631,6 +641,25 @@ func (w *ClientWorkspace) ReadSkill(ctx context.Context, skillID string) ([]byte
 		Source:      skills.SourceType(resp.Result.Source),
 		Builtin:     resp.Result.Builtin,
 	}, nil
+}
+
+func (w *ClientWorkspace) ReloadModelDiscovery(ctx context.Context) (int, error) {
+	added, err := w.client.ReloadModelDiscovery(ctx, w.workspaceID())
+	if err != nil {
+		return added, err
+	}
+	if added == 0 {
+		// Nothing changed server-side, so the cached snapshot is
+		// already current.
+		return 0, nil
+	}
+	// Pull the server's updated config so the newly discovered models are
+	// visible in this client's cached view (e.g. the /models dialog). A
+	// stale snapshot must not masquerade as success.
+	if err := w.refreshWorkspaceErr(); err != nil {
+		return added, fmt.Errorf("reload succeeded but refreshing workspace failed: %w", err)
+	}
+	return added, nil
 }
 
 // -- MCP operations --

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -156,6 +156,10 @@ type Workspace interface {
 	InitializePrompt() (string, error)
 	ListSkills(ctx context.Context) ([]skills.CatalogEntry, error)
 	ReadSkill(ctx context.Context, skillID string) ([]byte, skills.SkillReadResult, error)
+	// ReloadModelDiscovery re-runs model discovery for custom providers and
+	// merges any newly found models into the in-memory config. It returns
+	// the number of models added across all providers.
+	ReloadModelDiscovery(ctx context.Context) (int, error)
 
 	// MCP operations (server-side in client mode)
 	MCPGetStates() map[string]mcptools.ClientInfo

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -216,6 +216,10 @@ type Workspace interface {
 	InitializePrompt() (string, error)
 	ListSkills(ctx context.Context) ([]skills.CatalogEntry, error)
 	ReadSkill(ctx context.Context, skillID string) ([]byte, skills.SkillReadResult, error)
+	// ReloadModelDiscovery re-runs model discovery for custom providers and
+	// merges any newly found models into the in-memory config. It returns
+	// the number of models added across all providers.
+	ReloadModelDiscovery(ctx context.Context) (int, error)
 
 	// MCP operations (server-side in client mode)
 	MCPGetStates() map[string]mcptools.ClientInfo


### PR DESCRIPTION
Posted by `@joestump-agent` at `@joestump`'s direction.

## What & why

There's currently no way to reload model discovery without restarting Crush. Local providers — Ollama, LM Studio, llama.cpp, LiteLLM, etc. — can gain models at runtime (an `ollama pull` mid-session), but discovery only runs at startup, so newly pulled models stay invisible until you quit and relaunch.

This adds a **`ctrl+r` "reload"** action to the `/models` dialog that re-runs model discovery for custom providers, merges any newly found models into the in-memory config, refreshes the list **in place** (preserving whatever you've typed as a filter), and reports how many models turned up.

## How it works

- **Shared discovery helper.** The concurrent discovery loop is factored out of `configureProviders` into `discoverProviderModels` (`internal/config/discovery.go`) so load-time discovery and interactive reload stay in lockstep. Load keeps its original trigger semantics; reload *forces* discovery for every custom provider that hasn't opted out via `discover_models: false`.
- **`ConfigStore.ReloadModelDiscovery(ctx) (int, error)`** re-runs discovery (10s timeout), merges results, and returns the count of newly added models. Like startup discovery, results are **ephemeral** — recomputed each time, never persisted to disk.
- **Dialog UX.** `ctrl+r` → `ActionReloadModelDiscovery` → background reload → the list rebuilds via a new `Models.ReloadItems()` that re-applies the active filter. A toast reports `Discovered N new models` / `No new models found`. The dialog stays open throughout.
- **Both runtime modes.** Wired through the `Workspace` interface: `AppWorkspace` calls the store directly; `ClientWorkspace` proxies to a new `POST /v1/workspaces/{id}/config/reload-discovery` endpoint and then refreshes its cached config so the client's dialog sees the new models.

## Scope

This reloads **custom/local provider discovery** (the `discover` package) — the case where models genuinely appear at runtime. It does not re-fetch the known/catwalk (models.dev) provider list, which is memoized per-process and is a separate concern.

## Testing

- New `internal/config/discovery_test.go`: `providerWantsDiscovery` trigger matrix (load vs. force/reload), an end-to-end reload against an `httptest` server whose model list grows between passes (verifies the new model is picked up, `added` count is correct, and user-specified model metadata is preserved), and an opt-out (`discover_models: false`) test asserting the provider is never queried.
- New `internal/ui/dialog/models_test.go` covering `ReloadItems()` filter preservation.
- `go build ./...`, `go vet`, and `gofmt` clean; `internal/config`, `discover`, `ui/dialog`, `workspace`, `server`, and `client` package tests pass.

💘 Generated with Crush

Assisted-by: Claude Fable 5