### PR TITLE
fix(hooks): send hook_event_name so Claude Code hooks can tell events apart

### DIFF
--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"strings"
 	"sync"
@@ -220,6 +221,20 @@ func TestBuildPayload(t *testing.T) {
 	require.Contains(t, s, `"tool_name":"bash"`)
 	// tool_input should be an object, not a string.
 	require.Contains(t, s, `"tool_input":{"command":"ls"}`)
+}
+
+// A Claude Code hook is one command that receives every event and tells them
+// apart by hook_event_name, so a payload without that key sends a shared hook
+// down its default branch and it does nothing. Nothing errors and nothing is
+// logged, which is the worst shape for a hook whose job is refusing a call.
+func TestBuildPayloadCarriesClaudeCodeEventKey(t *testing.T) {
+	t.Parallel()
+	payload := BuildPayload(EventPreToolUse, "sess-1", "/work", "bash", `{"command":"ls"}`)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(payload, &decoded))
+	require.Equal(t, EventPreToolUse, decoded["hook_event_name"])
+	require.Equal(t, EventPreToolUse, decoded["event"])
 }
 
 func TestRunnerExitCode0Allow(t *testing.T) {

--- a/internal/hooks/input.go
+++ b/internal/hooks/input.go
@@ -19,13 +19,17 @@ const SupportedOutputVersion = 1
 // Payload is the JSON structure piped to hook commands via stdin.
 // ToolInput is emitted as a parsed JSON object for compatibility with
 // Claude Code hooks (which expect tool_input to be an object, not a
-// string).
+// string). The event name is emitted twice for the same reason: a Claude
+// Code hook is a single command wired to every event and reads
+// hook_event_name to tell them apart, so without that key it takes its
+// default branch and silently does nothing.
 type Payload struct {
-	Event     string          `json:"event"`
-	SessionID string          `json:"session_id"`
-	CWD       string          `json:"cwd"`
-	ToolName  string          `json:"tool_name"`
-	ToolInput json.RawMessage `json:"tool_input"`
+	Event         string          `json:"event"`
+	HookEventName string          `json:"hook_event_name"`
+	SessionID     string          `json:"session_id"`
+	CWD           string          `json:"cwd"`
+	ToolName      string          `json:"tool_name"`
+	ToolInput     json.RawMessage `json:"tool_input"`
 }
 
 // BuildPayload constructs the JSON stdin payload for a hook command.
@@ -35,11 +39,12 @@ func BuildPayload(eventName, sessionID, cwd, toolName, toolInputJSON string) []b
 		toolInput = json.RawMessage("{}")
 	}
 	p := Payload{
-		Event:     eventName,
-		SessionID: sessionID,
-		CWD:       cwd,
-		ToolName:  toolName,
-		ToolInput: toolInput,
+		Event:         eventName,
+		HookEventName: eventName,
+		SessionID:     sessionID,
+		CWD:           cwd,
+		ToolName:      toolName,
+		ToolInput:     toolInput,
 	}
 	data, err := json.Marshal(p)
 	if err != nil {


### PR DESCRIPTION
## What

`BuildPayload` names the event `event`. Claude Code names the same field `hook_event_name`. A Claude Code hook is a single command wired to every event and branches on that key, so under Crush it falls through to its default branch and does nothing. Nothing errors and nothing is logged.

The payload already emits `tool_input` as an object for Claude Code compatibility, and `parseStdout` already understands `hookSpecificOutput`, and the runner already honours exit code 2. The greeting is the one part of the contract that is still Crush-only.

## Reproduction

A third-party Claude Code `PreToolUse` guard, same repo, same command (`git push --force origin main`), fed the payload Crush sends today:

```
events recorded: 0
```

Same guard, same command, with `hook_event_name` present:

```
events recorded: 2   (CHECK_FAIL, STOP)
```

## Change

The event name is emitted under both keys. `event` is untouched, so hooks written for Crush are unaffected.

## Verification

- `go test ./internal/hooks/...` passes; the new test fails without the change (`expected: "PreToolUse", actual: <nil>`)
- `gofmt -l internal/hooks/` clean
- `go vet ./internal/hooks/...` clean

## AI disclosure

Written with AI assistance. I understand the change, can debug it independently, and can discuss it without AI help.
