### PR TITLE
fix(agent): keep tool results next to the call they answer

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1545,7 +1545,7 @@ If not, please feel free to ignore. Again do not mention this message to the use
 		}
 	}
 
-	for _, m := range msgs {
+	for _, m := range orderToolResultsAfterCalls(msgs) {
 		if len(m.Parts) == 0 {
 			continue
 		}
@@ -1606,6 +1606,72 @@ func filterFileParts(parts []fantasy.MessagePart) []fantasy.MessagePart {
 		filtered = append(filtered, part)
 	}
 	return filtered
+}
+
+// orderToolResultsAfterCalls returns the history with every tool message moved
+// to directly after the assistant message holding the tool call it answers,
+// pushing anything recorded in between after it.
+//
+// Providers require the results answering a tool call to be the first thing in
+// the turn following it, so anything persisted while that call is still in
+// flight breaks the request: consecutive same-role messages are merged into a
+// single turn, so an interleaved user message does not just sit between the
+// two, it pulls the results in behind its own content. Since the history is
+// replayed on every turn the request keeps failing, leaving the session
+// permanently unusable. Bang-mode shell command output is the case seen in the
+// wild, but the reordering is deliberately blind to what was interleaved.
+//
+// Tool messages whose call is not in the history are left where they are, for
+// filterOrphanedToolResults to report and drop.
+func orderToolResultsAfterCalls(msgs []message.Message) []message.Message {
+	callingMessage := make(map[string]string)
+	for _, m := range msgs {
+		if m.Role != message.Assistant {
+			continue
+		}
+		for _, tc := range m.ToolCalls() {
+			callingMessage[tc.ID] = m.ID
+		}
+	}
+
+	// The assistant message a tool message belongs behind, if its call is in
+	// the history at all.
+	answers := func(m message.Message) (string, bool) {
+		if m.Role != message.Tool {
+			return "", false
+		}
+		results := m.ToolResults()
+		if len(results) == 0 {
+			return "", false
+		}
+		// Every result in a tool message answers the same assistant turn:
+		// results are persisted per turn, so keying on the first is enough
+		// to find the message they all belong behind.
+		id, ok := callingMessage[results[0].ToolCallID]
+		return id, ok
+	}
+
+	resultsFor := make(map[string][]message.Message)
+	for _, m := range msgs {
+		if id, ok := answers(m); ok {
+			resultsFor[id] = append(resultsFor[id], m)
+		}
+	}
+	if len(resultsFor) == 0 {
+		return msgs
+	}
+
+	ordered := make([]message.Message, 0, len(msgs))
+	for _, m := range msgs {
+		if _, ok := answers(m); ok {
+			continue
+		}
+		ordered = append(ordered, m)
+		if m.Role == message.Assistant {
+			ordered = append(ordered, resultsFor[m.ID]...)
+		}
+	}
+	return ordered
 }
 
 // filterOrphanedToolResults converts a tool message to a fantasy.Message,

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -893,6 +893,146 @@ func TestPreparePrompt_OrphanedToolUseMixed(t *testing.T) {
 	require.Equal(t, 1, syntheticCount, "expected exactly one synthetic result for the orphaned call")
 }
 
+func TestPreparePrompt_MessageBetweenToolCallAndResult(t *testing.T) {
+	// Anything persisted while a tool call is in flight lands between the call
+	// and its result; the reordering must not depend on what that was.
+	tests := []struct {
+		name        string
+		interleaved message.ContentPart
+	}{
+		{"bang-mode shell command", message.ShellCommand{Command: "make deploy", Output: "deploying"}},
+		{"prompt submitted mid-turn", message.TextContent{Text: "actually, stop"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := testEnv(t)
+			sa := testSessionAgent(env, nil, nil, "test prompt")
+			agent := sa.(*sessionAgent)
+
+			ctx := t.Context()
+			sess, err := env.sessions.Create(ctx, "test")
+			require.NoError(t, err)
+
+			_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+				Role: message.Assistant,
+				Parts: []message.ContentPart{
+					message.ToolCall{
+						ID:       "call_in_flight",
+						Name:     "view",
+						Input:    `{"path":"/foo"}`,
+						Finished: true,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+				Role:  message.User,
+				Parts: []message.ContentPart{tc.interleaved},
+			})
+			require.NoError(t, err)
+
+			_, err = env.messages.Create(ctx, sess.ID, message.CreateMessageParams{
+				Role:  message.Tool,
+				Parts: []message.ContentPart{message.ToolResult{ToolCallID: "call_in_flight", Name: "view", Content: "file contents"}},
+			})
+			require.NoError(t, err)
+
+			msgs, err := env.messages.List(ctx, sess.ID)
+			require.NoError(t, err)
+
+			history, _ := agent.preparePrompt(msgs, true)
+
+			// The result has to come before the interleaved message: providers
+			// merge consecutive same-role messages into one turn, so leaving it
+			// behind that message also leaves it behind that message's content,
+			// and the call counts as unanswered.
+			roles := make([]fantasy.MessageRole, 0, len(history))
+			for _, msg := range history {
+				roles = append(roles, msg.Role)
+			}
+			require.Equal(t, []fantasy.MessageRole{
+				fantasy.MessageRoleUser, // the todo reminder preparePrompt prepends
+				fantasy.MessageRoleAssistant,
+				fantasy.MessageRoleTool,
+				fantasy.MessageRoleUser,
+			}, roles)
+		})
+	}
+}
+
+func TestPreparePrompt_MultipleCallsKeepOrder(t *testing.T) {
+	// Two calls answered across two turns, each with a message interleaved
+	// before its result. Every result must land behind its own call, and the
+	// relative order of the two turns must be preserved.
+	env := testEnv(t)
+	sa := testSessionAgent(env, nil, nil, "test prompt")
+	agent := sa.(*sessionAgent)
+
+	ctx := t.Context()
+	sess, err := env.sessions.Create(ctx, "test")
+	require.NoError(t, err)
+
+	call := func(id string) message.CreateMessageParams {
+		return message.CreateMessageParams{
+			Role: message.Assistant,
+			Parts: []message.ContentPart{
+				message.ToolCall{ID: id, Name: "view", Input: `{"path":"/foo"}`, Finished: true},
+			},
+		}
+	}
+	interleave := func(text string) message.CreateMessageParams {
+		return message.CreateMessageParams{
+			Role:  message.User,
+			Parts: []message.ContentPart{message.TextContent{Text: text}},
+		}
+	}
+	result := func(id string) message.CreateMessageParams {
+		return message.CreateMessageParams{
+			Role:  message.Tool,
+			Parts: []message.ContentPart{message.ToolResult{ToolCallID: id, Name: "view", Content: "file contents"}},
+		}
+	}
+
+	// First turn: call, interleaved message, result. Then the same again.
+	for _, params := range []message.CreateMessageParams{
+		call("call_1"), interleave("first"), result("call_1"),
+		call("call_2"), interleave("second"), result("call_2"),
+	} {
+		_, err = env.messages.Create(ctx, sess.ID, params)
+		require.NoError(t, err)
+	}
+
+	msgs, err := env.messages.List(ctx, sess.ID)
+	require.NoError(t, err)
+
+	history, _ := agent.preparePrompt(msgs, true)
+
+	// Each result sits directly behind its own call, and the two turns keep
+	// their original order.
+	roles := make([]fantasy.MessageRole, 0, len(history))
+	for _, msg := range history {
+		roles = append(roles, msg.Role)
+	}
+	require.Equal(t, []fantasy.MessageRole{
+		fantasy.MessageRoleUser, // the todo reminder preparePrompt prepends
+		fantasy.MessageRoleAssistant,
+		fantasy.MessageRoleTool,
+		fantasy.MessageRoleUser,
+		fantasy.MessageRoleAssistant,
+		fantasy.MessageRoleTool,
+		fantasy.MessageRoleUser,
+	}, roles)
+
+	// The result behind each call answers that call, not the other one.
+	firstResult, ok := fantasy.AsMessagePart[fantasy.ToolResultPart](history[2].Content[0])
+	require.True(t, ok)
+	require.Equal(t, "call_1", firstResult.ToolCallID)
+	secondResult, ok := fantasy.AsMessagePart[fantasy.ToolResultPart](history[5].Content[0])
+	require.True(t, ok)
+	require.Equal(t, "call_2", secondResult.ToolCallID)
+}
+
 func TestWorkaroundProviderMediaLimitations_TextOnlyModel(t *testing.T) {
 	env := testEnv(t)
 	sa := testSessionAgent(env, nil, nil, "test prompt")


### PR DESCRIPTION
Persisting anything while a tool call is still in flight can permanently break a session. Every following request fails with `tool_use ids were found without tool_result blocks immediately after`, and each retry replays the same stored history, so the conversation can never be resumed. Short of abandoning it, there is no way back in.

## What actually happens

Providers require the results answering a tool call to be the first thing in the turn following it. Consecutive same-role messages are merged into a single turn, so a message recorded while a call is in flight does not merely sit between the call and its result: it pulls the result in *behind its own content*, and the call then counts as unanswered.

The trigger seen in the wild is a bang-mode shell command, which is stored as a user message the moment it finishes, sometimes while a tool call has not yet returned. But the trigger is incidental. Anything persisted mid-call produces the same breakage.

This also explains why the existing repair pass saw nothing wrong: it looks results up by ID across the whole session, and the result was genuinely there. The problem was never a missing result, only its position.

## The fix

When the history is assembled, each tool message is moved to directly after the assistant message holding the call it answers, and whatever was recorded in between is pushed after it. The reordering is positional and blind to what was interleaved, so it covers every case, not just bang-mode output.

Both existing repair helpers are left untouched and still run on top of the reordered history: orphaned calls (no result anywhere) still get a synthetic result, and genuinely orphaned results (no call anywhere) are still dropped and logged. Only the ordering changed.

## Tests

- `TestPreparePrompt_MessageBetweenToolCallAndResult` covers two different interleaved kinds (bang-mode shell output and a mid-turn prompt) to pin down that the fix does not care which it was.
- `TestPreparePrompt_MultipleCallsKeepOrder` covers two calls across two turns, each with a message interleaved before its result, to confirm every result lands behind its own call and the turns keep their original order.