### PR TITLE
fix(server): typing lag over TCP in client/server mode

### DIFF
--- a/internal/ui/model/header.go
+++ b/internal/ui/model/header.go
@@ -61,7 +61,9 @@ func (h *header) refresh() {
 	h.logo = ""
 }
 
-// drawHeader draws the header for the given session.
+// drawHeader draws the header for the given session. lspErrorCount comes
+// from the UI's memoized LSP state: drawing runs on every frame and must not
+// probe the workspace (a synchronous HTTP round-trip in client/server mode).
 func (h *header) drawHeader(
 	scr uv.Screen,
 	area uv.Rectangle,
@@ -69,6 +71,7 @@ func (h *header) drawHeader(
 	compact bool,
 	detailsOpen bool,
 	width int,
+	lspErrorCount int,
 	hyperCredits *int,
 ) {
 	t := h.com.Styles
@@ -92,10 +95,6 @@ func (h *header) drawHeader(
 	b.WriteString(h.compactLogo)
 
 	availDetailWidth := width - leftPadding - rightPadding - lipgloss.Width(b.String()) - minHeaderDiags - diagToDetailsSpacing
-	lspErrorCount := 0
-	for _, info := range h.com.Workspace.LSPGetStates() {
-		lspErrorCount += info.DiagnosticCount
-	}
 	details := renderHeaderDetails(
 		h.com,
 		session,

--- a/internal/ui/model/landing.go
+++ b/internal/ui/model/landing.go
@@ -9,11 +9,14 @@ import (
 	"github.com/charmbracelet/ultraviolet/layout"
 )
 
-// selectedLargeModel returns the currently selected large language model from
-// the agent coordinator, if one exists.
+// selectedLargeModel returns the currently selected large language model as
+// memoized by the off-thread busy/agent probe (see workspace_cache.go), or
+// nil when the agent isn't ready. It must never probe the workspace: it is
+// called on every frame and AgentIsReady/AgentModel are synchronous HTTP
+// round-trips in client/server mode.
 func (m *UI) selectedLargeModel() *workspace.AgentModel {
-	if m.com.Workspace.AgentIsReady() {
-		model := m.com.Workspace.AgentModel()
+	if m.agentReady {
+		model := m.agentModel
 		return &model
 	}
 	return nil

--- a/internal/ui/model/lsp.go
+++ b/internal/ui/model/lsp.go
@@ -19,7 +19,10 @@ import (
 // lspStatesTTL bounds how long the memoized LSP state may go without a
 // re-probe being scheduled; LSP events normally refresh it much sooner. The
 // backstop covers events missed across SSE reconnects in client/server
-// mode. Package var so tests can pin it.
+// mode, so it can be an order of magnitude looser than the busy/permission
+// TTL (which drives interactive affordances like the spinner and queue
+// pill): a few seconds of stale LSP counts is invisible, a few seconds of
+// stale busy state is not. Package var so tests can pin it.
 var lspStatesTTL = 5 * time.Second
 
 // lspStatesMsg delivers LSP states and per-server diagnostic counts fetched

--- a/internal/ui/model/lsp.go
+++ b/internal/ui/model/lsp.go
@@ -5,7 +5,9 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"time"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/lsp"
 	"github.com/charmbracelet/crush/internal/ui/common"
@@ -14,33 +16,105 @@ import (
 	"github.com/charmbracelet/x/powernap/pkg/lsp/protocol"
 )
 
+// lspStatesTTL bounds how long the memoized LSP state may go without a
+// re-probe being scheduled; LSP events normally refresh it much sooner. The
+// backstop covers events missed across SSE reconnects in client/server
+// mode. Package var so tests can pin it.
+var lspStatesTTL = 5 * time.Second
+
+// lspStatesMsg delivers LSP states and per-server diagnostic counts fetched
+// off-thread.
+type lspStatesMsg struct {
+	states      map[string]workspace.LSPClientInfo
+	diagnostics map[string]lsp.DiagnosticCounts
+}
+
 // LSPInfo wraps LSP client information with diagnostic counts by severity.
 type LSPInfo struct {
 	workspace.LSPClientInfo
 	Diagnostics map[protocol.DiagnosticSeverity]int
 }
 
+// requestLSPRefresh schedules an off-thread refresh of the memoized LSP
+// state. While a fetch is already in flight it only marks the state dirty;
+// applyLSPStates re-dispatches so the freshest data still lands.
+func (m *UI) requestLSPRefresh() tea.Cmd {
+	if m.lspFetchInFlight {
+		m.lspRefreshQueued = true
+		return nil
+	}
+	return m.dispatchLSPRefresh()
+}
+
+// dispatchLSPRefresh returns a command that fetches the LSP states and
+// per-server diagnostic counts off the Update goroutine (each a synchronous
+// HTTP round-trip in client/server mode), delivering an lspStatesMsg. It
+// returns nil while a fetch is already in flight. The closure captures only
+// locals (never m) so it is safe off-thread.
+func (m *UI) dispatchLSPRefresh() tea.Cmd {
+	if m.lspFetchInFlight || m.com == nil || m.com.Workspace == nil {
+		return nil
+	}
+	m.lspFetchInFlight = true
+	// Stamp the check time at dispatch too so the TTL backstop doesn't
+	// keep re-requesting while this fetch is in flight.
+	m.lspCheckedAt = time.Now()
+	ws := m.com.Workspace
+	return func() tea.Msg {
+		states := ws.LSPGetStates()
+		diagnostics := make(map[string]lsp.DiagnosticCounts, len(states))
+		for name := range states {
+			diagnostics[name] = ws.LSPGetDiagnosticCounts(name)
+		}
+		return lspStatesMsg{states: states, diagnostics: diagnostics}
+	}
+}
+
+// applyLSPStates stores an off-thread LSP fetch result and re-dispatches
+// when events arrived while it was in flight. Runs on the Update goroutine.
+func (m *UI) applyLSPStates(msg lspStatesMsg) tea.Cmd {
+	m.lspFetchInFlight = false
+	m.lspCheckedAt = time.Now()
+	m.lspStates = msg.states
+	m.lspDiagnostics = msg.diagnostics
+	if m.lspRefreshQueued {
+		m.lspRefreshQueued = false
+		return m.dispatchLSPRefresh()
+	}
+	return nil
+}
+
+// lspErrorCount returns the total diagnostic count across the memoized LSP
+// states, shown in the compact header.
+func (m *UI) lspErrorCount() int {
+	count := 0
+	for _, info := range m.lspStates {
+		count += info.DiagnosticCount
+	}
+	return count
+}
+
 // lspInfo renders the LSP status section showing active LSP clients and their
-// diagnostic counts.
+// diagnostic counts. It renders from the memoized state only: this runs on
+// every frame, and the workspace probes behind it are synchronous HTTP
+// round-trips in client/server mode. LSP events (plus the TTL backstop)
+// keep the memoized state fresh off-thread; see requestLSPRefresh.
 func (m *UI) lspInfo(width, maxItems int, isSection bool) string {
 	t := m.com.Styles
 
-	// Always pull fresh state to avoid race with async TrackConfigured.
-	m.lspStates = m.com.Workspace.LSPGetStates()
 	states := slices.SortedFunc(maps.Values(m.lspStates), func(a, b workspace.LSPClientInfo) int {
 		return strings.Compare(a.Name, b.Name)
 	})
 
 	var lsps []LSPInfo
 	for _, state := range states {
-		lspErrs := map[protocol.DiagnosticSeverity]int{}
-		counts := m.com.Workspace.LSPGetDiagnosticCounts(state.Name)
-		lspErrs[protocol.SeverityError] = counts.Error
-		lspErrs[protocol.SeverityWarning] = counts.Warning
-		lspErrs[protocol.SeverityHint] = counts.Hint
-		lspErrs[protocol.SeverityInformation] = counts.Information
-
-		lsps = append(lsps, LSPInfo{LSPClientInfo: state, Diagnostics: lspErrs})
+		counts := m.lspDiagnostics[state.Name]
+		lsps = append(lsps, LSPInfo{LSPClientInfo: state, Diagnostics: map[protocol.DiagnosticSeverity]int{
+			protocol.SeverityError:       counts.Error,
+			protocol.SeverityWarning:     counts.Warning,
+			protocol.SeverityHint:        counts.Hint,
+			protocol.SeverityInformation: counts.Information,
+		}})
 	}
 
 	title := t.Resource.Heading.Render("LSPs")

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/lsp"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/session"
@@ -32,6 +33,9 @@ type countingWorkspace struct {
 	agentBusy bool
 	yolo      bool
 	queued    []string
+	model     workspace.AgentModel
+	lspStates map[string]workspace.LSPClientInfo
+	lspDiags  map[string]lsp.DiagnosticCounts
 
 	readyCalls      int
 	agentBusyCalls  int
@@ -41,6 +45,9 @@ type countingWorkspace struct {
 	permSetCalls    int
 	clearQueueCalls int
 	cancelCalls     int
+	modelCalls      int
+	lspStateCalls   int
+	lspDiagCalls    int
 }
 
 func (w *countingWorkspace) AgentIsReady() bool { w.readyCalls++; return w.ready }
@@ -74,6 +81,21 @@ func (w *countingWorkspace) PermissionSetSkipRequests(skip bool) {
 func (w *countingWorkspace) AgentClearQueue(string) { w.clearQueueCalls++; w.queued = nil }
 func (w *countingWorkspace) AgentCancel(string)     { w.cancelCalls++ }
 
+func (w *countingWorkspace) AgentModel() workspace.AgentModel {
+	w.modelCalls++
+	return w.model
+}
+
+func (w *countingWorkspace) LSPGetStates() map[string]workspace.LSPClientInfo {
+	w.lspStateCalls++
+	return w.lspStates
+}
+
+func (w *countingWorkspace) LSPGetDiagnosticCounts(name string) lsp.DiagnosticCounts {
+	w.lspDiagCalls++
+	return w.lspDiags[name]
+}
+
 func (w *countingWorkspace) ListMessages(context.Context, string) ([]message.Message, error) {
 	return nil, nil
 }
@@ -87,17 +109,19 @@ func (w *countingWorkspace) LSPStart(context.Context, string) {}
 func (w *countingWorkspace) Config() *config.Config { return nil }
 
 // syncProbes sums every synchronous counter; Update/View must keep this at
-// zero — the busy/queue invariant is that no workspace call ever happens on
-// the Update goroutine.
+// zero — the invariant is that no workspace call ever happens on the Update
+// goroutine (which is also the render loop).
 func (w *countingWorkspace) syncProbes() int {
 	return w.readyCalls + w.agentBusyCalls +
-		w.queuedCalls + w.queueListCalls + w.permCalls
+		w.queuedCalls + w.queueListCalls + w.permCalls +
+		w.modelCalls + w.lspStateCalls + w.lspDiagCalls
 }
 
 func (w *countingWorkspace) resetCounters() {
 	w.readyCalls, w.agentBusyCalls = 0, 0
 	w.queuedCalls, w.queueListCalls, w.permCalls = 0, 0, 0
 	w.permSetCalls, w.clearQueueCalls, w.cancelCalls = 0, 0, 0
+	w.modelCalls, w.lspStateCalls, w.lspDiagCalls = 0, 0, 0
 }
 
 // newBusyUI builds a UI wired to the stub workspace with an active session
@@ -125,10 +149,11 @@ func newBusyUI(ws *countingWorkspace) *UI {
 // boundary (the tests using it must not call t.Parallel).
 func pinTTLs(t *testing.T) {
 	t.Helper()
-	oldBusy, oldQueue := busyCacheTTL, promptQueueTTL
+	oldBusy, oldQueue, oldLSP := busyCacheTTL, promptQueueTTL, lspStatesTTL
 	busyCacheTTL = time.Hour
 	promptQueueTTL = time.Hour
-	t.Cleanup(func() { busyCacheTTL, promptQueueTTL = oldBusy, oldQueue })
+	lspStatesTTL = time.Hour
+	t.Cleanup(func() { busyCacheTTL, promptQueueTTL, lspStatesTTL = oldBusy, oldQueue, oldLSP })
 }
 
 // warmCaches marks all memoized workspace state fresh so only explicit
@@ -136,7 +161,9 @@ func pinTTLs(t *testing.T) {
 func warmCaches(m *UI, busy bool) {
 	m.agentBusyCache.set(busy)
 	m.yoloCache.set(false)
+	m.agentReady = true
 	m.promptQueueCheckedAt = time.Now()
+	m.lspCheckedAt = time.Now()
 }
 
 // runCmds executes a command tree the way the Bubble Tea runtime would,
@@ -151,7 +178,7 @@ func runCmds(m *UI, cmd tea.Cmd) {
 		for _, c := range msg {
 			runCmds(m, c)
 		}
-	case busyStateMsg, promptQueueMsg, agentRunSubmittedMsg:
+	case busyStateMsg, promptQueueMsg, agentRunSubmittedMsg, lspStatesMsg, agentModelChangedMsg:
 		_, next := m.Update(msg)
 		runCmds(m, next)
 	}
@@ -527,6 +554,129 @@ func TestStalePromptQueuePreservesSessionScoping(t *testing.T) {
 	require.Zero(t, m.promptQueue,
 		"a result from a different session must never populate the queue")
 	require.NotEmpty(t, cmds, "a session-mismatched result must re-fetch for the current session")
+}
+
+// TestRenderHelpersDoNotProbeWorkspace pins the render-path side of the
+// invariant for the model and LSP info: selectedLargeModel, lspInfo, and
+// lspErrorCount render from memoized state only. They run on every frame
+// (landing view, sidebar, compact header), and the probes behind them
+// (AgentIsReady, AgentModel, LSPGetStates, LSPGetDiagnosticCounts) are
+// synchronous HTTP round-trips in client/server mode.
+func TestRenderHelpersDoNotProbeWorkspace(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
+	m.agentReady = true
+	m.lspStates = map[string]workspace.LSPClientInfo{
+		"gopls": {Name: "gopls", State: lsp.StateReady, DiagnosticCount: 3},
+	}
+	m.lspDiagnostics = map[string]lsp.DiagnosticCounts{
+		"gopls": {Error: 2, Warning: 1},
+	}
+
+	for range 10 {
+		require.NotNil(t, m.selectedLargeModel())
+		m.lspInfo(40, 5, true)
+		require.Equal(t, 3, m.lspErrorCount())
+	}
+
+	// modelInfo reaches provider config only through the memoized model;
+	// with the agent not ready it renders the empty state.
+	m.agentReady = false
+	for range 10 {
+		m.modelInfo(40)
+	}
+
+	require.Zero(t, ws.syncProbes(), "render helpers must never probe the workspace")
+}
+
+// TestBusyRefreshCarriesReadyAndModel: the off-thread busy probe must also
+// deliver the coordinator's readiness and selected model so the sidebar and
+// landing view render them without per-frame probes.
+func TestBusyRefreshCarriesReadyAndModel(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{
+		ready: true,
+		model: workspace.AgentModel{ModelCfg: config.SelectedModel{Model: "test-model", Provider: "prov"}},
+	}
+	m := newBusyUI(ws)
+	require.Nil(t, m.selectedLargeModel(), "before any probe the model is unknown")
+
+	_, cmd := m.Update(plainMsg{}) // stale caches: the backstop dispatches
+	runCmds(m, cmd)
+
+	require.True(t, m.agentReady, "the probe must land readiness in the cache")
+	sel := m.selectedLargeModel()
+	require.NotNil(t, sel)
+	require.Equal(t, "test-model", sel.ModelCfg.Model, "the probe must land the model in the cache")
+}
+
+// TestAgentModelChangedRefreshesModel: after a model change
+// (selection/thinking/reasoning cmds sequence agentModelChangedCmd), the
+// handler must re-fetch ready/model off-thread — no synchronous probe — and
+// the fresh model must replace the memoized one.
+func TestAgentModelChangedRefreshesModel(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{
+		ready: true,
+		model: workspace.AgentModel{ModelCfg: config.SelectedModel{Model: "new-model"}},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.agentModel = workspace.AgentModel{ModelCfg: config.SelectedModel{Model: "old-model"}}
+	ws.resetCounters()
+
+	_, cmd := m.Update(agentModelChangedMsg{})
+	require.Zero(t, ws.syncProbes(), "the model-change handler must not probe synchronously")
+	require.True(t, m.busyFetchInFlight, "a model change must schedule a ready/model refresh")
+
+	runCmds(m, cmd)
+	require.Equal(t, "new-model", m.agentModel.ModelCfg.Model,
+		"the refreshed model must land in the cache")
+}
+
+// TestLSPEventRefreshIsOffThreadAndDeduped pins the LSP side of the
+// invariant: an LSP event must not fetch states synchronously in Update
+// (LSPGetStates + per-server LSPGetDiagnosticCounts are HTTP round-trips in
+// client/server mode, and diagnostics events arrive per edited file). It
+// schedules one off-thread fetch, dedups while one is in flight, and
+// re-dispatches a queued refresh when the in-flight fetch lands.
+func TestLSPEventRefreshIsOffThreadAndDeduped(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{
+		ready:     true,
+		lspStates: map[string]workspace.LSPClientInfo{"gopls": {Name: "gopls", DiagnosticCount: 3}},
+		lspDiags:  map[string]lsp.DiagnosticCounts{"gopls": {Error: 2, Warning: 1}},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	ws.resetCounters()
+
+	_, cmd := m.Update(pubsub.Event[workspace.LSPEvent]{
+		Payload: workspace.LSPEvent{Type: workspace.LSPEventDiagnosticsChanged, Name: "gopls"},
+	})
+	require.Zero(t, ws.syncProbes(), "the LSP event handler must not probe synchronously")
+	require.True(t, m.lspFetchInFlight, "an LSP event must schedule an off-thread refresh")
+
+	// A second event while the fetch is in flight queues a re-fetch instead
+	// of stacking another dispatch.
+	m.Update(pubsub.Event[workspace.LSPEvent]{
+		Payload: workspace.LSPEvent{Type: workspace.LSPEventDiagnosticsChanged, Name: "gopls"},
+	})
+	require.Zero(t, ws.syncProbes())
+	require.True(t, m.lspRefreshQueued, "an event during an in-flight fetch must queue a re-fetch")
+
+	runCmds(m, cmd)
+	require.False(t, m.lspFetchInFlight)
+	require.False(t, m.lspRefreshQueued, "the queued flag must clear once the re-dispatched fetch lands")
+	require.Equal(t, 3, m.lspStates["gopls"].DiagnosticCount, "fetched states must land in the cache")
+	require.Equal(t, 2, m.lspDiagnostics["gopls"].Error, "fetched severity counts must land in the cache")
+	require.Equal(t, 3, m.lspErrorCount())
+	require.Equal(t, 2, ws.lspStateCalls, "one fetch plus the queued re-fetch")
 }
 
 // TestRemoteYoloToggleUpdatesEditorPrompt pins the second fix: when an

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -638,6 +638,37 @@ func TestAgentModelChangedRefreshesModel(t *testing.T) {
 		"the refreshed model must land in the cache")
 }
 
+// TestMCPStateChangedRefreshesModel pins the fourth UpdateAgentModel call
+// site: an MCP state change rebuilds the agent, which can change the
+// effective model, so the memoized ready/model state must be re-fetched
+// off-thread afterwards — the edge the updateAgentModelCmd helper exists to
+// make unforgettable.
+func TestMCPStateChangedRefreshesModel(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{
+		ready: true,
+		model: workspace.AgentModel{ModelCfg: config.SelectedModel{Model: "post-mcp-model"}},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.agentModel = workspace.AgentModel{ModelCfg: config.SelectedModel{Model: "pre-mcp-model"}}
+	ws.resetCounters()
+
+	// handleStateChanged sequences the rebuild with agentModelChangedCmd;
+	// tea.Sequence's wrapper msg is unexported, so drive the two steps the
+	// way the runtime would: run the cmd (the stub records the call), then
+	// deliver the invalidation message.
+	_ = m.handleStateChanged()()
+	_, cmd := m.Update(agentModelChangedMsg{})
+	require.True(t, m.busyFetchInFlight, "an MCP state change must schedule a ready/model refresh")
+	runCmds(m, cmd)
+
+	require.True(t, m.agentReady)
+	require.Equal(t, "post-mcp-model", m.agentModel.ModelCfg.Model,
+		"an MCP state change must refresh the memoized model")
+}
+
 // TestLSPEventRefreshIsOffThreadAndDeduped pins the LSP side of the
 // invariant: an LSP event must not fetch states synchronously in Update
 // (LSPGetStates + per-server LSPGetDiagnosticCounts are HTTP round-trips in

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -39,6 +39,7 @@ import (
 	"github.com/charmbracelet/crush/internal/fsext"
 	"github.com/charmbracelet/crush/internal/history"
 	"github.com/charmbracelet/crush/internal/home"
+	"github.com/charmbracelet/crush/internal/lsp"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/pubsub"
@@ -272,8 +273,19 @@ type UI struct {
 		yesInitializeSelected bool
 	}
 
-	// lsp
-	lspStates map[string]workspace.LSPClientInfo
+	// lspStates / lspDiagnostics memoize the workspace LSP state and
+	// per-server severity counts (each probe behind them is a synchronous
+	// HTTP round-trip in client/server mode, and the sidebar, landing view,
+	// and compact header render them every frame). LSP events refresh them
+	// off-thread with a TTL backstop; see lsp.go.
+	lspStates        map[string]workspace.LSPClientInfo
+	lspDiagnostics   map[string]lsp.DiagnosticCounts
+	lspFetchInFlight bool
+	// lspRefreshQueued records that an LSP event arrived while a fetch was
+	// already in flight; applyLSPStates re-dispatches so the freshest state
+	// still lands.
+	lspRefreshQueued bool
+	lspCheckedAt     time.Time
 
 	// mcp
 	mcpStates map[string]mcp.ClientInfo
@@ -335,6 +347,13 @@ type UI struct {
 	agentBusyCache    ttlCache
 	yoloCache         ttlCache
 	busyFetchInFlight bool
+	// agentReady / agentModel memoize the coordinator readiness and
+	// selected model (AgentIsReady/AgentModel are synchronous HTTP GETs in
+	// client/server mode, and modelInfo renders them every frame). Seeded
+	// once at construction and refreshed by the same off-thread probe as
+	// agentBusyCache.
+	agentReady bool
+	agentModel workspace.AgentModel
 	// busyFetchGen is bumped by every busy/permission state transition;
 	// like promptQueueGen it lets a stale in-flight probe result be
 	// discarded and re-fetched instead of clobbering newer state.
@@ -445,6 +464,14 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 	// and View never probe the workspace synchronously.
 	yolo := com.Workspace.PermissionSkipRequests()
 	ui.yoloCache.set(yolo)
+
+	// Seed the memoized agent ready/model state the same way so the first
+	// frame renders the model info; the busy probe keeps it fresh
+	// afterwards.
+	if com.Workspace.AgentIsReady() {
+		ui.agentReady = true
+		ui.agentModel = com.Workspace.AgentModel()
+	}
 	ui.setEditorPrompt(yolo)
 	ui.randomizePlaceholders()
 	ui.textarea.Placeholder = ui.readyPlaceholder
@@ -489,8 +516,10 @@ func (m *UI) Init() tea.Cmd {
 	cmds = append(cmds, m.loadCustomCommands())
 	// load prompt history async
 	cmds = append(cmds, m.loadPromptHistory())
-	// load initial LSP state
-	m.lspStates = m.com.Workspace.LSPGetStates()
+	// Prime the memoized LSP state off-thread.
+	if cmd := m.requestLSPRefresh(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
 	// load initial session if specified
 	if cmd := m.loadInitialSession(); cmd != nil {
 		cmds = append(cmds, cmd)
@@ -683,6 +712,17 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, m.applyBusyState(msg)...)
 	case promptQueueMsg:
 		cmds = append(cmds, m.applyPromptQueue(msg)...)
+	case lspStatesMsg:
+		if cmd := m.applyLSPStates(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	case agentModelChangedMsg:
+		// The coordinator model changed (selection, thinking, reasoning):
+		// re-fetch the memoized ready/model state off-thread.
+		m.invalidateBusyCaches()
+		if cmd := m.dispatchBusyRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case agentRunSubmittedMsg:
 		// A prompt was just accepted (run started or enqueued): fetch the
 		// authoritative busy/queue state to confirm the optimistic values
@@ -877,9 +917,16 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case pubsub.Event[history.File]:
 		cmds = append(cmds, m.handleFileEvent(msg.Payload))
 	case pubsub.Event[app.LSPEvent]:
-		m.lspStates = m.com.Workspace.LSPGetStates()
+		// Refresh the memoized LSP state off-thread: LSPGetStates is a
+		// synchronous HTTP round-trip in client/server mode and diagnostics
+		// events can arrive per edited file.
+		if cmd := m.requestLSPRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case pubsub.Event[workspace.LSPEvent]:
-		m.lspStates = m.com.Workspace.LSPGetStates()
+		if cmd := m.requestLSPRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case pubsub.Event[skills.Event]:
 		m.skillStates = msg.Payload.States
 	case pubsub.Event[mcp.Event]:
@@ -1843,7 +1890,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		}
 		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionToggleThinking:
-		cmds = append(cmds, func() tea.Msg {
+		cmds = append(cmds, tea.Sequence(func() tea.Msg {
 			cfg := m.com.Config()
 			if cfg == nil {
 				return util.ReportError(errors.New("configuration not found"))()
@@ -1865,7 +1912,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 				status = "enabled"
 			}
 			return util.NewInfoMsg("Thinking mode " + status)
-		})
+		}, agentModelChangedCmd))
 		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionToggleTransparentBackground:
 		cmds = append(cmds, func() tea.Msg {
@@ -1933,10 +1980,10 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			break
 		}
 
-		cmds = append(cmds, func() tea.Msg {
+		cmds = append(cmds, tea.Sequence(func() tea.Msg {
 			m.com.Workspace.UpdateAgentModel(context.TODO())
 			return util.NewInfoMsg("Reasoning effort set to " + msg.Effort)
-		})
+		}, agentModelChangedCmd))
 		m.dialog.CloseDialog(dialog.ReasoningID)
 	case dialog.ActionPermissionResponse:
 		m.dialog.CloseDialog(dialog.PermissionsID)
@@ -2144,7 +2191,7 @@ func (m *UI) handleSelectModel(msg dialog.ActionSelectModel) tea.Cmd {
 		}
 	}
 
-	cmds = append(cmds, func() tea.Msg {
+	cmds = append(cmds, tea.Sequence(func() tea.Msg {
 		if err := m.com.Workspace.UpdateAgentModel(context.TODO()); err != nil {
 			return util.ReportError(err)
 		}
@@ -2159,7 +2206,7 @@ func (m *UI) handleSelectModel(msg dialog.ActionSelectModel) tea.Cmd {
 		modelMsg := fmt.Sprintf("%s model changed to %s", modelType, modelName)
 
 		return util.NewInfoMsg(modelMsg)
-	})
+	}, agentModelChangedCmd))
 
 	m.dialog.CloseDialog(dialog.APIKeyInputID)
 	m.dialog.CloseDialog(dialog.OAuthID)
@@ -2170,6 +2217,13 @@ func (m *UI) handleSelectModel(msg dialog.ActionSelectModel) tea.Cmd {
 		m.com.Config().SetupAgents()
 		if err := m.com.Workspace.InitCoderAgent(context.TODO()); err != nil {
 			cmds = append(cmds, util.ReportError(err))
+		}
+		// The agent just came up: re-fetch the memoized ready/model state
+		// so the landing view shows the selected model without waiting for
+		// the TTL backstop.
+		m.invalidateBusyCaches()
+		if cmd := m.dispatchBusyRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
 		}
 	} else if m.com.IsHyper() {
 		cmds = append(cmds, m.fetchHyperCredits())
@@ -2711,6 +2765,7 @@ func (m *UI) drawHeader(scr uv.Screen, area uv.Rectangle) {
 		m.isCompact,
 		m.detailsOpen,
 		area.Dx(),
+		m.lspErrorCount(),
 		m.hyperCredits,
 	)
 }
@@ -4071,7 +4126,9 @@ func (m *UI) cancelAgent() tea.Cmd {
 		return nil
 	}
 
-	if !m.com.Workspace.AgentIsReady() {
+	// Gate on the memoized ready state: esc is a hot key and AgentIsReady
+	// is a synchronous HTTP round-trip in client/server mode.
+	if !m.agentReady {
 		return nil
 	}
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1890,7 +1890,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		}
 		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionToggleThinking:
-		cmds = append(cmds, tea.Sequence(func() tea.Msg {
+		cmds = append(cmds, m.updateAgentModelCmd(func() tea.Msg {
 			cfg := m.com.Config()
 			if cfg == nil {
 				return util.ReportError(errors.New("configuration not found"))()
@@ -1912,7 +1912,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 				status = "enabled"
 			}
 			return util.NewInfoMsg("Thinking mode " + status)
-		}, agentModelChangedCmd))
+		}))
 		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionToggleTransparentBackground:
 		cmds = append(cmds, func() tea.Msg {
@@ -1980,10 +1980,10 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			break
 		}
 
-		cmds = append(cmds, tea.Sequence(func() tea.Msg {
+		cmds = append(cmds, m.updateAgentModelCmd(func() tea.Msg {
 			m.com.Workspace.UpdateAgentModel(context.TODO())
 			return util.NewInfoMsg("Reasoning effort set to " + msg.Effort)
-		}, agentModelChangedCmd))
+		}))
 		m.dialog.CloseDialog(dialog.ReasoningID)
 	case dialog.ActionPermissionResponse:
 		m.dialog.CloseDialog(dialog.PermissionsID)
@@ -2191,7 +2191,7 @@ func (m *UI) handleSelectModel(msg dialog.ActionSelectModel) tea.Cmd {
 		}
 	}
 
-	cmds = append(cmds, tea.Sequence(func() tea.Msg {
+	cmds = append(cmds, m.updateAgentModelCmd(func() tea.Msg {
 		if err := m.com.Workspace.UpdateAgentModel(context.TODO()); err != nil {
 			return util.ReportError(err)
 		}
@@ -2206,7 +2206,7 @@ func (m *UI) handleSelectModel(msg dialog.ActionSelectModel) tea.Cmd {
 		modelMsg := fmt.Sprintf("%s model changed to %s", modelType, modelName)
 
 		return util.NewInfoMsg(modelMsg)
-	}, agentModelChangedCmd))
+	}))
 
 	m.dialog.CloseDialog(dialog.APIKeyInputID)
 	m.dialog.CloseDialog(dialog.OAuthID)
@@ -4832,12 +4832,12 @@ func (m *UI) runMCPPrompt(clientID, promptID string, arguments map[string]string
 }
 
 func (m *UI) handleStateChanged() tea.Cmd {
-	return func() tea.Msg {
+	return m.updateAgentModelCmd(func() tea.Msg {
 		m.com.Workspace.UpdateAgentModel(context.Background())
 		return mcpStateChangedMsg{
 			states: m.com.Workspace.MCPGetStates(),
 		}
-	}
+	})
 }
 
 func handleMCPPromptsEvent(ws workspace.Workspace, name string) tea.Cmd {

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -3,28 +3,32 @@ package model
 // Memoized workspace state.
 //
 // In client/server mode every workspace probe (busy checks, permission mode,
-// queued prompts) is a synchronous HTTP round-trip, and the Update goroutine
-// is the render loop — blocking it freezes typing. The UI therefore never
-// probes the workspace synchronously from Update or View:
+// queued prompts, agent readiness/model, LSP state) is a synchronous HTTP
+// round-trip, and the Update goroutine is the render loop — blocking it
+// freezes typing. The UI therefore never probes the workspace synchronously
+// from Update or View:
 //
-//   - Reads (isAgentBusy, yoloModeCached, promptQueue) always return the
-//     memoized value, stale or not.
+//   - Reads (isAgentBusy, yoloModeCached, promptQueue, selectedLargeModel,
+//     lspInfo) always return the memoized value, stale or not.
 //   - State edges (message created, agent finished/errored, prompt
-//     submitted, cancel, session switch, yolo toggle) invalidate or
-//     write through the caches and dispatch an off-thread refresh cmd.
+//     submitted, cancel, session switch, yolo toggle, model change, LSP
+//     events) invalidate or write through the caches and dispatch an
+//     off-thread refresh cmd.
 //   - A TTL backstop at the end of Update re-dispatches a refresh whenever
 //     the memoized state has gone stale, so unrelated churn (typing,
 //     resize storms, spinner ticks) only ever schedules async work.
 //
-// Fresh values arrive as busyStateMsg / promptQueueMsg and are applied on
-// the Update goroutine, per the UI guidelines (no IO in Update, no model
-// mutation inside commands).
+// Fresh values arrive as busyStateMsg / promptQueueMsg / lspStatesMsg and
+// are applied on the Update goroutine, per the UI guidelines (no IO in
+// Update, no model mutation inside commands).
 
 import (
 	"slices"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/charmbracelet/crush/internal/workspace"
 )
 
 // busyCacheTTL bounds how long the memoized busy/permission state may go
@@ -66,8 +70,13 @@ type busyStateMsg struct {
 	// session switch, ...) and is discarded, then re-fetched, so the
 	// authoritative refresh is never lost to an older in-flight request.
 	gen       uint64
+	ready     bool
 	agentBusy bool
 	yolo      bool
+	// model is the coordinator's selected model, fetched by the same probe
+	// so the sidebar/landing model info renders from memoized state. Zero
+	// (and ignored) when ready is false.
+	model workspace.AgentModel
 }
 
 // promptQueueMsg delivers the queued prompts fetched off-thread.
@@ -86,6 +95,15 @@ type promptQueueMsg struct {
 // started a run or was enqueued behind one), so busy and queue state should
 // be re-fetched.
 type agentRunSubmittedMsg struct{}
+
+// agentModelChangedMsg reports that the coordinator's model was updated
+// (model selection, thinking toggle, reasoning effort), so the memoized
+// ready/model state should be re-fetched without waiting for the TTL.
+type agentModelChangedMsg struct{}
+
+// agentModelChangedCmd is sequenced after cmds that call UpdateAgentModel so
+// the refresh probes the coordinator only once the update has completed.
+func agentModelChangedCmd() tea.Msg { return agentModelChangedMsg{} }
 
 // currentSessionID returns the active session's ID, or "" when none.
 func (m *UI) currentSessionID() string {
@@ -127,7 +145,9 @@ func (m *UI) dispatchBusyRefresh() tea.Cmd {
 	return func() tea.Msg {
 		st := busyStateMsg{gen: gen}
 		if ws.AgentIsReady() {
+			st.ready = true
 			st.agentBusy = ws.AgentIsBusy()
+			st.model = ws.AgentModel()
 		}
 		st.yolo = ws.PermissionSkipRequests()
 		return st
@@ -152,6 +172,8 @@ func (m *UI) applyBusyState(msg busyStateMsg) []tea.Cmd {
 	prevYolo := m.yoloModeCached()
 	m.agentBusyCache.set(msg.agentBusy)
 	m.yoloCache.set(msg.yolo)
+	m.agentReady = msg.ready
+	m.agentModel = msg.model
 	if prevYolo != msg.yolo {
 		// A remote/async toggle changed yolo mode: update the editor
 		// prompt function so the prompt icon/style tracks the new mode.
@@ -252,6 +274,11 @@ func (m *UI) staleWorkspaceRefreshCmds() []tea.Cmd {
 	}
 	if m.hasSession() && time.Since(m.promptQueueCheckedAt) >= promptQueueTTL {
 		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	if time.Since(m.lspCheckedAt) >= lspStatesTTL {
+		if cmd := m.dispatchLSPRefresh(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	}

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -6,7 +6,9 @@ package model
 // queued prompts, agent readiness/model, LSP state) is a synchronous HTTP
 // round-trip, and the Update goroutine is the render loop — blocking it
 // freezes typing. The UI therefore never probes the workspace synchronously
-// from Update or View:
+// from Update or View. (The constructor is the one carve-out: New seeds the
+// yolo and ready/model caches synchronously so the first frame has values to
+// render; Init then refreshes them off-thread.)
 //
 //   - Reads (isAgentBusy, yoloModeCached, promptQueue, selectedLargeModel,
 //     lspInfo) always return the memoized value, stale or not.
@@ -103,6 +105,8 @@ type agentModelChangedMsg struct{}
 
 // agentModelChangedCmd is sequenced after cmds that call UpdateAgentModel so
 // the refresh probes the coordinator only once the update has completed.
+// Callers should reach for updateAgentModelCmd rather than sequencing this
+// by hand.
 func agentModelChangedCmd() tea.Msg { return agentModelChangedMsg{} }
 
 // currentSessionID returns the active session's ID, or "" when none.
@@ -152,6 +156,16 @@ func (m *UI) dispatchBusyRefresh() tea.Cmd {
 		st.yolo = ws.PermissionSkipRequests()
 		return st
 	}
+}
+
+// updateAgentModelCmd sequences a coordinator model rebuild
+// (UpdateAgentModel) with the invalidation of the memoized ready/model
+// state. Callers wrap their pre-work in pre; the memoized model must only
+// be re-probed after the rebuild lands (a synchronous HTTP round-trip in
+// client/server mode), so the message drives the refresh instead of each
+// call site remembering to.
+func (m *UI) updateAgentModelCmd(pre tea.Cmd) tea.Cmd {
+	return tea.Sequence(pre, agentModelChangedCmd)
 }
 
 // applyBusyState stores an off-thread probe result and reacts to busy


### PR DESCRIPTION
Oof. When crush is run in client/server mode, and the server was remote over TCP, typing became unbearably slow. This is because all sorts of Bubble Tea events were hitting the server…_synchronously_.

This revision fixes the behavior and a bunch of other associated behavior like this. Typing will now happens on the client, and does _not_ ping the server.