### PR TITLE
fix (tools): correctly report duckduckgo ratelimit events

### DIFF
--- a/internal/agent/tools/search.go
+++ b/internal/agent/tools/search.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -45,6 +46,22 @@ var acceptLanguages = []string{
 	"en-CA,en;q=0.9,en-US;q=0.8",
 }
 
+// errSearchRateLimited reports that DuckDuckGo served a bot-check page
+// instead of results.
+var errSearchRateLimited = errors.New(
+	"DuckDuckGo is rate-limiting this machine. " +
+		"Do not retry or rephrase; wait a few minutes or fetch known URLs directly")
+
+// ddgAnomalyMarkers are substrings of the bot-detection page DuckDuckGo
+// Lite serves (with HTTP 200) instead of results once a client trips its
+// rate limiter.  Parsing that page yields zero results, which would
+// otherwise masquerade as "your query found nothing".
+var ddgAnomalyMarkers = []string{
+	"anomaly-modal",
+	"/anomaly.js",
+	"Unfortunately, bots use DuckDuckGo too",
+}
+
 func searchDuckDuckGo(ctx context.Context, client *http.Client, query string, maxResults int) ([]SearchResult, error) {
 	if maxResults <= 0 {
 		maxResults = 10
@@ -65,7 +82,13 @@ func searchDuckDuckGo(ctx context.Context, client *http.Client, query string, ma
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+	// A 202 from DuckDuckGo is the anomaly-challenge interstitial, not a
+	// result page; report throttling rather than parsing it into an
+	// empty result set.
+	if resp.StatusCode == http.StatusAccepted {
+		return nil, errSearchRateLimited
+	}
+	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("search failed with status code: %d", resp.StatusCode)
 	}
 
@@ -74,7 +97,14 @@ func searchDuckDuckGo(ctx context.Context, client *http.Client, query string, ma
 		return nil, fmt.Errorf("failed to read response: %w", err)
 	}
 
-	return parseLiteSearchResults(string(body), maxResults)
+	content := string(body)
+	for _, marker := range ddgAnomalyMarkers {
+		if strings.Contains(content, marker) {
+			return nil, errSearchRateLimited
+		}
+	}
+
+	return parseLiteSearchResults(content, maxResults)
 }
 
 func setRandomizedHeaders(req *http.Request) {

--- a/internal/agent/tools/search.go
+++ b/internal/agent/tools/search.go
@@ -62,12 +62,16 @@ var ddgAnomalyMarkers = []string{
 	"Unfortunately, bots use DuckDuckGo too",
 }
 
+// ddgLiteEndpoint is a package var so tests can point the search at a
+// local httptest server.
+var ddgLiteEndpoint = "https://lite.duckduckgo.com/lite/?q="
+
 func searchDuckDuckGo(ctx context.Context, client *http.Client, query string, maxResults int) ([]SearchResult, error) {
 	if maxResults <= 0 {
 		maxResults = 10
 	}
 
-	searchURL := "https://lite.duckduckgo.com/lite/?q=" + url.QueryEscape(query)
+	searchURL := ddgLiteEndpoint + url.QueryEscape(query)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", searchURL, nil)
 	if err != nil {

--- a/internal/agent/tools/search_test.go
+++ b/internal/agent/tools/search_test.go
@@ -1,0 +1,76 @@
+package tools
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// serveSearchStub points the DuckDuckGo endpoint at a local server
+// returning the given status and body, and restores it on cleanup.
+func serveSearchStub(t *testing.T, status int, body string) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	orig := ddgLiteEndpoint
+	ddgLiteEndpoint = srv.URL + "/lite/?q="
+	t.Cleanup(func() { ddgLiteEndpoint = orig })
+}
+
+// loadAnomalyPage reads the real bot-check payload captured from
+// lite.duckduckgo.com on 2026-07-29 (HTTP 202, captcha modal).
+func loadAnomalyPage(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("testdata/ddg_anomaly_202.html")
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+	return string(data)
+}
+
+// TestSearchRateLimitedOn202 verifies the 202 anomaly-challenge
+// interstitial is reported as throttling, not parsed into an empty
+// result set.
+func TestSearchRateLimitedOn202(t *testing.T) {
+	serveSearchStub(t, http.StatusAccepted, loadAnomalyPage(t))
+	_, err := searchDuckDuckGo(context.Background(), http.DefaultClient, "anything", 10)
+	if !errors.Is(err, errSearchRateLimited) {
+		t.Fatalf("expected errSearchRateLimited, got %v", err)
+	}
+}
+
+// TestSearchRateLimitedOnAnomalyPage verifies the captcha modal is
+// detected by content as well: DuckDuckGo also serves the same page
+// with HTTP 200 once a client is flagged.
+func TestSearchRateLimitedOnAnomalyPage(t *testing.T) {
+	serveSearchStub(t, http.StatusOK, loadAnomalyPage(t))
+	_, err := searchDuckDuckGo(context.Background(), http.DefaultClient, "anything", 10)
+	if !errors.Is(err, errSearchRateLimited) {
+		t.Fatalf("expected errSearchRateLimited, got %v", err)
+	}
+}
+
+// TestSearchParsesNormalResults guards against false positives: a
+// genuine results page still parses.
+func TestSearchParsesNormalResults(t *testing.T) {
+	page := `<html><body><table>
+<tr><td><a class="result-link" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpost">Example Post</a></td></tr>
+<tr><td class="result-snippet">A snippet about the example post.</td></tr>
+</table></body></html>`
+	serveSearchStub(t, http.StatusOK, page)
+	results, err := searchDuckDuckGo(context.Background(), http.DefaultClient, "example", 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 || results[0].Link != "https://example.com/post" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+

--- a/internal/agent/tools/testdata/ddg_anomaly_202.html
+++ b/internal/agent/tools/testdata/ddg_anomaly_202.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>DuckDuckGo</title>
+</head>
+<body>
+    <center id="lite_wrapper">
+        <form id="challenge-form" action="//duckduckgo.com/anomaly.js?sv=lite&cc=botnet" method="POST">
+            <div class="anomaly-modal__mask">
+                <div class="anomaly-modal__modal" data-testid="anomaly-modal">
+                    <div class="anomaly-modal__title">Unfortunately, bots use DuckDuckGo too.</div>
+                    <div class="anomaly-modal__description">Please complete the following challenge to confirm this search was made by a human.</div>
+                    <div class="anomaly-modal__instructions">Select all squares containing a duck:</div>
+                </div>
+            </div>
+        </form>
+    </center>
+</body>
+</html>


### PR DESCRIPTION
I've noticed that if crush is running agentic fetch and the fetch-agent uses the search tool quickly/frequently enough, it will trigger a rate limit block by duckduckgo.  In such a case, the search tool's response to the agent will be "No results found".  This happens because duckduckgo's rate limiting reply is not a "retry-after", it's a 2xx that includes a captcha so that a human user could continue their search.

Misreporting a rate-limit as an empty result is a problem, particularly if you've set a relatively strong model as your "small" default.  Using Kimi 2.6 as my small model, I've managed to spend *over an hour* inside a single agentic fetch call in which kimi keeps trying different strategies to figure out why search terms that *obviously* should return plenty of results are instead returning "no results found".

The issue is easily fixable via a crush patch -- mod the search tool so that if it gets results that look like a captcha page triggered by rate limiting, the tool tells the agent "looks like we hit a rate limit", rather than "no results found".

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [N/A] I have created a discussion that was approved by a maintainer (for new features).
