### PR TITLE
feat(mcp): add explicit OAuth config, SSE transport OAuth, and metadata fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,29 @@ which do expand.
   }
 }
 ```
+}
+
+For `http` and `sse` servers that require OAuth, set the `oauth`
+field instead of a static `Authorization` header. Crush performs the
+authorization-code flow with PKCE in your browser, and persists the
+token to disk for subsequent sessions.
+
+```json
+{
+  "mcp": {
+    "datadog": {
+      "type": "http",
+      "url": "https://example.com/mcp/datadog/",
+      "timeout": 120,
+      "oauth": {}
+    }
+  }
+}
+```
+
+When `oauth` is not explicitly configured but the server has no
+`Authorization` header, Crush auto-detects OAuth capability and
+triggers the browser flow on the first 401.
 
 ### Hooks
 

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -618,16 +618,27 @@ func createTransport(ctx context.Context, m config.MCPConfig, resolver config.Va
 			Endpoint:   url,
 			HTTPClient: client,
 		}
-		// Enable OAuth for HTTP servers that don't have a static
-		// Authorization header. This allows browser-based OAuth flows
-		// (e.g. Cairn, other MCP servers using OIDC) to work
-		// automatically: on 401, the SDK opens a browser for the user
-		// to authenticate, captures the callback, and retries.
-		//
-		// The interactive flow can take far longer than the connection
-		// timeout, so hand the handler a way to suspend that timeout once
-		// authorization actually begins.
-		if !hasAuthHeader(headers) {
+		if m.OAuth != nil {
+			// Normalize the URL by stripping any trailing slash for
+			// Protected Resource Metadata (PRM) discovery. The PRM
+			// "resource" field typically does not have a trailing
+			// slash, and the SDK performs a strict string comparison.
+			normalizedURL := strings.TrimSuffix(url, "/")
+			handler, err := buildExplicitOAuthHandler(normalizedURL, normalizedURL, m.OAuth)
+			if err != nil {
+				return nil, fmt.Errorf("mcp oauth: %w", err)
+			}
+			transport.OAuthHandler = handler
+		} else if !hasAuthHeader(headers) {
+			// Enable OAuth for HTTP servers that don't have a static
+			// Authorization header. This allows browser-based OAuth flows
+			// (e.g. Cairn, other MCP servers using OIDC) to work
+			// automatically: on 401, the SDK opens a browser for the user
+			// to authenticate, captures the callback, and retries.
+			//
+			// The interactive flow can take far longer than the connection
+			// timeout, so hand the handler a way to suspend that timeout once
+			// authorization actually begins.
 			var stopConnTimeout func()
 			if connTimeout != nil {
 				stopConnTimeout = func() { connTimeout.Stop() }
@@ -647,10 +658,27 @@ func createTransport(ctx context.Context, m config.MCPConfig, resolver config.Va
 		if err != nil {
 			return nil, err
 		}
+		var transport http.RoundTripper = &headerRoundTripper{headers: headers}
+		if m.OAuth != nil {
+			// Normalize URL for PRM discovery (see HTTP case above).
+			normalizedURL := strings.TrimSuffix(url, "/")
+			handler, err := buildExplicitOAuthHandler(normalizedURL, normalizedURL, m.OAuth)
+			if err != nil {
+				return nil, fmt.Errorf("mcp oauth: %w", err)
+			}
+			transport = newOAuthRoundTripperWithBase(handler, transport)
+		} else if !hasAuthHeader(headers) {
+			// Auto-detect OAuth: SSE doesn't support OAuthHandler natively,
+			// so wrap the transport with our own round-tripper.
+			var stopConnTimeout func()
+			if connTimeout != nil {
+				stopConnTimeout = func() { connTimeout.Stop() }
+			}
+			handler := newMCPOAuthHandler(url, stopConnTimeout)
+			transport = newOAuthRoundTripperWithBase(handler, transport)
+		}
 		client := &http.Client{
-			Transport: &headerRoundTripper{
-				headers: headers,
-			},
+			Transport: transport,
 		}
 		return &mcp.SSEClientTransport{
 			Endpoint:   url,

--- a/internal/agent/tools/mcp/init_test.go
+++ b/internal/agent/tools/mcp/init_test.go
@@ -386,15 +386,22 @@ func TestCreateTransport_HeadersResolution(t *testing.T) {
 		m := config.MCPConfig{
 			Type:    config.MCPSSE,
 			URL:     "https://mcp.example.com/events",
-			Headers: map[string]string{"Authorization": "$MISSING_TOKEN"},
+			Headers: map[string]string{"X-API-Key": "$MISSING_TOKEN"},
 		}
 		tr, err := createTransport(t.Context(), m, r, nil)
 		require.NoError(t, err)
 		sse, ok := tr.(*mcp.SSEClientTransport)
 		require.True(t, ok)
-		rt, ok := sse.HTTPClient.Transport.(*headerRoundTripper)
+		// SSE auto-detects OAuth when no Authorization header is present and
+		// wraps the transport in oauthRoundTripper. Unwrap to get the
+		// underlying headerRoundTripper.
+		base := sse.HTTPClient.Transport
+		if oa, ok := base.(*oauthRoundTripper); ok {
+			base = oa.base
+		}
+		rt, ok := base.(*headerRoundTripper)
 		require.True(t, ok)
-		require.NotContains(t, rt.headers, "Authorization")
+		require.NotContains(t, rt.headers, "X-API-Key")
 	})
 }
 

--- a/internal/agent/tools/mcp/oauth.go
+++ b/internal/agent/tools/mcp/oauth.go
@@ -1,9 +1,12 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -480,4 +483,369 @@ func openBrowserAndCapture(ctx context.Context, authURL string, port int, server
 // config file. The token store lives alongside it.
 func globalConfigPath() string {
 	return filepath.Dir(config.GlobalConfig())
+}
+
+// buildExplicitOAuthHandler creates an auth.OAuthHandler using the
+// explicit OAuth configuration from the user's crush.json. It supports
+// three registration methods: client ID metadata URL, pre-registered
+// client credentials, or dynamic client registration.
+func buildExplicitOAuthHandler(serverName string, serverURL string, cfg *config.MCPOAuthConfig) (auth.OAuthHandler, error) {
+	cs := &callbackServer{
+		resultCh: make(chan callbackResult, 1),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", cs.handleCallback)
+
+	port := cfg.CallbackPort
+	if port == 0 {
+		var err error
+		port, err = allocateCallbackPort(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("oauth callback server: %w", err)
+		}
+	}
+
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return nil, fmt.Errorf("listen on port %d: %w", port, err)
+	}
+
+	listenPort := ln.Addr().(*net.TCPAddr).Port
+	cs.srv = &http.Server{Handler: mux}
+
+	go func() {
+		if err := cs.srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			slog.Warn("MCP OAuth callback server error", "error", err)
+		}
+	}()
+
+	redirectURL := fmt.Sprintf("http://localhost:%d/callback", listenPort)
+
+	handlerCfg := &auth.AuthorizationCodeHandlerConfig{
+		RedirectURL: redirectURL,
+		AuthorizationCodeFetcher: func(ctx context.Context, args *auth.AuthorizationArgs) (*auth.AuthorizationResult, error) {
+			authURL := stripResourceParam(args.URL)
+			slog.Info("Opening browser for MCP OAuth authorization", "url", authURL)
+			if err := browser.OpenURL(authURL); err != nil {
+				slog.Warn("Failed to open browser for OAuth, please open the URL manually", "url", authURL, "error", err)
+			}
+			select {
+			case result := <-cs.resultCh:
+				cs.shutdown()
+				if result.err != nil {
+					return nil, result.err
+				}
+				return &auth.AuthorizationResult{Code: result.code, State: result.state}, nil
+			case <-ctx.Done():
+				cs.shutdown()
+				return nil, ctx.Err()
+			}
+		},
+		Client: &http.Client{
+			Transport: newMetadataFixupRoundTripper(http.DefaultTransport),
+		},
+	}
+
+	switch {
+	case cfg.ClientIDMetadataURL != "":
+		handlerCfg.ClientIDMetadataDocumentConfig = &auth.ClientIDMetadataDocumentConfig{
+			URL: cfg.ClientIDMetadataURL,
+		}
+	case cfg.ClientID != "":
+		creds := &oauthex.ClientCredentials{ClientID: cfg.ClientID}
+		if cfg.ClientSecret != "" {
+			creds.ClientSecretAuth = &oauthex.ClientSecretAuth{ClientSecret: cfg.ClientSecret}
+		}
+		handlerCfg.PreregisteredClient = creds
+	default:
+		handlerCfg.DynamicClientRegistrationConfig = &auth.DynamicClientRegistrationConfig{
+			Metadata: &oauthex.ClientRegistrationMetadata{
+				ClientName:              "Crush MCP Client",
+				RedirectURIs:            []string{redirectURL},
+				TokenEndpointAuthMethod: "none",
+				GrantTypes:              []string{"authorization_code", "refresh_token"},
+				ResponseTypes:           []string{"code"},
+			},
+		}
+	}
+
+	inner, err := auth.NewAuthorizationCodeHandler(handlerCfg)
+	if err != nil {
+		return nil, fmt.Errorf("oauth handler: %w", err)
+	}
+
+	store := sharedTokenStore()
+
+	return &explicitOAuthHandler{
+		inner:     inner,
+		store:     store,
+		serverURL: serverURL,
+	}, nil
+}
+
+// explicitOAuthHandler wraps the SDK's AuthorizationCodeHandler for
+// usage with explicit OAuth configuration from crush.json.
+type explicitOAuthHandler struct {
+	inner     *auth.AuthorizationCodeHandler
+	store     *tokenStore
+	serverURL string
+
+	mu     sync.Mutex
+	source oauth2.TokenSource
+}
+
+func (h *explicitOAuthHandler) TokenSource(ctx context.Context) (oauth2.TokenSource, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.source != nil {
+		return h.source, nil
+	}
+
+	if saved, ok := h.store.get(h.serverURL); ok && saved.Token != nil && saved.Token.Valid() {
+		h.source = oauth2.StaticTokenSource(saved.Token)
+		return h.source, nil
+	}
+
+	return nil, nil
+}
+
+func (h *explicitOAuthHandler) Authorize(ctx context.Context, req *http.Request, resp *http.Response) error {
+	if err := h.inner.Authorize(ctx, req, resp); err != nil {
+		return err
+	}
+
+	ts, err := h.inner.TokenSource(ctx)
+	if err != nil || ts == nil {
+		return nil
+	}
+
+	token, err := ts.Token()
+	if err != nil || token == nil {
+		return nil
+	}
+
+	h.mu.Lock()
+	h.source = &persistingTokenSource{base: ts, save: func(t *oauth2.Token) error {
+		h.store.save(h.serverURL, mcptoken{Token: t})
+		return nil
+	}}
+	h.mu.Unlock()
+
+	h.store.save(h.serverURL, mcptoken{Token: token})
+	return nil
+}
+
+// persistingTokenSource wraps an oauth2.TokenSource and saves the
+// token whenever a new one is obtained (i.e. after a refresh).
+type persistingTokenSource struct {
+	base      oauth2.TokenSource
+	save      func(*oauth2.Token) error
+	lastToken *oauth2.Token
+	saveMu    sync.Mutex
+}
+
+func (s *persistingTokenSource) Token() (*oauth2.Token, error) {
+	token, err := s.base.Token()
+	if err != nil {
+		return nil, err
+	}
+
+	s.saveMu.Lock()
+	if s.lastToken == nil || token.AccessToken != s.lastToken.AccessToken {
+		s.lastToken = token
+		if saveErr := s.save(token); saveErr != nil {
+			slog.Warn("Failed to save refreshed MCP OAuth token", "error", saveErr)
+		}
+	}
+	s.saveMu.Unlock()
+
+	return token, nil
+}
+
+// callbackServer runs a local HTTP server that receives the OAuth
+// redirect after the user authorizes in their browser.
+type callbackServer struct {
+	resultCh chan callbackResult
+	srv      *http.Server
+}
+
+// callbackResult is sent from the HTTP handler to the waiting fetcher.
+type callbackResult struct {
+	code  string
+	state string
+	err   error
+}
+
+func (cs *callbackServer) handleCallback(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	code := query.Get("code")
+	state := query.Get("state")
+
+	if errParam := query.Get("error"); errParam != "" {
+		errorDesc := query.Get("error_description")
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "<h1>Authorization failed</h1><p>%s: %s</p>", html.EscapeString(errParam), html.EscapeString(errorDesc))
+		cs.resultCh <- callbackResult{err: fmt.Errorf("%s: %s", errParam, errorDesc)}
+		return
+	}
+
+	if code == "" {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintln(w, "<h1>Missing authorization code</h1>")
+		cs.resultCh <- callbackResult{err: fmt.Errorf("missing authorization code")}
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintln(w, "<h1>Authorization successful</h1><p>You can close this tab and return to Crush.</p>")
+
+	cs.resultCh <- callbackResult{code: code, state: state}
+}
+
+func (cs *callbackServer) shutdown() {
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = cs.srv.Shutdown(shutdownCtx)
+}
+
+// oauthRoundTripper injects a bearer token from an OAuth token source
+// into outgoing requests. Used for SSE transports that don't support
+// the OAuthHandler interface natively.
+type oauthRoundTripper struct {
+	base    http.RoundTripper
+	handler auth.OAuthHandler
+}
+
+func newOAuthRoundTripperWithBase(handler auth.OAuthHandler, base http.RoundTripper) *oauthRoundTripper {
+	return &oauthRoundTripper{base: base, handler: handler}
+}
+
+func (rt *oauthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+
+	resp, err := rt.doRequestWithToken(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		if authErr := rt.handler.Authorize(ctx, req, resp); authErr != nil {
+			return resp, nil
+		}
+		resp.Body.Close()
+
+		return rt.doRequestWithToken(ctx, req.Clone(ctx))
+	}
+
+	return resp, nil
+}
+
+func (rt *oauthRoundTripper) doRequestWithToken(ctx context.Context, req *http.Request) (*http.Response, error) {
+	ts, err := rt.handler.TokenSource(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("oauth token source: %w", err)
+	}
+
+	if ts != nil {
+		token, err := ts.Token()
+		if err == nil && token != nil {
+			req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+		}
+	}
+
+	return rt.base.RoundTrip(req)
+}
+
+// metadataFixupRoundTripper intercepts responses from OAuth metadata
+// endpoints (/.well-known/oauth-authorization-server and
+// /.well-known/oauth-protected-resource) and normalizes the "issuer"
+// field to strip trailing slashes. Some OAuth servers return an issuer
+// with a trailing slash that doesn't match the URL the metadata was
+// fetched from, causing the SDK's strict RFC 8414 validation to fail.
+type metadataFixupRoundTripper struct {
+	base http.RoundTripper
+}
+
+func newMetadataFixupRoundTripper(base http.RoundTripper) *metadataFixupRoundTripper {
+	return &metadataFixupRoundTripper{base: base}
+}
+
+func (rt *metadataFixupRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if !isMetadataEndpoint(req.URL.Path) {
+		return resp, nil
+	}
+
+	if resp.StatusCode != http.StatusOK || resp.Body == nil {
+		return resp, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("read metadata response: %w", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return resp, nil
+	}
+
+	changed := false
+	if issuer, ok := raw["issuer"].(string); ok && strings.HasSuffix(issuer, "/") {
+		raw["issuer"] = strings.TrimSuffix(issuer, "/")
+		changed = true
+	}
+
+	if !changed {
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return resp, nil
+	}
+
+	fixed, err := json.Marshal(raw)
+	if err != nil {
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return resp, nil
+	}
+
+	slog.Debug("Normalized OAuth metadata issuer trailing slash", "url", req.URL.String())
+	resp.Body = io.NopCloser(bytes.NewReader(fixed))
+	resp.ContentLength = int64(len(fixed))
+	resp.Header.Set("Content-Length", fmt.Sprintf("%d", len(fixed)))
+	return resp, nil
+}
+
+func isMetadataEndpoint(path string) bool {
+	return strings.Contains(path, "/.well-known/oauth-authorization-server") ||
+		strings.Contains(path, "/.well-known/oauth-protected-resource")
+}
+
+// stripResourceParam removes the "resource" query parameter from an
+// authorization URL. Some authorization servers reject the "resource"
+// parameter (RFC 8707) in the authorization request with server_error.
+// However, they DO support it in the token exchange, which is needed
+// to scope the access token to the correct resource. So we strip it
+// from the authorization URL only.
+func stripResourceParam(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	q := u.Query()
+	if q.Has("resource") {
+		q.Del("resource")
+		u.RawQuery = q.Encode()
+		slog.Debug("Stripped resource parameter from authorization URL")
+	}
+	return u.String()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -204,6 +204,39 @@ type MCPConfig struct {
 	// omitted from the outgoing request rather than sent as
 	// "Header:".
 	Headers map[string]string `json:"headers,omitempty" jsonschema:"description=HTTP headers for HTTP/SSE MCP servers"`
+
+	// OAuth configures dynamic OAuth 2.1 token acquisition for
+	// HTTP/SSE MCP servers. When set, Crush performs the MCP
+	// authorization-code flow (metadata discovery, PKCE, optional
+	// client registration) and injects bearer tokens automatically.
+	// When not set, Crush auto-detects OAuth capability when no
+	// static Authorization header is present.
+	OAuth *MCPOAuthConfig `json:"oauth,omitempty" jsonschema:"description=OAuth 2.1 configuration for dynamic token acquisition"`
+}
+
+// MCPOAuthConfig configures the OAuth 2.1 authorization-code flow
+// for an MCP server, as defined by the MCP specification. At least
+// one client registration method must be configured:
+// ClientIDMetadataURL or pre-registered client credentials. If
+// neither is set, dynamic client registration (RFC 7591) is used.
+type MCPOAuthConfig struct {
+	// ClientIDMetadataURL is the client ID metadata document URL
+	// (SEP-991 style). When set and the authorization server
+	// supports it, this is used as the client identifier.
+	ClientIDMetadataURL string `json:"client_id_metadata_url,omitempty" jsonschema:"description=Client ID metadata document URL (SEP-991)"`
+
+	// ClientID is the pre-registered client identifier. Must be
+	// used together with ClientSecret (for confidential clients)
+	// or alone (for public clients).
+	ClientID string `json:"client_id,omitempty" jsonschema:"description=Pre-registered OAuth client ID"`
+
+	// ClientSecret is the pre-registered client secret for
+	// confidential clients. Leave empty for public clients.
+	ClientSecret string `json:"client_secret,omitempty" jsonschema:"description=Pre-registered OAuth client secret"`
+
+	// CallbackPort is the TCP port for the local redirect server.
+	// Defaults to a random ephemeral port if 0 or unset.
+	CallbackPort int `json:"callback_port,omitempty" jsonschema:"description=Local TCP port for OAuth callback server,default=0"`
 }
 
 type LSPConfig struct {

--- a/schema.json
+++ b/schema.json
@@ -294,6 +294,10 @@
           },
           "type": "object",
           "description": "HTTP headers for HTTP/SSE MCP servers"
+        },
+        "oauth": {
+          "$ref": "#/$defs/MCPOAuthConfig",
+          "description": "OAuth 2.1 configuration for dynamic token acquisition"
         }
       },
       "additionalProperties": false,
@@ -301,6 +305,29 @@
       "required": [
         "type"
       ]
+    },
+    "MCPOAuthConfig": {
+      "properties": {
+        "client_id_metadata_url": {
+          "type": "string",
+          "description": "Client ID metadata document URL (SEP-991)"
+        },
+        "client_id": {
+          "type": "string",
+          "description": "Pre-registered OAuth client ID"
+        },
+        "client_secret": {
+          "type": "string",
+          "description": "Pre-registered OAuth client secret"
+        },
+        "callback_port": {
+          "type": "integer",
+          "description": "Local TCP port for OAuth callback server",
+          "default": 0
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "MCPs": {
       "additionalProperties": {


### PR DESCRIPTION
Previously, I created an MCP OAuth PR #3141 that I closed due to #2911 that was more complete.

However, since the #3348 was merged instead of the #2911, this PR adds some improvements from my previous PR.

- Add `MCPOAuthConfig` struct with `client_id`, `client_secret`, `client_id_metadata_url`, and `callback_port` fields, allowing users to pre-register clients or use **SEP-991** metadata instead of relying solely on dynamic registration
- Wire OAuth support into SSE transports via `oauthRoundTripper` (previously only HTTP transports had OAuth)
- Add `metadataFixupRoundTripper` to normalize trailing-slash issuers in OAuth metadata responses, fixing SDK strict **RFC 8414** validation
- Add `stripResourceParam` to drop the `resource` query parameter from authorization URLs that some servers reject
- Normalize trailing slashes from server URLs for Protected Resource Metadata discovery compatibility
- Document the `oauth` config field in `README` and `schema.json`

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
