### PR TITLE
feat(session): print session id on exit

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -144,6 +144,7 @@ crush --continue
 			slog.Error("TUI run error", "error", err)
 			return errors.New("Crush crashed. If metrics are enabled, we were notified about it. If you'd like to report it, please copy the stacktrace above and open an issue at https://github.com/charmbracelet/crush/issues/new?template=bug.yml") //nolint:staticcheck
 		}
+		printSessionResume(model)
 		return nil
 	},
 }
@@ -161,6 +162,25 @@ var heartbit = lipgloss.NewStyle().Foreground(charmtone.Dolly).SetString(`
        ▀▀██████████▀▀
            ▀▀▀▀▀▀
 `)
+
+// printSessionResume prints the session title and resume hint to stdout after
+// the TUI exits, so the user can resume the session with `crush -s <id>`.
+// Nothing is printed when there is no active session.
+func printSessionResume(model *ui.UI) {
+	sess := model.CurrentSession()
+	if sess == nil || sess.ID == "" {
+		return
+	}
+	out := colorprofile.NewWriter(os.Stdout, os.Environ())
+
+	labelStyle := lipgloss.NewStyle().Foreground(charmtone.Damson).Bold(true)
+	valueStyle := lipgloss.NewStyle().Foreground(charmtone.Malibu)
+	hash := session.HashID(sess.ID)[:7]
+	title := strings.ReplaceAll(sess.Title, "\n", " ")
+
+	fmt.Fprintln(out, labelStyle.Render("Session  ")+valueStyle.Render(title))
+	fmt.Fprintln(out, labelStyle.Render("Continue ")+valueStyle.Render("crush -s "+hash))
+}
 
 // copied from cobra:
 const defaultVersionTemplate = `{{with .DisplayName}}{{printf "%s " .}}{{end}}{{printf "version %s" .Version}}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -197,11 +197,13 @@ func printSessionResume(model *ui.UI) {
 		title = ansi.Truncate(title, titleWidth, "…")
 	}
 
+	thanks := lipgloss.NewStyle().Width(contentWidth).Render("Thanks for using Crush!")
+
 	sessionLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Session  ") + title
 	continueLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Continue ") + "crush -s " + hash
-	info := sessionLine + "\n" + continueLine
+	info := crushLogo + "\n" + thanks + "\n\n" + sessionLine + "\n" + continueLine
 
-	body := style.Width(tw).Render(crushLogo + "\n" + info)
+	body := style.Width(tw).Render(info)
 
 	fmt.Fprintln(out, body)
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -169,11 +169,7 @@ var heartbit = lipgloss.NewStyle().Foreground(charmtone.Dolly).SetString(`
 // the TUI exits, so the user can resume the session with `crush -s <id>`.
 // Nothing is printed when there is no active session.
 func printSessionResume(model *ui.UI) {
-	sess := model.CurrentSession()
-	if sess == nil || sess.ID == "" {
-		return
-	}
-	out := colorprofile.NewWriter(os.Stdout, os.Environ())
+	out := colorprofile.NewWriter(os.Stderr, os.Environ())
 
 	t := styles.ThemeForProvider("")
 	crushLogo := logo.Render(t.Logo.GradCanvas, version.Version, true, logo.Opts{
@@ -185,23 +181,30 @@ func printSessionResume(model *ui.UI) {
 		Hyper:        false,
 	})
 
-	hash := session.HashID(sess.ID)[:7]
-	title := strings.ReplaceAll(sess.Title, "\n", " ")
+	sess := model.CurrentSession()
+	hasSession := sess != nil && sess.ID != ""
 
 	tw, _, _ := term.GetSize(os.Stdout.Fd())
 	style := lipgloss.NewStyle().Padding(1, 3)
 	contentWidth := tw - style.GetHorizontalFrameSize()
-	labelWidth := lipgloss.Width("Session  ")
-	titleWidth := contentWidth - labelWidth
-	if titleWidth > 0 {
-		title = ansi.Truncate(title, titleWidth, "…")
-	}
 
 	thanks := lipgloss.NewStyle().Width(contentWidth).Render("Thanks for using Crush!")
+	info := crushLogo + "\n" + thanks
 
-	sessionLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Session  ") + title
-	continueLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Continue ") + "crush -s " + hash
-	info := crushLogo + "\n" + thanks + "\n\n" + sessionLine + "\n" + continueLine
+	if hasSession {
+		title := strings.ReplaceAll(sess.Title, "\n", " ")
+
+		labelWidth := lipgloss.Width("Session  ")
+		titleWidth := contentWidth - labelWidth
+		if titleWidth > 0 {
+			title = ansi.Truncate(title, titleWidth, "…")
+		}
+
+		hash := session.HashID(sess.ID)[:7]
+		sessionLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Session  ") + title
+		continueLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Continue ") + "crush -s " + hash
+		info += "\n" + sessionLine + "\n" + continueLine
+	}
 
 	body := style.Width(tw).Render(info)
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -37,7 +37,9 @@ import (
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/skills"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/logo"
 	ui "github.com/charmbracelet/crush/internal/ui/model"
+	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/crush/internal/version"
 	"github.com/charmbracelet/crush/internal/workspace"
 	uv "github.com/charmbracelet/ultraviolet"
@@ -173,13 +175,35 @@ func printSessionResume(model *ui.UI) {
 	}
 	out := colorprofile.NewWriter(os.Stdout, os.Environ())
 
-	labelStyle := lipgloss.NewStyle().Foreground(charmtone.Damson).Bold(true)
-	valueStyle := lipgloss.NewStyle().Foreground(charmtone.Malibu)
+	t := styles.ThemeForProvider("")
+	crushLogo := logo.Render(t.Logo.GradCanvas, version.Version, true, logo.Opts{
+		FieldColor:   t.Logo.FieldColor,
+		TitleColorA:  t.Logo.TitleColorA,
+		TitleColorB:  t.Logo.TitleColorB,
+		CharmColor:   t.Logo.CharmColor,
+		VersionColor: t.Logo.VersionColor,
+		Hyper:        false,
+	})
+
 	hash := session.HashID(sess.ID)[:7]
 	title := strings.ReplaceAll(sess.Title, "\n", " ")
 
-	fmt.Fprintln(out, labelStyle.Render("Session  ")+valueStyle.Render(title))
-	fmt.Fprintln(out, labelStyle.Render("Continue ")+valueStyle.Render("crush -s "+hash))
+	tw, _, _ := term.GetSize(os.Stdout.Fd())
+	style := lipgloss.NewStyle().Padding(1, 3)
+	contentWidth := tw - style.GetHorizontalFrameSize()
+	labelWidth := lipgloss.Width("Session  ")
+	titleWidth := contentWidth - labelWidth
+	if titleWidth > 0 {
+		title = ansi.Truncate(title, titleWidth, "…")
+	}
+
+	sessionLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Session  ") + title
+	continueLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Continue ") + "crush -s " + hash
+	info := sessionLine + "\n" + continueLine
+
+	body := style.Width(tw).Render(crushLogo + "\n" + info)
+
+	fmt.Fprintln(out, body)
 }
 
 // copied from cobra:

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -188,8 +189,9 @@ func printSessionResume(model *ui.UI) {
 	style := lipgloss.NewStyle().Padding(1, 3)
 	contentWidth := tw - style.GetHorizontalFrameSize()
 
-	thanks := lipgloss.NewStyle().Width(contentWidth).Render("Thanks for using Crush!")
-	info := crushLogo + "\n" + thanks
+	info := crushLogo +
+		"\nThanks for using Crush! " +
+		lipgloss.NewStyle().Width(contentWidth).Render(randomExitMessage())
 
 	if hasSession {
 		title := strings.ReplaceAll(sess.Title, "\n", " ")
@@ -203,7 +205,7 @@ func printSessionResume(model *ui.UI) {
 		hash := session.HashID(sess.ID)[:7]
 		sessionLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Session  ") + title
 		continueLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Continue ") + "crush -s " + hash
-		info += "\n" + sessionLine + "\n" + continueLine
+		info += "\n\n" + sessionLine + "\n" + continueLine
 	}
 
 	body := style.Width(tw).Render(info)
@@ -214,6 +216,20 @@ func printSessionResume(model *ui.UI) {
 // copied from cobra:
 const defaultVersionTemplate = `{{with .DisplayName}}{{printf "%s " .}}{{end}}{{printf "version %s" .Version}}
 `
+
+// randomExitMessage returns a random exit message.
+func randomExitMessage() string {
+	messages := []string{
+		"",
+		"See ya later.",
+		"You look great.",
+		"Have a gorgeous time.",
+		"Get some rest.",
+		"Come back soon.",
+		"You worked handsomely.",
+	}
+	return messages[rand.IntN(len(messages))]
+}
 
 func Execute() {
 	// FIXME: config.Load uses slog internally during provider resolution,

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -227,6 +227,20 @@ func randomExitMessage() string {
 		"Get some rest.",
 		"Come back soon.",
 		"You worked handsomely.",
+		"Time for a snack.",
+		"Who’s hungry?",
+		"That was fun.",
+		"See you at breakfast?",
+		"Time for a nap.",
+		"Who wants some spaghetti?",
+		"Take care of yourself.",
+		"Remember to hydrate.",
+		"Time for a swim?",
+		"You’re quite glamorous, you know.",
+		"Nice work.",
+		"You’re a sensation.",
+		"Where’s my eyeliner?",
+		"It’s tea time.",
 	}
 	return messages[rand.IntN(len(messages))]
 }

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3778,6 +3778,12 @@ func (m *UI) hasSession() bool {
 	return m.session != nil && m.session.ID != ""
 }
 
+// CurrentSession returns the active session, or nil when there is none.
+// It is safe to call after the TUI has exited.
+func (m *UI) CurrentSession() *session.Session {
+	return m.session
+}
+
 // mimeOf detects the MIME type of the given content.
 func mimeOf(content []byte) string {
 	mimeBufferSize := min(512, len(content))

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3883,6 +3883,12 @@ func (m *UI) hasSession() bool {
 	return m.session != nil && m.session.ID != ""
 }
 
+// CurrentSession returns the active session, or nil when there is none.
+// It is safe to call after the TUI has exited.
+func (m *UI) CurrentSession() *session.Session {
+	return m.session
+}
+
 // mimeOf detects the MIME type of the given content.
 func mimeOf(content []byte) string {
 	mimeBufferSize := min(512, len(content))


### PR DESCRIPTION
This small PR prints the session id and the command that the user can use to directly connect to the previous session.

This feature is something that I miss from opencode and would be a nice addition to crush 😄

<img src="https://github.com/user-attachments/assets/9a5b2a5f-735e-4bb6-982e-01dd94500d5f " alt="image" width="224" data-linear-height="66" />

Closes charmbracelet/crush#2810

- [X] I have read [`CONTRIBUTING.md`](<https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md>).
- [X] I have created a discussion that was approved by a maintainer (for new features).

***

Editor’s note: credit here also goes to @aisk, who first raised the issue and contributed code accordingly.

Supersedes: #2507

Co-Authored By: @aisk