### PR TITLE
fix(agent): update session usage when a request fails, not just on success

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1086,6 +1086,35 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		// timeout bounds the cleanup writes.
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cleanupCancel()
+		// A failed request (e.g. a context-length-exceeded rejection) never
+		// reaches OnStepFinish, so the session's usage counters are left at
+		// whatever the last *successful* step reported, understating the
+		// actual size of the request that just failed. Record what was
+		// actually attempted so the context-window indicator reflects
+		// reality instead of a stale, smaller number (#3384). Prefer the
+		// provider's own reported token count (parsed from the error body
+		// by providers/{anthropic,openai,google} in charm.land/fantasy) over
+		// a local estimate, since it's the exact figure the provider
+		// rejected the request for. Always pass estimated=true regardless
+		// of the source: the request was never billed, so this must never
+		// add phantom cost or fire a usage-telemetry event.
+		if !isCancelErr && len(stepMessages) > 0 {
+			sessionLock.Lock()
+			if failedSession, getErr := a.sessions.Get(cleanupCtx, call.SessionID); getErr == nil {
+				var promptTokens int64
+				var providerErr *fantasy.ProviderError
+				if errors.As(err, &providerErr) && providerErr.IsContextTooLarge() && providerErr.ContextUsedTokens > 0 {
+					promptTokens = int64(providerErr.ContextUsedTokens)
+				} else {
+					promptTokens = estimateMessageTokens(stepMessages)
+				}
+				a.updateSessionUsage(largeModel, &failedSession, fantasy.Usage{InputTokens: promptTokens}, nil, true)
+				if _, saveErr := a.sessions.Save(cleanupCtx, failedSession); saveErr == nil {
+					currentSession = failedSession
+				}
+			}
+			sessionLock.Unlock()
+		}
 		// Ensure we finish thinking on error to close the reasoning state.
 		currentAssistant.FinishThinking()
 		toolCalls := currentAssistant.ToolCalls()

--- a/internal/agent/context_window_error_test.go
+++ b/internal/agent/context_window_error_test.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/require"
+)
+
+// contextOverflowModel succeeds on its first Stream call with a small
+// usage figure, then fails every subsequent call with a *fantasy.ProviderError
+// carrying context-too-large fields, simulating a provider (e.g. OpenRouter)
+// rejecting a request because the running conversation grew past the
+// model's context window.
+type contextOverflowModel struct {
+	calls      atomic.Int64
+	usedTokens int
+	maxTokens  int
+}
+
+func (m *contextOverflowModel) Provider() string { return "fake" }
+func (m *contextOverflowModel) Model() string    { return "fake-model" }
+
+func (m *contextOverflowModel) Generate(context.Context, fantasy.Call) (*fantasy.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *contextOverflowModel) Stream(_ context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
+	if m.calls.Add(1) == 1 {
+		return func(yield func(fantasy.StreamPart) bool) {
+			if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "1"}) {
+				return
+			}
+			if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "1", Delta: "ok"}) {
+				return
+			}
+			if !yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "1"}) {
+				return
+			}
+			yield(fantasy.StreamPart{
+				Type:         fantasy.StreamPartTypeFinish,
+				FinishReason: fantasy.FinishReasonStop,
+				Usage:        fantasy.Usage{InputTokens: 500, OutputTokens: 20},
+			})
+		}, nil
+	}
+	return nil, &fantasy.ProviderError{
+		Title:              "context_length_exceeded",
+		Message:            "This model's maximum context length is exceeded",
+		ContextTooLargeErr: true,
+		ContextUsedTokens:  m.usedTokens,
+		ContextMaxTokens:   m.maxTokens,
+	}
+}
+
+func (m *contextOverflowModel) GenerateObject(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *contextOverflowModel) StreamObject(context.Context, fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+// TestRun_ContextTooLargeErrorUpdatesSessionUsage reproduces #3384: after a
+// request is rejected for exceeding the model's context window, the
+// session's displayed usage must reflect the provider's reported (larger)
+// figure for the failed request, not the smaller usage left over from the
+// last *successful* step.
+func TestRun_ContextTooLargeErrorUpdatesSessionUsage(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	large := &contextOverflowModel{usedTokens: 270000, maxTokens: 262144}
+	small := &finishStreamModel{text: "title"}
+	sa := testSessionAgent(env, large, small, "system").(*sessionAgent)
+
+	sess, err := env.sessions.Create(t.Context(), "session")
+	require.NoError(t, err)
+
+	// First turn succeeds; session usage reflects the small reported usage.
+	_, err = sa.Run(t.Context(), SessionAgentCall{SessionID: sess.ID, Prompt: "first"})
+	require.NoError(t, err)
+
+	sess, err = env.sessions.Get(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.Equal(t, int64(500), sess.PromptTokens, "baseline usage from the successful first turn")
+
+	// Second turn is rejected for exceeding the context window.
+	_, err = sa.Run(t.Context(), SessionAgentCall{SessionID: sess.ID, Prompt: "second"})
+	require.Error(t, err)
+
+	sess, err = env.sessions.Get(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.Equal(t, int64(270000), sess.PromptTokens,
+		"session usage must reflect the provider's reported context size for the rejected request, not the stale successful-step figure")
+	require.True(t, sess.EstimatedUsage, "a failed, unbilled request must never be recorded as authoritative billed usage")
+}


### PR DESCRIPTION
Fixes #3384.

## The bug

The sidebar's context-window percentage is driven by `session.PromptTokens`/`session.CompletionTokens`, which only get written in `OnStepFinish` (`internal/agent/agent.go`) — i.e. only on a *successful* step. A request that OpenRouter (or any provider) rejects outright for exceeding the model's context window never produces a `StepResult`, so `OnStepFinish` never fires, and the session keeps whatever usage the last successful step reported. That's exactly the report: crush showed 62% (165k/262k) — stale, from before the conversation grew — while OpenRouter's own error said the actual request exceeded 262k.

## The fix

In the existing error-handling branch of `Run` (after `currentAssistant != nil`, so `PrepareStep` already ran and `stepMessages` holds what was about to be sent), record what was actually attempted:

1. **Prefer the provider's own number.** `charm.land/fantasy`'s Anthropic/OpenAI/Google providers already parse a context-length-exceeded error body into `ProviderError.ContextUsedTokens` / `ContextMaxTokens` (`IsContextTooLarge()`) — crush just never read them. This is the exact figure the provider rejected the request for, more precise than any local estimate.
2. **Fall back to the existing local estimator** (`estimateMessageTokens`, already used elsewhere in this file for the "successful step, zero usage" case) when the error isn't a parsed context-too-large error.
3. Always call `updateSessionUsage(..., estimated=true)` regardless of which source won — the request was never billed by the provider, so this must never add phantom cost or fire the usage-telemetry event that a real successful step does.

## Testing

Added `TestRun_ContextTooLargeErrorUpdatesSessionUsage`: drives a real `sessionAgent.Run()` through a fake `fantasy.LanguageModel` that succeeds once (small usage) and then fails with a `*fantasy.ProviderError{ContextTooLargeErr: true, ContextUsedTokens: 270000, ...}`, and asserts the session reflects the larger, provider-reported figure afterward (not the stale successful-step number). Confirmed red against current `main`, green with the fix.

- `go test ./internal/agent/... ./internal/ui/...` — 1134 passed (1 unrelated pre-existing failure on `main` too: `TestGlobFilesScopedPrefixMatchesUnscoped`, a Windows temp-path casing issue, confirmed unrelated by reproducing it on a clean checkout)
- `go build ./...` — clean
