### PR TITLE
fix(mcp): rewrite multi-tenant OAuth issuer mismatches in metadata

### DIFF
--- a/internal/oauth/mcp/handler.go
+++ b/internal/oauth/mcp/handler.go
@@ -240,7 +240,8 @@ func NewHandler(
 	}
 	h.inner = inner
 
-	slog.Info("MCP OAuth handler created",
+	slog.Info(
+		"MCP OAuth handler created",
 		"name", serverName,
 		"redirect_url", redirectURL,
 		"restored_token", h.cachedToken != nil,
@@ -435,11 +436,16 @@ func (r *callbackReceiver) close() {
 	}
 }
 
-// metadataFixupRoundTripper normalizes trailing-slash issuers in OAuth
-// metadata responses. Some servers return an issuer with a trailing slash
-// that doesn't match the URL the metadata was fetched from, causing the
-// SDK's strict RFC 8414 validation to reject it. Based on Bruno Krugel's
-// fix from PR #3396.
+// metadataFixupRoundTripper normalizes issuers in OAuth metadata responses
+// so they pass the SDK's strict RFC 8414 validation. It handles two cases:
+//
+//  1. Trailing-slash issuers that don't match the discovery URL.
+//  2. Multi-tenant issuers: some providers (e.g., Atlassian) use a
+//     tenant-specific path for discovery but return a shared, top-level
+//     issuer in the metadata. The round tripper rewrites the issuer to
+//     match the discovery URL when they share the same origin.
+//
+// Based on Bruno Krugel's fix from PR #3396.
 type metadataFixupRoundTripper struct {
 	base http.RoundTripper
 }
@@ -453,36 +459,82 @@ func (rt *metadataFixupRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 	if err != nil {
 		return nil, err
 	}
-	if !isMetadataEndpoint(req.URL.Path) || resp.StatusCode != http.StatusOK || resp.Body == nil {
+	if !isIssuerMetadataEndpoint(req.URL.Path) || resp.StatusCode != http.StatusOK || resp.Body == nil {
 		return resp, nil
 	}
 
-	body, err := io.ReadAll(resp.Body)
-	resp.Body.Close()
+	// Cap the read to match the SDK's own metadata size limit (1 MiB) so
+	// a misbehaving server can't exhaust memory here. Oversized bodies
+	// are passed through untouched; the SDK will reject them.
+	const maxMetadataSize = 1 << 20
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxMetadataSize+1))
 	if err != nil {
+		resp.Body.Close()
 		return nil, fmt.Errorf("read metadata response: %w", err)
 	}
+	if len(body) > maxMetadataSize {
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{io.MultiReader(bytes.NewReader(body), resp.Body), resp.Body}
+		return resp, nil
+	}
+	resp.Body.Close()
 
+	// Decode with json.Number so re-marshaling doesn't mangle large
+	// integers into scientific notation.
 	var raw map[string]any
-	if json.Unmarshal(body, &raw) != nil {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	if dec.Decode(&raw) != nil {
 		resp.Body = io.NopCloser(bytes.NewReader(body))
 		return resp, nil
 	}
 
 	issuer, ok := raw["issuer"].(string)
-	if !ok || !strings.HasSuffix(issuer, "/") {
+	if !ok {
 		resp.Body = io.NopCloser(bytes.NewReader(body))
 		return resp, nil
 	}
 
-	raw["issuer"] = strings.TrimSuffix(issuer, "/")
+	changed := false
+
+	// Normalize trailing-slash issuers so they pass strict RFC 8414
+	// validation.
+	if strings.HasSuffix(issuer, "/") {
+		issuer = strings.TrimSuffix(issuer, "/")
+		raw["issuer"] = issuer
+		changed = true
+		slog.Debug("Normalized OAuth metadata issuer trailing slash", "url", req.URL.String())
+	}
+
+	// Rewrite the issuer for multi-tenant authorization servers. Some
+	// providers (e.g., Atlassian) use a tenant-specific path for
+	// discovery but return a shared, top-level issuer in the metadata.
+	// The SDK rejects this because the issuer doesn't match the
+	// discovery URL. When the metadata issuer shares the same origin
+	// as the discovery URL and is an ancestor path of it, rewrite the
+	// issuer to match the discovery URL.
+	if expected := issuerFromMetadataURL(req.URL.String()); expected != "" && issuer != expected {
+		if sameOrigin(issuer, expected) && isAncestorPath(issuer, expected) {
+			raw["issuer"] = expected
+			changed = true
+			slog.Debug("Rewrote OAuth metadata issuer for multi-tenant provider",
+				"original", issuer, "rewritten", expected, "url", req.URL.String())
+		}
+	}
+
+	if !changed {
+		resp.Body = io.NopCloser(bytes.NewReader(body))
+		return resp, nil
+	}
+
 	fixed, err := json.Marshal(raw)
 	if err != nil {
 		resp.Body = io.NopCloser(bytes.NewReader(body))
 		return resp, nil
 	}
 
-	slog.Debug("Normalized OAuth metadata issuer trailing slash", "url", req.URL.String())
 	resp.Body = io.NopCloser(bytes.NewReader(fixed))
 	resp.ContentLength = int64(len(fixed))
 	resp.Header.Set("Content-Length", fmt.Sprintf("%d", len(fixed)))
@@ -490,9 +542,10 @@ func (rt *metadataFixupRoundTripper) RoundTrip(req *http.Request) (*http.Respons
 }
 
 // newOAuthMetadataClient creates an HTTP client for the OAuth flow that
-// smooths over two nonstandard behaviors seen behind corporate proxies:
+// smooths over nonstandard behaviors seen in the wild:
 //
-//  1. Trailing-slash issuers in metadata responses, normalized by
+//  1. Issuer mismatches in metadata responses (trailing slashes and
+//     multi-tenant shared issuers), normalized by
 //     metadataFixupRoundTripper so they pass the SDK's strict RFC 8414
 //     validation.
 //  2. Metadata discovery requests that get 3xx-redirected to an
@@ -529,9 +582,106 @@ func newOAuthMetadataClient(base http.RoundTripper, serverURL string) *http.Clie
 	}
 }
 
+// isMetadataEndpoint reports whether path is a metadata discovery endpoint
+// subject to the redirect rewrite in newOAuthMetadataClient.
 func isMetadataEndpoint(path string) bool {
 	return strings.Contains(path, "/.well-known/oauth-authorization-server") ||
 		strings.Contains(path, "/.well-known/oauth-protected-resource")
+}
+
+// isIssuerMetadataEndpoint reports whether path is an authorization server
+// metadata discovery endpoint, i.e. one whose response carries an "issuer"
+// field validated by the SDK. Protected resource metadata is excluded: it
+// has no issuer and must not be rewritten.
+func isIssuerMetadataEndpoint(path string) bool {
+	return strings.Contains(path, "/.well-known/oauth-authorization-server") ||
+		strings.Contains(path, "/.well-known/openid-configuration")
+}
+
+// issuerFromMetadataURL reverses the SDK's metadata-URL construction to
+// recover the issuer URL that the SDK will compare against the metadata's
+// "issuer" field. The SDK builds discovery URLs from the issuer URL using
+// these patterns (see authorizationServerMetadataURLs in the go-sdk):
+//
+//	issuer "https://x.com"           → "https://x.com/.well-known/oauth-authorization-server"
+//	issuer "https://x.com/tenant"   → "https://x.com/.well-known/oauth-authorization-server/tenant"
+//	issuer "https://x.com/tenant"   → "https://x.com/.well-known/openid-configuration/tenant"
+//	issuer "https://x.com/tenant"   → "https://x.com/tenant/.well-known/openid-configuration"
+//
+// Given any of those discovery URLs, this function returns the original
+// issuer URL. Returns "" if the path doesn't look like a metadata URL.
+func issuerFromMetadataURL(metadataURL string) string {
+	u, err := url.Parse(metadataURL)
+	if err != nil {
+		return ""
+	}
+	path := strings.TrimRight(u.Path, "/")
+
+	// Path-insertion variant:
+	//   /.well-known/oauth-authorization-server[/tenant]
+	//   /.well-known/openid-configuration[/tenant]
+	for _, prefix := range []string{
+		"/.well-known/oauth-authorization-server",
+		"/.well-known/openid-configuration",
+	} {
+		if path == prefix {
+			u.Path = ""
+			return u.String()
+		}
+		if strings.HasPrefix(path, prefix+"/") {
+			u.Path = "/" + strings.TrimPrefix(path, prefix+"/")
+			return u.String()
+		}
+	}
+
+	// Path-appending variant:
+	//   /tenant/.well-known/openid-configuration
+	if idx := strings.LastIndex(path, "/.well-known/openid-configuration"); idx >= 0 {
+		tenant := path[:idx]
+		u.Path = tenant
+		if u.Path == "/" || u.Path == "" {
+			u.Path = ""
+		}
+		return u.String()
+	}
+
+	return ""
+}
+
+// sameOrigin reports whether two URLs share the same scheme and host.
+func sameOrigin(a, b string) bool {
+	ua, erra := url.Parse(a)
+	ub, errb := url.Parse(b)
+	if erra != nil || errb != nil {
+		return false
+	}
+	return ua.Scheme == ub.Scheme && ua.Host == ub.Host
+}
+
+// isAncestorPath reports whether ancestor is a path ancestor of descendant:
+// "https://x.com" is an ancestor of "https://x.com/tenant1", and
+// "https://x.com/a" is an ancestor of "https://x.com/a/b", but
+// "https://x.com/a" is NOT an ancestor of "https://x.com/ab".
+// Both URLs must share the same scheme and host.
+func isAncestorPath(ancestor, descendant string) bool {
+	ua, erra := url.Parse(ancestor)
+	ud, errd := url.Parse(descendant)
+	if erra != nil || errd != nil {
+		return false
+	}
+	if ua.Scheme != ud.Scheme || ua.Host != ud.Host {
+		return false
+	}
+	ap := strings.TrimSuffix(ua.Path, "/")
+	dp := strings.TrimSuffix(ud.Path, "/")
+	if ap == dp {
+		return true
+	}
+	if ap == "" {
+		// Root ancestor: any non-empty path on the same host is a descendant.
+		return dp != ""
+	}
+	return strings.HasPrefix(dp, ap+"/")
 }
 
 // stripResourceParam removes the "resource" query parameter from an

--- a/internal/oauth/mcp/handler_test.go
+++ b/internal/oauth/mcp/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -399,4 +400,301 @@ func TestHandler_BackgroundAuthorizeRefused(t *testing.T) {
 
 	err = authorizeWith401(t, h, base, mcpURL)
 	require.ErrorIs(t, err, ErrInteractiveAuthRequired)
+}
+
+// newFakeMultiTenantAS starts an httptest server that simulates a
+// multi-tenant authorization server like Atlassian's: the protected resource
+// metadata points to a tenant-specific auth server URL, but the metadata at
+// that URL returns a shared, top-level issuer. Without the
+// metadataFixupRoundTripper's issuer rewrite, the SDK's strict RFC 8414
+// validation rejects the mismatch.
+func newFakeMultiTenantAS(t *testing.T, opts fakeASOpts) (base, mcpURL string) {
+	t.Helper()
+	var baseURL string
+	writeJSON := func(w http.ResponseWriter, v any) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(v)
+	}
+
+	expiresIn := opts.tokenExpiresIn
+	if expiresIn == 0 {
+		expiresIn = 3600
+	}
+
+	mux := http.NewServeMux()
+	// The protected resource metadata advertises a tenant-specific auth
+	// server URL.
+	mux.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]any{
+			"resource":              baseURL + "/mcp",
+			"authorization_servers": []string{baseURL + "/tenant123"},
+		})
+	})
+	// The authorization server metadata is served at the tenant-specific
+	// path but returns a shared, top-level issuer.
+	mux.HandleFunc("/.well-known/oauth-authorization-server/tenant123", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, map[string]any{
+			"issuer":                           baseURL, // shared issuer, no tenant path
+			"authorization_endpoint":           baseURL + "/authorize",
+			"token_endpoint":                   baseURL + "/token",
+			"registration_endpoint":            baseURL + "/register",
+			"code_challenge_methods_supported": []string{"S256"},
+			"scopes_supported":                 []string{"offline_access"},
+		})
+	})
+	mux.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		if opts.failRegister {
+			http.Error(w, "registration not supported", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, map[string]any{
+			"client_id":                  opts.clientID,
+			"token_endpoint_auth_method": "none",
+		})
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		access := opts.accessToken
+		if r.Form.Get("grant_type") == "refresh_token" && opts.refreshedToken != "" {
+			access = opts.refreshedToken
+		}
+		writeJSON(w, map[string]any{
+			"access_token":  access,
+			"refresh_token": opts.refreshToken,
+			"token_type":    "Bearer",
+			"expires_in":    expiresIn,
+		})
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	baseURL = srv.URL
+	return srv.URL, srv.URL + "/mcp"
+}
+
+// TestHandler_MultiTenantIssuerRewrite proves the metadataFixupRoundTripper
+// rewrites the issuer in a multi-tenant authorization server's metadata so
+// it matches the tenant-specific discovery URL. Without the rewrite, the
+// SDK's strict RFC 8414 issuer validation rejects Atlassian-style providers
+// whose shared issuer differs from the tenant-specific discovery URL.
+func TestHandler_MultiTenantIssuerRewrite(t *testing.T) {
+	base, mcpURL := newFakeMultiTenantAS(t, fakeASOpts{
+		clientID:     "mt-client",
+		accessToken:  "mt-access",
+		refreshToken: "mt-refresh",
+	})
+
+	var (
+		mu    sync.Mutex
+		saved *oauth.Token
+	)
+	h, err := NewHandler("test", mcpURL, nil, nil, func(tok *oauth.Token) {
+		mu.Lock()
+		saved = tok
+		mu.Unlock()
+	}, true, 0)
+	require.NoError(t, err)
+	t.Cleanup(h.Close)
+	h.openURL = browserRedirect("mt-code")
+
+	require.NoError(t, authorizeWith401(t, h, base, mcpURL))
+
+	ts, err := h.TokenSource(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, ts)
+	tok, err := ts.Token()
+	require.NoError(t, err)
+	require.Equal(t, "mt-access", tok.AccessToken)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotNil(t, saved, "token must be persisted via the saver")
+	require.Equal(t, "mt-access", saved.AccessToken)
+}
+
+func TestIssuerFromMetadataURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"no path - oauth", "https://x.com/.well-known/oauth-authorization-server", "https://x.com"},
+		{"no path - oidc", "https://x.com/.well-known/openid-configuration", "https://x.com"},
+		{"tenant path-insertion - oauth", "https://auth.atlassian.com/.well-known/oauth-authorization-server/VCeDs123", "https://auth.atlassian.com/VCeDs123"},
+		{"tenant path-insertion - oidc", "https://auth.atlassian.com/.well-known/openid-configuration/VCeDs123", "https://auth.atlassian.com/VCeDs123"},
+		{"tenant path-appending - oidc", "https://auth.atlassian.com/VCeDs123/.well-known/openid-configuration", "https://auth.atlassian.com/VCeDs123"},
+		{"non-metadata path", "https://x.com/token", ""},
+		{"invalid url", "://bad", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := issuerFromMetadataURL(tt.url)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSameOrigin(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"same", "https://x.com", "https://x.com", true},
+		{"same diff path", "https://x.com/a", "https://x.com/b", true},
+		{"diff scheme", "http://x.com", "https://x.com", false},
+		{"diff host", "https://x.com", "https://y.com", false},
+		{"invalid a", "://bad", "https://x.com", false},
+		{"invalid b", "https://x.com", "://bad", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, sameOrigin(tt.a, tt.b))
+		})
+	}
+}
+
+func TestIsAncestorPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                 string
+		ancestor, descendant string
+		want                 bool
+	}{
+		{"root to tenant", "https://x.com", "https://x.com/tenant1", true},
+		{"parent to child", "https://x.com/a", "https://x.com/a/b", true},
+		{"equal", "https://x.com/a", "https://x.com/a", true},
+		{"not ancestor - prefix", "https://x.com/a", "https://x.com/ab", false},
+		{"diff host", "https://x.com", "https://y.com/tenant1", false},
+		{"diff scheme", "http://x.com", "https://x.com/tenant1", false},
+		{"invalid ancestor", "://bad", "https://x.com/tenant1", false},
+		{"invalid descendant", "https://x.com", "://bad", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, isAncestorPath(tt.ancestor, tt.descendant))
+		})
+	}
+}
+
+// staticResponseTripper returns a canned JSON response for any request,
+// letting us exercise the metadataFixupRoundTripper in isolation.
+type staticResponseTripper struct {
+	body   string
+	status int
+}
+
+func (s staticResponseTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: s.status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(s.body)),
+	}, nil
+}
+
+// roundTripIssuer sends a request for metadataURL through the fixup round
+// tripper with the given canned body and returns the issuer from the
+// (possibly rewritten) response.
+func roundTripIssuer(t *testing.T, metadataURL, body string) string {
+	t.Helper()
+	rt := newMetadataFixupRoundTripper(staticResponseTripper{body: body, status: http.StatusOK})
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, metadataURL, nil)
+	require.NoError(t, err)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(raw, &meta))
+	issuer, _ := meta["issuer"].(string)
+	return issuer
+}
+
+// TestMetadataFixup_RewritesSameOriginAncestor proves the multi-tenant
+// rewrite fires only in the intended case.
+func TestMetadataFixup_RewritesSameOriginAncestor(t *testing.T) {
+	t.Parallel()
+	got := roundTripIssuer(
+		t,
+		"https://auth.atlassian.com/.well-known/oauth-authorization-server/tenant1",
+		`{"issuer":"https://auth.atlassian.com"}`,
+	)
+	require.Equal(t, "https://auth.atlassian.com/tenant1", got)
+}
+
+// TestMetadataFixup_SecurityBoundaries proves the issuer rewrite never
+// fires when it would let a server impersonate a different issuer: a
+// cross-host issuer, a cross-scheme issuer, or a non-ancestor path must
+// all pass through untouched so the SDK's strict validation rejects them.
+func TestMetadataFixup_SecurityBoundaries(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		metadataURL string
+		issuer      string
+	}{
+		{
+			"cross-host issuer is not rewritten",
+			"https://auth.atlassian.com/.well-known/oauth-authorization-server/tenant1",
+			"https://evil.example.com",
+		},
+		{
+			"cross-scheme issuer is not rewritten",
+			"https://auth.atlassian.com/.well-known/oauth-authorization-server/tenant1",
+			"http://auth.atlassian.com",
+		},
+		{
+			"non-ancestor path is not rewritten",
+			"https://auth.atlassian.com/.well-known/oauth-authorization-server/tenant1",
+			"https://auth.atlassian.com/other",
+		},
+		{
+			"descendant issuer is not rewritten",
+			"https://auth.atlassian.com/.well-known/oauth-authorization-server/tenant1",
+			"https://auth.atlassian.com/tenant1/deeper",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := roundTripIssuer(t, tt.metadataURL, `{"issuer":"`+tt.issuer+`"}`)
+			require.Equal(t, tt.issuer, got, "issuer must pass through unmodified")
+		})
+	}
+}
+
+// TestMetadataFixup_ProtectedResourceUntouched proves protected resource
+// metadata responses are never modified even if they contain an issuer-like
+// field.
+func TestMetadataFixup_ProtectedResourceUntouched(t *testing.T) {
+	t.Parallel()
+	body := `{"resource":"https://x.com/mcp","issuer":"https://elsewhere.com/"}`
+	rt := newMetadataFixupRoundTripper(staticResponseTripper{body: body, status: http.StatusOK})
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet,
+		"https://x.com/.well-known/oauth-protected-resource/mcp", nil)
+	require.NoError(t, err)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.JSONEq(t, body, string(raw), "protected resource metadata must pass through byte-identical")
+}
+
+// TestMetadataFixup_TrailingSlashStillNormalized guards the pre-existing
+// trailing-slash normalization behavior.
+func TestMetadataFixup_TrailingSlashStillNormalized(t *testing.T) {
+	t.Parallel()
+	got := roundTripIssuer(
+		t,
+		"https://x.com/.well-known/oauth-authorization-server",
+		`{"issuer":"https://x.com/"}`,
+	)
+	require.Equal(t, "https://x.com", got)
 }


### PR DESCRIPTION
Fixes #3419.

The Jira MCP server (`https://mcp.atlassian.com/v1/mcp/authv2`) requires
OAuth, which v0.87.0 added support for. But the OAuth 2.1 implementation's
strict RFC 8414 issuer validation is incompatible with Atlassian's
multi-tenant authorization server: discovery resolves a tenant-specific URL
(`https://auth.atlassian.com/VCeDs...`), while the metadata response returns
a shared, top-level issuer (`https://auth.atlassian.com`). The mismatch fails
before authorization can complete:

calling "initialize": sending "initialize": rejected by transport: failed to
get authorization server metadata: metadata issuer
"https://auth.atlassian.com" does not match issuer URL
"https://auth.atlassian.com/VCeDsk..."

This is a common pattern for multi-tenant providers that front many tenants
with one authorization server: the tenant-specific path is used for
discovery and routing, but the canonical issuer stays at the top-level
domain.

## Fix

Extends `metadataFixupRoundTripper` (already normalizing trailing-slash
issuers per #3396) to also rewrite the issuer when:

- it shares the same origin (scheme + host) as the discovery URL, and
- it is a path ancestor of the discovery URL (e.g. `https://x.com` is an
  ancestor of `https://x.com/tenant1`; `https://x.com/a` is *not* an
  ancestor of `https://x.com/ab`).

Both conditions must hold before the rewrite fires, so a server can't use
this to impersonate a different issuer — cross-host, cross-scheme, and
non-ancestor-path mismatches all pass through untouched and are still
rejected by the SDK's validation as before. Protected resource metadata
(which has no `issuer` field) is never touched.

## Test plan

- [x] New unit tests, all passing:
  - `TestHandler_MultiTenantIssuerRewrite` — end-to-end handler test against
    a fake multi-tenant AS (tenant-specific discovery, shared issuer)
  - `TestIssuerFromMetadataURL`, `TestSameOrigin`, `TestIsAncestorPath` —
    table-driven unit tests for the new helpers
  - `TestMetadataFixup_RewritesSameOriginAncestor` — proves the rewrite
    fires for the intended Atlassian-shaped case
  - `TestMetadataFixup_SecurityBoundaries` — proves it does *not* fire for
    cross-host, cross-scheme, non-ancestor, or descendant issuers
  - `TestMetadataFixup_ProtectedResourceUntouched`,
    `TestMetadataFixup_TrailingSlashStillNormalized` — regression guards for
    existing behavior
- [x] `go build ./...`, `go vet ./...` (no new findings; one pre-existing
  unrelated warning in `internal/csync/maps.go`), `gofmt -l` clean
- [x] `go test ./...` — all oauth/MCP packages pass; the only repo-wide
  failures are pre-existing environment issues (missing GCP ADC
  credentials in `internal/backend`, `internal/server`,
  `internal/workspace`), confirmed present and identical on the parent
  commit (`e68041a6`), so this change introduces no regressions
- [x] Manual: built the binary and ran the real OAuth flow end-to-end
  against the live Atlassian Rovo MCP server
  (`https://mcp.atlassian.com/v1/mcp/authv2`) with `oauth: true`. Debug
  logs confirmed the rewrite fired
  (`Rewrote OAuth metadata issuer for multi-tenant provider`), the browser
  consent flow completed, and the token was persisted and used
  successfully — where the same flow fails with the issuer-mismatch error
  above on `main`.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
