### PR TITLE
fix(security): several codeql fixes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,11 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
 jobs:
   lint:
     uses: charmbracelet/meta/.github/workflows/lint.yml@main

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,6 +5,12 @@ on:
     - cron: "0 0 * * *" # every day at midnight
   workflow_dispatch: # allows manual triggering
 
+permissions:
+  contents: write
+  id-token: write
+  packages: write
+  actions: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ concurrency:
   group: goreleaser
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  id-token: write
+  packages: write
+
 jobs:
   goreleaser:
     uses: charmbracelet/meta/.github/workflows/goreleaser.yml@main

--- a/.github/workflows/schema-update.yml
+++ b/.github/workflows/schema-update.yml
@@ -8,6 +8,9 @@ on:
       - "internal/agent/hyper/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-schema:
     runs-on: ubuntu-latest

--- a/internal/agent/tools/edit.go
+++ b/internal/agent/tools/edit.go
@@ -115,11 +115,6 @@ func createNewFile(edit editContext, filePath, content string, call fantasy.Tool
 		return fantasy.ToolResponse{}, fmt.Errorf("failed to access file: %w", err)
 	}
 
-	dir := filepath.Dir(filePath)
-	if err = os.MkdirAll(dir, 0o755); err != nil {
-		return fantasy.ToolResponse{}, fmt.Errorf("failed to create parent directories: %w", err)
-	}
-
 	sessionID := GetSessionFromContext(edit.ctx)
 	if sessionID == "" {
 		return fantasy.ToolResponse{}, fmt.Errorf("session ID is required for creating a new file")
@@ -158,6 +153,10 @@ func createNewFile(edit editContext, filePath, content string, call fantasy.Tool
 			Removals:   removals,
 		})
 		return resp, nil
+	}
+
+	if err = os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+		return fantasy.ToolResponse{}, fmt.Errorf("failed to create parent directories: %w", err)
 	}
 
 	err = os.WriteFile(filePath, []byte(content), 0o644)

--- a/internal/agent/tools/multiedit.go
+++ b/internal/agent/tools/multiedit.go
@@ -159,12 +159,6 @@ func processMultiEditWithCreation(edit editContext, params MultiEditParams, call
 		return fantasy.ToolResponse{}, fmt.Errorf("failed to access file: %w", err)
 	}
 
-	// Create parent directories
-	dir := filepath.Dir(params.FilePath)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fantasy.ToolResponse{}, fmt.Errorf("failed to create parent directories: %w", err)
-	}
-
 	currentContent, failedEdits, whitespaceCorrected := applyEditsToContent(firstEdit.NewString, params.Edits[1:], 1)
 
 	// Get session and message IDs
@@ -213,6 +207,9 @@ func processMultiEditWithCreation(edit editContext, params MultiEditParams, call
 	}
 
 	// Write the file
+	if err := os.MkdirAll(filepath.Dir(params.FilePath), 0o755); err != nil {
+		return fantasy.ToolResponse{}, fmt.Errorf("failed to create parent directories: %w", err)
+	}
 	err = os.WriteFile(params.FilePath, []byte(currentContent), 0o644)
 	if err != nil {
 		return fantasy.ToolResponse{}, fmt.Errorf("failed to write file: %w", err)

--- a/internal/agent/tools/write.go
+++ b/internal/agent/tools/write.go
@@ -86,11 +86,6 @@ func NewWriteTool(
 				return fantasy.ToolResponse{}, fmt.Errorf("error checking file: %w", err)
 			}
 
-			dir := filepath.Dir(filePath)
-			if err = os.MkdirAll(dir, 0o755); err != nil {
-				return fantasy.ToolResponse{}, fmt.Errorf("error creating directory: %w", err)
-			}
-
 			oldContent := ""
 			if fileInfo != nil && !fileInfo.IsDir() {
 				oldBytes, readErr := os.ReadFile(filePath)
@@ -132,6 +127,10 @@ func NewWriteTool(
 					Removals:  removals,
 				})
 				return resp, nil
+			}
+
+			if err = os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
+				return fantasy.ToolResponse{}, fmt.Errorf("error creating directory: %w", err)
 			}
 
 			err = os.WriteFile(filePath, []byte(params.Content), 0o644)


### PR DESCRIPTION
The write, edit, and multiedit tools all called os.MkdirAll before showing the permission prompt, so a denied request still left empty directories behind. An agent could mkdir -p anywhere on the machine with no consent. Move MkdirAll to just before os.WriteFile, matching the ordering the download tool already uses.

Also added proper permission scoping on all the github workflows to avoid excessive permissions