### PR TITLE
fix(paste): attach clipboard image when paste content is empty

### DIFF
--- a/internal/ui/model/paste_image_test.go
+++ b/internal/ui/model/paste_image_test.go
@@ -1,0 +1,222 @@
+package model
+
+import (
+	"reflect"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
+	"github.com/charmbracelet/crush/internal/ui/util"
+	"github.com/stretchr/testify/require"
+)
+
+// imageCapableConfig returns a config whose coder agent points at a model
+// with SupportsImages=true, so currentModelSupportsImages() is true.
+func imageCapableConfig() *config.Config {
+	providers := csync.NewMap[string, config.ProviderConfig]()
+	providers.Set("test-provider", config.ProviderConfig{
+		ID: "test-provider",
+		Models: []catwalk.Model{
+			{ID: "test-model", SupportsImages: true},
+		},
+	})
+	return &config.Config{
+		Models: map[config.SelectedModelType]config.SelectedModel{
+			config.SelectedModelTypeLarge: {
+				Provider: "test-provider",
+				Model:    "test-model",
+			},
+		},
+		Providers: providers,
+		Agents: map[string]config.Agent{
+			config.AgentCoder: {Model: config.SelectedModelTypeLarge},
+		},
+	}
+}
+
+// imageIncapableConfig returns a config with no models, so
+// currentModelSupportsImages() is false.
+func imageIncapableConfig() *config.Config {
+	return &config.Config{
+		Providers: csync.NewMap[string, config.ProviderConfig](),
+		Agents:    map[string]config.Agent{},
+	}
+}
+
+// newPasteTestUI returns a fully wired test UI (focus, textarea, dialog) whose
+// workspace reports the given config.
+func newPasteTestUI(cfg *config.Config) *UI {
+	u := newTestUI()
+	u.com.Workspace = &testWorkspace{cfg: cfg}
+	u.dialog = dialog.NewOverlay()
+	return u
+}
+
+// clipboardCmdPointer returns the function pointer for the
+// pasteImageFromClipboard method value on u. The paste-routing tests below
+// assert against it to prove handlePasteMsg took the clipboard-fallback branch
+// WITHOUT executing the returned command (which would touch the real system
+// clipboard and go flaky per-environment).
+//
+// This deliberately couples the tests to the *mechanism* — handlePasteMsg
+// returning m.pasteImageFromClipboard directly — rather than the behavior. Any
+// future wrapping of that return (e.g. adding a warn-toast closure) will break
+// these assertions even when routing is still correct; that is intentional, and
+// whoever trips it should update the pointer comparison to match the new
+// return shape rather than reverting the production change.
+func clipboardCmdPointer(u *UI) uintptr {
+	return reflect.ValueOf(u.pasteImageFromClipboard).Pointer()
+}
+
+// TestHandlePasteMsg_EmptyContentRoutesToClipboardImage is a regression test
+// for the macOS paste bug: CMD+V of a clipboard image does nothing.
+//
+// When the system clipboard holds an image (not text), the terminal's
+// bracketed paste produces an empty tea.PasteMsg. Before the fix,
+// handlePasteMsg flowed through the text-paste path and silently did nothing
+// (empty text insert). After the fix, an empty paste on an image-capable
+// model delegates to pasteImageFromClipboard so image data on the clipboard
+// is attached instead.
+func TestHandlePasteMsg_EmptyContentRoutesToClipboardImage(t *testing.T) {
+	t.Parallel()
+
+	u := newPasteTestUI(imageCapableConfig())
+	u.textarea.SetValue("existing text")
+
+	// Empty paste - simulates clipboard holding an image on macOS.
+	cmd := u.handlePasteMsg(tea.PasteMsg{Content: ""})
+
+	// The textarea value must be unchanged.
+	require.Equal(t, "existing text", u.textarea.Value(),
+		"empty paste must not modify textarea content; it should route to clipboard image fallback")
+
+	// The returned command must be the pasteImageFromClipboard method value,
+	// proving the clipboard fallback path was taken (not the text insert path).
+	require.NotNil(t, cmd, "empty paste must return a command (the clipboard fallback)")
+	require.Equal(t, clipboardCmdPointer(u), reflect.ValueOf(cmd).Pointer(),
+		"empty paste must route to pasteImageFromClipboard, not the text insertion path")
+}
+
+// TestHandlePasteMsg_EmptyContentOnImageIncapableModelWarns ensures the
+// clipboard-image fallback is gated to image-capable models, mirroring the
+// key-bound path. On a text-only model, an empty paste must not attach an
+// image chip that would be silently dropped at send time — but it must not
+// silently no-op either: it returns a warning command so the user can see
+// why nothing landed.
+func TestHandlePasteMsg_EmptyContentOnImageIncapableModelWarns(t *testing.T) {
+	t.Parallel()
+
+	u := newPasteTestUI(imageIncapableConfig())
+	u.textarea.SetValue("existing text")
+	require.False(t, u.currentModelSupportsImages(),
+		"test precondition: the stub config must be image-incapable")
+
+	cmd := u.handlePasteMsg(tea.PasteMsg{Content: ""})
+
+	require.NotNil(t, cmd,
+		"empty paste on an image-incapable model must return a warning command, not nil")
+	msg := cmd()
+	infoMsg, ok := msg.(util.InfoMsg)
+	require.True(t, ok, "expected util.InfoMsg, got %T", msg)
+	require.Equal(t, util.InfoTypeWarn, infoMsg.Type,
+		"incapable-model paste must warn the user")
+	require.Contains(t, infoMsg.Msg, "doesn't support images")
+	require.NotEqual(t, clipboardCmdPointer(u), reflect.ValueOf(cmd).Pointer(),
+		"empty paste on an image-incapable model must not route to clipboard image fallback")
+	require.Equal(t, "existing text", u.textarea.Value(),
+		"empty paste must not modify textarea content")
+}
+
+// TestPasteImageKeyOnImageIncapableModelWarns exercises the key-bound path
+// (ctrl+v / super+v): on a text-only model it must not attach an image, but
+// must surface a warning instead of silently doing nothing.
+func TestPasteImageKeyOnImageIncapableModelWarns(t *testing.T) {
+	t.Parallel()
+
+	u := newTestUI()
+	u.com.Workspace = &testWorkspace{cfg: imageIncapableConfig()}
+	u.dialog = dialog.NewOverlay()
+	u.keyMap = DefaultKeyMap()
+	u.attachments = attachments.New(nil, attachments.Keymap{})
+	require.False(t, u.currentModelSupportsImages(),
+		"test precondition: the stub config must be image-incapable")
+
+	cmd := u.handleKeyPressMsg(tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl})
+
+	require.NotNil(t, cmd,
+		"paste-image key on an image-incapable model must return a warning command, not nil")
+	msg := cmd()
+	// The editor path batches commands; unwrap to find the warning.
+	var infoMsg util.InfoMsg
+	found := false
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, c := range batch {
+			if c == nil {
+				continue
+			}
+			if im, ok := c().(util.InfoMsg); ok {
+				infoMsg = im
+				found = true
+				break
+			}
+		}
+	} else if im, ok := msg.(util.InfoMsg); ok {
+		infoMsg = im
+		found = true
+	}
+	require.True(t, found, "expected a util.InfoMsg warning, got %T", msg)
+	require.Equal(t, util.InfoTypeWarn, infoMsg.Type,
+		"paste-image key on an image-incapable model must warn the user")
+	require.Contains(t, infoMsg.Msg, "doesn't support images")
+}
+
+// TestHandlePasteMsg_WhitespaceOnlyContentInsertsText ensures that a
+// whitespace-only paste is NOT routed to the clipboard fallback — the macOS
+// repro produces a strictly empty message, and the fix uses a strict == ""
+// check so genuine whitespace pastes (e.g. pasting indentation) still insert
+// as text rather than being silently dropped.
+func TestHandlePasteMsg_WhitespaceOnlyContentInsertsText(t *testing.T) {
+	t.Parallel()
+
+	u := newPasteTestUI(imageCapableConfig())
+	u.textarea.SetValue("")
+
+	cmd := u.handlePasteMsg(tea.PasteMsg{Content: "   \n\t  "})
+
+	// Whitespace content is real text and must be inserted (the textarea may
+	// tab-expand, so we check it's non-empty rather than byte-identical),
+	// not swallowed by the clipboard fallback.
+	require.NotEqual(t, "", u.textarea.Value(),
+		"whitespace-only paste must insert as text, not route to clipboard fallback")
+
+	// It must NOT route to the clipboard image path.
+	if cmd != nil {
+		require.NotEqual(t, clipboardCmdPointer(u), reflect.ValueOf(cmd).Pointer(),
+			"whitespace-only paste must not route to clipboard image fallback")
+	}
+}
+
+// TestHandlePasteMsg_NonEmptyContentInsertsText is the control test: real
+// text paste content must still go through the normal text insertion path
+// and must NOT route to the clipboard fallback.
+func TestHandlePasteMsg_NonEmptyContentInsertsText(t *testing.T) {
+	t.Parallel()
+
+	u := newPasteTestUI(imageCapableConfig())
+	u.textarea.SetValue("")
+
+	cmd := u.handlePasteMsg(tea.PasteMsg{Content: "hello world"})
+
+	require.Contains(t, u.textarea.Value(), "hello world",
+		"non-empty paste must insert text into the textarea")
+
+	// Non-empty text must NOT route to the clipboard image path.
+	if cmd != nil {
+		require.NotEqual(t, clipboardCmdPointer(u), reflect.ValueOf(cmd).Pointer(),
+			"non-empty paste must not route to clipboard image fallback")
+	}
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2437,6 +2437,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 
 			case key.Matches(msg, m.keyMap.Editor.PasteImage):
 				if !m.currentModelSupportsImages() {
+					cmds = append(cmds, util.ReportWarn(fmt.Sprintf("%s doesn't support images", m.currentModelName())))
 					break
 				}
 				cmds = append(cmds, m.pasteImageFromClipboard)
@@ -3248,6 +3249,25 @@ func (m *UI) currentModelSupportsImages() bool {
 	}
 	model := cfg.GetModelByType(agentCfg.Model)
 	return model != nil && model.SupportsImages
+}
+
+// currentModelName returns the display name of the coder agent's current
+// model for user-facing messages, falling back to "current model" when the
+// selection cannot be resolved.
+func (m *UI) currentModelName() string {
+	cfg := m.com.Config()
+	if cfg == nil {
+		return "current model"
+	}
+	agentCfg, ok := cfg.Agents[config.AgentCoder]
+	if !ok {
+		return "current model"
+	}
+	selected, ok := cfg.Models[agentCfg.Model]
+	if !ok || selected.Model == "" {
+		return "current model"
+	}
+	return selected.Model
 }
 
 // toggleCompactMode toggles compact mode between uiChat and uiChatCompact states.
@@ -4608,6 +4628,27 @@ func (m *UI) handlePasteMsg(msg tea.PasteMsg) tea.Cmd {
 
 	if m.focus != uiFocusEditor {
 		return nil
+	}
+
+	// When the pasted content is strictly empty, the clipboard likely holds
+	// a non-text format (e.g. an image copied from Preview on macOS). On
+	// macOS, terminal emulators intercept CMD+V and send the clipboard's
+	// text via bracketed paste; if the clipboard has an image instead of
+	// text, the resulting PasteMsg is empty. Fall back to reading image data
+	// from the native clipboard so the paste is not silently swallowed.
+	//
+	// The check is a strict == "" rather than TrimSpace: the macOS repro
+	// produces a strictly empty message, and trimming would also swallow
+	// genuine whitespace-only pastes (silently dropping them when no image is
+	// found). Mirroring the key-bound path, the fallback is gated to
+	// image-capable models so a text-only model doesn't attach an image chip
+	// that would be silently dropped at send time — but warn instead of
+	// no-oping so the user knows why nothing landed.
+	if msg.Content == "" {
+		if m.currentModelSupportsImages() {
+			return m.pasteImageFromClipboard
+		}
+		return util.ReportWarn(fmt.Sprintf("%s doesn't support images", m.currentModelName()))
 	}
 
 	if hasPasteExceededThreshold(msg) {


### PR DESCRIPTION
## Problem

On macOS, copying an image (e.g. from Preview) and pressing CMD+V in the chat editor does nothing. Terminal emulators intercept CMD+V and deliver the clipboard's **text** via bracketed paste; when the clipboard holds an image instead of text, the resulting `tea.PasteMsg` is strictly empty, and `handlePasteMsg` fell through the text-paste path and silently inserted nothing. The image-only clipboard is never checked.

## Fix

Two changes in `internal/ui/model/ui.go`:

1. **Empty-paste fallback**: when the pasted content is strictly empty, `handlePasteMsg` now delegates to `pasteImageFromClipboard` (the same path as the ctrl+v `PasteImage` binding), so image data on the native clipboard is attached as a pending attachment. The check is a strict `== ""` rather than `TrimSpace`, so genuine whitespace-only pastes still insert as text. Like the key-bound path, the fallback is gated to image-capable models.

2. **Warn on image-incapable models**: both paste-image entry points (the key binding and the new fallback) previously returned `nil` silently when the current model didn't support images — a paste vanished with zero feedback, which made the macOS bug undiagnosable from the UX. They now surface a warning naming the current model (\"gpt-4o-mini doesn't support images\").

## Tests

New `internal/ui/model/paste_image_test.go` covers:

- empty paste → routes to the clipboard-image fallback (asserted via function-pointer identity, without touching the real system clipboard)
- empty paste on an image-incapable model → warning, not the fallback
- ctrl+v on an image-incapable model → warning
- whitespace-only paste → still inserts as text (not swallowed by the fallback)
- non-empty paste → unchanged text insertion path

## Verification

- `go test ./internal/ui/...` — all pass
- `go vet ./internal/ui/...` — clean
- `gofumpt -l internal/ui/` — clean
- `golangci-lint run ./internal/ui/...` — 0 issues
- This fix has been running in a downstream fork for a few days; the empty-paste routing tests pin the mechanism without depending on host clipboard state.