### PR TITLE
feat: add Atlas Cloud provider

### DIFF
--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -122,6 +122,49 @@ func UpdateHyper(pathOrURL string) error {
 	return nil
 }
 
+const atlasCloudProviderID catwalk.InferenceProvider = "atlascloud"
+
+func atlasCloudProvider() catwalk.Provider {
+	return catwalk.Provider{
+		Name:                "Atlas Cloud",
+		ID:                  atlasCloudProviderID,
+		APIKey:              "$ATLASCLOUD_API_KEY",
+		APIEndpoint:         "https://api.atlascloud.ai/v1",
+		Type:                catwalk.TypeOpenAICompat,
+		DefaultLargeModelID: "deepseek-ai/deepseek-v4-pro",
+		DefaultSmallModelID: "qwen/qwen3.5-flash",
+		Models: []catwalk.Model{
+			{
+				ID:               "deepseek-ai/deepseek-v4-pro",
+				Name:             "DeepSeek V4 Pro",
+				CostPer1MIn:      1.68,
+				CostPer1MOut:     3.38,
+				ContextWindow:    1048576,
+				DefaultMaxTokens: 4096,
+				CanReason:        true,
+			},
+			{
+				ID:               "qwen/qwen3.5-flash",
+				Name:             "Qwen3.5 Flash",
+				CostPer1MIn:      0.1,
+				CostPer1MOut:     0.4,
+				ContextWindow:    1000000,
+				DefaultMaxTokens: 4096,
+				SupportsImages:   true,
+			},
+		},
+	}
+}
+
+func appendAtlasCloudProvider(providers []catwalk.Provider) []catwalk.Provider {
+	if slices.ContainsFunc(providers, func(p catwalk.Provider) bool {
+		return p.ID == atlasCloudProviderID
+	}) {
+		return providers
+	}
+	return append(providers, atlasCloudProvider())
+}
+
 var (
 	catwalkSyncer = &catwalkSync{}
 	hyperSyncer   = &hyperSync{}
@@ -190,6 +233,9 @@ func Providers(cfg *Config) ([]catwalk.Provider, error) {
 			providerList = append([]catwalk.Provider{hyperProvider}, slices.Collect(providers.Seq())...)
 		} else {
 			providerList = slices.Collect(providers.Seq())
+		}
+		if !customProvidersOnly {
+			providerList = appendAtlasCloudProvider(providerList)
 		}
 		providerErr = errors.Join(errs...)
 	})

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -8,6 +9,8 @@ import (
 	"testing"
 
 	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/env"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,6 +20,25 @@ func resetProviderState() {
 	providerErr = nil
 	catwalkSyncer = &catwalkSync{}
 	hyperSyncer = &hyperSync{}
+}
+
+func requireAtlasCloudProvider(t *testing.T, providers []catwalk.Provider) {
+	t.Helper()
+
+	for _, provider := range providers {
+		if provider.ID == atlasCloudProviderID {
+			require.Equal(t, "Atlas Cloud", provider.Name)
+			require.Equal(t, "$ATLASCLOUD_API_KEY", provider.APIKey)
+			require.Equal(t, "https://api.atlascloud.ai/v1", provider.APIEndpoint)
+			require.Equal(t, catwalk.TypeOpenAICompat, provider.Type)
+			require.Equal(t, "deepseek-ai/deepseek-v4-pro", provider.DefaultLargeModelID)
+			require.Equal(t, "qwen/qwen3.5-flash", provider.DefaultSmallModelID)
+			require.Len(t, provider.Models, 2)
+			return
+		}
+	}
+
+	require.Fail(t, "Atlas Cloud provider not found")
 }
 
 func TestProviders_Integration_AutoUpdateDisabled(t *testing.T) {
@@ -50,6 +72,72 @@ func TestProviders_Integration_AutoUpdateDisabled(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, providers)
 	require.Greater(t, len(providers), 5, "Expected embedded providers")
+	requireAtlasCloudProvider(t, providers)
+}
+
+func TestAtlasCloudProvider(t *testing.T) {
+	provider := atlasCloudProvider()
+
+	require.Equal(t, catwalk.InferenceProvider("atlascloud"), provider.ID)
+	require.Equal(t, "Atlas Cloud", provider.Name)
+	require.Equal(t, "$ATLASCLOUD_API_KEY", provider.APIKey)
+	require.Equal(t, "https://api.atlascloud.ai/v1", provider.APIEndpoint)
+	require.Equal(t, catwalk.TypeOpenAICompat, provider.Type)
+	require.Equal(t, "deepseek-ai/deepseek-v4-pro", provider.DefaultLargeModelID)
+	require.Equal(t, "qwen/qwen3.5-flash", provider.DefaultSmallModelID)
+	require.Len(t, provider.Models, 2)
+	require.Equal(t, "deepseek-ai/deepseek-v4-pro", provider.Models[0].ID)
+	require.Equal(t, "qwen/qwen3.5-flash", provider.Models[1].ID)
+}
+
+func TestAppendAtlasCloudProviderDedupes(t *testing.T) {
+	providers := []catwalk.Provider{{ID: "openai"}, atlasCloudProvider()}
+
+	got := appendAtlasCloudProvider(providers)
+
+	require.Len(t, got, len(providers))
+	require.Equal(t, providers, got)
+}
+
+func TestProvidersDisableDefaultProvidersOmitsAtlasCloud(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+
+	resetProviderState()
+	defer resetProviderState()
+
+	cfg := &Config{
+		Options: &Options{
+			DisableDefaultProviders: true,
+		},
+	}
+
+	providers, err := Providers(cfg)
+	require.NoError(t, err)
+	require.Empty(t, providers)
+}
+
+func TestConfigConfigureProvidersAtlasCloudFromEnv(t *testing.T) {
+	cfg := &Config{
+		Providers: csync.NewMap[string, ProviderConfig](),
+	}
+	cfg.setDefaults("/tmp", "")
+
+	env := env.NewFromMap(map[string]string{
+		"ATLASCLOUD_API_KEY": "test-key",
+	})
+	resolver := NewShellVariableResolver(env)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, []catwalk.Provider{atlasCloudProvider()})
+	require.NoError(t, err)
+
+	provider, exists := cfg.Providers.Get("atlascloud")
+	require.True(t, exists)
+	require.Equal(t, "Atlas Cloud", provider.Name)
+	require.Equal(t, "test-key", provider.APIKey)
+	require.Equal(t, "$ATLASCLOUD_API_KEY", provider.APIKeyTemplate)
+	require.Equal(t, "https://api.atlascloud.ai/v1", provider.BaseURL)
+	require.Equal(t, catwalk.TypeOpenAICompat, provider.Type)
+	require.Len(t, provider.Models, 2)
 }
 
 func TestProviders_Integration_WithMockClients(t *testing.T) {


### PR DESCRIPTION
## Summary
- add Atlas Cloud as a built-in OpenAI-compatible provider in the local provider list
- wire the provider to `ATLASCLOUD_API_KEY` with `https://api.atlascloud.ai/v1`
- include live-verified default models for large/small model selection and focused config tests

## Validation
- `git diff --check`
- verified changed files do not touch README/docs or promotional sections
- live Atlas model catalog returned 365 displayable models and confirmed:
  - `deepseek-ai/deepseek-v4-pro`
  - `qwen/qwen3.5-flash`

I could not run Go tests locally because `go`, `gofmt`, and `gofumpt` are not installed in this environment (`go test ./internal/config ...` fails with `command not found: go`).

No README/docs changes, no sponsor/logo/credits/partner additions.
