### PR TITLE
fix: resolve short session IDs in local 'crush run --session'

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -147,6 +147,15 @@ crush run --continue "Follow up on your last response"
 		}
 
 		appWs := ws.(*workspace.AppWorkspace)
+
+		if sessionID != "" {
+			sess, err := resolveSessionID(ctx, appWs.App().Sessions, sessionID)
+			if err != nil {
+				return err
+			}
+			sessionID = sess.ID
+		}
+
 		return appWs.App().RunNonInteractive(ctx, os.Stdout, prompt, largeModel, smallModel, quiet || verbose, sessionID, useLast)
 	},
 }


### PR DESCRIPTION
The local (non-client-server) path passed the session ID directly to a raw UUID lookup, so the 7-char hashes shown by 'crush session list' always failed with 'session not found'. Now resolves prefixes through the same git-style disambiguation used by session show/delete/rename.