### PR TITLE
fix(providers): don’t pick a provider just because its key is in the env

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -167,6 +167,13 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 		slog.Warn("No agent configuration found")
 		return app, nil
 	}
+	// Without a selected model there is nothing to talk to yet. The TUI
+	// prompts for one; non-interactive runs pick the first available model
+	// when they initialize the agent.
+	if !cfg.HasSelectedModel(config.SelectedModelTypeLarge) {
+		slog.Warn("No model selected")
+		return app, nil
+	}
 	if err := app.InitCoderAgent(ctx); err != nil {
 		return nil, fmt.Errorf("failed to initialize coder agent: %w", err)
 	}
@@ -612,7 +619,31 @@ func (app *App) InitCoderAgent(ctx context.Context) error {
 // InitCoderAgentNonInteractive initializes the coder agent without
 // interactive-only tools (e.g. question).
 func (app *App) InitCoderAgentNonInteractive(ctx context.Context) error {
+	app.ensureModelForNonInteractive()
 	return app.initCoderAgent(ctx, false)
+}
+
+// ensureModelForNonInteractive selects the first available model when the
+// user has never chosen one. Non-interactive runs cannot show the model
+// picker, so they fall back to the top of the model list rather than
+// failing. The choice lives in memory only and is never written to the
+// user's config.
+func (app *App) ensureModelForNonInteractive() {
+	cfg := app.config.Config()
+	if cfg.HasSelectedModel(config.SelectedModelTypeLarge) {
+		return
+	}
+	knownProviders, err := config.Providers(cfg)
+	if err != nil {
+		slog.Warn("Failed to load providers while selecting a fallback model", "error", err)
+	}
+	model, ok := cfg.FirstAvailableModel(knownProviders)
+	if !ok {
+		return
+	}
+	slog.Info("No model selected, falling back to first available model", "provider", model.Provider, "model", model.Model)
+	app.config.OverridePreferredModel(config.SelectedModelTypeLarge, model)
+	app.config.OverridePreferredModel(config.SelectedModelTypeSmall, app.GetDefaultSmallModel(model.Provider))
 }
 
 func (app *App) initCoderAgent(ctx context.Context, interactive bool) error {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -353,7 +353,8 @@ func setupClientServerWorkspace(cmd *cobra.Command) (workspace.Workspace, func()
 
 	clientWs := workspace.NewClientWorkspace(c, *protoWs)
 
-	if protoWs.Config.IsConfigured() {
+	// Skip agent init until a model is selected; the TUI prompts for one.
+	if protoWs.Config.IsConfigured() && protoWs.Config.HasSelectedModel(config.SelectedModelTypeLarge) {
 		if err := clientWs.InitCoderAgent(cmd.Context()); err != nil {
 			slog.Error("Failed to initialize coder agent", "error", err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -721,6 +721,99 @@ func (c *Config) IsConfigured() bool {
 	return len(c.EnabledProviders()) > 0
 }
 
+// HasSelectedModel reports whether a usable model is selected for the
+// given type. It is false on a fresh install even when credentials are
+// present in the environment, since Crush no longer guesses a provider.
+func (c *Config) HasSelectedModel(modelType SelectedModelType) bool {
+	selected, ok := c.Models[modelType]
+	if !ok || selected.Provider == "" || selected.Model == "" {
+		return false
+	}
+	return c.GetModel(selected.Provider, selected.Model) != nil
+}
+
+// applySelectedModels stores the resolved selections, dropping any type
+// that could not be resolved so callers can detect that no model has been
+// chosen yet.
+func (c *Config) applySelectedModels(resolved resolvedModels) {
+	if c.Models == nil {
+		c.Models = make(map[SelectedModelType]SelectedModel)
+	}
+	for modelType, entry := range map[SelectedModelType]struct {
+		model SelectedModel
+		ok    bool
+	}{
+		SelectedModelTypeLarge: {resolved.Large, resolved.HasLarge},
+		SelectedModelTypeSmall: {resolved.Small, resolved.HasSmall},
+	} {
+		if entry.ok {
+			c.Models[modelType] = entry.model
+		} else {
+			delete(c.Models, modelType)
+		}
+	}
+}
+
+// orderedProviders returns the enabled providers that have models, in
+// catalog order first and then alphabetically by ID. The stable order keeps
+// model lookups reproducible across runs, unlike map iteration.
+func (c *Config) orderedProviders(knownProviders []catwalk.Provider) []ProviderConfig {
+	ordered := make([]ProviderConfig, 0, c.Providers.Len())
+	seen := make(map[string]bool, c.Providers.Len())
+	add := func(providerConfig ProviderConfig) {
+		if providerConfig.Disable || len(providerConfig.Models) == 0 || seen[providerConfig.ID] {
+			return
+		}
+		seen[providerConfig.ID] = true
+		ordered = append(ordered, providerConfig)
+	}
+
+	for _, p := range knownProviders {
+		if providerConfig, ok := c.Providers.Get(string(p.ID)); ok {
+			add(providerConfig)
+		}
+	}
+
+	remaining := slices.Collect(c.Providers.Seq())
+	slices.SortFunc(remaining, func(a, b ProviderConfig) int {
+		return strings.Compare(a.ID, b.ID)
+	})
+	for _, providerConfig := range remaining {
+		add(providerConfig)
+	}
+	return ordered
+}
+
+// FirstAvailableModel returns the first model of the first enabled
+// provider, preferring catalog order so the result matches the top of the
+// model list shown in the TUI. It exists for non-interactive runs, which
+// have no way to prompt for a selection; the result is never persisted.
+func (c *Config) FirstAvailableModel(knownProviders []catwalk.Provider) (SelectedModel, bool) {
+	for _, providerConfig := range c.orderedProviders(knownProviders) {
+		model := providerConfig.Models[0]
+		return SelectedModel{
+			Provider:        providerConfig.ID,
+			Model:           model.ID,
+			MaxTokens:       model.DefaultMaxTokens,
+			ReasoningEffort: model.DefaultReasoningEffort,
+		}, true
+	}
+	return SelectedModel{}, false
+}
+
+// providerForModel finds the enabled provider offering the given model ID.
+// It lets a config name a model without naming a provider.
+func (c *Config) providerForModel(knownProviders []catwalk.Provider, modelID string) (string, bool) {
+	for _, providerConfig := range c.orderedProviders(knownProviders) {
+		if slices.ContainsFunc(providerConfig.Models, func(m catwalk.Model) bool {
+			return m.ID == modelID
+		}) {
+			return providerConfig.ID, true
+		}
+	}
+	return "", false
+}
+
 func (c *Config) GetModel(provider, model string) *catwalk.Model {
 	if providerConfig, ok := c.Providers.Get(provider); ok {
 		for _, m := range providerConfig.Models {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -136,28 +136,7 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 		return store, nil
 	}
 
-	resolved, err := resolveSelectedModels(cfg, store.knownProviders)
-	if err != nil {
-		return nil, fmt.Errorf("failed to configure selected models: %w", err)
-	}
-	cfg.Models[SelectedModelTypeLarge] = resolved.Large
-	cfg.Models[SelectedModelTypeSmall] = resolved.Small
-
-	// Persist any fallback corrections while we still hold writeMu.
-	if resolved.LargeFallback {
-		if err := store.updateLocked(ScopeGlobal, func(c *Config) map[string]any {
-			return store.updatePreferredModelFields(c, SelectedModelTypeLarge, resolved.Large)
-		}); err != nil {
-			return nil, fmt.Errorf("failed to update preferred large model: %w", err)
-		}
-	}
-	if resolved.SmallFallback {
-		if err := store.updateLocked(ScopeGlobal, func(c *Config) map[string]any {
-			return store.updatePreferredModelFields(c, SelectedModelTypeSmall, resolved.Small)
-		}); err != nil {
-			return nil, fmt.Errorf("failed to update preferred small model: %w", err)
-		}
-	}
+	cfg.applySelectedModels(resolveSelectedModels(cfg, store.knownProviders))
 	store.SetupAgents()
 
 	// Capture initial staleness snapshot
@@ -693,214 +672,92 @@ func (c *Config) applyLSPDefaults() {
 	}
 }
 
-func (c *Config) defaultModelSelection(knownProviders []catwalk.Provider) (largeModel SelectedModel, smallModel SelectedModel, err error) {
-	if len(knownProviders) == 0 && c.Providers.Len() == 0 {
-		err = fmt.Errorf("no providers configured, please configure at least one provider")
-		return largeModel, smallModel, err
-	}
-
-	// Use the first provider enabled based on the known providers order
-	// if no provider found that is known use the first provider configured
-	for _, p := range knownProviders {
-		providerConfig, ok := c.Providers.Get(string(p.ID))
-		if !ok || providerConfig.Disable {
-			continue
-		}
-		defaultLargeModel := c.GetModel(string(p.ID), p.DefaultLargeModelID)
-		if defaultLargeModel == nil {
-			slog.Warn("Default large model %s not found for provider %s", p.DefaultLargeModelID, p.ID)
-			if len(providerConfig.Models) == 0 {
-				return largeModel, smallModel, fmt.Errorf("default large model %s not found for provider %s", p.DefaultLargeModelID, p.ID)
-			}
-			defaultLargeModel = &providerConfig.Models[0]
-		}
-		largeModel = SelectedModel{
-			Provider:        string(p.ID),
-			Model:           defaultLargeModel.ID,
-			MaxTokens:       defaultLargeModel.DefaultMaxTokens,
-			ReasoningEffort: defaultLargeModel.DefaultReasoningEffort,
-		}
-
-		defaultSmallModel := c.GetModel(string(p.ID), p.DefaultSmallModelID)
-		if defaultSmallModel == nil {
-			slog.Warn("Default small model %s not found for provider %s", p.DefaultSmallModelID, p.ID)
-			if len(providerConfig.Models) == 0 {
-				return largeModel, smallModel, fmt.Errorf("default small model %s not found for provider %s", p.DefaultSmallModelID, p.ID)
-			}
-			defaultSmallModel = &providerConfig.Models[0]
-		}
-		smallModel = SelectedModel{
-			Provider:        string(p.ID),
-			Model:           defaultSmallModel.ID,
-			MaxTokens:       defaultSmallModel.DefaultMaxTokens,
-			ReasoningEffort: defaultSmallModel.DefaultReasoningEffort,
-		}
-		return largeModel, smallModel, err
-	}
-
-	enabledProviders := c.EnabledProviders()
-	slices.SortFunc(enabledProviders, func(a, b ProviderConfig) int {
-		return strings.Compare(a.ID, b.ID)
-	})
-
-	if len(enabledProviders) == 0 {
-		err = fmt.Errorf("no providers configured, please configure at least one provider")
-		return largeModel, smallModel, err
-	}
-
-	providerConfig := enabledProviders[0]
-	if len(providerConfig.Models) == 0 {
-		err = fmt.Errorf("provider %s has no models configured", providerConfig.ID)
-		return largeModel, smallModel, err
-	}
-	defaultLargeModel := c.GetModel(providerConfig.ID, providerConfig.Models[0].ID)
-	largeModel = SelectedModel{
-		Provider:  providerConfig.ID,
-		Model:     defaultLargeModel.ID,
-		MaxTokens: defaultLargeModel.DefaultMaxTokens,
-	}
-	defaultSmallModel := c.GetModel(providerConfig.ID, providerConfig.Models[0].ID)
-	smallModel = SelectedModel{
-		Provider:  providerConfig.ID,
-		Model:     defaultSmallModel.ID,
-		MaxTokens: defaultSmallModel.DefaultMaxTokens,
-	}
-	return largeModel, smallModel, err
-}
-
 // resolvedModels holds the result of resolving user-configured model
 // selections against the provider catalog.
 type resolvedModels struct {
-	Large         SelectedModel
-	Small         SelectedModel
-	LargeFallback bool // true if Large was corrected to a default
-	SmallFallback bool // true if Small was corrected to a default
+	Large    SelectedModel
+	Small    SelectedModel
+	HasLarge bool
+	HasSmall bool
 }
 
 // resolveSelectedModels validates the user's configured model selections
-// against the provider catalog, falling back to defaults when a model ID is
-// invalid. It is pure resolution logic: it does not mutate the store or
-// touch disk. The caller assigns the results to c.Models and persists any
-// fallback corrections as appropriate.
-func resolveSelectedModels(cfg *Config, knownProviders []catwalk.Provider) (resolvedModels, error) {
+// against the provider catalog. Selections that are missing or no longer
+// resolvable are dropped rather than replaced with a guess: Crush never
+// picks a provider on the user's behalf just because credentials for it
+// happen to be present in the environment. When only the large model is
+// configured, the small model is derived from the same provider.
+//
+// It is pure resolution logic: it does not mutate the store or touch disk.
+func resolveSelectedModels(cfg *Config, knownProviders []catwalk.Provider) resolvedModels {
 	var result resolvedModels
-	defaultLarge, defaultSmall, err := cfg.defaultModelSelection(knownProviders)
-	if err != nil {
-		return result, fmt.Errorf("failed to select default models: %w", err)
-	}
-	large, small := defaultLarge, defaultSmall
+	result.Large, result.HasLarge = resolveSelectedModel(cfg, knownProviders, cfg.Models[SelectedModelTypeLarge])
+	result.Small, result.HasSmall = resolveSelectedModel(cfg, knownProviders, cfg.Models[SelectedModelTypeSmall])
 
-	largeModelSelected, largeModelConfigured := cfg.Models[SelectedModelTypeLarge]
-	if largeModelConfigured {
-		if largeModelSelected.Model != "" {
-			large.Model = largeModelSelected.Model
+	if result.HasLarge && !result.HasSmall {
+		result.Small, result.HasSmall = deriveSmallModel(cfg, knownProviders, result.Large)
+	}
+	return result
+}
+
+// resolveSelectedModel validates a single model selection against the
+// provider catalog, filling in catalog defaults for unset fields. A
+// selection that names a model but no provider is matched to the first
+// provider offering that model. It returns false when the selection is
+// empty or the provider or model no longer exists, in which case the caller
+// must drop the selection.
+func resolveSelectedModel(cfg *Config, knownProviders []catwalk.Provider, selected SelectedModel) (SelectedModel, bool) {
+	if selected.Model == "" {
+		return SelectedModel{}, false
+	}
+	if selected.Provider == "" {
+		provider, ok := cfg.providerForModel(knownProviders, selected.Model)
+		if !ok {
+			return SelectedModel{}, false
 		}
-		if largeModelSelected.Provider != "" {
-			large.Provider = largeModelSelected.Provider
+		selected.Provider = provider
+	}
+	providerConfig, ok := cfg.Providers.Get(selected.Provider)
+	if !ok || providerConfig.Disable {
+		return SelectedModel{}, false
+	}
+	model := cfg.GetModel(selected.Provider, selected.Model)
+	if model == nil {
+		return SelectedModel{}, false
+	}
+	resolved := selected
+	resolved.ProviderOptions = maps.Clone(selected.ProviderOptions)
+	if resolved.MaxTokens <= 0 {
+		resolved.MaxTokens = model.DefaultMaxTokens
+	}
+	if resolved.ReasoningEffort == "" {
+		resolved.ReasoningEffort = model.DefaultReasoningEffort
+	}
+	return resolved, true
+}
+
+// deriveSmallModel picks the small model for a large model selection whose
+// small counterpart isn't configured. Providers outside the catalog reuse
+// the large model, which keeps local and OpenAI-compatible setups from
+// requesting two different models concurrently.
+func deriveSmallModel(cfg *Config, knownProviders []catwalk.Provider, large SelectedModel) (SelectedModel, bool) {
+	for _, p := range knownProviders {
+		if string(p.ID) != large.Provider {
+			continue
 		}
-		model := cfg.GetModel(large.Provider, large.Model)
+		model := cfg.GetModel(large.Provider, p.DefaultSmallModelID)
 		if model == nil {
-			large = defaultLarge
-			result.LargeFallback = true
-		} else {
-			if largeModelSelected.MaxTokens > 0 {
-				large.MaxTokens = largeModelSelected.MaxTokens
-			} else {
-				large.MaxTokens = model.DefaultMaxTokens
-			}
-			if largeModelSelected.ReasoningEffort != "" {
-				large.ReasoningEffort = largeModelSelected.ReasoningEffort
-			} else {
-				large.ReasoningEffort = model.DefaultReasoningEffort
-			}
-			large.Think = largeModelSelected.Think
-			if largeModelSelected.Temperature != nil {
-				large.Temperature = largeModelSelected.Temperature
-			}
-			if largeModelSelected.TopP != nil {
-				large.TopP = largeModelSelected.TopP
-			}
-			if largeModelSelected.TopK != nil {
-				large.TopK = largeModelSelected.TopK
-			}
-			if largeModelSelected.FrequencyPenalty != nil {
-				large.FrequencyPenalty = largeModelSelected.FrequencyPenalty
-			}
-			if largeModelSelected.PresencePenalty != nil {
-				large.PresencePenalty = largeModelSelected.PresencePenalty
-			}
-			if largeModelSelected.ProviderOptions != nil {
-				large.ProviderOptions = maps.Clone(largeModelSelected.ProviderOptions)
-			}
+			break
 		}
+		return SelectedModel{
+			Provider:        large.Provider,
+			Model:           p.DefaultSmallModelID,
+			MaxTokens:       model.DefaultMaxTokens,
+			ReasoningEffort: model.DefaultReasoningEffort,
+		}, true
 	}
-	smallModelSelected, smallModelConfigured := cfg.Models[SelectedModelTypeSmall]
-	if smallModelConfigured {
-		if smallModelSelected.Model != "" {
-			small.Model = smallModelSelected.Model
-		}
-		if smallModelSelected.Provider != "" {
-			small.Provider = smallModelSelected.Provider
-		}
-
-		model := cfg.GetModel(small.Provider, small.Model)
-		if model == nil {
-			small = defaultSmall
-			result.SmallFallback = true
-		} else {
-			if smallModelSelected.MaxTokens > 0 {
-				small.MaxTokens = smallModelSelected.MaxTokens
-			} else {
-				small.MaxTokens = model.DefaultMaxTokens
-			}
-			if smallModelSelected.ReasoningEffort != "" {
-				small.ReasoningEffort = smallModelSelected.ReasoningEffort
-			} else {
-				small.ReasoningEffort = model.DefaultReasoningEffort
-			}
-			if smallModelSelected.Temperature != nil {
-				small.Temperature = smallModelSelected.Temperature
-			}
-			if smallModelSelected.TopP != nil {
-				small.TopP = smallModelSelected.TopP
-			}
-			if smallModelSelected.TopK != nil {
-				small.TopK = smallModelSelected.TopK
-			}
-			if smallModelSelected.FrequencyPenalty != nil {
-				small.FrequencyPenalty = smallModelSelected.FrequencyPenalty
-			}
-			if smallModelSelected.PresencePenalty != nil {
-				small.PresencePenalty = smallModelSelected.PresencePenalty
-			}
-			if smallModelSelected.ProviderOptions != nil {
-				small.ProviderOptions = maps.Clone(smallModelSelected.ProviderOptions)
-			}
-			small.Think = smallModelSelected.Think
-		}
-	}
-
-	// When small isn't explicitly configured and the provider isn't a
-	// known built-in, use the large model as the small model. This
-	// prevents two different models from being requested concurrently
-	// for local/openai-compat providers.
-	if !smallModelConfigured {
-		isKnownProvider := false
-		for _, kp := range knownProviders {
-			if string(kp.ID) == small.Provider {
-				isKnownProvider = true
-				break
-			}
-		}
-		if !isKnownProvider {
-			slog.Warn("Using large model as small model for unknown provider", "provider", large.Provider, "model", large.Model)
-			small = large
-		}
-	}
-
-	result.Large = large
-	result.Small = small
-	return result, nil
+	slog.Warn("Using large model as small model", "provider", large.Provider, "model", large.Model)
+	return large, true
 }
 
 // lookupConfigs searches config files starting at cwd and walking up

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"charm.land/catwalk/pkg/catwalk"
 	"github.com/charmbracelet/crush/internal/csync"
@@ -1313,172 +1312,67 @@ func TestConfig_configureProvidersEnhancedCredentialValidation(t *testing.T) {
 	})
 }
 
-func TestConfig_defaultModelSelection(t *testing.T) {
-	t.Run("default behavior uses the default models for given provider", func(t *testing.T) {
-		knownProviders := []catwalk.Provider{
-			{
-				ID:                  "openai",
-				APIKey:              "abc",
-				DefaultLargeModelID: "large-model",
-				DefaultSmallModelID: "small-model",
-				Models: []catwalk.Model{
-					{
-						ID:               "large-model",
-						DefaultMaxTokens: 1000,
-					},
-					{
-						ID:               "small-model",
-						DefaultMaxTokens: 500,
-					},
-				},
+func TestConfig_FirstAvailableModel(t *testing.T) {
+	knownProviders := []catwalk.Provider{
+		{
+			ID:                  "openai",
+			APIKey:              "abc",
+			DefaultLargeModelID: "large-model",
+			DefaultSmallModelID: "small-model",
+			Models: []catwalk.Model{
+				{ID: "large-model", DefaultMaxTokens: 1000},
+				{ID: "small-model", DefaultMaxTokens: 500},
 			},
-		}
+		},
+	}
 
-		cfg := &Config{}
+	configure := func(t *testing.T, cfg *Config, providers []catwalk.Provider) {
+		t.Helper()
 		cfg.setDefaults("/tmp", "")
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
-		require.NoError(t, err)
+		require.NoError(t, cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, providers))
+	}
 
-		large, small, err := cfg.defaultModelSelection(knownProviders)
-		require.NoError(t, err)
-		require.Equal(t, "large-model", large.Model)
-		require.Equal(t, "openai", large.Provider)
-		require.Equal(t, int64(1000), large.MaxTokens)
-		require.Equal(t, "small-model", small.Model)
-		require.Equal(t, "openai", small.Provider)
-		require.Equal(t, int64(500), small.MaxTokens)
-	})
-	t.Run("should error if no providers configured", func(t *testing.T) {
-		knownProviders := []catwalk.Provider{
-			{
-				ID:                  "openai",
-				APIKey:              "$MISSING_KEY",
-				DefaultLargeModelID: "large-model",
-				DefaultSmallModelID: "small-model",
-				Models: []catwalk.Model{
-					{
-						ID:               "large-model",
-						DefaultMaxTokens: 1000,
-					},
-					{
-						ID:               "small-model",
-						DefaultMaxTokens: 500,
-					},
-				},
-			},
-		}
-
+	t.Run("returns the first model of the first catalog provider", func(t *testing.T) {
 		cfg := &Config{}
-		cfg.setDefaults("/tmp", "")
-		env := env.NewFromMap(map[string]string{})
-		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
-		require.NoError(t, err)
+		configure(t, cfg, knownProviders)
 
-		_, _, err = cfg.defaultModelSelection(knownProviders)
-		require.Error(t, err)
-	})
-	t.Run("should not error if model is missing", func(t *testing.T) {
-		knownProviders := []catwalk.Provider{
-			{
-				ID:                  "openai",
-				APIKey:              "abc",
-				DefaultLargeModelID: "large-model",
-				DefaultSmallModelID: "small-model",
-				Models: []catwalk.Model{
-					{
-						ID:               "not-large-model",
-						DefaultMaxTokens: 1000,
-					},
-					{
-						ID:               "small-model",
-						DefaultMaxTokens: 500,
-					},
-				},
-			},
-		}
-
-		cfg := &Config{}
-		cfg.setDefaults("/tmp", "")
-		env := env.NewFromMap(map[string]string{})
-		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
-		require.NoError(t, err)
-		_, _, err = cfg.defaultModelSelection(knownProviders)
-		require.NoError(t, err)
+		model, ok := cfg.FirstAvailableModel(knownProviders)
+		require.True(t, ok)
+		require.Equal(t, "openai", model.Provider)
+		require.Equal(t, "large-model", model.Model)
+		require.Equal(t, int64(1000), model.MaxTokens)
 	})
 
-	t.Run("should configure the default models with a custom provider", func(t *testing.T) {
-		knownProviders := []catwalk.Provider{
+	t.Run("falls back to a custom provider when no catalog provider is usable", func(t *testing.T) {
+		unusable := []catwalk.Provider{
 			{
 				ID:                  "openai",
-				APIKey:              "$MISSING", // will not be included in the config
+				APIKey:              "$MISSING", // not configured
 				DefaultLargeModelID: "large-model",
-				DefaultSmallModelID: "small-model",
-				Models: []catwalk.Model{
-					{
-						ID:               "not-large-model",
-						DefaultMaxTokens: 1000,
-					},
-					{
-						ID:               "small-model",
-						DefaultMaxTokens: 500,
-					},
-				},
+				Models:              []catwalk.Model{{ID: "large-model", DefaultMaxTokens: 1000}},
 			},
 		}
-
 		cfg := &Config{
 			Providers: csync.NewMapFrom(map[string]ProviderConfig{
 				"custom": {
 					APIKey:  "test-key",
 					BaseURL: "https://api.custom.com/v1",
-					Models: []catwalk.Model{
-						{
-							ID:               "model",
-							DefaultMaxTokens: 600,
-						},
-					},
+					Models:  []catwalk.Model{{ID: "model", DefaultMaxTokens: 600}},
 				},
 			}),
 		}
-		cfg.setDefaults("/tmp", "")
-		env := env.NewFromMap(map[string]string{})
-		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
-		require.NoError(t, err)
-		large, small, err := cfg.defaultModelSelection(knownProviders)
-		require.NoError(t, err)
-		require.Equal(t, "model", large.Model)
-		require.Equal(t, "custom", large.Provider)
-		require.Equal(t, int64(600), large.MaxTokens)
-		require.Equal(t, "model", small.Model)
-		require.Equal(t, "custom", small.Provider)
-		require.Equal(t, int64(600), small.MaxTokens)
+		configure(t, cfg, unusable)
+
+		model, ok := cfg.FirstAvailableModel(unusable)
+		require.True(t, ok)
+		require.Equal(t, "custom", model.Provider)
+		require.Equal(t, "model", model.Model)
+		require.Equal(t, int64(600), model.MaxTokens)
 	})
 
-	t.Run("should fail if no model configured", func(t *testing.T) {
-		knownProviders := []catwalk.Provider{
-			{
-				ID:                  "openai",
-				APIKey:              "$MISSING", // will not be included in the config
-				DefaultLargeModelID: "large-model",
-				DefaultSmallModelID: "small-model",
-				Models: []catwalk.Model{
-					{
-						ID:               "not-large-model",
-						DefaultMaxTokens: 1000,
-					},
-					{
-						ID:               "small-model",
-						DefaultMaxTokens: 500,
-					},
-				},
-			},
-		}
-
+	t.Run("reports nothing when the only provider has no models", func(t *testing.T) {
 		cfg := &Config{
 			Providers: csync.NewMapFrom(map[string]ProviderConfig{
 				"custom": {
@@ -1488,61 +1382,18 @@ func TestConfig_defaultModelSelection(t *testing.T) {
 				},
 			}),
 		}
-		cfg.setDefaults("/tmp", "")
-		env := env.NewFromMap(map[string]string{})
-		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
-		require.NoError(t, err)
-		_, _, err = cfg.defaultModelSelection(knownProviders)
-		require.Error(t, err)
-	})
-	t.Run("should use the default provider first", func(t *testing.T) {
-		knownProviders := []catwalk.Provider{
-			{
-				ID:                  "openai",
-				APIKey:              "set",
-				DefaultLargeModelID: "large-model",
-				DefaultSmallModelID: "small-model",
-				Models: []catwalk.Model{
-					{
-						ID:               "large-model",
-						DefaultMaxTokens: 1000,
-					},
-					{
-						ID:               "small-model",
-						DefaultMaxTokens: 500,
-					},
-				},
-			},
-		}
+		configure(t, cfg, nil)
 
-		cfg := &Config{
-			Providers: csync.NewMapFrom(map[string]ProviderConfig{
-				"custom": {
-					APIKey:  "test-key",
-					BaseURL: "https://api.custom.com/v1",
-					Models: []catwalk.Model{
-						{
-							ID:               "large-model",
-							DefaultMaxTokens: 1000,
-						},
-					},
-				},
-			}),
-		}
-		cfg.setDefaults("/tmp", "")
-		env := env.NewFromMap(map[string]string{})
-		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
-		require.NoError(t, err)
-		large, small, err := cfg.defaultModelSelection(knownProviders)
-		require.NoError(t, err)
-		require.Equal(t, "large-model", large.Model)
-		require.Equal(t, "openai", large.Provider)
-		require.Equal(t, int64(1000), large.MaxTokens)
-		require.Equal(t, "small-model", small.Model)
-		require.Equal(t, "openai", small.Provider)
-		require.Equal(t, int64(500), small.MaxTokens)
+		_, ok := cfg.FirstAvailableModel(nil)
+		require.False(t, ok)
+	})
+
+	t.Run("reports nothing when no provider is configured", func(t *testing.T) {
+		cfg := &Config{}
+		configure(t, cfg, nil)
+
+		_, ok := cfg.FirstAvailableModel(nil)
+		require.False(t, ok)
 	})
 }
 
@@ -1758,12 +1609,8 @@ func TestConfig_setDefaultsDisableDefaultProvidersEnvVar(t *testing.T) {
 }
 
 func TestConfig_configureSelectedModels(t *testing.T) {
-	t.Run("reload mode should not persist fallback defaults", func(t *testing.T) {
-		dir := t.TempDir()
-		globalPath := filepath.Join(dir, "crush.json")
-		require.NoError(t, os.WriteFile(globalPath, []byte(`{"models":{"large":{"provider":"ghost","model":"missing"}}}`), 0o600))
-
-		knownProviders := []catwalk.Provider{
+	openAIProvider := func() []catwalk.Provider {
+		return []catwalk.Provider{
 			{
 				ID:                  "openai",
 				APIKey:              "abc",
@@ -1775,7 +1622,35 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 				},
 			},
 		}
+	}
 
+	configure := func(t *testing.T, cfg *Config, knownProviders []catwalk.Provider) {
+		t.Helper()
+		cfg.setDefaults("/tmp", "")
+		env := env.NewFromMap(map[string]string{})
+		resolver := NewShellVariableResolver(env)
+		require.NoError(t, cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders))
+	}
+
+	t.Run("no selection stays unselected even with credentials available", func(t *testing.T) {
+		knownProviders := openAIProvider()
+		cfg := &Config{}
+		configure(t, cfg, knownProviders)
+
+		cfg.applySelectedModels(resolveSelectedModels(cfg, knownProviders))
+
+		require.False(t, cfg.HasSelectedModel(SelectedModelTypeLarge))
+		require.False(t, cfg.HasSelectedModel(SelectedModelTypeSmall))
+		require.NotContains(t, cfg.Models, SelectedModelTypeLarge)
+		require.NotContains(t, cfg.Models, SelectedModelTypeSmall)
+	})
+
+	t.Run("a stale selection is cleared rather than replaced", func(t *testing.T) {
+		dir := t.TempDir()
+		globalPath := filepath.Join(dir, "crush.json")
+		require.NoError(t, os.WriteFile(globalPath, []byte(`{"models":{"large":{"provider":"ghost","model":"missing"}}}`), 0o600))
+
+		knownProviders := openAIProvider()
 		cfg := &Config{
 			Models: map[SelectedModelType]SelectedModel{
 				SelectedModelTypeLarge: {Provider: "ghost", Model: "missing"},
@@ -1785,66 +1660,31 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 		store := &ConfigStore{config: cfg, globalDataPath: globalPath}
 		env := env.NewFromMap(map[string]string{})
 		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(context.Background(), store, env, resolver, knownProviders)
-		require.NoError(t, err)
+		require.NoError(t, cfg.configureProviders(context.Background(), store, env, resolver, knownProviders))
 
-		resolved, resolveErr := resolveSelectedModels(cfg, knownProviders)
-		require.NoError(t, resolveErr)
-		cfg.Models[SelectedModelTypeLarge] = resolved.Large
-		cfg.Models[SelectedModelTypeSmall] = resolved.Small
+		cfg.applySelectedModels(resolveSelectedModels(cfg, knownProviders))
 
-		// In-memory falls back to default.
-		require.True(t, resolved.LargeFallback)
-		require.Equal(t, "openai", cfg.Models[SelectedModelTypeLarge].Provider)
-		require.Equal(t, "large-model", cfg.Models[SelectedModelTypeLarge].Model)
+		require.False(t, cfg.HasSelectedModel(SelectedModelTypeLarge))
 
-		// Disk remains unchanged (resolveSelectedModels never persists).
+		// Disk remains unchanged: resolution never persists a guess.
 		data, readErr := os.ReadFile(globalPath)
 		require.NoError(t, readErr)
 		require.Contains(t, string(data), `"provider":"ghost"`)
-		require.Contains(t, string(data), `"model":"missing"`)
 	})
-	t.Run("should override defaults", func(t *testing.T) {
-		knownProviders := []catwalk.Provider{
-			{
-				ID:                  "openai",
-				APIKey:              "abc",
-				DefaultLargeModelID: "large-model",
-				DefaultSmallModelID: "small-model",
-				Models: []catwalk.Model{
-					{
-						ID:               "larger-model",
-						DefaultMaxTokens: 2000,
-					},
-					{
-						ID:               "large-model",
-						DefaultMaxTokens: 1000,
-					},
-					{
-						ID:               "small-model",
-						DefaultMaxTokens: 500,
-					},
-				},
-			},
-		}
+
+	t.Run("a large selection derives the provider's small model", func(t *testing.T) {
+		knownProviders := openAIProvider()
+		knownProviders[0].Models = append([]catwalk.Model{{ID: "larger-model", DefaultMaxTokens: 2000}}, knownProviders[0].Models...)
 
 		cfg := &Config{
 			Models: map[SelectedModelType]SelectedModel{
-				"large": {
-					Model: "larger-model",
-				},
+				SelectedModelTypeLarge: {Provider: "openai", Model: "larger-model"},
 			},
 		}
-		cfg.setDefaults("/tmp", "")
-		env := env.NewFromMap(map[string]string{})
-		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
-		require.NoError(t, err)
+		configure(t, cfg, knownProviders)
 
-		resolved, resolveErr := resolveSelectedModels(cfg, knownProviders)
-		require.NoError(t, resolveErr)
-		cfg.Models[SelectedModelTypeLarge] = resolved.Large
-		cfg.Models[SelectedModelTypeSmall] = resolved.Small
+		cfg.applySelectedModels(resolveSelectedModels(cfg, knownProviders))
+
 		large := cfg.Models[SelectedModelTypeLarge]
 		small := cfg.Models[SelectedModelTypeSmall]
 		require.Equal(t, "larger-model", large.Model)
@@ -1854,188 +1694,99 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 		require.Equal(t, "openai", small.Provider)
 		require.Equal(t, int64(500), small.MaxTokens)
 	})
-	t.Run("should be possible to use multiple providers", func(t *testing.T) {
-		knownProviders := []catwalk.Provider{
-			{
-				ID:                  "openai",
-				APIKey:              "abc",
-				DefaultLargeModelID: "large-model",
-				DefaultSmallModelID: "small-model",
-				Models: []catwalk.Model{
-					{
-						ID:               "large-model",
-						DefaultMaxTokens: 1000,
-					},
-					{
-						ID:               "small-model",
-						DefaultMaxTokens: 500,
-					},
-				},
-			},
-			{
-				ID:                  "anthropic",
-				APIKey:              "abc",
-				DefaultLargeModelID: "a-large-model",
-				DefaultSmallModelID: "a-small-model",
-				Models: []catwalk.Model{
-					{
-						ID:               "a-large-model",
-						DefaultMaxTokens: 1000,
-					},
-					{
-						ID:               "a-small-model",
-						DefaultMaxTokens: 200,
-					},
-				},
+
+	t.Run("a model without a provider is matched to one that offers it", func(t *testing.T) {
+		knownProviders := openAIProvider()
+		cfg := &Config{
+			Models: map[SelectedModelType]SelectedModel{
+				SelectedModelTypeLarge: {Model: "large-model"},
 			},
 		}
+		configure(t, cfg, knownProviders)
+
+		cfg.applySelectedModels(resolveSelectedModels(cfg, knownProviders))
+
+		require.Equal(t, "openai", cfg.Models[SelectedModelTypeLarge].Provider)
+		require.Equal(t, int64(1000), cfg.Models[SelectedModelTypeLarge].MaxTokens)
+	})
+
+	t.Run("large and small may come from different providers", func(t *testing.T) {
+		knownProviders := append(openAIProvider(), catwalk.Provider{
+			ID:                  "anthropic",
+			APIKey:              "abc",
+			DefaultLargeModelID: "a-large-model",
+			DefaultSmallModelID: "a-small-model",
+			Models: []catwalk.Model{
+				{ID: "a-large-model", DefaultMaxTokens: 1000},
+				{ID: "a-small-model", DefaultMaxTokens: 200},
+			},
+		})
 
 		cfg := &Config{
 			Models: map[SelectedModelType]SelectedModel{
-				"small": {
-					Model:     "a-small-model",
-					Provider:  "anthropic",
-					MaxTokens: 300,
-				},
+				SelectedModelTypeLarge: {Provider: "openai", Model: "large-model"},
+				SelectedModelTypeSmall: {Provider: "anthropic", Model: "a-small-model", MaxTokens: 300},
 			},
 		}
-		cfg.setDefaults("/tmp", "")
-		env := env.NewFromMap(map[string]string{})
-		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
-		require.NoError(t, err)
+		configure(t, cfg, knownProviders)
 
-		resolved, resolveErr := resolveSelectedModels(cfg, knownProviders)
-		require.NoError(t, resolveErr)
-		cfg.Models[SelectedModelTypeLarge] = resolved.Large
-		cfg.Models[SelectedModelTypeSmall] = resolved.Small
+		cfg.applySelectedModels(resolveSelectedModels(cfg, knownProviders))
+
 		large := cfg.Models[SelectedModelTypeLarge]
 		small := cfg.Models[SelectedModelTypeSmall]
 		require.Equal(t, "large-model", large.Model)
 		require.Equal(t, "openai", large.Provider)
-		require.Equal(t, int64(1000), large.MaxTokens)
 		require.Equal(t, "a-small-model", small.Model)
 		require.Equal(t, "anthropic", small.Provider)
 		require.Equal(t, int64(300), small.MaxTokens)
 	})
 
-	t.Run("should override the max tokens only", func(t *testing.T) {
-		knownProviders := []catwalk.Provider{
-			{
-				ID:                  "openai",
-				APIKey:              "abc",
-				DefaultLargeModelID: "large-model",
-				DefaultSmallModelID: "small-model",
-				Models: []catwalk.Model{
-					{
-						ID:               "large-model",
-						DefaultMaxTokens: 1000,
-					},
-					{
-						ID:               "small-model",
-						DefaultMaxTokens: 500,
-					},
-				},
-			},
-		}
-
+	t.Run("max tokens set without a model does not select anything", func(t *testing.T) {
+		knownProviders := openAIProvider()
 		cfg := &Config{
 			Models: map[SelectedModelType]SelectedModel{
-				"large": {
-					MaxTokens: 100,
-				},
+				SelectedModelTypeLarge: {MaxTokens: 100},
 			},
 		}
-		cfg.setDefaults("/tmp", "")
-		env := env.NewFromMap(map[string]string{})
-		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(context.Background(), testStore(cfg), env, resolver, knownProviders)
-		require.NoError(t, err)
+		configure(t, cfg, knownProviders)
 
-		resolved, resolveErr := resolveSelectedModels(cfg, knownProviders)
-		require.NoError(t, resolveErr)
-		cfg.Models[SelectedModelTypeLarge] = resolved.Large
-		cfg.Models[SelectedModelTypeSmall] = resolved.Small
-		large := cfg.Models[SelectedModelTypeLarge]
-		require.Equal(t, "large-model", large.Model)
-		require.Equal(t, "openai", large.Provider)
-		require.Equal(t, int64(100), large.MaxTokens)
+		cfg.applySelectedModels(resolveSelectedModels(cfg, knownProviders))
+
+		require.False(t, cfg.HasSelectedModel(SelectedModelTypeLarge))
 	})
-	t.Run("resolve and persist fallback under writeMu does not deadlock", func(t *testing.T) {
-		dir := t.TempDir()
-		globalPath := filepath.Join(dir, "crush.json")
-		require.NoError(t, os.WriteFile(globalPath, []byte(`{}`), 0o600))
 
-		knownProviders := []catwalk.Provider{
-			{
-				ID:                  "openai",
-				APIKey:              "abc",
-				DefaultLargeModelID: "large-model",
-				DefaultSmallModelID: "small-model",
-				Models: []catwalk.Model{
-					{ID: "large-model", DefaultMaxTokens: 1000},
-					{ID: "small-model", DefaultMaxTokens: 500},
-				},
-			},
-		}
-
+	t.Run("an explicit max tokens override survives resolution", func(t *testing.T) {
+		knownProviders := openAIProvider()
 		cfg := &Config{
 			Models: map[SelectedModelType]SelectedModel{
-				SelectedModelTypeLarge: {Provider: "openai", Model: "this-model-does-not-exist"},
-				SelectedModelTypeSmall: {Provider: "openai", Model: "also-does-not-exist"},
+				SelectedModelTypeLarge: {Provider: "openai", Model: "large-model", MaxTokens: 100},
 			},
 		}
-		cfg.setDefaults(dir, "")
-		store := &ConfigStore{config: cfg, globalDataPath: globalPath}
-		env := env.NewFromMap(map[string]string{})
-		resolver := NewShellVariableResolver(env)
-		err := cfg.configureProviders(context.Background(), store, env, resolver, knownProviders)
-		require.NoError(t, err)
+		configure(t, cfg, knownProviders)
 
-		// Simulate the Load path: resolve (pure), then persist fallbacks
-		// under writeMu using updateLocked. Before the refactor, the
-		// combined configureSelectedModels(persist=true) self-deadlocked
-		// because UpdatePreferredModel re-acquired writeMu.
-		done := make(chan error, 1)
-		go func() {
-			resolved, resolveErr := resolveSelectedModels(cfg, knownProviders)
-			if resolveErr != nil {
-				done <- resolveErr
-				return
-			}
-			cfg.Models[SelectedModelTypeLarge] = resolved.Large
-			cfg.Models[SelectedModelTypeSmall] = resolved.Small
+		cfg.applySelectedModels(resolveSelectedModels(cfg, knownProviders))
 
-			store.writeMu.Lock()
-			defer store.writeMu.Unlock()
-			if resolved.LargeFallback {
-				if err := store.updateLocked(ScopeGlobal, func(c *Config) map[string]any {
-					return store.updatePreferredModelFields(c, SelectedModelTypeLarge, resolved.Large)
-				}); err != nil {
-					done <- err
-					return
-				}
-			}
-			if resolved.SmallFallback {
-				if err := store.updateLocked(ScopeGlobal, func(c *Config) map[string]any {
-					return store.updatePreferredModelFields(c, SelectedModelTypeSmall, resolved.Small)
-				}); err != nil {
-					done <- err
-					return
-				}
-			}
-			done <- nil
-		}()
+		require.Equal(t, int64(100), cfg.Models[SelectedModelTypeLarge].MaxTokens)
+	})
 
-		select {
-		case err := <-done:
-			require.NoError(t, err)
-			// Should have fallen back to defaults.
-			require.Equal(t, "large-model", cfg.Models[SelectedModelTypeLarge].Model)
-			require.Equal(t, "small-model", cfg.Models[SelectedModelTypeSmall].Model)
-		case <-time.After(5 * time.Second):
-			t.Fatal("resolve + persist deadlocked under writeMu")
+	t.Run("an unknown provider reuses the large model as the small model", func(t *testing.T) {
+		cfg := &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"custom": {
+					APIKey:  "test-key",
+					BaseURL: "https://api.custom.com/v1",
+					Models:  []catwalk.Model{{ID: "model", DefaultMaxTokens: 600}},
+				},
+			}),
+			Models: map[SelectedModelType]SelectedModel{
+				SelectedModelTypeLarge: {Provider: "custom", Model: "model"},
+			},
 		}
+		configure(t, cfg, nil)
+
+		cfg.applySelectedModels(resolveSelectedModels(cfg, nil))
+
+		require.Equal(t, cfg.Models[SelectedModelTypeLarge], cfg.Models[SelectedModelTypeSmall])
 	})
 }
 

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -1144,17 +1144,6 @@ func (s *ConfigStore) reloadFromDiskLocked(ctx context.Context) error {
 		return fmt.Errorf("invalid hook configuration on reload: %w", err)
 	}
 
-	// Save current state for potential rollback BEFORE configureProviders,
-	// which may write to disk via RemoveConfigField (e.g. removing stale
-	// OAuth providers). Capturing after would snapshot a config that has
-	// already been mutated, and the rollback would restore corrupted state.
-	oldConfig := s.Config()
-	oldLoadedPaths := s.loadedPaths
-	oldResolver := s.resolver
-	oldKnownProviders := s.knownProviders
-	oldOverrides := s.overrides
-	oldWorkspacePath := s.workspacePath
-
 	// Preserve runtime overrides
 	overrides := s.overrides
 
@@ -1194,29 +1183,13 @@ func (s *ConfigStore) reloadFromDiskLocked(ctx context.Context) error {
 	s.workspacePath = workspacePath
 
 	// Mirror startup flow: setup models and agents against NEW config.
-	var setupErr error
+	// Resolving models cannot fail: an unresolvable selection is dropped
+	// rather than substituted, so there is nothing to roll back to here.
 	if !cfg.IsConfigured() {
 		slog.Warn("No providers configured after reload")
 	} else {
-		resolved, resolveErr := resolveSelectedModels(cfg, providers)
-		if resolveErr != nil {
-			setupErr = fmt.Errorf("failed to configure selected models during reload: %w", resolveErr)
-		} else {
-			cfg.Models[SelectedModelTypeLarge] = resolved.Large
-			cfg.Models[SelectedModelTypeSmall] = resolved.Small
-			s.SetupAgents()
-		}
-	}
-
-	// Rollback on setup failure
-	if setupErr != nil {
-		s.setConfig(oldConfig)
-		s.loadedPaths = oldLoadedPaths
-		s.resolver = oldResolver
-		s.knownProviders = oldKnownProviders
-		s.overrides = oldOverrides
-		s.workspacePath = oldWorkspacePath
-		return setupErr
+		cfg.applySelectedModels(resolveSelectedModels(cfg, providers))
+		s.SetupAgents()
 	}
 
 	// Rebuild staleness tracking. Track every discovered config path, not

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -487,10 +487,14 @@ func (m *Models) setProviderItems() error {
 
 	// Set model groups in the list.
 	m.list.SetGroups(groups...)
-	m.list.SetSelectedItem(selectedItemID)
 	if selectedItemID != "" {
+		m.list.SetSelectedItem(selectedItemID)
 		m.list.ScrollToSelected()
 	} else {
+		// With nothing selected yet, highlight the first actual model.
+		// Index 0 is a group header, which is not selectable, so leaving
+		// the highlight there would make the first Enter do nothing.
+		m.list.SelectFirst()
 		m.list.ScrollToTop()
 	}
 

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -454,7 +454,12 @@ func (m *Models) setProviderItems() error {
 	if len(recentItems) > 0 {
 		recentGroup := NewModelGroup(t, "Recently used", false)
 
-		var validRecentItems []config.SelectedModel
+		// Recents that cannot be resolved right now are skipped for
+		// display but left in the config. Whether a provider is available
+		// depends on the environment Crush happened to be launched from, so
+		// pruning the stored list here would permanently discard history
+		// over a temporarily missing API key. The list is already bounded
+		// when entries are added.
 		for _, recent := range recentItems {
 			key := modelKey(recent.Provider, recent.Model)
 			item, ok := itemsMap[key]
@@ -466,17 +471,9 @@ func (m *Models) setProviderItems() error {
 			item = NewModelItem(t, item.prov, item.model, m.modelType, true)
 			item.showProvider = true
 
-			validRecentItems = append(validRecentItems, recent)
 			recentGroup.AppendItems(item)
 			if recent.Model == currentModel.Model && recent.Provider == currentModel.Provider {
 				selectedItemID = item.ID()
-			}
-		}
-
-		if len(validRecentItems) != len(recentItems) {
-			// FIXME: Does this need to be here? Is it mutating the config during a read?
-			if err := m.com.Workspace.SetConfigField(config.ScopeGlobal, fmt.Sprintf("recent_models.%s", selectedType), validRecentItems); err != nil {
-				return fmt.Errorf("failed to update recent models: %w", err)
 			}
 		}
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -485,7 +485,10 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 
 	desiredState := uiLanding
 	desiredFocus := uiFocusEditor
-	if !com.Config().IsConfigured() {
+	if !com.Config().IsConfigured() || !com.Config().HasSelectedModel(config.SelectedModelTypeLarge) {
+		// No provider, or providers are available but the user has never
+		// picked a model. Either way the model picker is the only thing
+		// standing between them and a usable session.
 		desiredState = uiOnboarding
 	} else if n, _ := com.Workspace.ProjectNeedsInitialization(); n {
 		desiredState = uiInitialize


### PR DESCRIPTION
This fix keeps the model picker from defaulting to the first known provider it can find an find an env var for, which was usually Anthropic. This meant a couple things:

1. If there was an error fetching the provider on startup it would pick the default model from the the first provider it had an env var for.
2. The onboarding model picker would choose a model from the middle of the list, again usually Anthropic.

Generated notes below.

***

Crush would auto-select a provider based on whichever credentials happened to be sitting in your environment, walking the provider list in a fixed order — so in practice a lot of people silently ended up on Anthropic. Worse, that guess was **written to your global config**, so it looked like a choice you had made and it stuck.

The same code path also fired whenever a saved selection stopped resolving (provider temporarily missing an API key, a model retired from the catalog, an expired token, a bad network moment). A transient failure would therefore permanently rewrite your saved model.

## What changed

- **Nothing is guessed.** A model selection that is missing or no longer resolvable is dropped instead of being replaced.
- **Nothing is persisted.** Startup no longer writes a corrected selection to your config, so a transient failure can't permanently change your setup. Your file is left exactly as you wrote it.
- **You get the picker instead.** With no usable model, the TUI opens the model list scrolled to the top, whether that's because no provider is configured or because a provider is configured but you've never chosen a model. That's the common first-run path for anyone with an API key exported.
- **Scripts keep working.** `crush run` and other non-interactive entry points can't prompt, so they fall back to the first available model. That fallback lives in memory only and is never saved.

Credential discovery from the environment is unchanged — that's still how providers become *available*. The only thing that goes away is treating "has credentials" as "user picked this".

Configs that name a model without naming a provider (`models.large.model` with no `provider`) still work: the model is matched against the providers that offer it, in a stable order.

## Note

A related bug is fixed separately in #3486: a failed provider-cache write could remove Hyper from the catalog, which is the most common way a saved selection became unresolvable in the first place. These two are independent and can land in either order, but this PR is the one that makes the damage non-permanent.

💘 Generated with Crush