### PR TITLE
fix(mcp): normalize oauth metadata redirects

### DIFF
--- a/internal/oauth/mcp/handler.go
+++ b/internal/oauth/mcp/handler.go
@@ -172,10 +172,10 @@ func NewHandler(
 		NewTokenSource:           newTokenSource,
 		// Use a metadata-fixing HTTP client so trailing-slash issuers in
 		// OAuth metadata responses don't trip the SDK's strict RFC 8414
-		// validation. Based on Bruno Krugel's fix from PR #3396.
-		Client: &http.Client{
-			Transport: newMetadataFixupRoundTripper(http.DefaultTransport),
-		},
+		// validation. Also rewrite internal-cluster redirects back to the
+		// external hostname so the flow works outside the cluster.
+		// Based on Bruno Krugel's fix from PR #3396.
+		Client: newOAuthMetadataClient(http.DefaultTransport, serverURL),
 		DynamicClientRegistrationConfig: &auth.DynamicClientRegistrationConfig{
 			Metadata: &oauthex.ClientRegistrationMetadata{
 				ClientName:   "Crush",
@@ -487,6 +487,36 @@ func (rt *metadataFixupRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 	resp.ContentLength = int64(len(fixed))
 	resp.Header.Set("Content-Length", fmt.Sprintf("%d", len(fixed)))
 	return resp, nil
+}
+
+// newOAuthMetadataClient creates an HTTP client that fixes two OAuth
+// metadata issues:
+//  1. Trailing-slash issuers: normalized via metadataFixupRoundTripper.
+//  2. Host-changing redirects: when a redirect sends the client to a
+//     different host (e.g. an internal cluster address behind a proxy),
+//     the target is rewritten to the original MCP server hostname, so
+//     the flow stays reachable.
+func newOAuthMetadataClient(base http.RoundTripper, serverURL string) *http.Client {
+	originalHost := ""
+	originalScheme := "https"
+	if u, err := url.Parse(serverURL); err == nil {
+		originalHost = u.Host
+		originalScheme = u.Scheme
+	}
+	return &http.Client{
+		Transport: newMetadataFixupRoundTripper(base),
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if originalHost != "" && req.URL.Host != originalHost {
+				req.URL.Host = originalHost
+				req.URL.Scheme = originalScheme
+				req.Host = originalHost
+			}
+			if len(via) >= 10 {
+				return fmt.Errorf("too many redirects")
+			}
+			return nil
+		},
+	}
 }
 
 func isMetadataEndpoint(path string) bool {

--- a/internal/oauth/mcp/handler.go
+++ b/internal/oauth/mcp/handler.go
@@ -489,16 +489,22 @@ func (rt *metadataFixupRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 	return resp, nil
 }
 
-// newOAuthMetadataClient creates an HTTP client that fixes two OAuth
-// metadata issues:
-//  1. Trailing-slash issuers: normalized via metadataFixupRoundTripper.
-//  2. Host-changing redirects: when a redirect sends the client to a
-//     different host (e.g. an internal cluster address behind a proxy),
-//     the target is rewritten to the original MCP server hostname, so
-//     the flow stays reachable.
+// newOAuthMetadataClient creates an HTTP client for the OAuth flow that
+// smooths over two nonstandard behaviors seen behind corporate proxies:
+//
+//  1. Trailing-slash issuers in metadata responses, normalized by
+//     metadataFixupRoundTripper so they pass the SDK's strict RFC 8414
+//     validation.
+//  2. Metadata discovery requests that get 3xx-redirected to an
+//     unreachable internal host (e.g. a cluster address behind a proxy).
+//     Well-known discovery is never supposed to hop hosts via redirects
+//     (the authorization server location comes from the metadata body,
+//     not a Location header), so for metadata endpoints we rewrite the
+//     redirect back to the original MCP host. Token, registration, and
+//     authorize requests are left untouched, so a separately hosted
+//     identity provider keeps working.
 func newOAuthMetadataClient(base http.RoundTripper, serverURL string) *http.Client {
-	originalHost := ""
-	originalScheme := "https"
+	var originalHost, originalScheme string
 	if u, err := url.Parse(serverURL); err == nil {
 		originalHost = u.Host
 		originalScheme = u.Scheme
@@ -506,13 +512,17 @@ func newOAuthMetadataClient(base http.RoundTripper, serverURL string) *http.Clie
 	return &http.Client{
 		Transport: newMetadataFixupRoundTripper(base),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if originalHost != "" && req.URL.Host != originalHost {
+			// Supplying CheckRedirect replaces net/http's default, so
+			// re-enforce its 10-redirect cap here.
+			if len(via) >= 10 {
+				return fmt.Errorf("stopped after 10 redirects")
+			}
+			if originalHost != "" && isMetadataEndpoint(req.URL.Path) && req.URL.Host != originalHost {
+				slog.Debug("Rewriting OAuth metadata redirect back to original host",
+					"from", req.URL.Host, "to", originalHost)
 				req.URL.Host = originalHost
 				req.URL.Scheme = originalScheme
 				req.Host = originalHost
-			}
-			if len(via) >= 10 {
-				return fmt.Errorf("too many redirects")
 			}
 			return nil
 		},

--- a/internal/ui/model/mcp.go
+++ b/internal/ui/model/mcp.go
@@ -83,7 +83,7 @@ func mcpList(t *styles.Styles, mcps []mcp.ClientInfo, width, maxItems int) strin
 				description = t.Resource.StatusText.Render(fmt.Sprintf("error: %s", m.Error.Error()))
 			}
 		case mcp.StateNeedsAuth:
-			icon = t.Resource.ErrorIcon.String()
+			icon = t.Resource.NeedsAuthIcon.String()
 			description = t.Resource.StatusText.Render("needs authentication")
 		case mcp.StateDisabled:
 			icon = t.Resource.DisabledIcon.String()

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -805,6 +805,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Resource.BusyIcon = s.Resource.OfflineIcon.Foreground(o.busy)
 	s.Resource.ErrorIcon = s.Resource.OfflineIcon.Foreground(o.destructive)
 	s.Resource.OnlineIcon = s.Resource.OfflineIcon.Foreground(o.successMostSubtle)
+	s.Resource.NeedsAuthIcon = s.Resource.OfflineIcon.Foreground(o.info)
 	s.Resource.DisabledIcon = lipgloss.NewStyle().Foreground(o.fgMoreSubtle).SetString("●")
 	s.Resource.AdditionalText = lipgloss.NewStyle().Foreground(o.fgMostSubtle)
 	s.Resource.CapabilityCount = lipgloss.NewStyle().Foreground(o.fgMostSubtle)

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -256,6 +256,7 @@ type Styles struct {
 		BusyIcon        lipgloss.Style // Busy/starting status icon
 		ErrorIcon       lipgloss.Style // Error status icon
 		OnlineIcon      lipgloss.Style // Online/ready status icon
+		NeedsAuthIcon   lipgloss.Style // Needs authentication status icon
 		AdditionalText  lipgloss.Style // "None" and "…and N more" text
 		CapabilityCount lipgloss.Style // "N tools" / "N prompts" / "N resources"
 		RowTitleBase    lipgloss.Style // Base style applied over row titles in common.Status


### PR DESCRIPTION
After rebasing my OAuth branch, I noticed that for one MCP that is behind the company proxy, the ASM fetch received a status code `307` and was redirected to the internal URL and failed.

This fix will normalize the URL if receive a `307` and will use the URL that is configured in `crush.json`.

I also changed the icon color to be blue instead of red when waiting for the MCP authentication


- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
