### PR TITLE
fix(tui): keep onboarding status notifications visible

### DIFF
--- a/internal/ui/model/onboarding_status_test.go
+++ b/internal/ui/model/onboarding_status_test.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"image"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
+	"github.com/charmbracelet/crush/internal/ui/util"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/stretchr/testify/require"
+)
+
+type statusCoveringDialog struct{}
+
+func (statusCoveringDialog) ID() string { return "status-covering" }
+
+func (statusCoveringDialog) HandleMsg(tea.Msg) dialog.Action { return nil }
+
+func (statusCoveringDialog) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	row := image.Rect(area.Min.X, area.Max.Y-1, area.Max.X, area.Max.Y)
+	uv.NewStyledString(strings.Repeat("x", row.Dx())).Draw(scr, row)
+	return nil
+}
+
+func TestDraw_OnboardingStatusRendersAboveDialog(t *testing.T) {
+	t.Parallel()
+
+	u := newTestUI()
+	u.state = uiOnboarding
+	u.width = 60
+	u.height = 20
+	u.header = newHeader(u.com)
+	u.dialog = dialog.NewOverlay(statusCoveringDialog{})
+	u.status.SetInfoMsg(util.InfoMsg{
+		Type: util.InfoTypeUpdate,
+		Msg:  "Update ready",
+	})
+
+	canvas := uv.NewScreenBuffer(u.width, u.height)
+	u.Draw(canvas, canvas.Bounds())
+	require.Contains(t, canvas.Render(), "Update ready")
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2796,7 +2796,9 @@ func (m *UI) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	// Add status and help layer
 	m.status.SetHideHelp(isOnboarding)
-	m.status.Draw(scr, layout.status)
+	if !isOnboarding {
+		m.status.Draw(scr, layout.status)
+	}
 
 	// Draw completions popup if open
 	if !isOnboarding && m.completionsOpen && m.completions.HasItems() {
@@ -2832,7 +2834,17 @@ func (m *UI) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	// the full screen bounds because the dialogs will position themselves
 	// accordingly.
 	if m.dialog.HasDialogs() {
-		return m.dialog.Draw(scr, scr.Bounds())
+		cur := m.dialog.Draw(scr, scr.Bounds())
+		if isOnboarding {
+			// Keep copy confirmations and update notices visible above the
+			// bottom-aligned onboarding dialog.
+			m.status.Draw(scr, layout.status)
+		}
+		return cur
+	}
+
+	if isOnboarding {
+		m.status.Draw(scr, layout.status)
 	}
 
 	switch m.focus {


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (not applicable: this is a bug fix for #3044).

Fixes #3044

## What was happening

Hey, I had a look at this on current `main`.

The status row was drawn before the onboarding dialog. Because that dialog is bottom-aligned, it could overwrite the row containing clipboard confirmations and update notices. The notification still existed in state, but it wasn't visible.

## How I reproduced it

I've added a render regression test that puts the UI in onboarding state, draws a dialog over the bottom row, and checks that an update notice remains visible.

Before the change, the test fails because the dialog replaces the entire status row. After the change, it passes consistently.

## What changed

During onboarding, the status row is now drawn after the dialog. The normal landing, chat, and initialize render order is unchanged.

The dialog cursor is preserved, and the status layer still hides onboarding help text as before.

## Validation

Run on Apple M4, `darwin/arm64`, Go 1.26.5:

- `go test -race -failfast ./...`
- `go build -race ./...`
- `golangci-lint run --path-mode=abs --config=.golangci.yml --timeout=5m`
- `./scripts/check_log_capitalization.sh`
- `go mod tidy` (no diff)
- `go test ./internal/ui/model -run TestDraw_OnboardingStatusRendersAboveDialog -count=10`

This isn't a performance change, so there isn't a benchmark comparison.

## Risk

The change is limited to onboarding render order. When a notification is active, it intentionally owns the final status row instead of letting the onboarding dialog cover it.
