### PR TITLE
fix(illumos): support building and running crush"

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ Or just install it with Go:
 go install github.com/charmbracelet/crush@latest
 ```
 
+On illumos (OpenIndiana, OmniOS), the command above works as-is. Only native
+OS notifications are unavailable there; terminal-based notifications (OSC) and
+the terminal bell still work. On Oracle Solaris, add `-tags sqlite3_dotlk` so
+the local database uses dot-file locking:
+
+```
+go install -tags sqlite3_dotlk github.com/charmbracelet/crush@latest
+```
+
 > [!WARNING]
 > Productivity may increase when using Crush and you may find yourself nerd
 > sniped when first using the application. If the symptoms persist, join the

--- a/internal/shell/coreutils_exec.go
+++ b/internal/shell/coreutils_exec.go
@@ -1,0 +1,12 @@
+//go:build !solaris && !illumos
+
+package shell
+
+import (
+	"mvdan.cc/sh/moreinterp/coreutils"
+)
+
+// coreUtilsExecHandler installs mvdan.cc/sh's Go coreutils. It is only wired
+// in when useGoCoreUtils is set. On illumos and solaris, coreutils_exec_stub.go
+// supplies a nil handler because the coreutils package does not build there.
+var coreUtilsExecHandler execMiddleware = coreutils.ExecHandler

--- a/internal/shell/coreutils_exec_stub.go
+++ b/internal/shell/coreutils_exec_stub.go
@@ -1,0 +1,8 @@
+//go:build solaris || illumos
+
+package shell
+
+// coreUtilsExecHandler is nil on illumos and solaris: mvdan.cc/sh's coreutils
+// package does not compile there, so the Go coreutils middleware is simply
+// unavailable. standardHandlers skips it when the handler is nil.
+var coreUtilsExecHandler execMiddleware

--- a/internal/shell/dispatch.go
+++ b/internal/shell/dispatch.go
@@ -45,7 +45,7 @@ const probeWindow = 128
 // blockFuncs is the block list used when building the nested runner for the
 // shell-source case, so deny rules apply recursively to commands invoked
 // from in-process scripts.
-func scriptDispatchHandler(blockFuncs []BlockFunc) func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
+func scriptDispatchHandler(blockFuncs []BlockFunc) execMiddleware {
 	return func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
 		return func(ctx context.Context, args []string) error {
 			if len(args) == 0 || !isPathPrefixed(args[0]) {

--- a/internal/shell/run.go
+++ b/internal/shell/run.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"strings"
 
-	"mvdan.cc/sh/moreinterp/coreutils"
 	"mvdan.cc/sh/v3/expand"
 	"mvdan.cc/sh/v3/interp"
 	"mvdan.cc/sh/v3/syntax"
@@ -285,6 +284,11 @@ func withoutHerdrEnv(env []string) []string {
 	return result
 }
 
+// execMiddleware wraps a base [interp.ExecHandlerFunc], composing like HTTP
+// middleware: each layer either handles a command itself or delegates to the
+// next handler in the chain.
+type execMiddleware = func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc
+
 // standardHandlers returns the exec-handler middleware chain used by both
 // [Run] and [Shell]. Order matters:
 //  1. builtins first (so Crush's in-process jq wins over any PATH binary);
@@ -294,21 +298,21 @@ func withoutHerdrEnv(env []string) []string {
 //     script exec's rather than the outer path-prefixed wrapper;
 //  3. block list;
 //  4. optional Go coreutils (only when useGoCoreUtils is on).
-func standardHandlers(blockFuncs []BlockFunc) []func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
-	handlers := []func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc{
+func standardHandlers(blockFuncs []BlockFunc) []execMiddleware {
+	handlers := []execMiddleware{
 		builtinHandler(),
 		scriptDispatchHandler(blockFuncs),
 		blockHandler(blockFuncs),
 	}
-	if useGoCoreUtils {
-		handlers = append(handlers, coreutils.ExecHandler)
+	if useGoCoreUtils && coreUtilsExecHandler != nil {
+		handlers = append(handlers, coreUtilsExecHandler)
 	}
 	return handlers
 }
 
 // builtinHandler returns middleware that dispatches recognized Crush
 // builtins to their in-process Go implementations. Currently: jq.
-func builtinHandler() func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
+func builtinHandler() execMiddleware {
 	return func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
 		return func(ctx context.Context, args []string) error {
 			if len(args) == 0 {
@@ -328,7 +332,7 @@ func builtinHandler() func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
 // blockHandler returns middleware that rejects commands matched by any of
 // the provided [BlockFunc]s before they reach the underlying exec path.
 // A nil or empty blockFuncs slice is a no-op.
-func blockHandler(blockFuncs []BlockFunc) func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
+func blockHandler(blockFuncs []BlockFunc) execMiddleware {
 	return func(next interp.ExecHandlerFunc) interp.ExecHandlerFunc {
 		return func(ctx context.Context, args []string) error {
 			if len(args) == 0 {

--- a/internal/ui/dialog/notifications.go
+++ b/internal/ui/dialog/notifications.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/list"
+	"github.com/charmbracelet/crush/internal/ui/notification"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/sahilm/fuzzy"
@@ -241,17 +242,22 @@ func (n *Notifications) setItems() {
 
 	items := make([]list.FilterableItem, 0, len(AllNotificationStyles))
 	selectedIndex := 0
-	for i, style := range AllNotificationStyles {
+	for _, style := range AllNotificationStyles {
+		// Native OS notifications don't build on every platform
+		// (illumos/solaris); hide the option where it can't work.
+		if style.ID == "native" && !notification.NativeSupported {
+			continue
+		}
 		item := &NotificationItem{
 			Versioned: list.NewVersioned(),
 			style:     style,
 			isCurrent: style.ID == currentStyle,
 			t:         n.com.Styles,
 		}
-		items = append(items, item)
 		if style.ID == currentStyle {
-			selectedIndex = i
+			selectedIndex = len(items)
 		}
+		items = append(items, item)
 	}
 
 	n.list.SetItems(items...)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -545,6 +545,10 @@ func selectNotificationBackend(caps common.Capabilities, cfg *config.Config) not
 	if cfg != nil && cfg.Options != nil && cfg.Options.NotificationStyle != "" {
 		switch cfg.Options.NotificationStyle {
 		case "native":
+			if !notification.NativeSupported {
+				slog.Debug("Native notifications unavailable on this platform; using OSC backend", "osc99_supported", caps.OSC99Notifications)
+				return notification.NewOSCBackend(notification.Icon, caps.OSC99Notifications)
+			}
 			slog.Debug("Using native backend (user preference)")
 			return notification.NewNativeBackend(notification.Icon)
 		case "osc":
@@ -574,9 +578,10 @@ func selectNotificationBackend(caps common.Capabilities, cfg *config.Config) not
 
 	// Local sessions: prefer OSC on macOS because the native backend (beeep)
 	// uses terminal-notifier or AppleScript, which is slow and doesn't display
-	// icons properly. OSC 99 provides a more polished experience with icon support.
-	if runtime.GOOS == "darwin" {
-		slog.Debug("Selected OSCBackend for local macOS session", "osc99_supported", caps.OSC99Notifications)
+	// icons properly. Also prefer OSC where native notifications are unavailable
+	// (illumos/solaris). OSC 99 provides a polished experience with icon support.
+	if runtime.GOOS == "darwin" || !notification.NativeSupported {
+		slog.Debug("Selected OSCBackend for local session", "osc99_supported", caps.OSC99Notifications, "native_supported", notification.NativeSupported)
 		return notification.NewOSCBackend(notification.Icon, caps.OSC99Notifications)
 	}
 

--- a/internal/ui/notification/native.go
+++ b/internal/ui/notification/native.go
@@ -4,11 +4,14 @@ import (
 	"log/slog"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/gen2brain/beeep"
 )
 
 // NativeBackend sends desktop notifications using the native OS notification
-// system via beeep.
+// system. The actual delivery function is supplied per-platform via
+// defaultNotifyFunc; on illumos/solaris (where beeep's dbus dependency does
+// not build) it is a no-op. Selection logic avoids this backend there and
+// uses a terminal-based backend instead, so this is only a safety net. See
+// NativeSupported.
 type NativeBackend struct {
 	// icon is the notification icon data (PNG bytes).
 	icon []byte
@@ -18,10 +21,9 @@ type NativeBackend struct {
 
 // NewNativeBackend creates a new native notification backend.
 func NewNativeBackend(icon []byte) *NativeBackend {
-	beeep.AppName = "Crush"
 	return &NativeBackend{
 		icon:       icon,
-		notifyFunc: beeep.Notify,
+		notifyFunc: defaultNotifyFunc,
 	}
 }
 
@@ -48,5 +50,5 @@ func (b *NativeBackend) SetNotifyFunc(fn func(title, message string, icon any) e
 
 // ResetNotifyFunc resets the notification function to the default.
 func (b *NativeBackend) ResetNotifyFunc() {
-	b.notifyFunc = beeep.Notify
+	b.notifyFunc = defaultNotifyFunc
 }

--- a/internal/ui/notification/native_beeep.go
+++ b/internal/ui/notification/native_beeep.go
@@ -1,0 +1,19 @@
+//go:build !solaris && !illumos
+
+package notification
+
+import "github.com/gen2brain/beeep"
+
+// NativeSupported reports whether native OS notifications are available on
+// this platform. It is false on illumos/solaris, where beeep's dbus
+// dependency does not build. Callers use it to hide the native option and
+// pick a terminal-based backend instead.
+const NativeSupported = true
+
+// defaultNotifyFunc delivers notifications through beeep on platforms where
+// its dependencies build.
+var defaultNotifyFunc = beeep.Notify
+
+func init() {
+	beeep.AppName = "Crush"
+}

--- a/internal/ui/notification/native_stub.go
+++ b/internal/ui/notification/native_stub.go
@@ -1,0 +1,16 @@
+//go:build solaris || illumos
+
+package notification
+
+// NativeSupported reports whether native OS notifications are available on
+// this platform. It is false on illumos/solaris: beeep pulls in
+// github.com/godbus/dbus/v5, whose connection code is excluded on the solaris
+// build tag (which illumos also satisfies) and has no replacement, so it fails
+// to compile. OSC and bell backends still work, so callers hide the native
+// option and fall back to a terminal-based backend.
+const NativeSupported = false
+
+// defaultNotifyFunc is a no-op fallback so NewNativeBackend still compiles if
+// something forces the native backend on an unsupported platform. Selection
+// logic avoids the native backend here, so this is only a safety net.
+var defaultNotifyFunc = func(title, message string, icon any) error { return nil }


### PR DESCRIPTION
Avoid the unsupported u-root coreutils implementation on illumos and document the required Go install command.

Use the sqlite3_dotlk build tag where required by illumos distributions.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
