### PR TITLE
fix: MCP servers never load when running in server-client mode

### DIFF
--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -83,6 +83,13 @@ var (
 	renewMusMu sync.Mutex
 	renewMus   = map[string]*sync.Mutex{}
 
+	// gens hands out a per-server generation number. teardown bumps a
+	// server's generation; an init goroutine captures it at launch and only
+	// commits its session if the generation is still current. A config
+	// change that restarts a server mid-connect thus invalidates the
+	// in-flight attempt instead of letting it register a stale session.
+	gens = csync.NewMap[string, uint64]()
+
 	// newSession creates a client session. It is a seam so tests can exercise
 	// renewal concurrency without spawning a real transport.
 	newSession = createSession
@@ -172,7 +179,7 @@ type Counts struct {
 	Resources int
 }
 
-// ClientInfo holds information about an MCP client's state
+// ClientInfo holds information about an MCP client's state.
 type ClientInfo struct {
 	Name        string
 	State       State
@@ -180,6 +187,20 @@ type ClientInfo struct {
 	Client      *ClientSession
 	Counts      Counts
 	ConnectedAt time.Time
+
+	// Config is the configuration the server last successfully connected
+	// with. Reconcile compares it against the live config to decide whether
+	// a connected server needs a restart. It is recorded by updateState on
+	// StateConnected and cleared on StateDisabled, so it never has to be
+	// synced by hand.
+	Config config.MCPConfig
+
+	// PendingConfig is the configuration an in-flight initialization is
+	// connecting with. It is set on StateStarting so a config change that
+	// arrives mid-connect is compared against the attempt actually in
+	// progress rather than the last successful one, which would leave the
+	// server skipped as "starting" and never restarted for the new config.
+	PendingConfig *config.MCPConfig
 }
 
 // SubscribeEvents returns a channel for MCP events.
@@ -265,28 +286,7 @@ func Initialize(ctx context.Context, permissions permission.Service, cfg *config
 
 		// Set initial starting state
 		wg.Add(1)
-		go func(name string, m config.MCPConfig) {
-			defer func() {
-				wg.Done()
-				if r := recover(); r != nil {
-					var err error
-					switch v := r.(type) {
-					case error:
-						err = v
-					case string:
-						err = fmt.Errorf("panic: %s", v)
-					default:
-						err = fmt.Errorf("panic: %v", v)
-					}
-					updateState(name, StateError, err, nil, Counts{})
-					slog.Error("Panic in MCP client initialization", "error", err, "name", name)
-				}
-			}()
-
-			if err := initClient(ctx, cfg, name, m, cfg.Resolver()); err != nil {
-				slog.Debug("Failed to initialize MCP client", "name", name, "error", err)
-			}
-		}(name, m)
+		goInitClient(ctx, cfg, name, m, &wg)
 	}
 	wg.Wait()
 	initOnce.Do(func() { close(initDone) })
@@ -325,7 +325,7 @@ func InitializeSingle(ctx context.Context, name string, cfg *config.ConfigStore)
 		return nil
 	}
 
-	return initClient(ctx, cfg, name, m, cfg.Resolver())
+	return initClient(ctx, cfg, name, m, currentGen(name), cfg.Resolver())
 }
 
 // AuthenticateMCP initiates the OAuth flow for an MCP server that is in
@@ -342,7 +342,7 @@ func AuthenticateMCP(ctx context.Context, cfg *config.ConfigStore, name string) 
 		return fmt.Errorf("mcp '%s' does not use OAuth authentication", name)
 	}
 
-	updateState(name, StateStarting, nil, nil, Counts{})
+	updateState(name, StateStarting, nil, nil, Counts{}, withPending(m))
 
 	// This is the user-initiated flow, so permit the interactive browser
 	// authorization the handler otherwise withholds during startup.
@@ -350,7 +350,7 @@ func AuthenticateMCP(ctx context.Context, cfg *config.ConfigStore, name string) 
 
 	// The OAuth handler persists the token automatically as it is
 	// exchanged, so a successful connection has already saved it.
-	_, err := connectAndRegister(ctx, cfg, name, m, cfg.Resolver(), channelEnabled(cfg.Overrides().EnabledChannels, name))
+	_, err := connectAndRegister(ctx, cfg, name, m, currentGen(name), cfg.Resolver(), channelEnabled(cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		return err
 	}
@@ -392,7 +392,10 @@ func PendingAuthMCPs(cfg *config.ConfigStore) []PendingAuthServer {
 }
 
 // initClient initializes a single MCP client with the given configuration.
-func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m config.MCPConfig, resolver config.VariableResolver) error {
+// gen is the server generation captured when the attempt was launched; the
+// resulting session is only committed if the generation is still current, so
+// a config change that restarts the server mid-connect discards this attempt.
+func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m config.MCPConfig, gen uint64, resolver config.VariableResolver) error {
 	// OAuth MCPs without a usable cached token require user interaction
 	// (browser auth). If a cached token exists with an access token
 	// (even if expired), try connecting first so the SDK can attempt a
@@ -408,8 +411,8 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 		return nil
 	}
 
-	updateState(name, StateStarting, nil, nil, Counts{})
-	_, err := connectAndRegister(ctx, cfg, name, m, resolver, channelEnabled(cfg.Overrides().EnabledChannels, name))
+	updateState(name, StateStarting, nil, nil, Counts{}, withPending(m))
+	_, err := connectAndRegister(ctx, cfg, name, m, gen, resolver, channelEnabled(cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		// If an OAuth MCP fails because the saved token is no longer
 		// valid (e.g. refresh token expired or revoked) or no token
@@ -433,10 +436,25 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 // registers them in global state, and transitions to StateConnected.
 // Returns the session so callers can perform post-processing (e.g.
 // token persistence).
-func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name string, m config.MCPConfig, resolver config.VariableResolver, channelOptIn bool) (*ClientSession, error) {
+//
+// gen is the generation captured when this attempt was launched. If the
+// server was torn down since (generation bumped), the freshly built session
+// is closed and discarded instead of being registered over whatever the
+// newer attempt is doing. This is what makes a config change that lands
+// mid-connect converge on the latest config rather than a stale one.
+func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name string, m config.MCPConfig, gen uint64, resolver config.VariableResolver, channelOptIn bool) (*ClientSession, error) {
 	session, err := createSession(ctx, cfg, name, m, resolver, channelOptIn)
 	if err != nil {
 		return nil, err
+	}
+
+	// A teardown ran while we were connecting: a newer attempt owns this
+	// server now. Bail before writing to any shared registry so we don't
+	// clobber the newer attempt's registrations; just drop our own session.
+	if currentGen(name) != gen {
+		slog.Debug("Discarding stale MCP session after config change", "name", name)
+		closeSession(name, session)
+		return nil, context.Canceled
 	}
 
 	toolCount, err := registerSessionTools(ctx, cfg, name, session)
@@ -455,13 +473,22 @@ func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name strin
 		return nil, err
 	}
 
+	// Re-check before publishing: if a teardown landed during registration a
+	// newer attempt owns the registries now, so leave them and our session
+	// alone rather than overwriting its state.
+	if currentGen(name) != gen {
+		slog.Debug("Discarding stale MCP session after config change", "name", name)
+		closeSession(name, session)
+		return nil, context.Canceled
+	}
+
 	updatePrompts(name, prompts)
 	sessions.Set(name, session)
 
 	updateState(name, StateConnected, nil, session, Counts{
 		Tools:   toolCount,
 		Prompts: len(prompts),
-	})
+	}, withConfig(m))
 
 	return session, nil
 }
@@ -471,18 +498,67 @@ func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name strin
 
 // DisableSingle disables and closes a single MCP client by name.
 func DisableSingle(cfg *config.ConfigStore, name string) error {
+	// teardown bumps the generation, invalidating any in-flight connect, and
+	// the StateDisabled transition clears the recorded config so a later
+	// re-enable (even with an unchanged config) is seen as new and restarts.
+	teardown(name)
+	updateState(name, StateDisabled, nil, nil, Counts{})
+	slog.Info("Disabled mcp client", "name", name)
+	return nil
+}
+
+// goInitClient launches initClient in a goroutine with panic recovery.
+// Shared by Initialize and Reinitialize so the panic-to-state policy
+// lives in one place. wg, if non-nil, is Done when the attempt finishes
+// (success or failure); Initialize uses it to await startup. The goroutine
+// captures the server's generation at launch so a concurrent teardown
+// invalidates its result rather than letting it register a stale session.
+func goInitClient(ctx context.Context, cfg *config.ConfigStore, name string, m config.MCPConfig, wg *sync.WaitGroup) {
+	gen := currentGen(name)
+	go func() {
+		if wg != nil {
+			defer wg.Done()
+		}
+		defer func() {
+			if r := recover(); r != nil {
+				var err error
+				switch v := r.(type) {
+				case error:
+					err = v
+				case string:
+					err = fmt.Errorf("panic: %s", v)
+				default:
+					err = fmt.Errorf("panic: %v", v)
+				}
+				updateState(name, StateError, err, nil, Counts{})
+				slog.Error("Panic in MCP client initialization", "error", err, "name", name)
+			}
+		}()
+		if err := initClient(ctx, cfg, name, m, gen, cfg.Resolver()); err != nil {
+			slog.Debug("Failed to initialize MCP client", "name", name, "error", err)
+		}
+	}()
+}
+
+// currentGen returns a server's current generation without bumping it.
+func currentGen(name string) uint64 {
+	g, _ := gens.Get(name)
+	return g
+}
+
+// teardown closes a server's session and clears its tools, prompts,
+// resources, and auth state, then bumps the server's generation so any
+// in-flight initialization for it is discarded on commit. It leaves the
+// states entry intact; callers decide whether to delete or update it.
+// Shared by DisableSingle, removeServer, and the restart path in
+// Reinitialize.
+func teardown(name string) {
+	g, _ := gens.Get(name)
+	gens.Set(name, g+1)
 	if session, ok := sessions.Take(name); ok {
 		closeSession(name, session)
 	}
-
-	// Clear tools, prompts, resources, and auth state for this MCP.
 	clearMCPData(name)
-
-	// Update state to disabled.
-	updateState(name, StateDisabled, nil, nil, Counts{})
-
-	slog.Info("Disabled mcp client", "name", name)
-	return nil
 }
 
 func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string) (*ClientSession, error) {
@@ -528,6 +604,9 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	// resources from the registry.
 	updateState(name, StateError, maybeTimeoutErr(pingErr, timeout), nil, state.Counts)
 
+	// Capture the generation so a reconcile teardown that lands mid-renewal
+	// invalidates this rebuild instead of letting it clobber the newer one.
+	gen := currentGen(name)
 	newSess, err := newSession(ctx, cfg, name, m, cfg.Resolver(), channelEnabled(cfg.Overrides().EnabledChannels, name))
 	if err != nil {
 		clearMCPData(name)
@@ -542,6 +621,14 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 			slog.Info("MCP OAuth session expired, re-authentication required", "name", name, "error", err)
 		}
 		return nil, err
+	}
+
+	// A reconcile teardown ran while we were rebuilding: a newer attempt owns
+	// this server now. Bail before writing to any shared registry so we don't
+	// clobber the newer attempt's registrations; just drop our own session.
+	if currentGen(name) != gen {
+		closeSession(name, newSess)
+		return nil, context.Canceled
 	}
 
 	// StateError cleared this server's tools, prompts, and resources from the
@@ -575,8 +662,16 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	}
 	counts.Resources = updateResources(name, resources)
 
+	// Re-check before publishing: if a teardown landed during registration a
+	// newer attempt owns the registries now, so leave them and our session
+	// alone rather than overwriting its state.
+	if currentGen(name) != gen {
+		closeSession(name, newSess)
+		return nil, context.Canceled
+	}
+
 	sessions.Set(name, newSess)
-	updateState(name, StateConnected, nil, newSess, counts)
+	updateState(name, StateConnected, nil, newSess, counts, withConfig(m))
 	return newSess, nil
 }
 
@@ -599,18 +694,55 @@ func closeSession(name string, s *ClientSession) {
 	}
 }
 
-// updateState updates the state of an MCP client and publishes an event
-func updateState(name string, state State, err error, client *ClientSession, counts Counts) {
-	info := ClientInfo{
-		Name:   name,
-		State:  state,
-		Error:  err,
-		Client: client,
-		Counts: counts,
+// stateOpt mutates the ClientInfo a transition is about to publish. Config
+// recording is opt-in: only the sites that actually own a config (the connect
+// and starting paths) pass one, so the many error and count-refresh call sites
+// can't accidentally clobber the recorded config by passing a zero value.
+type stateOpt func(*ClientInfo)
+
+// withConfig records the config now in effect. Used on StateConnected.
+func withConfig(m config.MCPConfig) stateOpt {
+	return func(i *ClientInfo) {
+		i.Config = m
+		i.PendingConfig = nil
+	}
+}
+
+// withPending records the config an in-flight attempt is connecting with.
+// Used on StateStarting.
+func withPending(m config.MCPConfig) stateOpt {
+	return func(i *ClientInfo) {
+		mc := m
+		i.PendingConfig = &mc
+	}
+}
+
+// updateState updates the state of an MCP client and publishes an event.
+//
+// Config bookkeeping is split between the caller and the state machine:
+//   - Callers that own a config opt in via withConfig (StateConnected) or
+//     withPending (StateStarting). Everyone else leaves the recorded config
+//     untouched, so an error or count refresh can't wipe it.
+//   - The state machine owns the transitions with fixed semantics:
+//     StateDisabled clears both so a later re-enable with an unchanged config
+//     is seen as new rather than skipped as already initialized.
+func updateState(name string, state State, err error, client *ClientSession, counts Counts, opts ...stateOpt) {
+	prev, _ := states.Get(name)
+	info := prev
+	info.Name = name
+	info.State = state
+	info.Error = err
+	info.Client = client
+	info.Counts = counts
+	for _, opt := range opts {
+		opt(&info)
 	}
 	switch state {
 	case StateConnected:
 		info.ConnectedAt = time.Now()
+	case StateDisabled:
+		info.Config = config.MCPConfig{}
+		info.PendingConfig = nil
 	case StateError:
 		// A session that has errored is dead to us. Atomically remove it and
 		// close it so the child process and its stdio pipes are released — the

--- a/internal/agent/tools/mcp/init_test.go
+++ b/internal/agent/tools/mcp/init_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"maps"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/env"
+	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -522,5 +524,246 @@ func TestCreateSession_ResolutionFailureUpdatesState(t *testing.T) {
 			require.Contains(t, info.Error.Error(), tc.wantErrContains)
 			require.Nil(t, info.Client, "no client session on failure")
 		})
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	t.Parallel()
+
+	base := config.MCPConfig{
+		Type: config.MCPHttp,
+		URL:  "https://example.com/mcp",
+	}
+	changed := func() config.MCPConfig { m := base; m.URL = "https://other.com/mcp"; return m }()
+	disabled := func() config.MCPConfig { m := base; m.Disabled = true; return m }()
+	ptr := func(m config.MCPConfig) *config.MCPConfig { return &m }
+
+	// server seeds the running state reconcile diffs against: a state, the
+	// config the server last connected with (Config), and, for a server
+	// mid-connect, the config that attempt is connecting with (PendingConfig).
+	type server struct {
+		state   State
+		config  config.MCPConfig
+		pending *config.MCPConfig
+	}
+
+	tests := []struct {
+		name    string
+		servers map[string]server
+		current config.MCPs
+		want    map[string]reinitAction
+	}{
+		{
+			name:    "new server starts",
+			current: config.MCPs{"a": base},
+			want:    map[string]reinitAction{"a": reinitStart},
+		},
+		{
+			name:    "removed server is cleaned up",
+			servers: map[string]server{"gone": {state: StateConnected, config: base}},
+			current: config.MCPs{},
+			want:    map[string]reinitAction{"gone": reinitRemove},
+		},
+		{
+			name:    "unchanged connected server is skipped",
+			servers: map[string]server{"a": {state: StateConnected, config: base}},
+			current: config.MCPs{"a": base},
+			want:    map[string]reinitAction{},
+		},
+		{
+			name:    "changed config restarts",
+			servers: map[string]server{"a": {state: StateConnected, config: base}},
+			current: config.MCPs{"a": changed},
+			want:    map[string]reinitAction{"a": reinitStart},
+		},
+		{
+			name:    "disabled server is disabled",
+			servers: map[string]server{"a": {state: StateConnected, config: base}},
+			current: config.MCPs{"a": disabled},
+			want:    map[string]reinitAction{"a": reinitDisable},
+		},
+		{
+			name:    "already disabled server is skipped",
+			servers: map[string]server{"a": {state: StateDisabled}},
+			current: config.MCPs{"a": disabled},
+			want:    map[string]reinitAction{},
+		},
+		{
+			// Regression: disabling clears the recorded config, so a server
+			// left disabled with an unchanged config must restart on re-enable
+			// rather than being skipped as "already initialized".
+			name:    "re-enabled server restarts despite unchanged config",
+			servers: map[string]server{"a": {state: StateDisabled}},
+			current: config.MCPs{"a": base},
+			want:    map[string]reinitAction{"a": reinitStart},
+		},
+		{
+			name:    "errored server restarts",
+			servers: map[string]server{"a": {state: StateError, config: base}},
+			current: config.MCPs{"a": base},
+			want:    map[string]reinitAction{"a": reinitStart},
+		},
+		{
+			name:    "starting server connecting with current config is left alone",
+			servers: map[string]server{"a": {state: StateStarting, pending: ptr(base)}},
+			current: config.MCPs{"a": base},
+			want:    map[string]reinitAction{},
+		},
+		{
+			// Regression: a config change that lands while a server is still
+			// connecting must restart it, otherwise the in-flight attempt
+			// connects with the old config and the change is silently lost.
+			name:    "starting server with changed config restarts",
+			servers: map[string]server{"a": {state: StateStarting, pending: ptr(base)}},
+			current: config.MCPs{"a": changed},
+			want:    map[string]reinitAction{"a": reinitStart},
+		},
+		{
+			name: "mixed scenario",
+			servers: map[string]server{
+				"keep":    {state: StateConnected, config: base},
+				"remove":  {state: StateConnected, config: base},
+				"restart": {state: StateConnected, config: base},
+			},
+			current: config.MCPs{
+				"keep":    base,
+				"restart": changed,
+				"new":     base,
+			},
+			want: map[string]reinitAction{
+				"remove":  reinitRemove,
+				"restart": reinitStart,
+				"new":     reinitStart,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			running := make(map[string]ClientInfo, len(tc.servers))
+			for name, s := range tc.servers {
+				running[name] = ClientInfo{
+					Name:          name,
+					State:         s.state,
+					Config:        s.config,
+					PendingConfig: s.pending,
+				}
+			}
+			got := reconcile(tc.current, running)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMCPConfigEqual(t *testing.T) {
+	t.Parallel()
+
+	base := config.MCPConfig{
+		Type:    config.MCPHttp,
+		URL:     "https://example.com/mcp",
+		Headers: map[string]string{"Authorization": "Bearer tok"},
+		Timeout: 30,
+	}
+
+	tests := []struct {
+		name string
+		a, b config.MCPConfig
+		want bool
+	}{
+		{"identical", base, base, true},
+		{"different URL", base, func() config.MCPConfig { m := base; m.URL = "https://other.com/mcp"; return m }(), false},
+		{"different headers", base, func() config.MCPConfig {
+			m := base
+			m.Headers = map[string]string{"Authorization": "Bearer other"}
+			return m
+		}(), false},
+		{"different timeout", base, func() config.MCPConfig { m := base; m.Timeout = 60; return m }(), false},
+		{"different type", base, func() config.MCPConfig { m := base; m.Type = config.MCPStdio; return m }(), false},
+		{
+			"OAuthToken ignored",
+			base,
+			func() config.MCPConfig {
+				m := base
+				m.OAuthToken = &oauth.Token{AccessToken: "x"}
+				return m
+			}(),
+			true,
+		},
+		{
+			"both OAuthToken ignored",
+			func() config.MCPConfig {
+				m := base
+				m.OAuthToken = &oauth.Token{AccessToken: "x"}
+				return m
+			}(),
+			func() config.MCPConfig {
+				m := base
+				m.OAuthToken = &oauth.Token{AccessToken: "y"}
+				return m
+			}(),
+			true,
+		},
+		{"disabled vs enabled", base, func() config.MCPConfig { m := base; m.Disabled = true; return m }(), false},
+		{"oauth flag", base, func() config.MCPConfig { m := base; m.OAuth = true; return m }(), false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, mcpConfigEqual(tc.a, tc.b))
+		})
+	}
+}
+
+// TestMCPConfigEqualExhaustive guards mcpConfigEqual against drift. It
+// enumerates every field of config.MCPConfig via reflection and fails if a
+// field is neither compared by mcpConfigEqual nor explicitly excluded here.
+// Adding a field to MCPConfig now forces a conscious decision about whether
+// it should trigger a server restart, rather than being silently ignored.
+func TestMCPConfigEqualExhaustive(t *testing.T) {
+	t.Parallel()
+
+	// Fields intentionally excluded from the comparison.
+	excluded := map[string]bool{
+		"OAuthToken": true, // internally managed, refreshed out-of-band.
+	}
+
+	typ := reflect.TypeOf(config.MCPConfig{})
+	for i := range typ.NumField() {
+		name := typ.Field(i).Name
+		if excluded[name] {
+			continue
+		}
+		// Build two configs that differ only in this field and assert the
+		// difference is detected.
+		a := config.MCPConfig{}
+		b := config.MCPConfig{}
+		setDistinct(typ.Field(i).Type, reflect.ValueOf(&a).Elem().Field(i))
+		require.False(t, mcpConfigEqual(a, b),
+			"mcpConfigEqual ignores field %q; add it to the comparison or to the excluded set", name)
+	}
+}
+
+// setDistinct assigns a non-zero value of the given type so two structs
+// differ in exactly one field.
+func setDistinct(typ reflect.Type, field reflect.Value) {
+	switch typ.Kind() {
+	case reflect.String:
+		field.SetString("x")
+	case reflect.Bool:
+		field.SetBool(true)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		field.SetInt(1)
+	case reflect.Slice:
+		field.Set(reflect.MakeSlice(typ, 1, 1))
+	case reflect.Map:
+		m := reflect.MakeMap(typ)
+		m.SetMapIndex(reflect.Zero(typ.Key()), reflect.Zero(typ.Elem()))
+		field.Set(m)
+	case reflect.Ptr:
+		field.Set(reflect.New(typ.Elem()))
+	default:
+		panic("setDistinct: unhandled kind " + typ.Kind().String())
 	}
 }

--- a/internal/agent/tools/mcp/lifecycle.go
+++ b/internal/agent/tools/mcp/lifecycle.go
@@ -1,0 +1,187 @@
+package mcp
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"slices"
+	"sync"
+
+	"github.com/charmbracelet/crush/internal/config"
+)
+
+// reinitAction describes how to reconcile one MCP server against the
+// current config.
+type reinitAction int
+
+const (
+	reinitDisable reinitAction = iota + 1
+	reinitRemove
+	reinitStart
+)
+
+// reconcile diffs running MCP state against the current config and returns
+// the action to take for each server. It is a pure function: all state is
+// passed in, nothing global is read or mutated, so the reconciliation
+// decision can be tested with plain maps.
+//
+// The config a server last connected with lives on its ClientInfo (Config),
+// and the config an in-flight attempt is connecting with lives on
+// PendingConfig. Reconcile compares the live config against whichever is
+// relevant for the server's state:
+//
+//   - A starting server is left alone only while it is connecting with the
+//     current config. If the config changed since it started, it restarts so
+//     the new config takes effect instead of being lost to the in-flight
+//     attempt.
+//   - A connected server restarts when its config differs from the one it
+//     connected with.
+//   - Every other state (new, errored, needs-auth, disabled) restarts: new
+//     and disabled servers carry no config, and retrying a failed server on
+//     each config write is the desired recovery path.
+//
+// Servers gone from config are removed entirely; enabled-in-config servers
+// marked disabled are disabled.
+func reconcile(current config.MCPs, running map[string]ClientInfo) map[string]reinitAction {
+	actions := map[string]reinitAction{}
+
+	// Servers no longer in config are removed entirely.
+	for name := range running {
+		if _, exists := current[name]; !exists {
+			actions[name] = reinitRemove
+		}
+	}
+
+	for name, m := range current {
+		info, exists := running[name]
+		if m.Disabled {
+			if exists && info.State != StateDisabled {
+				actions[name] = reinitDisable
+			}
+			continue
+		}
+
+		if exists {
+			switch info.State {
+			case StateStarting:
+				// Restart only if the config changed since this attempt
+				// started; otherwise let the in-flight attempt settle so
+				// rapid writes don't pile up overlapping init goroutines.
+				if info.PendingConfig != nil && mcpConfigEqual(*info.PendingConfig, m) {
+					continue
+				}
+			case StateConnected:
+				if mcpConfigEqual(info.Config, m) {
+					continue
+				}
+			}
+		}
+		actions[name] = reinitStart
+	}
+
+	return actions
+}
+
+// reinitMu guards reinitRunning and reinitDirty.
+var (
+	reinitMu      sync.Mutex
+	reinitRunning bool
+	reinitDirty   bool
+)
+
+// Reinitialize reconciles running MCP servers against the current config.
+// Servers added since the last call are started, servers removed are torn
+// down, and servers whose config changed are restarted. Unchanged servers
+// keep their existing sessions.
+//
+// MCP state is process-global, so reconciliation is single-flighted: at
+// most one runs at a time. A config write that arrives mid-run just sets a
+// dirty flag and returns; the running reconciliation loops once more to
+// pick up the newer state. This coalesces a burst of rapid writes into at
+// most two reconciles instead of queueing a redundant no-op pass per write,
+// while still guaranteeing the final state reflects the latest config.
+func Reinitialize(ctx context.Context, cfg *config.ConfigStore) {
+	reinitMu.Lock()
+	if reinitRunning {
+		reinitDirty = true
+		reinitMu.Unlock()
+		return
+	}
+	reinitRunning = true
+	reinitMu.Unlock()
+
+	for {
+		reconcileOnce(ctx, cfg)
+
+		reinitMu.Lock()
+		if !reinitDirty {
+			reinitRunning = false
+			reinitMu.Unlock()
+			return
+		}
+		reinitDirty = false
+		reinitMu.Unlock()
+	}
+}
+
+// reconcileOnce applies one reconciliation pass against the current config.
+func reconcileOnce(ctx context.Context, cfg *config.ConfigStore) {
+	current := cfg.Config().MCP
+	actions := reconcile(current, states.Copy())
+	for name, action := range actions {
+		switch action {
+		case reinitRemove:
+			slog.Info("Removing MCP server no longer in config", "name", name)
+			removeServer(name)
+		case reinitDisable:
+			slog.Info("Disabling MCP server", "name", name)
+			DisableSingle(cfg, name)
+		case reinitStart:
+			m := current[name]
+			if _, exists := states.Get(name); exists {
+				slog.Info("Re-initializing MCP server after config change", "name", name)
+			} else {
+				slog.Info("Initializing new MCP server after config change", "name", name)
+			}
+			// teardown bumps the generation, invalidating any in-flight
+			// attempt for this server. The StateStarting transition records
+			// m as PendingConfig so a subsequent reconcile can tell whether
+			// the attempt now in flight matches the latest config.
+			teardown(name)
+			updateState(name, StateStarting, nil, nil, Counts{}, withPending(m))
+			goInitClient(ctx, cfg, name, m, nil)
+		}
+	}
+}
+
+// removeServer fully tears down an MCP server and deletes its state
+// entry. Unlike DisableSingle (which keeps the entry as StateDisabled),
+// this is for servers that no longer exist in config at all.
+func removeServer(name string) {
+	teardown(name)
+	states.Del(name)
+	gens.Del(name)
+}
+
+// mcpConfigEqual reports whether two MCPConfig values are equal, ignoring
+// the internally-managed OAuthToken field. Field-by-field rather than
+// reflect.DeepEqual so the comparison is explicit about what matters.
+// TestMCPConfigEqualExhaustive guards against drift: it fails at test
+// time if a new field is added to MCPConfig without a decision about
+// whether it participates here.
+func mcpConfigEqual(a, b config.MCPConfig) bool {
+	return a.Command == b.Command &&
+		maps.Equal(a.Env, b.Env) &&
+		slices.Equal(a.Args, b.Args) &&
+		a.Type == b.Type &&
+		a.URL == b.URL &&
+		a.Disabled == b.Disabled &&
+		slices.Equal(a.DisabledTools, b.DisabledTools) &&
+		slices.Equal(a.EnabledTools, b.EnabledTools) &&
+		a.Timeout == b.Timeout &&
+		maps.Equal(a.Headers, b.Headers) &&
+		a.OAuth == b.OAuth &&
+		a.OAuthClientID == b.OAuthClientID &&
+		a.OAuthClientSecret == b.OAuthClientSecret &&
+		a.OAuthCallbackPort == b.OAuthCallbackPort
+}

--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -123,6 +123,48 @@ func TestUpdateState_ErrorClosesSessionAndClearsTools(t *testing.T) {
 	require.Equal(t, StateError, info.State)
 }
 
+// TestUpdateState_ConfigBookkeeping pins the config snapshot reconcile relies
+// on: StateConnected records the config now in effect and clears any pending
+// attempt, StateStarting records the config the in-flight attempt is using,
+// StateDisabled clears the recorded config so a re-enable restarts, and every
+// other transition preserves what was there.
+func TestUpdateState_ConfigBookkeeping(t *testing.T) {
+	const name = "test-config-bookkeeping"
+	t.Cleanup(func() {
+		states.Del(name)
+	})
+
+	base := config.MCPConfig{Type: config.MCPHttp, URL: "https://example.com/mcp"}
+	changed := base
+	changed.URL = "https://other.com/mcp"
+
+	// Connecting records the config and clears any pending attempt.
+	updateState(name, StateStarting, nil, nil, Counts{}, withPending(base))
+	updateState(name, StateConnected, nil, nil, Counts{}, withConfig(base))
+	info, _ := GetState(name)
+	require.Equal(t, base, info.Config, "connected state must record its config")
+	require.Nil(t, info.PendingConfig, "connected state must clear the pending config")
+
+	// Starting records the config the attempt is connecting with.
+	updateState(name, StateStarting, nil, nil, Counts{}, withPending(changed))
+	info, _ = GetState(name)
+	require.NotNil(t, info.PendingConfig, "starting state must record the pending config")
+	require.Equal(t, changed, *info.PendingConfig)
+	require.Equal(t, base, info.Config, "starting must not disturb the last connected config")
+
+	// An error preserves both so reconcile can still reason about the server.
+	updateState(name, StateError, errors.New("boom"), nil, Counts{})
+	info, _ = GetState(name)
+	require.Equal(t, base, info.Config, "error must preserve the connected config")
+	require.NotNil(t, info.PendingConfig, "error must preserve the pending config")
+
+	// Disabling clears both so a re-enable with an unchanged config restarts.
+	updateState(name, StateDisabled, nil, nil, Counts{})
+	info, _ = GetState(name)
+	require.Equal(t, config.MCPConfig{}, info.Config, "disabled must clear the connected config")
+	require.Nil(t, info.PendingConfig, "disabled must clear the pending config")
+}
+
 // TestUpdateState_ErrorClearsPromptsAndResources pins that a StateError
 // transition also drops the dead server's prompts and resources, not just its
 // tools. Leaving them registered lets a disconnected server keep advertising

--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -17,11 +17,20 @@ import (
 
 // publishConfigChanged publishes a ConfigChanged event on the workspace's
 // event broker so all subscribers (e.g. remote clients) refresh their
-// cached config snapshot.
+// cached config snapshot. It also re-initializes any MCP servers whose
+// configuration changed as a result of the write.
 func publishConfigChanged(ws *Workspace) {
 	if ws == nil || ws.App == nil {
 		return
 	}
+
+	// Re-init MCP servers whose config changed. MCP state is process-global,
+	// so this only needs to happen once regardless of which workspace
+	// triggered the write. Run async so unrelated config writes (model
+	// switches, API keys) don't block on MCP reconciliation. Bound to the
+	// workspace ctx so teardown cancels any in-flight init.
+	go mcptools.Reinitialize(ws.ctx, ws.Cfg)
+
 	ws.SendEvent(pubsub.Event[proto.ConfigChanged]{
 		Type:    pubsub.UpdatedEvent,
 		Payload: proto.ConfigChanged{WorkspaceID: ws.ID},


### PR DESCRIPTION
This apparently fixes a bug where I wasn't able to load MCP servers (at all). Kimi summary:

***

When connecting to an already-running Crush daemon, MCP servers stayed stuck in their initial failed state and never loaded. The daemon only initialized MCP clients once — when the workspace was first created. If that initialization failed (bad config, missing auth, server down), there was no recovery path: subsequent config changes were picked up for providers and models but not for MCP servers. The workspace had to be fully torn down (all clients disconnect) and recreated before MCP servers would attempt to connect again.

Now, config changes trigger MCP re-initialization in place. Servers whose config was added, removed, or modified are started, stopped, or restarted as needed. Unchanged servers keep their existing sessions.