### PR TITLE
fix(baseten): fix "none" reasoning level

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -552,7 +552,7 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 
 		case string(catwalk.InferenceProviderBaseten):
 			extraBody["chat_template_args"] = map[string]any{
-				"enable_thinking": model.ModelCfg.Think || reasoningEffort != "",
+				"enable_thinking": model.ModelCfg.Think || reasoningEffort != "" && reasoningEffort != "none",
 			}
 
 		case string(catwalk.InferenceProviderOpenCodeGo), string(catwalk.InferenceProviderOpenCodeZen):


### PR DESCRIPTION
Fixes this error:

> Invalid request: Conflicting thinking controls: `reasoning_effort` is 'none', but `chat_template_kwargs.enable_thinking` is True.