### PR TITLE
feat(agent): deferred MCP tool loading via tool_search

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -127,6 +127,10 @@ type coordinator struct {
 	currentAgent SessionAgent
 	agents       map[string]SessionAgent
 
+	// toolSearch holds the deferred-tool catalog + activation state for the
+	// current session when tool_search (deferred loading) is enabled.
+	toolSearch *toolSearch
+
 	// Skills discovery results (session-start snapshot).
 	allSkills    []*skills.Skill // Pre-filter: all discovered after dedup.
 	activeSkills []*skills.Skill // Post-filter: active skills only.
@@ -794,6 +798,14 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 		return strings.Compare(a.Info().Name, b.Info().Name)
 	})
 
+	// Deferred tool loading: for the top-level agent, optionally keep MCP tool
+	// schemas out of context until the model requests them via tool_search.
+	if opts := c.cfg.Config().Options.ToolSearch; opts != nil && opts.Enabled && !isSubAgent {
+		if deferred, ok := c.buildDeferredTools(filteredTools, hookRunner, opts); ok {
+			return deferred, nil
+		}
+	}
+
 	// Wrap tools with hook interception for the top-level agent only.
 	// Sub-agents (the `agent` task tool, `agentic_fetch`, etc.) run
 	// without hook interception to avoid firing the user's hook N times
@@ -802,6 +814,56 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 	filteredTools = wrapToolsWithHooks(filteredTools, hookRunner, isSubAgent)
 
 	return filteredTools, nil
+}
+
+// buildDeferredTools partitions the assembled tool list into an always-loaded
+// core (built-in tools) and a deferred catalog (MCP tools). When the number of
+// MCP tools exceeds the configured threshold, it returns the core set plus a
+// tool_search meta-tool the model uses to load catalog tools on demand; the
+// deferred tools stay out of context until then. It returns ok=false when there
+// are too few MCP tools to be worth deferring, so the caller loads everything.
+func (c *coordinator) buildDeferredTools(all []fantasy.AgentTool, hookRunner *hooks.Runner, opts *config.ToolSearchOptions) ([]fantasy.AgentTool, bool) {
+	var coreRaw, mcpRaw []fantasy.AgentTool
+	for _, t := range all {
+		if _, ok := t.(interface{ MCP() string }); ok {
+			mcpRaw = append(mcpRaw, t)
+		} else {
+			coreRaw = append(coreRaw, t)
+		}
+	}
+
+	threshold := opts.Threshold
+	if threshold <= 0 {
+		threshold = defaultToolSearchThreshold
+	}
+	if len(mcpRaw) <= threshold {
+		return nil, false
+	}
+
+	// Wrap each partition so PreToolUse hooks still fire on deferred MCP tools
+	// once they are activated.
+	core := wrapToolsWithHooks(coreRaw, hookRunner, false)
+	catalog := wrapToolsWithHooks(mcpRaw, hookRunner, false)
+
+	ts := newToolSearch(catalog, c.toolSearch)
+	// apply pushes the new effective tool set onto the running agent; the next
+	// PrepareStep picks it up. currentAgent may be unset at build time, so it
+	// is resolved lazily when a search actually runs.
+	apply := func(tools []fantasy.AgentTool) {
+		if c.currentAgent != nil {
+			c.currentAgent.SetTools(tools)
+		}
+	}
+	core = append(core, ts.tool(apply))
+	slices.SortFunc(core, func(a, b fantasy.AgentTool) int {
+		return strings.Compare(a.Info().Name, b.Info().Name)
+	})
+	ts.core = core
+	c.toolSearch = ts
+
+	slog.Debug("tool search enabled: deferring MCP tools",
+		"deferred", len(catalog), "core", len(core), "threshold", threshold)
+	return ts.effective(), true
 }
 
 // TODO: when we support multiple agents we need to change this so that we pass in the agent specific model config

--- a/internal/agent/tool_search.go
+++ b/internal/agent/tool_search.go
@@ -1,0 +1,217 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"charm.land/fantasy"
+)
+
+// ToolSearchToolName is the name of the meta-tool that lets the model discover
+// deferred tools on demand instead of loading every MCP tool schema into
+// context up front.
+const ToolSearchToolName = "tool_search"
+
+// defaultToolSearchThreshold is the number of MCP tools above which deferral
+// kicks in. Below it, deferral is not worth the extra round-trip and the tools
+// are loaded normally.
+const defaultToolSearchThreshold = 20
+
+// maxToolSearchResults caps how many tools a single search activates.
+const maxToolSearchResults = 5
+
+const toolSearchDescription = `Discover tools that are available but not currently loaded.
+
+Many tools (typically from connected MCP servers) are deferred to keep the
+context window small — their full schemas are not loaded until you ask for them.
+Call this tool with keywords or a short description of the capability you need
+(for example "query bigquery", "search dbt models", "read incident"). Matching
+tools are loaded and become callable on your next turn. The response lists the
+tools that were loaded, with their names and descriptions.`
+
+// toolSearchInput is the input schema for the tool_search meta-tool.
+type toolSearchInput struct {
+	Query string `json:"query" description:"Keywords or a short natural-language description of the capability you need."`
+}
+
+// toolSearch holds a per-session catalog of deferred tools and the subset that
+// has been activated (loaded) via the tool_search meta-tool. It is safe for
+// concurrent use: the meta-tool's Run may mutate the activated set while the
+// agent loop reads the effective set on each step.
+type toolSearch struct {
+	mu        sync.Mutex
+	core      []fantasy.AgentTool          // always-loaded tools (built-ins + the search tool)
+	catalog   []fantasy.AgentTool          // deferred tools, searchable but not loaded up front
+	activated map[string]fantasy.AgentTool // name -> deferred tool that has been loaded
+}
+
+// newToolSearch builds a tool-search state over the given deferred catalog. If
+// prev describes the same catalog (same set of tool names), its activated set
+// is carried over so tools discovered earlier in a conversation stay loaded.
+func newToolSearch(catalog []fantasy.AgentTool, prev *toolSearch) *toolSearch {
+	ts := &toolSearch{
+		catalog:   catalog,
+		activated: make(map[string]fantasy.AgentTool),
+	}
+	if prev != nil && sameCatalog(prev.catalog, catalog) {
+		prev.mu.Lock()
+		for name, tool := range prev.activated {
+			ts.activated[name] = tool
+		}
+		prev.mu.Unlock()
+	}
+	return ts
+}
+
+// effective returns the tools the model should see this turn: the core set plus
+// any deferred tools that have been activated, sorted by name for a stable
+// (cache-friendly) ordering.
+func (ts *toolSearch) effective() []fantasy.AgentTool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	out := make([]fantasy.AgentTool, 0, len(ts.core)+len(ts.activated))
+	out = append(out, ts.core...)
+	for _, t := range ts.activated {
+		out = append(out, t)
+	}
+	slices.SortFunc(out, func(a, b fantasy.AgentTool) int {
+		return strings.Compare(a.Info().Name, b.Info().Name)
+	})
+	return out
+}
+
+// activate matches catalog tools against query, marks the best matches as
+// loaded, and returns the tools that were newly activated (for reporting to the
+// model). Already-activated matches are skipped.
+func (ts *toolSearch) activate(query string) []fantasy.AgentTool {
+	ranked := rankTools(ts.catalog, query)
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	var loaded []fantasy.AgentTool
+	for _, t := range ranked {
+		if len(loaded) >= maxToolSearchResults {
+			break
+		}
+		name := t.Info().Name
+		if _, ok := ts.activated[name]; ok {
+			continue
+		}
+		ts.activated[name] = t
+		loaded = append(loaded, t)
+	}
+	return loaded
+}
+
+// tool returns the fantasy meta-tool. apply is invoked after each successful
+// search with the new effective tool set, so the running agent picks up newly
+// activated tools on its next step.
+func (ts *toolSearch) tool(apply func([]fantasy.AgentTool)) fantasy.AgentTool {
+	return fantasy.NewParallelAgentTool(
+		ToolSearchToolName,
+		toolSearchDescription,
+		func(ctx context.Context, in toolSearchInput, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			query := strings.TrimSpace(in.Query)
+			if query == "" {
+				return fantasy.NewTextErrorResponse("query is required"), nil
+			}
+			loaded := ts.activate(query)
+			if apply != nil {
+				apply(ts.effective())
+			}
+			if len(loaded) == 0 {
+				return fantasy.NewTextResponse(fmt.Sprintf(
+					"No tools matched %q. Try different or broader keywords.", query,
+				)), nil
+			}
+			var b strings.Builder
+			fmt.Fprintf(&b, "Loaded %d tool(s) — you can call them on your next turn:\n", len(loaded))
+			for _, t := range loaded {
+				info := t.Info()
+				fmt.Fprintf(&b, "\n- %s: %s", info.Name, firstLine(info.Description))
+			}
+			return fantasy.NewTextResponse(b.String()), nil
+		},
+	)
+}
+
+// rankTools returns catalog tools that match query, best first. Matching is a
+// dependency-free case-insensitive token-overlap over each tool's name and
+// description; name matches are weighted more heavily. It is intentionally
+// simple — enough for on-demand discovery without pulling in a search library.
+func rankTools(catalog []fantasy.AgentTool, query string) []fantasy.AgentTool {
+	terms := tokenize(query)
+	if len(terms) == 0 {
+		return nil
+	}
+	type scored struct {
+		tool  fantasy.AgentTool
+		score int
+	}
+	ranked := make([]scored, 0, len(catalog))
+	for _, t := range catalog {
+		info := t.Info()
+		name := strings.ToLower(info.Name)
+		hay := name + " " + strings.ToLower(info.Description)
+		score := 0
+		for _, term := range terms {
+			if !strings.Contains(hay, term) {
+				continue
+			}
+			score++
+			if strings.Contains(name, term) {
+				score += 2
+			}
+		}
+		if score > 0 {
+			ranked = append(ranked, scored{tool: t, score: score})
+		}
+	}
+	slices.SortStableFunc(ranked, func(a, b scored) int { return b.score - a.score })
+	out := make([]fantasy.AgentTool, len(ranked))
+	for i, s := range ranked {
+		out[i] = s.tool
+	}
+	return out
+}
+
+// tokenize lower-cases s and splits it into alphanumeric/`_`/`-` terms of length
+// > 1, dropping trivial tokens.
+func tokenize(s string) []string {
+	fields := strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return !(r == '_' || r == '-' || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'))
+	})
+	out := fields[:0]
+	for _, f := range fields {
+		if len(f) > 1 {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}
+
+// sameCatalog reports whether a and b contain the same set of tool names.
+func sameCatalog(a, b []fantasy.AgentTool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(a))
+	for _, t := range a {
+		seen[t.Info().Name] = struct{}{}
+	}
+	for _, t := range b {
+		if _, ok := seen[t.Info().Name]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/agent/tool_search_test.go
+++ b/internal/agent/tool_search_test.go
@@ -1,0 +1,120 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"charm.land/fantasy"
+)
+
+func ft(name, desc string) fantasy.AgentTool {
+	return fantasy.NewAgentTool(name, desc,
+		func(ctx context.Context, in struct{}, call fantasy.ToolCall) (fantasy.ToolResponse, error) {
+			return fantasy.NewTextResponse(""), nil
+		},
+	)
+}
+
+func names(tools []fantasy.AgentTool) []string {
+	out := make([]string, len(tools))
+	for i, t := range tools {
+		out[i] = t.Info().Name
+	}
+	return out
+}
+
+func TestRankTools(t *testing.T) {
+	catalog := []fantasy.AgentTool{
+		ft("live_bq_query", "Run a BigQuery SQL query"),
+		ft("dbt_search", "Search dbt models by name"),
+		ft("grep", "Search files with a regex"),
+	}
+
+	ranked := rankTools(catalog, "bigquery sql")
+	if len(ranked) == 0 || ranked[0].Info().Name != "live_bq_query" {
+		t.Fatalf("expected live_bq_query first, got %v", names(ranked))
+	}
+
+	// Name-token matches should outrank description-only matches.
+	ranked = rankTools(catalog, "search")
+	if len(ranked) == 0 || ranked[0].Info().Name != "dbt_search" {
+		t.Fatalf("expected dbt_search first for 'search', got %v", names(ranked))
+	}
+
+	if got := rankTools(catalog, "nonexistent"); len(got) != 0 {
+		t.Fatalf("expected no matches, got %v", names(got))
+	}
+}
+
+func TestActivateCapsAndSkipsDupes(t *testing.T) {
+	var catalog []fantasy.AgentTool
+	for _, n := range []string{"t1", "t2", "t3", "t4", "t5", "t6", "t7"} {
+		catalog = append(catalog, ft(n, "handles data records"))
+	}
+	ts := newToolSearch(catalog, nil)
+
+	first := ts.activate("data")
+	if len(first) != maxToolSearchResults {
+		t.Fatalf("expected %d activated, got %d", maxToolSearchResults, len(first))
+	}
+	second := ts.activate("data")
+	if len(second) != len(catalog)-maxToolSearchResults {
+		t.Fatalf("expected remaining %d activated, got %d", len(catalog)-maxToolSearchResults, len(second))
+	}
+	if third := ts.activate("data"); len(third) != 0 {
+		t.Fatalf("expected nothing new to activate, got %d", len(third))
+	}
+}
+
+func TestEffectiveIsCorePlusActivatedSorted(t *testing.T) {
+	ts := newToolSearch([]fantasy.AgentTool{ft("zeta_tool", "d"), ft("alpha_tool", "d")}, nil)
+	ts.core = []fantasy.AgentTool{ft("bash", ""), ft("tool_search", "")}
+
+	// Only core before any activation.
+	if got := names(ts.effective()); len(got) != 2 {
+		t.Fatalf("expected 2 core tools, got %v", got)
+	}
+
+	ts.activate("zeta")
+	got := names(ts.effective())
+	want := []string{"bash", "tool_search", "zeta_tool"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("effective not sorted: got %v want %v", got, want)
+		}
+	}
+}
+
+func TestCarryOverActivationOnlyWhenCatalogUnchanged(t *testing.T) {
+	catalog := []fantasy.AgentTool{ft("alpha", "d"), ft("beta", "d")}
+	prev := newToolSearch(catalog, nil)
+	prev.activate("alpha")
+
+	// Same catalog -> activation carried over.
+	same := newToolSearch([]fantasy.AgentTool{ft("alpha", "d"), ft("beta", "d")}, prev)
+	if _, ok := same.activated["alpha"]; !ok {
+		t.Fatal("expected activation carried over for identical catalog")
+	}
+
+	// Different catalog -> activation reset.
+	diff := newToolSearch([]fantasy.AgentTool{ft("alpha", "d"), ft("gamma", "d")}, prev)
+	if len(diff.activated) != 0 {
+		t.Fatalf("expected reset activation for changed catalog, got %d", len(diff.activated))
+	}
+}
+
+func TestTokenizeDropsTrivialTokens(t *testing.T) {
+	got := tokenize("Query BigQuery a b live_bq")
+	want := map[string]bool{"query": true, "bigquery": true, "live_bq": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %v want keys %v", got, want)
+	}
+	for _, term := range got {
+		if !want[term] {
+			t.Fatalf("unexpected token %q in %v", term, got)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -323,17 +323,28 @@ type Options struct {
 	// the SQLite database and workspace overrides. Relative paths are
 	// resolved against the working directory; absolute paths are used
 	// verbatim. After defaulting the stored value is always absolute.
-	DataDirectory             string       `json:"data_directory,omitempty" jsonschema:"description=Directory for storing application data. Relative paths are resolved against the working directory; absolute paths are used as-is.,default=.crush,example=.crush"`
-	DisabledTools             []string     `json:"disabled_tools,omitempty" jsonschema:"description=List of built-in tools to disable and hide from the agent,example=bash,example=sourcegraph"`
-	DisableProviderAutoUpdate bool         `json:"disable_provider_auto_update,omitempty" jsonschema:"description=Disable providers auto-update,default=false"`
-	DisableDefaultProviders   bool         `json:"disable_default_providers,omitempty" jsonschema:"description=Ignore all default/embedded providers. When enabled\\, providers must be fully specified in the config file with base_url\\, models\\, and api_key - no merging with defaults occurs,default=false"`
-	Attribution               *Attribution `json:"attribution,omitempty" jsonschema:"description=Attribution settings for generated content"`
-	DisableMetrics            bool         `json:"disable_metrics,omitempty" jsonschema:"description=Disable sending metrics,default=false"`
-	InitializeAs              string       `json:"initialize_as,omitempty" jsonschema:"description=Name of the context file to create/update during project initialization,default=AGENTS.md,example=AGENTS.md,example=CRUSH.md,example=CLAUDE.md,example=docs/LLMs.md"`
-	AutoLSP                   *bool        `json:"auto_lsp,omitempty" jsonschema:"description=Automatically setup LSPs based on root markers,default=true"`
-	Progress                  *bool        `json:"progress,omitempty" jsonschema:"description=Show indeterminate progress updates during long operations,default=true"`
-	Notifications             string       `json:"notifications,omitempty" jsonschema:"description=Notification style to use. Options: auto (default)\\, native\\, osc\\, bell\\, disabled. Auto selects based on environment: native for local sessions\\, osc for SSH (with automatic OSC 99/777 detection).,enum=auto,enum=native,enum=osc,enum=bell,enum=disabled,default=auto"`
-	DisabledSkills            []string     `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
+	DataDirectory             string             `json:"data_directory,omitempty" jsonschema:"description=Directory for storing application data. Relative paths are resolved against the working directory; absolute paths are used as-is.,default=.crush,example=.crush"`
+	DisabledTools             []string           `json:"disabled_tools,omitempty" jsonschema:"description=List of built-in tools to disable and hide from the agent,example=bash,example=sourcegraph"`
+	DisableProviderAutoUpdate bool               `json:"disable_provider_auto_update,omitempty" jsonschema:"description=Disable providers auto-update,default=false"`
+	DisableDefaultProviders   bool               `json:"disable_default_providers,omitempty" jsonschema:"description=Ignore all default/embedded providers. When enabled\\, providers must be fully specified in the config file with base_url\\, models\\, and api_key - no merging with defaults occurs,default=false"`
+	Attribution               *Attribution       `json:"attribution,omitempty" jsonschema:"description=Attribution settings for generated content"`
+	DisableMetrics            bool               `json:"disable_metrics,omitempty" jsonschema:"description=Disable sending metrics,default=false"`
+	InitializeAs              string             `json:"initialize_as,omitempty" jsonschema:"description=Name of the context file to create/update during project initialization,default=AGENTS.md,example=AGENTS.md,example=CRUSH.md,example=CLAUDE.md,example=docs/LLMs.md"`
+	AutoLSP                   *bool              `json:"auto_lsp,omitempty" jsonschema:"description=Automatically setup LSPs based on root markers,default=true"`
+	Progress                  *bool              `json:"progress,omitempty" jsonschema:"description=Show indeterminate progress updates during long operations,default=true"`
+	Notifications             string             `json:"notifications,omitempty" jsonschema:"description=Notification style to use. Options: auto (default)\\, native\\, osc\\, bell\\, disabled. Auto selects based on environment: native for local sessions\\, osc for SSH (with automatic OSC 99/777 detection).,enum=auto,enum=native,enum=osc,enum=bell,enum=disabled,default=auto"`
+	DisabledSkills            []string           `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
+	ToolSearch                *ToolSearchOptions `json:"tool_search,omitempty" jsonschema:"description=Deferred (on-demand) loading of MCP tools to reduce context usage"`
+}
+
+// ToolSearchOptions configures deferred tool loading. When enabled, MCP tool
+// schemas are kept out of the model's context until the model discovers them
+// via the built-in tool_search meta-tool. This reduces per-turn context usage
+// for setups with many MCP tools, at the cost of an occasional extra
+// discovery round-trip. Applies to the top-level agent only.
+type ToolSearchOptions struct {
+	Enabled   bool `json:"enabled,omitempty" jsonschema:"description=Enable deferred tool loading via a tool_search meta-tool,default=false"`
+	Threshold int  `json:"threshold,omitempty" jsonschema:"description=Only defer MCP tools when the total number of MCP tools exceeds this threshold,default=20"`
 }
 
 type MCPs map[string]MCPConfig

--- a/schema.json
+++ b/schema.json
@@ -571,6 +571,10 @@
           },
           "type": "array",
           "description": "List of skill names to disable and hide from the agent"
+        },
+        "tool_search": {
+          "$ref": "#/$defs/ToolSearchOptions",
+          "description": "Deferred (on-demand) loading of MCP tools to reduce context usage"
         }
       },
       "additionalProperties": false,
@@ -878,6 +882,22 @@
           "examples": [
             100
           ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "ToolSearchOptions": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable deferred tool loading via a tool_search meta-tool",
+          "default": false
+        },
+        "threshold": {
+          "type": "integer",
+          "description": "Only defer MCP tools when the total number of MCP tools exceeds this threshold",
+          "default": 20
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## What

Adds opt-in **deferred tool loading** for MCP tools via a built-in `tool_search` meta-tool, so setups with many MCP servers don't pay the full tool-schema context cost on every turn.

## Why

Every connected MCP server's tool schemas are loaded into context on every request. A handful of servers can add tens of thousands of tokens before any work happens, and tool-selection accuracy degrades once the toolset grows past ~30–50 tools. Deferring MCP tools behind a search keeps the per-turn context small and the visible toolset focused.

## How it works

- New `options.tool_search` config: `{ "enabled": bool, "threshold": int (default 20) }`.
- When enabled and the number of MCP tools exceeds `threshold`, `buildTools` partitions tools into an always-loaded **core** (built-ins) and a deferred **catalog** (MCP tools). The model sees only core + a `tool_search` tool.
- The model calls `tool_search` with keywords; matching catalog tools are activated and pushed onto the running agent via `SetTools`. Because tools are recomputed each step in `PrepareStep`, they become callable on the next turn — no restart.
- Activated tools persist for the conversation and reset when the MCP catalog changes.

## Notes / scope

- **Opt-in** (default off) — no behavior change unless configured.
- **Provider-agnostic** — implemented client-side (a normal tool + the existing dynamic tool list), so it works with any model, not just Anthropic.
- **Top-level agent only** — sub-agents are unaffected.
- PreToolUse **hooks are preserved** on activated tools (both partitions are hook-wrapped).
- Ranking is a dependency-free case-insensitive token-overlap over tool name + description (name matches weighted higher). Straightforward to swap for BM25/embeddings later.

## Testing

- Unit tests for ranking, activation (cap + dedupe), effective-set composition, catalog-change reset, and tokenization.
- `go build ./...` clean, `schema.json` regenerated; verified end-to-end against a live setup with 40+ MCP tools — schemas deferred out of context, model discovers and calls tools on demand.

## Config example

```json
{
  "options": {
    "tool_search": { "enabled": true, "threshold": 20 }
  }
}
```
