### PR TITLE
fix(ux): prevent command palette cursor from being moved

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -186,7 +186,7 @@ require (
 	github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	github.com/yuin/goldmark v1.7.8 // indirect
+	github.com/yuin/goldmark v1.7.17 // indirect
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -419,8 +419,8 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.7.1/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
-github.com/yuin/goldmark v1.7.8 h1:iERMLn0/QJeHFhxSt3p6PeN9mGnvIKSpG9YYorDMnic=
-github.com/yuin/goldmark v1.7.8/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=
+github.com/yuin/goldmark v1.7.17 h1:p36OVWwRb246iHxA/U4p8OPEpOTESm4n+g+8t0EE5uA=
+github.com/yuin/goldmark v1.7.17/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yuin/goldmark-emoji v1.0.5 h1:EMVWyCGPlXJfUXBXpuMu+ii3TIaxbVBnEX9uaDC4cIk=
 github.com/yuin/goldmark-emoji v1.0.5/go.mod h1:tTkZEbwu5wkPmgTcitqddVxY9osFZiavD+r4AzQrh1U=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -160,7 +160,7 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 		c.dockerMCPAvailable = &msg.available
 		c.dockerMCPCheckInFlight = false
 		if c.selected == SystemCommands {
-			// Preserve the current selection across the rebuild to avoid reset when the list is rebuilt.
+			// Preserve the current selection across the rebuild to avoid reset
 			var prevID string
 			if item, ok := c.list.SelectedItem().(*CommandItem); ok && item != nil {
 				prevID = item.id

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -160,7 +160,21 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 		c.dockerMCPAvailable = &msg.available
 		c.dockerMCPCheckInFlight = false
 		if c.selected == SystemCommands {
+			// Preserve the current selection across the rebuild to avoid reset when the list is rebuilt.
+			var prevID string
+			if item, ok := c.list.SelectedItem().(*CommandItem); ok && item != nil {
+				prevID = item.id
+			}
 			c.setCommandItems(c.selected)
+			if prevID != "" {
+				for i, it := range c.list.FilteredItems() {
+					if ci, ok := it.(*CommandItem); ok && ci != nil && ci.id == prevID {
+						c.list.SetSelected(i)
+						c.list.ScrollToSelected()
+						break
+					}
+				}
+			}
 		}
 		return nil
 	case spinner.TickMsg:
@@ -556,15 +570,15 @@ func (c *Commands) SetMCPPrompts(mcpPrompts []commands.MCPPrompt) {
 }
 
 // StartLoading implements [LoadingDialog].
-func (a *Commands) StartLoading() tea.Cmd {
-	if a.loading {
+func (c *Commands) StartLoading() tea.Cmd {
+	if c.loading {
 		return nil
 	}
-	a.loading = true
-	return a.spinner.Tick
+	c.loading = true
+	return c.spinner.Tick
 }
 
 // StopLoading implements [LoadingDialog].
-func (a *Commands) StopLoading() {
-	a.loading = false
+func (c *Commands) StopLoading() {
+	c.loading = false
 }

--- a/internal/ui/dialog/oauth.go
+++ b/internal/ui/dialog/oauth.go
@@ -414,29 +414,29 @@ func (m *OAuth) ShortHelp() []key.Binding {
 	}
 }
 
-func (d *OAuth) copyCode() tea.Cmd {
-	if d.State != OAuthStateDisplay {
+func (m *OAuth) copyCode() tea.Cmd {
+	if m.State != OAuthStateDisplay {
 		return nil
 	}
-	return common.CopyToClipboard(d.userCode, "Code copied to clipboard")
+	return common.CopyToClipboard(m.userCode, "Code copied to clipboard")
 }
 
-func (d *OAuth) copyURL() tea.Cmd {
-	if d.State != OAuthStateDisplay {
+func (m *OAuth) copyURL() tea.Cmd {
+	if m.State != OAuthStateDisplay {
 		return nil
 	}
-	return common.CopyToClipboard(d.verificationURL, "URL copied to clipboard")
+	return common.CopyToClipboard(m.verificationURL, "URL copied to clipboard")
 }
 
-func (d *OAuth) copyCodeAndOpenURL() tea.Cmd {
-	if d.State != OAuthStateDisplay {
+func (m *OAuth) copyCodeAndOpenURL() tea.Cmd {
+	if m.State != OAuthStateDisplay {
 		return nil
 	}
 	return common.CopyToClipboardWithCallback(
-		d.userCode,
+		m.userCode,
 		"Code copied and URL opened",
 		func() tea.Msg {
-			if err := browser.OpenURL(d.verificationURL); err != nil {
+			if err := browser.OpenURL(m.verificationURL); err != nil {
 				return ActionOAuthErrored{fmt.Errorf("failed to open browser: %w", err)}
 			}
 			return nil

--- a/internal/ui/dialog/question_editor.go
+++ b/internal/ui/dialog/question_editor.go
@@ -225,12 +225,6 @@ func (e *questionEditor) noteCursor(screenRow, areaMinX, prefixWidth int) *tea.C
 	return tc
 }
 
-// hasNote reports whether a note exists for the given key.
-func (e *questionEditor) hasNote(key string) bool {
-	_, ok := e.notes[key]
-	return ok
-}
-
 // drawStandaloneNote draws a note editor or saved note directly
 // onto the screen (not via line list). Used by YesNo which doesn't
 // use the line-list model. Returns the cursor or nil.


### PR DESCRIPTION
This fixes a really annoying behavior that happens when you open the command palette and move the cursor before `Enable Docker MCP Catalog` is loaded.

Once it loads, it would reset the cursor to the first position again.

Also fixed some lint errors and updated a lib to fix a security issue.


https://github.com/user-attachments/assets/30fdeea2-aa07-4215-87ab-8a380bd5d768


https://github.com/user-attachments/assets/9494af60-607d-4e61-bf91-97768727c1ff




- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
