### PR TITLE
fix(job_output): add timeout to prevent indefinite blocking on wait=true

### DIFF
--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -64,12 +64,13 @@ var bashDescriptionTpl = template.Must(
 )
 
 type bashDescriptionData struct {
-	BannedCommands  string
-	MaxOutputLength int
-	Attribution     config.Attribution
-	ModelID         string
-	RgAvailable     bool
-	GhAvailable     bool
+	BannedCommands           string
+	MaxOutputLength          int
+	MaxAutoBackgroundSeconds int
+	Attribution              config.Attribution
+	ModelID                  string
+	RgAvailable              bool
+	GhAvailable              bool
 }
 
 var bannedCommands = []string{
@@ -149,12 +150,13 @@ func bashDescription(attribution *config.Attribution, modelID string) string {
 	bannedCommandsStr := strings.Join(bannedCommands, ", ")
 	var out bytes.Buffer
 	if err := bashDescriptionTpl.Execute(&out, bashDescriptionData{
-		BannedCommands:  bannedCommandsStr,
-		MaxOutputLength: MaxOutputLength,
-		Attribution:     *attribution,
-		ModelID:         modelID,
-		RgAvailable:     getRg() != "",
-		GhAvailable:     ghAvailable,
+		BannedCommands:           bannedCommandsStr,
+		MaxOutputLength:          MaxOutputLength,
+		MaxAutoBackgroundSeconds: DefaultAutoBackgroundAfter,
+		Attribution:              *attribution,
+		ModelID:                  modelID,
+		RgAvailable:              getRg() != "",
+		GhAvailable:              ghAvailable,
 	}); err != nil {
 		// this should never happen.
 		panic("failed to execute bash description template: " + err.Error())

--- a/internal/agent/tools/bash.md.tpl
+++ b/internal/agent/tools/bash.md.tpl
@@ -21,6 +21,7 @@ Common shell builtins and core utils available on Windows.
 - Chain with ';' or '&&', avoid newlines except in quoted strings
 - Each command runs in independent shell (no state persistence between calls)
 - Prefer absolute paths over 'cd' (use 'cd' only if user explicitly requests)
+- IMPORTANT: When starting long-running processes (servers, watchers, daemons), the command auto-moves to background after {{ .MaxAutoBackgroundSeconds }} seconds. Use job_output with wait=false (polling) or a short timeout_seconds to check status. NEVER use job_output with wait=true on a server process — it will block until timeout.
 {{- if .RgAvailable }}
 - Ripgrep (`rg`) is available; prefer it over `grep` for faster, more intuitive searching
 {{- end }}

--- a/internal/agent/tools/job_output.go
+++ b/internal/agent/tools/job_output.go
@@ -5,13 +5,16 @@ import (
 	_ "embed"
 	"fmt"
 	"strings"
+	"time"
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/shell"
 )
 
 const (
-	JobOutputToolName = "job_output"
+	JobOutputToolName    = "job_output"
+	DefaultWaitTimeout   = 60 // seconds: default max wait time when wait=true
+	MaxWaitTimeout       = 600 // seconds: absolute max wait time (10 minutes)
 )
 
 //go:embed job_output.md
@@ -20,6 +23,11 @@ var jobOutputDescription string
 type JobOutputParams struct {
 	ShellID string `json:"shell_id" description:"The ID of the background shell to retrieve output from"`
 	Wait    bool   `json:"wait" description:"If true, block until the background shell completes before returning output"`
+	// TimeoutSeconds sets the maximum time to wait in seconds when wait=true.
+	// Default: 60. Setting to 0 uses the default. Maximum: 600 (10 minutes).
+	// For long-running processes (e.g. servers), set to a reasonable value
+	// or use wait=false (the default) to poll periodically instead.
+	TimeoutSeconds int `json:"timeout_seconds,omitempty" description:"Max wait time in seconds when wait=true (default: 60, max: 600)"`
 }
 
 type JobOutputResponseMetadata struct {
@@ -46,7 +54,16 @@ func NewJobOutputTool() fantasy.AgentTool {
 			}
 
 			if params.Wait {
-				bgShell.WaitContext(ctx)
+				timeout := DefaultWaitTimeout
+				if params.TimeoutSeconds > 0 {
+					timeout = params.TimeoutSeconds
+				}
+				if timeout > MaxWaitTimeout {
+					timeout = MaxWaitTimeout
+				}
+				waitCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+				defer cancel()
+				bgShell.WaitContext(waitCtx)
 			}
 
 			stdout, stderr, done, err := bgShell.GetOutput()

--- a/internal/agent/tools/job_output.md
+++ b/internal/agent/tools/job_output.md
@@ -1,1 +1,1 @@
-Get stdout/stderr from a background shell by ID; set wait=true to block until completion.
+Get stdout/stderr from a background shell by ID; set wait=true to block until completion (with configurable timeout, default 60s, max 600s). For long-running processes (e.g. servers), use wait=false to poll periodically instead.


### PR DESCRIPTION
## Problem

`job_output(shell_id="X", wait=true)` **blocks forever** when used on a long-running process (e.g. a web server, dev server, or any process that never exits).

This is a particularly nasty bug because:
- **Short commands** (build, test, git) complete instantly → never trigger it
- **Long-running processes** (start server, run watcher) → **exactly the scenario where users ask an AI coding assistant to "run my project"** → deadlock

The root cause: `WaitContext` only returns when:
1. The process exits — server never exits → never fires
2. The context is cancelled — no timeout is set → never fires

## Fix

Added a `timeout_seconds` parameter to `JobOutputParams` (default: 60, max: 600). When `wait=true`, the `WaitContext` call is now wrapped with `context.WithTimeout`, so the tool **always returns within the configured timeout**.

### Changes

| File | Change |
|------|--------|
| job_output.go | Added TimeoutSeconds field + context.WithTimeout wrapper |
| job_output.md | Updated description to mention timeout |
| bash.go | Added MaxAutoBackgroundSeconds to template data |
| bash.md.tpl | Added warning: NEVER use wait=true on server processes |

### Example

```
# Before: blocks forever on a running server
job_output(shell_id="022", wait=true)  → never returns

# After: returns within timeout
job_output(shell_id="022", wait=true)                → returns after 60s
job_output(shell_id="022", wait=true, timeout_seconds=300) → 5min
```