### PR TITLE
feat: add configurable allowed_commands for the bash tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,44 @@ permissions. Use this with care.
 permissions allow view ls grep edit mcp_context7_get-library-doc
 ```
 
+### Allowing Blocked Commands
+
+The `bash` tool blocks a set of potentially dangerous commands by default (for
+example `ssh`, `curl`, `systemctl`, and various package managers). You can
+selectively remove commands from that blocklist with `options.allowed_commands`:
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "options": {
+    "allowed_commands": ["ssh", "curl", "scp"]
+  }
+}
+```
+
+The same can be set for a single session via CLI flags or environment variables
+(flags take precedence over the environment variables):
+
+```bash
+# Allow specific commands (repeatable flag, or a comma-separated env var).
+crush --allow-commands ssh --allow-commands curl
+CRUSH_ALLOW_COMMANDS="ssh,curl,scp" crush
+
+# Remove every command restriction (dangerous).
+crush --allow-all-commands
+CRUSH_ALLOW_ALL_COMMANDS=1 crush
+```
+
+Two things to keep in mind:
+
+- `allowed_commands` only removes commands from the exact-command blocklist. It
+  does **not** unlock the package-manager argument blocks (such as `apt install`
+  or `npm -g`); use `allow_all_commands` (or `--allow-all-commands`) to remove
+  those as well.
+- Allowing a command does not auto-approve it. Blocked commands are simply a
+  hard filter in front of the normal permission flow, so an allowed command is
+  still subject to the usual permission prompt unless you also enable `--yolo`.
+
 ### Disabling Built-In Tools
 
 You can also deny tools, hiding then from the agent entirely:

--- a/README.md
+++ b/README.md
@@ -525,6 +525,44 @@ permissions. Use this with care.
 You can also skip all permission prompts entirely by running Crush with the
 `--yolo` flag. Be very, very careful with this feature.
 
+### Allowing Blocked Commands
+
+The `bash` tool blocks a set of potentially dangerous commands by default (for
+example `ssh`, `curl`, `systemctl`, and various package managers). You can
+selectively remove commands from that blocklist with `options.allowed_commands`:
+
+```json
+{
+  "$schema": "https://charm.land/crush.json",
+  "options": {
+    "allowed_commands": ["ssh", "curl", "scp"]
+  }
+}
+```
+
+The same can be set for a single session via CLI flags or environment variables
+(flags take precedence over the environment variables):
+
+```bash
+# Allow specific commands (repeatable flag, or a comma-separated env var).
+crush --allow-commands ssh --allow-commands curl
+CRUSH_ALLOW_COMMANDS="ssh,curl,scp" crush
+
+# Remove every command restriction (dangerous).
+crush --allow-all-commands
+CRUSH_ALLOW_ALL_COMMANDS=1 crush
+```
+
+Two things to keep in mind:
+
+- `allowed_commands` only removes commands from the exact-command blocklist. It
+  does **not** unlock the package-manager argument blocks (such as `apt install`
+  or `npm -g`); use `allow_all_commands` (or `--allow-all-commands`) to remove
+  those as well.
+- Allowing a command does not auto-approve it. Blocked commands are simply a
+  hard filter in front of the normal permission flow, so an allowed command is
+  still subject to the usual permission prompt unless you also enable `--yolo`.
+
 ### Disabling Built-In Tools
 
 If you'd like to prevent Crush from using certain built-in tools entirely, you

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ crush --allow-all-commands
 CRUSH_ALLOW_ALL_COMMANDS=1 crush
 ```
 
-Two things to keep in mind:
+Three things to keep in mind:
 
 - `allowed_commands` only removes commands from the exact-command blocklist. It
   does **not** unlock the package-manager argument blocks (such as `apt install`
@@ -562,6 +562,13 @@ Two things to keep in mind:
 - Allowing a command does not auto-approve it. Blocked commands are simply a
   hard filter in front of the normal permission flow, so an allowed command is
   still subject to the usual permission prompt unless you also enable `--yolo`.
+- The blocklist is a guardrail, not a sandbox. It matches the command name of
+  each command the shell actually runs, so chained and substituted commands
+  (`cd /tmp && curl …`, `CMD=curl; $CMD …`) are matched correctly — but anything
+  that reaches a binary through another program (`sh -c "curl …"`, `python -c`,
+  `make`, `find -exec`) is out of its reach by construction. Treat it as
+  protection against a model casually reaching for the wrong tool, not as a
+  security boundary around an untrusted one.
 
 ### Disabling Built-In Tools
 

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ crush --allow-all-commands
 CRUSH_ALLOW_ALL_COMMANDS=1 crush
 ```
 
-Two things to keep in mind:
+Three things to keep in mind:
 
 - `allowed_commands` only removes commands from the exact-command blocklist. It
   does **not** unlock the package-manager argument blocks (such as `apt install`
@@ -546,6 +546,13 @@ Two things to keep in mind:
 - Allowing a command does not auto-approve it. Blocked commands are simply a
   hard filter in front of the normal permission flow, so an allowed command is
   still subject to the usual permission prompt unless you also enable `--yolo`.
+- The blocklist is a guardrail, not a sandbox. It matches the command name of
+  each command the shell actually runs, so chained and substituted commands
+  (`cd /tmp && curl …`, `CMD=curl; $CMD …`) are matched correctly — but anything
+  that reaches a binary through another program (`sh -c "curl …"`, `python -c`,
+  `make`, `find -exec`) is out of its reach by construction. Treat it as
+  protection against a model casually reaching for the wrong tool, not as a
+  security boundary around an untrusted one.
 
 ### Disabling Built-In Tools
 

--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -167,7 +167,7 @@ func coderAgent(r *vcr.Recorder, env fakeEnv, large, small fantasy.LanguageModel
 	}
 
 	allTools := []fantasy.AgentTool{
-		tools.NewBashTool(env.permissions, env.workingDir, cfg.Config().Options.Attribution, modelName),
+		tools.NewBashTool(env.permissions, env.workingDir, cfg.Config().Options.Attribution, modelName, cfg.Config().Options.AllowedCommands, cfg.Config().Options.AllowAllCommands),
 		tools.NewDownloadTool(env.permissions, env.workingDir, r.GetDefaultClient()),
 		tools.NewEditTool(nil, env.permissions, env.history, *env.filetracker, env.workingDir),
 		tools.NewMultiEditTool(nil, env.permissions, env.history, *env.filetracker, env.workingDir),

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -704,6 +704,15 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 
 	logFile := filepath.Join(c.cfg.Config().Options.DataDirectory, "logs", "crush.log")
 
+	// Effective bash allow-list: config-file values plus any runtime overrides
+	// from --allow-commands / --allow-all-commands (or their env vars). The
+	// overrides live on the store rather than in Options so they survive the
+	// config reloads triggered by MCP reconnects and model changes.
+	bashOpts := c.cfg.Config().Options
+	bashOverrides := c.cfg.Overrides()
+	allowedCommands := append(append([]string{}, bashOpts.AllowedCommands...), bashOverrides.AllowedCommands...)
+	allowAllCommands := bashOpts.AllowAllCommands || bashOverrides.AllowAllCommands
+
 	// Build hook runner if PreToolUse hooks are configured.
 	var hookRunner *hooks.Runner
 	if preToolHooks := c.cfg.Config().Hooks[hooks.EventPreToolUse]; len(preToolHooks) > 0 {
@@ -712,7 +721,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 
 	allTools = append(
 		allTools,
-		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Options.Attribution, modelID),
+		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Options.Attribution, modelID, allowedCommands, allowAllCommands),
 		tools.NewCrushInfoTool(c.cfg, c.lspManager, c.allSkills, c.activeSkills, c.skillTracker),
 		tools.NewCrushLogsTool(logFile),
 		tools.NewJobOutputTool(),

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -145,8 +145,47 @@ var bannedCommands = []string{
 	"ufw",
 }
 
-func bashDescription(attribution *config.Attribution, modelID string) string {
-	bannedCommandsStr := strings.Join(bannedCommands, ", ")
+// effectiveBannedCommands returns the default banned command list with any
+// entries in allowed removed. The order of the defaults is preserved so the
+// tool description and the enforcement layer never drift apart.
+func effectiveBannedCommands(allowed []string) []string {
+	allowedSet := make(map[string]struct{}, len(allowed))
+	for _, cmd := range allowed {
+		allowedSet[cmd] = struct{}{}
+	}
+	effective := make([]string, 0, len(bannedCommands))
+	for _, cmd := range bannedCommands {
+		if _, ok := allowedSet[cmd]; !ok {
+			effective = append(effective, cmd)
+		}
+	}
+	return effective
+}
+
+// UnknownAllowedCommands returns the entries in allowed that are not present
+// in the default banned list. Such entries subtract nothing from the block
+// list and usually indicate a typo, so callers can warn about them.
+func UnknownAllowedCommands(allowed []string) []string {
+	bannedSet := make(map[string]struct{}, len(bannedCommands))
+	for _, cmd := range bannedCommands {
+		bannedSet[cmd] = struct{}{}
+	}
+	var unknown []string
+	for _, cmd := range allowed {
+		if _, ok := bannedSet[cmd]; !ok {
+			unknown = append(unknown, cmd)
+		}
+	}
+	return unknown
+}
+
+func bashDescription(attribution *config.Attribution, modelID string, allowedCommands []string, allowAllCommands bool) string {
+	// Build the effective banned list for display. When every command is
+	// allowed the block list is empty.
+	bannedCommandsStr := "(none - all commands allowed)"
+	if !allowAllCommands {
+		bannedCommandsStr = strings.Join(effectiveBannedCommands(allowedCommands), ", ")
+	}
 	var out bytes.Buffer
 	if err := bashDescriptionTpl.Execute(&out, bashDescriptionData{
 		BannedCommands:  bannedCommandsStr,
@@ -162,9 +201,16 @@ func bashDescription(attribution *config.Attribution, modelID string) string {
 	return out.String()
 }
 
-func blockFuncs() []shell.BlockFunc {
+func blockFuncs(allowedCommands []string, allowAllCommands bool) []shell.BlockFunc {
+	// If allowAllCommands is set, don't block any commands. Note this also
+	// removes the argument-level blockers below (apt install, npm -g, ...);
+	// allowed_commands only subtracts from the exact-command block list.
+	if allowAllCommands {
+		return []shell.BlockFunc{}
+	}
+
 	return []shell.BlockFunc{
-		shell.CommandsBlocker(bannedCommands),
+		shell.CommandsBlocker(effectiveBannedCommands(allowedCommands)),
 
 		// System package managers
 		shell.ArgumentsBlocker("apk", []string{"add"}, nil),
@@ -194,10 +240,10 @@ func blockFuncs() []shell.BlockFunc {
 	}
 }
 
-func NewBashTool(permissions permission.Service, workingDir string, attribution *config.Attribution, modelID string) fantasy.AgentTool {
+func NewBashTool(permissions permission.Service, workingDir string, attribution *config.Attribution, modelID string, allowedCommands []string, allowAllCommands bool) fantasy.AgentTool {
 	return fantasy.NewAgentTool(
 		BashToolName,
-		string(bashDescription(attribution, modelID)),
+		string(bashDescription(attribution, modelID, allowedCommands, allowAllCommands)),
 		func(ctx context.Context, params BashParams, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
 			if params.Command == "" {
 				return fantasy.NewTextErrorResponse("missing command"), nil
@@ -251,7 +297,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 				bgManager := shell.GetBackgroundShellManager()
 				bgManager.Cleanup()
 				// Use background context so it continues after tool returns
-				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(allowedCommands, allowAllCommands), params.Command, params.Description)
 				if err != nil {
 					return fantasy.ToolResponse{}, fmt.Errorf("error starting background shell: %w", err)
 				}
@@ -306,7 +352,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 			// Start with detached context so it can survive if moved to background
 			bgManager := shell.GetBackgroundShellManager()
 			bgManager.Cleanup()
-			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(allowedCommands, allowAllCommands), params.Command, params.Description)
 			if err != nil {
 				return fantasy.ToolResponse{}, fmt.Errorf("error starting shell: %w", err)
 			}

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -117,7 +117,7 @@ func (m *recordingPermissionService) SubscribeNotifications(ctx context.Context)
 func newBashToolForTest(workingDir string) fantasy.AgentTool {
 	permissions := &mockBashPermissionService{Broker: pubsub.NewBroker[permission.PermissionRequest]()}
 	attribution := &config.Attribution{TrailerStyle: config.TrailerStyleNone}
-	return NewBashTool(permissions, workingDir, attribution, "test-model")
+	return NewBashTool(permissions, workingDir, attribution, "test-model", nil, false)
 }
 
 func newBashToolWithRecordingPerms(workingDir string, allow bool) (fantasy.AgentTool, *recordingPermissionService) {
@@ -126,7 +126,7 @@ func newBashToolWithRecordingPerms(workingDir string, allow bool) (fantasy.Agent
 		allow:  allow,
 	}
 	attribution := &config.Attribution{TrailerStyle: config.TrailerStyleNone}
-	return NewBashTool(perms, workingDir, attribution, "test-model"), perms
+	return NewBashTool(perms, workingDir, attribution, "test-model", nil, false), perms
 }
 
 func TestBashTool_ChainedCommandsRequirePermission(t *testing.T) {
@@ -210,4 +210,55 @@ func TestTruncateOutputEmoji(t *testing.T) {
 	out := TruncateOutput(content)
 	require.True(t, utf8.ValidString(out), "truncated output must stay valid UTF-8")
 	require.Contains(t, out, "lines truncated")
+}
+
+func TestEffectiveBannedCommands(t *testing.T) {
+	t.Parallel()
+
+	// No allowances: the effective list matches the defaults exactly.
+	require.Equal(t, bannedCommands, effectiveBannedCommands(nil))
+
+	// Allowing a banned command removes it while preserving order and the
+	// rest of the list.
+	effective := effectiveBannedCommands([]string{"ssh", "curl"})
+	require.NotContains(t, effective, "ssh")
+	require.NotContains(t, effective, "curl")
+	require.Contains(t, effective, "systemctl")
+	require.Len(t, effective, len(bannedCommands)-2)
+
+	// Unknown allowances subtract nothing.
+	require.Equal(t, bannedCommands, effectiveBannedCommands([]string{"definitely-not-banned"}))
+}
+
+func TestUnknownAllowedCommands(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, UnknownAllowedCommands(nil))
+	require.Empty(t, UnknownAllowedCommands([]string{"ssh", "curl"}))
+	require.Equal(t, []string{"shh"}, UnknownAllowedCommands([]string{"ssh", "shh"}))
+}
+
+func TestBlockFuncs_AllowedCommandNotBlocked(t *testing.T) {
+	t.Parallel()
+
+	// By default, ssh is blocked by the first (commands) blocker.
+	require.True(t, blockFuncs(nil, false)[0]([]string{"ssh"}))
+
+	// Allowing ssh unblocks it, but a still-banned command stays blocked.
+	allowed := blockFuncs([]string{"ssh"}, false)
+	require.False(t, allowed[0]([]string{"ssh"}))
+	require.True(t, allowed[0]([]string{"systemctl"}))
+
+	// Allowing ssh does not touch the argument-level blockers (apt install).
+	stillBlocksAptInstall := false
+	for _, fn := range allowed {
+		if fn([]string{"apt", "install", "cowsay"}) {
+			stillBlocksAptInstall = true
+			break
+		}
+	}
+	require.True(t, stillBlocksAptInstall, "allowed_commands must not unlock package-manager argument blocks")
+
+	// allowAllCommands drops every blocker, including argument-level ones.
+	require.Empty(t, blockFuncs(nil, true))
 }

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/csync"
@@ -354,6 +355,11 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 
 	cfg.Overrides().SkipPermissionRequests = args.YOLO
 	cfg.Overrides().EnabledChannels = args.Channels
+	cfg.Overrides().AllowAllCommands = args.AllowAllCommands
+	cfg.Overrides().AllowedCommands = args.AllowedCommands
+	if unknown := tools.UnknownAllowedCommands(append(append([]string{}, cfg.Config().Options.AllowedCommands...), args.AllowedCommands...)); len(unknown) > 0 {
+		slog.Warn("Ignoring allow-commands entries not in the default banned list", "commands", unknown)
+	}
 
 	if err := createDotCrushDir(cfg.Config().Options.DataDirectory); err != nil {
 		return nil, proto.Workspace{}, fmt.Errorf("failed to create data directory: %w", err)
@@ -856,15 +862,17 @@ func validateClientID(id string) (string, error) {
 func workspaceToProto(ws *Workspace) proto.Workspace {
 	cfg := ws.Cfg.Config()
 	out := proto.Workspace{
-		ID:       ws.ID,
-		Path:     ws.Path,
-		YOLO:     ws.Cfg.Overrides().SkipPermissionRequests,
-		Channels: ws.Cfg.Overrides().EnabledChannels,
-		DataDir:  cfg.Options.DataDirectory,
-		Debug:    cfg.Options.Debug,
-		Config:   cfg,
-		Env:      ws.Env,
-		Version:  version.Version,
+		ID:               ws.ID,
+		Path:             ws.Path,
+		YOLO:             ws.Cfg.Overrides().SkipPermissionRequests,
+		Channels:         ws.Cfg.Overrides().EnabledChannels,
+		AllowAllCommands: ws.Cfg.Overrides().AllowAllCommands,
+		AllowedCommands:  ws.Cfg.Overrides().AllowedCommands,
+		DataDir:          cfg.Options.DataDirectory,
+		Debug:            cfg.Options.Debug,
+		Config:           cfg,
+		Env:              ws.Env,
+		Version:          version.Version,
 	}
 	if ws.Skills != nil {
 		out.Skills = skillStatesToProto(ws.Skills.States())
@@ -883,11 +891,14 @@ func workspaceToProto(ws *Workspace) proto.Workspace {
 // while the first set one will still log the mismatch.
 func logFirstWinsMismatch(existing *Workspace, args proto.Workspace) {
 	existingCfg := existing.Cfg.Config()
-	existingYOLO := existing.Cfg.Overrides().SkipPermissionRequests
-	existingChannels := existing.Cfg.Overrides().EnabledChannels
+	existingOverrides := existing.Cfg.Overrides()
+	existingYOLO := existingOverrides.SkipPermissionRequests
+	existingChannels := existingOverrides.EnabledChannels
 	if existingYOLO == args.YOLO &&
 		existingCfg.Options.Debug == args.Debug &&
 		existingCfg.Options.DataDirectory == args.DataDir &&
+		existingOverrides.AllowAllCommands == args.AllowAllCommands &&
+		stringSlicesEqual(existingOverrides.AllowedCommands, args.AllowedCommands) &&
 		stringSlicesEqual(existing.Env, args.Env) &&
 		stringSlicesEqual(existingChannels, args.Channels) {
 		return
@@ -902,6 +913,10 @@ func logFirstWinsMismatch(existing *Workspace, args proto.Workspace) {
 		"requested_debug", args.Debug,
 		"existing_data_dir", existingCfg.Options.DataDirectory,
 		"requested_data_dir", args.DataDir,
+		"existing_allow_all_commands", existingOverrides.AllowAllCommands,
+		"requested_allow_all_commands", args.AllowAllCommands,
+		"existing_allowed_commands", existingOverrides.AllowedCommands,
+		"requested_allowed_commands", args.AllowedCommands,
 		"existing_env", existing.Env,
 		"requested_env", args.Env,
 		"existing_channels", existingChannels,

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/csync"
@@ -418,6 +419,11 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 
 	cfg.Overrides().SkipPermissionRequests = args.YOLO
 	cfg.Overrides().EnabledChannels = args.Channels
+	cfg.Overrides().AllowAllCommands = args.AllowAllCommands
+	cfg.Overrides().AllowedCommands = args.AllowedCommands
+	if unknown := tools.UnknownAllowedCommands(append(append([]string{}, cfg.Config().Options.AllowedCommands...), args.AllowedCommands...)); len(unknown) > 0 {
+		slog.Warn("Ignoring allow-commands entries not in the default banned list", "commands", unknown)
+	}
 
 	if err := createDotCrushDir(cfg.Config().Options.DataDirectory); err != nil {
 		return nil, proto.Workspace{}, fmt.Errorf("failed to create data directory: %w", err)
@@ -1069,15 +1075,17 @@ func validateClientID(id string) (string, error) {
 func workspaceToProto(ws *Workspace) proto.Workspace {
 	cfg := ws.Cfg.Config()
 	out := proto.Workspace{
-		ID:       ws.ID,
-		Path:     ws.Path,
-		YOLO:     ws.Cfg.Overrides().SkipPermissionRequests,
-		Channels: ws.Cfg.Overrides().EnabledChannels,
-		DataDir:  cfg.Options.DataDirectory,
-		Debug:    cfg.Options.Debug,
-		Config:   cfg,
-		Env:      ws.Env,
-		Version:  version.Version,
+		ID:               ws.ID,
+		Path:             ws.Path,
+		YOLO:             ws.Cfg.Overrides().SkipPermissionRequests,
+		Channels:         ws.Cfg.Overrides().EnabledChannels,
+		AllowAllCommands: ws.Cfg.Overrides().AllowAllCommands,
+		AllowedCommands:  ws.Cfg.Overrides().AllowedCommands,
+		DataDir:          cfg.Options.DataDirectory,
+		Debug:            cfg.Options.Debug,
+		Config:           cfg,
+		Env:              ws.Env,
+		Version:          version.Version,
 	}
 	if ws.Skills != nil {
 		out.Skills = skillStatesToProto(ws.Skills.States())
@@ -1096,11 +1104,14 @@ func workspaceToProto(ws *Workspace) proto.Workspace {
 // while the first set one will still log the mismatch.
 func logFirstWinsMismatch(existing *Workspace, args proto.Workspace) {
 	existingCfg := existing.Cfg.Config()
-	existingYOLO := existing.Cfg.Overrides().SkipPermissionRequests
-	existingChannels := existing.Cfg.Overrides().EnabledChannels
+	existingOverrides := existing.Cfg.Overrides()
+	existingYOLO := existingOverrides.SkipPermissionRequests
+	existingChannels := existingOverrides.EnabledChannels
 	if existingYOLO == args.YOLO &&
 		existingCfg.Options.Debug == args.Debug &&
 		existingCfg.Options.DataDirectory == args.DataDir &&
+		existingOverrides.AllowAllCommands == args.AllowAllCommands &&
+		stringSlicesEqual(existingOverrides.AllowedCommands, args.AllowedCommands) &&
 		stringSlicesEqual(existing.Env, args.Env) &&
 		stringSlicesEqual(existingChannels, args.Channels) {
 		return
@@ -1115,6 +1126,10 @@ func logFirstWinsMismatch(existing *Workspace, args proto.Workspace) {
 		"requested_debug", args.Debug,
 		"existing_data_dir", existingCfg.Options.DataDirectory,
 		"requested_data_dir", args.DataDir,
+		"existing_allow_all_commands", existingOverrides.AllowAllCommands,
+		"requested_allow_all_commands", args.AllowAllCommands,
+		"existing_allowed_commands", existingOverrides.AllowedCommands,
+		"requested_allowed_commands", args.AllowedCommands,
 		"existing_env", existing.Env,
 		"requested_env", args.Env,
 		"existing_channels", existingChannels,

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -711,6 +711,14 @@ func TestFirstWinsMismatch_LogsOnFlagDifferences(t *testing.T) {
 			name:   "env",
 			mutate: func(p *proto.Workspace) { p.Env = []string{"NEW=val"} },
 		},
+		{
+			name:   "allow-all-commands",
+			mutate: func(p *proto.Workspace) { p.AllowAllCommands = true },
+		},
+		{
+			name:   "allowed-commands",
+			mutate: func(p *proto.Workspace) { p.AllowedCommands = []string{"ssh"} },
+		},
 	}
 
 	for _, tc := range tests {
@@ -745,6 +753,8 @@ func TestFirstWinsMismatch_LogsOnFlagDifferences(t *testing.T) {
 			// Existing workspace's YOLO and Debug must not change.
 			require.Equal(t, originalYOLO, wsA.Cfg.Overrides().SkipPermissionRequests, "YOLO must be immutable on first-wins")
 			require.Equal(t, originalDebug, wsA.Cfg.Config().Options.Debug, "Debug must be immutable on first-wins")
+			require.False(t, wsA.Cfg.Overrides().AllowAllCommands, "AllowAllCommands must be immutable on first-wins")
+			require.Empty(t, wsA.Cfg.Overrides().AllowedCommands, "AllowedCommands must be immutable on first-wins")
 		})
 	}
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	fang "charm.land/fang/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/colorprofile"
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/client"
 	"github.com/charmbracelet/crush/internal/config"
@@ -61,6 +62,8 @@ func init() {
 	_ = rootCmd.PersistentFlags().MarkHidden("channels")
 	rootCmd.Flags().StringP("session", "s", "", "Continue a previous session by ID")
 	rootCmd.Flags().BoolP("continue", "C", false, "Continue the most recent session")
+	rootCmd.Flags().StringSlice("allow-commands", nil, "Allow specific commands from the default bash blocklist (repeatable); does not affect package-manager argument blocks like 'apt install'. Env: CRUSH_ALLOW_COMMANDS (comma-separated)")
+	rootCmd.Flags().Bool("allow-all-commands", false, "Remove all bash blocklist restrictions, including package-manager blocks (dangerous). Env: CRUSH_ALLOW_ALL_COMMANDS")
 	rootCmd.MarkFlagsMutuallyExclusive("session", "continue")
 
 	rootCmd.AddCommand(
@@ -247,12 +250,50 @@ func setupWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error) {
 	return setupLocalWorkspace(cmd)
 }
 
+// resolveAllowCommands returns the bash allow-command settings from flags,
+// falling back to the CRUSH_ALLOW_COMMANDS / CRUSH_ALLOW_ALL_COMMANDS
+// environment variables for 12-factor compliance. CLI flags take precedence
+// over env vars. Comma-separated env entries are trimmed and empties dropped.
+func resolveAllowCommands(cmd *cobra.Command) (allowCommands []string, allowAllCommands bool) {
+	allowCommands, _ = cmd.Flags().GetStringSlice("allow-commands")
+	allowAllCommands, _ = cmd.Flags().GetBool("allow-all-commands")
+
+	if !allowAllCommands {
+		if v := os.Getenv("CRUSH_ALLOW_ALL_COMMANDS"); v != "" {
+			allowAllCommands = strings.EqualFold(v, "true") || v == "1"
+		}
+	}
+	if len(allowCommands) == 0 {
+		if v := os.Getenv("CRUSH_ALLOW_COMMANDS"); v != "" {
+			for _, c := range strings.Split(v, ",") {
+				if c = strings.TrimSpace(c); c != "" {
+					allowCommands = append(allowCommands, c)
+				}
+			}
+		}
+	}
+	return allowCommands, allowAllCommands
+}
+
+// warnUnknownAllowedCommands logs a startup warning for allow-command entries
+// (from config and flags/env) that aren't in the default banned list, since
+// they subtract nothing and usually indicate a typo.
+func warnUnknownAllowedCommands(configAllowed, flagAllowed []string) {
+	combined := make([]string, 0, len(configAllowed)+len(flagAllowed))
+	combined = append(combined, configAllowed...)
+	combined = append(combined, flagAllowed...)
+	if unknown := tools.UnknownAllowedCommands(combined); len(unknown) > 0 {
+		slog.Warn("Ignoring allow-commands entries not in the default banned list", "commands", unknown)
+	}
+}
+
 // setupLocalWorkspace creates an in-process app.App and wraps it in an
 // AppWorkspace.
 func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error) {
 	debug, _ := cmd.Flags().GetBool("debug")
 	yolo, _ := cmd.Flags().GetBool("yolo")
 	channels, _ := cmd.Flags().GetStringSlice("channels")
+	allowCommands, allowAllCommands := resolveAllowCommands(cmd)
 	dataDir, _ := cmd.Flags().GetString("data-dir")
 	ctx := cmd.Context()
 
@@ -269,6 +310,11 @@ func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error
 	cfg := store.Config()
 	store.Overrides().SkipPermissionRequests = yolo
 	store.Overrides().EnabledChannels = channels
+	// Held as runtime overrides (not written into Options) so they survive the
+	// config reloads triggered by MCP reconnects and model changes.
+	store.Overrides().AllowAllCommands = allowAllCommands
+	store.Overrides().AllowedCommands = allowCommands
+	warnUnknownAllowedCommands(cfg.Options.AllowedCommands, allowCommands)
 
 	if err := os.MkdirAll(cfg.Options.DataDirectory, 0o700); err != nil {
 		return nil, nil, fmt.Errorf("failed to create data directory: %q %w", cfg.Options.DataDirectory, err)
@@ -377,6 +423,7 @@ func connectToServer(cmd *cobra.Command) (*client.Client, *proto.Workspace, func
 	debug, _ := cmd.Flags().GetBool("debug")
 	yolo, _ := cmd.Flags().GetBool("yolo")
 	channels, _ := cmd.Flags().GetStringSlice("channels")
+	allowCommands, allowAllCommands := resolveAllowCommands(cmd)
 	dataDir, _ := cmd.Flags().GetString("data-dir")
 	ctx := cmd.Context()
 
@@ -391,13 +438,15 @@ func connectToServer(cmd *cobra.Command) (*client.Client, *proto.Workspace, func
 	}
 
 	wsReq := proto.Workspace{
-		Path:     cwd,
-		DataDir:  dataDir,
-		Debug:    debug,
-		YOLO:     yolo,
-		Channels: channels,
-		Version:  version.Version,
-		Env:      os.Environ(),
+		Path:             cwd,
+		DataDir:          dataDir,
+		Debug:            debug,
+		YOLO:             yolo,
+		Channels:         channels,
+		AllowAllCommands: allowAllCommands,
+		AllowedCommands:  allowCommands,
+		Version:          version.Version,
+		Env:              os.Environ(),
 	}
 
 	ws, err := c.CreateWorkspace(ctx, wsReq)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	fang "charm.land/fang/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/colorprofile"
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/client"
 	"github.com/charmbracelet/crush/internal/config"
@@ -64,6 +65,8 @@ func init() {
 	_ = rootCmd.PersistentFlags().MarkHidden("channels")
 	rootCmd.Flags().StringP("session", "s", "", "Continue a previous session by ID")
 	rootCmd.Flags().BoolP("continue", "C", false, "Continue the most recent session")
+	rootCmd.Flags().StringSlice("allow-commands", nil, "Allow specific commands from the default bash blocklist (repeatable); does not affect package-manager argument blocks like 'apt install'. Env: CRUSH_ALLOW_COMMANDS (comma-separated)")
+	rootCmd.Flags().Bool("allow-all-commands", false, "Remove all bash blocklist restrictions, including package-manager blocks (dangerous). Env: CRUSH_ALLOW_ALL_COMMANDS")
 	rootCmd.MarkFlagsMutuallyExclusive("session", "continue")
 
 	rootCmd.AddCommand(
@@ -326,12 +329,50 @@ func setupWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error) {
 	return setupLocalWorkspace(cmd)
 }
 
+// resolveAllowCommands returns the bash allow-command settings from flags,
+// falling back to the CRUSH_ALLOW_COMMANDS / CRUSH_ALLOW_ALL_COMMANDS
+// environment variables for 12-factor compliance. CLI flags take precedence
+// over env vars. Comma-separated env entries are trimmed and empties dropped.
+func resolveAllowCommands(cmd *cobra.Command) (allowCommands []string, allowAllCommands bool) {
+	allowCommands, _ = cmd.Flags().GetStringSlice("allow-commands")
+	allowAllCommands, _ = cmd.Flags().GetBool("allow-all-commands")
+
+	if !allowAllCommands {
+		if v := os.Getenv("CRUSH_ALLOW_ALL_COMMANDS"); v != "" {
+			allowAllCommands = strings.EqualFold(v, "true") || v == "1"
+		}
+	}
+	if len(allowCommands) == 0 {
+		if v := os.Getenv("CRUSH_ALLOW_COMMANDS"); v != "" {
+			for _, c := range strings.Split(v, ",") {
+				if c = strings.TrimSpace(c); c != "" {
+					allowCommands = append(allowCommands, c)
+				}
+			}
+		}
+	}
+	return allowCommands, allowAllCommands
+}
+
+// warnUnknownAllowedCommands logs a startup warning for allow-command entries
+// (from config and flags/env) that aren't in the default banned list, since
+// they subtract nothing and usually indicate a typo.
+func warnUnknownAllowedCommands(configAllowed, flagAllowed []string) {
+	combined := make([]string, 0, len(configAllowed)+len(flagAllowed))
+	combined = append(combined, configAllowed...)
+	combined = append(combined, flagAllowed...)
+	if unknown := tools.UnknownAllowedCommands(combined); len(unknown) > 0 {
+		slog.Warn("Ignoring allow-commands entries not in the default banned list", "commands", unknown)
+	}
+}
+
 // setupLocalWorkspace creates an in-process app.App and wraps it in an
 // AppWorkspace.
 func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error) {
 	debug, _ := cmd.Flags().GetBool("debug")
 	yolo, _ := cmd.Flags().GetBool("yolo")
 	channels, _ := cmd.Flags().GetStringSlice("channels")
+	allowCommands, allowAllCommands := resolveAllowCommands(cmd)
 	dataDir, _ := cmd.Flags().GetString("data-dir")
 	ctx := cmd.Context()
 
@@ -348,6 +389,11 @@ func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error
 	cfg := store.Config()
 	store.Overrides().SkipPermissionRequests = yolo
 	store.Overrides().EnabledChannels = channels
+	// Held as runtime overrides (not written into Options) so they survive the
+	// config reloads triggered by MCP reconnects and model changes.
+	store.Overrides().AllowAllCommands = allowAllCommands
+	store.Overrides().AllowedCommands = allowCommands
+	warnUnknownAllowedCommands(cfg.Options.AllowedCommands, allowCommands)
 
 	if err := os.MkdirAll(cfg.Options.DataDirectory, 0o700); err != nil {
 		return nil, nil, fmt.Errorf("failed to create data directory: %q %w", cfg.Options.DataDirectory, err)
@@ -459,6 +505,7 @@ func connectToServer(cmd *cobra.Command) (*client.Client, *proto.Workspace, func
 	debug, _ := cmd.Flags().GetBool("debug")
 	yolo, _ := cmd.Flags().GetBool("yolo")
 	channels, _ := cmd.Flags().GetStringSlice("channels")
+	allowCommands, allowAllCommands := resolveAllowCommands(cmd)
 	dataDir, _ := cmd.Flags().GetString("data-dir")
 
 	cwd, err := ResolveCwd(cmd)
@@ -472,13 +519,15 @@ func connectToServer(cmd *cobra.Command) (*client.Client, *proto.Workspace, func
 	}
 
 	wsReq := proto.Workspace{
-		Path:     cwd,
-		DataDir:  dataDir,
-		Debug:    debug,
-		YOLO:     yolo,
-		Channels: channels,
-		Version:  version.Version,
-		Env:      os.Environ(),
+		Path:             cwd,
+		DataDir:          dataDir,
+		Debug:            debug,
+		YOLO:             yolo,
+		Channels:         channels,
+		AllowAllCommands: allowAllCommands,
+		AllowedCommands:  allowCommands,
+		Version:          version.Version,
+		Env:              os.Environ(),
 	}
 
 	ws, err := createWorkspaceOnLiveServer(cmd.Context(), c, wsReq, func() error {

--- a/internal/cmd/root_allow_commands_test.go
+++ b/internal/cmd/root_allow_commands_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func newAllowCommandsTestCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().StringSlice("allow-commands", nil, "")
+	cmd.Flags().Bool("allow-all-commands", false, "")
+	return cmd
+}
+
+func TestResolveAllowCommands_EnvTrimsWhitespaceAndDropsEmpties(t *testing.T) {
+	t.Setenv("CRUSH_ALLOW_COMMANDS", "ssh, curl ,,scp ")
+	t.Setenv("CRUSH_ALLOW_ALL_COMMANDS", "")
+
+	allow, all := resolveAllowCommands(newAllowCommandsTestCmd())
+	require.False(t, all)
+	require.Equal(t, []string{"ssh", "curl", "scp"}, allow)
+}
+
+func TestResolveAllowCommands_FlagsTakePrecedenceOverEnv(t *testing.T) {
+	t.Setenv("CRUSH_ALLOW_COMMANDS", "curl")
+	t.Setenv("CRUSH_ALLOW_ALL_COMMANDS", "true")
+
+	cmd := newAllowCommandsTestCmd()
+	require.NoError(t, cmd.Flags().Set("allow-commands", "ssh"))
+
+	allow, all := resolveAllowCommands(cmd)
+	// Flag was provided, so env is ignored for allow-commands.
+	require.Equal(t, []string{"ssh"}, allow)
+	// allow-all-commands flag was not set, so it falls back to the env var.
+	require.True(t, all)
+}
+
+func TestResolveAllowCommands_AllCommandsEnvVariants(t *testing.T) {
+	for _, tc := range []struct {
+		val  string
+		want bool
+	}{
+		{"true", true},
+		{"TRUE", true},
+		{"1", true},
+		{"false", false},
+		{"0", false},
+		{"", false},
+	} {
+		t.Run(tc.val, func(t *testing.T) {
+			t.Setenv("CRUSH_ALLOW_ALL_COMMANDS", tc.val)
+			t.Setenv("CRUSH_ALLOW_COMMANDS", "")
+			_, all := resolveAllowCommands(newAllowCommandsTestCmd())
+			require.Equal(t, tc.want, all)
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -331,6 +331,19 @@ type Options struct {
 	DisableNotifications      bool         `json:"disable_notifications,omitempty" jsonschema:"description=Deprecated: Use notification_style instead. Disable desktop notifications,default=false"`
 	NotificationStyle         string       `json:"notification_style,omitempty" jsonschema:"description=Notification style to use. Options: auto (default), native, osc, bell, disabled. Auto selects based on environment: native for local sessions, osc for SSH (with automatic OSC 99/777 detection).,enum=auto,enum=native,enum=osc,enum=bell,enum=disabled,default=auto"`
 	DisabledSkills            []string     `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
+	// AllowedCommands specifies commands that should be removed from the default
+	// banned commands list, allowing the agent to execute them via the bash tool.
+	// This provides a way to selectively enable commands like "ssh" or "curl"
+	// that are blocked by default for security reasons. It only subtracts from
+	// the exact-command block list; package-manager argument blocks such as
+	// "apt install" or "npm -g" are unaffected. Allowed commands are still
+	// subject to the normal permission prompt (they are not auto-approved).
+	AllowedCommands []string `json:"allowed_commands,omitempty" jsonschema:"description=List of commands to allow that are normally banned. Only affects the exact-command block list; package-manager argument blocks (e.g. 'apt install') are unaffected. Allowed commands still require permission approval.,example=ssh,example=curl,example=scp"`
+	// AllowAllCommands removes all restrictions from the banned commands list,
+	// allowing the agent to execute any command via the bash tool. Unlike
+	// allowed_commands, this also removes the package-manager argument blocks.
+	// This is a dangerous option and should be used with caution.
+	AllowAllCommands bool `json:"allow_all_commands,omitempty" jsonschema:"description=Remove all command restrictions from the bash tool, including package-manager argument blocks (dangerous). Commands still require permission approval unless yolo mode is enabled.,default=false"`
 }
 
 type MCPs map[string]MCPConfig

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -334,6 +334,19 @@ type Options struct {
 	Progress                  *bool        `json:"progress,omitempty" jsonschema:"description=Show indeterminate progress updates during long operations,default=true"`
 	Notifications             string       `json:"notifications,omitempty" jsonschema:"description=Notification style to use. Options: auto (default)\\, native\\, osc\\, bell\\, disabled. Auto selects based on environment: native for local sessions\\, osc for SSH (with automatic OSC 99/777 detection).,enum=auto,enum=native,enum=osc,enum=bell,enum=disabled,default=auto"`
 	DisabledSkills            []string     `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
+	// AllowedCommands specifies commands that should be removed from the default
+	// banned commands list, allowing the agent to execute them via the bash tool.
+	// This provides a way to selectively enable commands like "ssh" or "curl"
+	// that are blocked by default for security reasons. It only subtracts from
+	// the exact-command block list; package-manager argument blocks such as
+	// "apt install" or "npm -g" are unaffected. Allowed commands are still
+	// subject to the normal permission prompt (they are not auto-approved).
+	AllowedCommands []string `json:"allowed_commands,omitempty" jsonschema:"description=List of commands to allow that are normally banned. Only affects the exact-command block list; package-manager argument blocks (e.g. 'apt install') are unaffected. Allowed commands still require permission approval.,example=ssh,example=curl,example=scp"`
+	// AllowAllCommands removes all restrictions from the banned commands list,
+	// allowing the agent to execute any command via the bash tool. Unlike
+	// allowed_commands, this also removes the package-manager argument blocks.
+	// This is a dangerous option and should be used with caution.
+	AllowAllCommands bool `json:"allow_all_commands,omitempty" jsonschema:"description=Remove all command restrictions from the bash tool, including package-manager argument blocks (dangerous). Commands still require permission approval unless yolo mode is enabled.,default=false"`
 }
 
 type MCPs map[string]MCPConfig

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -68,6 +68,15 @@ type RuntimeOverrides struct {
 	// selection made here always outranks whatever the shared config file
 	// happens to hold — see pinPreferredModelLocked.
 	Models map[SelectedModelType]SelectedModel
+	// AllowAllCommands, when true, removes every bash-tool command block for
+	// this session (via the --allow-all-commands flag or CRUSH_ALLOW_ALL_COMMANDS).
+	AllowAllCommands bool
+	// AllowedCommands lists commands to drop from the bash tool's default
+	// banned list for this session (via the --allow-commands flag or
+	// CRUSH_ALLOW_COMMANDS). It is merged with options.allowed_commands from
+	// the config file. Held here rather than in Options so it survives config
+	// reloads.
+	AllowedCommands []string
 }
 
 // ConfigStore is the single entry point for all config access. It owns the

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -25,6 +25,13 @@ type Workspace struct {
 	// Channels lists the MCP servers opted in as channels for this workspace
 	// (from the --channels flag).
 	Channels []string `json:"channels,omitempty"`
+	// AllowAllCommands removes every bash-tool command block for this
+	// workspace (from the --allow-all-commands flag or CRUSH_ALLOW_ALL_COMMANDS).
+	AllowAllCommands bool `json:"allow_all_commands,omitempty"`
+	// AllowedCommands lists commands to drop from the bash tool's default
+	// banned list for this workspace (from the --allow-commands flag or
+	// CRUSH_ALLOW_COMMANDS).
+	AllowedCommands []string `json:"allowed_commands,omitempty"`
 	// Skills carries the snapshot of skill discovery state at workspace
 	// creation time. Subsequent updates flow through the SSE event
 	// stream.

--- a/internal/shell/command_block_test.go
+++ b/internal/shell/command_block_test.go
@@ -297,6 +297,36 @@ func TestCommandsBlocker(t *testing.T) {
 			input:       []string{"CURL", "https://example.com"},
 			shouldBlock: false,
 		},
+		{
+			name:        "block absolute path to banned command",
+			banned:      []string{"curl"},
+			input:       []string{"/usr/bin/curl", "https://example.com"},
+			shouldBlock: true,
+		},
+		{
+			name:        "block relative path to banned command",
+			banned:      []string{"curl"},
+			input:       []string{"./curl", "https://example.com"},
+			shouldBlock: true,
+		},
+		{
+			name:        "block dot-dot path to banned command",
+			banned:      []string{"scp"},
+			input:       []string{"../../bin/scp", "file", "host:/tmp"},
+			shouldBlock: true,
+		},
+		{
+			name:        "path to non-banned command still allowed",
+			banned:      []string{"curl"},
+			input:       []string{"/usr/bin/echo", "hello"},
+			shouldBlock: false,
+		},
+		{
+			name:        "trailing slash still matches",
+			banned:      []string{"curl"},
+			input:       []string{"/usr/bin/curl/", "x"},
+			shouldBlock: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/shell/command_block_windows_test.go
+++ b/internal/shell/command_block_windows_test.go
@@ -1,0 +1,57 @@
+//go:build windows
+
+package shell
+
+import "testing"
+
+// TestCommandsBlocker_WindowsNormalization covers the two spellings that
+// only exist on Windows: backslash separators and the executable
+// extension that PATH resolution appends. Both name the same binary as a
+// bare `curl`, so the block list has to see through them.
+func TestCommandsBlocker_WindowsNormalization(t *testing.T) {
+	tests := []struct {
+		name        string
+		banned      []string
+		input       []string
+		shouldBlock bool
+	}{
+		{
+			name:        "backslash path",
+			banned:      []string{"curl"},
+			input:       []string{`C:\Windows\System32\curl`, "https://example.com"},
+			shouldBlock: true,
+		},
+		{
+			name:        "exe extension",
+			banned:      []string{"curl"},
+			input:       []string{"curl.exe", "https://example.com"},
+			shouldBlock: true,
+		},
+		{
+			name:        "backslash path with exe extension",
+			banned:      []string{"curl"},
+			input:       []string{`C:\Windows\System32\curl.exe`, "https://example.com"},
+			shouldBlock: true,
+		},
+		{
+			name:        "bat extension",
+			banned:      []string{"scp"},
+			input:       []string{"scp.bat", "file", "host:/tmp"},
+			shouldBlock: true,
+		},
+		{
+			name:        "unrelated extension is not stripped",
+			banned:      []string{"curl"},
+			input:       []string{"curl.txt"},
+			shouldBlock: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CommandsBlocker(tt.banned)(tt.input); got != tt.shouldBlock {
+				t.Errorf("block=%v, want %v for input %v", got, tt.shouldBlock, tt.input)
+			}
+		})
+	}
+}

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -16,6 +16,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
+	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -185,7 +188,9 @@ func (s *Shell) SetBlockFuncs(blockFuncs []BlockFunc) {
 	s.blockFuncs = blockFuncs
 }
 
-// CommandsBlocker creates a BlockFunc that blocks exact command matches
+// CommandsBlocker creates a BlockFunc that blocks exact command matches.
+// argv[0] is reduced to a bare command name first, so a path-prefixed
+// invocation cannot slip past a rule written for the bare name.
 func CommandsBlocker(cmds []string) BlockFunc {
 	bannedSet := make(map[string]struct{})
 	for _, cmd := range cmds {
@@ -196,10 +201,40 @@ func CommandsBlocker(cmds []string) BlockFunc {
 		if len(args) == 0 {
 			return false
 		}
-		_, ok := bannedSet[args[0]]
+		_, ok := bannedSet[commandName(args[0])]
 		return ok
 	}
 }
+
+// commandName reduces argv[0] to the name the block list is written in
+// terms of. `/usr/bin/curl` and `./curl` name the same binary as a bare
+// `curl`, so deny rules have to see through the path prefix.
+//
+// Note this only normalizes the spelling of argv[0]; it does not resolve
+// symlinks or follow PATH. A blocked binary copied to another name is
+// still reachable — see the README on why the block list is a guardrail
+// rather than a sandbox.
+func commandName(arg string) string {
+	if arg == "" {
+		return arg
+	}
+	if runtime.GOOS == "windows" {
+		// Windows accepts either separator, and executables carry an
+		// extension that the block list never spells out.
+		arg = strings.ReplaceAll(arg, "\\", "/")
+		base := path.Base(arg)
+		ext := strings.ToLower(filepath.Ext(base))
+		if slices.Contains(windowsExecExts, ext) {
+			base = base[:len(base)-len(ext)]
+		}
+		return base
+	}
+	return path.Base(arg)
+}
+
+// windowsExecExts are the extensions Windows appends to an executable
+// name during PATH resolution. Lowercased for comparison.
+var windowsExecExts = []string{".exe", ".com", ".bat", ".cmd"}
 
 // ArgumentsBlocker creates a BlockFunc that blocks specific subcommand
 func ArgumentsBlocker(cmd string, args []string, flags []string) BlockFunc {

--- a/schema.json
+++ b/schema.json
@@ -569,6 +569,23 @@
           },
           "type": "array",
           "description": "List of skill names to disable and hide from the agent"
+        },
+        "allowed_commands": {
+          "items": {
+            "type": "string",
+            "examples": [
+              "ssh",
+              "curl",
+              "scp"
+            ]
+          },
+          "type": "array",
+          "description": "List of commands to allow that are normally banned. Only affects the exact-command block list; package-manager argument blocks (e.g. 'apt install') are unaffected. Allowed commands still require permission approval."
+        },
+        "allow_all_commands": {
+          "type": "boolean",
+          "description": "Remove all command restrictions from the bash tool",
+          "default": false
         }
       },
       "additionalProperties": false,

--- a/schema.json
+++ b/schema.json
@@ -571,6 +571,23 @@
           },
           "type": "array",
           "description": "List of skill names to disable and hide from the agent"
+        },
+        "allowed_commands": {
+          "items": {
+            "type": "string",
+            "examples": [
+              "ssh",
+              "curl",
+              "scp"
+            ]
+          },
+          "type": "array",
+          "description": "List of commands to allow that are normally banned. Only affects the exact-command block list; package-manager argument blocks (e.g. 'apt install') are unaffected. Allowed commands still require permission approval."
+        },
+        "allow_all_commands": {
+          "type": "boolean",
+          "description": "Remove all command restrictions from the bash tool",
+          "default": false
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Posted by `@joestump-agent` at `@joestump`'s direction.

## What & why

The bash tool blocks a fixed set of commands (`ssh`, `curl`, package managers, …) with no way to opt out short of forking. That's a sane default, but it gets in the way of legitimate workflows — deploy scripts that `ssh`, API debugging with `curl`, etc.

This adds `options.allowed_commands` to selectively remove entries from the default banned list, and `options.allow_all_commands` to remove every restriction, with matching CLI flags (`--allow-commands`, `--allow-all-commands`) and environment variables (`CRUSH_ALLOW_COMMANDS`, `CRUSH_ALLOW_ALL_COMMANDS`) for per-session and 12-factor use.

## Design notes

- **Runtime overrides, not config mutation.** Flag/env values are held in `store.Overrides()` so they survive the config reloads triggered by MCP reconnects and model changes, and are merged with the config file's `allowed_commands` when the tool is built. A shared `effectiveBannedCommands` helper keeps the tool description and the enforcement layer from drifting.
- **Not an auto-approve.** Banned commands are a hard filter in front of the normal permission flow — an allowed command is still subject to the usual permission prompt unless `--yolo` is also set.
- **Typo guard.** A startup warning flags allow-commands entries that aren't in the default banned list, which would otherwise silently no-op.
- **Client/server mode.** The settings ride the `CreateWorkspace` request; since a second client attaching to the same path keeps the first workspace's flags (first-wins), the mismatch debug log now covers these fields too — they're security-relevant, so a client requesting the default blocklist that lands in an `--allow-all-commands` workspace gets a visible trace.
- **Backward compatible.** With no config, the banned list is exactly as before.

README documents the option, flags, env vars, and the `allowed_commands` vs `allow_all_commands` distinction (exact-command blocklist vs package-manager argument blocks); `schema.json` regenerated.

## Testing

- `internal/agent/tools`: effective-banned-list merge and enforcement tests
- `internal/cmd/root_allow_commands_test.go`: flag/env resolution matrix
- `internal/backend`: first-wins mismatch log fires on allow-command differences; existing workspace's overrides stay immutable
- `go build ./...`, `gofmt` clean

💘 Generated with Crush

Assisted-by: Claude Fable 5