### PR TITLE
fix(lsp): normalize Windows drive-letter paths from URIs

### DIFF
--- a/internal/agent/tools/lsp_call_hierarchy.go
+++ b/internal/agent/tools/lsp_call_hierarchy.go
@@ -9,6 +9,7 @@ import (
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/lsp"
+	"github.com/charmbracelet/crush/internal/lsp/util"
 )
 
 type CallHierarchyParams struct {
@@ -62,7 +63,7 @@ func NewCallHierarchyTool(lspManager *lsp.Manager) fantasy.AgentTool {
 				} else {
 					fmt.Fprintf(&b, "%d caller(s):\n\n", len(calls))
 					for _, c := range calls {
-						path, _ := c.From.URI.Path()
+						path, _ := util.PathFromURI(c.From.URI)
 						line := c.From.Range.Start.Line + 1
 						fmt.Fprintf(&b, "  %s:%d — %s\n", path, line, c.From.Name)
 					}
@@ -77,7 +78,7 @@ func NewCallHierarchyTool(lspManager *lsp.Manager) fantasy.AgentTool {
 				} else {
 					fmt.Fprintf(&b, "%d callee(s):\n\n", len(calls))
 					for _, c := range calls {
-						path, _ := c.To.URI.Path()
+						path, _ := util.PathFromURI(c.To.URI)
 						line := c.To.Range.Start.Line + 1
 						fmt.Fprintf(&b, "  %s:%d — %s\n", path, line, c.To.Name)
 					}

--- a/internal/agent/tools/lsp_definition.go
+++ b/internal/agent/tools/lsp_definition.go
@@ -11,6 +11,7 @@ import (
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/lsp"
+	"github.com/charmbracelet/crush/internal/lsp/util"
 	"github.com/charmbracelet/x/powernap/pkg/lsp/protocol"
 )
 
@@ -77,7 +78,7 @@ func formatDefinitions(locations []protocol.Location) (string, *DefinitionRespon
 	var firstMeta *DefinitionResponseMetadata
 
 	for _, loc := range locations {
-		path, err := loc.URI.Path()
+		path, err := util.PathFromURI(loc.URI)
 		if err != nil {
 			slog.Error("Failed to convert URI to path", "uri", loc.URI, "error", err)
 			continue

--- a/internal/agent/tools/lsp_helpers.go
+++ b/internal/agent/tools/lsp_helpers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/crush/internal/lsp"
+	"github.com/charmbracelet/crush/internal/lsp/util"
 	"github.com/charmbracelet/x/powernap/pkg/lsp/protocol"
 )
 
@@ -109,7 +110,7 @@ func collectAffectedFiles(edit *protocol.WorkspaceEdit) []string {
 	var files []string
 
 	for uri := range edit.Changes {
-		path, err := uri.Path()
+		path, err := util.PathFromURI(uri)
 		if err != nil {
 			continue
 		}
@@ -120,7 +121,7 @@ func collectAffectedFiles(edit *protocol.WorkspaceEdit) []string {
 	}
 
 	addURI := func(uri protocol.DocumentURI) {
-		path, err := uri.Path()
+		path, err := util.PathFromURI(uri)
 		if err != nil {
 			return
 		}

--- a/internal/agent/tools/references.go
+++ b/internal/agent/tools/references.go
@@ -14,6 +14,7 @@ import (
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/lsp"
+	"github.com/charmbracelet/crush/internal/lsp/util"
 	"github.com/charmbracelet/x/powernap/pkg/lsp/protocol"
 )
 
@@ -77,7 +78,7 @@ func NewReferencesTool(lspManager *lsp.Manager) fantasy.AgentTool {
 func groupByFilename(locations []protocol.Location) map[string][]protocol.Location {
 	files := make(map[string][]protocol.Location)
 	for _, loc := range locations {
-		path, err := loc.URI.Path()
+		path, err := util.PathFromURI(loc.URI)
 		if err != nil {
 			slog.Error("Failed to convert location URI to path", "uri", loc.URI, "error", err)
 			continue

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/crush/internal/csync"
 	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/home"
+	"github.com/charmbracelet/crush/internal/lsp/util"
 	powernap "github.com/charmbracelet/x/powernap/pkg/lsp"
 	"github.com/charmbracelet/x/powernap/pkg/lsp/protocol"
 	"github.com/charmbracelet/x/powernap/pkg/transport"
@@ -584,7 +585,7 @@ func (c *Client) RefreshOpenFiles(ctx context.Context) {
 		return
 	}
 	for uri, info := range c.openFiles.Seq2() {
-		path, err := protocol.DocumentURI(uri).Path()
+		path, err := util.PathFromURI(protocol.DocumentURI(uri))
 		if err != nil {
 			slog.Warn("Failed to convert URI to path", "uri", uri, "error", err)
 			continue

--- a/internal/lsp/util/edit.go
+++ b/internal/lsp/util/edit.go
@@ -12,7 +12,7 @@ import (
 )
 
 func applyTextEdits(uri protocol.DocumentURI, edits []protocol.TextEdit, encoding powernap.OffsetEncoding) error {
-	path, err := uri.Path()
+	path, err := PathFromURI(uri)
 	if err != nil {
 		return fmt.Errorf("invalid URI: %w", err)
 	}
@@ -170,7 +170,7 @@ func applyTextEdit(lines []string, edit protocol.TextEdit, encoding powernap.Off
 // applyDocumentChange applies a DocumentChange (create/rename/delete operations)
 func applyDocumentChange(change protocol.DocumentChange, encoding powernap.OffsetEncoding) error {
 	if change.CreateFile != nil {
-		path, err := change.CreateFile.URI.Path()
+		path, err := PathFromURI(change.CreateFile.URI)
 		if err != nil {
 			return fmt.Errorf("invalid URI: %w", err)
 		}
@@ -190,7 +190,7 @@ func applyDocumentChange(change protocol.DocumentChange, encoding powernap.Offse
 	}
 
 	if change.DeleteFile != nil {
-		path, err := change.DeleteFile.URI.Path()
+		path, err := PathFromURI(change.DeleteFile.URI)
 		if err != nil {
 			return fmt.Errorf("invalid URI: %w", err)
 		}
@@ -210,12 +210,12 @@ func applyDocumentChange(change protocol.DocumentChange, encoding powernap.Offse
 		var newPath, oldPath string
 		var err error
 
-		oldPath, err = change.RenameFile.OldURI.Path()
+		oldPath, err = PathFromURI(change.RenameFile.OldURI)
 		if err != nil {
 			return err
 		}
 
-		newPath, err = change.RenameFile.NewURI.Path()
+		newPath, err = PathFromURI(change.RenameFile.NewURI)
 		if err != nil {
 			return err
 		}

--- a/internal/lsp/util/path.go
+++ b/internal/lsp/util/path.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"github.com/charmbracelet/x/powernap/pkg/lsp/protocol"
+)
+
+// PathFromURI converts a LSP document URI to a filesystem path.
+//
+// It works around a path-normalization issue where converting a file URI back
+// to a path can leave a leading path separator in front of a Windows drive
+// letter (for example "\G:\foo" instead of "G:\foo"). Such paths are invalid
+// on Windows, because a leading separator turns them into root-relative or
+// UNC-style paths, which causes file reads and LSP refreshes to fail.
+// See issue #3089.
+func PathFromURI(uri protocol.DocumentURI) (string, error) {
+	path, err := uri.Path()
+	if err != nil {
+		return "", err
+	}
+	return normalizeWindowsDrivePath(path), nil
+}
+
+// normalizeWindowsDrivePath strips a stray leading path separator that may
+// appear in front of a Windows drive letter after a URI-to-path conversion
+// (for example "\G:\foo" or "/G:/foo" becomes "G:\foo").
+func normalizeWindowsDrivePath(path string) string {
+	if len(path) >= 3 &&
+		isPathSeparator(path[0]) &&
+		isASCIILetter(path[1]) &&
+		path[2] == ':' {
+		return path[1:]
+	}
+	return path
+}
+
+func isPathSeparator(b byte) bool {
+	return b == '/' || b == '\\'
+}
+
+func isASCIILetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}

--- a/internal/lsp/util/path_test.go
+++ b/internal/lsp/util/path_test.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/powernap/pkg/lsp/protocol"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeWindowsDrivePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"unix absolute", "/home/user/file.go", "/home/user/file.go"},
+		{"unix relative", "file.go", "file.go"},
+		{"windows drive backslash prefix", `\G:\_AIXM\AIXMUnity\GameManager.cs`, `G:\_AIXM\AIXMUnity\GameManager.cs`},
+		{"windows drive slash prefix", "/G:/_AIXM/AIXMUnity/GameManager.cs", "G:/_AIXM/AIXMUnity/GameManager.cs"},
+		{"windows drive no prefix", `G:\_AIXM\AIXMUnity\GameManager.cs`, `G:\_AIXM\AIXMUnity\GameManager.cs`},
+		{"unc path unchanged", `\\server\share\file.go`, `\\server\share\file.go`},
+		{"short string", "a:", "a:"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, normalizeWindowsDrivePath(tc.in))
+		})
+	}
+}
+
+func TestPathFromURIStripsWindowsDrivePrefix(t *testing.T) {
+	t.Parallel()
+
+	// A Windows file URI whose URI-to-path conversion leaves a leading path
+	// separator in front of the drive letter must be normalized back to a
+	// valid absolute path. See issue #3089.
+	path, err := PathFromURI(protocol.DocumentURI("file:///G:/_AIXM/AIXMUnity/GameManager.cs"))
+	require.NoError(t, err)
+	require.Equal(t, "G:/_AIXM/AIXMUnity/GameManager.cs", path)
+}
+
+func TestPathFromURINonWindows(t *testing.T) {
+	t.Parallel()
+
+	path, err := PathFromURI(protocol.DocumentURI("file:///home/user/file.go"))
+	require.NoError(t, err)
+	require.Equal(t, "/home/user/file.go", path)
+}


### PR DESCRIPTION
## Summary

On Windows, converting a LSP file URI back to a filesystem path could leave a leading path separator in front of the drive letter (e.g. `\G:\foo` instead of `G:\foo`). Such paths are invalid on Windows — a leading separator turns them into root-relative or UNC-style paths — so file refreshes and edit application failed with:

```
open \\G:\\_AIXM\\AIXMUnity\\Assets\\Scripts\\Core\\GameManager.cs:
The filename, directory name, or volume label syntax is incorrect.
```

This broke LSP file sync/refresh on Windows (reported with the codely-unity LSP).

## Root cause

`protocol.DocumentURI.Path()` returns the raw URI path (`/G:/...`) and applies `filepath.FromSlash`, but the leading separator before a Windows drive letter is only stripped when the drive-letter detection succeeds. When it does not, the result keeps the leading separator, which becomes `\` after slash conversion, yielding `\G:\...`.

## Changes

- Add `internal/lsp/util/PathFromURI`, which converts a `protocol.DocumentURI` to a path and strips a stray leading path separator in front of a Windows drive letter.
- Route every URI to filesystem-path conversion through it: LSP `RefreshOpenFiles`, edit application (`util/edit.go`), and the LSP tools that format locations (definition, references, call hierarchy, affected-file collection).
- Add unit tests for the normalization.

Fixes #3089
