### PR TITLE
fix(lsp): handle window/workDoneProgress/create to prevent server crash

### DIFF
--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -103,6 +103,13 @@ func New(
 
 // Initialize initializes the LSP client and returns the server capabilities.
 func (c *Client) Initialize(ctx context.Context, workspaceDir string) (*protocol.InitializeResult, error) {
+	// Register handlers for requests the server may send during the
+	// initialize handshake itself (e.g. typescript-language-server issuing
+	// window/workDoneProgress/create while loading the project, before
+	// initialize has returned). Registering after client.Initialize() is too
+	// late for those — the server treats an unhandled response as fatal.
+	c.registerHandlers()
+
 	if err := c.client.Initialize(ctx, false); err != nil {
 		return nil, fmt.Errorf("failed to initialize the lsp client: %w", err)
 	}
@@ -126,8 +133,6 @@ func (c *Client) Initialize(ctx context.Context, workspaceDir string) (*protocol
 	result := &protocol.InitializeResult{
 		Capabilities: protocolCaps,
 	}
-
-	c.registerHandlers()
 
 	return result, nil
 }
@@ -227,6 +232,7 @@ func (c *Client) registerHandlers() {
 	c.RegisterServerRequestHandler("workspace/applyEdit", HandleApplyEdit(c.client.GetOffsetEncoding()))
 	c.RegisterServerRequestHandler("workspace/configuration", HandleWorkspaceConfiguration)
 	c.RegisterServerRequestHandler("client/registerCapability", HandleRegisterCapability)
+	c.RegisterServerRequestHandler("window/workDoneProgress/create", HandleWorkDoneProgressCreate)
 	c.RegisterNotificationHandler("window/showMessage", func(ctx context.Context, method string, params json.RawMessage) {
 		if c.debug {
 			HandleServerMessage(ctx, method, params)
@@ -270,12 +276,15 @@ func (c *Client) Restart() error {
 
 	c.SetServerState(StateStarting)
 
+	// Register handlers before Initialize so servers that send
+	// requests during the handshake (e.g. window/workDoneProgress/create)
+	// don't crash on an unhandled response.
+	c.registerHandlers()
+
 	if err := c.client.Initialize(initCtx, false); err != nil {
 		c.SetServerState(StateError)
 		return fmt.Errorf("failed to initialize lsp client: %w", err)
 	}
-
-	c.registerHandlers()
 
 	if err := c.WaitForServerReady(initCtx); err != nil {
 		slog.Error("Server failed to become ready after restart", "name", c.name, "error", err)

--- a/internal/lsp/handlers.go
+++ b/internal/lsp/handlers.go
@@ -15,6 +15,16 @@ func HandleWorkspaceConfiguration(_ context.Context, _ string, params json.RawMe
 	return []map[string]any{{}}, nil
 }
 
+// HandleWorkDoneProgressCreate handles server-initiated window/workDoneProgress/create
+// requests. The client advertises window.workDoneProgress: true in its capabilities
+// (see makeClientCapabilities in powernap), which per the LSP spec grants servers
+// permission to send this request — so it must be answered, even as a no-op, or the
+// server (e.g. typescript-language-server) treats the unhandled response as fatal and
+// crashes. See github.com/charmbracelet/x issue tracking powernap capability gaps.
+func HandleWorkDoneProgressCreate(_ context.Context, _ string, _ json.RawMessage) (any, error) {
+	return nil, nil
+}
+
 // HandleRegisterCapability handles capability registration requests
 func HandleRegisterCapability(_ context.Context, _ string, params json.RawMessage) (any, error) {
 	var registerParams protocol.RegistrationParams


### PR DESCRIPTION
## Summary
- The client advertises `window.workDoneProgress: true` in its initialize capabilities (via powernap's `makeClientCapabilities`), which per the LSP spec grants servers permission to send `window/workDoneProgress/create` requests back to the client.
- No handler was registered for this method. When a server actually sends it (e.g. `typescript-language-server` during project loading, before `initialize` even returns), the request goes unanswered and the server treats the failure as fatal — crashing the whole language server process with an unhandled `ResponseError`.
- Fix: add a no-op `HandleWorkDoneProgressCreate` handler (same pattern as the existing no-op `HandleWorkspaceConfiguration`), and register handlers **before** calling `client.Initialize()` instead of after — servers may send this request during the initialize handshake itself, so registering afterward is too late for that window.

## Repro
1. Configure a `typescript` LSP server pointing at `typescript-language-server --stdio` for `.js`/`.ts` files.
2. Pin `typescript@5.9.3` locally in a workspace (needed separately since `typescript@7.x` no longer ships `tsserver.js` — unrelated issue).
3. Run any LSP tool (`lsp_symbols`, `lsp_references`, etc.) against a file in that workspace.

**Before:** server crashes during init with `ResponseError: no handler for method: window/workDoneProgress/create`, subsequent LSP calls fail with `jsonrpc2: connection is closed`.

**After:** server initializes successfully; `lsp_symbols`/`lsp_references` return correct results.

## Test plan
- [x] Built from this branch, ran `lsp_symbols` and `lsp_references` against a real `.js` file with `typescript-language-server` configured — both returned correct results instead of crashing.
- [x] `go build ./internal/lsp/...` compiles clean.