### PR TITLE
fix(config): retry transient Windows rename failures in atomicWriteFi…

### DIFF
--- a/internal/config/atomicwrite.go
+++ b/internal/config/atomicwrite.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // atomicWriteFile writes data to a file atomically by writing to a unique
@@ -30,9 +31,33 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		os.Remove(tmp)
 		return err
 	}
-	if err := os.Rename(tmp, path); err != nil {
+	if err := renameFile(tmp, path); err != nil {
 		os.Remove(tmp)
 		return err
 	}
 	return nil
+}
+
+// renameRetryBudget bounds how long renameFile keeps retrying transient
+// failures before giving up and returning the error.
+const renameRetryBudget = 2 * time.Second
+
+// renameFile renames tmp over path. On Windows the rename fails with
+// ERROR_ACCESS_DENIED or ERROR_SHARING_VIOLATION while another process
+// (antivirus, search indexer) or a concurrent reader briefly holds a
+// handle on the destination, so transient failures are retried with
+// backoff. On other platforms isTransientRenameError is always false
+// and this is a plain os.Rename.
+func renameFile(tmp, path string) error {
+	var slept time.Duration
+	delay := time.Millisecond
+	for {
+		err := os.Rename(tmp, path)
+		if err == nil || !isTransientRenameError(err) || slept >= renameRetryBudget {
+			return err
+		}
+		time.Sleep(delay)
+		slept += delay
+		delay = min(delay*2, 50*time.Millisecond)
+	}
 }

--- a/internal/config/atomicwrite_unix.go
+++ b/internal/config/atomicwrite_unix.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package config
+
+// isTransientRenameError reports whether err is a rename failure that
+// can resolve on its own. Only Windows has such failures.
+func isTransientRenameError(error) bool { return false }

--- a/internal/config/atomicwrite_windows.go
+++ b/internal/config/atomicwrite_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package config
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// isTransientRenameError reports whether err is a Windows rename
+// failure that can resolve on its own: replacing the destination fails
+// while another handle (a concurrent reader, antivirus, or the search
+// indexer) is briefly open on it without FILE_SHARE_DELETE.
+func isTransientRenameError(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_SHARING_VIOLATION)
+}

--- a/internal/config/atomicwrite_windows_test.go
+++ b/internal/config/atomicwrite_windows_test.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+// Regression test for the windows-latest CI flake where
+// TestConfigStore_SetConfigFields_concurrentInProcess failed with
+// "rename ...crush.json.<rand>.tmp ...crush.json: Access is denied":
+// renaming over a destination while another handle is open on it
+// without sharing must be retried until the handle closes, not
+// surfaced as an error.
+func TestAtomicWriteFile_RetriesWhileDestinationHandleOpen(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.json")
+	require.NoError(t, atomicWriteFile(path, []byte(`{"v":1}`), 0o600))
+
+	// Hold the destination open with no sharing flags so the rename
+	// fails with ERROR_ACCESS_DENIED/ERROR_SHARING_VIOLATION until the
+	// handle closes, mimicking an antivirus scan or exclusive reader.
+	p, err := windows.UTF16PtrFromString(path)
+	require.NoError(t, err)
+	h, err := windows.CreateFile(p, windows.GENERIC_READ, 0, nil,
+		windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
+	require.NoError(t, err)
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		windows.CloseHandle(h)
+	}()
+
+	require.NoError(t, atomicWriteFile(path, []byte(`{"v":2}`), 0o600))
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"v":2}`, string(data))
+}


### PR DESCRIPTION
…le (#175)

TestConfigStore_SetConfigFields_concurrentInProcess flakes on windows-latest with "rename crush.json.<rand>.tmp crush.json: Access is denied". The store's write path is fully serialized (in-process mutex + cross-process flock), so the failing rename means an external process — antivirus or the search indexer on the CI runner — briefly held a handle on the destination without FILE_SHARE_DELETE, which makes MoveFileEx(REPLACE_EXISTING) fail with ERROR_ACCESS_DENIED or ERROR_SHARING_VIOLATION.

Retry those two errors with exponential backoff (1ms doubling to 50ms, 2s budget) on Windows only; other platforms keep a plain os.Rename. Adds a Windows regression test that holds the destination open with no sharing flags and verifies the write succeeds once the handle closes.

Example failing run:
https://github.com/joestump-agent/crush/actions/runs/29724740625/job/88295137885

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
