### PR TITLE
feat(mcp): support static OAuth client ID for MCP servers

### DIFF
--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -632,7 +632,11 @@ func createTransport(ctx context.Context, m config.MCPConfig, resolver config.Va
 			if connTimeout != nil {
 				stopConnTimeout = func() { connTimeout.Stop() }
 			}
-			transport.OAuthHandler = newMCPOAuthHandler(url, stopConnTimeout)
+			oauthClientID, err := m.ResolvedOAuthClientID(resolver)
+			if err != nil {
+				return nil, err
+			}
+			transport.OAuthHandler = newMCPOAuthHandler(url, stopConnTimeout, oauthClientID, m.OAuthRedirectPort)
 		}
 		return transport, nil
 	case config.MCPSSE:

--- a/internal/agent/tools/mcp/oauth.go
+++ b/internal/agent/tools/mcp/oauth.go
@@ -141,6 +141,17 @@ type mcpOAuthHandler struct {
 	// openURL opens a URL in the user's browser. Injected so tests can
 	// simulate a headless environment or drive the callback directly.
 	openURL func(string) error
+	// staticClientID, when non-empty, is a pre-registered OAuth client ID
+	// (config: mcp.<name>.oauth_client_id). When set, discoverAndRegister
+	// skips RFC 7591 dynamic client registration and authenticates as
+	// this client directly, for authorization servers that only accept
+	// clients registered out-of-band.
+	staticClientID string
+	// redirectPort, when non-zero, fixes the local callback port instead
+	// of allocating an ephemeral one. Required alongside staticClientID
+	// so the redirect URI (http://localhost:<port>/callback) is stable
+	// and can be pre-registered with the authorization server.
+	redirectPort int
 
 	mu       sync.Mutex
 	tokenSrc oauth2.TokenSource
@@ -148,13 +159,15 @@ type mcpOAuthHandler struct {
 
 var _ auth.OAuthHandler = (*mcpOAuthHandler)(nil)
 
-func newMCPOAuthHandler(serverURL string, stopConnTimeout func()) *mcpOAuthHandler {
+func newMCPOAuthHandler(serverURL string, stopConnTimeout func(), staticClientID string, redirectPort int) *mcpOAuthHandler {
 	store := sharedTokenStore()
 	h := &mcpOAuthHandler{
 		serverURL:       serverURL,
 		store:           store,
 		stopConnTimeout: stopConnTimeout,
 		openURL:         browser.OpenURL,
+		staticClientID:  staticClientID,
+		redirectPort:    redirectPort,
 	}
 	// Restore any saved token so we can skip the browser flow on
 	// subsequent startups. The client ID, secret and endpoints are
@@ -219,7 +232,7 @@ func (h *mcpOAuthHandler) Authorize(ctx context.Context, req *http.Request, resp
 	authCtx, cancel := context.WithTimeout(ctx, oauthInteractiveTimeout)
 	defer cancel()
 
-	port, err := allocateCallbackPort(authCtx)
+	port, err := allocateCallbackPort(authCtx, h.redirectPort)
 	if err != nil {
 		resp.Body.Close()
 		return err
@@ -292,14 +305,29 @@ func (h *mcpOAuthHandler) buildInner(reg *clientRegistration, port int, redirect
 	return auth.NewAuthorizationCodeHandler(cfg)
 }
 
-// discoverAndRegister discovers the authorization server for the MCP server and
-// dynamically registers a client with it, returning the client credentials and
-// endpoints needed to complete and later refresh the flow.
+// discoverAndRegister discovers the authorization server for the MCP server
+// and either registers a client dynamically with it or, when a static client
+// ID was configured (mcp.<name>.oauth_client_id), uses that client directly.
+// It returns the client credentials and endpoints needed to complete and
+// later refresh the flow.
 func (h *mcpOAuthHandler) discoverAndRegister(ctx context.Context, redirectURL string) (*clientRegistration, error) {
 	client := &http.Client{Timeout: 30 * time.Second}
 	asm, err := h.discoverAuthServer(ctx, client)
 	if err != nil {
 		return nil, err
+	}
+	if h.staticClientID != "" {
+		// The authorization server doesn't need to support RFC 7591 dynamic
+		// client registration; the client was pre-registered out-of-band
+		// (e.g. in the provider's developer console) with a redirect URI
+		// matching redirectURL. No client secret: this path is for public
+		// clients using PKCE.
+		return &clientRegistration{
+			clientID:  h.staticClientID,
+			authURL:   asm.AuthorizationEndpoint,
+			tokenURL:  asm.TokenEndpoint,
+			authStyle: oauth2.AuthStyleInParams,
+		}, nil
 	}
 	if asm.RegistrationEndpoint == "" {
 		return nil, fmt.Errorf("authorization server %q does not support dynamic client registration", asm.Issuer)
@@ -401,13 +429,19 @@ func authStyleForRegistration(reg *oauthex.ClientRegistrationResponse, asm *oaut
 	return oauth2.AuthStyleAutoDetect
 }
 
-// allocateCallbackPort reserves a free localhost port for the OAuth callback
-// server. The listener is closed immediately; the callback server re-listens on
-// the same port.
-func allocateCallbackPort(ctx context.Context) (int, error) {
+// allocateCallbackPort reserves a localhost port for the OAuth callback
+// server. The listener is closed immediately; the callback server re-listens
+// on the same port. If preferredPort is non-zero, that exact port is
+// reserved (failing if it's already in use) instead of an ephemeral one —
+// used when a static OAuth client's redirect URI was pre-registered with a
+// fixed port.
+func allocateCallbackPort(ctx context.Context, preferredPort int) (int, error) {
 	var lc net.ListenConfig
-	ln, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	ln, err := lc.Listen(ctx, "tcp", fmt.Sprintf("127.0.0.1:%d", preferredPort))
 	if err != nil {
+		if preferredPort != 0 {
+			return 0, fmt.Errorf("failed to bind configured oauth_redirect_port %d: %w", preferredPort, err)
+		}
 		return 0, fmt.Errorf("failed to allocate callback port: %w", err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port

--- a/internal/agent/tools/mcp/oauth_flow_test.go
+++ b/internal/agent/tools/mcp/oauth_flow_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -161,6 +162,34 @@ func TestDiscoverAndRegister(t *testing.T) {
 		_, err := h.discoverAndRegister(t.Context(), "http://localhost:1/callback")
 		require.Error(t, err)
 	})
+
+	t.Run("static client ID skips dynamic registration", func(t *testing.T) {
+		t.Parallel()
+		base, mcpURL := newOAuthTestServer(t, oauthServerOpts{
+			servePRM: true, serveASM: true, registrationEndpoint: false,
+		})
+		h := &mcpOAuthHandler{serverURL: mcpURL, staticClientID: "preregistered-client-id"}
+		reg, err := h.discoverAndRegister(t.Context(), "http://localhost:1/callback")
+		require.NoError(t, err)
+		require.Equal(t, "preregistered-client-id", reg.clientID)
+		require.Empty(t, reg.clientSecret)
+		require.Equal(t, base+"/authorize", reg.authURL)
+		require.Equal(t, base+"/token", reg.tokenURL)
+		require.Equal(t, oauth2.AuthStyleInParams, reg.authStyle)
+	})
+
+	t.Run("static client ID does not require a registration endpoint", func(t *testing.T) {
+		t.Parallel()
+		// Same server as "auth server without registration endpoint" above,
+		// which fails for dynamic registration — but a static client ID
+		// should succeed against it.
+		_, mcpURL := newOAuthTestServer(t, oauthServerOpts{
+			servePRM: true, serveASM: true, registrationEndpoint: false,
+		})
+		h := &mcpOAuthHandler{serverURL: mcpURL, staticClientID: "static-id"}
+		_, err := h.discoverAndRegister(t.Context(), "http://localhost:1/callback")
+		require.NoError(t, err)
+	})
 }
 
 // TestAuthorize_EndToEnd drives the entire authorization-code flow against a
@@ -203,7 +232,7 @@ func TestAuthorize_EndToEnd(t *testing.T) {
 	t.Setenv("CRUSH_GLOBAL_CONFIG", t.TempDir())
 
 	stopped := false
-	h := newMCPOAuthHandler(mcpURL, func() { stopped = true })
+	h := newMCPOAuthHandler(mcpURL, func() { stopped = true }, "", 0)
 	h.openURL = simulateBrowser
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, mcpURL, nil)
@@ -223,7 +252,7 @@ func TestAuthorize_EndToEnd(t *testing.T) {
 
 	// And persisted with the registered client ID so refresh works after a
 	// restart. A brand-new handler restores it without any browser.
-	h2 := newMCPOAuthHandler(mcpURL, nil)
+	h2 := newMCPOAuthHandler(mcpURL, nil, "", 0)
 	saved, ok := h2.store.get(mcpURL)
 	require.True(t, ok, "token must be persisted")
 	require.Equal(t, "e2e-client-id", saved.ClientID, "the registered client ID must be persisted for refresh")
@@ -404,7 +433,7 @@ func TestOpenBrowserAndCapture(t *testing.T) {
 			t.Parallel()
 			open := func(string) error { return tt.openErr }
 
-			port, err := allocateCallbackPort(t.Context())
+			port, err := allocateCallbackPort(t.Context(), 0)
 			require.NoError(t, err)
 
 			type outcome struct {
@@ -439,7 +468,7 @@ func TestOpenBrowserAndCapture(t *testing.T) {
 
 func TestOpenBrowserAndCapture_ContextCancelled(t *testing.T) {
 	t.Parallel()
-	port, err := allocateCallbackPort(context.Background())
+	port, err := allocateCallbackPort(context.Background(), 0)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -450,6 +479,30 @@ func TestOpenBrowserAndCapture_ContextCancelled(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, res)
+}
+
+// TestAllocateCallbackPort_Preferred proves a preferred port is honoured
+// exactly (needed so a static OAuth client's pre-registered redirect URI
+// stays valid across runs), and that a second attempt to bind the same port
+// while it's held fails loudly instead of silently falling back.
+func TestAllocateCallbackPort_Preferred(t *testing.T) {
+	t.Parallel()
+
+	port, err := allocateCallbackPort(t.Context(), 0)
+	require.NoError(t, err)
+
+	got, err := allocateCallbackPort(t.Context(), port)
+	require.NoError(t, err)
+	require.Equal(t, port, got)
+
+	var lc net.ListenConfig
+	ln, err := lc.Listen(t.Context(), "tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	require.NoError(t, err)
+	defer ln.Close()
+
+	_, err = allocateCallbackPort(t.Context(), port)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "oauth_redirect_port")
 }
 
 // TestTokenStore_SaveMergesConcurrentDiskWrites proves save() preserves entries

--- a/internal/agent/tools/mcp/oauth_test.go
+++ b/internal/agent/tools/mcp/oauth_test.go
@@ -103,7 +103,7 @@ func TestMCPOAuthHandler_TokenSourceEmptyByDefault(t *testing.T) {
 	// token source, which tells the transport to send requests without
 	// an Authorization header (triggering the 401 → Authorize flow).
 	t.Setenv("CRUSH_GLOBAL_CONFIG", t.TempDir())
-	h := newMCPOAuthHandler("https://mcp.example.com/mcp", nil)
+	h := newMCPOAuthHandler("https://mcp.example.com/mcp", nil, "", 0)
 	ts, err := h.TokenSource(t.Context())
 	require.NoError(t, err)
 	require.Nil(t, ts)
@@ -163,7 +163,7 @@ func TestMCPOAuthHandler_RestoresSavedToken(t *testing.T) {
 	saved.Endpoints.TokenURL = "https://auth.example.com/token"
 	seed.save(serverURL, saved)
 
-	h := newMCPOAuthHandler(serverURL, nil)
+	h := newMCPOAuthHandler(serverURL, nil, "", 0)
 	ts, err := h.TokenSource(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, ts, "a saved token should produce a non-nil token source")
@@ -213,7 +213,7 @@ func TestMCPOAuthHandler_RestoredTokenRefreshes(t *testing.T) {
 	saved.Endpoints.TokenURL = tokenSrv.URL
 	seed.save(serverURL, saved)
 
-	h := newMCPOAuthHandler(serverURL, nil)
+	h := newMCPOAuthHandler(serverURL, nil, "", 0)
 	ts, err := h.TokenSource(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, ts)
@@ -243,7 +243,7 @@ func TestMCPOAuthHandler_ForbiddenPreservesToken(t *testing.T) {
 	saved.Endpoints.TokenURL = "https://auth.example.com/token"
 	seed.save(serverURL, saved)
 
-	h := newMCPOAuthHandler(serverURL, nil)
+	h := newMCPOAuthHandler(serverURL, nil, "", 0)
 
 	resp := &http.Response{
 		StatusCode: http.StatusForbidden,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -204,6 +204,21 @@ type MCPConfig struct {
 	// omitted from the outgoing request rather than sent as
 	// "Header:".
 	Headers map[string]string `json:"headers,omitempty" jsonschema:"description=HTTP headers for HTTP/SSE MCP servers"`
+
+	// OAuthClientID configures a pre-registered ("static") public OAuth
+	// client for HTTP/SSE MCP servers whose authorization server does
+	// not support RFC 7591 dynamic client registration. When set, Crush
+	// skips dynamic registration and authenticates as this client
+	// directly. Value runs through shell expansion at MCP startup, so
+	// $VAR and $(cmd) work.
+	OAuthClientID string `json:"oauth_client_id,omitempty" jsonschema:"description=Pre-registered OAuth client ID for authorization servers that do not support dynamic client registration"`
+
+	// OAuthRedirectPort fixes the local port used for the OAuth
+	// callback (http://localhost:<port>/callback) so the redirect URI
+	// is stable across runs and can be pre-registered with the
+	// authorization server ahead of time. Required when OAuthClientID
+	// is set, since an ephemeral port can't be pre-registered.
+	OAuthRedirectPort int `json:"oauth_redirect_port,omitempty" jsonschema:"description=Fixed local port for the OAuth callback redirect URI\\, required when oauth_client_id is set,example=51536"`
 }
 
 type LSPConfig struct {
@@ -399,6 +414,23 @@ func (m MCPConfig) ResolvedURL(r VariableResolver) (string, error) {
 	v, err := r.ResolveValue(m.URL)
 	if err != nil {
 		return "", fmt.Errorf("url: %w", err)
+	}
+	return v, nil
+}
+
+// ResolvedOAuthClientID returns m.OAuthClientID expanded through the
+// given resolver. The receiver is not mutated. Errors from the
+// resolver are already sanitized by ResolveValue and are wrapped with
+// %w for errors.Is/As.
+//
+// See ResolvedEnv for guidance on picking a resolver.
+func (m MCPConfig) ResolvedOAuthClientID(r VariableResolver) (string, error) {
+	if m.OAuthClientID == "" {
+		return "", nil
+	}
+	v, err := r.ResolveValue(m.OAuthClientID)
+	if err != nil {
+		return "", fmt.Errorf("oauth_client_id: %w", err)
 	}
 	return v, nil
 }


### PR DESCRIPTION
## Summary

#3348 just landed on `main` and added automatic browser-based OAuth for HTTP MCP servers, but it assumes the authorization server supports RFC 7591 dynamic client registration. Some authorization servers don't, and only accept OAuth clients that were pre-registered out-of-band, so those servers are unusable with Crush's MCP OAuth flow today.

This PR builds on #3348 to support that case:

- Adds `oauth_client_id` to `MCPConfig`: a pre-registered public OAuth client ID. When set, `discoverAndRegister` skips RFC 7591 dynamic registration and authenticates as this client directly.
- Adds `oauth_redirect_port` to `MCPConfig`: fixes the local OAuth callback port instead of allocating an ephemeral one, so the redirect URI (`http://localhost:<port>/callback`) stays stable and can be pre-registered with the authorization server ahead of time.
- Both values run through Crush's existing variable resolver/shell expansion at MCP startup.

## Test plan

- `go test ./internal/agent/tools/mcp/... ./internal/config/...`
- Added test coverage for:
  - static client ID skipping dynamic registration
  - static client ID working against an authorization server without a registration endpoint
  - `allocateCallbackPort` honoring a preferred port and failing loudly if it's already bound
