### PR TITLE
fix(mcp): prevent panic when auth signal fires twice

### DIFF
--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -652,6 +652,14 @@ func (s *ConfigStore) WaitForTokenChange(ctx context.Context, providerID string)
 
 	select {
 	case <-ch:
+		// Remove the consumed signal so a subsequent
+		// SignalAuthComplete does not close an already-closed
+		// channel.
+		s.authSignalMu.Lock()
+		if s.authSignals[providerID] == ch {
+			delete(s.authSignals, providerID)
+		}
+		s.authSignalMu.Unlock()
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -667,8 +675,13 @@ func (s *ConfigStore) SignalAuthComplete(providerID string) {
 	s.authSignalMu.Lock()
 	defer s.authSignalMu.Unlock()
 	if ch, ok := s.authSignals[providerID]; ok {
-		close(ch)
 		delete(s.authSignals, providerID)
+		select {
+		case <-ch:
+			// Already closed by a previous signal; nothing to do.
+		default:
+			close(ch)
+		}
 	} else {
 		// No waiter yet. Pre-create a closed channel so the next
 		// WaitForTokenChange returns immediately.


### PR DESCRIPTION
This fix a crash during OAuth login caused by closing an already-closed channel in the auth signal mechanism.

Here’s the panic:

```
goroutine 384238 [running]:
runtime/debug.Stack()
        /Users/user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.5.darwin-arm64/src/runtime/debug/stack.go:26 +0x64
charm.land/bubbletea/v2.(*Program).recoverFromGoPanic(0x1ecb7c48f4a0, {0x1069e2a80, 0x106fd7990})
        /Users/user/go/pkg/mod/charm.land/bubbletea/v2@v2.0.8/tea.go:1304 +0xf0
charm.land/bubbletea/v2.(*Program).execBatchMsg.func2.1()
        /Users/user/go/pkg/mod/charm.land/bubbletea/v2@v2.0.8/tea.go:940 +0x38
panic({0x1069e2a80?, 0x106fd7990?})
        /Users/user/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.26.5.darwin-arm64/src/runtime/panic.go:860 +0x12c
github.com/charmbracelet/crush/internal/config.(*ConfigStore).SignalAuthComplete(0x1ecb7ba4c870, {0x1ecb7bd3c08b, 0x5})
        /Users/user/code/charm/crush/internal/config/store.go:655 +0x170
github.com/charmbracelet/crush/internal/workspace.(*AppWorkspace).SetProviderAPIKey(0x1ecb7c0cc060, 0x10360b61c?, {0x1ecb7bd3c08b, 0x5}, {0x106ab5080?, 0x1ecb7bed7600?})
        /Users/user/code/charm/crush/internal/workspace/app_workspace.go:359 +0x58
github.com/charmbracelet/crush/internal/ui/dialog.(*OAuth).HandleMsg.(*OAuth).saveCredential.func1()
        /Users/user/code/charm/crush/internal/ui/dialog/oauth.go:459 +0x3c
charm.land/bubbletea/v2.(*Program).execBatchMsg.func2()
        /Users/user/go/pkg/mod/charm.land/bubbletea/v2@v2.0.8/tea.go:945 +0x84
created by charm.land/bubbletea/v2.(*Program).execBatchMsg in goroutine 384235
        /Users/user/go/pkg/mod/charm.land/bubbletea/v2@v2.0.8/tea.go:934 +0xf0
```

💘 Generated with Crush