### PR TITLE
[feat] add custom template dir

### DIFF
--- a/.github/cla-signatures.json
+++ b/.github/cla-signatures.json
@@ -2207,6 +2207,14 @@
       "created_at": "2026-07-24T05:54:53Z",
       "repoId": 987670088,
       "pullRequestNo": 3411
+    },
+    {
+      "name": "bclermont",
+      "id": 474302,
+      "comment_id": 4967709688,
+      "created_at": "2026-07-24T10:48:00Z",
+      "repoId": 987670088,
+      "pullRequestNo": 3413
     }
   ]
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -180,6 +180,7 @@ type sessionAgent struct {
 	isYolo               bool
 	notify               pubsub.Publisher[notify.Notification]
 	runComplete          pubsub.Publisher[notify.RunComplete]
+	config               *config.ConfigStore
 
 	messageQueue   *csync.Map[string, []SessionAgentCall]
 	activeRequests *csync.Map[string, *activeCancel]
@@ -235,6 +236,7 @@ type SessionAgentOptions struct {
 	Tools                []fantasy.AgentTool
 	Notify               pubsub.Publisher[notify.Notification]
 	RunComplete          pubsub.Publisher[notify.RunComplete]
+	Config               *config.ConfigStore
 }
 
 func NewSessionAgent(
@@ -253,6 +255,7 @@ func NewSessionAgent(
 		isYolo:               opts.IsYolo,
 		notify:               opts.Notify,
 		runComplete:          opts.RunComplete,
+		config:               opts.Config,
 		messageQueue:         csync.NewMap[string, []SessionAgentCall](),
 		activeRequests:       csync.NewMap[string, *activeCancel](),
 		dispatchMu:           csync.NewMap[string, *sync.Mutex](),
@@ -1357,7 +1360,7 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 
 	agent := fantasy.NewAgent(
 		largeModel.Model,
-		fantasy.WithSystemPrompt(string(summaryPrompt)),
+		fantasy.WithSystemPrompt(a.loadTemplate("summary.md", summaryPrompt)),
 		fantasy.WithUserAgent(userAgent),
 	)
 	summaryMessage, err := a.messages.Create(ctx, sessionID, message.CreateMessageParams{
@@ -1769,6 +1772,8 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 		{"large", largeModel},
 	}
 
+	titlePromptStr := a.loadTemplate("title.md", titlePrompt)
+
 	var resp *fantasy.AgentResult
 	var err error
 	var model Model
@@ -1778,7 +1783,7 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 		if attempt.model.CatwalkCfg.CanReason {
 			tok = attempt.model.CatwalkCfg.DefaultMaxTokens
 		}
-		agent := newAgent(attempt.model.Model, titlePrompt, tok)
+		agent := newAgent(attempt.model.Model, []byte(titlePromptStr), tok)
 		resp, err = agent.Stream(ctx, streamCall)
 		if err == nil && resp.Response.FinishReason != fantasy.FinishReasonLength {
 			model = attempt.model
@@ -2274,4 +2279,18 @@ func sanitizeToolInput(toolName, toolCallID, input string) (string, bool) {
 		return "{}", true
 	}
 	return input, false
+}
+
+// loadTemplate loads a template from the configured template path if available,
+// otherwise falls back to the provided embedded template.
+func (a *sessionAgent) loadTemplate(name string, embedded []byte) string {
+	if a.config == nil {
+		return string(embedded)
+	}
+	loader := NewTemplateLoader(a.config)
+	s, err := loader.LoadTemplateString(name, embedded)
+	if err != nil {
+		return string(embedded)
+	}
+	return s
 }

--- a/internal/agent/agent_tool.go
+++ b/internal/agent/agent_tool.go
@@ -28,7 +28,7 @@ func (c *coordinator) agentTool(ctx context.Context) (fantasy.AgentTool, error) 
 	if !ok {
 		return nil, errors.New("task agent not configured")
 	}
-	prompt, err := taskPrompt(prompt.WithWorkingDir(c.cfg.WorkingDir()))
+	prompt, err := taskPrompt(c.cfg, prompt.WithWorkingDir(c.cfg.WorkingDir()))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/agentic_fetch_tool.go
+++ b/internal/agent/agentic_fetch_tool.go
@@ -174,33 +174,34 @@ func (c *coordinator) agenticFetchTool(_ context.Context, client *http.Client) (
 			}
 
 			// Sub-agent tools run without hook interception. The top-level
-			// `agentic_fetch` call itself is already wrapped from the coder's
-			// side; firing hooks again for every inner tool call would run
-			// the user's hooks N times per delegated turn.
+				// `agentic_fetch` call itself is already wrapped from the coder's
+				// side; firing hooks again for every inner tool call would run
+				// the user's hooks N times per delegated turn.
 
-			agent := NewSessionAgent(SessionAgentOptions{
-				LargeModel:           small, // Use small model for both (fetch doesn't need large)
-				SmallModel:           small,
-				SystemPromptPrefix:   smallProviderCfg.SystemPromptPrefix,
-				SystemPrompt:         systemPrompt,
-				DisableAutoSummarize: c.cfg.Config().Options.DisableAutoSummarize,
-				IsYolo:               c.permissions.SkipRequests(),
-				Sessions:             c.sessions,
-				Messages:             c.messages,
-				Tools:                fetchTools,
-			})
+				agent := NewSessionAgent(SessionAgentOptions{
+					LargeModel:           small, // Use small model for both (fetch doesn't need large)
+					SmallModel:           small,
+					SystemPromptPrefix:   smallProviderCfg.SystemPromptPrefix,
+					SystemPrompt:         systemPrompt,
+					DisableAutoSummarize: c.cfg.Config().Options.DisableAutoSummarize,
+					IsYolo:               c.permissions.SkipRequests(),
+					Sessions:             c.sessions,
+					Messages:             c.messages,
+					Tools:                fetchTools,
+					Config:               c.cfg,
+				})
 
-			return c.runSubAgent(ctx, subAgentParams{
-				Agent:          agent,
-				SessionID:      validationResult.SessionID,
-				AgentMessageID: validationResult.AgentMessageID,
-				ToolCallID:     call.ID,
-				Prompt:         fullPrompt,
-				SessionTitle:   "Fetch Analysis",
-				SessionSetup: func(sessionID string) {
-					c.permissions.AutoApproveSession(sessionID)
-				},
-			})
+				return c.runSubAgent(ctx, subAgentParams{
+					Agent:          agent,
+					SessionID:      validationResult.SessionID,
+					AgentMessageID: validationResult.AgentMessageID,
+					ToolCallID:     call.ID,
+					Prompt:         fullPrompt,
+					SessionTitle:   "Fetch Analysis",
+					SessionSetup: func(sessionID string) {
+						c.permissions.AutoApproveSession(sessionID)
+					},
+				})
 		},
 	), nil
 }

--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -128,14 +128,6 @@ func coderAgent(r *vcr.Recorder, env fakeEnv, large, small fantasy.LanguageModel
 		t, _ := time.Parse("1/2/2006", "1/1/2025")
 		return t
 	}
-	prompt, err := coderPrompt(
-		prompt.WithTimeFunc(fixedTime),
-		prompt.WithPlatform("linux"),
-		prompt.WithWorkingDir(filepath.ToSlash(env.workingDir)),
-	)
-	if err != nil {
-		return nil, err
-	}
 	cfg, err := config.Init(env.workingDir, "", false)
 	if err != nil {
 		return nil, err
@@ -154,6 +146,16 @@ func coderAgent(r *vcr.Recorder, env fakeEnv, large, small fantasy.LanguageModel
 	cfg.Config().Options.ContextPaths = nil
 	cfg.Config().Options.GlobalContextPaths = nil
 	cfg.Config().LSP = nil
+
+	prompt, err := coderPrompt(
+		cfg,
+		prompt.WithTimeFunc(fixedTime),
+		prompt.WithPlatform("linux"),
+		prompt.WithWorkingDir(filepath.ToSlash(env.workingDir)),
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	systemPrompt, err := prompt.Build(context.TODO(), large.Provider(), large.Model(), cfg)
 	if err != nil {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -188,7 +188,7 @@ func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, 
 	}
 
 	// TODO: make this dynamic when we support multiple agents
-	prompt, err := coderPrompt(prompt.WithWorkingDir(c.cfg.WorkingDir()))
+	prompt, err := coderPrompt(c.cfg, prompt.WithWorkingDir(c.cfg.WorkingDir()))
 	if err != nil {
 		return nil, err
 	}
@@ -625,6 +625,7 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		Tools:                nil,
 		Notify:               c.notify,
 		RunComplete:          c.runComplete,
+		Config:               c.cfg,
 	})
 
 	// The readiness goroutines below perform one-time setup — building the

--- a/internal/agent/coordinator_readiness_test.go
+++ b/internal/agent/coordinator_readiness_test.go
@@ -68,7 +68,7 @@ func TestBuildAgentReadinessSurvivesCallerCancellation(t *testing.T) {
 	// builds a coordinator, so the parked goroutine is harmless.
 	mcp.ArmInit()
 
-	p, err := coderPrompt(prompt.WithWorkingDir(env.workingDir))
+	p, err := coderPrompt(cfg, prompt.WithWorkingDir(env.workingDir))
 	require.NoError(t, err)
 	agentCfg := cfg.Config().Agents[config.AgentCoder]
 

--- a/internal/agent/prompts.go
+++ b/internal/agent/prompts.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	_ "embed"
 
 	"github.com/charmbracelet/crush/internal/agent/prompt"
@@ -17,16 +19,61 @@ var taskPromptTmpl []byte
 //go:embed templates/initialize.md.tpl
 var initializePromptTmpl []byte
 
-func coderPrompt(opts ...prompt.Option) (*prompt.Prompt, error) {
-	systemPrompt, err := prompt.NewPrompt("coder", string(coderPromptTmpl), opts...)
+// TemplateLoader loads templates from a filesystem path with fallback to embedded templates.
+type TemplateLoader struct {
+	config *config.ConfigStore
+}
+
+func NewTemplateLoader(cfg *config.ConfigStore) *TemplateLoader {
+	return &TemplateLoader{config: cfg}
+}
+
+// LoadTemplateString loads a template from the filesystem if TemplatePath is configured,
+// otherwise falls back to the provided embedded template.
+func (tl *TemplateLoader) LoadTemplateString(name string, embedded []byte) (string, error) {
+	if tl.config == nil || tl.config.Config().Options == nil {
+		return string(embedded), nil
+	}
+
+	templatePath := tl.config.Config().Options.TemplatePath
+	if templatePath == "" {
+		return string(embedded), nil
+	}
+
+	fullPath := filepath.Join(templatePath, name)
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		// Fall back to embedded template
+		return string(embedded), nil
+	}
+
+	return string(data), nil
+}
+
+func coderPrompt(cfg *config.ConfigStore, opts ...prompt.Option) (*prompt.Prompt, error) {
+	tmpl := string(coderPromptTmpl)
+	if cfg != nil {
+		loader := NewTemplateLoader(cfg)
+		if s, err := loader.LoadTemplateString("coder.md.tpl", coderPromptTmpl); err == nil {
+			tmpl = s
+		}
+	}
+	systemPrompt, err := prompt.NewPrompt("coder", tmpl, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return systemPrompt, nil
 }
 
-func taskPrompt(opts ...prompt.Option) (*prompt.Prompt, error) {
-	systemPrompt, err := prompt.NewPrompt("task", string(taskPromptTmpl), opts...)
+func taskPrompt(cfg *config.ConfigStore, opts ...prompt.Option) (*prompt.Prompt, error) {
+	tmpl := string(taskPromptTmpl)
+	if cfg != nil {
+		loader := NewTemplateLoader(cfg)
+		if s, err := loader.LoadTemplateString("task.md.tpl", taskPromptTmpl); err == nil {
+			tmpl = s
+		}
+	}
+	systemPrompt, err := prompt.NewPrompt("task", tmpl, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -34,7 +81,14 @@ func taskPrompt(opts ...prompt.Option) (*prompt.Prompt, error) {
 }
 
 func InitializePrompt(cfg *config.ConfigStore) (string, error) {
-	systemPrompt, err := prompt.NewPrompt("initialize", string(initializePromptTmpl))
+	tmpl := string(initializePromptTmpl)
+	if cfg != nil {
+		loader := NewTemplateLoader(cfg)
+		if s, err := loader.LoadTemplateString("initialize.md.tpl", initializePromptTmpl); err == nil {
+			tmpl = s
+		}
+	}
+	systemPrompt, err := prompt.NewPrompt("initialize", tmpl)
 	if err != nil {
 		return "", err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -305,6 +305,7 @@ type Options struct {
 	ContextPaths         []string    `json:"context_paths,omitempty" jsonschema:"description=Paths to files containing context information for the AI,example=.cursorrules,example=CRUSH.md"`
 	GlobalContextPaths   []string    `json:"global_context_paths,omitempty" jsonschema:"description=Paths to files containing global context information for the AI,default=~/.config/crush/CRUSH.md,default=~/.config/AGENTS.md"`
 	SkillsPaths          []string    `json:"skills_paths,omitempty" jsonschema:"description=Paths to directories containing Agent Skills (folders with SKILL.md files),example=~/.config/crush/skills,example=./skills"`
+	TemplatePath         string      `json:"template_path,omitempty" jsonschema:"description=Directory path to look for agent templates first before falling back to embedded templates,example=/tmp/templates"`
 	TUI                  *TUIOptions `json:"tui,omitempty" jsonschema:"description=Terminal user interface options"`
 	Debug                bool        `json:"debug,omitempty" jsonschema:"description=Enable debug logging,default=false"`
 	DebugLSP             bool        `json:"debug_lsp,omitempty" jsonschema:"description=Enable debug logging for LSP servers,default=false"`


### PR DESCRIPTION
Some instructions in `internal/agent/templates/coder.md.tpl` are in contradiction of my own instructions, causing the agent to be confused. Different users would probably want to enforce different system prompt. This allow to easily tweak those templates

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).

no, as that file do not even exists

- [ ] I have created a discussion that was approved by a maintainer (for new features).

no