### PR TITLE
fix(agent): retry title generation with a larger budget for unconfigured reasoning models

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1713,6 +1713,18 @@ func hasUserTextMessage(msgs []message.Message) bool {
 	return false
 }
 
+// shouldRetryTitleWithLargerBudget reports whether a title-generation
+// attempt that hit the token limit should be retried with a larger output
+// budget: canReason is false (so the small 40-token budget was used, not
+// the model's larger DefaultMaxTokens) but the model produced reasoning
+// content anyway, meaning it reasons by its own template default
+// regardless of what its config declares. A model that hit the limit
+// without producing any reasoning content just needs a different fix
+// (or model), not a bigger budget, so this reports false for that case.
+func shouldRetryTitleWithLargerBudget(canReason bool, finishReason fantasy.FinishReason, reasoningText string) bool {
+	return !canReason && finishReason == fantasy.FinishReasonLength && reasoningText != ""
+}
+
 // GenerateTitle generates a session title based on the initial prompt.
 func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, userPrompt string) {
 	if userPrompt == "" {
@@ -1779,6 +1791,29 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 		}
 		agent := newAgent(attempt.model.Model, titlePrompt, tok)
 		resp, err = agent.Stream(ctx, streamCall)
+
+		// A model whose reasoning capability isn't declared in its config
+		// (common for a hand-configured custom/local provider, e.g. a
+		// local llama.cpp server) still emits reasoning content if its own
+		// chat template does so by default -- the "/no_think" prompt hack
+		// above only works for templates that respect it. If the tiny
+		// 40-token budget was entirely consumed by hidden reasoning, that's
+		// a strong, template-agnostic signal this model needs the larger
+		// budget regardless of what CatwalkCfg.CanReason says. Retry once
+		// with it before giving up on this model -- otherwise a thinking
+		// model whose config never marked it as reasoning-capable burns
+		// the whole budget on reasoning, produces no title text, and every
+		// attempt falls through to the "Untitled Session" fallback.
+		if err == nil && shouldRetryTitleWithLargerBudget(attempt.model.CatwalkCfg.CanReason, resp.Response.FinishReason, resp.Response.Content.ReasoningText()) {
+			biggerTok := attempt.model.CatwalkCfg.DefaultMaxTokens
+			if biggerTok <= tok {
+				biggerTok = 2000
+			}
+			slog.Debug("Title generation hit token limit but model was reasoning; retrying with a larger budget", "model", attempt.name)
+			agent = newAgent(attempt.model.Model, titlePrompt, biggerTok)
+			resp, err = agent.Stream(ctx, streamCall)
+		}
+
 		if err == nil && resp.Response.FinishReason != fantasy.FinishReasonLength {
 			model = attempt.model
 			slog.Debug("Generated title with " + attempt.name + " model")

--- a/internal/agent/title_retry_test.go
+++ b/internal/agent/title_retry_test.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"testing"
+
+	"charm.land/fantasy"
+)
+
+// Regression test for a real reported bug (charmbracelet/crush#3284): a
+// thinking-capable local model (e.g. a hand-configured llama.cpp server)
+// whose config never declared CatwalkCfg.CanReason still reasons by its
+// own chat template default, burns the tiny 40-token title budget on
+// hidden reasoning, and every attempt falls through to "Untitled Session".
+func TestShouldRetryTitleWithLargerBudget(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		canReason     bool
+		finishReason  fantasy.FinishReason
+		reasoningText string
+		want          bool
+	}{
+		{
+			name:          "unconfigured reasoning model hit limit while thinking",
+			canReason:     false,
+			finishReason:  fantasy.FinishReasonLength,
+			reasoningText: "let me think about a good title...",
+			want:          true,
+		},
+		{
+			name:          "already used the bumped budget (CanReason true) -- no further retry",
+			canReason:     true,
+			finishReason:  fantasy.FinishReasonLength,
+			reasoningText: "let me think about a good title...",
+			want:          false,
+		},
+		{
+			name:          "hit limit but no reasoning content -- not a thinking-budget problem",
+			canReason:     false,
+			finishReason:  fantasy.FinishReasonLength,
+			reasoningText: "",
+			want:          false,
+		},
+		{
+			name:          "finished normally -- no retry needed",
+			canReason:     false,
+			finishReason:  fantasy.FinishReasonStop,
+			reasoningText: "",
+			want:          false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := shouldRetryTitleWithLargerBudget(tc.canReason, tc.finishReason, tc.reasoningText)
+			if got != tc.want {
+				t.Errorf("shouldRetryTitleWithLargerBudget(%v, %v, %q) = %v, want %v",
+					tc.canReason, tc.finishReason, tc.reasoningText, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3284.

## Root cause

`GenerateTitle` already bumps the output-token budget for models flagged `CatwalkCfg.CanReason` (40 → `DefaultMaxTokens`), specifically so a thinking model doesn't burn its whole budget on hidden reasoning content before producing a title. It also tries a `/no_think` prompt hack for templates that respect it.

`CanReason` comes from static model metadata (Catwalk's known-model registry). A hand-configured custom/local provider — like a local llama.cpp server serving a thinking-capable model — has no such metadata unless the user explicitly sets it. If it's unset, the model still reasons by its own chat template default (the `/no_think` hack only works for templates that specifically respect that convention) — crush just doesn't *know* to give it room. So it burns the tiny 40-token budget entirely on hidden reasoning, produces no title text, and every attempt (small model, then large model) falls through to the `"Untitled Session"` fallback — matching this issue's exact symptom.

## Fix

Detect this directly instead of depending on correct prior configuration: if a title attempt hits `FinishReasonLength` and the response contains reasoning content even though `CanReason` was false, that's a template-agnostic signal the model needs more room regardless of what its config declares. Retry that same attempt once with a larger budget (`DefaultMaxTokens`, or a 2000-token fallback if that's also unset for a custom model) before moving to the next model attempt.

Extracted the decision into `shouldRetryTitleWithLargerBudget` so it's directly unit-testable without mocking the full `Stream`/`Agent` machinery.

## Testing

- Added `TestShouldRetryTitleWithLargerBudget` (4 cases: unconfigured reasoning model hitting the limit → retry; already-bumped budget → no further retry; hit limit with no reasoning content → not a thinking-budget problem, no retry; finished normally → no retry).
- `go build ./...` and `go vet ./internal/agent/...` clean.
- Confirmed no other test in the package broke: `go test ./internal/agent/... -run "^$"` compiles clean across all subpackages.