### PR TITLE
Bugfix: Preserve replayed message whitespace and queued follow-up prompts

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -423,6 +423,36 @@ func (a *sessionAgent) drainQueueForStep(sessionID string) (fold, canceledWithRu
 	return fold, canceledWithRunID
 }
 
+type foldedPromptInsertion struct {
+	index    int
+	messages []fantasy.Message
+}
+
+// applyFoldedPromptInsertions restores queued prompts that PrepareStep added
+// during an earlier autonomous step. Fantasy rebuilds each step from its
+// original prompt plus model/tool responses, so PrepareStep-only additions
+// otherwise disappear on the following step and invalidate the prompt prefix.
+func applyFoldedPromptInsertions(messages []fantasy.Message, insertions []foldedPromptInsertion) []fantasy.Message {
+	if len(insertions) == 0 {
+		return messages
+	}
+
+	extra := 0
+	for _, insertion := range insertions {
+		extra += len(insertion.messages)
+	}
+	result := make([]fantasy.Message, 0, len(messages)+extra)
+	start := 0
+	for _, insertion := range insertions {
+		index := min(max(insertion.index, start), len(messages))
+		result = append(result, messages[start:index]...)
+		result = append(result, insertion.messages...)
+		start = index
+	}
+	result = append(result, messages[start:]...)
+	return result
+}
+
 // publishCanceledQueueDrops emits a terminal cancelled RunComplete for
 // every dropped queued call that carries a RunID. A queued prompt removed
 // from the queue without ever running — covered by a pending cancel, or
@@ -786,6 +816,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	a.eventPromptSent(call.SessionID)
 
 	var stepMessages []fantasy.Message
+	var foldedPromptInsertions []foldedPromptInsertion
 	var shouldSummarize bool
 	sanitizedToolCalls := make(map[string]bool)
 	// Don't send MaxOutputTokens if 0 — some providers (e.g. LM Studio) reject it
@@ -806,11 +837,6 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		TopK:             call.TopK,
 		FrequencyPenalty: call.FrequencyPenalty,
 		PrepareStep: func(callContext context.Context, options fantasy.PrepareStepFunctionOptions) (_ context.Context, prepared fantasy.PrepareStepResult, err error) {
-			prepared.Messages = options.Messages
-			for i := range prepared.Messages {
-				prepared.Messages[i].ProviderOptions = nil
-			}
-
 			// Use latest tools (updated by SetTools when MCP tools change).
 			prepared.Tools = a.tools.Copy()
 
@@ -827,12 +853,24 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			// RunComplete) via the recursive run path below.
 			fold, canceledRunIDs := a.drainQueueForStep(call.SessionID)
 			a.publishCanceledQueueDrops(canceledRunIDs)
+			var foldedMessages []fantasy.Message
 			for _, queued := range fold {
 				userMessage, createErr := a.createUserMessage(callContext, queued)
 				if createErr != nil {
 					return callContext, prepared, createErr
 				}
-				prepared.Messages = append(prepared.Messages, userMessage.ToAIMessage()...)
+				foldedMessages = append(foldedMessages, userMessage.ToAIMessage()...)
+			}
+			if len(foldedMessages) > 0 {
+				foldedPromptInsertions = append(foldedPromptInsertions, foldedPromptInsertion{
+					index:    len(options.Messages),
+					messages: foldedMessages,
+				})
+			}
+
+			prepared.Messages = applyFoldedPromptInsertions(options.Messages, foldedPromptInsertions)
+			for i := range prepared.Messages {
+				prepared.Messages[i].ProviderOptions = nil
 			}
 
 			prepared.Messages = a.workaroundProviderMediaLimitations(prepared.Messages, largeModel)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -906,13 +906,6 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			return a.messages.Update(genCtx, *currentAssistant)
 		},
 		OnTextDelta: func(id string, text string) error {
-			// Strip leading newline from initial text content. This is is
-			// particularly important in non-interactive mode where leading
-			// newlines are very visible.
-			if len(currentAssistant.Parts) == 0 {
-				text = strings.TrimPrefix(text, "\n")
-			}
-
 			currentAssistant.AppendContent(text)
 			return a.messages.Update(genCtx, *currentAssistant)
 		},

--- a/internal/agent/context_replay_test.go
+++ b/internal/agent/context_replay_test.go
@@ -1,0 +1,357 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"charm.land/fantasy"
+	"charm.land/fantasy/providers/openaicompat"
+	"github.com/stretchr/testify/require"
+)
+
+type replayProbeModel struct {
+	mu            sync.Mutex
+	calls         []fantasy.Call
+	secondEntered chan struct{}
+	releaseSecond chan struct{}
+}
+
+func (m *replayProbeModel) Provider() string { return "fake" }
+func (m *replayProbeModel) Model() string    { return "replay-probe" }
+
+func (m *replayProbeModel) Generate(context.Context, fantasy.Call) (*fantasy.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *replayProbeModel) Stream(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+	m.mu.Lock()
+	callNumber := len(m.calls)
+	call.Prompt = cloneFantasyMessages([]fantasy.Message(call.Prompt))
+	m.calls = append(m.calls, call)
+	m.mu.Unlock()
+	if callNumber == 1 && m.secondEntered != nil {
+		close(m.secondEntered)
+		<-m.releaseSecond
+	}
+
+	return func(yield func(fantasy.StreamPart) bool) {
+		switch callNumber {
+		case 0:
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeReasoningStart, ID: "reasoning-1", Delta: "Thinking.\n"})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeReasoningEnd, ID: "reasoning-1"})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "text-1"})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "text-1", Delta: "Working on it.\n\n"})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "text-1"})
+			yield(fantasy.StreamPart{
+				Type:          fantasy.StreamPartTypeToolCall,
+				ID:            "call-1",
+				ToolCallName:  "echo",
+				ToolCallInput: `{"message":"hello"}`,
+			})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonToolCalls})
+		case 1:
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "text-2"})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "text-2", Delta: "\nFinal answer.\n\n"})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "text-2"})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop})
+		default:
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "text-3"})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "text-3", Delta: "continued"})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "text-3"})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop})
+		}
+	}, nil
+}
+
+func (m *replayProbeModel) GenerateObject(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *replayProbeModel) StreamObject(context.Context, fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *replayProbeModel) recordedCalls() []fantasy.Call {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	calls := make([]fantasy.Call, len(m.calls))
+	for i, call := range m.calls {
+		calls[i] = call
+		calls[i].Prompt = cloneFantasyMessages(call.Prompt)
+	}
+	return calls
+}
+
+type longReplayProbeModel struct {
+	mu        sync.Mutex
+	calls     []fantasy.Call
+	toolSteps int
+}
+
+func (m *longReplayProbeModel) Provider() string { return "fake" }
+func (m *longReplayProbeModel) Model() string    { return "long-replay-probe" }
+
+func (m *longReplayProbeModel) Generate(context.Context, fantasy.Call) (*fantasy.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *longReplayProbeModel) Stream(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+	m.mu.Lock()
+	callNumber := len(m.calls)
+	call.Prompt = cloneFantasyMessages([]fantasy.Message(call.Prompt))
+	m.calls = append(m.calls, call)
+	m.mu.Unlock()
+
+	return func(yield func(fantasy.StreamPart) bool) {
+		if callNumber < m.toolSteps {
+			padding := strings.Repeat(fmt.Sprintf("step-%02d payload ", callNumber), 160)
+			yield(fantasy.StreamPart{
+				Type:  fantasy.StreamPartTypeReasoningStart,
+				ID:    fmt.Sprintf("reasoning-%02d", callNumber),
+				Delta: fmt.Sprintf("Reasoning step %02d.\n%s\n", callNumber, padding),
+			})
+			yield(fantasy.StreamPart{
+				Type: fantasy.StreamPartTypeReasoningEnd,
+				ID:   fmt.Sprintf("reasoning-%02d", callNumber),
+			})
+			if callNumber%3 != 2 {
+				yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: fmt.Sprintf("text-%02d", callNumber)})
+				yield(fantasy.StreamPart{
+					Type:  fantasy.StreamPartTypeTextDelta,
+					ID:    fmt.Sprintf("text-%02d", callNumber),
+					Delta: fmt.Sprintf("\nProgress step %02d.\n%s\n\n", callNumber, padding),
+				})
+				yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: fmt.Sprintf("text-%02d", callNumber)})
+			}
+			for toolIndex := range 2 {
+				yield(fantasy.StreamPart{
+					Type:          fantasy.StreamPartTypeToolCall,
+					ID:            fmt.Sprintf("call-%02d-%d", callNumber, toolIndex),
+					ToolCallName:  "echo",
+					ToolCallInput: fmt.Sprintf(`{"message":"tool step %02d result %d"}`, callNumber, toolIndex),
+				})
+			}
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonToolCalls})
+			return
+		}
+
+		if callNumber == m.toolSteps {
+			yield(fantasy.StreamPart{
+				Type:  fantasy.StreamPartTypeReasoningStart,
+				ID:    "terminal-reasoning",
+				Delta: "The long tool loop is complete.\n",
+			})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeReasoningEnd, ID: "terminal-reasoning"})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "terminal-text"})
+			yield(fantasy.StreamPart{
+				Type:  fantasy.StreamPartTypeTextDelta,
+				ID:    "terminal-text",
+				Delta: "\nStopped with a progress report.\n\n",
+			})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "terminal-text"})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop})
+			return
+		}
+
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "continued-text"})
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "continued-text", Delta: "Continuing."})
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "continued-text"})
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop})
+	}, nil
+}
+
+func (m *longReplayProbeModel) GenerateObject(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *longReplayProbeModel) StreamObject(context.Context, fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *longReplayProbeModel) recordedCalls() []fantasy.Call {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	calls := make([]fantasy.Call, len(m.calls))
+	for i, call := range m.calls {
+		calls[i] = call
+		calls[i].Prompt = cloneFantasyMessages(call.Prompt)
+	}
+	return calls
+}
+
+func openAICompatMessages(t *testing.T, prompt fantasy.Prompt) []json.RawMessage {
+	t.Helper()
+
+	messages, warnings := openaicompat.ToPromptFunc(prompt, "", "")
+	require.Empty(t, warnings)
+	result := make([]json.RawMessage, len(messages))
+	for i, msg := range messages {
+		data, err := json.Marshal(msg)
+		require.NoError(t, err)
+		result[i] = data
+	}
+	return result
+}
+
+func withoutProviderOptions(messages []fantasy.Message) []fantasy.Message {
+	messages = cloneFantasyMessages(messages)
+	for i := range messages {
+		messages[i].ProviderOptions = nil
+		for j, part := range messages[i].Content {
+			switch part := part.(type) {
+			case fantasy.TextPart:
+				part.ProviderOptions = nil
+				messages[i].Content[j] = part
+			case fantasy.ReasoningPart:
+				part.ProviderOptions = nil
+				messages[i].Content[j] = part
+			case fantasy.ToolCallPart:
+				part.ProviderOptions = nil
+				messages[i].Content[j] = part
+			case fantasy.ToolResultPart:
+				part.ProviderOptions = nil
+				messages[i].Content[j] = part
+			}
+		}
+	}
+	return messages
+}
+
+func TestRun_ReplaysPersistedHistoryWithoutChangingPromptPrefix(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	model := &replayProbeModel{
+		secondEntered: make(chan struct{}),
+		releaseSecond: make(chan struct{}),
+	}
+	small := &finishStreamModel{text: "title"}
+	echo := fantasy.NewAgentTool(
+		"echo",
+		"Echo the input.",
+		func(_ context.Context, input struct {
+			Message string `json:"message"`
+		}, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			return fantasy.NewTextResponse("Echo: " + input.Message), nil
+		},
+	)
+	agent := testSessionAgent(env, model, small, "system", echo)
+
+	sess, err := env.sessions.Create(t.Context(), "session")
+	require.NoError(t, err)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, runErr := agent.Run(t.Context(), SessionAgentCall{
+			SessionID: sess.ID,
+			RunID:     "first-run",
+			Prompt:    "  first turn\n\n",
+		})
+		firstDone <- runErr
+	}()
+
+	select {
+	case <-model.secondEntered:
+	case <-t.Context().Done():
+		t.Fatal("second autonomous step did not start")
+	}
+
+	_, err = agent.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		RunID:     "second-run",
+		Prompt:    "second turn",
+	})
+	require.NoError(t, err)
+	close(model.releaseSecond)
+	require.NoError(t, <-firstDone)
+
+	calls := model.recordedCalls()
+	require.Len(t, calls, 3)
+
+	replayedPrompt := withoutProviderOptions(calls[2].Prompt)
+
+	inMemoryWirePrefix := openAICompatMessages(t, calls[1].Prompt)
+	replayedWirePrompt := openAICompatMessages(t, calls[2].Prompt)
+	require.Greater(t, len(replayedWirePrompt), len(inMemoryWirePrefix))
+	require.Equal(t, inMemoryWirePrefix, replayedWirePrompt[:len(inMemoryWirePrefix)])
+	require.Equal(t, calls[1].Tools, calls[2].Tools)
+
+	var foundFinalAnswer bool
+	for _, msg := range replayedPrompt {
+		if msg.Role != fantasy.MessageRoleAssistant {
+			continue
+		}
+		for _, part := range msg.Content {
+			text, ok := part.(fantasy.TextPart)
+			if ok && text.Text == "\nFinal answer.\n\n" {
+				foundFinalAnswer = true
+			}
+		}
+	}
+	require.True(t, foundFinalAnswer)
+}
+
+func TestRun_ReplaysLongOpenAIHistoryWithoutChangingWirePrefix(t *testing.T) {
+	t.Parallel()
+
+	const toolSteps = 12
+
+	env := testEnv(t)
+	model := &longReplayProbeModel{toolSteps: toolSteps}
+	small := &finishStreamModel{text: "title"}
+	echo := fantasy.NewAgentTool(
+		"echo",
+		"Echo the input.",
+		func(_ context.Context, input struct {
+			Message string `json:"message"`
+		}, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			response := fantasy.NewTextResponse("Echo: " + input.Message)
+			return fantasy.WithResponseMetadata(response, map[string]string{"source": input.Message}), nil
+		},
+	)
+	agent := testSessionAgent(env, model, small, "system", echo)
+
+	sess, err := env.sessions.Create(t.Context(), "session")
+	require.NoError(t, err)
+
+	_, err = agent.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		RunID:     "long-run",
+		Prompt:    "work through the long task",
+	})
+	require.NoError(t, err)
+
+	_, err = agent.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		RunID:     "continue-run",
+		Prompt:    "please continue",
+	})
+	require.NoError(t, err)
+
+	calls := model.recordedCalls()
+	require.Len(t, calls, toolSteps+2)
+
+	inMemoryPrompt := withoutProviderOptions(calls[toolSteps].Prompt)
+	replayedPrompt := withoutProviderOptions(calls[toolSteps+1].Prompt)
+	require.Greater(t, len(replayedPrompt), len(inMemoryPrompt))
+
+	inMemoryWirePrefix := openAICompatMessages(t, calls[toolSteps].Prompt)
+	replayedWirePrompt := openAICompatMessages(t, calls[toolSteps+1].Prompt)
+	require.Greater(t, len(replayedWirePrompt), len(inMemoryWirePrefix))
+	require.Greater(t, len(inMemoryWirePrefix), toolSteps*3)
+	require.Equal(t, inMemoryWirePrefix, replayedWirePrompt[:len(inMemoryWirePrefix)])
+	require.Equal(t, calls[toolSteps].Tools, calls[toolSteps+1].Tools)
+
+	var wireBytes int
+	for _, msg := range inMemoryWirePrefix {
+		wireBytes += len(msg)
+	}
+	require.Greater(t, wireBytes, 50_000)
+}

--- a/internal/agent/context_replay_test.go
+++ b/internal/agent/context_replay_test.go
@@ -238,7 +238,8 @@ func TestRun_ReplaysPersistedHistoryWithoutChangingPromptPrefix(t *testing.T) {
 		"Echo the input.",
 		func(_ context.Context, input struct {
 			Message string `json:"message"`
-		}, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+		}, _ fantasy.ToolCall,
+		) (fantasy.ToolResponse, error) {
 			return fantasy.NewTextResponse("Echo: " + input.Message), nil
 		},
 	)
@@ -311,7 +312,8 @@ func TestRun_ReplaysLongOpenAIHistoryWithoutChangingWirePrefix(t *testing.T) {
 		"Echo the input.",
 		func(_ context.Context, input struct {
 			Message string `json:"message"`
-		}, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+		}, _ fantasy.ToolCall,
+		) (fantasy.ToolResponse, error) {
 			response := fantasy.NewTextResponse("Echo: " + input.Message)
 			return fantasy.WithResponseMetadata(response, map[string]string{"source": input.Message}), nil
 		},

--- a/internal/agent/folded_prompt_test.go
+++ b/internal/agent/folded_prompt_test.go
@@ -91,7 +91,8 @@ func TestRun_PreservesFoldedQueuedPromptAcrossAutonomousSteps(t *testing.T) {
 		"Echo the input.",
 		func(_ context.Context, input struct {
 			Message string `json:"message"`
-		}, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+		}, _ fantasy.ToolCall,
+		) (fantasy.ToolResponse, error) {
 			return fantasy.NewTextResponse("Echo: " + input.Message), nil
 		},
 	)

--- a/internal/agent/folded_prompt_test.go
+++ b/internal/agent/folded_prompt_test.go
@@ -1,0 +1,143 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/require"
+)
+
+type foldedPromptProbeModel struct {
+	mu            sync.Mutex
+	calls         []fantasy.Call
+	secondEntered chan struct{}
+	releaseSecond chan struct{}
+}
+
+func (m *foldedPromptProbeModel) Provider() string { return "fake" }
+func (m *foldedPromptProbeModel) Model() string    { return "folded-prompt-probe" }
+
+func (m *foldedPromptProbeModel) Generate(context.Context, fantasy.Call) (*fantasy.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *foldedPromptProbeModel) Stream(_ context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+	m.mu.Lock()
+	callNumber := len(m.calls)
+	call.Prompt = cloneFantasyMessages([]fantasy.Message(call.Prompt))
+	m.calls = append(m.calls, call)
+	m.mu.Unlock()
+
+	if callNumber == 1 {
+		close(m.secondEntered)
+		<-m.releaseSecond
+	}
+
+	return func(yield func(fantasy.StreamPart) bool) {
+		if callNumber < 3 {
+			yield(fantasy.StreamPart{
+				Type:          fantasy.StreamPartTypeToolCall,
+				ID:            fmt.Sprintf("folded-call-%d", callNumber),
+				ToolCallName:  "echo",
+				ToolCallInput: fmt.Sprintf(`{"message":"folded step %d"}`, callNumber),
+			})
+			yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonToolCalls})
+			return
+		}
+
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "folded-final"})
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "folded-final", Delta: "Finished."})
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "folded-final"})
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop})
+	}, nil
+}
+
+func (m *foldedPromptProbeModel) GenerateObject(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *foldedPromptProbeModel) StreamObject(context.Context, fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *foldedPromptProbeModel) recordedCalls() []fantasy.Call {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	calls := make([]fantasy.Call, len(m.calls))
+	for i, call := range m.calls {
+		calls[i] = call
+		calls[i].Prompt = cloneFantasyMessages(call.Prompt)
+	}
+	return calls
+}
+
+func TestRun_PreservesFoldedQueuedPromptAcrossAutonomousSteps(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	model := &foldedPromptProbeModel{
+		secondEntered: make(chan struct{}),
+		releaseSecond: make(chan struct{}),
+	}
+	small := &finishStreamModel{text: "title"}
+	echo := fantasy.NewAgentTool(
+		"echo",
+		"Echo the input.",
+		func(_ context.Context, input struct {
+			Message string `json:"message"`
+		}, _ fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			return fantasy.NewTextResponse("Echo: " + input.Message), nil
+		},
+	)
+	agent := testSessionAgent(env, model, small, "system", echo)
+
+	sess, err := env.sessions.Create(t.Context(), "session")
+	require.NoError(t, err)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, runErr := agent.Run(t.Context(), SessionAgentCall{
+			SessionID: sess.ID,
+			Prompt:    "initial task",
+		})
+		firstDone <- runErr
+	}()
+
+	select {
+	case <-model.secondEntered:
+	case <-t.Context().Done():
+		t.Fatal("second autonomous step did not start")
+	}
+
+	const queuedPrompt = "Please pause and report progress."
+	_, err = agent.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		Prompt:    queuedPrompt,
+	})
+	require.NoError(t, err)
+	close(model.releaseSecond)
+	require.NoError(t, <-firstDone)
+
+	calls := model.recordedCalls()
+	require.Len(t, calls, 4)
+
+	foldedWirePrompt := openAICompatMessages(t, calls[2].Prompt)
+	nextWirePrompt := openAICompatMessages(t, calls[3].Prompt)
+	require.Greater(t, len(nextWirePrompt), len(foldedWirePrompt))
+	require.Equal(t, foldedWirePrompt, nextWirePrompt[:len(foldedWirePrompt)])
+
+	queuedMessage := foldedWirePrompt[len(foldedWirePrompt)-1]
+	var decoded struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	require.NoError(t, json.Unmarshal(queuedMessage, &decoded))
+	require.Equal(t, "user", decoded.Role)
+	require.Equal(t, queuedPrompt, decoded.Content)
+}

--- a/internal/message/content.go
+++ b/internal/message/content.go
@@ -534,7 +534,7 @@ func (m *Message) ToAIMessage() []fantasy.Message {
 	switch m.Role {
 	case User:
 		var parts []fantasy.MessagePart
-		text := strings.TrimSpace(m.Content().Text)
+		text := m.Content().Text
 		var textAttachments []Attachment
 		for _, content := range m.BinaryContent() {
 			if !strings.HasPrefix(content.MIMEType, "text/") {
@@ -576,7 +576,7 @@ func (m *Message) ToAIMessage() []fantasy.Message {
 		})
 	case Assistant:
 		var parts []fantasy.MessagePart
-		text := strings.TrimSpace(m.Content().Text)
+		text := m.Content().Text
 		if text != "" {
 			parts = append(parts, fantasy.TextPart{Text: text})
 		}

--- a/internal/message/content_test.go
+++ b/internal/message/content_test.go
@@ -116,6 +116,61 @@ func TestToAIMessage_ASCIIButInvalidBase64(t *testing.T) {
 	require.Equal(t, mediaLoadFailedPlaceholder, textContent.Text)
 }
 
+func TestToAIMessage_PreservesUserWhitespace(t *testing.T) {
+	t.Parallel()
+
+	msg := &Message{
+		Role: User,
+		Parts: []ContentPart{
+			TextContent{Text: "  keep user whitespace\n\n"},
+		},
+	}
+
+	messages := msg.ToAIMessage()
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].Content, 1)
+
+	text, ok := messages[0].Content[0].(fantasy.TextPart)
+	require.True(t, ok)
+	require.Equal(t, "  keep user whitespace\n\n", text.Text)
+}
+
+func TestToAIMessage_PreservesWhitespaceOnlyUserContent(t *testing.T) {
+	t.Parallel()
+
+	msg := &Message{
+		Role: User,
+		Parts: []ContentPart{
+			TextContent{Text: " \n\n"},
+		},
+	}
+
+	messages := msg.ToAIMessage()
+	require.Len(t, messages, 1)
+	require.Equal(t, []fantasy.MessagePart{
+		fantasy.TextPart{Text: " \n\n"},
+	}, messages[0].Content)
+}
+
+func TestToAIMessage_PreservesAssistantWhitespace(t *testing.T) {
+	t.Parallel()
+
+	msg := &Message{
+		Role: Assistant,
+		Parts: []ContentPart{
+			TextContent{Text: "\nProgress update:\n\n"},
+		},
+	}
+
+	messages := msg.ToAIMessage()
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].Content, 1)
+
+	text, ok := messages[0].Content[0].(fantasy.TextPart)
+	require.True(t, ok)
+	require.Equal(t, "\nProgress update:\n\n", text.Text)
+}
+
 func BenchmarkPromptWithTextAttachments(b *testing.B) {
 	cases := []struct {
 		name        string


### PR DESCRIPTION
Issue description:
 - I have noticed that the prompt cache was often missed with crush after a turn or queued user message. Especially if you write a user message while the agent is running and the message is queued, later on, the session will revert back the previous user message's prompt cache prefix and do prompt processing again without utilising the cache. The impact is for local AI (llama-server) often very long prompt processing and for cloud providers increased cost due to expensive read cache misses. Debugging into the issue I found two root causes (see below).

Disclaimer: The analysis/coding was mostly carried out by AI tooling; I reviewed the final change and test coverage and guided the analysis.

 This fixes two session-continuity issues:
  - Preserve user and assistant whitespace when rebuilding persisted conversation history, keeping later prompts byte-for-byte consistent with the original context for prompt-cache reuse.
  - Retain queued follow-up prompts across autonomous tool-use steps so they are not lost when the model advances to another step.

  Tests cover whitespace round-tripping, short and long history replay, and queued prompts during autonomous runs. Of the six new tests, five pertain to the smaller whitespace fix and one pertains to the larger queued follow-up prompt fix. I have tested the fix locally with llama-server and the prompt cache works much more reliable now (no more misses during active sessions).

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
 
