### PR TITLE
feat: add Exa as default web search provider

### DIFF
--- a/internal/agent/agentic_fetch_tool.go
+++ b/internal/agent/agentic_fetch_tool.go
@@ -163,7 +163,11 @@ func (c *coordinator) agenticFetchTool(_ context.Context, client *http.Client) (
 			}
 
 			webFetchTool := tools.NewWebFetchTool(tmpDir, client)
-			webSearchTool := tools.NewWebSearchTool(client)
+			webSearchConfig := c.cfg.Config().Tools.WebSearch
+			webSearchTool := tools.NewWebSearchTool(client, tools.WebSearchOptions{
+				DefaultEngine: webSearchConfig.Engine(),
+				ExaAPIKey:     webSearchConfig.ResolvedExaAPIKey(c.cfg.Resolver()),
+			})
 			fetchTools := []fantasy.AgentTool{
 				webFetchTool,
 				webSearchTool,

--- a/internal/agent/tools/exa_search.go
+++ b/internal/agent/tools/exa_search.go
@@ -1,0 +1,329 @@
+package tools
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/crush/internal/version"
+)
+
+const (
+	exaEndpoint       = "https://mcp.exa.ai/mcp"
+	exaToolName       = "web_search_exa"
+	exaRequestTimeout = 25 * time.Second
+	exaResponseLimit  = 4 << 20
+	exaResultLimit    = 1000
+	exaOutputLimit    = 12000
+)
+
+type exaSearchRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int             `json:"id"`
+	Method  string          `json:"method"`
+	Params  exaSearchParams `json:"params"`
+}
+
+type exaSearchParams struct {
+	Name      string             `json:"name"`
+	Arguments exaSearchArguments `json:"arguments"`
+}
+
+type exaSearchArguments struct {
+	Query      string `json:"query"`
+	NumResults int    `json:"numResults"`
+}
+
+type exaSearchResponse struct {
+	Result *struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		IsError bool `json:"isError"`
+	} `json:"result"`
+	Error *exaRPCError `json:"error"`
+}
+
+type exaRPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+func searchExa(ctx context.Context, client *http.Client, apiKey, query string, maxResults int) ([]SearchResult, error) {
+	if maxResults <= 0 {
+		maxResults = 10
+	}
+	endpoint := exaEndpoint
+	if apiKey != "" {
+		endpoint += "?" + url.Values{"exaApiKey": {apiKey}}.Encode()
+	}
+
+	body, err := json.Marshal(exaSearchRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "tools/call",
+		Params: exaSearchParams{
+			Name: exaToolName,
+			Arguments: exaSearchArguments{
+				Query:      query,
+				NumResults: maxResults,
+			},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode Exa request: %w", err)
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, exaRequestTimeout)
+	defer cancel()
+
+	var responseBody []byte
+	for attempt := 0; attempt < 2; attempt++ {
+		req, err := http.NewRequestWithContext(callCtx, http.MethodPost, endpoint, bytes.NewReader(body))
+		if err != nil {
+			return nil, errors.New("failed to create Exa request")
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		req.Header.Set("User-Agent", "crush/"+version.Version)
+		req.Header.Set("x-exa-integration", "crush")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			var urlErr *url.Error
+			if errors.As(err, &urlErr) && urlErr.Err != nil {
+				return nil, fmt.Errorf("failed to execute Exa search: %w", urlErr.Err)
+			}
+			return nil, errors.New("failed to execute Exa search")
+		}
+		responseBody, err = io.ReadAll(io.LimitReader(resp.Body, exaResponseLimit+1))
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read Exa response: %w", err)
+		}
+		if len(responseBody) > exaResponseLimit {
+			return nil, fmt.Errorf("exa response exceeded %d bytes", exaResponseLimit)
+		}
+		if resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode < 500 {
+			if resp.StatusCode < 400 {
+				break
+			}
+			return nil, fmt.Errorf("exa search failed with status code %d", resp.StatusCode)
+		}
+		if attempt == 1 {
+			return nil, fmt.Errorf("exa search failed with status code %d", resp.StatusCode)
+		}
+		if err := waitExaRetry(callCtx, resp.Header.Get("Retry-After")); err != nil {
+			return nil, err
+		}
+	}
+
+	text, err := parseExaResponse(responseBody)
+	if err != nil {
+		return nil, err
+	}
+	return parseExaSearchResults(text, maxResults), nil
+}
+
+func waitExaRetry(ctx context.Context, retryAfter string) error {
+	delay := 100 * time.Millisecond
+	if seconds, err := strconv.Atoi(strings.TrimSpace(retryAfter)); err == nil && seconds >= 0 && seconds <= 5 {
+		delay = time.Duration(seconds) * time.Second
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func parseExaResponse(body []byte) (string, error) {
+	if text, ok, err := parseExaPayload(bytes.TrimSpace(body)); ok {
+		if err != nil {
+			return "", err
+		}
+		return text, nil
+	}
+
+	var texts []string
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	scanner.Buffer(make([]byte, 1024), exaResponseLimit)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		if text, ok, err := parseExaPayload([]byte(strings.TrimSpace(strings.TrimPrefix(line, "data: ")))); ok {
+			if err != nil {
+				return "", err
+			}
+			texts = append(texts, text)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to parse Exa response: %w", err)
+	}
+	if len(texts) == 0 {
+		return "", errors.New("exa response contained no search results")
+	}
+	return strings.Join(texts, "\n"), nil
+}
+
+func parseExaPayload(body []byte) (string, bool, error) {
+	var response exaSearchResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", false, nil
+	}
+	if response.Error != nil {
+		return "", true, fmt.Errorf("exa JSON-RPC error %d: %s", response.Error.Code, response.Error.Message)
+	}
+	if response.Result == nil {
+		return "", false, nil
+	}
+	if response.Result.IsError {
+		var messages []string
+		for _, content := range response.Result.Content {
+			if content.Type == "text" && strings.TrimSpace(content.Text) != "" {
+				messages = append(messages, strings.TrimSpace(content.Text))
+			}
+		}
+		if len(messages) == 0 {
+			return "", true, errors.New("exa tool call failed")
+		}
+		return "", true, fmt.Errorf("exa tool call failed: %s", strings.Join(messages, " "))
+	}
+	if len(response.Result.Content) == 0 {
+		return "", false, nil
+	}
+	for _, content := range response.Result.Content {
+		if content.Type == "text" && strings.TrimSpace(content.Text) != "" {
+			return content.Text, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func parseExaSearchResults(blob string, maxResults int) []SearchResult {
+	if maxResults <= 0 {
+		maxResults = 10
+	}
+	lines := strings.Split(blob, "\n")
+	var starts []int
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "Title: ") {
+			starts = append(starts, i)
+		}
+	}
+	if len(starts) == 0 {
+		if strings.TrimSpace(blob) == "" {
+			return nil
+		}
+		return []SearchResult{{
+			Title:    "Exa search results",
+			Snippet:  truncateRunes(cleanExaText(blob), exaResultLimit),
+			Position: 1,
+		}}
+	}
+
+	results := make([]SearchResult, 0, min(len(starts), maxResults))
+	for i, start := range starts {
+		if len(results) >= maxResults {
+			break
+		}
+		end := len(lines)
+		if i+1 < len(starts) {
+			end = starts[i+1]
+		}
+		result := parseExaEntry(lines[start:end])
+		if result.Title == "" {
+			continue
+		}
+		result.Position = len(results) + 1
+		result.Snippet = truncateRunes(result.Snippet, exaResultLimit)
+		results = append(results, result)
+	}
+	return results
+}
+
+func parseExaEntry(lines []string) SearchResult {
+	var result SearchResult
+	var highlights []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "Title: "):
+			result.Title = strings.TrimSpace(strings.TrimPrefix(line, "Title: "))
+		case strings.HasPrefix(line, "URL: "):
+			result.Link = strings.TrimSpace(strings.TrimPrefix(line, "URL: "))
+		case strings.HasPrefix(line, "Highlights:"):
+			highlights = append(highlights, strings.TrimSpace(strings.TrimPrefix(line, "Highlights:")))
+		case line != "" && len(highlights) > 0:
+			highlights = append(highlights, line)
+		}
+	}
+	result.Snippet = cleanExaText(strings.Join(highlights, " "))
+	return result
+}
+
+func cleanExaText(value string) string {
+	value = strings.ReplaceAll(value, "\r", " ")
+	value = strings.ReplaceAll(value, " ... ", " ")
+	value = strings.ReplaceAll(value, " … ", " ")
+	lines := strings.Split(value, "\n")
+	cleaned := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "> "))
+		if line == "" || line == "..." || line == "…" {
+			continue
+		}
+		cleaned = append(cleaned, line)
+	}
+	return strings.Join(strings.Fields(strings.Join(cleaned, " ")), " ")
+}
+
+func truncateRunes(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	runes := []rune(value)
+	if len(runes) <= limit {
+		return value
+	}
+	if limit <= 1 {
+		return "…"
+	}
+	return string(runes[:limit-1]) + "…"
+}
+
+func truncateBytes(value string, limit int) string {
+	if len(value) <= limit {
+		return value
+	}
+	if limit <= len("…") {
+		return "…"
+	}
+	keep := limit - len("…")
+	if keep <= 0 {
+		return "…"
+	}
+	if keep > len(value) {
+		keep = len(value)
+	}
+	for keep > 0 && !utf8.RuneStart(value[keep-1]) {
+		keep--
+	}
+	return value[:keep] + "…"
+}

--- a/internal/agent/tools/exa_search_integration_test.go
+++ b/internal/agent/tools/exa_search_integration_test.go
@@ -1,0 +1,20 @@
+//go:build integration
+
+package tools
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestExaHostedIntegration(t *testing.T) {
+	results, err := searchExa(context.Background(), http.DefaultClient, "", "Go programming language", 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected Exa results")
+	}
+	t.Logf("received %d Exa results, output bytes=%d", len(results), len(formatExaSearchResults(results)))
+}

--- a/internal/agent/tools/exa_search_test.go
+++ b/internal/agent/tools/exa_search_test.go
@@ -1,0 +1,228 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseExaResponse(t *testing.T) {
+	t.Parallel()
+
+	payload := `{"result":{"content":[{"type":"text","text":"Title: One\nURL: https://one.example\nHighlights: First"}]}}`
+	tests := []struct {
+		name    string
+		body    string
+		want    string
+		wantErr string
+	}{
+		{name: "plain JSON", body: payload, want: "Title: One\nURL: https://one.example\nHighlights: First"},
+		{name: "SSE", body: "event: message\ndata: " + payload + "\n\n", want: "Title: One\nURL: https://one.example\nHighlights: First"},
+		{name: "multiple data lines", body: "data: " + payload + "\ndata: " + strings.Replace(payload, "One", "Two", 1), want: "Title: One\nURL: https://one.example\nHighlights: First\nTitle: Two\nURL: https://one.example\nHighlights: First"},
+		{name: "no data lines", body: "event: ping\n", wantErr: "no search results"},
+		{name: "malformed JSON", body: "data: {bad}", wantErr: "no search results"},
+		{name: "empty content", body: `{"result":{"content":[]}}`, wantErr: "no search results"},
+		{name: "JSON-RPC error", body: `{"error":{"code":-32600,"message":"invalid request"}}`, wantErr: "-32600: invalid request"},
+		{name: "tool error", body: `{"result":{"isError":true,"content":[{"type":"text","text":"search failed"}]}}`, wantErr: "exa tool call failed: search failed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseExaResponse([]byte(tt.body))
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseExaSearchResults(t *testing.T) {
+	t.Parallel()
+
+	blob := `Title: First
+URL: https://first.example
+Published: 2025-01-01
+Author: Author
+Highlights: > A useful first result.
+...
+More detail.
+
+Title: Second
+URL: https://second.example
+Highlights: Second result.
+
+Title: Third
+Highlights: Third result.`
+	results := parseExaSearchResults(blob, 3)
+	require.Len(t, results, 3)
+	require.Equal(t, SearchResult{
+		Title:    "First",
+		Link:     "https://first.example",
+		Snippet:  "A useful first result. More detail.",
+		Position: 1,
+	}, results[0])
+	require.Equal(t, 2, results[1].Position)
+	require.Equal(t, 3, results[2].Position)
+	require.Empty(t, results[2].Link)
+}
+
+func TestParseExaSearchResultsDegradesUnparseableBlob(t *testing.T) {
+	t.Parallel()
+
+	results := parseExaSearchResults(strings.Repeat("a", exaResultLimit+100), 10)
+	require.Len(t, results, 1)
+	require.Equal(t, "Exa search results", results[0].Title)
+	require.LessOrEqual(t, len([]rune(results[0].Snippet)), exaResultLimit)
+}
+
+func TestFormatExaSearchResultsHasOutputCap(t *testing.T) {
+	t.Parallel()
+
+	results := []SearchResult{{Title: "Title", Snippet: strings.Repeat("x", exaOutputLimit)}}
+	require.LessOrEqual(t, len(formatExaSearchResults(results)), exaOutputLimit)
+}
+
+func TestDegradedExaResultOmitsEmptyURL(t *testing.T) {
+	t.Parallel()
+
+	results := parseExaSearchResults("unstructured result text", 1)
+	require.NotContains(t, formatExaSearchResults(results), "URL:")
+}
+
+func TestExaFailuresFallBackToDuckDuckGo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		exaReply     func() (*http.Response, error)
+		wantExaCalls int32
+	}{
+		{
+			name:         "server error is retried once",
+			exaReply:     func() (*http.Response, error) { return response(http.StatusInternalServerError, `{}`), nil },
+			wantExaCalls: 2,
+		},
+		{
+			name:         "rate limit is retried once",
+			exaReply:     func() (*http.Response, error) { return response(http.StatusTooManyRequests, `{}`), nil },
+			wantExaCalls: 2,
+		},
+		{
+			name:         "transport failure is not retried",
+			exaReply:     func() (*http.Response, error) { return nil, context.DeadlineExceeded },
+			wantExaCalls: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var exaCalls atomic.Int32
+			client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if isExaRequest(req) {
+					exaCalls.Add(1)
+					return tt.exaReply()
+				}
+				return response(http.StatusOK, `<html><a class="result-link" href="https://ddg.example">DDG</a><td class="result-snippet">Fallback</td></html>`), nil
+			})}
+			tool := NewWebSearchTool(client, WebSearchOptions{DefaultEngine: config.SearchEngineExa})
+
+			result := runWebSearchTool(t, tool, WebSearchParams{Query: "test", MaxResults: 1})
+			require.Contains(t, result.Content, "fell back to DuckDuckGo")
+			require.Contains(t, result.Content, "DDG")
+			require.Equal(t, tt.wantExaCalls, exaCalls.Load())
+		})
+	}
+}
+
+func TestSearchExaCallerCancellationDoesNotFallback(t *testing.T) {
+	t.Parallel()
+
+	calledDDG := atomic.Bool{}
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if isExaRequest(req) {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}
+		calledDDG.Store(true)
+		return response(http.StatusOK, `{}`), nil
+	})}
+	tool := NewWebSearchTool(client, WebSearchOptions{DefaultEngine: config.SearchEngineExa})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	input, err := json.Marshal(WebSearchParams{Query: "test"})
+	require.NoError(t, err)
+	_, err = tool.Run(ctx, fantasy.ToolCall{Name: WebSearchToolName, Input: string(input)})
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, calledDDG.Load())
+}
+
+func TestSearchExaOutboundRequest(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		require.Equal(t, "key with spaces", req.URL.Query().Get("exaApiKey"))
+		require.Equal(t, "crush", req.Header.Get("x-exa-integration"))
+		require.Equal(t, "crush/"+version.Version, req.Header.Get("User-Agent"))
+		return response(http.StatusOK, `{"result":{"content":[{"type":"text","text":"Title: Result\nURL: https://example.com\nHighlights: Text"}]}}`), nil
+	})}
+	results, err := searchExa(context.Background(), client, "key with spaces", "test", 1)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+}
+
+func TestSearchExaErrorPreservesCauseWithoutEndpoint(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, context.DeadlineExceeded
+	})}
+	_, err := searchExa(context.Background(), client, "secret", "test", 1)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NotContains(t, err.Error(), "mcp.exa.ai")
+	require.NotContains(t, err.Error(), "secret")
+}
+
+func isExaRequest(req *http.Request) bool {
+	return strings.Contains(req.URL.Host, "exa.ai")
+}
+
+func response(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (r roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return r(req)
+}
+
+func runWebSearchTool(t *testing.T, tool fantasy.AgentTool, params WebSearchParams) fantasy.ToolResponse {
+	t.Helper()
+	input, err := json.Marshal(params)
+	require.NoError(t, err)
+	response, err := tool.Run(context.Background(), fantasy.ToolCall{
+		ID:    "test-call",
+		Name:  WebSearchToolName,
+		Input: string(input),
+	})
+	require.NoError(t, err)
+	return response
+}

--- a/internal/agent/tools/search.go
+++ b/internal/agent/tools/search.go
@@ -228,7 +228,9 @@ func formatSearchResults(results []SearchResult) string {
 	fmt.Fprintf(&sb, "Found %d search results:\n\n", len(results))
 	for _, result := range results {
 		fmt.Fprintf(&sb, "%d. %s\n", result.Position, result.Title)
-		fmt.Fprintf(&sb, "   URL: %s\n", result.Link)
+		if result.Link != "" {
+			fmt.Fprintf(&sb, "   URL: %s\n", result.Link)
+		}
 		fmt.Fprintf(&sb, "   Summary: %s\n\n", result.Snippet)
 	}
 	return sb.String()

--- a/internal/agent/tools/web_search.go
+++ b/internal/agent/tools/web_search.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"charm.land/fantasy"
+	"github.com/charmbracelet/crush/internal/config"
 )
 
 //go:embed web_search.md.tpl
@@ -19,8 +20,13 @@ var webSearchDescriptionTpl = template.Must(
 		Parse(string(webSearchDescriptionTmpl)),
 )
 
+type WebSearchOptions struct {
+	DefaultEngine config.SearchEngine
+	ExaAPIKey     string
+}
+
 // NewWebSearchTool creates a web search tool for sub-agents (no permissions needed).
-func NewWebSearchTool(client *http.Client) fantasy.AgentTool {
+func NewWebSearchTool(client *http.Client, opts WebSearchOptions) fantasy.AgentTool {
 	if client == nil {
 		transport := http.DefaultTransport.(*http.Transport).Clone()
 		transport.MaxIdleConns = 100
@@ -49,14 +55,40 @@ func NewWebSearchTool(client *http.Client) fantasy.AgentTool {
 				maxResults = 20
 			}
 
+			engine := opts.DefaultEngine
+			if !engine.Valid() {
+				engine = config.SearchEngineExa
+			}
+
+			if engine == config.SearchEngineExa {
+				results, err := searchExa(ctx, client, opts.ExaAPIKey, params.Query, maxResults)
+				if err == nil {
+					slog.Debug("Web search completed", "engine", engine, "query", params.Query, "results", len(results))
+					return fantasy.NewTextResponse(formatExaSearchResults(results)), nil
+				}
+				if ctx.Err() != nil {
+					return fantasy.ToolResponse{}, ctx.Err()
+				}
+				slog.Warn("Exa web search failed; falling back to DuckDuckGo", "error", err)
+				maybeDelaySearch()
+				results, fallbackErr := searchDuckDuckGo(ctx, client, params.Query, maxResults)
+				if fallbackErr != nil {
+					return fantasy.NewTextErrorResponse("Failed to search with Exa and DuckDuckGo: " + fallbackErr.Error()), nil
+				}
+				return fantasy.NewTextResponse("[Exa search failed; fell back to DuckDuckGo.]\n\n" + formatSearchResults(results)), nil
+			}
+
 			maybeDelaySearch()
 			results, err := searchDuckDuckGo(ctx, client, params.Query, maxResults)
-			slog.Debug("Web search completed", "query", params.Query, "results", len(results), "err", err)
+			slog.Debug("Web search completed", "engine", engine, "query", params.Query, "results", len(results), "err", err)
 			if err != nil {
 				return fantasy.NewTextErrorResponse("Failed to search: " + err.Error()), nil
 			}
-
 			return fantasy.NewTextResponse(formatSearchResults(results)), nil
 		},
 	)
+}
+
+func formatExaSearchResults(results []SearchResult) string {
+	return truncateBytes(formatSearchResults(results), exaOutputLimit)
 }

--- a/internal/agent/tools/web_search.md.tpl
+++ b/internal/agent/tools/web_search.md.tpl
@@ -1,2 +1,2 @@
-Search the web via DuckDuckGo; returns titles, URLs, and snippets. Follow up with web_fetch to get full page content.
+Search the web via Exa or DuckDuckGo. Returns titles, URLs, and snippets. Follow up with web_fetch to get full page content.
 {{- if .GhAvailable }} For GitHub searches when an exact repo name, issue, or link is provided, use `gh search` in bash instead.{{- end }}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,11 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"maps"
 	"net/http"
 	"net/url"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"charm.land/catwalk/pkg/catwalk"
@@ -569,10 +571,70 @@ type Agent struct {
 	ContextPaths []string `json:"context_paths,omitempty"`
 }
 
+type SearchEngine string
+
+const (
+	SearchEngineExa        SearchEngine = "exa"
+	SearchEngineDuckDuckGo SearchEngine = "duckduckgo"
+)
+
+var invalidSearchEngineWarnings sync.Map
+
+func (s SearchEngine) String() string {
+	return string(s)
+}
+
+func (s SearchEngine) Valid() bool {
+	switch s {
+	case SearchEngineExa, SearchEngineDuckDuckGo:
+		return true
+	default:
+		return false
+	}
+}
+
 type Tools struct {
-	Ls   ToolLs   `json:"ls,omitzero"`
-	Grep ToolGrep `json:"grep,omitzero"`
-	Glob ToolGlob `json:"glob,omitzero"`
+	Ls        ToolLs        `json:"ls,omitzero"`
+	Grep      ToolGrep      `json:"grep,omitzero"`
+	Glob      ToolGlob      `json:"glob,omitzero"`
+	WebSearch ToolWebSearch `json:"web_search,omitzero" jsonschema:"description=Web search tool configuration"`
+}
+
+func (Tools) JSONSchemaExtend(schema *jsonschema.Schema) {
+	schema.Required = slices.DeleteFunc(schema.Required, func(required string) bool {
+		return required == "web_search"
+	})
+}
+
+type ToolWebSearch struct {
+	SearchEngine SearchEngine `json:"search_engine,omitempty" jsonschema:"description=Default search engine for web_search,enum=exa,enum=duckduckgo,default=exa"`
+	ExaAPIKey    string       `json:"exa_api_key,omitempty" jsonschema:"description=Optional Exa API key or environment variable reference,example=$EXA_API_KEY"`
+}
+
+func (t ToolWebSearch) Engine() SearchEngine {
+	if t.SearchEngine.Valid() {
+		return t.SearchEngine
+	}
+	if t.SearchEngine != "" {
+		if _, loaded := invalidSearchEngineWarnings.LoadOrStore(t.SearchEngine, struct{}{}); !loaded {
+			slog.Warn("Invalid configured web search engine; defaulting to Exa", "engine", t.SearchEngine)
+		}
+	}
+	return SearchEngineExa
+}
+
+func (t ToolWebSearch) ResolvedExaAPIKey(resolver VariableResolver) string {
+	if t.ExaAPIKey == "" {
+		return ""
+	}
+	if resolver == nil {
+		return t.ExaAPIKey
+	}
+	resolved, err := resolver.ResolveValue(t.ExaAPIKey)
+	if err != nil {
+		return ""
+	}
+	return resolved
 }
 
 type ToolLs struct {

--- a/internal/config/search_engine_test.go
+++ b/internal/config/search_engine_test.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/env"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolWebSearchDefaultsToExa(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, SearchEngineExa, ToolWebSearch{}.Engine())
+	require.Equal(t, SearchEngineExa, ToolWebSearch{SearchEngine: "invalid"}.Engine())
+	require.Equal(t, SearchEngineDuckDuckGo, ToolWebSearch{SearchEngine: SearchEngineDuckDuckGo}.Engine())
+}
+
+func TestToolWebSearchResolvedExaAPIKey(t *testing.T) {
+	t.Parallel()
+
+	cfg := ToolWebSearch{ExaAPIKey: "$EXA_API_KEY"}
+	resolver := NewShellVariableResolver(env.NewFromMap(map[string]string{"EXA_API_KEY": "resolved-key"}))
+
+	require.Equal(t, "resolved-key", cfg.ResolvedExaAPIKey(resolver))
+	require.Equal(t, "$EXA_API_KEY", cfg.ResolvedExaAPIKey(nil))
+	require.Empty(t, cfg.ResolvedExaAPIKey(stubResolver{err: errors.New("resolver failure")}))
+	require.Empty(t, ToolWebSearch{}.ResolvedExaAPIKey(resolver))
+}

--- a/schema.json
+++ b/schema.json
@@ -883,6 +883,28 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "ToolWebSearch": {
+      "properties": {
+        "search_engine": {
+          "type": "string",
+          "enum": [
+            "exa",
+            "duckduckgo"
+          ],
+          "description": "Default search engine for web_search",
+          "default": "exa"
+        },
+        "exa_api_key": {
+          "type": "string",
+          "description": "Optional Exa API key or environment variable reference",
+          "examples": [
+            "$EXA_API_KEY"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "Tools": {
       "properties": {
         "ls": {
@@ -893,6 +915,10 @@
         },
         "glob": {
           "$ref": "#/$defs/ToolGlob"
+        },
+        "web_search": {
+          "$ref": "#/$defs/ToolWebSearch",
+          "description": "Web search tool configuration"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Related to charmbracelet/crush#2664

## Summary

`web_search` (inside `agentic_fetch`) currently scrapes DDG and is pretty flaky! This makes Exa the default via its free hosted MCP (`https://mcp.exa.ai/mcp`) with no signup or API key required

Engine selection is configured in crush.json:

```json
{
  "tools": {
    "web_search": {
      "search_engine": "exa",
      "exa_api_key": "$EXA_API_KEY"
    }
  }
}
```

* `EXA_API_KEY` is optional if you need higher rate limits otherwise it's free without API key
* this keeps DDG as both an explicit config choice and the automatic fallback when Exa fails

## Testing
* [x] `go test ./internal/agent/tools ./internal/config ./internal/cmd`
* [x] `go test -tags integration ./internal/agent/tools -run TestExaHostedIntegration -v`
* [x] Local testing
<img src="https://github.com/user-attachments/assets/f22052d7-ac14-4868-bd79-f597a9ba697f " alt="CleanShot 2026-07-27 at 16 57 36@2x" width="1616" data-linear-height="666" />

<img src="https://github.com/user-attachments/assets/54b9f9c6-1576-49f0-8a68-d5df83c1c076 " alt="CleanShot 2026-07-27 at 17 01 17@2x" width="3056" data-linear-height="2250" />