### PR TITLE
fix(ui): normalize bare carriage returns to newlines

### DIFF
--- a/internal/stringext/string.go
+++ b/internal/stringext/string.go
@@ -17,6 +17,7 @@ func Capitalize(text string) string {
 // converts tabs to four spaces, and trims leading and trailing whitespace.
 func NormalizeSpace(content string) string {
 	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
 	content = strings.ReplaceAll(content, "\t", "    ")
 	content = strings.TrimSpace(content)
 	return content

--- a/internal/stringext/string_test.go
+++ b/internal/stringext/string_test.go
@@ -7,6 +7,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNormalizeSpace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "crlf", input: "a\r\nb", expected: "a\nb"},
+		{name: "bare cr", input: "Rebasing (1/5)\rRebasing (2/5)\r", expected: "Rebasing (1/5)\nRebasing (2/5)"},
+		{name: "tabs", input: "a\tb", expected: "a    b"},
+		{name: "mixed", input: "a\r\nb\rc\td ", expected: "a\nb\nc    d"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, NormalizeSpace(tt.input))
+		})
+	}
+}
+
 func TestIsValidBase64(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This revision fixes rendering errors like this: 

<p><img width="692" height="266" src="https://github.com/user-attachments/assets/7fc5284e-24d9-4b33-9773-fcb8ee696cf4" /></p>

Here’s what it looks like with this patch:

<p><img width="685" height="250" src="https://github.com/user-attachments/assets/b70da02e-881e-4565-ace2-dc579756a40c" /></p>

And here's the fix, as described by the LLM:

Bare `\r` characters from tools like git progress output were being preserved and rendered as terminal cursor resets, causing visual corruption in tool result output. Convert them to newlines during whitespace normalization so they display as plain text.