### PR TITLE
feat(chat): click-to-copy icon on finished messages

### DIFF
--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -439,15 +439,15 @@ func (a *AssistantMessageItem) renderMessageContent(width int) (string, int) {
 			head = out[:idx+1]
 			lastLine = out[idx+1:]
 		}
-		// Glamour pads the last line to the full render width with styled
-		// spaces, so appending the icon after it would push the line one
-		// cell past the item width, where the compositor clips it (and a
-		// chat-relative mouse x can never reach). Overwrite the trailing
-		// padding instead so the line stays within width.
-		iconCol := lipgloss.Width(lastLine)
-		if maxCol := width - iconWidth; iconCol > maxCol {
-			iconCol = max(maxCol, 0)
+		// The icon hugs the right edge of the item: pad (or truncate)
+		// the last line so the icon's rightmost cell lands on the item
+		// width, keeping the line within width so the compositor does
+		// not clip it and a chat-relative mouse x can reach it.
+		iconCol := max(width-iconWidth, 0)
+		if w := lipgloss.Width(lastLine); w > iconCol {
 			lastLine = ansi.Truncate(lastLine, iconCol, "")
+		} else {
+			lastLine += strings.Repeat(" ", iconCol-w)
 		}
 		a.copyIconColStart = iconCol
 		a.copyIconColEnd = iconCol + iconWidth

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -20,6 +20,11 @@ import (
 // truncated in the collapsed state.
 const assistantMessageTruncateFormat = "… (%d lines hidden) [click or space to expand]"
 
+// assistantCopyIcon is the click-to-copy glyph rendered as a right-aligned
+// footer on finished assistant messages. Clicking it copies the message's
+// raw Markdown source (not the glamour-rendered text) to the clipboard.
+const assistantCopyIcon = "⎘"
+
 // assistantMessageTailWindowFormat is shown above a tail-windowed thinking
 // block to advertise that earlier lines exist and that the user can
 // promote the view to a full expansion. The promotion is wired through
@@ -181,6 +186,16 @@ type AssistantMessageItem struct {
 	thinkingHash       uint64
 	thinkingHashLen    int
 	thinkingHashSample string
+
+	// Click-to-copy footer geometry, recorded during renderMessageContent
+	// so HandleMouseClickCmd can hit-test without re-deriving the layout.
+	// copyIconRow is the item-relative row of the footer line, or -1 when
+	// the footer is not rendered (streaming, empty, or non-copyable end
+	// states). copyIconColStart/End bound the icon's cell span within the
+	// line (start inclusive, end exclusive).
+	copyIconRow      int
+	copyIconColStart int
+	copyIconColEnd   int
 
 	// Per-section render caches. Splitting these out means content
 	// streaming does not invalidate the (often expensive) thinking
@@ -408,6 +423,27 @@ func (a *AssistantMessageItem) renderMessageContent(width int) (string, int) {
 	}
 
 	out := strings.Join(messageParts, "\n")
+
+	// Click-to-copy footer: a right-aligned ⎘ on its own line below the
+	// message, shown once the message is finished and has copyable content.
+	// The icon copies the raw Markdown source via HandleMouseClickCmd.
+	a.copyIconRow = -1
+	if a.message.IsFinished() && content != "" {
+		icon := a.sty.Messages.AssistantCopyIcon.Render(assistantCopyIcon)
+		iconWidth := lipgloss.Width(icon)
+		pad := width - iconWidth
+		if pad < 0 {
+			pad = 0
+		}
+		footer := strings.Repeat(" ", pad) + icon
+		// The footer line index is the current height plus one for the blank
+		// separator line inserted between the body and the footer.
+		a.copyIconRow = lipgloss.Height(out) + 1
+		a.copyIconColStart = pad
+		a.copyIconColEnd = pad + iconWidth
+		out += "\n\n" + footer
+	}
+
 	return out, lipgloss.Height(out)
 }
 
@@ -762,12 +798,33 @@ func (a *AssistantMessageItem) tailWindowWouldTruncate() bool {
 // path. Toggling here directly would double-toggle because the caller always
 // runs the generic path after a handled click.
 func (a *AssistantMessageItem) HandleMouseClick(btn ansi.MouseButton, x, y int) bool {
+	handled, _ := a.HandleMouseClickCmd(btn, x, y)
+	return handled
+}
+
+// HandleMouseClickCmd implements [list.MouseClickCommandable]. A click on
+// the click-to-copy footer returns the copy command, which suppresses the
+// generic expansion toggle in the chat click dispatcher; a click on the
+// thinking box reports handled with a nil command so expansion proceeds
+// through the generic [Expandable] path (see HandleMouseClick for why the
+// toggle itself must not run here).
+func (a *AssistantMessageItem) HandleMouseClickCmd(btn ansi.MouseButton, x, y int) (bool, tea.Cmd) {
 	if btn != ansi.MouseLeft {
-		return false
+		return false, nil
 	}
-	// Only the thinking box is clickable; other regions of the assistant
-	// message should not trigger expansion.
-	return a.thinkingBoxHeight > 0 && y < a.thinkingBoxHeight
+	// The click-to-copy footer wins over every other region: it is a
+	// discrete action, not an expansion target. The copy takes the raw
+	// Markdown source (the same text the c/y keybinding copies), not the
+	// glamour-rendered output. Click coordinates are chat-relative, so the
+	// content column is offset by MessageLeftPaddingTotal (the prefix bar).
+	if a.copyIconRow >= 0 && y == a.copyIconRow &&
+		x >= a.copyIconColStart+MessageLeftPaddingTotal && x < a.copyIconColEnd+MessageLeftPaddingTotal {
+		text := a.message.Content().Text
+		return true, common.CopyToClipboard(text, "Message copied to clipboard")
+	}
+	// Only the thinking box is clickable for expansion; other regions of
+	// the assistant message should not trigger expansion.
+	return a.thinkingBoxHeight > 0 && y < a.thinkingBoxHeight, nil
 }
 
 // HandleKeyEvent implements KeyEventHandler.

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -20,8 +20,8 @@ import (
 // truncated in the collapsed state.
 const assistantMessageTruncateFormat = "… (%d lines hidden) [click or space to expand]"
 
-// assistantCopyIcon is the click-to-copy glyph rendered as a right-aligned
-// footer on finished assistant messages. Clicking it copies the message's
+// assistantCopyIcon is the click-to-copy glyph rendered right-aligned on
+// the last content line of finished assistant messages. Clicking it copies the message's
 // raw Markdown source (not the glamour-rendered text) to the clipboard.
 const assistantCopyIcon = "⎘"
 
@@ -187,11 +187,12 @@ type AssistantMessageItem struct {
 	thinkingHashLen    int
 	thinkingHashSample string
 
-	// Click-to-copy footer geometry, recorded during renderMessageContent
+	// Click-to-copy icon geometry, recorded during renderMessageContent
 	// so HandleMouseClickCmd can hit-test without re-deriving the layout.
-	// copyIconRow is the item-relative row of the footer line, or -1 when
-	// the footer is not rendered (streaming, empty, or non-copyable end
-	// states). copyIconColStart/End bound the icon's cell span within the
+	// copyIconRow is the item-relative row the icon sits on (the last
+	// content line), or -1 when not rendered (streaming, empty, or
+	// non-copyable end states). copyIconColStart/End bound the icon's
+	// cell span within the
 	// line (start inclusive, end exclusive).
 	copyIconRow      int
 	copyIconColStart int
@@ -424,24 +425,24 @@ func (a *AssistantMessageItem) renderMessageContent(width int) (string, int) {
 
 	out := strings.Join(messageParts, "\n")
 
-	// Click-to-copy footer: a right-aligned ⎘ on its own line below the
-	// message, shown once the message is finished and has copyable content.
+	// Click-to-copy icon: right-aligned ⎘ appended to the last content
+	// line, shown only while the message item is focused (selected).
 	// The icon copies the raw Markdown source via HandleMouseClickCmd.
 	a.copyIconRow = -1
-	if a.message.IsFinished() && content != "" {
+	if a.message.IsFinished() && content != "" && a.focused {
 		icon := a.sty.Messages.AssistantCopyIcon.Render(assistantCopyIcon)
 		iconWidth := lipgloss.Width(icon)
-		pad := width - iconWidth
-		if pad < 0 {
-			pad = 0
+		a.copyIconRow = lipgloss.Height(out) - 1
+		// Glamour pads the last line to full width with styled spaces,
+		// so the icon lands at the current line width. Record the actual
+		// column so hit-testing agrees with the rendered position.
+		lastLine := out
+		if idx := strings.LastIndex(out, "\n"); idx >= 0 {
+			lastLine = out[idx+1:]
 		}
-		footer := strings.Repeat(" ", pad) + icon
-		// The footer line index is the current height plus one for the blank
-		// separator line inserted between the body and the footer.
-		a.copyIconRow = lipgloss.Height(out) + 1
-		a.copyIconColStart = pad
-		a.copyIconColEnd = pad + iconWidth
-		out += "\n\n" + footer
+		a.copyIconColStart = lipgloss.Width(lastLine)
+		a.copyIconColEnd = a.copyIconColStart + iconWidth
+		out += icon
 	}
 
 	return out, lipgloss.Height(out)
@@ -803,7 +804,7 @@ func (a *AssistantMessageItem) HandleMouseClick(btn ansi.MouseButton, x, y int) 
 }
 
 // HandleMouseClickCmd implements [list.MouseClickCommandable]. A click on
-// the click-to-copy footer returns the copy command, which suppresses the
+// the click-to-copy icon returns the copy command, which suppresses the
 // generic expansion toggle in the chat click dispatcher; a click on the
 // thinking box reports handled with a nil command so expansion proceeds
 // through the generic [Expandable] path (see HandleMouseClick for why the
@@ -812,7 +813,7 @@ func (a *AssistantMessageItem) HandleMouseClickCmd(btn ansi.MouseButton, x, y in
 	if btn != ansi.MouseLeft {
 		return false, nil
 	}
-	// The click-to-copy footer wins over every other region: it is a
+	// The click-to-copy icon wins over every other region: it is a
 	// discrete action, not an expansion target. The copy takes the raw
 	// Markdown source (the same text the c/y keybinding copies), not the
 	// glamour-rendered output. Click coordinates are chat-relative, so the

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -433,16 +433,25 @@ func (a *AssistantMessageItem) renderMessageContent(width int) (string, int) {
 		icon := a.sty.Messages.AssistantCopyIcon.Render(assistantCopyIcon)
 		iconWidth := lipgloss.Width(icon)
 		a.copyIconRow = lipgloss.Height(out) - 1
-		// Glamour pads the last line to full width with styled spaces,
-		// so the icon lands at the current line width. Record the actual
-		// column so hit-testing agrees with the rendered position.
+		head := ""
 		lastLine := out
 		if idx := strings.LastIndex(out, "\n"); idx >= 0 {
+			head = out[:idx+1]
 			lastLine = out[idx+1:]
 		}
-		a.copyIconColStart = lipgloss.Width(lastLine)
-		a.copyIconColEnd = a.copyIconColStart + iconWidth
-		out += icon
+		// Glamour pads the last line to the full render width with styled
+		// spaces, so appending the icon after it would push the line one
+		// cell past the item width, where the compositor clips it (and a
+		// chat-relative mouse x can never reach). Overwrite the trailing
+		// padding instead so the line stays within width.
+		iconCol := lipgloss.Width(lastLine)
+		if maxCol := width - iconWidth; iconCol > maxCol {
+			iconCol = max(maxCol, 0)
+			lastLine = ansi.Truncate(lastLine, iconCol, "")
+		}
+		a.copyIconColStart = iconCol
+		a.copyIconColEnd = iconCol + iconWidth
+		out = head + lastLine + icon
 	}
 
 	return out, lipgloss.Height(out)

--- a/internal/ui/chat/assistant_test.go
+++ b/internal/ui/chat/assistant_test.go
@@ -156,8 +156,8 @@ func finishedTextMessage(id, text string) *message.Message {
 }
 
 // TestAssistantMessageItemCopyFooterRendered guards the render side of the
-// click-to-copy footer: a finished message with content must render the ⎘
-// footer on its own row at the right edge, and the recorded click geometry
+// click-to-copy icon: a finished message with content must render the ⎘
+// right-aligned on the last content row, and the recorded click geometry
 // must agree with the rendered output.
 func TestAssistantMessageItemCopyFooterRendered(t *testing.T) {
 	t.Parallel()
@@ -165,22 +165,23 @@ func TestAssistantMessageItemCopyFooterRendered(t *testing.T) {
 	sty := styles.CharmtonePantera()
 	msg := finishedTextMessage("copy-1", "hello **world**")
 	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item.SetFocused(true)
 
 	const width = 40
 	rendered := item.RawRender(width)
 	lines := strings.Split(rendered, "\n")
 
-	require.GreaterOrEqual(t, item.copyIconRow, 0, "finished message with content must render the copy footer")
-	require.Less(t, item.copyIconRow, len(lines), "recorded footer row must be within the rendered output")
-	// The blank separator line precedes the footer row.
-	require.Empty(t, strings.TrimSpace(lines[item.copyIconRow-1]),
-		"the line above the footer must be the blank separator")
+	require.GreaterOrEqual(t, item.copyIconRow, 0, "finished message with content must render the copy icon")
+	require.Less(t, item.copyIconRow, len(lines), "recorded icon row must be within the rendered output")
+	// The icon is inline on the last content row, not on a separate footer.
+	require.Equal(t, len(lines)-1, item.copyIconRow,
+		"icon row must be the last rendered line")
 
-	footerLine := lines[item.copyIconRow]
-	require.Contains(t, footerLine, "⎘", "footer line must contain the copy glyph")
+	iconLine := lines[item.copyIconRow]
+	require.Contains(t, iconLine, "⎘", "last line must contain the copy glyph")
 	// The glyph must be right-aligned inside the capped content width:
 	// strip ANSI styling before measuring its cell offset within the line.
-	plain := ansi.Strip(footerLine)
+	plain := ansi.Strip(iconLine)
 	require.Equal(t, item.copyIconColStart, len([]rune(strings.Split(plain, "⎘")[0])),
 		"icon must sit at the recorded start column")
 	require.Equal(t, item.copyIconColStart+1, item.copyIconColEnd,
@@ -188,8 +189,8 @@ func TestAssistantMessageItemCopyFooterRendered(t *testing.T) {
 }
 
 // TestAssistantMessageItemCopyFooterSuppressed guards the states where the
-// footer must not render: a still-streaming message and an empty finished
-// message.
+// icon must not render: a still-streaming message, an empty finished
+// message, and a finished message that is not focused.
 func TestAssistantMessageItemCopyFooterSuppressed(t *testing.T) {
 	t.Parallel()
 
@@ -199,7 +200,7 @@ func TestAssistantMessageItemCopyFooterSuppressed(t *testing.T) {
 	streaming := NewAssistantMessageItem(&sty, thinkingMessage("copy-2", "", "partial")).(*AssistantMessageItem)
 	streaming.RawRender(40)
 	require.Equal(t, -1, streaming.copyIconRow,
-		"streaming message must not render the copy footer")
+		"streaming message must not render the copy icon")
 
 	// Finished but empty content: nothing worth copying.
 	empty := NewAssistantMessageItem(&sty, &message.Message{
@@ -209,15 +210,22 @@ func TestAssistantMessageItemCopyFooterSuppressed(t *testing.T) {
 			message.Finish{Reason: message.FinishReasonEndTurn, Time: testFinishTime},
 		},
 	}).(*AssistantMessageItem)
+	empty.SetFocused(true)
 	empty.RawRender(40)
 	require.Equal(t, -1, empty.copyIconRow,
-		"empty finished message must not render the copy footer")
+		"empty finished message must not render the copy icon")
+
+	// Finished with content but unfocused: icon hidden.
+	unfocused := NewAssistantMessageItem(&sty, finishedTextMessage("copy-3b", "hello **world**")).(*AssistantMessageItem)
+	unfocused.RawRender(40)
+	require.Equal(t, -1, unfocused.copyIconRow,
+		"unfocused finished message must not render the copy icon")
 }
 
 // TestAssistantMessageItemCopyIconClick guards the click contract: a click
-// on the footer glyph must be handled, return a non-nil command (the
+// on the copy glyph must be handled, return a non-nil command (the
 // clipboard copy), and leave the view-mode untouched so the generic
-// expansion path cannot fire. Clicks elsewhere on the footer row or with
+// expansion path cannot fire. Clicks elsewhere on the icon row or with
 // the wrong button must not copy.
 func TestAssistantMessageItemCopyIconClick(t *testing.T) {
 	t.Parallel()
@@ -225,6 +233,7 @@ func TestAssistantMessageItemCopyIconClick(t *testing.T) {
 	sty := styles.CharmtonePantera()
 	msg := finishedTextMessage("copy-4", "raw **markdown** body")
 	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item.SetFocused(true)
 	item.RawRender(40)
 	require.GreaterOrEqual(t, item.copyIconRow, 0)
 

--- a/internal/ui/chat/assistant_test.go
+++ b/internal/ui/chat/assistant_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/message"
@@ -139,4 +140,134 @@ func TestAssistantMessageItemHandleMouseClick(t *testing.T) {
 	// Non-left button is ignored.
 	require.False(t, item.HandleMouseClick(ansi.MouseRight, 0, 2))
 	require.Equal(t, thinkingCollapsed, item.thinkingViewMode)
+}
+
+// finishedTextMessage builds an assistant message with the given Markdown
+// text and an end_turn finish part, so the click-to-copy footer renders.
+func finishedTextMessage(id, text string) *message.Message {
+	return &message.Message{
+		ID:   id,
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: text},
+			message.Finish{Reason: message.FinishReasonEndTurn, Time: testFinishTime},
+		},
+	}
+}
+
+// TestAssistantMessageItemCopyFooterRendered guards the render side of the
+// click-to-copy footer: a finished message with content must render the ⎘
+// footer on its own row at the right edge, and the recorded click geometry
+// must agree with the rendered output.
+func TestAssistantMessageItemCopyFooterRendered(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	msg := finishedTextMessage("copy-1", "hello **world**")
+	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+
+	const width = 40
+	rendered := item.RawRender(width)
+	lines := strings.Split(rendered, "\n")
+
+	require.GreaterOrEqual(t, item.copyIconRow, 0, "finished message with content must render the copy footer")
+	require.Less(t, item.copyIconRow, len(lines), "recorded footer row must be within the rendered output")
+	// The blank separator line precedes the footer row.
+	require.Empty(t, strings.TrimSpace(lines[item.copyIconRow-1]),
+		"the line above the footer must be the blank separator")
+
+	footerLine := lines[item.copyIconRow]
+	require.Contains(t, footerLine, "⎘", "footer line must contain the copy glyph")
+	// The glyph must be right-aligned inside the capped content width:
+	// strip ANSI styling before measuring its cell offset within the line.
+	plain := ansi.Strip(footerLine)
+	require.Equal(t, item.copyIconColStart, len([]rune(strings.Split(plain, "⎘")[0])),
+		"icon must sit at the recorded start column")
+	require.Equal(t, item.copyIconColStart+1, item.copyIconColEnd,
+		"the single-cell glyph must span exactly one column")
+}
+
+// TestAssistantMessageItemCopyFooterSuppressed guards the states where the
+// footer must not render: a still-streaming message and an empty finished
+// message.
+func TestAssistantMessageItemCopyFooterSuppressed(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+
+	// Streaming: no Finish part yet, so IsFinished is false.
+	streaming := NewAssistantMessageItem(&sty, thinkingMessage("copy-2", "", "partial")).(*AssistantMessageItem)
+	streaming.RawRender(40)
+	require.Equal(t, -1, streaming.copyIconRow,
+		"streaming message must not render the copy footer")
+
+	// Finished but empty content: nothing worth copying.
+	empty := NewAssistantMessageItem(&sty, &message.Message{
+		ID:   "copy-3",
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.Finish{Reason: message.FinishReasonEndTurn, Time: testFinishTime},
+		},
+	}).(*AssistantMessageItem)
+	empty.RawRender(40)
+	require.Equal(t, -1, empty.copyIconRow,
+		"empty finished message must not render the copy footer")
+}
+
+// TestAssistantMessageItemCopyIconClick guards the click contract: a click
+// on the footer glyph must be handled, return a non-nil command (the
+// clipboard copy), and leave the view-mode untouched so the generic
+// expansion path cannot fire. Clicks elsewhere on the footer row or with
+// the wrong button must not copy.
+func TestAssistantMessageItemCopyIconClick(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	msg := finishedTextMessage("copy-4", "raw **markdown** body")
+	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item.RawRender(40)
+	require.GreaterOrEqual(t, item.copyIconRow, 0)
+
+	// Click on the glyph: x is chat-relative, so the content column is
+	// offset by MessageLeftPaddingTotal.
+	handled, cmd := item.HandleMouseClickCmd(ansi.MouseLeft,
+		item.copyIconColStart+MessageLeftPaddingTotal, item.copyIconRow)
+	require.True(t, handled, "click on the copy glyph must be handled")
+	require.NotNil(t, cmd, "click on the copy glyph must produce the copy command")
+	require.Equal(t, thinkingCollapsed, item.thinkingViewMode,
+		"a copy click must not disturb the expansion state machine")
+
+	// Click to the left of the glyph on the same row is not a copy.
+	handled, cmd = item.HandleMouseClickCmd(ansi.MouseLeft, 0, item.copyIconRow)
+	require.False(t, handled, "click outside the glyph span must not copy")
+	require.Nil(t, cmd)
+
+	// Right button on the glyph is ignored.
+	handled, cmd = item.HandleMouseClickCmd(ansi.MouseRight,
+		item.copyIconColStart+MessageLeftPaddingTotal, item.copyIconRow)
+	require.False(t, handled)
+	require.Nil(t, cmd)
+
+	// The plain MouseClickable path (defensive: chat falls back to it)
+	// must agree the glyph click is handled without producing a toggle.
+	require.True(t, item.HandleMouseClick(ansi.MouseLeft,
+		item.copyIconColStart+MessageLeftPaddingTotal, item.copyIconRow))
+	require.Equal(t, thinkingCollapsed, item.thinkingViewMode)
+}
+
+// TestAssistantMessageItemThinkingClickStillExpands guards against the new
+// commandable path breaking the old expansion contract: a click on the
+// thinking box reports handled with a nil command so the generic
+// Expandable toggle in model/chat.go still fires.
+func TestAssistantMessageItemThinkingClickStillExpands(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{ID: "copy-5", Role: message.Assistant}
+	item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	item.thinkingBoxHeight = 5
+
+	handled, cmd := item.HandleMouseClickCmd(ansi.MouseLeft, 0, 2)
+	require.True(t, handled, "thinking-box click must still be handled")
+	require.Nil(t, cmd, "thinking-box click must not produce a command (expansion proceeds)")
 }

--- a/internal/ui/chat/assistant_test.go
+++ b/internal/ui/chat/assistant_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/x/ansi"
@@ -262,6 +263,33 @@ func TestAssistantMessageItemCopyIconClick(t *testing.T) {
 	require.True(t, item.HandleMouseClick(ansi.MouseLeft,
 		item.copyIconColStart+MessageLeftPaddingTotal, item.copyIconRow))
 	require.Equal(t, thinkingCollapsed, item.thinkingViewMode)
+}
+
+// TestAssistantMessageItemCopyIconStaysWithinWidth guards against the icon
+// overflowing the item width: glamour pads the last content line to the
+// full capped width, so the icon must overwrite trailing padding rather
+// than extend the line. A line wider than the item width is clipped by the
+// screen compositor, making the icon invisible and unclickable on any
+// terminal narrower than maxTextWidth+2.
+func TestAssistantMessageItemCopyIconStaysWithinWidth(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	for _, width := range []int{30, 80, 120} {
+		msg := finishedTextMessage("copy-5", "hello **world** with a longer line of text that wraps")
+		item := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+		item.SetFocused(true)
+		rendered := item.RawRender(width)
+
+		capped := cappedMessageWidth(width)
+		for i, line := range strings.Split(rendered, "\n") {
+			require.LessOrEqual(t, lipgloss.Width(line), capped,
+				"line %d must not exceed the capped content width at width %d", i, width)
+		}
+		require.Contains(t, rendered, "⎘", "icon must still render")
+		require.Less(t, item.copyIconColEnd, width,
+			"icon must end within the item width so the mouse can reach it")
+	}
 }
 
 // TestAssistantMessageItemThinkingClickStillExpands guards against the new

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -108,13 +108,25 @@ func (m *UserMessageItem) RawRender(width int) string {
 		icon := m.sty.Messages.AssistantCopyIcon.Render(assistantCopyIcon)
 		iconWidth := lipgloss.Width(icon)
 		m.copyIconRow = height - 1
+		head := ""
 		lastLine := content
 		if idx := strings.LastIndex(content, "\n"); idx >= 0 {
+			head = content[:idx+1]
 			lastLine = content[idx+1:]
 		}
-		m.copyIconColStart = lipgloss.Width(lastLine)
-		m.copyIconColEnd = m.copyIconColStart + iconWidth
-		content += icon
+		// Glamour pads the last line to the full render width with styled
+		// spaces, so appending the icon after it would push the line one
+		// cell past the item width, where the compositor clips it (and a
+		// chat-relative mouse x can never reach). Overwrite the trailing
+		// padding instead so the line stays within width.
+		iconCol := lipgloss.Width(lastLine)
+		if maxCol := cappedWidth - iconWidth; iconCol > maxCol {
+			iconCol = max(maxCol, 0)
+			lastLine = ansi.Truncate(lastLine, iconCol, "")
+		}
+		m.copyIconColStart = iconCol
+		m.copyIconColEnd = iconCol + iconWidth
+		content = head + lastLine + icon
 		height = lipgloss.Height(content)
 	}
 

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -114,15 +114,15 @@ func (m *UserMessageItem) RawRender(width int) string {
 			head = content[:idx+1]
 			lastLine = content[idx+1:]
 		}
-		// Glamour pads the last line to the full render width with styled
-		// spaces, so appending the icon after it would push the line one
-		// cell past the item width, where the compositor clips it (and a
-		// chat-relative mouse x can never reach). Overwrite the trailing
-		// padding instead so the line stays within width.
-		iconCol := lipgloss.Width(lastLine)
-		if maxCol := cappedWidth - iconWidth; iconCol > maxCol {
-			iconCol = max(maxCol, 0)
+		// The icon hugs the right edge of the item: pad (or truncate)
+		// the last line so the icon's rightmost cell lands on the item
+		// width, keeping the line within width so the compositor does
+		// not clip it and a chat-relative mouse x can reach it.
+		iconCol := max(cappedWidth-iconWidth, 0)
+		if w := lipgloss.Width(lastLine); w > iconCol {
 			lastLine = ansi.Truncate(lastLine, iconCol, "")
+		} else {
+			lastLine += strings.Repeat(" ", iconCol-w)
 		}
 		m.copyIconColStart = iconCol
 		m.copyIconColEnd = iconCol + iconWidth

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/list"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // skillInvocation represents the XML structure for a loaded skill.
@@ -31,6 +32,12 @@ type UserMessageItem struct {
 	attachments *attachments.Renderer
 	message     *message.Message
 	sty         *styles.Styles
+
+	// Click-to-copy icon geometry, recorded during RawRender so
+	// HandleMouseClickCmd can hit-test without re-deriving the layout.
+	copyIconRow      int
+	copyIconColStart int
+	copyIconColEnd   int
 }
 
 // NewUserMessageItem creates a new UserMessageItem.
@@ -58,45 +65,59 @@ func (m *UserMessageItem) RawRender(width int) string {
 	cappedWidth := cappedMessageWidth(width)
 
 	content, height, ok := m.getCachedRender(cappedWidth)
-	// cache hit
-	if ok {
-		return m.renderHighlighted(content, cappedWidth, height)
-	}
+	if !ok {
+		msgContent := strings.TrimSpace(m.message.Content().Text)
 
-	msgContent := strings.TrimSpace(m.message.Content().Text)
+		// Check if this is a skill invocation (loaded_skill XML)
+		if strings.HasPrefix(msgContent, "<loaded_skill>") {
+			content = m.renderSkillInvocation(msgContent, cappedWidth)
+		} else {
+			renderer := common.MarkdownRenderer(m.sty, cappedWidth)
+			mu := common.LockMarkdownRenderer(renderer)
 
-	// Check if this is a skill invocation (loaded_skill XML)
-	if strings.HasPrefix(msgContent, "<loaded_skill>") {
-		content = m.renderSkillInvocation(msgContent, cappedWidth)
+			mu.Lock()
+			result, err := renderer.Render(msgContent)
+			mu.Unlock()
+
+			if err != nil {
+				content = msgContent
+			} else {
+				content = strings.TrimSuffix(result, "\n")
+			}
+
+			if len(m.message.BinaryContent()) > 0 {
+				attachmentsStr := m.renderAttachments(cappedWidth)
+				if content == "" {
+					content = attachmentsStr
+				} else {
+					content = strings.Join([]string{content, "", attachmentsStr}, "\n")
+				}
+			}
+		}
+
 		height = lipgloss.Height(content)
 		m.setCachedRender(content, cappedWidth, height)
-		return m.renderHighlighted(content, cappedWidth, height)
 	}
 
-	renderer := common.MarkdownRenderer(m.sty, cappedWidth)
-	mu := common.LockMarkdownRenderer(renderer)
-
-	mu.Lock()
-	result, err := renderer.Render(msgContent)
-	mu.Unlock()
-
-	if err != nil {
-		content = msgContent
-	} else {
-		content = strings.TrimSuffix(result, "\n")
-	}
-
-	if len(m.message.BinaryContent()) > 0 {
-		attachmentsStr := m.renderAttachments(cappedWidth)
-		if content == "" {
-			content = attachmentsStr
-		} else {
-			content = strings.Join([]string{content, "", attachmentsStr}, "\n")
+	// Click-to-copy icon: right-aligned ⎘ appended to the last content
+	// line, shown only while the message item is focused (selected).
+	// The icon copies the raw Markdown source via HandleMouseClickCmd.
+	m.copyIconRow = -1
+	msgText := strings.TrimSpace(m.message.Content().Text)
+	if msgText != "" && m.focused {
+		icon := m.sty.Messages.AssistantCopyIcon.Render(assistantCopyIcon)
+		iconWidth := lipgloss.Width(icon)
+		m.copyIconRow = height - 1
+		lastLine := content
+		if idx := strings.LastIndex(content, "\n"); idx >= 0 {
+			lastLine = content[idx+1:]
 		}
+		m.copyIconColStart = lipgloss.Width(lastLine)
+		m.copyIconColEnd = m.copyIconColStart + iconWidth
+		content += icon
+		height = lipgloss.Height(content)
 	}
 
-	height = lipgloss.Height(content)
-	m.setCachedRender(content, cappedWidth, height)
 	return m.renderHighlighted(content, cappedWidth, height)
 }
 
@@ -171,6 +192,29 @@ func (m *UserMessageItem) renderAttachments(width int) string {
 	// This message is already posted, so the attachment can't be removed;
 	// don't render the remove button.
 	return m.attachments.Render(attachments, false, false, width)
+}
+
+// HandleMouseClick implements [list.MouseClickable]. Defers to
+// HandleMouseClickCmd; the command return is discarded because the
+// generic click dispatcher only checks the handled flag on this path.
+func (m *UserMessageItem) HandleMouseClick(btn ansi.MouseButton, x, y int) bool {
+	handled, _ := m.HandleMouseClickCmd(btn, x, y)
+	return handled
+}
+
+// HandleMouseClickCmd implements [list.MouseClickCommandable]. A click on
+// the click-to-copy icon returns the copy command, which suppresses the
+// generic expansion toggle in the chat click dispatcher.
+func (m *UserMessageItem) HandleMouseClickCmd(btn ansi.MouseButton, x, y int) (bool, tea.Cmd) {
+	if btn != ansi.MouseLeft {
+		return false, nil
+	}
+	if m.copyIconRow >= 0 && y == m.copyIconRow &&
+		x >= m.copyIconColStart+MessageLeftPaddingTotal && x < m.copyIconColEnd+MessageLeftPaddingTotal {
+		text := m.message.Content().Text
+		return true, common.CopyToClipboard(text, "Message copied to clipboard")
+	}
+	return false, nil
 }
 
 // HandleKeyEvent implements KeyEventHandler.

--- a/internal/ui/chat/user_test.go
+++ b/internal/ui/chat/user_test.go
@@ -1,0 +1,109 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestUserItem(text string, createdAt int64) *UserMessageItem {
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:        "test-id",
+		Role:      message.User,
+		CreatedAt: createdAt,
+		Parts:     []message.ContentPart{message.TextContent{Text: text}},
+	}
+	r := attachments.NewRenderer(
+		sty.Attachments.Normal,
+		sty.Attachments.Deleting,
+		sty.Attachments.Image,
+		sty.Attachments.Text,
+		sty.Attachments.Skill,
+		sty.Attachments.Remove,
+	)
+	return NewUserMessageItem(&sty, msg, r).(*UserMessageItem)
+}
+
+// TestUserMessageItemCopyIconRenderedFocused verifies that a focused user
+// message with content renders the ⎘ icon on the last content row, and
+// the recorded click geometry agrees with the rendered output.
+func TestUserMessageItemCopyIconRenderedFocused(t *testing.T) {
+	t.Parallel()
+
+	item := newTestUserItem("hello **world**", 0)
+	item.SetFocused(true)
+
+	const width = 40
+	rendered := item.RawRender(width)
+	lines := strings.Split(rendered, "\n")
+
+	require.GreaterOrEqual(t, item.copyIconRow, 0, "focused message with content must render the copy icon")
+	require.Less(t, item.copyIconRow, len(lines), "recorded icon row must be within the rendered output")
+	require.Equal(t, len(lines)-1, item.copyIconRow,
+		"icon row must be the last rendered line")
+
+	iconLine := lines[item.copyIconRow]
+	require.Contains(t, iconLine, "⎘", "last line must contain the copy glyph")
+	plain := ansi.Strip(iconLine)
+	require.Equal(t, item.copyIconColStart, len([]rune(strings.Split(plain, "⎘")[0])),
+		"icon must sit at the recorded start column")
+	require.Equal(t, item.copyIconColStart+1, item.copyIconColEnd,
+		"the single-cell glyph must span exactly one column")
+}
+
+// TestUserMessageItemCopyIconSuppressed verifies the states where the
+// icon must not render: unfocused and empty content.
+func TestUserMessageItemCopyIconSuppressed(t *testing.T) {
+	t.Parallel()
+
+	// Unfocused: icon hidden.
+	unfocused := newTestUserItem("hello world", 0)
+	unfocused.RawRender(40)
+	require.Equal(t, -1, unfocused.copyIconRow,
+		"unfocused message must not render the copy icon")
+
+	// Empty content: nothing to copy.
+	empty := newTestUserItem("", 0)
+	empty.SetFocused(true)
+	empty.RawRender(40)
+	require.Equal(t, -1, empty.copyIconRow,
+		"empty message must not render the copy icon")
+}
+
+// TestUserMessageItemCopyIconClick verifies the click contract: a click
+// on the copy glyph must be handled and return the copy command.
+func TestUserMessageItemCopyIconClick(t *testing.T) {
+	t.Parallel()
+
+	item := newTestUserItem("copy my **prompt**", 0)
+	item.SetFocused(true)
+	item.RawRender(40)
+	require.GreaterOrEqual(t, item.copyIconRow, 0)
+
+	// Click on the glyph: x is chat-relative, so offset by MessageLeftPaddingTotal.
+	handled, cmd := item.HandleMouseClickCmd(ansi.MouseLeft,
+		item.copyIconColStart+MessageLeftPaddingTotal, item.copyIconRow)
+	require.True(t, handled, "click on the copy glyph must be handled")
+	require.NotNil(t, cmd, "click on the copy glyph must produce the copy command")
+
+	// Click to the left of the glyph on the same row is not a copy.
+	handled, cmd = item.HandleMouseClickCmd(ansi.MouseLeft, 0, item.copyIconRow)
+	require.False(t, handled, "click outside the glyph span must not copy")
+	require.Nil(t, cmd)
+
+	// Right button on the glyph is ignored.
+	handled, cmd = item.HandleMouseClickCmd(ansi.MouseRight,
+		item.copyIconColStart+MessageLeftPaddingTotal, item.copyIconRow)
+	require.False(t, handled)
+	require.Nil(t, cmd)
+
+	// The plain MouseClickable path must agree.
+	require.True(t, item.HandleMouseClick(ansi.MouseLeft,
+		item.copyIconColStart+MessageLeftPaddingTotal, item.copyIconRow))
+}

--- a/internal/ui/chat/user_test.go
+++ b/internal/ui/chat/user_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/styles"
@@ -74,6 +75,31 @@ func TestUserMessageItemCopyIconSuppressed(t *testing.T) {
 	empty.RawRender(40)
 	require.Equal(t, -1, empty.copyIconRow,
 		"empty message must not render the copy icon")
+}
+
+// TestUserMessageItemCopyIconStaysWithinWidth guards against the icon
+// overflowing the item width: glamour pads the last content line to the
+// full capped width, so the icon must overwrite trailing padding rather
+// than extend the line. A line wider than the item width is clipped by the
+// screen compositor, making the icon invisible and unclickable on any
+// terminal narrower than maxTextWidth+2.
+func TestUserMessageItemCopyIconStaysWithinWidth(t *testing.T) {
+	t.Parallel()
+
+	for _, width := range []int{30, 80, 120} {
+		item := newTestUserItem("hello **world** with a longer line of text that wraps", 0)
+		item.SetFocused(true)
+		rendered := item.RawRender(width)
+
+		capped := cappedMessageWidth(width)
+		for i, line := range strings.Split(rendered, "\n") {
+			require.LessOrEqual(t, lipgloss.Width(line), capped,
+				"line %d must not exceed the capped content width at width %d", i, width)
+		}
+		require.Contains(t, rendered, "⎘", "icon must still render")
+		require.Less(t, item.copyIconColEnd, width,
+			"icon must end within the item width so the mouse can reach it")
+	}
 }
 
 // TestUserMessageItemCopyIconClick verifies the click contract: a click

--- a/internal/ui/list/item.go
+++ b/internal/ui/list/item.go
@@ -3,6 +3,7 @@ package list
 import (
 	"strings"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
 )
 
@@ -97,6 +98,20 @@ type MouseClickable interface {
 	// HandleMouseClick processes a mouse click event at the given coordinates.
 	// It returns true if the event was handled, false otherwise.
 	HandleMouseClick(btn ansi.MouseButton, x, y int) bool
+}
+
+// MouseClickCommandable is an optional extension of [MouseClickable] for
+// items whose click regions can produce a command (e.g. copying text to the
+// clipboard) rather than only signalling hit detection. The chat click
+// dispatcher prefers this interface over [MouseClickable] when an item
+// implements both: a non-nil returned command suppresses the generic
+// expansion toggle that a plain handled click would otherwise trigger.
+type MouseClickCommandable interface {
+	// HandleMouseClickCmd processes a mouse click event at the given
+	// coordinates. It returns whether the event was handled and an optional
+	// command to run. A handled click with a nil command keeps the generic
+	// post-click behavior (expansion); a non-nil command replaces it.
+	HandleMouseClickCmd(btn ansi.MouseButton, x, y int) (bool, tea.Cmd)
 }
 
 // SpacerItem is a spacer item that adds vertical space in the list.

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -910,41 +910,52 @@ func (m *Chat) HandleMouseDown(x, y int) (bool, tea.Cmd) {
 
 // HandleDelayedClick handles a delayed single-click action (like expansion).
 // It only executes if the click ID matches (i.e., no double-click occurred)
-// and no text selection was made (drag to select).
-func (m *Chat) HandleDelayedClick(msg DelayedClickMsg) bool {
+// and no text selection was made (drag to select). It returns whether the
+// click was handled and an optional command produced by the clicked item
+// (e.g. a clipboard copy from a click-to-copy affordance).
+func (m *Chat) HandleDelayedClick(msg DelayedClickMsg) (bool, tea.Cmd) {
 	// Ignore if this click was superseded by a newer click (double/triple).
 	if msg.ClickID != m.pendingClickID {
-		return false
+		return false, nil
 	}
 
 	// Don't expand if user dragged to select text.
 	if m.HasHighlight() {
-		return false
+		return false, nil
 	}
 
 	// Execute the click action (e.g., expansion).
 	selectedItem := m.list.SelectedItem()
-	if clickable, ok := selectedItem.(list.MouseClickable); ok {
-		handled := clickable.HandleMouseClick(ansi.MouseButton1, msg.X, msg.Y)
-		// Toggle expansion only when the item signalled it handled the
-		// click. Items like AssistantMessageItem only report handled when
-		// the click is on their expandable region, so this avoids
-		// toggling expansion for clicks outside the clickable area.
-		if handled {
-			if expandable, ok := selectedItem.(chat.Expandable); ok {
-				wasFollowing := m.follow
-				if !expandable.ToggleExpanded() {
-					m.ScrollToIndex(m.list.Selected())
-				}
-				if wasFollowing {
-					m.ScrollToBottom()
-				}
-			}
-		}
-		return handled
+	var handled bool
+	var cmd tea.Cmd
+	if commandable, ok := selectedItem.(list.MouseClickCommandable); ok {
+		// Items that can produce click commands get first refusal. A
+		// non-nil command (e.g. copy-to-clipboard) replaces the generic
+		// expansion toggle below.
+		handled, cmd = commandable.HandleMouseClickCmd(ansi.MouseButton1, msg.X, msg.Y)
+	} else if clickable, ok := selectedItem.(list.MouseClickable); ok {
+		handled = clickable.HandleMouseClick(ansi.MouseButton1, msg.X, msg.Y)
+	} else {
+		return false, nil
 	}
 
-	return false
+	// Toggle expansion only when the item signalled it handled the
+	// click without producing a command of its own. Items like
+	// AssistantMessageItem only report handled when the click is on
+	// their expandable region, so this avoids toggling expansion for
+	// clicks outside the clickable area.
+	if handled && cmd == nil {
+		if expandable, ok := selectedItem.(chat.Expandable); ok {
+			wasFollowing := m.follow
+			if !expandable.ToggleExpanded() {
+				m.ScrollToIndex(m.list.Selected())
+			}
+			if wasFollowing {
+				m.ScrollToBottom()
+			}
+		}
+	}
+	return handled, cmd
 }
 
 // HandleMouseUp handles mouse up events for the chat component.

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -953,8 +953,10 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case copyChatHighlightMsg:
 		cmds = append(cmds, m.copyChatHighlight())
 	case DelayedClickMsg:
-		// Handle delayed single-click action (e.g., expansion).
-		m.chat.HandleDelayedClick(msg)
+		// Handle delayed single-click action (e.g., expansion, copy).
+		if _, cmd := m.chat.HandleDelayedClick(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case tea.MouseClickMsg:
 		// Pass mouse events to dialogs first if any are open.
 		if m.dialog.HasDialogs() {

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -906,6 +906,7 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Messages.AssistantInfoProvider = subtle
 	s.Messages.AssistantInfoDuration = subtle
 	s.Messages.AssistantCanceled = lipgloss.NewStyle().Foreground(o.fgSubtle).Italic(true)
+	s.Messages.AssistantCopyIcon = muted
 
 	// Thinking section styles
 	s.Messages.ThinkingBox = subtle.Background(o.bgLeastVisible)

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -312,6 +312,7 @@ type Styles struct {
 		AssistantInfoProvider  lipgloss.Style
 		AssistantInfoDuration  lipgloss.Style
 		AssistantCanceled      lipgloss.Style // Italic "Canceled" footer
+		AssistantCopyIcon      lipgloss.Style // Muted click-to-copy footer glyph
 	}
 
 	// Tool - styles for tool call rendering


### PR DESCRIPTION
## Summary

Finished assistant messages and user messages render a ⎘ glyph on the last content row while the item is focused. Clicking it copies the message's raw Markdown source to the clipboard (the same text the `c`/`y` keybinding copies), via OSC 52 plus the native clipboard, with the usual toast confirmation.

## How it works

- Items can now implement `list.MouseClickCommandable` to return a command from a click; a non-nil command replaces the generic expansion toggle for that click. The existing `MouseClickable` path is unchanged for other items — previously every handled click was coupled to the expansion toggle, which would have made a copy click also expand the thinking block.
- The icon renders inline on the last content row (no extra footer rows), only while the message item is focused, keeping the chat clean when scrolling history.
- The glyph's rightmost cell is pinned to the item width so it sits at the right edge, and the last line is truncated rather than extended when it would overflow, so the icon is never clipped by the compositor at narrower terminal widths.

## Verification

- Unit tests cover the assistant and user copy affordances: icon rendered on the focused last row with click geometry agreeing with rendered output, suppression when unfocused/empty, and the click contract (handled + copy command on glyph, ignored off-glyph and on right-click).
- `go build ./...`, `go test ./internal/ui/...`, and `go vet` are clean.

## Provenance

Reviewed and merged on our fork as:
- https://github.com/joestump-agent/crush/pull/208
- https://github.com/joestump-agent/crush/pull/210
- https://github.com/joestump-agent/crush/pull/213

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Crush](https://github.com/charmbracelet/crush).