### PR TITLE
fix(db): fall back to rollback journal when WAL locking fails

### DIFF
--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -4,20 +4,37 @@ import (
 	"context"
 	"database/sql"
 	"embed"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/pressly/goose/v3"
 )
 
-var (
-	pragmas = map[string]string{
+// SQLite result codes relevant to filesystem locking failures. These
+// are driver-independent numeric values from the SQLite C API.
+const (
+	sqliteProtocol  = 15   // SQLITE_PROTOCOL: database lock protocol error.
+	sqliteIOErrLock = 3850 // SQLITE_IOERR_LOCK: I/O error within file locking.
+)
+
+// pragmas returns the connection pragmas applied when opening a
+// database. journalMode overrides the default WAL journal; pass "" to
+// keep WAL. WAL relies on shared-memory locking that network
+// filesystems (NFS, SMB) do not support, so Connect falls back to the
+// rollback journal ("DELETE") when WAL locking fails.
+func pragmas(journalMode string) map[string]string {
+	if journalMode == "" {
+		journalMode = "WAL"
+	}
+	return map[string]string{
 		"foreign_keys":  "ON",
-		"journal_mode":  "WAL",
+		"journal_mode":  journalMode,
 		"page_size":     "4096",
 		"temp_store":    "MEMORY",
 		"cache_size":    "-8000",
@@ -25,6 +42,9 @@ var (
 		"secure_delete": "ON",
 		"busy_timeout":  "30000",
 	}
+}
+
+var (
 	gooseInitOnce sync.Once
 	gooseInitErr  error
 )
@@ -126,31 +146,26 @@ func Connect(ctx context.Context, dataDir string, opts ...ConnectOption) (*sql.D
 		}
 	}
 
-	conn, err := openDB(dbPath)
-	if err != nil {
-		if lock != nil {
-			lock.release()
-		}
-		return nil, err
-	}
-
-	// Serialize all access through a single connection. SQLite
-	// serializes writes at the file level anyway, and allowing multiple
-	// pool connections to interleave writes/checkpoints (especially
-	// under concurrent sub-agents) has caused WAL/header desync
-	// resulting in SQLITE_NOTADB (26) on the next open.
-	conn.SetMaxOpenConns(1)
-
 	releaseLock := func() {
 		if lock != nil {
 			lock.release()
 		}
 	}
 
-	if err = conn.PingContext(ctx); err != nil {
-		conn.Close()
+	// Open with WAL first; if the filesystem cannot support WAL's
+	// shared-memory locking (NFS, SMB, some FUSE mounts) SQLite either
+	// fails with a lock-protocol error or silently stays on the
+	// rollback journal. Either way, retry once with the rollback
+	// journal, which only needs POSIX file locks.
+	conn, err := openAndPing(ctx, dbPath, "")
+	if isLockProtocolError(err) || errors.Is(err, errWALUnavailable) {
+		slog.Warn("WAL journal mode unsupported on this filesystem, falling back to rollback journal",
+			"path", dbPath, "error", err)
+		conn, err = openAndPing(ctx, dbPath, "DELETE")
+	}
+	if err != nil {
 		releaseLock()
-		return nil, fmt.Errorf("failed to connect to database: %w", err)
+		return nil, err
 	}
 
 	if err := initGoose(); err != nil {
@@ -236,6 +251,61 @@ func ConnectReadOnly(ctx context.Context, dbPath string) (*sql.DB, error) {
 	}
 
 	return db, nil
+}
+
+// errWALUnavailable signals that WAL was requested but the database
+// did not actually enter WAL mode. SQLite silently ignores a failed
+// journal_mode change (returning the current mode instead of an
+// error), so on filesystems that cannot support WAL we detect the
+// mismatch ourselves and treat it like a lock-protocol failure.
+var errWALUnavailable = errors.New("database did not enter WAL journal mode")
+
+// openAndPing opens the database with the given journal mode ("" for
+// the WAL default), serializes it to a single connection, verifies it
+// responds to a ping, and confirms the requested journal mode took
+// effect. On failure the connection is closed and a filesystem-hinting
+// error is returned.
+func openAndPing(ctx context.Context, dbPath, journalMode string) (*sql.DB, error) {
+	conn, err := openDB(dbPath, journalMode)
+	if err != nil {
+		return nil, err
+	}
+
+	// Serialize all access through a single connection. SQLite
+	// serializes writes at the file level anyway, and allowing multiple
+	// pool connections to interleave writes/checkpoints (especially
+	// under concurrent sub-agents) has caused WAL/header desync
+	// resulting in SQLITE_NOTADB (26) on the next open.
+	conn.SetMaxOpenConns(1)
+
+	if err := conn.PingContext(ctx); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to connect to database: %w", maybeLockHint(err))
+	}
+
+	// Confirm the journal mode actually applied. WAL silently falls
+	// back to the rollback journal on filesystems without shared-memory
+	// locking; catch that so Connect can retry cleanly.
+	want := strings.ToLower(pragmas(journalMode)["journal_mode"])
+	var got string
+	if err := conn.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&got); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("failed to connect to database: %w", maybeLockHint(err))
+	}
+	if want == "wal" && got != "wal" {
+		conn.Close()
+		return nil, fmt.Errorf("failed to connect to database: %w", maybeLockHint(errWALUnavailable))
+	}
+	return conn, nil
+}
+
+// maybeLockHint appends a filesystem hint to locking failures so users
+// on NFS/SMB understand the cause and the data_directory workaround.
+func maybeLockHint(err error) error {
+	if !errors.Is(err, errWALUnavailable) && !isLockProtocolError(err) {
+		return err
+	}
+	return fmt.Errorf("%w (the data directory may be on a network filesystem such as NFS or SMB that does not support SQLite locking; set options.data_directory to a local path)", err)
 }
 
 func initGoose() error {

--- a/internal/db/connect_modernc.go
+++ b/internal/db/connect_modernc.go
@@ -4,10 +4,11 @@ package db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/url"
 
-	_ "modernc.org/sqlite"
+	sqlite "modernc.org/sqlite"
 )
 
 func openDBReadOnly(dbPath string) (*sql.DB, error) {
@@ -25,11 +26,11 @@ func openDBReadOnly(dbPath string) (*sql.DB, error) {
 	return db, nil
 }
 
-func openDB(dbPath string) (*sql.DB, error) {
+func openDB(dbPath, journalMode string) (*sql.DB, error) {
 	// Set pragmas for better performance via _pragma query params.
 	// Format: _pragma=name(value)
 	params := url.Values{}
-	for name, value := range pragmas {
+	for name, value := range pragmas(journalMode) {
 		params.Add("_pragma", fmt.Sprintf("%s(%s)", name, value))
 	}
 	// Use BEGIN IMMEDIATE so writers acquire the reserved lock up front,
@@ -43,4 +44,15 @@ func openDB(dbPath string) (*sql.DB, error) {
 	}
 
 	return db, nil
+}
+
+// isLockProtocolError reports whether err is a SQLite lock-protocol or
+// lock I/O error, the signature of a filesystem (NFS, SMB, FUSE) that
+// cannot support WAL's shared-memory locking.
+func isLockProtocolError(err error) bool {
+	if sqliteErr, ok := errors.AsType[*sqlite.Error](err); ok {
+		code := sqliteErr.Code()
+		return code == sqliteProtocol || code == sqliteIOErrLock
+	}
+	return false
 }

--- a/internal/db/connect_ncruces.go
+++ b/internal/db/connect_ncruces.go
@@ -4,6 +4,7 @@ package db
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/ncruces/go-sqlite3"
@@ -20,7 +21,7 @@ func openDBReadOnly(dbPath string) (*sql.DB, error) {
 	return db, nil
 }
 
-func openDB(dbPath string) (*sql.DB, error) {
+func openDB(dbPath, journalMode string) (*sql.DB, error) {
 	// Use BEGIN IMMEDIATE so writers acquire the reserved lock up front,
 	// preventing deferred-to-writer upgrade deadlocks. The "file:" prefix
 	// is required for the ncruces driver to parse query parameters.
@@ -28,7 +29,7 @@ func openDB(dbPath string) (*sql.DB, error) {
 	db, err := driver.Open(dsn, func(c *sqlite3.Conn) error {
 		// Set pragmas for better performance via _pragma query params.
 		// Format: PRAGMA name = value;
-		for name, value := range pragmas {
+		for name, value := range pragmas(journalMode) {
 			if err := c.Exec(fmt.Sprintf("PRAGMA %s = %s;", name, value)); err != nil {
 				return fmt.Errorf("failed to set pragma %q: %w", name, err)
 			}
@@ -40,4 +41,15 @@ func openDB(dbPath string) (*sql.DB, error) {
 	}
 
 	return db, nil
+}
+
+// isLockProtocolError reports whether err is a SQLite lock-protocol or
+// lock I/O error, the signature of a filesystem (NFS, SMB, FUSE) that
+// cannot support WAL's shared-memory locking.
+func isLockProtocolError(err error) bool {
+	if sqliteErr, ok := errors.AsType[*sqlite3.Error](err); ok {
+		code := int(sqliteErr.Code())
+		return code == sqliteProtocol || code == sqliteIOErrLock
+	}
+	return false
 }

--- a/internal/db/journal_test.go
+++ b/internal/db/journal_test.go
@@ -1,0 +1,63 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPragmas_DefaultsToWAL(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "WAL", pragmas("")["journal_mode"])
+	require.Equal(t, "DELETE", pragmas("DELETE")["journal_mode"])
+	// The rest of the pragmas are independent of journal mode.
+	require.Equal(t, "ON", pragmas("")["foreign_keys"])
+	require.Equal(t, "ON", pragmas("DELETE")["foreign_keys"])
+}
+
+func TestConnect_UsesWALByDefault(t *testing.T) {
+	t.Cleanup(ResetPool)
+
+	dataDir := t.TempDir()
+	conn, err := Connect(context.Background(), dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { Release(dataDir) })
+
+	var mode string
+	require.NoError(t, conn.QueryRowContext(context.Background(), "PRAGMA journal_mode").Scan(&mode))
+	require.Equal(t, "wal", mode)
+}
+
+func TestIsLockProtocolError(t *testing.T) {
+	t.Parallel()
+
+	// A plain, non-SQLite error is never a lock-protocol error.
+	require.False(t, isLockProtocolError(errors.New("boom")))
+	require.False(t, isLockProtocolError(nil))
+
+	// A real SQLite error surfaced by the driver must be recognized so
+	// the WAL fallback and the filesystem hint engage.
+	db, err := openDB(filepath.Join(t.TempDir(), "x.db"), "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.ExecContext(context.Background(), "this is not sql")
+	require.Error(t, err)
+	require.False(t, isLockProtocolError(err), "a syntax error is not a lock-protocol error")
+}
+
+func TestMaybeLockHint(t *testing.T) {
+	t.Parallel()
+
+	plain := errors.New("boom")
+	require.Same(t, plain, maybeLockHint(plain), "non-lock errors pass through untouched")
+
+	// A WAL-unavailable error gets the filesystem hint appended while
+	// remaining matchable via errors.Is.
+	hinted := maybeLockHint(errWALUnavailable)
+	require.ErrorIs(t, hinted, errWALUnavailable)
+	require.Contains(t, hinted.Error(), "data_directory")
+}


### PR DESCRIPTION
Crush crashes at startup with `locking protocol (15)` whenever its data  <br>directory sits on a network filesystem such as NFS, SMB, or some FUSE  <br>mounts. WAL journal mode relies on shared-memory locking (the `-shm`  <br>mmap) that those filesystems do not provide, and Crush hard-codes  <br>`journal_mode=WAL`.

Closes charmbracelet/crush#3461. Related: [#473](<https://github.com/charmbracelet/crush/issues/473>), [#465](<https://github.com/charmbracelet/crush/issues/465>), charmbracelet/crush#2903.

## What this does

On connect, Crush now verifies that WAL actually took effect rather than  <br>assuming the pragma succeeded. SQLite fails in two ways on these mounts:  <br>it either returns `SQLITE_PROTOCOL` / `SQLITE_IOERR_LOCK` outright, or it  <br>silently ignores the journal-mode change and stays on the rollback  <br>journal. Both are detected, and Crush retries once with the rollback  <br>journal (`DELETE`), which only needs POSIX file locks.

Locking failures also get a one-line hint pointing at  <br>`options.data_directory` for users who would rather keep state on local  <br>storage than accept the fallback.

## Impact

* Local-disk users see no behavioral change; the fallback never engages  <br>when WAL works. The only addition is a single read-only  <br>`PRAGMA journal_mode` check at connect time, and connections are pooled  <br>so that runs once per process.
* Network-mount users get a working startup instead of a crash. The  <br>rollback journal is heavier on fsyncs than WAL, but Crush is already  <br>single-connection with immediate locking (`SetMaxOpenConns(1)`,  <br>`_txlock=immediate`), so the WAL concurrency advantage was not in play  <br>to begin with.

## Testing

Added `internal/db/journal_test.go` covering pragma defaults, WAL-by-default  <br>on a real connection, lock-error recognition, and the hint path. Full suite  <br>green, `golangci-lint` clean.