### PR TITLE
Extract accumulateStepCosts helper to remove duplicated logic

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1438,18 +1438,7 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		return err
 	}
 
-	var openrouterCost *float64
-	for _, step := range resp.Steps {
-		stepCost := a.openrouterCost(step.ProviderMetadata)
-		if stepCost != nil {
-			newCost := *stepCost
-			if openrouterCost != nil {
-				newCost += *openrouterCost
-			}
-			openrouterCost = &newCost
-		}
-		extractHyperCredits(step.ProviderMetadata)
-	}
+	openrouterCost := a.accumulateStepCosts(resp.Steps)
 
 	a.updateSessionUsage(largeModel, &currentSession, resp.TotalUsage, openrouterCost, false)
 
@@ -1832,18 +1821,7 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 	}
 
 	// Calculate usage and cost.
-	var openrouterCost *float64
-	for _, step := range resp.Steps {
-		stepCost := a.openrouterCost(step.ProviderMetadata)
-		if stepCost != nil {
-			newCost := *stepCost
-			if openrouterCost != nil {
-				newCost += *openrouterCost
-			}
-			openrouterCost = &newCost
-		}
-		extractHyperCredits(step.ProviderMetadata)
-	}
+	openrouterCost := a.accumulateStepCosts(resp.Steps)
 
 	modelConfig := model.CatwalkCfg
 	cost := modelConfig.CostPer1MInCached/1e6*float64(resp.TotalUsage.CacheCreationTokens) +
@@ -1872,6 +1850,25 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 		return
 	}
 	titleSaved = true
+}
+
+// accumulateStepCosts iterates over provider step metadata to accumulate
+// OpenRouter costs and extract Hyper credits. It returns the total OpenRouter
+// cost, or nil if none was reported.
+func (a *sessionAgent) accumulateStepCosts(steps []fantasy.StepResult) *float64 {
+	var total *float64
+	for _, step := range steps {
+		stepCost := a.openrouterCost(step.ProviderMetadata)
+		if stepCost != nil {
+			newCost := *stepCost
+			if total != nil {
+				newCost += *total
+			}
+			total = &newCost
+		}
+		extractHyperCredits(step.ProviderMetadata)
+	}
+	return total
 }
 
 func (a *sessionAgent) openrouterCost(metadata fantasy.ProviderMetadata) *float64 {


### PR DESCRIPTION
The Summarize and GenerateTitle methods both iterate over provider step
metadata to accumulate OpenRouter costs and extract Hyper credits using
identical 12-line loop blocks. This change extracts the shared logic into
a single accumulateStepCosts helper method.

The refactoring is purely mechanical: the extracted code is identical in
both call sites, and the new helper is placed directly above the existing
openrouterCost method that it depends on. No behavior, signatures, or
imports are changed. The diff is -3 lines net, and the helper is
self-contained with no side effects beyond those already present in the
original duplicated blocks.