### PR TITLE
fix: reduce default and suggested mcp timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,16 +370,16 @@ for Server-Sent Events.
 
 # Add a local MCP server that runs a Node.js script.
 mcp add filesystem --command node --args /path/to/mcp-server.js \
-  --timeout 120 --disabled-tools some-tool-name --env NODE_ENV production
+  --timeout 10 --disabled-tools some-tool-name --env NODE_ENV production
 
 # Add a GitHub MCP server that uses an API token.
 mcp add github --type http --url "https://api.githubcopilot.com/mcp/" \
-  --timeout 120 --header Authorization "Bearer $GH_PAT" \
+  --timeout 10 --header Authorization "Bearer $GH_PAT" \
   --disabled-tools create_issue --disabled-tools create_pull_request
 
 # Add a streaming MCP server that uses SSE.
 mcp add streaming-service --type sse --url "https://example.com/mcp/sse" \
-  --timeout 120 --header API-Key "$API_KEY"
+  --timeout 10 --header API-Key "$API_KEY"
 ```
 
 #### MCP OAuth

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -1200,9 +1200,9 @@ func mcpTimeout(m config.MCPConfig) time.Duration {
 	// OAuth flows require user interaction in a browser, so use a
 	// generous default to avoid timing out mid-auth.
 	if m.OAuth {
-		return 5 * time.Minute
+		return 30 * time.Second
 	}
-	return 15 * time.Second
+	return 10 * time.Second
 }
 
 // hasUsableToken returns true if the saved OAuth token has an access

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -199,7 +199,7 @@ type MCPConfig struct {
 	Disabled      bool              `json:"disabled,omitempty" jsonschema:"description=Whether this MCP server is disabled,default=false"`
 	DisabledTools []string          `json:"disabled_tools,omitempty" jsonschema:"description=List of tools from this MCP server to disable,example=get-library-doc"`
 	EnabledTools  []string          `json:"enabled_tools,omitempty" jsonschema:"description=Allow list of tools from this MCP server,example=get-library-doc"`
-	Timeout       int               `json:"timeout,omitempty" jsonschema:"description=Timeout in seconds for MCP server connections,default=15,example=30,example=60,example=120"`
+	Timeout       int               `json:"timeout,omitempty" jsonschema:"description=Timeout in seconds for MCP server connections,default=10,example=30,example=60,example=120"`
 
 	// Headers are HTTP headers for HTTP/SSE MCP servers. Values run
 	// through shell expansion at MCP startup, so $VAR and $(cmd)


### PR DESCRIPTION
120 seconds is way too long. When the MCP is not responding it means Crush will wait 2 minutes after opening to send the first prompt. This makes Crush feel broken or unresponsible.

The `--timeout` suggestion in docs is still there, so if the user needs more he can just set a different timeout.