### PR TITLE
fix(mcp): remove orphaned tokens from oauths MCP

### DIFF
--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -254,27 +254,9 @@ func Initialize(ctx context.Context, permissions permission.Service, cfg *config
 	ArmInit()
 	slog.Info("Initializing MCP clients")
 
-	// Clean up orphaned MCP entries: when a user removes an MCP from
-	// their crush.json, the persisted data config still has the MCP
-	// entry (e.g. an OAuth token), which gets merged back as a phantom
-	// MCP with no type or URL. Remove the entire entry before iterating.
-	var orphans []string
-	for name, m := range cfg.Config().MCP {
-		if m.Type == "" {
-			orphans = append(orphans, name)
-		}
-	}
-	for _, name := range orphans {
-		slog.Info("Cleaning up orphaned MCP config entry", "name", name)
-		removeMCPCfgEntry(cfg, name)
-	}
-
 	var wg sync.WaitGroup
 	// Initialize states for all configured MCPs
 	for name, m := range cfg.Config().MCP {
-		if m.Type == "" {
-			continue
-		}
 		if m.Disabled {
 			updateState(name, StateDisabled, nil, nil, Counts{})
 			slog.Debug("Skipping disabled MCP", "name", name)
@@ -1032,17 +1014,6 @@ func isOAuthInitErr(err error) bool {
 	return strings.Contains(msg, "invalid_grant") ||
 		strings.Contains(msg, "invalid_client") ||
 		strings.Contains(msg, "no token available")
-}
-
-// removeMCPCfgEntry removes the entire mcp.<name> entry from the
-// global data config. This is used to clean up orphaned MCP entries
-// that have no type or URL (left behind when a user removes an MCP
-// from their crush.json but the persisted data config still has it).
-func removeMCPCfgEntry(cfg *config.ConfigStore, name string) {
-	key := fmt.Sprintf("mcp.%s", name)
-	if err := cfg.RemoveConfigField(config.ScopeGlobal, key); err != nil {
-		slog.Warn("Failed to remove orphaned MCP config entry", "name", name, "error", err)
-	}
 }
 
 // clearOAuthToken removes the persisted OAuth token for a named MCP

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -254,24 +254,27 @@ func Initialize(ctx context.Context, permissions permission.Service, cfg *config
 	ArmInit()
 	slog.Info("Initializing MCP clients")
 
-	// Clean up orphaned OAuth tokens: when a user removes an MCP from
-	// their crush.json, the persisted OAuth token in the data config
-	// still lingers and gets merged back as a phantom MCP entry with
-	// no type or URL. Remove those before they cause errors.
+	// Clean up orphaned MCP entries: when a user removes an MCP from
+	// their crush.json, the persisted data config still has the MCP
+	// entry (e.g. an OAuth token), which gets merged back as a phantom
+	// MCP with no type or URL. Remove the entire entry before iterating.
 	var orphans []string
 	for name, m := range cfg.Config().MCP {
-		if m.Type == "" && m.OAuthToken != nil {
+		if m.Type == "" {
 			orphans = append(orphans, name)
 		}
 	}
 	for _, name := range orphans {
-		slog.Info("Cleaning up orphaned MCP OAuth token", "name", name)
-		clearOAuthToken(cfg, name)
+		slog.Info("Cleaning up orphaned MCP config entry", "name", name)
+		removeMCPCfgEntry(cfg, name)
 	}
 
 	var wg sync.WaitGroup
 	// Initialize states for all configured MCPs
 	for name, m := range cfg.Config().MCP {
+		if m.Type == "" {
+			continue
+		}
 		if m.Disabled {
 			updateState(name, StateDisabled, nil, nil, Counts{})
 			slog.Debug("Skipping disabled MCP", "name", name)
@@ -1029,6 +1032,17 @@ func isOAuthInitErr(err error) bool {
 	return strings.Contains(msg, "invalid_grant") ||
 		strings.Contains(msg, "invalid_client") ||
 		strings.Contains(msg, "no token available")
+}
+
+// removeMCPCfgEntry removes the entire mcp.<name> entry from the
+// global data config. This is used to clean up orphaned MCP entries
+// that have no type or URL (left behind when a user removes an MCP
+// from their crush.json but the persisted data config still has it).
+func removeMCPCfgEntry(cfg *config.ConfigStore, name string) {
+	key := fmt.Sprintf("mcp.%s", name)
+	if err := cfg.RemoveConfigField(config.ScopeGlobal, key); err != nil {
+		slog.Warn("Failed to remove orphaned MCP config entry", "name", name, "error", err)
+	}
 }
 
 // clearOAuthToken removes the persisted OAuth token for a named MCP

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -253,6 +253,22 @@ func Close(ctx context.Context) error {
 func Initialize(ctx context.Context, permissions permission.Service, cfg *config.ConfigStore) {
 	ArmInit()
 	slog.Info("Initializing MCP clients")
+
+	// Clean up orphaned OAuth tokens: when a user removes an MCP from
+	// their crush.json, the persisted OAuth token in the data config
+	// still lingers and gets merged back as a phantom MCP entry with
+	// no type or URL. Remove those before they cause errors.
+	var orphans []string
+	for name, m := range cfg.Config().MCP {
+		if m.Type == "" && m.OAuthToken != nil {
+			orphans = append(orphans, name)
+		}
+	}
+	for _, name := range orphans {
+		slog.Info("Cleaning up orphaned MCP OAuth token", "name", name)
+		clearOAuthToken(cfg, name)
+	}
+
 	var wg sync.WaitGroup
 	// Initialize states for all configured MCPs
 	for name, m := range cfg.Config().MCP {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -234,6 +234,12 @@ type MCPConfig struct {
 	OAuthToken *oauth.Token `json:"oauth_token,omitempty" jsonschema:"-"`
 }
 
+// isOrphanedToken reports whether this entry is a leftover OAuth token
+// with no real server config.
+func (m MCPConfig) isOrphanedToken() bool {
+	return m.Type == "" && m.Command == "" && m.URL == "" && m.OAuthToken != nil
+}
+
 type LSPConfig struct {
 	Disabled    bool              `json:"disabled,omitempty" jsonschema:"description=Whether this LSP server is disabled,default=false"`
 	Command     string            `json:"command,omitempty" jsonschema:"description=Command to execute for the LSP server,example=gopls"`

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -539,6 +539,13 @@ func (c *Config) setDefaults(workingDir, dataDir string) {
 	if c.MCP == nil {
 		c.MCP = make(map[string]MCPConfig)
 	}
+	// Drop orphaned OAuth token entries left behind when a user removes
+	// an MCP from crush.json. See MCPConfig.isOrphanedToken.
+	for name, m := range c.MCP {
+		if m.isOrphanedToken() {
+			delete(c.MCP, name)
+		}
+	}
 	if c.LSP == nil {
 		c.LSP = make(map[string]LSPConfig)
 	}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -16,6 +16,7 @@ import (
 	"charm.land/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/csync"
 	"github.com/charmbracelet/crush/internal/env"
+	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -202,6 +203,24 @@ func TestConfig_setDefaults(t *testing.T) {
 		for _, path := range defaultContextPaths {
 			require.Contains(t, cfg.Options.ContextPaths, path)
 		}
+	})
+
+	t.Run("prunes orphaned OAuth token MCP entries but keeps real ones", func(t *testing.T) {
+		cfg := &Config{
+			MCP: map[string]MCPConfig{
+				"orphan":     {OAuthToken: &oauth.Token{AccessToken: "stale"}},
+				"real-http":  {Type: MCPHttp, URL: "https://example.com/mcp", OAuthToken: &oauth.Token{AccessToken: "live"}},
+				"real-stdio": {Type: MCPStdio, Command: "npx"},
+				"malformed":  {Command: "npx"}, // missing type but has a command: surface the error, don't prune
+			},
+		}
+
+		cfg.setDefaults(t.TempDir(), "")
+
+		require.NotContains(t, cfg.MCP, "orphan", "orphaned token entry should be pruned")
+		require.Contains(t, cfg.MCP, "real-http")
+		require.Contains(t, cfg.MCP, "real-stdio")
+		require.Contains(t, cfg.MCP, "malformed", "malformed entry should survive so its error surfaces")
 	})
 
 	t.Run("resolves relative configured data directory from working directory", func(t *testing.T) {


### PR DESCRIPTION
Another fix for oauth MCPs, if we add and authenticate in an OAuth MCP and later remove the config from our `crush.json`

We will result in orphaned entries in the mcp-oauth-tokens that will result in mcp entries with errors, example from log:

```
{"time":"2026-07-24T17:55:31.48167-03:00","level":"ERROR","source":{"function":"github.com/charmbracelet/crush/internal/agent/tools/mcp.createSession","file":"/Users/bruno.krugel/GitHub/crush/internal/agent/tools/mcp/init.go","line":652},"msg":"Error creating MCP client","error":"unsupported mcp type: ","name":"memory"}
```

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
