### PR TITLE
fix(agent): stop title generation from outliving its run

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -57,6 +57,13 @@ const (
 	largeContextWindowThreshold = 200_000
 	largeContextWindowBuffer    = 20_000
 	smallContextWindowRatio     = 0.2
+
+	// titleGenerationTimeout bounds one call to GenerateTitle, covering
+	// both the small-model attempt and the large-model retry. Titles from
+	// a reasoning model can take tens of seconds, so the bound is
+	// generous; it exists to keep a stalled request finite, not to cut
+	// slow ones short.
+	titleGenerationTimeout = 60 * time.Second
 )
 
 var userAgent = fmt.Sprintf("Charm-Crush/%s (https://charm.land/crush)", version.Version)
@@ -220,6 +227,12 @@ type sessionAgent struct {
 	// across the agent. Cancel uses its current value as the per-session
 	// high-water mark.
 	acceptSeqGen uint64
+	// titleWG tracks in-flight title generation. Those goroutines run on
+	// a context detached from the run (see startTitleGeneration), so a
+	// cancel cannot stop them and nothing else knows they exist. The
+	// group is what lets Run and CancelAll join them before whoever owns
+	// the database closes it.
+	titleWG sync.WaitGroup
 }
 
 type SessionAgentOptions struct {
@@ -649,6 +662,17 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	}
 	sessMu.Unlock()
 
+	// waitForTitle is set below when this run spawns title generation. It
+	// is deferred here, ahead of the cancel and the activeRequests
+	// cleanup, so it runs last: the session stops reporting busy and the
+	// run context is released before Run blocks on the title write.
+	var waitForTitle func()
+	defer func() {
+		if waitForTitle != nil {
+			waitForTitle()
+		}
+	}()
+
 	defer cancel()
 	// Conditional cleanup: only remove our entry if it hasn't been replaced
 	// by a newer run. Without this guard, the deferred Del fires after a
@@ -701,12 +725,8 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	}
 
 	// Generate title from the first real (non-shell) user prompt.
-	// can take tens of seconds. Blocking Run on it delays the
-	// response to the caller. Use a detached context so the title
-	// goroutine survives Run's cancel.
 	if !hasUserTextMessage(msgs) {
-		titleCtx := context.WithoutCancel(ctx)
-		go a.GenerateTitle(titleCtx, call.SessionID, call.Prompt)
+		waitForTitle = a.startTitleGeneration(ctx, call.SessionID, call.Prompt)
 	}
 
 	// Add the user message to the session.
@@ -1724,11 +1744,60 @@ func hasUserTextMessage(msgs []message.Message) bool {
 	return false
 }
 
+// startTitleGeneration generates the session title on its own goroutine and
+// returns a function that blocks until that goroutine is done.
+//
+// The title call can take tens of seconds on a reasoning model, so it must not
+// sit in front of the model's response, and it runs on a context detached from
+// the run so a cancel (or a workspace shutdown) can't drop the title write.
+// That detachment is exactly why the caller has to join it: nothing can stop
+// this goroutine, and if it outlives the database handle its writes fail with
+// "sql: database is closed" and the session keeps its placeholder title. Run
+// defers the returned wait and CancelAll drains the same group, so a title
+// write is never left in flight past the lifetime of whoever owns the
+// database. GenerateTitle bounds itself with titleGenerationTimeout, so both
+// waits terminate.
+func (a *sessionAgent) startTitleGeneration(ctx context.Context, sessionID, userPrompt string) func() {
+	titleCtx := context.WithoutCancel(ctx)
+	done := make(chan struct{})
+	a.titleWG.Add(1)
+	go func() {
+		// Done first, so a caller released by done also observes the
+		// group as drained.
+		defer close(done)
+		defer a.titleWG.Done()
+		a.GenerateTitle(titleCtx, sessionID, userPrompt)
+	}()
+	return func() { <-done }
+}
+
+// waitForTitles blocks until every in-flight title generation has finished or
+// timeout elapses, whichever comes first.
+func (a *sessionAgent) waitForTitles(timeout time.Duration) {
+	done := make(chan struct{})
+	go func() {
+		a.titleWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+	}
+}
+
 // GenerateTitle generates a session title based on the initial prompt.
 func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, userPrompt string) {
 	if userPrompt == "" {
 		return
 	}
+
+	// Bound the attempt. Callers hand this a context detached from the
+	// run, so without a deadline a stalled request would pin the
+	// goroutine, and anything waiting on it, for the life of the
+	// process. The fallback below re-detaches, so it still runs after
+	// this deadline fires.
+	ctx, cancelTitle := context.WithTimeout(ctx, titleGenerationTimeout)
+	defer cancelTitle()
 
 	// Ensure the session always gets a title even if every path below
 	// fails or the context is cancelled before we finish.
@@ -2016,6 +2085,18 @@ func (a *sessionAgent) ClearQueue(sessionID string) {
 }
 
 func (a *sessionAgent) CancelAll() {
+	a.cancelActiveRuns()
+
+	// Title generation is detached from the run context, so the cancels
+	// above don't reach it and IsBusy never reported it. Drain it here:
+	// callers use CancelAll to make the agent quiescent before closing
+	// the database (see app.Shutdown).
+	a.waitForTitles(5 * time.Second)
+}
+
+// cancelActiveRuns cancels every active run and waits, within a bounded
+// budget, for them to unwind.
+func (a *sessionAgent) cancelActiveRuns() {
 	if !a.IsBusy() {
 		return
 	}

--- a/internal/agent/title_test.go
+++ b/internal/agent/title_test.go
@@ -1,0 +1,118 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"charm.land/fantasy"
+	"github.com/stretchr/testify/require"
+)
+
+// slowTitleModel is a small model whose Stream takes long enough to still be
+// in flight when a fast large model has already finished the turn.
+type slowTitleModel struct {
+	delay time.Duration
+	title string
+	// entered, when non-nil, receives once the stream has started, so a
+	// test can act at a point where title generation is provably in
+	// flight.
+	entered chan struct{}
+}
+
+func (slowTitleModel) Provider() string { return "fake" }
+func (slowTitleModel) Model() string    { return "fake-small" }
+
+func (slowTitleModel) Generate(context.Context, fantasy.Call) (*fantasy.Response, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m slowTitleModel) Stream(context.Context, fantasy.Call) (fantasy.StreamResponse, error) {
+	return func(yield func(fantasy.StreamPart) bool) {
+		if m.entered != nil {
+			select {
+			case m.entered <- struct{}{}:
+			default:
+			}
+		}
+		time.Sleep(m.delay)
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextStart, ID: "1"})
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextDelta, ID: "1", Delta: m.title})
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeTextEnd, ID: "1"})
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeFinish, FinishReason: fantasy.FinishReasonStop})
+	}, nil
+}
+
+func (slowTitleModel) GenerateObject(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (slowTitleModel) StreamObject(context.Context, fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+// TestRun_WaitsForTitleGeneration pins the lifetime of the title goroutine to
+// the run that spawned it. Title generation is detached from the run context
+// so a cancel can't drop the write; that also means nothing else can stop it,
+// and when it was left unjoined it kept running after its owner tore down the
+// database, writing into a closed connection ("sql: database is closed") and
+// leaving the session with a placeholder title. Run must not return until the
+// title has landed.
+func TestRun_WaitsForTitleGeneration(t *testing.T) {
+	t.Parallel()
+	env := testEnv(t)
+	small := slowTitleModel{delay: 250 * time.Millisecond, title: "a good title"}
+	sa := testSessionAgent(env, fastModel{}, small, "system")
+
+	sess, err := env.sessions.Create(t.Context(), "New Session")
+	require.NoError(t, err)
+
+	_, err = sa.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		Prompt:    "hello",
+	})
+	require.NoError(t, err)
+
+	got, err := env.sessions.Get(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.Equal(t, "a good title", got.Title)
+}
+
+// TestCancelAll_WaitsForTitleGeneration covers the shutdown path. app.Shutdown
+// calls CancelAll to make the agent quiescent and then closes the database, so
+// CancelAll has to drain title generation too — the run cancel it issues never
+// reaches those goroutines.
+func TestCancelAll_WaitsForTitleGeneration(t *testing.T) {
+	t.Parallel()
+	env := testEnv(t)
+	small := slowTitleModel{
+		delay:   250 * time.Millisecond,
+		title:   "shutdown title",
+		entered: make(chan struct{}, 1),
+	}
+	sa := testSessionAgent(env, fastModel{}, small, "system").(*sessionAgent)
+
+	sess, err := env.sessions.Create(t.Context(), "New Session")
+	require.NoError(t, err)
+
+	go func() {
+		_, _ = sa.Run(t.Context(), SessionAgentCall{
+			SessionID: sess.ID,
+			Prompt:    "hello",
+		})
+	}()
+
+	// Only cancel once title generation is provably in flight.
+	select {
+	case <-small.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("title generation never started")
+	}
+
+	sa.CancelAll()
+
+	got, err := env.sessions.Get(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.Equal(t, "shutdown title", got.Title)
+}


### PR DESCRIPTION
The title goroutine had no owner. `Run` spawned `GenerateTitle` on a detached context and never joined it, and neither did `CancelAll`, which only waits on `activeRequests`. So it outlived whoever started it and wrote to an already-closed database:

```
ERROR Failed to save session title and usage error="sql: database is closed"
```

Easiest repro is quitting while the first answer in a new session is still streaming: the session keeps its placeholder title. It also fires constantly in tests.

It's tracked now in a WaitGroup. `Run` joins it after the busy state and run context are already released, so cancel stays as responsive as before, and `CancelAll` drains the same group before shutdown closes the db. Generation is also bounded at 60s, since on a detached context a stalled request pinned the goroutine for the life of the process.