### PR TITLE
docs: add missing OAuth flags to mcp add in crush-config skill

### DIFF
--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -118,7 +118,8 @@ mcp remove <name>                              # alias: rm
 Flags: `--command CMD`, `--args ARG` (repeatable), `--env KEY VALUE`
 (repeatable), `--url URL`, `--header KEY VALUE` (repeatable), `--timeout N`,
 `--disabled BOOL`, `--disabled-tools TOOL` (repeatable), `--enabled-tools TOOL`
-(repeatable).
+(repeatable), `--oauth BOOL`, `--oauth-client-id ID`, `--oauth-client-secret SECRET`,
+`--oauth-callback-port PORT`.
 
 ```bash
 mcp add github --type http \


### PR DESCRIPTION
The `mcp add` command supports OAuth configuration via several flags, but these were missing from the `crush-config` skill documentation. This update adds `--oauth`, `--oauth-client-id`,
`--oauth-client-secret`, and `--oauth-callback-port` to the flags list.

Refs:
- https://github.com/charmbracelet/crush/issues/3473

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
