### PR TITLE
Hyper oauth parallel sessions

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"os"
@@ -124,10 +123,7 @@ func loginHyper(ws workspace.Workspace, force bool) error {
 		return fmt.Errorf("access token is not active")
 	}
 
-	if err := cmp.Or(
-		ws.SetConfigField(config.ScopeGlobal, "providers.hyper.api_key", token.AccessToken),
-		ws.SetConfigField(config.ScopeGlobal, "providers.hyper.oauth", token),
-	); err != nil {
+	if err := ws.SetProviderAPIKey(config.ScopeGlobal, "hyper", token); err != nil {
 		return err
 	}
 
@@ -203,10 +199,7 @@ func loginCopilot(ws workspace.Workspace, force bool) error {
 		token = t
 	}
 
-	if err := cmp.Or(
-		ws.SetConfigField(config.ScopeGlobal, "providers.copilot.api_key", token.AccessToken),
-		ws.SetConfigField(config.ScopeGlobal, "providers.copilot.oauth", token),
-	); err != nil {
+	if err := ws.SetProviderAPIKey(config.ScopeGlobal, "copilot", token); err != nil {
 		return err
 	}
 

--- a/internal/config/model_pin_test.go
+++ b/internal/config/model_pin_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// twoProviderConfig is a config file naming large as the given
+// provider/model, with both providers available so either choice resolves.
+func twoProviderConfig(provider, model string) string {
+	return `{
+		"models": {
+			"large": {"provider": "` + provider + `", "model": "` + model + `"}
+		},
+		"providers": {
+			"openai": {
+				"api_key": "test-key",
+				"models": [{"id": "gpt-4", "name": "GPT-4"}]
+			},
+			"anthropic": {
+				"api_key": "test-key-2",
+				"models": [{"id": "claude-3", "name": "Claude 3"}]
+			}
+		}
+	}`
+}
+
+// TestModelSelectionSurvivesPeerWrite is a regression test for the model
+// switching out from under the user when several Crush instances share the
+// global config file. A sibling instance selecting a different model must
+// not change ours, even though an unrelated config write (a token refresh,
+// for example) reloads the file we both write to.
+func TestModelSelectionSurvivesPeerWrite(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "crush.json")
+
+	t.Setenv("CRUSH_GLOBAL_CONFIG", dir)
+	t.Setenv("CRUSH_GLOBAL_DATA", dir)
+	resetProviderState()
+	t.Cleanup(resetProviderState)
+
+	require.NoError(t, os.WriteFile(configPath, []byte(twoProviderConfig("openai", "gpt-4")), 0o600))
+
+	store, err := Load(dir, dir, false)
+	require.NoError(t, err)
+	store.globalDataPath = configPath
+	store.CaptureStalenessSnapshot([]string{configPath})
+
+	// The user picks Claude in this instance.
+	require.NoError(t, store.UpdatePreferredModel(ScopeGlobal, SelectedModelTypeLarge, SelectedModel{
+		Provider: "anthropic",
+		Model:    "claude-3",
+	}))
+
+	// A sibling instance then picks GPT-4 and writes it to the shared file.
+	require.NoError(t, os.WriteFile(configPath, []byte(twoProviderConfig("openai", "gpt-4")), 0o600))
+
+	// Any reload (here explicit; in practice triggered by an unrelated
+	// write such as an OAuth token refresh) must leave our choice alone.
+	require.NoError(t, store.ReloadFromDisk(context.Background()))
+
+	large := store.Config().Models[SelectedModelTypeLarge]
+	require.Equal(t, "anthropic", large.Provider)
+	require.Equal(t, "claude-3", large.Model)
+}
+
+// TestModelSelectionYieldsToDiskWhenUnchosen verifies the other half of the
+// rule: a model type this instance never selected still follows the config
+// file, so external edits and `crush login` defaults keep working.
+func TestModelSelectionYieldsToDiskWhenUnchosen(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "crush.json")
+
+	t.Setenv("CRUSH_GLOBAL_CONFIG", dir)
+	t.Setenv("CRUSH_GLOBAL_DATA", dir)
+	resetProviderState()
+	t.Cleanup(resetProviderState)
+
+	require.NoError(t, os.WriteFile(configPath, []byte(twoProviderConfig("openai", "gpt-4")), 0o600))
+
+	store, err := Load(dir, dir, false)
+	require.NoError(t, err)
+	store.globalDataPath = configPath
+	store.CaptureStalenessSnapshot([]string{configPath})
+
+	require.NoError(t, os.WriteFile(configPath, []byte(twoProviderConfig("anthropic", "claude-3")), 0o600))
+	require.NoError(t, store.ReloadFromDisk(context.Background()))
+
+	large := store.Config().Models[SelectedModelTypeLarge]
+	require.Equal(t, "anthropic", large.Provider)
+	require.Equal(t, "claude-3", large.Model)
+}

--- a/internal/config/refresh_singleflight_test.go
+++ b/internal/config/refresh_singleflight_test.go
@@ -15,6 +15,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// writeTokenToDisk persists token as the hyper provider credential in the
+// config file at path, mimicking what another crush instance would leave
+// behind after a successful refresh.
+func writeTokenToDisk(t *testing.T, path string, token *oauth.Token) {
+	t.Helper()
+	configContent := fmt.Sprintf(`{
+		"providers": {
+			"hyper": {
+				"api_key": %q,
+				"oauth": {
+					"access_token": %q,
+					"refresh_token": %q,
+					"expires_in": %d,
+					"expires_at": %d
+				}
+			}
+		}
+	}`, token.AccessToken, token.AccessToken, token.RefreshToken, token.ExpiresIn, token.ExpiresAt)
+	require.NoError(t, os.WriteFile(path, []byte(configContent), 0o600))
+}
+
 // newRefreshTestStore builds a ConfigStore whose hyper provider holds an
 // expired OAuth token, persisted both in memory and on disk at configPath.
 // Stores that share a configPath also share the per-provider refresh lock,
@@ -30,19 +51,7 @@ func newRefreshTestStore(t *testing.T, configPath string, exchange func(ctx cont
 		ExpiresIn:    3600,
 		ExpiresAt:    time.Now().Add(-time.Hour).Unix(),
 	}
-	configContent := `{
-		"providers": {
-			"hyper": {
-				"oauth": {
-					"access_token": "at0",
-					"refresh_token": "rt0",
-					"expires_in": 3600,
-					"expires_at": ` + fmt.Sprintf("%d", expired.ExpiresAt) + `
-				}
-			}
-		}
-	}`
-	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o600))
+	writeTokenToDisk(t, configPath, expired)
 
 	providers := csync.NewMap[string, ProviderConfig]()
 	providers.Set("hyper", ProviderConfig{
@@ -172,4 +181,121 @@ func TestRefreshOAuthToken_CrossProcessAdopt(t *testing.T) {
 		require.Equal(t, "at1", pc.OAuthToken.AccessToken, name)
 		require.Equal(t, "rt1", pc.OAuthToken.RefreshToken, name)
 	}
+}
+
+// rotatingExchange models a provider that rotates refresh tokens and
+// revokes the previous one: presenting anything other than the currently
+// live refresh token fails the way a real reuse-detecting server would.
+// Tokens are handed out as at<n>/rt<n> starting at next. The returned
+// counters report successful exchanges and reuse attempts.
+func rotatingExchange(live string, next int) (exchange func(ctx context.Context, providerID, refreshToken string) (*oauth.Token, error), exchanges, reuse *atomic.Int64) {
+	var (
+		mu        sync.Mutex
+		exchanged atomic.Int64
+		reused    atomic.Int64
+	)
+	return func(ctx context.Context, providerID, refreshToken string) (*oauth.Token, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if refreshToken != live {
+			reused.Add(1)
+			return nil, &oauth.TokenExchangeError{StatusCode: 400, Body: `{"error":"invalid_grant"}`}
+		}
+		exchanged.Add(1)
+		token := &oauth.Token{
+			AccessToken:  fmt.Sprintf("at%d", next),
+			RefreshToken: fmt.Sprintf("rt%d", next),
+			ExpiresIn:    3600,
+			ExpiresAt:    time.Now().Add(time.Hour).Unix(),
+		}
+		live = token.RefreshToken
+		next++
+		return token, nil
+	}, &exchanged, &reused
+}
+
+// TestRefreshOAuthToken_StalePeerBorrowsRotatedRefreshToken covers the
+// instance that has been idle while a peer rotated the credential several
+// times. Its own refresh token is long dead, and the token on disk has
+// itself aged out, so there is nothing to adopt outright. The stale
+// instance must still recover by exchanging with the refresh token from
+// disk rather than presenting its own revoked one, which would revoke the
+// whole token family and force the user to log in again.
+func TestRefreshOAuthToken_StalePeerBorrowsRotatedRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "crush.json")
+	exchange, exchanges, reuse := rotatingExchange("rt3", 4)
+	store := newRefreshTestStore(t, configPath, exchange)
+
+	// Disk holds the peer's third rotation, whose access token has also
+	// expired. In memory we are still back on the original credential.
+	writeTokenToDisk(t, configPath, &oauth.Token{
+		AccessToken:  "at3",
+		RefreshToken: "rt3",
+		ExpiresIn:    3600,
+		ExpiresAt:    time.Now().Add(-time.Minute).Unix(),
+	})
+
+	require.NoError(t, store.RefreshOAuthToken(context.Background(), ScopeGlobal, "hyper"))
+	require.Equal(t, int64(1), exchanges.Load())
+	require.Equal(t, int64(0), reuse.Load(), "must not present its own revoked refresh token")
+
+	pc, ok := store.config.Providers.Get("hyper")
+	require.True(t, ok)
+	require.Equal(t, "at4", pc.OAuthToken.AccessToken)
+	require.Equal(t, "rt4", pc.OAuthToken.RefreshToken)
+	require.Equal(t, "at4", pc.APIKey)
+}
+
+// TestRefreshOAuthToken_AdoptsFresherDiskToken verifies that an instance
+// whose in-memory credential has aged out adopts a peer's still-valid
+// token from disk without spending an exchange at all.
+func TestRefreshOAuthToken_AdoptsFresherDiskToken(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "crush.json")
+	exchange, exchanges, _ := rotatingExchange("rt9", 10)
+	store := newRefreshTestStore(t, configPath, exchange)
+
+	writeTokenToDisk(t, configPath, &oauth.Token{
+		AccessToken:  "at9",
+		RefreshToken: "rt9",
+		ExpiresIn:    3600,
+		ExpiresAt:    time.Now().Add(time.Hour).Unix(),
+	})
+
+	require.NoError(t, store.RefreshOAuthToken(context.Background(), ScopeGlobal, "hyper"))
+	require.Equal(t, int64(0), exchanges.Load(), "a usable peer token needs no exchange")
+
+	pc, ok := store.config.Providers.Get("hyper")
+	require.True(t, ok)
+	require.Equal(t, "at9", pc.OAuthToken.AccessToken)
+	require.Equal(t, "at9", pc.APIKey)
+}
+
+// TestRefreshOAuthToken_IgnoresOlderDiskToken guards against walking
+// backwards: a config file holding an older credential than the one we
+// already have must not be adopted or borrowed from.
+func TestRefreshOAuthToken_IgnoresOlderDiskToken(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "crush.json")
+	exchange, exchanges, reuse := rotatingExchange("rt0", 1)
+	store := newRefreshTestStore(t, configPath, exchange)
+
+	writeTokenToDisk(t, configPath, &oauth.Token{
+		AccessToken:  "ancient",
+		RefreshToken: "ancient-rt",
+		ExpiresIn:    3600,
+		ExpiresAt:    time.Now().Add(-24 * time.Hour).Unix(),
+	})
+
+	require.NoError(t, store.RefreshOAuthToken(context.Background(), ScopeGlobal, "hyper"))
+	require.Equal(t, int64(1), exchanges.Load())
+	require.Equal(t, int64(0), reuse.Load())
+
+	pc, ok := store.config.Providers.Get("hyper")
+	require.True(t, ok)
+	require.Equal(t, "rt1", pc.OAuthToken.RefreshToken)
 }

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -37,6 +38,13 @@ const configLockDeadline = 5 * time.Second
 // revoking the whole token family.
 const refreshLockDeadline = 45 * time.Second
 
+// credentialWriteLockDeadline bounds how long a credential write (e.g.
+// storing the token from a fresh interactive login) waits for the
+// per-provider refresh lock. It is deliberately shorter than
+// refreshLockDeadline because a user is watching: if a peer is wedged we
+// would rather write and risk a rare clobber than hang the UI.
+const credentialWriteLockDeadline = 10 * time.Second
+
 // fileSnapshot captures metadata about a config file at a point in time.
 type fileSnapshot struct {
 	Path    string
@@ -55,6 +63,11 @@ type RuntimeOverrides struct {
 	// pushes channel events when it also appears here. Entries may be written
 	// as "server:<name>" or as a bare "<name>".
 	EnabledChannels []string
+	// Models records the model choices made in this instance, whether
+	// persisted or not. They are reapplied after a config reload so that a
+	// selection made here always outranks whatever the shared config file
+	// happens to hold — see pinPreferredModelLocked.
+	Models map[SelectedModelType]SelectedModel
 }
 
 // ConfigStore is the single entry point for all config access. It owns the
@@ -391,7 +404,23 @@ func (s *ConfigStore) OverridePreferredModel(modelType SelectedModelType, model 
 			c.Models = make(map[SelectedModelType]SelectedModel)
 		}
 		c.Models[modelType] = model
+		s.pinPreferredModelLocked(modelType, model)
 	})
+}
+
+// pinPreferredModelLocked records a model choice made in this instance so
+// that a later config reload cannot replace it with a choice made
+// somewhere else. Several Crush instances share one global config file, so
+// a reload triggered by an unrelated write (a token refresh, say) would
+// otherwise import whichever model a sibling instance last selected and
+// switch models out from under the user mid-session.
+//
+// Caller must hold writeMu.
+func (s *ConfigStore) pinPreferredModelLocked(modelType SelectedModelType, model SelectedModel) {
+	if s.overrides.Models == nil {
+		s.overrides.Models = make(map[SelectedModelType]SelectedModel)
+	}
+	s.overrides.Models[modelType] = model
 }
 
 // RemoveConfigField removes a key from the config file for the given scope.
@@ -434,12 +463,13 @@ func (s *ConfigStore) UpdatePreferredModel(scope Scope, modelType SelectedModelT
 
 // updatePreferredModelFields builds the fields map for persisting a preferred
 // model change. Shared between UpdatePreferredModel and direct updateLocked
-// callers (e.g. Load).
+// callers (e.g. Load). Caller must hold writeMu.
 func (s *ConfigStore) updatePreferredModelFields(c *Config, modelType SelectedModelType, model SelectedModel) map[string]any {
 	if c.Models == nil {
 		c.Models = make(map[SelectedModelType]SelectedModel)
 	}
 	c.Models[modelType] = model
+	s.pinPreferredModelLocked(modelType, model)
 
 	fields := map[string]any{
 		fmt.Sprintf("models.%s", modelType): model,
@@ -483,9 +513,15 @@ func (s *ConfigStore) SetProviderAPIKey(scope Scope, providerID string, apiKey a
 		}
 		setKeyOrToken = func() { providerConfig.APIKey = v }
 	case *oauth.Token:
-		if err := s.SetConfigFields(scope, map[string]any{
-			fmt.Sprintf("providers.%s.api_key", providerID): v.AccessToken,
-			fmt.Sprintf("providers.%s.oauth", providerID):   v,
+		// Hold the refresh lock across the write so a peer's in-flight
+		// token exchange cannot land on top of a credential the user just
+		// obtained interactively — which would silently invalidate the
+		// login they only just completed.
+		if err := s.withRefreshLock(providerID, func() error {
+			return s.SetConfigFields(scope, map[string]any{
+				fmt.Sprintf("providers.%s.api_key", providerID): v.AccessToken,
+				fmt.Sprintf("providers.%s.oauth", providerID):   v,
+			})
 		}); err != nil {
 			return err
 		}
@@ -588,7 +624,7 @@ func (s *ConfigStore) refreshOAuthTokenLocked(ctx context.Context, scope Scope, 
 		// Could not acquire the lock (peer wedged or deadline hit). Prefer a
 		// usable token already on disk over forcing our own exchange, which
 		// would risk reusing a rotated refresh token.
-		if diskToken := s.adoptableDiskToken(scope, providerID, entryToken); diskToken != nil {
+		if diskToken := s.usableDiskToken(scope, providerID, entryToken); diskToken != nil {
 			slog.Warn("Refresh lock unavailable; adopting token from disk", "provider", providerID, "error", lockErr)
 			return s.applyToken(providerConfig, diskToken, providerID)
 		}
@@ -596,33 +632,45 @@ func (s *ConfigStore) refreshOAuthTokenLocked(ctx context.Context, scope Scope, 
 	}
 	defer release()
 
-	// Did a peer rotate the token while we waited for the lock? If disk now
-	// holds a different, unexpired token, adopt it instead of exchanging.
-	if diskToken := s.adoptableDiskToken(scope, providerID, entryToken); diskToken != nil {
-		slog.Info("Adopting token refreshed by another session", "provider", providerID)
-		return s.applyToken(providerConfig, diskToken, providerID)
+	// Now that we hold the lock, disk is the authority on which credential
+	// is current: a peer may have rotated ours away while we waited. Adopt
+	// a newer token outright when it is still usable, and otherwise switch
+	// to its refresh token for the exchange below. Presenting our own
+	// already-rotated refresh token would trip the provider's reuse
+	// detection and revoke the whole family, forcing an interactive login.
+	if diskToken := s.newerDiskToken(scope, providerID, entryToken); diskToken != nil {
+		if !diskToken.IsExpired() {
+			slog.Info("Adopting token refreshed by another session", "provider", providerID)
+			return s.applyToken(providerConfig, diskToken, providerID)
+		}
+		slog.Info("Exchanging with refresh token rotated by another session", "provider", providerID)
+		entryToken = diskToken
 	}
 
-	// Disk still holds our token (or no usable peer token exists) and we hold
+	// Disk still holds our token (or no newer peer token exists) and we hold
 	// the lock, so we are the sole exchanger. Perform the exchange.
 	refreshedToken, refreshErr := s.exchange(ctx, providerID, entryToken.RefreshToken)
 	if refreshErr != nil {
 		// The exchange may have failed because a peer rotated the refresh
-		// token in a window we did not cover. Re-check disk and adopt.
-		if diskToken := s.adoptableDiskToken(scope, providerID, entryToken); diskToken != nil {
-			slog.Info("Adopting token refreshed by another session after exchange failure", "provider", providerID)
-			return s.applyToken(providerConfig, diskToken, providerID)
+		// token in a window we did not cover. Re-check disk: adopt a usable
+		// token, or retry once with the peer's newer refresh token.
+		if diskToken := s.newerDiskToken(scope, providerID, entryToken); diskToken != nil {
+			if !diskToken.IsExpired() {
+				slog.Info("Adopting token refreshed by another session after exchange failure", "provider", providerID)
+				return s.applyToken(providerConfig, diskToken, providerID)
+			}
+			slog.Info("Retrying exchange with refresh token rotated by another session", "provider", providerID)
+			refreshedToken, refreshErr = s.exchange(ctx, providerID, diskToken.RefreshToken)
 		}
+	}
+	if refreshErr != nil {
 		return fmt.Errorf("failed to refresh OAuth token for provider %s: %w", providerID, refreshErr)
 	}
 
 	slog.Info("Successfully refreshed OAuth token", "provider", providerID)
-	providerConfig.OAuthToken = refreshedToken
-	providerConfig.APIKey = refreshedToken.AccessToken
-	if providerID == string(catwalk.InferenceProviderCopilot) {
-		providerConfig.SetupGitHubCopilot()
+	if err := s.applyToken(providerConfig, refreshedToken, providerID); err != nil {
+		return err
 	}
-	cfg.Providers.Set(providerID, providerConfig)
 
 	if err := s.SetConfigFields(scope, map[string]any{
 		fmt.Sprintf("providers.%s.api_key", providerID): refreshedToken.AccessToken,
@@ -694,21 +742,49 @@ func (s *ConfigStore) SignalAuthComplete(providerID string) {
 	}
 }
 
-// adoptableDiskToken returns the on-disk token for the provider when it is
-// usable and differs from entryToken — i.e. when another session has
-// already refreshed it and we should adopt that result rather than running
-// our own exchange. It returns nil when there is nothing newer to adopt.
-func (s *ConfigStore) adoptableDiskToken(scope Scope, providerID string, entryToken *oauth.Token) *oauth.Token {
+// newerDiskToken returns the on-disk token for the provider when it is
+// newer than entryToken — i.e. another session (possibly in another
+// process) has already rotated the credential. It returns nil when disk
+// holds nothing newer than what we started with.
+//
+// Newness is judged by expiry as well as identity, so a config file that
+// somehow holds an older token cannot drag us backwards. The result may
+// itself be expired: providers that rotate refresh tokens invalidate ours
+// the moment a peer refreshes, so the peer's refresh token is the only one
+// the provider will still accept even after its access token ages out.
+// Callers decide whether to adopt the token wholesale or merely borrow its
+// refresh token.
+func (s *ConfigStore) newerDiskToken(scope Scope, providerID string, entryToken *oauth.Token) *oauth.Token {
 	diskToken, err := s.loadTokenFromDisk(scope, providerID)
 	if err != nil {
 		slog.Warn("Failed to read token from config file", "provider", providerID, "error", err)
 		return nil
 	}
-	if diskToken == nil || diskToken.IsExpired() {
+	if diskToken == nil {
 		return nil
 	}
 	if diskToken.AccessToken == entryToken.AccessToken {
-		// Same token we started with; nobody refreshed since.
+		// Same token we started with; nobody rotated since.
+		return nil
+	}
+	if diskToken.RefreshToken == "" && entryToken.RefreshToken != "" {
+		// Adopting would strand us with no way to refresh later, and
+		// there is nothing to borrow for an exchange.
+		return nil
+	}
+	if diskToken.ExpiresAt < entryToken.ExpiresAt {
+		// Older than ours; nothing to gain from adopting it.
+		return nil
+	}
+	return diskToken
+}
+
+// usableDiskToken returns the on-disk token only when it is both newer
+// than entryToken and still valid, meaning it can be adopted as-is with
+// no exchange at all.
+func (s *ConfigStore) usableDiskToken(scope Scope, providerID string, entryToken *oauth.Token) *oauth.Token {
+	diskToken := s.newerDiskToken(scope, providerID, entryToken)
+	if diskToken == nil || diskToken.IsExpired() {
 		return nil
 	}
 	return diskToken
@@ -729,6 +805,23 @@ func (s *ConfigStore) exchange(ctx context.Context, providerID, refreshToken str
 	default:
 		return nil, fmt.Errorf("OAuth refresh not supported for provider %s", providerID)
 	}
+}
+
+// withRefreshLock runs fn while holding the per-provider cross-process
+// refresh lock, so a credential write cannot interleave with a peer's
+// token exchange. Acquisition is best effort: when the lock cannot be
+// taken in time, fn runs anyway rather than blocking a write the user is
+// waiting on.
+func (s *ConfigStore) withRefreshLock(providerID string, fn func() error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), credentialWriteLockDeadline)
+	defer cancel()
+	release, err := lock.File(ctx, s.refreshLockPath(providerID))
+	if err != nil {
+		slog.Warn("Writing credentials without the refresh lock", "provider", providerID, "error", err)
+		return fn()
+	}
+	defer release()
+	return fn()
 }
 
 // refreshLockPath returns the path to the per-provider cross-process refresh
@@ -1052,6 +1145,13 @@ func (s *ConfigStore) reloadFromDiskLocked(ctx context.Context) error {
 
 	// Preserve runtime overrides
 	overrides := s.overrides
+
+	// Reapply model choices made in this instance. The global config file is
+	// shared, so it may now name a model a sibling instance selected; a
+	// reload triggered by an unrelated write must not swap the user's model
+	// mid-session. An external edit to the config still takes effect for any
+	// model type this instance never chose.
+	maps.Copy(cfg.Models, overrides.Models)
 
 	// Reconfigure providers
 	env := env.New()

--- a/internal/shell/dispatch_test.go
+++ b/internal/shell/dispatch_test.go
@@ -421,10 +421,14 @@ func TestDispatch_ProbeWindowClassifiesByHead(t *testing.T) {
 // TestDispatch_BinaryPassthroughExecutes copies a real binary from PATH
 // into a tempdir, invokes it via a path-prefixed argv[0], and verifies it
 // ran — i.e. the binary branch correctly returns through `next` to the
-// default exec handler. We use whichever of `true`/`echo` is available on
-// PATH so the test works on any Unix-y system; it skips on Windows where
-// the stock binaries don't share names and the Go test binary approach
-// is heavier than this test deserves.
+// default exec handler. It skips on Windows, where the stock binaries
+// don't share names and the Go test binary approach is heavier than this
+// test deserves.
+//
+// The copy keeps the source's filename. Some coreutils builds (Nix's, for
+// one) ship every utility as a single multi-call binary that picks its
+// behaviour from argv[0], so a renamed copy of `true` exits non-zero with
+// "unknown program" instead of succeeding.
 func TestDispatch_BinaryPassthroughExecutes(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("relies on a Unix-style PATH binary")
@@ -438,7 +442,7 @@ func TestDispatch_BinaryPassthroughExecutes(t *testing.T) {
 		t.Fatalf("read %s: %v", src, err)
 	}
 	dir := t.TempDir()
-	dst := filepath.Join(dir, "copied-true")
+	dst := filepath.Join(dir, filepath.Base(src))
 	if err := os.WriteFile(dst, data, 0o755); err != nil {
 		t.Fatalf("write %s: %v", dst, err)
 	}
@@ -452,7 +456,7 @@ func TestDispatch_BinaryPassthroughExecutes(t *testing.T) {
 		Env: os.Environ(),
 	})
 	if runErr != nil {
-		t.Fatalf("expected copy of /bin/true to exit 0, got: %v", runErr)
+		t.Fatalf("expected copy of %s to exit 0, got: %v", src, runErr)
 	}
 }
 


### PR DESCRIPTION
Several Crush instances share one global credential and one config file.
When one refreshed its access token, the others were left holding a
refresh token the provider had already revoked, so the next refresh
tripped reuse detection and killed the whole token family, forcing an
avoidable relogin. The same shared file also let one session's model
choice replace another's mid-conversation.

A session now defers to a credential another session rotated, borrowing
it even after its access token has aged out, since that is the only one
the provider still honors. Interactive logins are written without a peer
refresh landing on top of them. Model choices made in a session are
pinned for its lifetime, while model types the session never chose still
follow the config file so external edits keep working.