### PR TITLE
feat: add Friendli provider reasoning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ That said, you can also set environment variables for preferred providers:
 | `SYNTHETIC_API_KEY`         | Synthetic                                          |
 | `HF_TOKEN`                  | Hugging Face Inference                             |
 | `CEREBRAS_API_KEY`          | Cerebras                                           |
-| `FRIENDLI_API_KEY`          | Friendli                                           |
+| `FRIENDLI_API_KEY`          | FriendliAI                                           |
 | `OPENROUTER_API_KEY`        | OpenRouter                                         |
 | `IONET_API_KEY`             | io.net                                             |
 | `ALIBABA_SINGAPORE_API_KEY` | Alibaba (Singapore)                                |

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ That said, you can also set environment variables for preferred providers:
 | `SYNTHETIC_API_KEY`         | Synthetic                                          |
 | `HF_TOKEN`                  | Hugging Face Inference                             |
 | `CEREBRAS_API_KEY`          | Cerebras                                           |
-| `FRIENDLI_API_KEY`          | FriendliAI                                           |
+| `FRIENDLI_API_KEY`          | Friendli                                           |
 | `OPENROUTER_API_KEY`        | OpenRouter                                         |
 | `IONET_API_KEY`             | io.net                                             |
 | `ALIBABA_SINGAPORE_API_KEY` | Alibaba (Singapore)                                |

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ That said, you can also set environment variables for preferred providers:
 | `SYNTHETIC_API_KEY`         | Synthetic                                          |
 | `HF_TOKEN`                  | Hugging Face Inference                             |
 | `CEREBRAS_API_KEY`          | Cerebras                                           |
+| `FRIENDLI_API_KEY`          | Friendli                                           |
 | `OPENROUTER_API_KEY`        | OpenRouter                                         |
 | `IONET_API_KEY`             | io.net                                             |
 | `ALIBABA_SINGAPORE_API_KEY` | Alibaba (Singapore)                                |

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -577,6 +577,13 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 			if model.CatwalkCfg.CanReason {
 				extraBody["enable_thinking"] = model.ModelCfg.Think || reasoningEffort != ""
 			}
+
+		case "friendli":
+			extraBody["parse_reasoning"] = true
+			extraBody["include_reasoning"] = true
+			extraBody["chat_template_kwargs"] = map[string]any{
+				"enable_thinking": model.ModelCfg.Think || reasoningEffort != "" && reasoningEffort != "none",
+			}
 		}
 
 		mergedOptions["extra_body"] = extraBody

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -517,6 +517,9 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 				if !strings.HasPrefix(strings.ToLower(model.CatwalkCfg.ID), "minimax") {
 					mergedOptions["reasoning_effort"] = reasoningEffort
 				}
+			case "friendli":
+				// Friendli does not accept reasoning_effort; it uses
+				// chat_template_kwargs.enable_thinking instead.
 			default:
 				mergedOptions["reasoning_effort"] = reasoningEffort
 			}


### PR DESCRIPTION
## What

Adds Friendli-specific reasoning handling to the openai-compat provider switch in `coordinator.go`, and adds `FRIENDLI_API_KEY` to the environment variables table in the README.

Friendli is being added to Catwalk in https://github.com/charmbracelet/catwalk/pull/486. This PR handles the Crush-side coordinator support.

## Why the separate case

Friendli's reasoning API works differently from the other openai-compat providers. Instead of `reasoning_effort` or `thinking.type`, it uses:

- `chat_template_kwargs.enable_thinking` to toggle reasoning on controllable models
- `parse_reasoning` to split reasoning into a separate `reasoning_content` field
- `include_reasoning` to include reasoning content in the response

Without this case, reasoning content would stay inline in the `content` field, making it harder for Crush to distinguish between thinking and answer text.

## Note

The provider ID is referenced as a string literal (`"friendli"`) rather than `catwalk.InferenceProviderFriendli` because the Catwalk version in `go.mod` predates that constant. Once Catwalk is bumped, this can be switched to the typed constant.