### PR TITLE
fix(copilot): add additional responses models

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -75,6 +75,9 @@ var copilotResponsesModels = map[string]bool{
 	"gpt-5.4-mini":  true,
 	"gpt-5.5":       true,
 	"gpt-5-mini":    true,
+	"gpt-5.6-luna":  true,
+	"gpt-5.6-terra": true,
+	"gpt-5.6-sol":   true,
 }
 
 // OpenCode models that user Anthropic Messages API instead of Chat Completions.


### PR DESCRIPTION
## Description
Using GPT-5.6 with Copilot subscription failed since crush call the completions endpoint when models are not in the Copilot Response list.
<img width="624" height="104" alt="image" src="https://github.com/user-attachments/assets/e21ec030-9db6-452e-b659-51efcedbde1c" />

## Fix
Add these model to the Response List. Similar to https://github.com/charmbracelet/crush/pull/3029 

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
