### PR TITLE
chore(cli): hide --channels

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -58,6 +58,7 @@ func init() {
 	rootCmd.Flags().BoolP("help", "h", false, "Help")
 	rootCmd.Flags().BoolP("yolo", "y", false, "Automatically accept all permissions (dangerous mode)")
 	rootCmd.PersistentFlags().StringSlice("channels", nil, "MCP servers to enable as channels (repeatable), e.g. --channels server:webhook")
+	_ = rootCmd.PersistentFlags().MarkHidden("channels")
 	rootCmd.Flags().StringP("session", "s", "", "Continue a previous session by ID")
 	rootCmd.Flags().BoolP("continue", "C", false, "Continue the most recent session")
 	rootCmd.MarkFlagsMutuallyExclusive("session", "continue")


### PR DESCRIPTION
Hot on the heels of #3345, I'm hiding `--channels`, temporarily, until the rest of the feature is complete, just incase we need wiggle room to make design decisions.

/cc @joestump 