### PR TITLE
fix(mcp): bound MCP init waits so a wedged server can't blank the app…

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -236,11 +236,13 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 	// before initialization finished — most visibly on the first message.
 	//
 	// Non-interactive runs get a single shot at the tool palette, so they
-	// do wait for initialization to settle. The wait is bounded by each
-	// server's own connect timeout, so a hung server cannot stall the run
-	// indefinitely.
+	// do wait for initialization to settle — but bounded by InitWaitBudget
+	// rather than each server's connect timeout, so a server wedged
+	// mid-handshake cannot stall a headless run for minutes. Past the
+	// budget the turn proceeds without the stragglers; their tools simply
+	// stay absent from this run.
 	if !c.interactive {
-		if err := mcp.WaitForInit(ctx); err != nil {
+		if err := mcp.WaitForInitBudget(ctx, mcp.InitWaitBudget); err != nil {
 			return nil, fmt.Errorf("failed to wait for MCP initialization: %w", err)
 		}
 	}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -225,12 +225,17 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 		return nil, err
 	}
 
-	// Wait for MCP initialization to complete before building the tool list.
-	// Without this, slow-to-start MCP servers (e.g. stdio Python via uv) may
-	// not have registered their tools yet when buildTools reads the registry,
+	// Wait for MCP initialization before building the tool list. Without
+	// this, slow-to-start MCP servers (e.g. stdio Python via uv) may not
+	// have registered their tools yet when buildTools reads the registry,
 	// so their tools silently never appear in the LLM tool palette — even
-	// though crush_info reports them as connected.
-	if err := mcp.WaitForInit(ctx); err != nil {
+	// though crush_info reports them as connected. The wait is bounded:
+	// a server wedged mid-handshake would otherwise hold every turn
+	// hostage for its full connect timeout (up to minutes), with nothing
+	// on screen — no user message, no spinner. Past the budget the turn
+	// proceeds without the stragglers; buildTools runs again next turn,
+	// so their tools appear once they finish.
+	if err := mcp.WaitForInitBudget(ctx, mcp.InitWaitBudget); err != nil {
 		return nil, fmt.Errorf("failed to wait for MCP initialization: %w", err)
 	}
 
@@ -644,8 +649,8 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 	// fail at readyWg.Wait() before emitting anything — the client/server
 	// session hangs with no visible response. WithoutCancel drops
 	// cancellation while keeping context values; the work is bounded
-	// (WaitForInit by MCP init timeouts, the rest is local) so it always
-	// completes.
+	// (WaitForInitBudget by its wait budget, the rest is local) so it
+	// always completes.
 	initCtx := context.WithoutCancel(ctx)
 
 	c.readyWg.Go(func() error {
@@ -661,8 +666,12 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		// Wait for MCP servers to finish registering their tools before
 		// building the initial tool list. This ensures the first tool set
 		// (used if anything reads it before run() rebuilds) includes all
-		// MCP tools, not just fast-to-init ones.
-		if err := mcp.WaitForInit(initCtx); err != nil {
+		// MCP tools, not just fast-to-init ones. Bounded for the same
+		// reason as run(): every turn gates on readyWg.Wait(), so an MCP
+		// server wedged mid-handshake would otherwise blank the app for
+		// its full connect timeout. run() rebuilds the tool list each
+		// turn, so tools of servers that finish later still appear.
+		if err := mcp.WaitForInitBudget(initCtx, mcp.InitWaitBudget); err != nil {
 			return err
 		}
 		tools, err := c.buildTools(initCtx, agent, isSubAgent)

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -74,9 +74,13 @@ var (
 
 	// initStarted records whether Initialize has been armed. WaitForInit only
 	// blocks once initialization is expected; coordinators built outside app
-	// startup never arm it and so must not wait forever.
+	// startup never arm it and so must not wait forever. initArmedAt anchors
+	// WaitForInitBudget's deadline: the budget is measured from arming, not
+	// from each call, so sequential waiters share one deadline instead of
+	// stacking fresh budgets.
 	initMu      sync.Mutex
 	initStarted bool
+	initArmedAt time.Time
 
 	// renewMus serializes lazy session renewals per server so concurrent tool
 	// calls cannot race to rebuild the same session.
@@ -110,6 +114,7 @@ type suppressBrowserKey struct{}
 func ArmInit() {
 	initMu.Lock()
 	initStarted = true
+	initArmedAt = time.Now()
 	initMu.Unlock()
 }
 
@@ -333,6 +338,46 @@ func WaitForInit(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// InitWaitBudget bounds how long a message turn waits for MCP
+// initialization before proceeding without the servers that have not
+// finished. It is generously above a healthy stdio server's startup
+// (uv/npx take a few seconds) but far below the per-server handshake
+// timeouts (15s-120s): a server that wedges mid-handshake — e.g. one
+// that never answers the SEP-2575 server/discover probe — must not
+// make the whole app look dead while its timeout runs out.
+const InitWaitBudget = 10 * time.Second
+
+// WaitForInitBudget blocks like WaitForInit, but only until the budget —
+// measured from when initialization was armed, not from this call —
+// elapses. Anchoring the deadline at arming means the several sequential
+// waiters on a turn's path (readyWg's tool build, then the turn itself)
+// share one deadline instead of each stacking a fresh budget while a
+// server is wedged, and turns arriving after the deadline don't wait at
+// all. It returns nil both when initialization completed and when the
+// budget elapsed first — in the latter case the caller proceeds with
+// whatever servers have registered so far, and stragglers appear on a
+// later turn once they finish. The caller's own context ending is still
+// reported as an error.
+func WaitForInitBudget(ctx context.Context, budget time.Duration) error {
+	initMu.Lock()
+	started := initStarted
+	armedAt := initArmedAt
+	initMu.Unlock()
+	if !started {
+		return nil
+	}
+	waitCtx, cancel := context.WithDeadline(ctx, armedAt.Add(budget))
+	defer cancel()
+	if err := WaitForInit(waitCtx); err == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	slog.Warn("MCP initialization still pending after wait budget; continuing without unfinished servers", "budget", budget)
+	return nil
 }
 
 // InitializeSingle initializes a single MCP client by name.

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -74,9 +74,13 @@ var (
 
 	// initStarted records whether Initialize has been armed. WaitForInit only
 	// blocks once initialization is expected; coordinators built outside app
-	// startup never arm it and so must not wait forever.
+	// startup never arm it and so must not wait forever. initArmedAt anchors
+	// WaitForInitBudget's deadline: the budget is measured from arming, not
+	// from each call, so sequential waiters share one deadline instead of
+	// stacking fresh budgets.
 	initMu      sync.Mutex
 	initStarted bool
+	initArmedAt time.Time
 
 	// renewMus serializes lazy session renewals per server so concurrent tool
 	// calls cannot race to rebuild the same session.
@@ -102,6 +106,7 @@ var (
 func ArmInit() {
 	initMu.Lock()
 	initStarted = true
+	initArmedAt = time.Now()
 	initMu.Unlock()
 }
 
@@ -310,6 +315,46 @@ func WaitForInit(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// InitWaitBudget bounds how long a message turn waits for MCP
+// initialization before proceeding without the servers that have not
+// finished. It is generously above a healthy stdio server's startup
+// (uv/npx take a few seconds) but far below the per-server handshake
+// timeouts (15s-120s): a server that wedges mid-handshake — e.g. one
+// that never answers the SEP-2575 server/discover probe — must not
+// make the whole app look dead while its timeout runs out.
+const InitWaitBudget = 10 * time.Second
+
+// WaitForInitBudget blocks like WaitForInit, but only until the budget —
+// measured from when initialization was armed, not from this call —
+// elapses. Anchoring the deadline at arming means the several sequential
+// waiters on a turn's path (readyWg's tool build, then the turn itself)
+// share one deadline instead of each stacking a fresh budget while a
+// server is wedged, and turns arriving after the deadline don't wait at
+// all. It returns nil both when initialization completed and when the
+// budget elapsed first — in the latter case the caller proceeds with
+// whatever servers have registered so far, and stragglers appear on a
+// later turn once they finish. The caller's own context ending is still
+// reported as an error.
+func WaitForInitBudget(ctx context.Context, budget time.Duration) error {
+	initMu.Lock()
+	started := initStarted
+	armedAt := initArmedAt
+	initMu.Unlock()
+	if !started {
+		return nil
+	}
+	waitCtx, cancel := context.WithDeadline(ctx, armedAt.Add(budget))
+	defer cancel()
+	if err := WaitForInit(waitCtx); err == nil {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	slog.Warn("MCP initialization still pending after wait budget; continuing without unfinished servers", "budget", budget)
+	return nil
 }
 
 // InitializeSingle initializes a single MCP client by name.

--- a/internal/agent/tools/mcp/waitforinit_test.go
+++ b/internal/agent/tools/mcp/waitforinit_test.go
@@ -22,13 +22,16 @@ func swapInitGate(t *testing.T) chan struct{} {
 
 	initMu.Lock()
 	origStarted := initStarted
+	origArmedAt := initArmedAt
 	initStarted = true
+	initArmedAt = time.Now()
 	initMu.Unlock()
 
 	t.Cleanup(func() {
 		initDone = orig
 		initMu.Lock()
 		initStarted = origStarted
+		initArmedAt = origArmedAt
 		initMu.Unlock()
 	})
 	return initDone
@@ -78,6 +81,98 @@ func TestWaitForInit_ReturnsWhenNotArmed(t *testing.T) {
 	defer cancel()
 	require.NoError(t, WaitForInit(ctx),
 		"WaitForInit must return immediately when initialization was never armed")
+}
+
+// TestWaitForInitBudget_ProceedsWhenInitWedged is the regression test for the
+// "messages go into the void" hang: an MCP server that never answers its
+// handshake (e.g. a Python server that chokes on the SEP-2575 server/discover
+// probe without responding) keeps Initialize — and so the init gate — open for
+// its full connect timeout, up to minutes. Every turn gated on the open-ended
+// WaitForInit, so typing a message produced nothing: no persisted user
+// message, no spinner. The bounded wait must give up after its budget and let
+// the turn proceed without the wedged server.
+func TestWaitForInitBudget_ProceedsWhenInitWedged(t *testing.T) {
+	swapInitGate(t) // armed, never closed: initialization is wedged
+
+	start := time.Now()
+	require.NoError(t, WaitForInitBudget(context.Background(), 50*time.Millisecond),
+		"a wedged MCP initialization must not fail the turn once the budget elapses")
+	require.Less(t, time.Since(start), 5*time.Second,
+		"WaitForInitBudget must return promptly after its budget, not block until initialization finishes")
+}
+
+// TestWaitForInitBudget_ReturnsOnceInitCompletes pins that the budget is a
+// ceiling, not a delay: when initialization finishes within the budget the
+// wait ends immediately, preserving the #132 guarantee that a healthy
+// slow-to-start server's tools are registered before buildTools reads the
+// registry.
+func TestWaitForInitBudget_ReturnsOnceInitCompletes(t *testing.T) {
+	gate := swapInitGate(t)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		close(gate)
+	}()
+
+	start := time.Now()
+	require.NoError(t, WaitForInitBudget(context.Background(), 30*time.Second))
+	require.Less(t, time.Since(start), 5*time.Second,
+		"WaitForInitBudget must return as soon as initialization completes, not sit out its budget")
+}
+
+// TestWaitForInitBudget_CallerCancellationStillAborts pins that the budget
+// only absorbs its own deadline: the caller's context being cancelled (the
+// user hit esc, the request ended) still aborts the turn with an error rather
+// than being mistaken for an elapsed budget and silently proceeding.
+func TestWaitForInitBudget_CallerCancellationStillAborts(t *testing.T) {
+	swapInitGate(t) // armed, never closed
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	require.ErrorIs(t, WaitForInitBudget(ctx, 30*time.Second), context.Canceled,
+		"caller cancellation must surface as an error, not be swallowed like an elapsed budget")
+}
+
+// TestWaitForInitBudget_DeadlineIsAbsolute pins that the budget anchors at
+// ArmInit, not at each call: a turn's path holds several sequential waiters
+// (readyWg's tool build, then the turn's own gate), and per-call budgets would
+// stack into multiples of the budget while a server is wedged. A call arriving
+// after the armed-at deadline has already passed must return at once.
+func TestWaitForInitBudget_DeadlineIsAbsolute(t *testing.T) {
+	swapInitGate(t) // armed, never closed
+
+	// Rewind the arming time so the 30s budget is already spent.
+	initMu.Lock()
+	initArmedAt = time.Now().Add(-time.Minute)
+	initMu.Unlock()
+
+	start := time.Now()
+	require.NoError(t, WaitForInitBudget(context.Background(), 30*time.Second),
+		"a call after the armed-at deadline must proceed without waiting")
+	require.Less(t, time.Since(start), 5*time.Second,
+		"the budget must not restart per call once the armed-at deadline has passed")
+}
+
+// TestWaitForInitBudget_ReturnsWhenNotArmed mirrors WaitForInit's contract for
+// coordinators built outside app startup: nothing armed means nothing to wait
+// for.
+func TestWaitForInitBudget_ReturnsWhenNotArmed(t *testing.T) {
+	initMu.Lock()
+	orig := initStarted
+	initStarted = false
+	initMu.Unlock()
+	t.Cleanup(func() {
+		initMu.Lock()
+		initStarted = orig
+		initMu.Unlock()
+	})
+
+	require.NoError(t, WaitForInitBudget(context.Background(), 30*time.Second),
+		"WaitForInitBudget must return immediately when initialization was never armed")
 }
 
 // TestWaitForInit_ToolsVisibleAfterInit pins the visibility guarantee

--- a/internal/agent/tools/mcp/waitforinit_test.go
+++ b/internal/agent/tools/mcp/waitforinit_test.go
@@ -22,13 +22,16 @@ func swapInitGate(t *testing.T) chan struct{} {
 
 	initMu.Lock()
 	origStarted := initStarted
+	origArmedAt := initArmedAt
 	initStarted = true
+	initArmedAt = time.Now()
 	initMu.Unlock()
 
 	t.Cleanup(func() {
 		initDone = orig
 		initMu.Lock()
 		initStarted = origStarted
+		initArmedAt = origArmedAt
 		initMu.Unlock()
 	})
 	return initDone
@@ -75,6 +78,98 @@ func TestWaitForInit_ReturnsWhenNotArmed(t *testing.T) {
 	defer cancel()
 	require.NoError(t, WaitForInit(ctx),
 		"WaitForInit must return immediately when initialization was never armed")
+}
+
+// TestWaitForInitBudget_ProceedsWhenInitWedged is the regression test for the
+// "messages go into the void" hang: an MCP server that never answers its
+// handshake (e.g. a Python server that chokes on the SEP-2575 server/discover
+// probe without responding) keeps Initialize — and so the init gate — open for
+// its full connect timeout, up to minutes. Every turn gated on the open-ended
+// WaitForInit, so typing a message produced nothing: no persisted user
+// message, no spinner. The bounded wait must give up after its budget and let
+// the turn proceed without the wedged server.
+func TestWaitForInitBudget_ProceedsWhenInitWedged(t *testing.T) {
+	swapInitGate(t) // armed, never closed: initialization is wedged
+
+	start := time.Now()
+	require.NoError(t, WaitForInitBudget(context.Background(), 50*time.Millisecond),
+		"a wedged MCP initialization must not fail the turn once the budget elapses")
+	require.Less(t, time.Since(start), 5*time.Second,
+		"WaitForInitBudget must return promptly after its budget, not block until initialization finishes")
+}
+
+// TestWaitForInitBudget_ReturnsOnceInitCompletes pins that the budget is a
+// ceiling, not a delay: when initialization finishes within the budget the
+// wait ends immediately, preserving the #132 guarantee that a healthy
+// slow-to-start server's tools are registered before buildTools reads the
+// registry.
+func TestWaitForInitBudget_ReturnsOnceInitCompletes(t *testing.T) {
+	gate := swapInitGate(t)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		close(gate)
+	}()
+
+	start := time.Now()
+	require.NoError(t, WaitForInitBudget(context.Background(), 30*time.Second))
+	require.Less(t, time.Since(start), 5*time.Second,
+		"WaitForInitBudget must return as soon as initialization completes, not sit out its budget")
+}
+
+// TestWaitForInitBudget_CallerCancellationStillAborts pins that the budget
+// only absorbs its own deadline: the caller's context being cancelled (the
+// user hit esc, the request ended) still aborts the turn with an error rather
+// than being mistaken for an elapsed budget and silently proceeding.
+func TestWaitForInitBudget_CallerCancellationStillAborts(t *testing.T) {
+	swapInitGate(t) // armed, never closed
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	require.ErrorIs(t, WaitForInitBudget(ctx, 30*time.Second), context.Canceled,
+		"caller cancellation must surface as an error, not be swallowed like an elapsed budget")
+}
+
+// TestWaitForInitBudget_DeadlineIsAbsolute pins that the budget anchors at
+// ArmInit, not at each call: a turn's path holds several sequential waiters
+// (readyWg's tool build, then the turn's own gate), and per-call budgets would
+// stack into multiples of the budget while a server is wedged. A call arriving
+// after the armed-at deadline has already passed must return at once.
+func TestWaitForInitBudget_DeadlineIsAbsolute(t *testing.T) {
+	swapInitGate(t) // armed, never closed
+
+	// Rewind the arming time so the 30s budget is already spent.
+	initMu.Lock()
+	initArmedAt = time.Now().Add(-time.Minute)
+	initMu.Unlock()
+
+	start := time.Now()
+	require.NoError(t, WaitForInitBudget(context.Background(), 30*time.Second),
+		"a call after the armed-at deadline must proceed without waiting")
+	require.Less(t, time.Since(start), 5*time.Second,
+		"the budget must not restart per call once the armed-at deadline has passed")
+}
+
+// TestWaitForInitBudget_ReturnsWhenNotArmed mirrors WaitForInit's contract for
+// coordinators built outside app startup: nothing armed means nothing to wait
+// for.
+func TestWaitForInitBudget_ReturnsWhenNotArmed(t *testing.T) {
+	initMu.Lock()
+	orig := initStarted
+	initStarted = false
+	initMu.Unlock()
+	t.Cleanup(func() {
+		initMu.Lock()
+		initStarted = orig
+		initMu.Unlock()
+	})
+
+	require.NoError(t, WaitForInitBudget(context.Background(), 30*time.Second),
+		"WaitForInitBudget must return immediately when initialization was never armed")
 }
 
 // TestWaitForInit_ToolsVisibleAfterInit is the regression test for the bug the

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -315,8 +315,11 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 	// MCP initialization to settle before reading MCP tools. The coordinator
 	// waits again for the same reason (it is the gate the client/server path
 	// goes through); doing it here too surfaces the failure before we create a
-	// session, and lets the UpdateModels below see every MCP tool.
-	if err := mcp.WaitForInit(ctx); err != nil {
+	// session, and lets the UpdateModels below see every MCP tool. The wait is
+	// bounded so a server wedged mid-handshake cannot stall the one-shot run
+	// for its full connect timeout; past the budget the run proceeds without
+	// the unfinished servers' tools.
+	if err := mcp.WaitForInitBudget(ctx, mcp.InitWaitBudget); err != nil {
 		return fmt.Errorf("failed to wait for MCP initialization: %w", err)
 	}
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -311,8 +311,11 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 		}
 	}
 
-	// Wait for MCP initialization to complete before reading MCP tools.
-	if err := mcp.WaitForInit(ctx); err != nil {
+	// Wait for MCP initialization before reading MCP tools. Bounded so a
+	// server wedged mid-handshake cannot stall the one-shot run for its
+	// full connect timeout; past the budget the run proceeds without the
+	// unfinished servers' tools.
+	if err := mcp.WaitForInitBudget(ctx, mcp.InitWaitBudget); err != nil {
 		return fmt.Errorf("failed to wait for MCP initialization: %w", err)
 	}
 


### PR DESCRIPTION
… (#199)

An MCP server that wedges mid-handshake — e.g. a Python server that chokes on the new go-sdk's SEP-2575 server/discover probe without ever responding, while a background task keeps its process alive — held the init gate open for its full connect timeout (15s-120s per config). Every turn gated on the open-ended WaitForInit before persisting the user message or starting a spinner, so typing produced nothing at all: no message, no output, for minutes. The upstream sync's go-sdk bump made this reachable in practice; signal-mcp triggers it intermittently.

Replace the open-ended waits on the turn path (coordinator.run, the readyWg tool build, RunNonInteractive) with WaitForInitBudget: wait at most InitWaitBudget (10s), then proceed without the unfinished servers. The budget is anchored at ArmInit rather than per call, so the several sequential waiters on a turn share one deadline instead of stacking fresh budgets, and turns arriving after the deadline don't wait at all. Stragglers' tools appear on a later turn — buildTools runs per turn — and #132's guarantee is preserved for servers that finish within the budget. Caller cancellation still aborts with an error.

Verified against a never-responding stdio server (timeout 120): before, crush run stalled 2-3 minutes with no output; after, all waiters release at exactly +10s and the reply arrives seconds later.


Claude-Session: https://claude.ai/code/session_01A5MAxbsnTyKHBWxLiCya8V

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
