### PR TITLE
feat(bash): allow overriding banned commands via env var

### DIFF
--- a/internal/agent/tools/bash_allow.go
+++ b/internal/agent/tools/bash_allow.go
@@ -1,0 +1,30 @@
+package tools
+
+import (
+	"os"
+	"strings"
+)
+
+func init() {
+	v := strings.TrimSpace(os.Getenv("CRUSH_BASH_ALLOWED_COMMANDS"))
+	if v == "" {
+		return
+	}
+	if v == "*" {
+		bannedCommands = nil
+		return
+	}
+	allow := make(map[string]struct{})
+	for _, c := range strings.Split(v, ",") {
+		if c = strings.TrimSpace(c); c != "" {
+			allow[c] = struct{}{}
+		}
+	}
+	filtered := make([]string, 0, len(bannedCommands))
+	for _, c := range bannedCommands {
+		if _, ok := allow[c]; !ok {
+			filtered = append(filtered, c)
+		}
+	}
+	bannedCommands = filtered
+}


### PR DESCRIPTION
## Summary

- Adds `CRUSH_BASH_ALLOWED_COMMANDS` env var to let users opt out of the hardcoded command blocklist for trusted infra/ops workflows.
- Comma-separated list of commands to allow (e.g. `ssh,scp,curl,wget`), or `*` to disable the `CommandsBlocker` entirely.
- Argument-based install blockers (e.g. `pip install --user`) are intentionally untouched.
- Implemented as a single new file (`internal/agent/tools/bash_allow.go`) with no edits to `bash.go`, so the diff is minimal.

## Motivation

Closes #2474
Closes #2463

Currently `ssh`, `scp`, `curl`, `wget`, and other commands are hardcoded in `bannedCommands` with **no override mechanism** — not even `--yolo` bypasses them, since the block runs as shell-exec middleware *after* the permission check. This makes Crush impractical for legitimate ops/infra workflows (SSH to remote hosts, `curl` health checks, etc.).

The consensus in both issues is that a configurable allowlist in a config file would be ideal. This PR takes the minimal path first: an env var that filters the existing list in `init()`, so both the runtime blocker and the tool description (shown to the LLM) see the filtered list.

## Usage

```sh
# allow specific commands
export CRUSH_BASH_ALLOWED_COMMANDS="ssh,scp,curl,wget,sudo"

# disable the CommandsBlocker entirely
export CRUSH_BASH_ALLOWED_COMMANDS="*"
```

Defaults remain unchanged when the env var is unset.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/agent/tools/... ./internal/shell/...`
- [x] `gofumpt -l` clean
- [ ] Manual: verify `ssh`/`curl` run when listed in env var, still blocked when not

💘 Generated with Crush