### PR TITLE
test(proto): cover MCP and agent wire encoding

### DIFF
--- a/internal/proto/agent_test.go
+++ b/internal/proto/agent_test.go
@@ -1,0 +1,178 @@
+package proto_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentEventTypeTextRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	types := []proto.AgentEventType{
+		proto.AgentEventTypeError,
+		proto.AgentEventTypeResponse,
+		proto.AgentEventTypeSummarize,
+	}
+
+	for _, eventType := range types {
+		t.Run(string(eventType), func(t *testing.T) {
+			t.Parallel()
+
+			text, err := eventType.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, string(eventType), string(text))
+
+			var decoded proto.AgentEventType
+			require.NoError(t, decoded.UnmarshalText(text))
+			require.Equal(t, eventType, decoded)
+		})
+	}
+}
+
+func TestAgentEventJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	event := proto.AgentEvent{
+		Type:  proto.AgentEventTypeResponse,
+		RunID: "run-123",
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	var decoded proto.AgentEvent
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.Equal(t, event.Type, decoded.Type)
+	require.Equal(t, event.RunID, decoded.RunID)
+	require.NoError(t, decoded.Error)
+}
+
+// error is not a JSON type, so it crosses the wire as its message and is
+// rebuilt on the other side. `crush run` relies on this to attribute a
+// failure to the run that caused it.
+func TestAgentEventErrorCrossesTheWire(t *testing.T) {
+	t.Parallel()
+
+	event := proto.AgentEvent{
+		Type:  proto.AgentEventTypeError,
+		RunID: "run-123",
+		Error: errors.New("model unavailable"),
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "model unavailable")
+
+	var decoded proto.AgentEvent
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.Error(t, decoded.Error)
+	require.Equal(t, "model unavailable", decoded.Error.Error())
+	require.Equal(t, "run-123", decoded.RunID)
+}
+
+func TestAgentEventWithoutErrorOmitsIt(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(proto.AgentEvent{Type: proto.AgentEventTypeResponse})
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	require.NotContains(t, raw, "error")
+}
+
+func TestAgentEventSummarizeFields(t *testing.T) {
+	t.Parallel()
+
+	event := proto.AgentEvent{
+		Type:         proto.AgentEventTypeSummarize,
+		SessionID:    "session-1",
+		SessionTitle: "a title",
+		Progress:     "summarizing",
+		Done:         true,
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	var decoded proto.AgentEvent
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.Equal(t, event.SessionID, decoded.SessionID)
+	require.Equal(t, event.SessionTitle, decoded.SessionTitle)
+	require.Equal(t, event.Progress, decoded.Progress)
+	require.True(t, decoded.Done)
+}
+
+// the optional summarize fields stay off the wire when unset
+func TestAgentEventOmitsEmptyOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(proto.AgentEvent{Type: proto.AgentEventTypeResponse})
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	for _, key := range []string{"run_id", "session_id", "session_title", "progress", "done"} {
+		require.NotContains(t, raw, key)
+	}
+}
+
+func TestMessageRoleTextRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	roles := []proto.MessageRole{
+		proto.Assistant,
+		proto.User,
+		proto.System,
+		proto.Tool,
+	}
+
+	for _, role := range roles {
+		t.Run(string(role), func(t *testing.T) {
+			t.Parallel()
+
+			text, err := role.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, string(role), string(text))
+
+			var decoded proto.MessageRole
+			require.NoError(t, decoded.UnmarshalText(text))
+			require.Equal(t, role, decoded)
+		})
+	}
+}
+
+func TestFinishReasonTextRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	reasons := []proto.FinishReason{
+		proto.FinishReasonEndTurn,
+		proto.FinishReasonMaxTokens,
+		proto.FinishReasonToolUse,
+		proto.FinishReasonCanceled,
+		proto.FinishReasonError,
+		proto.FinishReasonUnknown,
+	}
+
+	for _, reason := range reasons {
+		t.Run(string(reason), func(t *testing.T) {
+			t.Parallel()
+
+			text, err := reason.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, string(reason), string(text))
+
+			var decoded proto.FinishReason
+			require.NoError(t, decoded.UnmarshalText(text))
+			require.Equal(t, reason, decoded)
+		})
+	}
+}

--- a/internal/proto/mcp_test.go
+++ b/internal/proto/mcp_test.go
@@ -1,0 +1,227 @@
+package proto_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPStateString(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		state    proto.MCPState
+		expected string
+	}{
+		"disabled":     {proto.MCPStateDisabled, "disabled"},
+		"starting":     {proto.MCPStateStarting, "starting"},
+		"connected":    {proto.MCPStateConnected, "connected"},
+		"error":        {proto.MCPStateError, "error"},
+		"needs auth":   {proto.MCPStateNeedsAuth, "needs auth"},
+		"out of range": {proto.MCPState(99), "unknown"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, tc.state.String())
+		})
+	}
+}
+
+func TestMCPStateTextRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	states := []proto.MCPState{
+		proto.MCPStateDisabled,
+		proto.MCPStateStarting,
+		proto.MCPStateConnected,
+		proto.MCPStateError,
+		proto.MCPStateNeedsAuth,
+	}
+
+	for _, state := range states {
+		t.Run(state.String(), func(t *testing.T) {
+			t.Parallel()
+
+			text, err := state.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, state.String(), string(text))
+
+			var decoded proto.MCPState
+			require.NoError(t, decoded.UnmarshalText(text))
+			require.Equal(t, state, decoded)
+		})
+	}
+}
+
+func TestMCPStateUnmarshalTextUnknown(t *testing.T) {
+	t.Parallel()
+
+	var state proto.MCPState
+	err := state.UnmarshalText([]byte("not a state"))
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a state")
+}
+
+// MCPState renders as its text form inside JSON, not as its numeric value.
+func TestMCPStateJSON(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(proto.MCPStateConnected)
+	require.NoError(t, err)
+	require.JSONEq(t, `"connected"`, string(data))
+
+	var state proto.MCPState
+	require.NoError(t, json.Unmarshal([]byte(`"needs auth"`), &state))
+	require.Equal(t, proto.MCPStateNeedsAuth, state)
+}
+
+func TestMCPEventTypeTextRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	types := []proto.MCPEventType{
+		proto.MCPEventStateChanged,
+		proto.MCPEventToolsListChanged,
+		proto.MCPEventPromptsListChanged,
+		proto.MCPEventResourcesListChanged,
+	}
+
+	for _, eventType := range types {
+		t.Run(string(eventType), func(t *testing.T) {
+			t.Parallel()
+
+			text, err := eventType.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, string(eventType), string(text))
+
+			var decoded proto.MCPEventType
+			require.NoError(t, decoded.UnmarshalText(text))
+			require.Equal(t, eventType, decoded)
+		})
+	}
+}
+
+func TestMCPEventJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	event := proto.MCPEvent{
+		Type:          proto.MCPEventStateChanged,
+		Name:          "some-server",
+		State:         proto.MCPStateConnected,
+		ToolCount:     3,
+		PromptCount:   2,
+		ResourceCount: 1,
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	var decoded proto.MCPEvent
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.Equal(t, event.Type, decoded.Type)
+	require.Equal(t, event.Name, decoded.Name)
+	require.Equal(t, event.State, decoded.State)
+	require.Equal(t, event.ToolCount, decoded.ToolCount)
+	require.Equal(t, event.PromptCount, decoded.PromptCount)
+	require.Equal(t, event.ResourceCount, decoded.ResourceCount)
+	require.NoError(t, decoded.Error)
+}
+
+// error is not a JSON type, so it crosses the wire as its message and is
+// rebuilt on the other side.
+func TestMCPEventErrorCrossesTheWire(t *testing.T) {
+	t.Parallel()
+
+	event := proto.MCPEvent{
+		Type:  proto.MCPEventStateChanged,
+		Name:  "some-server",
+		State: proto.MCPStateError,
+		Error: errors.New("connection refused"),
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+	require.Contains(t, string(data), "connection refused")
+
+	var decoded proto.MCPEvent
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.Error(t, decoded.Error)
+	require.Equal(t, "connection refused", decoded.Error.Error())
+}
+
+func TestMCPEventWithoutErrorOmitsIt(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(proto.MCPEvent{
+		Type:  proto.MCPEventStateChanged,
+		Name:  "some-server",
+		State: proto.MCPStateConnected,
+	})
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	require.NotContains(t, raw, "error")
+}
+
+func TestMCPClientInfoJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	connectedAt := time.Date(2024, time.March, 1, 12, 0, 0, 0, time.UTC)
+	info := proto.MCPClientInfo{
+		Name:          "some-server",
+		State:         proto.MCPStateConnected,
+		ToolCount:     5,
+		PromptCount:   4,
+		ResourceCount: 3,
+		ConnectedAt:   connectedAt,
+	}
+
+	data, err := json.Marshal(info)
+	require.NoError(t, err)
+
+	var decoded proto.MCPClientInfo
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.Equal(t, info.Name, decoded.Name)
+	require.Equal(t, info.State, decoded.State)
+	require.Equal(t, info.ToolCount, decoded.ToolCount)
+	require.Equal(t, info.PromptCount, decoded.PromptCount)
+	require.Equal(t, info.ResourceCount, decoded.ResourceCount)
+	require.True(t, decoded.ConnectedAt.Equal(connectedAt))
+	require.NoError(t, decoded.Error)
+}
+
+func TestMCPClientInfoErrorCrossesTheWire(t *testing.T) {
+	t.Parallel()
+
+	info := proto.MCPClientInfo{
+		Name:  "some-server",
+		State: proto.MCPStateError,
+		Error: errors.New("handshake failed"),
+	}
+
+	data, err := json.Marshal(info)
+	require.NoError(t, err)
+
+	var decoded proto.MCPClientInfo
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	require.Error(t, decoded.Error)
+	require.Equal(t, "handshake failed", decoded.Error.Error())
+}
+
+func TestMCPClientInfoUnmarshalInvalidState(t *testing.T) {
+	t.Parallel()
+
+	var info proto.MCPClientInfo
+	err := json.Unmarshal([]byte(`{"name":"x","state":"bogus"}`), &info)
+
+	require.Error(t, err)
+}


### PR DESCRIPTION
`internal/proto` is at 12.0% statement coverage. It is the client/server wire format, and most of it is pure encoding logic that can be tested directly.

This adds tests for:

- `MCPState`: `String`, text round-trip for every state, the `unknown` fallback for an out-of-range value, that an unrecognised name is rejected, and that it encodes as its text form inside JSON rather than as its numeric value
- `MCPEventType`, `AgentEventType`, `MessageRole` and `FinishReason` text round-trips
- `MCPEvent`, `MCPClientInfo` and `AgentEvent` JSON round-trips, including that the `error` field (which is not a JSON type) crosses the wire as its message and is rebuilt on decode, and that it is omitted when nil
- that `AgentEvent`'s optional fields (`run_id`, `session_id`, `session_title`, `progress`, `done`) stay off the wire when unset

Coverage goes from 12.0% to 34.3%. No non-test code is changed; `go vet` and `go test -race` pass.