### PR TITLE
fix(providers): swap the provider cache instead of rewriting it

### DIFF
--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -229,7 +229,11 @@ func (c cache[T]) Store(v T) error {
 		return fmt.Errorf("failed to marshal provider data: %w", err)
 	}
 
-	if err := os.WriteFile(c.path, data, 0o644); err != nil {
+	// Written through a temporary file and renamed into place. Several Crush
+	// instances start independently and race to refresh this cache, and a
+	// truncating write would let one of them read a half-written catalog and
+	// silently fall back to the bundled copy.
+	if err := atomicWriteFile(c.path, data, 0o644); err != nil {
 		return fmt.Errorf("failed to write provider data to cache: %w", err)
 	}
 	return nil

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -306,3 +306,38 @@ func TestCachePathFor(t *testing.T) {
 		})
 	}
 }
+
+// TestCacheStore_ReplacesFileInsteadOfRewritingIt guards the property that
+// several Crush instances depend on: the provider cache is swapped into place
+// as a finished file, never truncated and refilled underneath a reader that is
+// already reading it. A reader that loses that race cannot parse the catalog
+// and silently falls back to the bundled copy.
+func TestCacheStore_ReplacesFileInsteadOfRewritingIt(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "providers.json")
+	c := newCache[[]catwalk.Provider](path)
+
+	require.NoError(t, c.Store([]catwalk.Provider{{ID: "first", Name: "First"}}))
+	before, err := os.Stat(path)
+	require.NoError(t, err)
+
+	require.NoError(t, c.Store([]catwalk.Provider{{ID: "second", Name: "Second"}}))
+	after, err := os.Stat(path)
+	require.NoError(t, err)
+
+	require.False(t, os.SameFile(before, after),
+		"the cache should be replaced by a rename, not rewritten in place")
+
+	// The new contents are complete and no temporary files are left behind.
+	got, _, err := c.Get()
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, catwalk.InferenceProvider("second"), got[0].ID)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "only the cache file should remain")
+	require.Equal(t, "providers.json", entries[0].Name())
+}

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -327,8 +328,15 @@ func TestCacheStore_ReplacesFileInsteadOfRewritingIt(t *testing.T) {
 	after, err := os.Stat(path)
 	require.NoError(t, err)
 
-	require.False(t, os.SameFile(before, after),
-		"the cache should be replaced by a rename, not rewritten in place")
+	// os.Stat on Windows resolves file identity lazily by reopening the path,
+	// so both stats describe whichever file the path points at by the time
+	// they are compared and SameFile cannot observe the replacement. The
+	// write path is shared, so asserting this on the other platforms covers
+	// it. The checks below still run everywhere.
+	if runtime.GOOS != "windows" {
+		require.False(t, os.SameFile(before, after),
+			"the cache should be replaced by a rename, not rewritten in place")
+	}
 
 	// The new contents are complete and no temporary files are left behind.
 	got, _, err := c.Get()


### PR DESCRIPTION
Housekeeping. Generated summary below.

***

Crush saves its provider catalog to disk by truncating the file and refilling it. Several instances start independently and race to refresh that cache, so one of them can read a half-written catalog, fail to parse it, and quietly fall back to the copy bundled at release time. The user is left on a stale model list with no indication why.

The catalog is now written to a temporary file and renamed into place, using the same helper already used for config writes.

## Relationship to other PRs

Independent of #3486 and #3487, based directly on `main`, and can merge in any order. It removes one more way the provider catalog can silently degrade: #3486 stops a failed cache *write* from discarding a good catalog, and this stops a partial cache *read* from happening in the first place.

💘 Generated with Crush