### PR TITLE
fix(hyper): keep working cache when provider cache can't be written

### DIFF
--- a/internal/config/catwalk.go
+++ b/internal/config/catwalk.go
@@ -67,7 +67,10 @@ func (s *catwalkSync) Get(ctx context.Context) ([]catwalk.Provider, error) {
 			return
 		}
 		if err != nil {
-			// On error, fall back to cached (which defaults to embedded if empty).
+			// Fall back to cached (which defaults to embedded if empty).
+			// Being offline is routine and the fallback is sound, so this
+			// is logged rather than reported to the caller.
+			slog.Warn("Could not fetch providers from Catwalk", "error", err)
 			s.result = cached
 			return
 		}

--- a/internal/config/catwalk.go
+++ b/internal/config/catwalk.go
@@ -20,6 +20,7 @@ var _ syncer[[]catwalk.Provider] = (*catwalkSync)(nil)
 type catwalkSync struct {
 	once       sync.Once
 	result     []catwalk.Provider
+	err        error
 	cache      cache[[]catwalk.Provider]
 	client     catwalkClient
 	autoupdate bool
@@ -38,7 +39,8 @@ func (s *catwalkSync) Get(ctx context.Context) ([]catwalk.Provider, error) {
 		panic("called Get before Init")
 	}
 
-	var throwErr error
+	// The result and the error are memoized together so that every caller
+	// sees the same outcome, not just the one that won the once.
 	s.once.Do(func() {
 		if !s.autoupdate {
 			slog.Info("Using embedded Catwalk providers")
@@ -71,12 +73,15 @@ func (s *catwalkSync) Get(ctx context.Context) ([]catwalk.Provider, error) {
 		}
 		if len(result) == 0 {
 			s.result = cached
-			throwErr = errors.New("empty providers list from catwalk")
+			s.err = errors.New("empty providers list from catwalk")
 			return
 		}
 
+		// The catalog is usable from here on. A cache write failure only
+		// costs the next run a refresh, so it is reported alongside a valid
+		// result rather than in place of one.
 		s.result = result
-		throwErr = s.cache.Store(result)
+		s.err = s.cache.Store(result)
 	})
-	return s.result, throwErr
+	return s.result, s.err
 }

--- a/internal/config/hyper.go
+++ b/internal/config/hyper.go
@@ -25,6 +25,7 @@ var _ syncer[catwalk.Provider] = (*hyperSync)(nil)
 type hyperSync struct {
 	once       sync.Once
 	result     catwalk.Provider
+	err        error
 	cache      cache[catwalk.Provider]
 	client     hyperClient
 	autoupdate bool
@@ -43,7 +44,8 @@ func (s *hyperSync) Get(ctx context.Context) (catwalk.Provider, error) {
 		panic("called Get before Init")
 	}
 
-	var throwErr error
+	// The result and the error are memoized together so that every caller
+	// sees the same outcome, not just the one that won the once.
 	s.once.Do(func() {
 		if !s.autoupdate {
 			slog.Info("Using embedded Hyper provider")
@@ -69,16 +71,24 @@ func (s *hyperSync) Get(ctx context.Context) (catwalk.Provider, error) {
 			s.result = cached
 			return
 		}
+		if err != nil {
+			slog.Warn("Could not fetch the Hyper provider", "error", err)
+			s.result = cached
+			return
+		}
 		if len(result.Models) == 0 {
 			slog.Warn("Hyper did not return any models")
 			s.result = cached
 			return
 		}
 
+		// The provider is usable from here on. A cache write failure only
+		// costs the next run a refresh, so it is reported alongside a valid
+		// result rather than in place of one.
 		s.result = result
-		throwErr = s.cache.Store(result)
+		s.err = s.cache.Store(result)
 	})
-	return s.result, throwErr
+	return s.result, s.err
 }
 
 var _ hyperClient = realHyperClient{}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -100,10 +100,16 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 		assignIfNil(&cfg.Options.TUI.Transparent, true)
 	}
 
-	// Load known providers, this loads the config from catwalk
+	// Load known providers, this loads the config from catwalk. A failed
+	// refresh still yields the cached or embedded catalog, so only an empty
+	// list is fatal: starting up without providers is worse than starting
+	// up with slightly stale ones.
 	providers, err := Providers(cfg)
 	if err != nil {
-		return nil, err
+		if len(providers) == 0 {
+			return nil, err
+		}
+		slog.Warn("Continuing with the previously known providers", "error", err)
 	}
 	store.knownProviders = providers
 

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -136,10 +136,13 @@ var (
 // 2. load the cached providers
 // 3. try to get the fresh list of providers, and return either this new list,
 // the cached list, or the embedded list if all others fail.
+//
+// A returned error is advisory: it reports that providers could not be
+// refreshed or cached, not that none are available. Callers should surface it
+// as a warning and keep using the returned list.
 func Providers(cfg *Config) ([]catwalk.Provider, error) {
 	providerOnce.Do(func() {
 		var wg sync.WaitGroup
-		var errs []error
 		providers := csync.NewSlice[catwalk.Provider]()
 		autoupdate := !cfg.Options.DisableProviderAutoUpdate
 		customProvidersOnly := cfg.Options.DisableDefaultProviders
@@ -147,8 +150,10 @@ func Providers(cfg *Config) ([]catwalk.Provider, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 		defer cancel()
 
+		// Each goroutine owns its own error so the two can report
+		// independently without racing on a shared slice.
+		var catwalkErr, hyperErr error
 		var hyperProvider catwalk.Provider
-		var hyperFound bool
 
 		wg.Go(func() {
 			if customProvidersOnly {
@@ -159,11 +164,14 @@ func Providers(cfg *Config) ([]catwalk.Provider, error) {
 			path := cachePathFor("providers")
 			catwalkSyncer.Init(client, path, autoupdate)
 
+			// A failure to refresh or cache the catalog is worth
+			// reporting, but the syncer still hands back the cached or
+			// embedded list. Dropping that would leave the user with no
+			// providers at all over a transient disk or network problem.
 			items, err := catwalkSyncer.Get(ctx)
 			if err != nil {
 				catwalkURL := fmt.Sprintf("%s/v2/providers", cmp.Or(os.Getenv("CATWALK_URL"), defaultCatwalkURL))
-				errs = append(errs, fmt.Errorf("Crush was unable to fetch an updated list of providers from %s. Consider setting CRUSH_DISABLE_PROVIDER_AUTO_UPDATE=1 to use the embedded providers bundled at the time of this Crush release. You can also update providers manually. For more info see crush update-providers --help.\n\nCause: %w", catwalkURL, err)) //nolint:staticcheck
-				return
+				catwalkErr = fmt.Errorf("Crush was unable to fetch an updated list of providers from %s. Consider setting CRUSH_DISABLE_PROVIDER_AUTO_UPDATE=1 to use the embedded providers bundled at the time of this Crush release. You can also update providers manually. For more info see crush update-providers --help.\n\nCause: %w", catwalkURL, err) //nolint:staticcheck
 			}
 			providers.Append(items...)
 		})
@@ -175,23 +183,27 @@ func Providers(cfg *Config) ([]catwalk.Provider, error) {
 			path := cachePathFor("hyper")
 			hyperSyncer.Init(realHyperClient{baseURL: hyper.BaseURL()}, path, autoupdate)
 
+			// As above: keep whatever provider we were handed. The syncer
+			// already falls back to the cached or embedded copy, so an
+			// error here means "could not refresh", not "no Hyper". This
+			// matters more than for other providers because Hyper's
+			// endpoint and model list live in the catalog rather than in
+			// the user's config: dropping it signs a logged-in user out.
 			item, err := hyperSyncer.Get(ctx)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("Crush was unable to fetch updated information from Hyper: %w", err)) //nolint:staticcheck
-				return
+				hyperErr = fmt.Errorf("Crush was unable to fetch updated information from Hyper: %w", err) //nolint:staticcheck
 			}
 			hyperProvider = item
-			hyperFound = true
 		})
 
 		wg.Wait()
 
-		if hyperFound {
+		if hyperProvider.ID != "" {
 			providerList = append([]catwalk.Provider{hyperProvider}, slices.Collect(providers.Seq())...)
 		} else {
 			providerList = slices.Collect(providers.Seq())
 		}
-		providerErr = errors.Join(errs...)
+		providerErr = errors.Join(catwalkErr, hyperErr)
 	})
 	return providerList, providerErr
 }

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -137,9 +137,12 @@ var (
 // 3. try to get the fresh list of providers, and return either this new list,
 // the cached list, or the embedded list if all others fail.
 //
-// A returned error is advisory: it reports that providers could not be
-// refreshed or cached, not that none are available. Callers should surface it
-// as a warning and keep using the returned list.
+// A returned error is advisory: it reports that the catalog could not be
+// cached, or that an upstream returned nothing usable. It never means that no
+// providers are available, so callers should surface it as a warning and keep
+// using the returned list. A refresh that simply could not reach the network
+// is not an error at all: the cached or embedded catalog is a sound answer, so
+// those are logged and the fallback is returned.
 func Providers(cfg *Config) ([]catwalk.Provider, error) {
 	providerOnce.Do(func() {
 		var wg sync.WaitGroup

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -305,4 +306,94 @@ func TestCachePathFor(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestProviders_KeepsCatalogWhenCachingFails covers the case that used to
+// sign Hyper users out: the provider list was fetched successfully but could
+// not be written to the on-disk cache, and Providers discarded it. Hyper's
+// endpoint and models live in the catalog rather than in the user's config,
+// so losing it there removed the provider entirely and invalidated the
+// user's saved model.
+func TestProviders_KeepsCatalogWhenCachingFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+
+	// A file where a directory needs to be, so every cache write fails.
+	blocked := filepath.Join(tmpDir, "blocked")
+	require.NoError(t, os.WriteFile(blocked, []byte("block"), 0o644))
+	unwritable := filepath.Join(blocked, "subdir", "cache.json")
+
+	resetProviderState()
+	defer resetProviderState()
+
+	// Prime both syncers with mock clients so Providers reuses the memoized
+	// outcome instead of reaching the network.
+	catwalkSyncer.Init(&mockCatwalkClient{
+		providers: []catwalk.Provider{{Name: "Provider1", ID: "p1"}},
+	}, unwritable, true)
+	hyperSyncer.Init(&mockHyperClient{
+		provider: catwalk.Provider{
+			Name:   "Hyper",
+			ID:     "hyper",
+			Models: []catwalk.Model{{ID: "hyper-1", Name: "Hyper Model"}},
+		},
+	}, unwritable, true)
+
+	catwalkProviders, catwalkErr := catwalkSyncer.Get(t.Context())
+	require.Error(t, catwalkErr, "cache write should fail")
+	require.NotEmpty(t, catwalkProviders, "syncer still returns a usable catalog")
+
+	hyperProvider, hyperErr := hyperSyncer.Get(t.Context())
+	require.Error(t, hyperErr, "cache write should fail")
+	require.Equal(t, "Hyper", hyperProvider.Name)
+
+	providers, err := Providers(&Config{Options: &Options{}})
+
+	// The failure is reported, but as a warning alongside a usable catalog.
+	require.Error(t, err)
+	require.Len(t, providers, 2)
+	require.Equal(t, catwalk.InferenceProvider("hyper"), providers[0].ID, "Hyper stays at the front")
+	require.Equal(t, catwalk.InferenceProvider("p1"), providers[1].ID)
+}
+
+// TestProviders_FallsBackToEmbeddedHyper checks that Hyper is still in the
+// catalog when it could not be fetched at all, using the copy bundled with
+// this release.
+func TestProviders_FallsBackToEmbeddedHyper(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmpDir)
+
+	resetProviderState()
+	defer resetProviderState()
+
+	catwalkSyncer.Init(&mockCatwalkClient{
+		providers: []catwalk.Provider{{Name: "Provider1", ID: "p1"}},
+	}, filepath.Join(tmpDir, "providers.json"), true)
+	hyperSyncer.Init(&mockHyperClient{
+		err: errors.New("network error"),
+	}, filepath.Join(tmpDir, "hyper.json"), true)
+
+	_, _ = catwalkSyncer.Get(t.Context())
+	_, _ = hyperSyncer.Get(t.Context())
+
+	providers, err := Providers(&Config{Options: &Options{}})
+	require.NoError(t, err)
+	require.Len(t, providers, 2)
+	require.Equal(t, catwalk.InferenceProvider("hyper"), providers[0].ID)
+	require.NotEmpty(t, providers[0].Models, "the embedded Hyper provider carries models")
+}
+
+// TestProviders_HonorsDisableDefaultProviders makes sure the embedded Hyper
+// fallback does not smuggle a default provider back in.
+func TestProviders_HonorsDisableDefaultProviders(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+
+	resetProviderState()
+	defer resetProviderState()
+
+	providers, err := Providers(&Config{
+		Options: &Options{DisableDefaultProviders: true},
+	})
+	require.NoError(t, err)
+	require.Empty(t, providers)
 }

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -1174,7 +1174,10 @@ func (s *ConfigStore) reloadFromDiskLocked(ctx context.Context) error {
 
 	providers, err := Providers(cfg)
 	if err != nil {
-		return fmt.Errorf("failed to load providers during reload: %w", err)
+		if len(providers) == 0 {
+			return fmt.Errorf("failed to load providers during reload: %w", err)
+		}
+		slog.Warn("Reload continuing with the previously known providers", "error", err)
 	}
 
 	if err := cfg.configureProviders(ctx, s, env, resolver, providers); err != nil {

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -3,6 +3,7 @@ package dialog
 import (
 	"cmp"
 	"fmt"
+	"log/slog"
 	"slices"
 
 	"charm.land/bubbles/v2/help"
@@ -142,10 +143,15 @@ func NewModels(com *common.Common, isOnboarding bool) (*Models, error) {
 	)
 	m.keyMap.Close = CloseKey
 
+	// A stale catalog must not keep this dialog from opening: it is the
+	// only way for the user to choose a model.
 	var err error
 	m.providers, err = config.Providers(m.com.Config())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get providers: %w", err)
+		if len(m.providers) == 0 {
+			return nil, fmt.Errorf("failed to get providers: %w", err)
+		}
+		slog.Warn("Listing the previously known providers", "error", err)
 	}
 
 	if err := m.setProviderItems(); err != nil {
@@ -351,7 +357,7 @@ func (m *Models) setProviderItems() error {
 
 	// Get a list of known providers to compare against
 	knownProviders, err := config.Providers(cfg)
-	if err != nil {
+	if err != nil && len(knownProviders) == 0 {
 		return fmt.Errorf("failed to get providers: %w", err)
 	}
 


### PR DESCRIPTION
Basically, if Crush is loading and it can't cache a new Hyper provider list, maintain the prior list, rather than abandoning Hyper and picking another provider.

Generated description below.

***

Crush fetches its provider catalog on startup and then saves a copy to disk. If that save failed, the freshly fetched catalog was discarded along with it — even though it was perfectly usable.

Depending on timing, a single failed cache write could mean:

- **No providers at all.** The catalog fetch returns a valid list, then the write fails, then the list is dropped.
- **Crush refusing to start.** The startup path treated the error as fatal.
- **A model picker that will not open again.** The result is memoized for the process, so the dialog kept failing for the rest of the session — exactly when you need it most.
- **Being signed out of Hyper.** Hyper's endpoint and model list come from the catalog rather than from your config, so losing it there removes the provider entirely and invalidates your saved model.

That last one is how this was found: an intermittent "Crush randomly switched me from Hyper to another provider on startup" report.

## What changed

- A failed refresh or cache write is now **advisory**: it is reported as a warning while the cached or bundled catalog keeps being used. Only a genuinely empty catalog is fatal.
- Both catalog fetchers now remember their error alongside their result, so every caller sees the same outcome instead of the second and later callers silently getting `nil`.
- Fixes an unsynchronized write shared by the two concurrent fetches.

## Note

A related problem is **not** addressed here: when a saved model cannot be resolved, startup still overwrites your stored selection with a guess and persists it. That issue is fixed in #3487.

💘 Generated with Crush