### PR TITLE
fix(ui): prevent double spinner on session reload after kill

### DIFF
--- a/internal/ui/anim/anim.go
+++ b/internal/ui/anim/anim.go
@@ -89,7 +89,15 @@ func settingsHash(opts Settings) string {
 }
 
 // StepMsg is a message type used to trigger the next step in the animation.
-type StepMsg struct{ ID string }
+// Gen carries the generation of the tick chain that produced it. A chain
+// started by a later Start() bumps the Anim's generation, so ticks from an
+// older chain (mismatched Gen) are dropped instead of advancing the frame.
+// This is what keeps a single spinner from being driven by two concurrent
+// tick chains (which would render as a doubled, double-speed animation).
+type StepMsg struct {
+	ID  string
+	Gen int64
+}
 
 // Settings defines settings for the animation.
 type Settings struct {
@@ -137,6 +145,13 @@ type Anim struct {
 	id               string
 	suffix           func() string
 	suffixColor      color.Color
+
+	// gen identifies the currently armed tick chain. Start() bumps it and
+	// stamps every emitted StepMsg with the new value; Animate() drops ticks
+	// whose Gen does not match (unless Gen is the zero wildcard). Re-arming
+	// therefore supersedes any in-flight chain instead of running a second
+	// one concurrently, and Stop() bumps it to kill a chain outright.
+	gen atomic.Int64
 }
 
 // New creates a new Anim instance with the specified width and label.
@@ -380,14 +395,31 @@ func (a *Anim) Width() (w int) {
 	return w
 }
 
-// Start starts the animation.
+// Start starts the animation. It bumps the generation so any tick chain
+// started by a previous Start() is superseded: its in-flight StepMsgs carry
+// the old generation and are dropped by Animate() instead of advancing the
+// frame a second time. Without this, re-arming a spinner that still has a
+// live chain (e.g. reloading a session whose message never got a Finish
+// part) would run two chains concurrently and render a doubled animation.
 func (a *Anim) Start() tea.Cmd {
+	a.gen.Add(1)
 	return a.Step()
+}
+
+// Stop kills any in-flight tick chain without starting a new one. It bumps
+// the generation so outstanding StepMsgs no longer match; the next one to
+// arrive is dropped and the chain terminates.
+func (a *Anim) Stop() {
+	a.gen.Add(1)
 }
 
 // Animate advances the animation to the next step.
 func (a *Anim) Animate(msg StepMsg) tea.Cmd {
 	if msg.ID != a.id {
+		return nil
+	}
+	// Drop ticks from a superseded chain.
+	if msg.Gen != a.gen.Load() {
 		return nil
 	}
 
@@ -466,10 +498,13 @@ func (a *Anim) Render() string {
 	return b.String()
 }
 
-// Step is a command that triggers the next step in the animation.
+// Step is a command that triggers the next step in the animation. The
+// emitted StepMsg carries the current generation so Animate() can tell
+// whether this tick still belongs to the armed chain.
 func (a *Anim) Step() tea.Cmd {
+	gen := a.gen.Load()
 	return tea.Tick(time.Second/time.Duration(fps), func(t time.Time) tea.Msg {
-		return StepMsg{ID: a.id}
+		return StepMsg{ID: a.id, Gen: gen}
 	})
 }
 

--- a/internal/ui/anim/anim_test.go
+++ b/internal/ui/anim/anim_test.go
@@ -1,0 +1,238 @@
+package anim
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartSupersedesPreviousChain verifies that calling Start() twice
+// does not result in two concurrent tick chains advancing the same Anim.
+// The second Start() bumps the generation, so ticks from the first chain
+// (carrying the old generation) are dropped by Animate().
+func TestStartSupersedesPreviousChain(t *testing.T) {
+	t.Parallel()
+
+	a := New(Settings{ID: "test", Size: 5})
+
+	// First chain.
+	cmd1 := a.Start()
+	gen1 := a.gen.Load()
+	require.Equal(t, int64(1), gen1)
+
+	// Second chain supersedes the first.
+	cmd2 := a.Start()
+	gen2 := a.gen.Load()
+	require.Equal(t, int64(2), gen2)
+
+	// Execute both commands to get their StepMsgs.
+	msg1 := cmd1().(StepMsg)
+	msg2 := cmd2().(StepMsg)
+
+	require.Equal(t, gen1, msg1.Gen, "first chain carries old generation")
+	require.Equal(t, gen2, msg2.Gen, "second chain carries new generation")
+
+	// The old-generation tick must be dropped.
+	framesBefore := a.framesSinceStart.Load()
+	next := a.Animate(msg1)
+	require.Nil(t, next, "old-generation tick must not schedule another step")
+	require.Equal(t, framesBefore, a.framesSinceStart.Load(),
+		"old-generation tick must not advance the frame")
+
+	// The new-generation tick must advance.
+	next = a.Animate(msg2)
+	require.NotNil(t, next, "current-generation tick must schedule another step")
+	require.Equal(t, framesBefore+1, a.framesSinceStart.Load(),
+		"current-generation tick must advance the frame")
+}
+
+// TestStopKillsChain verifies that Stop() bumps the generation so any
+// in-flight tick chain is terminated.
+func TestStopKillsChain(t *testing.T) {
+	t.Parallel()
+
+	a := New(Settings{ID: "test", Size: 5})
+	cmd := a.Start()
+	msg := cmd().(StepMsg)
+
+	a.Stop()
+	require.NotEqual(t, msg.Gen, a.gen.Load(), "Stop must bump the generation")
+
+	// The in-flight tick must be dropped.
+	framesBefore := a.framesSinceStart.Load()
+	next := a.Animate(msg)
+	require.Nil(t, next, "tick after Stop must not schedule another step")
+	require.Equal(t, framesBefore, a.framesSinceStart.Load(),
+		"tick after Stop must not advance the frame")
+}
+
+// TestForeignIDStillDropped verifies that the existing ID gate still works
+// alongside the generation gate.
+func TestForeignIDStillDropped(t *testing.T) {
+	t.Parallel()
+
+	a := New(Settings{ID: "test", Size: 5})
+	cmd := a.Start()
+	msg := cmd().(StepMsg)
+
+	framesBefore := a.framesSinceStart.Load()
+	next := a.Animate(StepMsg{ID: "other", Gen: msg.Gen})
+	require.Nil(t, next)
+	require.Equal(t, framesBefore, a.framesSinceStart.Load(),
+		"foreign ID must not advance the frame")
+}
+
+// TestStepMsgCarriesGeneration verifies that Step() stamps the current
+// generation into the emitted StepMsg.
+func TestStepMsgCarriesGeneration(t *testing.T) {
+	t.Parallel()
+
+	a := New(Settings{ID: "test", Size: 5})
+	require.Equal(t, int64(0), a.gen.Load(), "fresh Anim starts at generation 0")
+
+	cmd := a.Step()
+	msg := cmd().(StepMsg)
+	require.Equal(t, int64(0), msg.Gen, "Step before Start carries gen 0")
+
+	a.Start()
+	cmd = a.Step()
+	msg = cmd().(StepMsg)
+	require.Equal(t, int64(1), msg.Gen, "Step after Start carries gen 1")
+}
+
+// TestAnimateSchedulesNextStep verifies the normal happy path: a matching
+// tick advances the frame and schedules the next step.
+func TestAnimateSchedulesNextStep(t *testing.T) {
+	t.Parallel()
+
+	a := New(Settings{ID: "test", Size: 5})
+	cmd := a.Start()
+	msg := cmd().(StepMsg)
+
+	next := a.Animate(msg)
+	require.NotNil(t, next, "matching tick must schedule the next step")
+
+	// The next command should also produce a StepMsg with the same gen.
+	nextMsg := next().(StepMsg)
+	require.Equal(t, msg.Gen, nextMsg.Gen, "chained tick must carry the same generation")
+	require.Equal(t, msg.ID, nextMsg.ID)
+}
+
+// TestSingleChainAdvances verifies that a single Start() produces a
+// working chain that advances frames on each tick.
+func TestSingleChainAdvances(t *testing.T) {
+	t.Parallel()
+
+	a := New(Settings{ID: "test", Size: 5})
+	cmd := a.Start()
+	require.NotNil(t, cmd)
+
+	msg := cmd().(StepMsg)
+	require.Equal(t, "test", msg.ID)
+	require.Equal(t, int64(1), msg.Gen)
+
+	// Advance a few frames.
+	for range 5 {
+		next := a.Animate(msg)
+		require.NotNil(t, next)
+		msg = next().(StepMsg)
+	}
+	require.Equal(t, int64(5), a.framesSinceStart.Load())
+}
+
+// TestConcurrentStartDoesNotDoubleAdvance simulates the bug scenario:
+// two Start() calls produce two chains, and both chains' ticks arrive.
+// Only the second chain's ticks should advance the frame.
+func TestConcurrentStartDoesNotDoubleAdvance(t *testing.T) {
+	t.Parallel()
+
+	a := New(Settings{ID: "test", Size: 5})
+
+	cmd1 := a.Start()
+	cmd2 := a.Start()
+
+	msg1 := cmd1().(StepMsg)
+	msg2 := cmd2().(StepMsg)
+
+	// Interleave ticks from both chains.
+	frames := int64(0)
+	for range 10 {
+		if next := a.Animate(msg1); next != nil {
+			frames++
+			msg1 = next().(StepMsg)
+		}
+		if next := a.Animate(msg2); next != nil {
+			frames++
+			msg2 = next().(StepMsg)
+		}
+	}
+
+	// Only chain 2 should have advanced. Chain 1's ticks are all dropped
+	// after the first Start() supersedes it.
+	require.Equal(t, int64(10), a.framesSinceStart.Load(),
+		"only the latest chain should advance the frame")
+	require.Equal(t, frames, a.framesSinceStart.Load())
+}
+
+// TestMultipleAnimsIndependent verifies that two Anim instances with
+// different IDs don't interfere with each other.
+func TestMultipleAnimsIndependent(t *testing.T) {
+	t.Parallel()
+
+	a1 := New(Settings{ID: "a1", Size: 5})
+	a2 := New(Settings{ID: "a2", Size: 5})
+
+	cmd1 := a1.Start()
+	cmd2 := a2.Start()
+
+	msg1 := cmd1().(StepMsg)
+	msg2 := cmd2().(StepMsg)
+
+	// Advance a1 only.
+	a1.Animate(msg1)
+	require.Equal(t, int64(1), a1.framesSinceStart.Load())
+	require.Equal(t, int64(0), a2.framesSinceStart.Load())
+
+	// Advance a2 only.
+	a2.Animate(msg2)
+	require.Equal(t, int64(1), a1.framesSinceStart.Load())
+	require.Equal(t, int64(1), a2.framesSinceStart.Load())
+
+	// Cross-talk: a1's tick must not advance a2.
+	a2.Animate(msg1)
+	require.Equal(t, int64(1), a2.framesSinceStart.Load())
+}
+
+// TestStopThenStart verifies that Stop() followed by Start() produces a
+// working chain with a fresh generation.
+func TestStopThenStart(t *testing.T) {
+	t.Parallel()
+
+	a := New(Settings{ID: "test", Size: 5})
+	cmd := a.Start()
+	msg := cmd().(StepMsg)
+
+	a.Stop()
+	genAfterStop := a.gen.Load()
+
+	cmd = a.Start()
+	msg2 := cmd().(StepMsg)
+	require.Equal(t, genAfterStop+1, msg2.Gen)
+
+	// Old tick must be dropped.
+	require.Nil(t, a.Animate(msg))
+
+	// New tick must work.
+	require.NotNil(t, a.Animate(msg2))
+}
+
+// TestAnimateWithoutStart verifies that Animate works on a fresh Anim
+// whose generation is still zero, matching a zero-gen StepMsg.
+func TestAnimateWithoutStart(t *testing.T) {
+	t.Parallel()
+
+	a := New(Settings{ID: "test", Size: 5})
+	msg := StepMsg{ID: "test", Gen: 0}
+	next := a.Animate(msg)
+	require.NotNil(t, next, "matching gen-0 tick must advance a fresh Anim")
+}

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -438,6 +438,41 @@ func TestBackstopRefreshesStaleCaches(t *testing.T) {
 	require.False(t, m.busyFetchInFlight, "fresh caches must not re-dispatch the backstop")
 }
 
+// TestSetSessionMessagesGatesAnimationsOnBusy verifies that reloading a
+// session does not start spinner animations when the agent is not busy.
+// A session that was killed mid-generation can persist an assistant message
+// with no Finish part, which still reports isSpinning() even though nothing
+// is running. Starting animations for it would leave a ghost "working"
+// spinner after the session is reloaded.
+func TestSetSessionMessagesGatesAnimationsOnBusy(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, agentBusy: false}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+
+	// A message that looks unfinished (no Finish part, no content).
+	msgs := []message.Message{
+		{
+			ID:        "m1",
+			SessionID: "s1",
+			Role:      message.Assistant,
+			Parts: []message.ContentPart{
+				message.ReasoningContent{Thinking: "thinking..."},
+			},
+		},
+	}
+
+	// When the agent is not busy, setSessionMessages must not start animations.
+	cmd := m.setSessionMessages(msgs)
+	require.Nil(t, cmd, "setSessionMessages must not start animations when agent is idle")
+
+	// When the agent is busy, animations should start.
+	warmCaches(m, true)
+	cmd = m.setSessionMessages(msgs)
+	require.NotNil(t, cmd, "setSessionMessages must start animations when agent is busy")
+}
+
 // TestStaleBusyRefreshDiscardedAndReDispatched pins the generation guard for
 // busy/permission state: a probe started before a newer state transition
 // (here an optimistic busy write) must not overwrite the newer value when it

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1376,12 +1376,19 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 	// Load nested tool calls for agent/agentic_fetch tools.
 	m.loadNestedToolCalls(items)
 
-	// If the user switches between sessions while the agent is working we want
-	// to make sure the animations are shown.
-	for _, item := range items {
-		if animatable, ok := item.(chat.Animatable); ok {
-			if cmd := animatable.StartAnimation(); cmd != nil {
-				cmds = append(cmds, cmd)
+	// If the user switches between sessions while the agent is working we
+	// want to make sure the animations are shown. Gate on the agent actually
+	// being busy: a session that was killed mid-generation can persist an
+	// assistant message with no Finish part, which still reports isSpinning()
+	// even though nothing is running. Starting animations for it here would
+	// leave a ghost "working" spinner (and a second one alongside any tool
+	// spinner) after the session is reloaded.
+	if m.isAgentBusy() {
+		for _, item := range items {
+			if animatable, ok := item.(chat.Animatable); ok {
+				if cmd := animatable.StartAnimation(); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
A session killed mid-generation can persist an assistant message with no Finish part, which still reports isSpinning() on reload. Gated animation start in setSessionMessages on isAgentBusy(), and add a generation counter to anim.Anim so Start() supersedes any in-flight chain instead of running a second one concurrently.

fixes CHARM-1764

<img width="568" height="702" alt="image" src="https://github.com/user-attachments/assets/ce77303a-a379-466b-85f8-a3b01812829a" />
