### PR TITLE
feat: A2UI — live agent- and MCP-served UI surfaces in the chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - **Session-Based:** maintain multiple work sessions and contexts per project
 - **LSP-Enhanced:** Crush uses LSPs for additional context, just like you do
 - **Extensible:** add capabilities via MCPs (`http`, `stdio`, and `sse`)
+- **UI-Fluent:** models and MCP servers can speak [A2UI](https://a2ui.org) via [a2tea](https://github.com/joestump-agent/a2tea) and Crush will draw it — cards, lists, forms, and buttons rendered live in the chat
 - **Works Everywhere:** first-class support in every terminal on macOS, Linux, Windows (PowerShell and WSL), Android, FreeBSD, OpenBSD, and NetBSD
 - **Industrial Grade:** built on the Charm ecosystem, powering 25k+ applications, from leading open source projects to business-critical infrastructure
 
@@ -243,6 +244,39 @@ Is there a provider you’d like to see in Crush? Is there an existing model tha
 Crush’s default model listing is managed in [Catwalk](https://github.com/charmbracelet/catwalk), a community-supported, open source repository of Crush-compatible models, and you’re welcome to contribute.
 
 <a href="https://github.com/charmbracelet/catwalk"><img width="174" height="174" alt="Catwalk Badge" src="https://github.com/user-attachments/assets/95b49515-fe82-4409-b10d-5beb0873787d" /></a>
+
+## A2UI
+
+Sometimes prose isn’t the best answer. When an assistant reply contains an
+[A2UI](https://a2ui.org) message — structured JSON describing UI, wrapped in
+`<a2ui-json>` tags — Crush renders it as an actual element in the chat instead
+of dumping raw JSON:
+
+```text
+<a2ui-json>{"version":"v0.9","updateComponents":{...}}</a2ui-json>
+
+        …becomes…
+
+╭──────────────────────────────╮
+│ Build passed                 │
+│ 142 tests, 0 failures.       │
+│ ──────────────────────────── │
+│ [ Details ]  [ Re-run ]      │
+╰──────────────────────────────╯
+```
+
+Parsing and rendering are handled by
+[a2tea](https://github.com/joestump-agent/a2tea), which speaks the real A2UI
+v0.9 protocol. Surfaces are live: Tab cycles a surface’s focus ring, inputs
+accept edits, and a button press either turns into an agent turn (for
+model-emitted surfaces) or rounds back to the owning MCP server’s
+`a2ui_action` tool (for server-served surfaces, e.g. an
+`application/a2ui+json` resource or an embedded tool-result surface).
+
+> [!NOTE]
+> Prose around a surface still renders as Markdown, and a block that fails to
+> parse shows an alert rather than silently disappearing. Deployments that
+> want plain text only can opt out with `disable_a2ui`.
 
 ## Configuration
 

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/itchyny/gojq v0.12.19
+	github.com/joestump-agent/a2tea v0.1.0
 	github.com/joho/godotenv v1.5.1
 	github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d
 	github.com/lucasb-eyer/go-colorful v1.4.0
@@ -63,6 +64,7 @@ require (
 	github.com/swaggo/swag v1.16.6
 	github.com/tidwall/gjson v1.19.0
 	github.com/tidwall/sjson v1.2.5
+	github.com/tmc/a2ui v0.0.0-20260605070129-b42a8925e473
 	github.com/zeebo/xxh3 v1.1.0
 	go.uber.org/goleak v1.3.0
 	golang.design/x/clipboard v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -254,6 +254,8 @@ github.com/jackmordaunt/icns/v3 v3.0.1 h1:xxot6aNuGrU+lNgxz5I5H0qSeCjNKp8uTXB1j8
 github.com/jackmordaunt/icns/v3 v3.0.1/go.mod h1:5sHL59nqTd2ynTnowxB/MDQFhKNqkK8X687uKNygaSQ=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
+github.com/joestump-agent/a2tea v0.1.0 h1:pIlPNDSB3HV4Tz8KqoAVlwwF0YSdaX5S8Rta/ISEdNI=
+github.com/joestump-agent/a2tea v0.1.0/go.mod h1:pg6ATa4oTrJfhPmfQ9a/Y/5xU9DTXZ8rGVvLj3NpEaE=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d h1:on25kP+Sx7sxUMRQiA8gdcToAGet4DK/EIA30mXre+4=
@@ -407,6 +409,8 @@ github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
+github.com/tmc/a2ui v0.0.0-20260605070129-b42a8925e473 h1:+B481G1UoRx0JbaP8BzlXNT9Q2tcsfsjx8wZYd4ePVo=
+github.com/tmc/a2ui v0.0.0-20260605070129-b42a8925e473/go.mod h1:3L0MaXHW3Z1+uJqusspGP4eLXTNhs+SLLPTlbbGr+R4=
 github.com/u-root/u-root v0.14.1-0.20250807200646-5e7721023dc7 h1:ax+jBy7xFhh+Ka0IGLmH5mft+YDuqvzEjSgWuAP0nsM=
 github.com/u-root/u-root v0.14.1-0.20250807200646-5e7721023dc7/go.mod h1:/0Qr7qJeDwWxoKku2xKQ4Szc+SwBE3g9VE8jNiamsmc=
 github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 h1:pyC9PaHYZFgEKFdlp3G8RaCKgVpHZnecvArXvPXcFkM=

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -83,7 +83,12 @@ type SessionAgentCall struct {
 	// reliable completion contract (e.g. `crush run` against a
 	// session that may be busy) MUST set it; SessionID alone is
 	// ambiguous when concurrent turns share the same session.
-	RunID            string
+	RunID string
+	// ContentWidth is the UI's chat content width hint in cells (0 when
+	// the turn has no interactive UI). Tools rendering width-sensitive
+	// remote content (e.g. A2UI surfaces with pre-sized bar geometry)
+	// use it to ask the server for exactly the right size.
+	ContentWidth     int
 	Prompt           string
 	ProviderOptions  fantasy.ProviderOptions
 	Attachments      []message.Attachment
@@ -874,6 +879,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			callContext = context.WithValue(callContext, tools.MessageIDContextKey, assistantMsg.ID)
 			callContext = context.WithValue(callContext, tools.SupportsImagesContextKey, largeModel.CatwalkCfg.SupportsImages)
 			callContext = context.WithValue(callContext, tools.ModelNameContextKey, largeModel.CatwalkCfg.Name)
+			callContext = context.WithValue(callContext, tools.ContentWidthContextKey, call.ContentWidth)
 			currentAssistant = &assistantMsg
 			return callContext, prepared, err
 		},

--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -150,7 +150,7 @@ func coderAgent(r *vcr.Recorder, env fakeEnv, large, small fantasy.LanguageModel
 
 	// Clear some fields to avoid issues with VCR cassette matching.
 	cfg.Config().Options.SkillsPaths = nil
-	cfg.Config().Options.DisabledSkills = []string{"crush-config"}
+	cfg.Config().Options.DisabledSkills = []string{"crush-config", "a2ui"}
 	cfg.Config().Options.ContextPaths = nil
 	cfg.Config().Options.GlobalContextPaths = nil
 	cfg.Config().LSP = nil

--- a/internal/agent/content_width.go
+++ b/internal/agent/content_width.go
@@ -1,0 +1,23 @@
+package agent
+
+import "context"
+
+type contentWidthContextKey struct{}
+
+// WithContentWidth returns ctx tagged with the UI's current chat content
+// width in cells. Tools that read width-sensitive remote content (e.g. an
+// A2UI resource whose server pre-renders bar geometry) use it to ask the
+// server for exactly the right size. Zero means "no hint".
+func WithContentWidth(ctx context.Context, width int) context.Context {
+	return context.WithValue(ctx, contentWidthContextKey{}, width)
+}
+
+// ContentWidthFromContext returns the UI content width in cells, or 0 when
+// the turn did not originate from an interactive UI (remote clients, headless
+// runs, channels).
+func ContentWidthFromContext(ctx context.Context) int {
+	if w, ok := ctx.Value(contentWidthContextKey{}).(int); ok {
+		return w
+	}
+	return 0
+}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -191,7 +191,13 @@ func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, 
 	}
 
 	// TODO: make this dynamic when we support multiple agents
-	prompt, err := coderPrompt(prompt.WithWorkingDir(c.cfg.WorkingDir()))
+	// A2UI is on unless the user disables it; see prompt.WithA2UI for the
+	// host-capability trade-off.
+	promptOpts := []prompt.Option{prompt.WithWorkingDir(c.cfg.WorkingDir())}
+	if !c.cfg.Config().Options.DisableA2UI {
+		promptOpts = append(promptOpts, prompt.WithA2UI())
+	}
+	prompt, err := coderPrompt(promptOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -286,6 +292,7 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 		return c.currentAgent.Run(ctx, SessionAgentCall{
 			SessionID:        sessionID,
 			RunID:            runID,
+			ContentWidth:     ContentWidthFromContext(ctx),
 			Prompt:           prompt,
 			Attachments:      attachments,
 			MaxOutputTokens:  maxTokens,
@@ -1430,7 +1437,12 @@ func (c *coordinator) runSubAgent(ctx context.Context, params subAgentParams) (f
 	// Run the agent
 	run := func() (*fantasy.AgentResult, error) {
 		return params.Agent.Run(ctx, SessionAgentCall{
-			SessionID:        session.ID,
+			SessionID: session.ID,
+			// Inherit the parent turn's UI width hint: the sub-agent's
+			// PrepareStep stamps call.ContentWidth over the tool-call
+			// context unconditionally, so leaving this zero would clobber
+			// the value the parent already carries.
+			ContentWidth:     tools.GetContentWidthFromContext(ctx),
 			Prompt:           params.Prompt,
 			MaxOutputTokens:  maxTokens,
 			ProviderOptions:  getProviderOptions(model, providerCfg),

--- a/internal/agent/prompt/prompt.go
+++ b/internal/agent/prompt/prompt.go
@@ -12,6 +12,8 @@ import (
 	"text/template"
 	"time"
 
+	a2ui "github.com/tmc/a2ui"
+
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/filepathext"
 	"github.com/charmbracelet/crush/internal/home"
@@ -26,6 +28,7 @@ type Prompt struct {
 	now        func() time.Time
 	platform   string
 	workingDir string
+	a2ui       bool
 }
 
 type PromptDat struct {
@@ -40,6 +43,8 @@ type PromptDat struct {
 	ContextFiles       []ContextFile
 	GlobalContextFiles []ContextFile
 	AvailSkillXML      string
+	A2UI               bool
+	A2UIVersion        string
 }
 
 type ContextFile struct {
@@ -64,6 +69,18 @@ func WithPlatform(platform string) Option {
 func WithWorkingDir(workingDir string) Option {
 	return func(p *Prompt) {
 		p.workingDir = workingDir
+	}
+}
+
+// WithA2UI enables the template's A2UI section, which tells the model it may
+// emit <a2ui-json> surfaces. Crush's chat TUI renders those blocks via a2tea;
+// consumers that only ever see plain text (scripted crush run, headless serve
+// clients) receive them as raw markup, so deployments that need plain-text
+// output can turn the section off with options.disable_a2ui — the coordinator
+// applies that setting.
+func WithA2UI() Option {
+	return func(p *Prompt) {
+		p.a2ui = true
 	}
 }
 
@@ -214,6 +231,8 @@ func (p *Prompt) promptData(ctx context.Context, provider, model string, store *
 		Platform:      platform,
 		Date:          p.now().Format("1/2/2006"),
 		AvailSkillXML: availSkillXML,
+		A2UI:          p.a2ui,
+		A2UIVersion:   a2ui.Version,
 	}
 	if isGit {
 		var err error

--- a/internal/agent/prompts_a2ui_test.go
+++ b/internal/agent/prompts_a2ui_test.go
@@ -1,0 +1,97 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/charmbracelet/crush/internal/agent/prompt"
+	a2tea "github.com/joestump-agent/a2tea"
+	"github.com/stretchr/testify/require"
+	a2ui "github.com/tmc/a2ui"
+)
+
+// renderCoderTemplate executes the embedded coder template directly with the
+// given data — no ConfigStore, no filesystem discovery — so the test is
+// hermetic and fast. Recorded agent cassettes build the coder prompt without
+// WithA2UI; pinning the gate here keeps those cassettes byte-stable.
+func renderCoderTemplate(t *testing.T, dat prompt.PromptDat) string {
+	t.Helper()
+	tpl, err := template.New("coder").Parse(string(coderPromptTmpl))
+	require.NoError(t, err)
+	var b strings.Builder
+	require.NoError(t, tpl.Execute(&b, dat))
+	return b.String()
+}
+
+func TestCoderPromptA2UIGate(t *testing.T) {
+	t.Parallel()
+
+	off := renderCoderTemplate(t, prompt.PromptDat{})
+	require.NotContains(t, off, "<a2ui>")
+
+	on := renderCoderTemplate(t, prompt.PromptDat{A2UI: true, A2UIVersion: a2ui.Version})
+	require.Contains(t, on, "<a2ui>")
+	// The example payload advertises the protocol version the pinned a2ui
+	// library actually speaks, not a hardcoded string.
+	require.Contains(t, on, `"version":"`+a2ui.Version+`"`)
+}
+
+// TestA2UIPromptCatalogRenders guards the prompt's component catalog against
+// drifting from what the pinned a2tea actually renders: every component the
+// <a2ui> section advertises must render as real content, not an
+// "[a2tea: ...]" placeholder (which is also what missing/unsupported kinds
+// fall back to). If an a2tea bump drops or regresses a component, this fails
+// instead of users seeing placeholder junk in chat.
+func TestA2UIPromptCatalogRenders(t *testing.T) {
+	t.Parallel()
+
+	text := func(id, s string) a2ui.Component {
+		return a2ui.Component{ID: id, Text: &a2ui.TextComponent{Text: a2ui.StringLiteral(s)}}
+	}
+
+	// One minimal surface per advertised component.
+	catalog := map[string][]a2ui.Component{
+		"Text":    {{ID: "t", Text: &a2ui.TextComponent{Text: a2ui.StringLiteral("hi"), Variant: a2ui.TextVariantH2}}},
+		"Card":    {{ID: "c", Card: &a2ui.CardComponent{Child: "t"}}, text("t", "hi")},
+		"Column":  {{ID: "c", Column: &a2ui.ColumnComponent{Children: a2ui.ChildList{IDs: []string{"t"}}}}, text("t", "hi")},
+		"Row":     {{ID: "r", Row: &a2ui.RowComponent{Children: a2ui.ChildList{IDs: []string{"t"}}}}, text("t", "hi")},
+		"List":    {{ID: "l", List: &a2ui.ListComponent{Children: a2ui.ChildList{IDs: []string{"t"}}}}, text("t", "hi")},
+		"Divider": {{ID: "d", Divider: &a2ui.DividerComponent{}}},
+		"Button":  {{ID: "b", Button: &a2ui.ButtonComponent{Child: "t"}}, text("t", "OK")},
+		"TextField": {{ID: "f", TextField: &a2ui.TextFieldComponent{
+			Label: a2ui.StringLiteral("Name"),
+		}}},
+		"CheckBox": {{ID: "cb", CheckBox: &a2ui.CheckBoxComponent{
+			Label: a2ui.StringLiteral("Done"),
+			Value: a2ui.BoolLiteral(true),
+		}}},
+		"ChoicePicker": {{ID: "cp", ChoicePicker: &a2ui.ChoicePickerComponent{
+			Options: []a2ui.ChoiceOption{{Value: "a", Label: a2ui.StringLiteral("A")}},
+			Value:   a2ui.DynamicStringList{Literal: []string{"a"}},
+		}}},
+		"Slider": {{ID: "s", Slider: &a2ui.SliderComponent{
+			Max:   100,
+			Value: a2ui.NumberLiteral(40),
+		}}},
+		"DateTimeInput": {{ID: "dt", DateTimeInput: &a2ui.DateTimeInputComponent{
+			Value: a2ui.StringLiteral("2026-07-11"),
+		}}},
+	}
+
+	for name, comps := range catalog {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			msgs := []a2ui.ServerMessage{{
+				Version:          a2ui.Version,
+				UpdateComponents: &a2ui.UpdateComponents{SurfaceID: "s", Components: comps},
+			}}
+			m, err := a2tea.Render(msgs)
+			require.NoError(t, err, "advertised component %s must render", name)
+			out := m.View().Content
+			require.NotContains(t, out, "[a2tea:",
+				"advertised component %s rendered a placeholder: %q", name, out)
+			require.NotEmpty(t, strings.TrimSpace(out))
+		})
+	}
+}

--- a/internal/agent/prompts_a2ui_test.go
+++ b/internal/agent/prompts_a2ui_test.go
@@ -1,11 +1,14 @@
 package agent
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 	"text/template"
 
 	"github.com/charmbracelet/crush/internal/agent/prompt"
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/skills"
 	a2tea "github.com/joestump-agent/a2tea"
 	"github.com/stretchr/testify/require"
 	a2ui "github.com/tmc/a2ui"
@@ -35,6 +38,74 @@ func TestCoderPromptA2UIGate(t *testing.T) {
 	// The example payload advertises the protocol version the pinned a2ui
 	// library actually speaks, not a hardcoded string.
 	require.Contains(t, on, `"version":"`+a2ui.Version+`"`)
+}
+
+// a2uiPromptSection returns the rendered <a2ui> block with A2UI enabled —
+// the configuration real users get, since the coordinator enables A2UI unless
+// options.disable_a2ui is set.
+func a2uiPromptSection(t *testing.T) string {
+	t.Helper()
+	full := renderCoderTemplate(t, prompt.PromptDat{A2UI: true, A2UIVersion: a2ui.Version})
+	start := strings.Index(full, "<a2ui>")
+	end := strings.Index(full, "</a2ui>")
+	require.GreaterOrEqual(t, start, 0, "prompt must contain an <a2ui> section")
+	require.Greater(t, end, start, "prompt must contain a closing </a2ui>")
+	return full[start:end]
+}
+
+// TestA2UIPromptNamesRealTools guards the <a2ui> section against telling the
+// model to call a tool that does not exist. The section ships enabled by
+// default (coordinator.go applies WithA2UI unless disable_a2ui), but the
+// recorded TestCoderAgent cassettes build the prompt WITHOUT A2UI — so no
+// cassette covers this text and a fabricated tool name would otherwise reach
+// users with the suite green.
+func TestA2UIPromptNamesRealTools(t *testing.T) {
+	t.Parallel()
+
+	section := a2uiPromptSection(t)
+
+	// Every MCP identifier the section mentions must be either a real
+	// registered tool or a real parameter of one. Extend these sets when the
+	// section starts naming something else.
+	knownTools := map[string]bool{
+		tools.ReadMCPResourceToolName:  true,
+		tools.ListMCPResourcesToolName: true,
+	}
+	knownParams := map[string]bool{"mcp_name": true}
+	for _, name := range regexp.MustCompile(`[a-z][a-z0-9_]{3,}`).FindAllString(section, -1) {
+		if !strings.Contains(name, "mcp") || knownParams[name] {
+			continue
+		}
+		require.True(t, knownTools[name],
+			"the <a2ui> section names %q, which is not a registered tool", name)
+	}
+
+	// read_mcp_resource requires mcp_name; a call example that omits it
+	// produces a tool error rather than a surface.
+	if strings.Contains(section, tools.ReadMCPResourceToolName) {
+		require.Contains(t, section, "mcp_name",
+			"the section tells the model to call %s but never mentions its required mcp_name parameter",
+			tools.ReadMCPResourceToolName)
+	}
+}
+
+// TestA2UIPromptInputEditabilityMatchesHost pins the section's claim about
+// input components to what the host actually does. Inputs are live: a button
+// press harvests FieldValues() and submits them (see A2UISubmissionPrompt and
+// internal/ui/model/a2ui_submit_test.go), and the a2ui skill documents them
+// under an "input components (editable)" heading. A prompt claiming they are
+// read-only talks the model out of a feature that works.
+func TestA2UIPromptInputEditabilityMatchesHost(t *testing.T) {
+	t.Parallel()
+
+	section := a2uiPromptSection(t)
+	require.NotContains(t, strings.ToLower(section), "read-only",
+		"input components are editable and submitted; the prompt must not call them read-only")
+
+	skill, err := skills.BuiltinFS().ReadFile("builtin/a2ui/SKILL.md")
+	require.NoError(t, err)
+	require.Contains(t, strings.ToLower(string(skill)), "input components (editable)",
+		"precondition: the a2ui skill documents inputs as editable")
 }
 
 // TestA2UIPromptCatalogRenders guards the prompt's component catalog against

--- a/internal/agent/templates/coder.md.tpl
+++ b/internal/agent/templates/coder.md.tpl
@@ -369,12 +369,22 @@ Adapt verbosity to match the work completed:
 </final_answers>
 {{if .A2UI}}
 <a2ui>
-You MAY include an A2UI surface when a compact visual genuinely helps — a status card, an option list, a progress readout. Most replies need none; prose stays primary.
+You MAY include an A2UI surface when a compact visual genuinely helps — a status card, an option list, a progress readout, a short form. Most replies need none; prose stays primary.
 
-Emit a single inline `<a2ui-json>{...}</a2ui-json>` block containing one `updateComponents` message, as in this example:
+**Two ways to surface A2UI — prefer the first when it applies:**
+1. **Read an MCP `/a2ui` resource** for server-owned data (a queue, a bundle, a trace, a dashboard). Find one with `list_mcp_resources`, then call `read_mcp_resource` with both the `mcp_name` and a concrete `uri` — resolve every `{placeholder}` in the template first (e.g. `mcp_name="switchboard", uri="switchboard://queue/reviews/a2ui"`). The host renders it for the user and hands you a one-line placeholder, NOT the JSON. Never re-echo or repeat that surface's JSON — the user can already see it.
+2. **Emit your own** with a single inline `<a2ui-json>{...}</a2ui-json>` block containing one `updateComponents` message, for ad-hoc visuals no server provides:
+
 <a2ui-json>{"version":"{{.A2UIVersion}}","updateComponents":{"surfaceId":"s1","components":[{"component":"Card","id":"root","child":"col"},{"component":"Column","id":"col","children":["title","body"]},{"component":"Text","id":"title","variant":"h2","text":"Build passed"},{"component":"Text","id":"body","text":"142 tests, 0 failures."}]}}</a2ui-json>
 
-Renderable components: Text (variants h1-h5, caption), Card, Column, Row, List, Divider, Button; input components render read-only. Never put code in a surface — use fenced code blocks.
+**Rules for self-authored surfaces:**
+- Components are a FLAT list linked by `id`. Every `child`/`children` id must reference a component in the array — a dangling id renders an error placeholder.
+- Renderable: Text (variants h1-h5, caption), Card, Column, Row, List, Divider, Button. Input components (TextField, CheckBox, ChoicePicker, Slider, DateTimeInput) are editable — their values come back to you when the user presses a Button on the surface.
+- A Button's label is a child Text component — NEVER a `text`/`label` field on the Button.
+- Never put code, logs, or long text in a surface — use fenced code blocks for those.
+- Do NOT append a width hint (`?w=`) yourself; the host sizes surfaces.
+
+Load the `a2ui` skill for the full component catalog and form templates.
 </a2ui>
 {{end}}
 <env>

--- a/internal/agent/templates/coder.md.tpl
+++ b/internal/agent/templates/coder.md.tpl
@@ -367,7 +367,16 @@ Adapt verbosity to match the work completed:
 - Don't use "Here's what I did" or "Let me know if..." style preambles/postambles
 - Keep tone direct and factual, like handing off work to a teammate
 </final_answers>
+{{if .A2UI}}
+<a2ui>
+You MAY include an A2UI surface when a compact visual genuinely helps — a status card, an option list, a progress readout. Most replies need none; prose stays primary.
 
+Emit a single inline `<a2ui-json>{...}</a2ui-json>` block containing one `updateComponents` message, as in this example:
+<a2ui-json>{"version":"{{.A2UIVersion}}","updateComponents":{"surfaceId":"s1","components":[{"component":"Card","id":"root","child":"col"},{"component":"Column","id":"col","children":["title","body"]},{"component":"Text","id":"title","variant":"h2","text":"Build passed"},{"component":"Text","id":"body","text":"142 tests, 0 failures."}]}}</a2ui-json>
+
+Renderable components: Text (variants h1-h5, caption), Card, Column, Row, List, Divider, Button; input components render read-only. Never put code in a surface — use fenced code blocks.
+</a2ui>
+{{end}}
 <env>
 Working directory: {{.WorkingDir}}
 Is directory a git repo: {{if .IsGitRepo}}yes{{else}}no{{end}}

--- a/internal/agent/tools/list_mcp_resources.go
+++ b/internal/agent/tools/list_mcp_resources.go
@@ -63,15 +63,16 @@ func NewListMCPResourcesTool(cfg *config.ConfigStore, permissions permission.Ser
 				return NewPermissionDeniedResponse(), nil
 			}
 
-			resources, err := mcp.ListResources(ctx, cfg, params.MCPName)
+			resources, templates, err := mcp.ListResources(ctx, cfg, params.MCPName)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}
-			if len(resources) == 0 {
+			if len(resources) == 0 && len(templates) == 0 {
 				return fantasy.NewTextResponse("No resources found"), nil
 			}
 
-			lines := make([]string, 0, len(resources))
+			lines := make([]string, 0, len(resources)+len(templates))
+
 			for _, resource := range resources {
 				if resource == nil {
 					continue
@@ -89,6 +90,24 @@ func NewListMCPResourcesTool(cfg *config.ConfigStore, permissions permission.Ser
 				}
 				if resource.Size > 0 {
 					line = fmt.Sprintf("%s [size: %d]", line, resource.Size)
+				}
+				lines = append(lines, line)
+			}
+
+			for _, template := range templates {
+				if template == nil {
+					continue
+				}
+				title := cmp.Or(template.Title, template.Name, template.URITemplate)
+				line := fmt.Sprintf("- [template] %s", title)
+				if template.URITemplate != "" {
+					line = fmt.Sprintf("%s (%s)", line, template.URITemplate)
+				}
+				if template.Description != "" {
+					line = fmt.Sprintf("%s: %s", line, template.Description)
+				}
+				if template.MIMEType != "" {
+					line = fmt.Sprintf("%s [mime: %s]", line, template.MIMEType)
 				}
 				lines = append(lines, line)
 			}

--- a/internal/agent/tools/list_mcp_resources.md
+++ b/internal/agent/tools/list_mcp_resources.md
@@ -1,1 +1,4 @@
-List available resource URIs from an MCP server by name; use before read_mcp_resource.
+List available resource URIs and resource templates from an MCP server by name; use before read_mcp_resource.
+
+Resource templates have URI templates (e.g. `cairn://run/{id}/a2ui`) that can be expanded to concrete URIs.
+To read a template resource, substitute the `{id}` parameter and pass the resulting URI to read_mcp_resource.

--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
@@ -130,6 +131,17 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 		return fantasy.NewTextErrorResponse(err.Error()), nil
 	}
 
+	// Divert A2UI surface payloads to UI-only metadata only when a chat UI
+	// will actually render them: on channel-originated turns the reply
+	// travels back over the channel and the model needs the payload to
+	// relay it, disable_a2ui deployments opted out of surfaces entirely,
+	// and a zero content width means no interactive UI tagged this turn.
+	// Mirrors the diversion rule in read_mcp_resource.go.
+	divert := GetChannelFromContext(ctx) == "" &&
+		!m.cfg.Config().Options.DisableA2UI &&
+		GetContentWidthFromContext(ctx) > 0
+	content, metadata := splitMCPToolResult(result, m.mcpName, divert)
+
 	switch result.Type {
 	case "image", "media":
 		if !GetSupportsImagesFromContext(ctx) {
@@ -143,9 +155,51 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 		} else {
 			response = fantasy.NewMediaResponse(result.Data, result.MediaType)
 		}
-		response.Content = result.Content
+		response.Content = content
+		if len(metadata.A2UISurfaces) > 0 {
+			response = fantasy.WithResponseMetadata(response, metadata)
+		}
 		return response, nil
 	default:
-		return fantasy.NewTextResponse(result.Content), nil
+		resp := fantasy.NewTextResponse(content)
+		if len(metadata.A2UISurfaces) > 0 {
+			resp = fantasy.WithResponseMetadata(resp, metadata)
+		}
+		return resp, nil
 	}
+}
+
+// splitMCPToolResult partitions an MCP tool result into model-facing text
+// and, when divert is set, UI-only A2UI surface payloads carried in response
+// metadata. The surfaces travel exactly like read_mcp_resource's: wrapped in
+// <a2ui-json> tags on ReadMCPResourceResponseMetadata, with a single-line
+// placeholder left for the model so it cannot echo the JSON back and
+// double-render the surface. When divert is false the raw payload is folded
+// back into the model-facing content (except payloads the server annotated
+// for the user only — hiding those from the model is the annotation's whole
+// point), so the model can still relay or summarize the data.
+func splitMCPToolResult(result mcp.ToolResult, mcpName string, divert bool) (string, ReadMCPResourceResponseMetadata) {
+	var metadata ReadMCPResourceResponseMetadata
+	content := result.Content
+	for _, surface := range result.Surfaces {
+		if divert {
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+surface.Payload+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, mcpName)
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(surface.URI)
+			placeholder := A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]"
+			if content != "" {
+				content += "\n"
+			}
+			content += placeholder
+			continue
+		}
+		if !surface.AssistantVisible {
+			continue
+		}
+		if content != "" {
+			content += "\n"
+		}
+		content += surface.Payload
+	}
+	return content, metadata
 }

--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -126,20 +126,26 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 		}
 	}
 
-	result, err := mcp.RunTool(ctx, m.cfg, m.mcpName, m.tool.Name, params.Input)
-	if err != nil {
-		return fantasy.NewTextErrorResponse(err.Error()), nil
-	}
-
 	// Divert A2UI surface payloads to UI-only metadata only when a chat UI
 	// will actually render them: on channel-originated turns the reply
 	// travels back over the channel and the model needs the payload to
 	// relay it, disable_a2ui deployments opted out of surfaces entirely,
 	// and a zero content width means no interactive UI tagged this turn.
 	// Mirrors the diversion rule in read_mcp_resource.go.
+	//
+	// Computed BEFORE the call so the same answer gates the A2UI capability
+	// crush claims in the call's _meta. Advertising a2ui on a turn that will
+	// not divert invites a surface payload we then fold into model-facing
+	// content as raw JSON.
 	divert := GetChannelFromContext(ctx) == "" &&
 		!m.cfg.Config().Options.DisableA2UI &&
 		GetContentWidthFromContext(ctx) > 0
+
+	result, err := mcp.RunTool(mcp.WithA2UICapable(ctx, divert), m.cfg, m.mcpName, m.tool.Name, params.Input)
+	if err != nil {
+		return fantasy.NewTextErrorResponse(err.Error()), nil
+	}
+
 	content, metadata := splitMCPToolResult(result, m.mcpName, divert)
 
 	switch result.Type {

--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -175,31 +175,53 @@ func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolRe
 // <a2ui-json> tags on ReadMCPResourceResponseMetadata, with a single-line
 // placeholder left for the model so it cannot echo the JSON back and
 // double-render the surface. When divert is false the raw payload is folded
-// back into the model-facing content (except payloads the server annotated
-// for the user only — hiding those from the model is the annotation's whole
-// point), so the model can still relay or summarize the data.
+// back into the model-facing content, so the model can still relay or
+// summarize the data.
+//
+// The audience annotation decides each surface's path (see a2uiAudience),
+// but only among renderers that actually exist: a ["user"]-only payload
+// renders and is withheld from the model; an ["assistant"]-only payload
+// reaches the model but is never rendered; an empty audience does both.
+//
+// The ["user"] case is conditional on something rendering it. The
+// annotation means "the user can already see this, don't repeat it" — so
+// when divert is false nothing renders the surface, the user sees nothing,
+// and the model is their only path to it. Withholding the payload there
+// leaves a headless run with an empty tool result and the agent replying
+// with nothing or a hallucinated summary.
 func splitMCPToolResult(result mcp.ToolResult, mcpName string, divert bool) (string, ReadMCPResourceResponseMetadata) {
 	var metadata ReadMCPResourceResponseMetadata
 	content := result.Content
-	for _, surface := range result.Surfaces {
-		if divert {
-			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+surface.Payload+"</a2ui-json>")
-			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, mcpName)
-			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(surface.URI)
-			placeholder := A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]"
-			if content != "" {
-				content += "\n"
-			}
-			content += placeholder
-			continue
-		}
-		if !surface.AssistantVisible {
-			continue
-		}
+	appendToContent := func(s string) {
 		if content != "" {
 			content += "\n"
 		}
-		content += surface.Payload
+		content += s
+	}
+	for _, surface := range result.Surfaces {
+		if divert && surface.RenderForUser {
+			// Render for the user via metadata; the model gets a
+			// placeholder so it cannot echo the JSON back and double-render.
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+surface.Payload+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, mcpName)
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(surface.URI)
+			appendToContent(A2UISurfacePlaceholderPrefix + uri + " from MCP server " + mcpName + " — the user can already see it; do not repeat or echo its JSON payload]")
+			continue
+		}
+		if !divert {
+			// Nothing will render this surface — it is a headless run, or
+			// the deployment disabled surfaces. The model is the user's
+			// only path to the payload, so fold it back whatever the
+			// audience says.
+			appendToContent(surface.Payload)
+			continue
+		}
+		// A chat UI is rendering this turn's surfaces, but not this one:
+		// it is ["assistant"]-only. It reaches the model alone.
+		if !surface.AssistantVisible {
+			continue
+		}
+		appendToContent(surface.Payload)
 	}
 	return content, metadata
 }

--- a/internal/agent/tools/mcp/a2ui.go
+++ b/internal/agent/tools/mcp/a2ui.go
@@ -6,6 +6,8 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/charmbracelet/crush/internal/config"
+
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	a2ui "github.com/tmc/a2ui"
@@ -19,6 +21,26 @@ import (
 var A2UIBasicCatalogID = "https://a2ui.org/specification/" +
 	strings.ReplaceAll(a2ui.Version, ".", "_") +
 	"/catalogs/basic/catalog.json"
+
+// a2uiDisabled reports whether this host has opted out of rendering A2UI
+// surfaces, and is the only way this package should read that option.
+//
+// Config.Options is a pointer and the config may not be loaded at all on
+// every path that opens a session — the OAuth re-auth flow reaches
+// createSession through BeginAuth, and a store built for a test carries a
+// Config with no Options at all. A bare cfg.Config().Options.DisableA2UI
+// panics on both. Absent configuration means "not disabled", matching the
+// zero value the option has once a config is loaded.
+func a2uiDisabled(cfg *config.ConfigStore) bool {
+	if cfg == nil {
+		return false
+	}
+	c := cfg.Config()
+	if c == nil || c.Options == nil {
+		return false
+	}
+	return c.Options.DisableA2UI
+}
 
 // a2uiClientCapabilities builds the A2UI capability payload a client
 // declares to an A2UI-over-MCP server, per the spec's capability negotiation:

--- a/internal/agent/tools/mcp/a2ui.go
+++ b/internal/agent/tools/mcp/a2ui.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
+	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -10,10 +12,13 @@ import (
 )
 
 // A2UIBasicCatalogID is the catalog the client advertises support for when
-// negotiating A2UI over MCP. It matches the embedded basic catalog for the
-// a2ui version crush compiles in (tmc/a2ui's a2uischema/schemas), so the
-// advertised ID and the rendered catalog never drift apart.
-const A2UIBasicCatalogID = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+// negotiating A2UI over MCP. The version segment is derived from a2ui.Version
+// rather than hardcoded, so bumping the a2ui dependency cannot leave crush
+// advertising a v0_9 catalog under a newer version key.
+// TestA2UIBasicCatalogIDTracksVersion pins the relationship.
+var A2UIBasicCatalogID = "https://a2ui.org/specification/" +
+	strings.ReplaceAll(a2ui.Version, ".", "_") +
+	"/catalogs/basic/catalog.json"
 
 // a2uiClientCapabilities builds the A2UI capability payload a client
 // declares to an A2UI-over-MCP server, per the spec's capability negotiation:
@@ -24,12 +29,17 @@ const A2UIBasicCatalogID = "https://a2ui.org/specification/v0_9/catalogs/basic/c
 // prompt uses), and the catalog list holds the compiled-in basic catalog, so
 // this payload, the prompt, and the renderer share one source of truth.
 func a2uiClientCapabilities() map[string]any {
+	return map[string]any{"a2ui": a2uiCapabilityPayload()}
+}
+
+// a2uiCapabilityPayload is the capability body itself, without the "a2ui"
+// wrapper key — the form the go-sdk's Extensions map wants, since the key
+// there is the extension ID.
+func a2uiCapabilityPayload() map[string]any {
 	return map[string]any{
-		"a2ui": map[string]any{
-			"clientCapabilities": map[string]any{
-				a2ui.Version: map[string]any{
-					"supportedCatalogIds": []string{A2UIBasicCatalogID},
-				},
+		"clientCapabilities": map[string]any{
+			a2ui.Version: map[string]any{
+				"supportedCatalogIds": []string{A2UIBasicCatalogID},
 			},
 		},
 	}
@@ -37,19 +47,81 @@ func a2uiClientCapabilities() map[string]any {
 
 // a2uiMetaCapabilities returns the A2UI capability payload for the `_meta`
 // field of an individual tools/call, the variant stateless servers expect
-// when they cannot carry initialize-time state. The shape is the same as the
-// initialize capability, hoisted under a single "a2ui" key.
+// when they cannot carry initialize-time state. It is byte-identical to the
+// initialize capability — same key, same shape — so the two can never drift.
 func a2uiMetaCapabilities() map[string]any {
 	return a2uiClientCapabilities()
 }
 
+// a2uiCapableKey marks a turn as one whose results crush will actually render
+// as surfaces. The initialize handshake is a session-level statement ("this
+// client CAN render A2UI"); this is the per-turn one ("this call will"). They
+// differ because a single session serves both chat turns and headless or
+// channel-originated turns, and only the former renders.
+type a2uiCapableKey struct{}
+
+// WithA2UICapable records whether the current turn will render A2UI surfaces.
+// Callers that drive a real chat UI leave it unset (the default is capable);
+// headless and channel-originated turns must set it false so crush does not
+// claim a capability it will not honor and get a surface it cannot draw.
+func WithA2UICapable(ctx context.Context, capable bool) context.Context {
+	return context.WithValue(ctx, a2uiCapableKey{}, capable)
+}
+
+// a2uiCapable reports whether this turn renders A2UI. Unset means capable, so
+// direct UI-initiated calls (the a2ui_action round-trip) keep working.
+func a2uiCapable(ctx context.Context) bool {
+	capable, ok := ctx.Value(a2uiCapableKey{}).(bool)
+	return !ok || capable
+}
+
+// a2uiRequestMeta returns the `_meta` an outgoing request should carry, or
+// nil when crush must not claim A2UI for it. Every RPC that can return a
+// surface goes through here — tools/call and resources/read alike — so a
+// stateless server keying off the per-request capability cannot see crush
+// claim A2UI on one RPC and stay silent on the other.
+func a2uiRequestMeta(ctx context.Context, disableA2UI bool) mcp.Meta {
+	if disableA2UI || !a2uiCapable(ctx) {
+		return nil
+	}
+	return mcp.Meta(a2uiMetaCapabilities())
+}
+
+// A2UIExtensionID is the extensions key carrying the A2UI capability, in the
+// go-sdk's required "{vendor-prefix}/{extension-name}" form.
+const A2UIExtensionID = "a2ui.org/a2ui"
+
+// a2uiSDKCapabilities returns the typed client capabilities to hand the SDK,
+// or nil when A2UI is disabled.
+//
+// This is deliberately belt-and-braces with the wire-level injection below.
+// The spec puts A2UI at a top-level "capabilities.a2ui" key, but the go-sdk
+// deserializes a peer's capabilities into a typed ClientCapabilities struct
+// that has no such field and no catch-all — so a go-sdk SERVER silently drops
+// the top-level key and never sees the claim. Extensions is the SDK's
+// sanctioned slot for exactly this and survives the round-trip intact.
+// Sending both means spec-conformant servers read the top-level key and
+// go-sdk servers read the extension; neither path alone reaches everyone.
+func a2uiSDKCapabilities(disableA2UI bool) *mcp.ClientCapabilities {
+	if disableA2UI {
+		return nil
+	}
+	caps := &mcp.ClientCapabilities{}
+	caps.AddExtension(A2UIExtensionID, a2uiCapabilityPayload())
+	return caps
+}
+
 // a2uiInitTransport wraps an mcp.Transport so the connection it yields
-// injects the A2UI client capability into the outgoing initialize request.
-// The go-sdk's typed ClientCapabilities has no slot for the spec's top-level
-// "a2ui" capabilities key (its Experimental/Extensions maps nest under their
-// own keys, which well-behaved servers do not read), so the capability is
-// merged into the serialized initialize params at the connection layer — the
-// same seam the channel transport uses to intercept the stream.
+// injects the A2UI client capability into the outgoing initialize request at
+// the spec's top-level "capabilities.a2ui" key. The go-sdk's typed
+// ClientCapabilities has no slot for that key, so it is merged into the
+// serialized params at the connection layer — the same seam the channel
+// transport uses to intercept the stream.
+//
+// This covers spec-conformant servers that read the raw capabilities object.
+// It does NOT reach a go-sdk server, which unmarshals into the typed struct
+// and drops the unknown key; a2uiSDKCapabilities carries the same payload in
+// Extensions for those. Both are sent, on purpose.
 type a2uiInitTransport struct {
 	inner mcp.Transport
 }
@@ -94,10 +166,12 @@ func (c *a2uiInitConn) Write(ctx context.Context, msg jsonrpc.Message) error {
 // "a2ui" key is respected, never overwritten.
 func injectA2UICapability(raw json.RawMessage) json.RawMessage {
 	if len(raw) == 0 {
+		slog.Warn("A2UI capability not advertised: initialize params were empty")
 		return nil
 	}
 	var params map[string]any
 	if err := json.Unmarshal(raw, &params); err != nil || params == nil {
+		slog.Warn("A2UI capability not advertised: initialize params did not decode as an object", "error", err)
 		return nil
 	}
 	caps, ok := params["capabilities"].(map[string]any)
@@ -105,6 +179,7 @@ func injectA2UICapability(raw json.RawMessage) json.RawMessage {
 		caps = map[string]any{}
 	}
 	if _, present := caps["a2ui"]; present {
+		// Already advertised by something upstream; leave it alone.
 		return nil
 	}
 	for k, v := range a2uiClientCapabilities() {
@@ -113,7 +188,12 @@ func injectA2UICapability(raw json.RawMessage) json.RawMessage {
 	params["capabilities"] = caps
 	out, err := json.Marshal(params)
 	if err != nil {
+		slog.Warn("A2UI capability not advertised: re-encoding initialize params failed", "error", err)
 		return nil
 	}
 	return out
 }
+
+// unwrapTransport implements [transportWrapper], so wrapping the transport
+// for A2UI never hides the stdio startup diagnostics maybeStdioErr digs out.
+func (t *a2uiInitTransport) unwrapTransport() mcp.Transport { return t.inner }

--- a/internal/agent/tools/mcp/a2ui.go
+++ b/internal/agent/tools/mcp/a2ui.go
@@ -1,0 +1,119 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	a2ui "github.com/tmc/a2ui"
+)
+
+// A2UIBasicCatalogID is the catalog the client advertises support for when
+// negotiating A2UI over MCP. It matches the embedded basic catalog for the
+// a2ui version crush compiles in (tmc/a2ui's a2uischema/schemas), so the
+// advertised ID and the rendered catalog never drift apart.
+const A2UIBasicCatalogID = "https://a2ui.org/specification/v0_9/catalogs/basic/catalog.json"
+
+// a2uiClientCapabilities builds the A2UI capability payload a client
+// declares to an A2UI-over-MCP server, per the spec's capability negotiation:
+//
+//	"a2ui": {"clientCapabilities": {"v0.9": {"supportedCatalogIds": [...]}}}
+//
+// The version key comes from a2ui.Version (the same constant the coder
+// prompt uses), and the catalog list holds the compiled-in basic catalog, so
+// this payload, the prompt, and the renderer share one source of truth.
+func a2uiClientCapabilities() map[string]any {
+	return map[string]any{
+		"a2ui": map[string]any{
+			"clientCapabilities": map[string]any{
+				a2ui.Version: map[string]any{
+					"supportedCatalogIds": []string{A2UIBasicCatalogID},
+				},
+			},
+		},
+	}
+}
+
+// a2uiMetaCapabilities returns the A2UI capability payload for the `_meta`
+// field of an individual tools/call, the variant stateless servers expect
+// when they cannot carry initialize-time state. The shape is the same as the
+// initialize capability, hoisted under a single "a2ui" key.
+func a2uiMetaCapabilities() map[string]any {
+	return a2uiClientCapabilities()
+}
+
+// a2uiInitTransport wraps an mcp.Transport so the connection it yields
+// injects the A2UI client capability into the outgoing initialize request.
+// The go-sdk's typed ClientCapabilities has no slot for the spec's top-level
+// "a2ui" capabilities key (its Experimental/Extensions maps nest under their
+// own keys, which well-behaved servers do not read), so the capability is
+// merged into the serialized initialize params at the connection layer — the
+// same seam the channel transport uses to intercept the stream.
+type a2uiInitTransport struct {
+	inner mcp.Transport
+}
+
+// Connect implements mcp.Transport.
+func (t *a2uiInitTransport) Connect(ctx context.Context) (mcp.Connection, error) {
+	conn, err := t.inner.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &a2uiInitConn{Connection: conn}, nil
+}
+
+// a2uiInitConn injects the A2UI capability into the initialize request's
+// params before they go on the wire.
+type a2uiInitConn struct {
+	mcp.Connection
+}
+
+// initializeMethod is the JSON-RPC method carrying the client's capabilities.
+const initializeMethod = "initialize"
+
+// Write intercepts the initialize request and merges the A2UI capability
+// into its params.capabilities before it goes on the wire. Any other message
+// passes through untouched; a params payload that does not decode as an
+// object is left alone rather than failing the handshake.
+func (c *a2uiInitConn) Write(ctx context.Context, msg jsonrpc.Message) error {
+	req, ok := msg.(*jsonrpc.Request)
+	if !ok || req.Method != initializeMethod {
+		return c.Connection.Write(ctx, msg)
+	}
+	params := injectA2UICapability(req.Params)
+	if params != nil {
+		req.Params = params
+	}
+	return c.Connection.Write(ctx, msg)
+}
+
+// injectA2UICapability merges the A2UI capability into an initialize
+// request's params JSON, returning the rewritten params or nil when no
+// rewrite was possible (params absent or not an object). A pre-existing
+// "a2ui" key is respected, never overwritten.
+func injectA2UICapability(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	var params map[string]any
+	if err := json.Unmarshal(raw, &params); err != nil || params == nil {
+		return nil
+	}
+	caps, ok := params["capabilities"].(map[string]any)
+	if !ok {
+		caps = map[string]any{}
+	}
+	if _, present := caps["a2ui"]; present {
+		return nil
+	}
+	for k, v := range a2uiClientCapabilities() {
+		caps[k] = v
+	}
+	params["capabilities"] = caps
+	out, err := json.Marshal(params)
+	if err != nil {
+		return nil
+	}
+	return out
+}

--- a/internal/agent/tools/mcp/a2ui_test.go
+++ b/internal/agent/tools/mcp/a2ui_test.go
@@ -1,0 +1,139 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// a2uiFakeConn records written messages instead of sending them anywhere, so a
+// test can drive a2uiInitConn.Write directly and inspect what would go on
+// the wire.
+type a2uiFakeConn struct {
+	mcp.Connection
+	written []*jsonrpc.Request
+}
+
+func (c *a2uiFakeConn) Write(_ context.Context, msg jsonrpc.Message) error {
+	if req, ok := msg.(*jsonrpc.Request); ok {
+		c.written = append(c.written, req)
+	}
+	return nil
+}
+
+// TestA2UIInitConnRewritesInitialize drives the injection against a
+// representative initialize request and asserts the advertised capability
+// shape — top-level a2ui key, version namespaced, compiled-in catalog — while
+// leaving the rest of the params (roots, clientInfo) intact.
+func TestA2UIInitConnRewritesInitialize(t *testing.T) {
+	t.Parallel()
+
+	fc := &a2uiFakeConn{}
+	conn := &a2uiInitConn{Connection: fc}
+
+	initParams, err := json.Marshal(map[string]any{
+		"protocolVersion": "2025-11-25",
+		"capabilities":    map[string]any{"roots": map[string]any{"listChanged": true}},
+		"clientInfo":      map[string]any{"name": "crush", "version": "1.0.0"},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, conn.Write(context.Background(), &jsonrpc.Request{
+		Method: "initialize",
+		Params: initParams,
+	}))
+	require.Len(t, fc.written, 1)
+
+	var params map[string]any
+	require.NoError(t, json.Unmarshal(fc.written[0].Params, &params))
+
+	caps, ok := params["capabilities"].(map[string]any)
+	require.True(t, ok, "initialize must carry a capabilities object")
+
+	// The A2UI capability is a top-level key, per the spec's negotiation.
+	a2uiCap, ok := caps["a2ui"].(map[string]any)
+	require.True(t, ok, "capabilities must carry a top-level a2ui key, got: %v", caps)
+	clientCaps, ok := a2uiCap["clientCapabilities"].(map[string]any)
+	require.True(t, ok, "a2ui must carry clientCapabilities")
+	v09, ok := clientCaps["v0.9"].(map[string]any)
+	require.True(t, ok, "clientCapabilities must carry the a2ui version key")
+	ids, ok := v09["supportedCatalogIds"].([]any)
+	require.True(t, ok, "v0.9 must carry supportedCatalogIds")
+	require.Len(t, ids, 1)
+	require.Equal(t, A2UIBasicCatalogID, ids[0])
+
+	// Existing capabilities and the rest of the handshake are preserved.
+	roots, ok := caps["roots"].(map[string]any)
+	require.True(t, ok, "roots must survive the merge")
+	require.Equal(t, true, roots["listChanged"])
+	require.Equal(t, "2025-11-25", params["protocolVersion"])
+}
+
+// TestA2UIInitConnPassesOtherMethods confirms non-initialize writes are not
+// rewritten.
+func TestA2UIInitConnPassesOtherMethods(t *testing.T) {
+	t.Parallel()
+
+	fc := &a2uiFakeConn{}
+	conn := &a2uiInitConn{Connection: fc}
+	require.NoError(t, conn.Write(context.Background(), &jsonrpc.Request{
+		Method: "notifications/initialized",
+		Params: json.RawMessage(`{}`),
+	}))
+	require.Len(t, fc.written, 1)
+	require.JSONEq(t, `{}`, string(fc.written[0].Params))
+}
+
+func TestInjectA2UICapability(t *testing.T) {
+	t.Parallel()
+
+	t.Run("merges into an empty capabilities object", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"x"}}`)
+		out := injectA2UICapability(raw)
+		require.NotNil(t, out)
+		var params map[string]any
+		require.NoError(t, json.Unmarshal(out, &params))
+		caps := params["capabilities"].(map[string]any)
+		require.Contains(t, caps, "a2ui")
+	})
+
+	t.Run("creates capabilities when absent", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{"protocolVersion":"2025-11-25"}`)
+		out := injectA2UICapability(raw)
+		require.NotNil(t, out)
+		var params map[string]any
+		require.NoError(t, json.Unmarshal(out, &params))
+		caps := params["capabilities"].(map[string]any)
+		require.Contains(t, caps, "a2ui")
+	})
+
+	t.Run("respects a pre-existing a2ui key", func(t *testing.T) {
+		t.Parallel()
+		raw := json.RawMessage(`{"capabilities":{"a2ui":{"custom":true}}}`)
+		require.Nil(t, injectA2UICapability(raw), "an explicit a2ui capability is never overwritten")
+	})
+
+	t.Run("leaves non-object params alone", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, injectA2UICapability(json.RawMessage(`null`)))
+		require.Nil(t, injectA2UICapability(json.RawMessage(`"string"`)))
+		require.Nil(t, injectA2UICapability(nil))
+	})
+}
+
+func TestA2UIMetaCapabilitiesShape(t *testing.T) {
+	t.Parallel()
+
+	meta := a2uiMetaCapabilities()
+	a2uiCap, ok := meta["a2ui"].(map[string]any)
+	require.True(t, ok)
+	clientCaps, ok := a2uiCap["clientCapabilities"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, clientCaps, "v0.9")
+}

--- a/internal/agent/tools/mcp/a2ui_test.go
+++ b/internal/agent/tools/mcp/a2ui_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/crush/internal/config"
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
@@ -238,4 +239,28 @@ func TestA2UIBasicCatalogIDTracksVersion(t *testing.T) {
 	slug := strings.ReplaceAll(a2ui.Version, ".", "_")
 	require.Contains(t, A2UIBasicCatalogID, "/"+slug+"/",
 		"catalog ID must carry the compiled-in a2ui version %q", a2ui.Version)
+}
+
+// TestA2UIDisabledToleratesAbsentOptions pins that reading the A2UI opt-out
+// never panics on a partially-populated config.
+//
+// Config.Options is a pointer, and createSession is reached from the OAuth
+// re-auth flow (BeginAuth -> runAuthFlow -> connectAndRegister) with whatever
+// store the caller held. A bare cfg.Config().Options.DisableA2UI crashed
+// TestBeginAuth_Concurrent outright, taking the process down with it rather
+// than failing one test.
+func TestA2UIDisabledToleratesAbsentOptions(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, a2uiDisabled(nil), "a nil store must read as not-disabled")
+	require.False(t, a2uiDisabled(config.NewTestStore(nil)),
+		"a store with no config must read as not-disabled")
+	require.False(t, a2uiDisabled(config.NewTestStore(&config.Config{})),
+		"a config with no Options must read as not-disabled")
+	require.False(t, a2uiDisabled(config.NewTestStore(&config.Config{
+		Options: &config.Options{},
+	})), "an explicit zero Options means A2UI stays enabled")
+	require.True(t, a2uiDisabled(config.NewTestStore(&config.Config{
+		Options: &config.Options{DisableA2UI: true},
+	})), "the opt-out must still be honored")
 }

--- a/internal/agent/tools/mcp/a2ui_test.go
+++ b/internal/agent/tools/mcp/a2ui_test.go
@@ -3,11 +3,14 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
+	a2ui "github.com/tmc/a2ui"
 )
 
 // a2uiFakeConn records written messages instead of sending them anywhere, so a
@@ -136,4 +139,103 @@ func TestA2UIMetaCapabilitiesShape(t *testing.T) {
 	clientCaps, ok := a2uiCap["clientCapabilities"].(map[string]any)
 	require.True(t, ok)
 	require.Contains(t, clientCaps, "v0.9")
+}
+
+// TestA2UIHandshakeReachesRealServer drives a real client/server initialize
+// over the SDK's in-memory transport, wrapped the way createSession wraps it,
+// and asserts what the SERVER actually observes — not what crush wrote.
+//
+// This is the gap the unit tests above cannot cover: they hand-build params
+// and call Write directly, so they pass even when the capability never
+// survives to the peer. It does not survive at the spec's top-level key,
+// because the go-sdk unmarshals capabilities into a typed struct with no such
+// field and no catch-all, which is exactly why the Extensions payload exists.
+func TestA2UIHandshakeReachesRealServer(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	srv := mcp.NewServer(&mcp.Implementation{Name: "probe", Version: "1"}, nil)
+	go func() { _, _ = srv.Connect(ctx, serverTransport, nil) }()
+
+	client := mcp.NewClient(
+		&mcp.Implementation{Name: "crush", Version: "1"},
+		&mcp.ClientOptions{Capabilities: a2uiSDKCapabilities(false)},
+	)
+	sess, err := client.Connect(ctx, &a2uiInitTransport{inner: clientTransport}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	var seen int
+	for ss := range srv.Sessions() {
+		seen++
+		params := ss.InitializeParams()
+		require.NotNil(t, params.Capabilities, "server must see client capabilities")
+		ext, ok := params.Capabilities.Extensions[A2UIExtensionID]
+		require.True(t, ok,
+			"server must observe the A2UI capability under %q; extensions=%v",
+			A2UIExtensionID, params.Capabilities.Extensions)
+
+		// The payload survives intact, version key and catalog included.
+		raw, err := json.Marshal(ext)
+		require.NoError(t, err)
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal(raw, &payload))
+		clientCaps, ok := payload["clientCapabilities"].(map[string]any)
+		require.True(t, ok, "extension payload must carry clientCapabilities, got %v", payload)
+		_, ok = clientCaps[a2ui.Version]
+		require.True(t, ok, "clientCapabilities must be keyed by %q, got %v", a2ui.Version, clientCaps)
+	}
+	require.Equal(t, 1, seen, "expected exactly one server session")
+}
+
+// TestA2UISDKCapabilitiesDisabled pins the opt-out: a deployment that set
+// disable_a2ui must not advertise the capability at all.
+func TestA2UISDKCapabilitiesDisabled(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, a2uiSDKCapabilities(true))
+}
+
+// TestA2UIRequestMetaGates pins both halves of the per-request claim: the
+// deployment opt-out (disable_a2ui) and the per-turn render check. Before
+// these gates existed, a headless `crush run` advertised a2ui and got back a
+// surface payload it folded into model-facing content as raw JSON.
+func TestA2UIRequestMetaGates(t *testing.T) {
+	t.Parallel()
+
+	const enabled, disabled = false, true
+
+	t.Run("enabled and capable claims a2ui", func(t *testing.T) {
+		t.Parallel()
+		meta := a2uiRequestMeta(context.Background(), enabled)
+		require.NotNil(t, meta)
+		require.Contains(t, map[string]any(meta), "a2ui")
+	})
+	t.Run("disable_a2ui suppresses the claim", func(t *testing.T) {
+		t.Parallel()
+		require.Nil(t, a2uiRequestMeta(context.Background(), disabled))
+	})
+	t.Run("a turn that will not render suppresses the claim", func(t *testing.T) {
+		t.Parallel()
+		ctx := WithA2UICapable(context.Background(), false)
+		require.Nil(t, a2uiRequestMeta(ctx, enabled),
+			"headless and channel turns must not claim a capability crush will not honor")
+	})
+	t.Run("explicitly capable claims a2ui", func(t *testing.T) {
+		t.Parallel()
+		ctx := WithA2UICapable(context.Background(), true)
+		require.NotNil(t, a2uiRequestMeta(ctx, enabled))
+	})
+}
+
+// TestA2UIBasicCatalogIDTracksVersion pins the catalog ID to the compiled-in
+// a2ui version. A dependency bump that moves a2ui.Version must move the
+// advertised catalog with it, or crush advertises a stale catalog under a
+// newer version key and a server negotiates against components it will not
+// receive.
+func TestA2UIBasicCatalogIDTracksVersion(t *testing.T) {
+	t.Parallel()
+	slug := strings.ReplaceAll(a2ui.Version, ".", "_")
+	require.Contains(t, A2UIBasicCatalogID, "/"+slug+"/",
+		"catalog ID must carry the compiled-in a2ui version %q", a2ui.Version)
 }

--- a/internal/agent/tools/mcp/channel.go
+++ b/internal/agent/tools/mcp/channel.go
@@ -321,3 +321,6 @@ func (c *channelConn) Read(ctx context.Context) (jsonrpc.Message, error) {
 		}
 	}
 }
+
+// unwrapTransport implements [transportWrapper].
+func (t *channelTransport) unwrapTransport() mcp.Transport { return t.inner }

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -958,6 +958,7 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 				level := parseLevel(string(req.Params.Level))
 				slog.Log(ctx, level, "MCP log", "name", name, "logger", req.Params.Logger, "data", req.Params.Data)
 			},
+			Capabilities: a2uiSDKCapabilities(cfg.Config().Options.DisableA2UI),
 		},
 	)
 
@@ -1003,10 +1004,40 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 // error.
 // this happens particularly when starting things with npx, e.g. if node can't
 // be found or some other error like that.
+// transportWrapper is implemented by every transport decorator crush layers
+// around the real transport, so diagnostics that need the underlying
+// transport (see maybeStdioErr) can reach it regardless of wrapping order.
+type transportWrapper interface {
+	unwrapTransport() mcp.Transport
+}
+
+// unwrapTransport peels every crush-owned decorator off a transport and
+// returns the innermost one.
+func unwrapTransport(transport mcp.Transport) mcp.Transport {
+	for {
+		w, ok := transport.(transportWrapper)
+		if !ok {
+			return transport
+		}
+		inner := w.unwrapTransport()
+		if inner == nil {
+			return transport
+		}
+		transport = inner
+	}
+}
+
 func maybeStdioErr(err error, transport mcp.Transport) error {
 	if !errors.Is(err, io.EOF) {
 		return err
 	}
+	// Transports are wrapped in one or more decorators before Connect (the
+	// channel gate, the A2UI capability injector); the stdio transport we're
+	// probing for is the innermost one. Unwrap all of them — without this the
+	// assertion below never matches and stdio startup failures report a bare
+	// EOF instead of the child's actual output. Every wrapper must implement
+	// unwrapTransport or it will hide this diagnostic again.
+	transport = unwrapTransport(transport)
 	ct, ok := transport.(*mcp.CommandTransport)
 	if !ok {
 		return err

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -925,7 +925,7 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 	// Advertise A2UI support in the initialize handshake so an A2UI-over-MCP
 	// server knows it can send surfaces. A host that won't render A2UI must
 	// not claim the capability.
-	if !cfg.Config().Options.DisableA2UI {
+	if !a2uiDisabled(cfg) {
 		transport = &a2uiInitTransport{inner: transport}
 	}
 
@@ -958,7 +958,7 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 				level := parseLevel(string(req.Params.Level))
 				slog.Log(ctx, level, "MCP log", "name", name, "logger", req.Params.Logger, "data", req.Params.Data)
 			},
-			Capabilities: a2uiSDKCapabilities(cfg.Config().Options.DisableA2UI),
+			Capabilities: a2uiSDKCapabilities(a2uiDisabled(cfg)),
 		},
 	)
 

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -1337,7 +1337,14 @@ func clearMCPData(name string) {
 func stdioCheck(old *exec.Cmd) error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, old.Path, old.Args...)
+	// old.Args includes argv0 as the first element; exec.CommandContext
+	// prepends old.Path as argv0, so we must skip it to avoid duplication
+	// (e.g. "npx npx -y pkg" instead of "npx -y pkg").
+	args := old.Args
+	if len(args) > 0 {
+		args = args[1:]
+	}
+	cmd := exec.CommandContext(ctx, old.Path, args...)
 	cmd.Env = old.Env
 	out, err := cmd.CombinedOutput()
 	if err == nil || errors.Is(ctx.Err(), context.DeadlineExceeded) {

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -580,8 +580,10 @@ func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name strin
 	// the listing with the same per-server timeout createSession enforces: a
 	// server that connects but then hangs on resources/list would otherwise
 	// stall startup — with the bound it degrades to a warn and a zero count.
+	// The listing error is ignored here for that reason: on the startup
+	// critical path a failed listing must not fail the connection.
 	listCtx, cancelList := context.WithTimeout(ctx, mcpTimeout(m))
-	resourceCount := refreshSessionResources(listCtx, name, session)
+	resourceCount, _ := refreshSessionResources(listCtx, name, session)
 	cancelList()
 
 	sessions.Set(name, session)
@@ -756,13 +758,22 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 	updatePrompts(name, prompts)
 	counts.Prompts = len(prompts)
 
-	resources, err := getResources(ctx, newSess)
+	// Resource templates go back in alongside the resources: A2UI surfaces
+	// are served through them, so a renewal that re-registers only the
+	// plain resources drops every surface URI out of the completions popup
+	// until the next restart.
+	//
+	// A listing failure here is fatal, exactly as it is for tools and
+	// prompts above: this is a renewal of a session we already refused
+	// once, so handing the caller a server that reports StateConnected
+	// with an empty resource registry hides the breakage behind a healthy
+	// status while every '@' completion for it silently disappears.
+	counts.Resources, err = refreshSessionResources(ctx, name, newSess)
 	if err != nil {
 		updateState(name, StateError, err, nil, Counts{})
 		closeSession(name, newSess)
 		return nil, err
 	}
-	counts.Resources = updateResources(name, resources)
 
 	// Re-check before publishing: if a teardown landed during registration a
 	// newer attempt owns the registries now, so leave them and our session

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -922,6 +922,13 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 	channelGate := newChannelGate()
 	transport = &channelTransport{inner: transport, name: name, gate: channelGate}
 
+	// Advertise A2UI support in the initialize handshake so an A2UI-over-MCP
+	// server knows it can send surfaces. A host that won't render A2UI must
+	// not claim the capability.
+	if !cfg.Config().Options.DisableA2UI {
+		transport = &a2uiInitTransport{inner: transport}
+	}
+
 	client := mcp.NewClient(
 		&mcp.Implementation{
 			Name:    "crush",

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -195,6 +195,15 @@ type ClientInfo struct {
 	Client      *ClientSession
 	Counts      Counts
 	ConnectedAt time.Time
+	// A2UITools lists the a2ui_* tools this server exposes. It rides on the
+	// state rather than being read from the tool registry via HasTool
+	// because the registry only exists in the process that owns the MCP
+	// sessions: a client/server TUI has an empty one, so a HasTool gate
+	// there is permanently false and the surface round-trip it guards can
+	// never fire. Only the a2ui_* subset is carried — the UI asks nothing
+	// else, and a full tool list would put every server's whole catalog on
+	// the wire on every state change.
+	A2UITools []string
 
 	// Config is the configuration the server last successfully connected
 	// with. Reconcile compares it against the live config to decide whether
@@ -209,6 +218,11 @@ type ClientInfo struct {
 	// progress rather than the last successful one, which would leave the
 	// server skipped as "starting" and never restarted for the new config.
 	PendingConfig *config.MCPConfig
+}
+
+// ServesA2UITool reports whether the server exposes the named a2ui_* tool.
+func (c ClientInfo) ServesA2UITool(toolName string) bool {
+	return slices.Contains(c.A2UITools, toolName)
 }
 
 // SubscribeEvents returns a channel for MCP events.
@@ -822,6 +836,9 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 	info.Error = err
 	info.Client = client
 	info.Counts = counts
+	// Snapshot the a2ui_* capability alongside the counts so a remote
+	// client learns it without reading this process's tool registry.
+	info.A2UITools = a2uiToolNames(name)
 	for _, opt := range opts {
 		opt(&info)
 	}

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -558,11 +558,24 @@ func connectAndRegister(ctx context.Context, cfg *config.ConfigStore, name strin
 	}
 
 	updatePrompts(name, prompts)
+
+	// Fetch resources and resource templates eagerly so the status display
+	// reflects the real count from the first connection, not a stale zero.
+	// Both helpers are no-ops when the server doesn't advertise the
+	// resources capability, and gracefully handle "method not found". Bound
+	// the listing with the same per-server timeout createSession enforces: a
+	// server that connects but then hangs on resources/list would otherwise
+	// stall startup — with the bound it degrades to a warn and a zero count.
+	listCtx, cancelList := context.WithTimeout(ctx, mcpTimeout(m))
+	resourceCount := refreshSessionResources(listCtx, name, session)
+	cancelList()
+
 	sessions.Set(name, session)
 
 	updateState(name, StateConnected, nil, session, Counts{
-		Tools:   toolCount,
-		Prompts: len(prompts),
+		Tools:     toolCount,
+		Prompts:   len(prompts),
+		Resources: resourceCount,
 	}, withConfig(m))
 
 	return session, nil

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -870,13 +870,14 @@ func updateState(name string, state State, err error, client *ClientSession, cou
 		if old, ok := sessions.Take(name); ok {
 			closeSession(name, old)
 		}
-		// Drop every registry entry for the dead server. Leaving prompts or
-		// resources behind lets a disconnected server keep advertising
-		// capabilities the agent can no longer fulfil, the same divergence the
-		// tool clear prevents.
+		// Drop every registry entry for the dead server. Leaving prompts,
+		// resources, or resource templates behind lets a disconnected server
+		// keep advertising capabilities the agent can no longer fulfil, the
+		// same divergence the tool clear prevents.
 		allTools.Del(name)
 		allPrompts.Del(name)
 		allResources.Del(name)
+		allResourceTemplates.Del(name)
 	}
 	states.Set(name, info)
 
@@ -1322,12 +1323,13 @@ func clearOAuthToken(cfg *config.ConfigStore, name string) {
 }
 
 // clearMCPData removes a stale MCP server's tools, prompts,
-// resources, and auth handlers from global state so they are not
-// served to the agent.
+// resources, resource templates, and auth handlers from global state so they
+// are not served to the agent.
 func clearMCPData(name string) {
 	allTools.Del(name)
 	allPrompts.Del(name)
 	allResources.Del(name)
+	allResourceTemplates.Del(name)
 	if h, ok := authURLs.Get(name); ok {
 		h.Close()
 		authURLs.Del(name)

--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -393,3 +393,140 @@ func TestGetOrRenewClient_RestoresPromptsAndResources(t *testing.T) {
 	require.Equal(t, Counts{Tools: 1, Prompts: 1, Resources: 1}, info.Counts,
 		"reported counts must match the restored registries")
 }
+
+// TestMaybeStdioErr_UnwrapsChannelTransport pins that maybeStdioErr sees
+// through the channelTransport wrapper to the inner CommandTransport. Every
+// transport is wrapped in a channelTransport before Connect, so without
+// unwrapping the *mcp.CommandTransport type assertion always fails and stdio
+// startup errors report bare EOF. We assert both that the unwrap reaches the
+// command (the error is no longer bare EOF) and that the re-executed child's
+// stderr text surfaces in the joined error.
+func TestMaybeStdioErr_UnwrapsChannelTransport(t *testing.T) {
+	cmd := exec.CommandContext(t.Context(), "sh", "-c", "echo 'startup failed: bad config'; exit 3")
+	inner := &mcp.CommandTransport{Command: cmd}
+	wrapped := &channelTransport{inner: inner, name: "t", gate: newChannelGate()}
+
+	got := maybeStdioErr(io.EOF, wrapped)
+	require.Error(t, got)
+	require.NotEqual(t, io.EOF.Error(), got.Error(),
+		"a wrapped channel transport must still reach the inner CommandTransport, joining the re-check instead of returning bare EOF")
+	require.Contains(t, got.Error(), "startup failed: bad config",
+		"the re-executed child's stderr must surface in the error")
+}
+
+// TestMaybeStdioErr_UnwrapsEveryWrapper pins the diagnostics fix against the
+// ACTUAL wrapper stack createSession builds, not a hand-rolled single layer.
+// A new decorator added on top (the A2UI capability injector was the first)
+// must not hide the child's stderr behind a bare EOF — which is exactly what
+// happened when a2uiInitTransport was layered outside channelTransport and
+// the old single-level unwrap stopped matching.
+func TestMaybeStdioErr_UnwrapsEveryWrapper(t *testing.T) {
+	cmd := exec.CommandContext(t.Context(), "sh", "-c", "echo boom-diagnostic >&2; exit 3")
+	var transport mcp.Transport = &mcp.CommandTransport{Command: cmd}
+	// Same order as createSession: channel gate first, then A2UI.
+	transport = &channelTransport{inner: transport, name: "t", gate: newChannelGate()}
+	transport = &a2uiInitTransport{inner: transport}
+
+	got := maybeStdioErr(io.EOF, transport)
+	require.ErrorContains(t, got, "boom-diagnostic",
+		"stdio diagnostics must survive every transport decorator")
+}
+
+// TestNameLock_ConcurrentFirstUseReturnsOneMutex pins that the per-name
+// lifecycle lock is minted atomically: racing first-use callers must all
+// receive the same mutex, or the serialization the whole lifecycle relies
+// on silently degrades to per-caller locks.
+func TestNameLock_ConcurrentFirstUseReturnsOneMutex(t *testing.T) {
+	const name = "test-name-lock-race"
+	t.Cleanup(func() { delete(renewMus, name) })
+
+	const n = 32
+	locks := make([]*sync.Mutex, n)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			locks[i] = renewLock(name)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i := 1; i < n; i++ {
+		require.Same(t, locks[0], locks[i], "all callers must share one lifecycle mutex")
+	}
+}
+
+// TestUpdateState_ErrorClearsResources pins that both StateError teardown
+// branches clear the resources and resource-template registries alongside
+// tools and prompts — a dead server must not keep advertising resources
+// (or templates) it can no longer serve.
+func TestUpdateState_ErrorClearsResources(t *testing.T) {
+	const name = "test-error-clears-resources"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+		states.Del(name)
+	})
+
+	sess, _ := liveSession(t, "res_tool")
+	sessions.Set(name, sess)
+	allResources.Set(name, []*Resource{{Name: "doc"}})
+	allResourceTemplates.Set(name, []*ResourceTemplate{{Name: "tmpl"}})
+
+	updateState(name, StateError, errors.New("listing broke"), sess, Counts{})
+	_, ok := allResources.Get(name)
+	require.False(t, ok, "current-session error must clear the resources registry")
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "current-session error must clear the resource-template registry")
+
+	sess2, _ := liveSession(t, "res_tool2")
+	sessions.Set(name, sess2)
+	allResources.Set(name, []*Resource{{Name: "doc2"}})
+	allResourceTemplates.Set(name, []*ResourceTemplate{{Name: "tmpl2"}})
+
+	updateState(name, StateError, errors.New("connect broke"), nil, Counts{})
+	_, ok = allResources.Get(name)
+	require.False(t, ok, "no-session error must clear the resources registry")
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "no-session error must clear the resource-template registry")
+}
+
+// TestDisableSingle_ClearsResourceTemplates pins that disabling a server
+// removes its resource templates (alongside tools, prompts, and resources)
+// from the registries — a disabled server's templates must stop appearing
+// as @-completions.
+func TestDisableSingle_ClearsResourceTemplates(t *testing.T) {
+	const name = "test-disable-clears-templates"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allTools.Del(name)
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+		states.Del(name)
+	})
+
+	cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{name: {Type: config.MCPStdio}}})
+
+	sess, sessCtx := liveSession(t, "tmpl_tool")
+	sessions.Set(name, sess)
+	allResources.Set(name, []*Resource{{Name: "doc"}})
+	allResourceTemplates.Set(name, []*ResourceTemplate{{Name: "tmpl", URITemplate: "x://{id}"}})
+
+	require.NoError(t, DisableSingle(cfg, name))
+
+	require.ErrorIs(t, sessCtx.Err(), context.Canceled, "disable must close the session")
+	_, ok := allResources.Get(name)
+	require.False(t, ok, "disable must clear the resources registry")
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "disable must clear the resource-template registry")
+
+	info, ok := GetState(name)
+	require.True(t, ok)
+	require.Equal(t, StateDisabled, info.State)
+}

--- a/internal/agent/tools/mcp/lifecycle_test.go
+++ b/internal/agent/tools/mcp/lifecycle_test.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"errors"
+	"io"
+	"os/exec"
 	"sync"
 	"sync/atomic"
 	"testing"

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -64,7 +64,7 @@ func ReadResource(ctx context.Context, cfg *config.ConfigStore, name, uri string
 	// Resource templates are how most A2UI surfaces are served, so this RPC
 	// carries the same capability claim as tools/call.
 	result, err := session.ReadResource(ctx, &mcp.ReadResourceParams{
-		Meta: a2uiRequestMeta(ctx, cfg.Config().Options.DisableA2UI),
+		Meta: a2uiRequestMeta(ctx, a2uiDisabled(cfg)),
 		URI:  uri,
 	})
 	if err != nil {

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -61,7 +61,12 @@ func ReadResource(ctx context.Context, cfg *config.ConfigStore, name, uri string
 	if err != nil {
 		return nil, err
 	}
-	result, err := session.ReadResource(ctx, &mcp.ReadResourceParams{URI: uri})
+	// Resource templates are how most A2UI surfaces are served, so this RPC
+	// carries the same capability claim as tools/call.
+	result, err := session.ReadResource(ctx, &mcp.ReadResourceParams{
+		Meta: a2uiRequestMeta(ctx, cfg.Config().Options.DisableA2UI),
+		URI:  uri,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -116,19 +116,25 @@ func getResources(ctx context.Context, c *ClientSession) ([]*Resource, error) {
 }
 
 // refreshSessionResources re-fetches a session's resources and resource
-// templates (best-effort: a listing failure degrades to an empty registry
-// and a warn, never an error) and installs them in the registries. It
-// returns the combined count for ClientInfo.Counts.Resources, so callers
-// publishing a StateConnected transition report exactly what the
-// registries hold.
-func refreshSessionResources(ctx context.Context, name string, session *ClientSession) int {
+// templates and installs them in the registries. It returns the combined
+// count for ClientInfo.Counts.Resources, so callers publishing a
+// StateConnected transition report exactly what the registries hold.
+//
+// The resources/list error is returned rather than swallowed: publishing
+// StateConnected over a failed listing shows the server as healthy while
+// every one of its resources has silently vanished from the completions
+// popup. Callers that must not fail on it — the startup path, where a
+// hang would stall WaitForInit — ignore it explicitly. Templates stay
+// best-effort: they are genuinely optional, and getResourceTemplates
+// already swallows method-not-found.
+func refreshSessionResources(ctx context.Context, name string, session *ClientSession) (int, error) {
 	resources, err := getResources(ctx, session)
 	if err != nil {
 		slog.Warn("Error listing MCP resources", "name", name, "error", err)
 		resources = nil
 	}
 	templates := listTemplatesBestEffort(ctx, session, name)
-	return updateResources(name, resources) + updateResourceTemplates(name, templates)
+	return updateResources(name, resources) + updateResourceTemplates(name, templates), err
 }
 
 // listTemplatesBestEffort lists a session's resource templates, treating any

--- a/internal/agent/tools/mcp/resources.go
+++ b/internal/agent/tools/mcp/resources.go
@@ -14,32 +14,45 @@ import (
 
 type Resource = mcp.Resource
 
+type ResourceTemplate = mcp.ResourceTemplate
+
 type ResourceContents = mcp.ResourceContents
 
-var allResources = csync.NewMap[string, []*Resource]()
+var (
+	allResources         = csync.NewMap[string, []*Resource]()
+	allResourceTemplates = csync.NewMap[string, []*ResourceTemplate]()
+)
 
 // Resources returns all available MCP resources.
 func Resources() iter.Seq2[string, []*Resource] {
 	return allResources.Seq2()
 }
 
-// ListResources returns the current resources for an MCP server.
-func ListResources(ctx context.Context, cfg *config.ConfigStore, name string) ([]*Resource, error) {
+// ResourceTemplates returns all available MCP resource templates.
+func ResourceTemplates() iter.Seq2[string, []*ResourceTemplate] {
+	return allResourceTemplates.Seq2()
+}
+
+// ListResources returns the current resources (including resource templates) for an MCP server.
+func ListResources(ctx context.Context, cfg *config.ConfigStore, name string) ([]*Resource, []*ResourceTemplate, error) {
 	session, err := getOrRenewClient(ctx, cfg, name)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	resources, err := getResources(ctx, session)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
+	templates := listTemplatesBestEffort(ctx, session, name)
+
 	resourceCount := updateResources(name, resources)
+	templateCount := updateResourceTemplates(name, templates)
 	prev, _ := states.Get(name)
-	prev.Counts.Resources = resourceCount
+	prev.Counts.Resources = resourceCount + templateCount
 	updateState(name, StateConnected, nil, session, prev.Counts)
-	return resources, nil
+	return resources, templates, nil
 }
 
 // ReadResource reads the contents of a resource from an MCP server.
@@ -55,9 +68,15 @@ func ReadResource(ctx context.Context, cfg *config.ConfigStore, name, uri string
 	return result.Contents, nil
 }
 
-// RefreshResources gets the updated list of resources from the MCP and updates the
+// RefreshResources gets the updated list of resources and resource templates from the MCP and updates the
 // global state.
 func RefreshResources(ctx context.Context, name string) {
+	// Runs under the per-name lifecycle lock so a concurrent renewal can't
+	// swap the session between our Get and the state update below.
+	mu := renewLock(name)
+	mu.Lock()
+	defer mu.Unlock()
+
 	session, ok := sessions.Get(name)
 	if !ok {
 		slog.Warn("Refresh resources: no session", "name", name)
@@ -66,14 +85,17 @@ func RefreshResources(ctx context.Context, name string) {
 
 	resources, err := getResources(ctx, session)
 	if err != nil {
-		updateState(name, StateError, err, nil, Counts{})
+		updateState(name, StateError, err, session, Counts{})
 		return
 	}
 
+	templates := listTemplatesBestEffort(ctx, session, name)
+
 	resourceCount := updateResources(name, resources)
+	templateCount := updateResourceTemplates(name, templates)
 
 	prev, _ := states.Get(name)
-	prev.Counts.Resources = resourceCount
+	prev.Counts.Resources = resourceCount + templateCount
 	updateState(name, StateConnected, nil, session, prev.Counts)
 }
 
@@ -93,6 +115,50 @@ func getResources(ctx context.Context, c *ClientSession) ([]*Resource, error) {
 	return result.Resources, nil
 }
 
+// refreshSessionResources re-fetches a session's resources and resource
+// templates (best-effort: a listing failure degrades to an empty registry
+// and a warn, never an error) and installs them in the registries. It
+// returns the combined count for ClientInfo.Counts.Resources, so callers
+// publishing a StateConnected transition report exactly what the
+// registries hold.
+func refreshSessionResources(ctx context.Context, name string, session *ClientSession) int {
+	resources, err := getResources(ctx, session)
+	if err != nil {
+		slog.Warn("Error listing MCP resources", "name", name, "error", err)
+		resources = nil
+	}
+	templates := listTemplatesBestEffort(ctx, session, name)
+	return updateResources(name, resources) + updateResourceTemplates(name, templates)
+}
+
+// listTemplatesBestEffort lists a session's resource templates, treating any
+// failure as "no templates". getResourceTemplates already swallows
+// method-not-found, so an error reaching here is a timeout, transport
+// failure, or server bug — never lack of support — and is logged as such,
+// with the server name so a multi-server config stays debuggable.
+func listTemplatesBestEffort(ctx context.Context, session *ClientSession, name string) []*ResourceTemplate {
+	templates, err := getResourceTemplates(ctx, session)
+	if err != nil {
+		slog.Warn("Error listing MCP resource templates", "name", name, "error", err)
+		return nil
+	}
+	return templates
+}
+
+func getResourceTemplates(ctx context.Context, c *ClientSession) ([]*ResourceTemplate, error) {
+	if c.InitializeResult().Capabilities.Resources == nil {
+		return nil, nil
+	}
+	result, err := c.ListResourceTemplates(ctx, &mcp.ListResourceTemplatesParams{})
+	if err != nil {
+		if isMethodNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return result.ResourceTemplates, nil
+}
+
 // isMethodNotFoundError checks if the error is a JSON-RPC "Method not found" error.
 func isMethodNotFoundError(err error) bool {
 	var rpcErr *jsonrpc.Error
@@ -106,4 +172,13 @@ func updateResources(name string, resources []*Resource) int {
 	}
 	allResources.Set(name, resources)
 	return len(resources)
+}
+
+func updateResourceTemplates(name string, templates []*ResourceTemplate) int {
+	if len(templates) == 0 {
+		allResourceTemplates.Del(name)
+		return 0
+	}
+	allResourceTemplates.Set(name, templates)
+	return len(templates)
 }

--- a/internal/agent/tools/mcp/resources_test.go
+++ b/internal/agent/tools/mcp/resources_test.go
@@ -1,0 +1,154 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// liveResourceSession spins up a real in-memory MCP server advertising the
+// given resources and resource templates and returns a connected client
+// session, mirroring liveSession for the resources side of the protocol.
+func liveResourceSession(t *testing.T, resources []*mcp.Resource, templates []*mcp.ResourceTemplate) *ClientSession {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "srv"}, nil)
+	handler := func(context.Context, *mcp.ReadResourceRequest) (*mcp.ReadResourceResult, error) {
+		return &mcp.ReadResourceResult{}, nil
+	}
+	for _, r := range resources {
+		server.AddResource(r, handler)
+	}
+	for _, tmpl := range templates {
+		server.AddResourceTemplate(tmpl, handler)
+	}
+	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	sess := &ClientSession{ClientSession: clientSession, cancel: cancel}
+	t.Cleanup(func() { _ = sess.Close() })
+	return sess
+}
+
+// TestUpdateResourceTemplates_SetAndDelOnEmpty pins the registry-write
+// semantics updateResourceTemplates shares with updateResources: a non-empty
+// list is installed and counted, an empty (or nil) list deletes the entry
+// outright — so a server that stops advertising templates does not linger
+// with an empty-but-present registry row.
+func TestUpdateResourceTemplates_SetAndDelOnEmpty(t *testing.T) {
+	const name = "test-update-resource-templates"
+	t.Cleanup(func() { allResourceTemplates.Del(name) })
+
+	count := updateResourceTemplates(name, []*ResourceTemplate{
+		{Name: "run", URITemplate: "cairn://run/{id}"},
+		{Name: "bundle", URITemplate: "cairn://bundle/{id}"},
+	})
+	require.Equal(t, 2, count)
+	got, ok := allResourceTemplates.Get(name)
+	require.True(t, ok)
+	require.Len(t, got, 2)
+
+	count = updateResourceTemplates(name, nil)
+	require.Equal(t, 0, count)
+	_, ok = allResourceTemplates.Get(name)
+	require.False(t, ok, "an empty template list must delete the registry entry")
+}
+
+// TestGetResourceTemplates_NoResourcesCapability pins the capability gate: a
+// server that does not advertise the resources capability yields (nil, nil)
+// without a wire call, so servers with no resources at all never produce
+// warns or errors from the template fetch.
+func TestGetResourceTemplates_NoResourcesCapability(t *testing.T) {
+	sess, _ := liveSession(t, "no_resources_tool")
+	t.Cleanup(func() { _ = sess.Close() })
+
+	templates, err := getResourceTemplates(context.Background(), sess)
+	require.NoError(t, err)
+	require.Nil(t, templates)
+}
+
+// TestGetResourceTemplates_ListsTemplates pins the happy path over a real
+// in-memory server: the declared templates come back with their URI
+// templates intact.
+func TestGetResourceTemplates_ListsTemplates(t *testing.T) {
+	sess := liveResourceSession(t, nil, []*mcp.ResourceTemplate{
+		{Name: "run", URITemplate: "cairn://run/{id}/a2ui"},
+	})
+
+	templates, err := getResourceTemplates(context.Background(), sess)
+	require.NoError(t, err)
+	require.Len(t, templates, 1)
+	require.Equal(t, "cairn://run/{id}/a2ui", templates[0].URITemplate)
+}
+
+// TestRefreshSessionResources_CountsSumResourcesAndTemplates pins the seam
+// initClient and the renewal path share: both registries are populated from
+// the session and the returned count — what Counts.Resources reports — is
+// the sum of concrete resources and templates.
+func TestRefreshSessionResources_CountsSumResourcesAndTemplates(t *testing.T) {
+	const name = "test-refresh-session-resources"
+	t.Cleanup(func() {
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+	})
+
+	sess := liveResourceSession(t,
+		[]*mcp.Resource{
+			{Name: "doc-a", URI: "test://doc-a"},
+			{Name: "doc-b", URI: "test://doc-b"},
+		},
+		[]*mcp.ResourceTemplate{
+			{Name: "run", URITemplate: "test://run/{id}"},
+		},
+	)
+
+	count := refreshSessionResources(context.Background(), name, sess)
+	require.Equal(t, 3, count, "count must sum resources and templates")
+
+	resources, ok := allResources.Get(name)
+	require.True(t, ok)
+	require.Len(t, resources, 2)
+	templates, ok := allResourceTemplates.Get(name)
+	require.True(t, ok)
+	require.Len(t, templates, 1)
+}
+
+// TestRefreshResources_UpdatesRegistriesAndCount pins the notification-driven
+// refresh path end to end: RefreshResources lists both resources and
+// templates from the live session and publishes their sum on the state.
+func TestRefreshResources_UpdatesRegistriesAndCount(t *testing.T) {
+	const name = "test-refresh-resources"
+	t.Cleanup(func() {
+		sessions.Del(name)
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+		states.Del(name)
+	})
+
+	sess := liveResourceSession(t,
+		[]*mcp.Resource{{Name: "doc", URI: "test://doc"}},
+		[]*mcp.ResourceTemplate{{Name: "run", URITemplate: "test://run/{id}"}},
+	)
+	sessions.Set(name, sess)
+
+	RefreshResources(context.Background(), name)
+
+	_, ok := allResources.Get(name)
+	require.True(t, ok, "refresh must install the listed resources")
+	_, ok = allResourceTemplates.Get(name)
+	require.True(t, ok, "refresh must install the listed templates")
+
+	info, ok := GetState(name)
+	require.True(t, ok)
+	require.Equal(t, StateConnected, info.State)
+	require.Equal(t, 2, info.Counts.Resources, "state count must sum resources and templates")
+}

--- a/internal/agent/tools/mcp/resources_test.go
+++ b/internal/agent/tools/mcp/resources_test.go
@@ -111,7 +111,8 @@ func TestRefreshSessionResources_CountsSumResourcesAndTemplates(t *testing.T) {
 		},
 	)
 
-	count := refreshSessionResources(context.Background(), name, sess)
+	count, err := refreshSessionResources(context.Background(), name, sess)
+	require.NoError(t, err)
 	require.Equal(t, 3, count, "count must sum resources and templates")
 
 	resources, ok := allResources.Get(name)
@@ -151,4 +152,36 @@ func TestRefreshResources_UpdatesRegistriesAndCount(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, StateConnected, info.State)
 	require.Equal(t, 2, info.Counts.Resources, "state count must sum resources and templates")
+}
+
+// TestRefreshSessionResources_ReturnsListingError pins that a resources/list
+// failure is reported rather than swallowed.
+//
+// The reconnect path (getOrRenewClient) treats it as fatal: it is renewing a
+// session that already failed once, so publishing StateConnected over a
+// failed listing shows the server as healthy in the MCP sidebar while every
+// one of its resources silently vanishes from the '@' completions popup. The
+// startup path deliberately ignores the error instead — a server that hangs
+// on resources/list must not stall WaitForInit — so the decision has to
+// belong to the caller, which means the error has to reach it.
+func TestRefreshSessionResources_ReturnsListingError(t *testing.T) {
+	const name = "test-refresh-resources-error"
+	t.Cleanup(func() {
+		allResources.Del(name)
+		allResourceTemplates.Del(name)
+	})
+
+	sess := liveResourceSession(t,
+		[]*mcp.Resource{{Name: "doc-a", URI: "test://doc-a"}},
+		nil,
+	)
+
+	// A cancelled context fails the listing the same way a wedged transport
+	// or a server bug on resources/list would.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	count, err := refreshSessionResources(ctx, name, sess)
+	require.Error(t, err, "a resources/list failure must reach the caller")
+	require.Zero(t, count, "a failed listing must not report a resource count")
 }

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -98,10 +98,22 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 	if err != nil {
 		return ToolResult{}, err
 	}
-	result, err := c.CallTool(ctx, &mcp.CallToolParams{
-		Name:      toolName,
-		Arguments: args,
-	})
+
+	// Attach the A2UI capability to the call's _meta for stateless servers
+	// that cannot carry initialize-time state. Gated the same way as the
+	// handshake advertisement: a host that won't render A2UI must not claim
+	// it.
+	var params *mcp.CallToolParams
+	if cfg.Config().Options.DisableA2UI {
+		params = &mcp.CallToolParams{Name: toolName, Arguments: args}
+	} else {
+		params = &mcp.CallToolParams{
+			Meta:      mcp.Meta(a2uiMetaCapabilities()),
+			Name:      toolName,
+			Arguments: args,
+		}
+	}
+	result, err := c.CallTool(ctx, params)
 	if err != nil {
 		return ToolResult{}, err
 	}

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -107,7 +107,7 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 	// a2ui there earns a surface payload that gets folded into model-facing
 	// content as raw JSON instead of an answer.
 	result, err := c.CallTool(ctx, &mcp.CallToolParams{
-		Meta:      a2uiRequestMeta(ctx, cfg.Config().Options.DisableA2UI),
+		Meta:      a2uiRequestMeta(ctx, a2uiDisabled(cfg)),
 		Name:      toolName,
 		Arguments: args,
 	})

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -69,29 +69,22 @@ func Tools() iter.Seq2[string, []*Tool] {
 	return allTools.Seq2()
 }
 
-// HasTool reports whether the named MCP server currently exposes a tool with
-// the given name. It backs the A2UI action round-trip: a server that serves
-// interactive surfaces may also expose the a2ui_action / a2ui_error tools
-// the client round-trips interactions through, and the client needs to know
-// before it commits to that path.
-func HasTool(name, toolName string) bool {
+// a2uiToolNames returns the a2ui_* tools an MCP server exposes, for
+// ClientInfo.A2UITools. The names travel with the state so a client/server
+// TUI — which never populates this registry — can still tell whether a
+// server speaks the surface round-trip.
+func a2uiToolNames(name string) []string {
 	tools, ok := allTools.Get(name)
 	if !ok {
-		return false
+		return nil
 	}
-	return slices.ContainsFunc(tools, func(t *Tool) bool { return t.Name == toolName })
-}
-
-// SetToolsForTest installs the given tool names for an MCP server in the
-// shared registry and returns a cleanup that removes them. It exists for
-// tests outside this package that need HasTool to observe a server's tools.
-func SetToolsForTest(name string, toolNames ...string) func() {
-	tools := make([]*Tool, len(toolNames))
-	for i, n := range toolNames {
-		tools[i] = &Tool{Name: n}
+	var out []string
+	for _, t := range tools {
+		if strings.HasPrefix(t.Name, "a2ui_") {
+			out = append(out, t.Name)
+		}
 	}
-	allTools.Set(name, tools)
-	return func() { allTools.Del(name) }
+	return out
 }
 
 // RunTool runs an MCP tool with the given input parameters.

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -100,20 +100,17 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 	}
 
 	// Attach the A2UI capability to the call's _meta for stateless servers
-	// that cannot carry initialize-time state. Gated the same way as the
-	// handshake advertisement: a host that won't render A2UI must not claim
-	// it.
-	var params *mcp.CallToolParams
-	if cfg.Config().Options.DisableA2UI {
-		params = &mcp.CallToolParams{Name: toolName, Arguments: args}
-	} else {
-		params = &mcp.CallToolParams{
-			Meta:      mcp.Meta(a2uiMetaCapabilities()),
-			Name:      toolName,
-			Arguments: args,
-		}
-	}
-	result, err := c.CallTool(ctx, params)
+	// that cannot carry initialize-time state. This is the per-turn claim, so
+	// it tracks whether THIS turn will actually render — not just whether the
+	// deployment allows surfaces. A headless `crush run` or a
+	// channel-originated turn does not divert surfaces to a UI, so claiming
+	// a2ui there earns a surface payload that gets folded into model-facing
+	// content as raw JSON instead of an answer.
+	result, err := c.CallTool(ctx, &mcp.CallToolParams{
+		Meta:      a2uiRequestMeta(ctx, cfg.Config().Options.DisableA2UI),
+		Name:      toolName,
+		Arguments: args,
+	})
 	if err != nil {
 		return ToolResult{}, err
 	}

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -39,6 +39,10 @@ type A2UISurface struct {
 	Payload string
 	// URI is the embedded resource's URI, for display/diagnostics.
 	URI string
+	// RenderForUser reports whether the payload should be rendered for the
+	// user. False only when the audience is ["assistant"] alone: the spec's
+	// verbalization contract renders for every audience except that one.
+	RenderForUser bool
 	// AssistantVisible reports whether the server annotated the payload
 	// for the LLM as well as the user (empty audience or one containing
 	// "assistant"). An audience of ["user"] alone hides the raw JSON from
@@ -151,10 +155,12 @@ func extractToolResult(result *mcp.CallToolResult) ToolResult {
 					payload = string(content.Resource.Blob)
 				}
 				if payload != "" {
+					render, assistantVisible := a2uiAudience(content.Annotations)
 					surfaces = append(surfaces, A2UISurface{
 						Payload:          payload,
 						URI:              content.Resource.URI,
-						AssistantVisible: a2uiAssistantVisible(content.Annotations),
+						RenderForUser:    render,
+						AssistantVisible: assistantVisible,
 					})
 				}
 				continue
@@ -196,16 +202,22 @@ func extractToolResult(result *mcp.CallToolResult) ToolResult {
 	}
 }
 
-// a2uiAssistantVisible reports whether an A2UI embedded resource's audience
-// annotations leave the payload visible to the LLM. Per the A2UI-over-MCP
-// verbalization contract: an empty audience is visible to both user and
-// assistant; an audience of ["user"] alone renders for the user but hides
-// the raw JSON from the model.
-func a2uiAssistantVisible(annotations *mcp.Annotations) bool {
+// a2uiAudience resolves an A2UI embedded resource's audience annotations
+// into the spec's verbalization contract:
+//
+//	audience (empty)      → render for the user, visible to the model
+//	["user"]              → render for the user, hidden from the model
+//	["assistant"]         → visible to the model, NOT rendered
+//	["user","assistant"]  → both
+//
+// It returns (renderForUser, assistantVisible).
+func a2uiAudience(annotations *mcp.Annotations) (bool, bool) {
 	if annotations == nil || len(annotations.Audience) == 0 {
-		return true
+		return true, true
 	}
-	return slices.Contains(annotations.Audience, mcp.Role("assistant"))
+	forUser := slices.Contains(annotations.Audience, mcp.Role("user"))
+	forAssistant := slices.Contains(annotations.Audience, mcp.Role("assistant"))
+	return forUser, forAssistant
 }
 
 // RefreshTools gets the updated list of tools from the MCP and updates the

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -17,12 +17,45 @@ import (
 
 type Tool = mcp.Tool
 
+// A2UIJSONMIMEType is the canonical MIME type identifying an A2UI surface
+// payload, per the A2UI-over-MCP contract. A2UILegacyMIMEType is the legacy
+// spelling reference clients also accept.
+const (
+	A2UIJSONMIMEType   = "application/a2ui+json"
+	A2UILegacyMIMEType = "application/json+a2ui"
+)
+
+// IsA2UIMIMEType reports whether mime identifies an A2UI surface payload,
+// accepting both the canonical and legacy spellings.
+func IsA2UIMIMEType(mime string) bool {
+	return mime == A2UIJSONMIMEType || mime == A2UILegacyMIMEType
+}
+
+// A2UISurface is a UI-only A2UI surface payload extracted from a tool
+// result's EmbeddedResource content. The chat UI renders it as a live
+// surface; the model never sees the raw JSON.
+type A2UISurface struct {
+	// Payload is the raw A2UI JSON.
+	Payload string
+	// URI is the embedded resource's URI, for display/diagnostics.
+	URI string
+	// AssistantVisible reports whether the server annotated the payload
+	// for the LLM as well as the user (empty audience or one containing
+	// "assistant"). An audience of ["user"] alone hides the raw JSON from
+	// the model.
+	AssistantVisible bool
+}
+
 // ToolResult represents the result of running an MCP tool.
 type ToolResult struct {
 	Type      string
 	Content   string
 	Data      []byte
 	MediaType string
+	// Surfaces carries any A2UI surface payloads found in the result's
+	// EmbeddedResource content. They are kept out of Content: the chat UI
+	// draws them, and the model only ever echoed the JSON back.
+	Surfaces []A2UISurface
 }
 
 var allTools = csync.NewMap[string, []*Tool]()
@@ -30,6 +63,31 @@ var allTools = csync.NewMap[string, []*Tool]()
 // Tools returns all available MCP tools.
 func Tools() iter.Seq2[string, []*Tool] {
 	return allTools.Seq2()
+}
+
+// HasTool reports whether the named MCP server currently exposes a tool with
+// the given name. It backs the A2UI action round-trip: a server that serves
+// interactive surfaces may also expose the a2ui_action / a2ui_error tools
+// the client round-trips interactions through, and the client needs to know
+// before it commits to that path.
+func HasTool(name, toolName string) bool {
+	tools, ok := allTools.Get(name)
+	if !ok {
+		return false
+	}
+	return slices.ContainsFunc(tools, func(t *Tool) bool { return t.Name == toolName })
+}
+
+// SetToolsForTest installs the given tool names for an MCP server in the
+// shared registry and returns a cleanup that removes them. It exists for
+// tests outside this package that need HasTool to observe a server's tools.
+func SetToolsForTest(name string, toolNames ...string) func() {
+	tools := make([]*Tool, len(toolNames))
+	for i, n := range toolNames {
+		tools[i] = &Tool{Name: n}
+	}
+	allTools.Set(name, tools)
+	return func() { allTools.Del(name) }
 }
 
 // RunTool runs an MCP tool with the given input parameters.
@@ -55,7 +113,15 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 		return ToolResult{Type: "text", Content: ""}, nil
 	}
 
+	return extractToolResult(result), nil
+}
+
+// extractToolResult partitions a CallToolResult's content into model-facing
+// text, binary media, and UI-only A2UI surfaces — the extraction half of
+// RunTool, split out so tests can drive it through a live in-memory server.
+func extractToolResult(result *mcp.CallToolResult) ToolResult {
 	var textParts []string
+	var surfaces []A2UISurface
 	var imageData []byte
 	var imageMimeType string
 	var audioData []byte
@@ -75,6 +141,25 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 				audioData = content.Data
 				audioMimeType = content.MIMEType
 			}
+		case *mcp.EmbeddedResource:
+			// A2UI surfaces arrive as embedded resources — pull them
+			// aside for the UI instead of stringifying them into the
+			// model-facing text.
+			if content.Resource != nil && IsA2UIMIMEType(content.Resource.MIMEType) {
+				payload := content.Resource.Text
+				if payload == "" && len(content.Resource.Blob) > 0 {
+					payload = string(content.Resource.Blob)
+				}
+				if payload != "" {
+					surfaces = append(surfaces, A2UISurface{
+						Payload:          payload,
+						URI:              content.Resource.URI,
+						AssistantVisible: a2uiAssistantVisible(content.Annotations),
+					})
+				}
+				continue
+			}
+			textParts = append(textParts, fmt.Sprintf("%v", v))
 		default:
 			textParts = append(textParts, fmt.Sprintf("%v", v))
 		}
@@ -90,7 +175,8 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 			Content:   textContent,
 			Data:      ensureRawBytes(imageData),
 			MediaType: imageMimeType,
-		}, nil
+			Surfaces:  surfaces,
+		}
 	}
 
 	if audioData != nil {
@@ -99,18 +185,38 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 			Content:   textContent,
 			Data:      ensureRawBytes(audioData),
 			MediaType: audioMimeType,
-		}, nil
+			Surfaces:  surfaces,
+		}
 	}
 
 	return ToolResult{
-		Type:    "text",
-		Content: textContent,
-	}, nil
+		Type:     "text",
+		Content:  textContent,
+		Surfaces: surfaces,
+	}
+}
+
+// a2uiAssistantVisible reports whether an A2UI embedded resource's audience
+// annotations leave the payload visible to the LLM. Per the A2UI-over-MCP
+// verbalization contract: an empty audience is visible to both user and
+// assistant; an audience of ["user"] alone renders for the user but hides
+// the raw JSON from the model.
+func a2uiAssistantVisible(annotations *mcp.Annotations) bool {
+	if annotations == nil || len(annotations.Audience) == 0 {
+		return true
+	}
+	return slices.Contains(annotations.Audience, mcp.Role("assistant"))
 }
 
 // RefreshTools gets the updated list of tools from the MCP and updates the
 // global state.
 func RefreshTools(ctx context.Context, cfg *config.ConfigStore, name string) {
+	// Runs under the per-name lifecycle lock so a concurrent renewal can't
+	// swap the session between our Get and the state update below.
+	mu := renewLock(name)
+	mu.Lock()
+	defer mu.Unlock()
+
 	session, ok := sessions.Get(name)
 	if !ok {
 		slog.Warn("Refresh tools: no session", "name", name)
@@ -119,7 +225,7 @@ func RefreshTools(ctx context.Context, cfg *config.ConfigStore, name string) {
 
 	tools, err := getTools(ctx, session)
 	if err != nil {
-		updateState(name, StateError, err, nil, Counts{})
+		updateState(name, StateError, err, session, Counts{})
 		return
 	}
 

--- a/internal/agent/tools/mcp/tools_a2ui_test.go
+++ b/internal/agent/tools/mcp/tools_a2ui_test.go
@@ -109,6 +109,24 @@ func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
 		res := runToolWithSession(t, sess, "get_card")
 		require.Len(t, res.Surfaces, 1)
 		require.False(t, res.Surfaces[0].AssistantVisible)
+		require.True(t, res.Surfaces[0].RenderForUser, "user audience still renders")
+	})
+
+	t.Run("assistant-only audience is visible to the model but not rendered", func(t *testing.T) {
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+				Annotations: &mcp.Annotations{Audience: []mcp.Role{"assistant"}},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.True(t, res.Surfaces[0].AssistantVisible)
+		require.False(t, res.Surfaces[0].RenderForUser, "assistant-only audience must not render")
 	})
 
 	t.Run("blob-delivered surface is normalized to text", func(t *testing.T) {

--- a/internal/agent/tools/mcp/tools_a2ui_test.go
+++ b/internal/agent/tools/mcp/tools_a2ui_test.go
@@ -1,0 +1,155 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testA2UIToolPayload = `{"version":"v0.9","updateComponents":{"surfaceId":"card","components":[` +
+	`{"component":"Text","id":"t","text":"Recipe"}]}}`
+
+// liveA2UIToolSession spins up an in-memory MCP server whose single tool
+// returns the given content items, and returns a connected client session.
+func liveA2UIToolSession(t *testing.T, toolName string, content []mcp.Content) *ClientSession {
+	t.Helper()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	server := mcp.NewServer(&mcp.Implementation{Name: "srv"}, nil)
+	mcp.AddTool(
+		server,
+		&mcp.Tool{Name: toolName, Description: "test tool"},
+		func(context.Context, *mcp.CallToolRequest, struct{}) (*mcp.CallToolResult, any, error) {
+			return &mcp.CallToolResult{Content: content}, nil, nil
+		},
+	)
+	serverSession, err := server.Connect(context.Background(), serverTransport, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush-test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+
+	sess := &ClientSession{ClientSession: clientSession, cancel: cancel}
+	t.Cleanup(func() { _ = sess.Close() })
+	return sess
+}
+
+// runToolWithSession calls the tool through the same extraction path RunTool
+// uses, without needing a registered config client.
+func runToolWithSession(t *testing.T, sess *ClientSession, toolName string) ToolResult {
+	t.Helper()
+	result, err := sess.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      toolName,
+		Arguments: map[string]any{},
+	})
+	require.NoError(t, err)
+	return extractToolResult(result)
+}
+
+func TestRunTool_A2UISurfaceExtraction(t *testing.T) {
+	t.Parallel()
+
+	t.Run("embedded A2UI resource becomes a surface, not text", func(t *testing.T) {
+		t.Parallel()
+
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.TextContent{Text: "Your recipe card"},
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://recipe-card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+
+		require.Equal(t, "Your recipe card", res.Content)
+		require.Len(t, res.Surfaces, 1)
+		require.Equal(t, testA2UIToolPayload, res.Surfaces[0].Payload)
+		require.Equal(t, "a2ui://recipe-card", res.Surfaces[0].URI)
+		require.True(t, res.Surfaces[0].AssistantVisible, "no audience annotation means visible to both")
+		require.NotContains(t, res.Content, "updateComponents")
+	})
+
+	t.Run("legacy MIME spelling is recognized", func(t *testing.T) {
+		t.Parallel()
+
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://form",
+					MIMEType: A2UILegacyMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+	})
+
+	t.Run("user-only audience hides the payload from the model", func(t *testing.T) {
+		t.Parallel()
+
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Text:     testA2UIToolPayload,
+				},
+				Annotations: &mcp.Annotations{Audience: []mcp.Role{"user"}},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.False(t, res.Surfaces[0].AssistantVisible)
+	})
+
+	t.Run("blob-delivered surface is normalized to text", func(t *testing.T) {
+		t.Parallel()
+
+		sess := liveA2UIToolSession(t, "get_card", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "a2ui://card",
+					MIMEType: A2UIJSONMIMEType,
+					Blob:     []byte(testA2UIToolPayload),
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_card")
+		require.Len(t, res.Surfaces, 1)
+		require.Equal(t, testA2UIToolPayload, res.Surfaces[0].Payload)
+	})
+
+	t.Run("non-A2UI embedded resource stays in the text", func(t *testing.T) {
+		t.Parallel()
+
+		sess := liveA2UIToolSession(t, "get_doc", []mcp.Content{
+			&mcp.EmbeddedResource{
+				Resource: &mcp.ResourceContents{
+					URI:      "file:///doc.md",
+					MIMEType: "text/markdown",
+					Text:     "# hello",
+				},
+			},
+		})
+		res := runToolWithSession(t, sess, "get_doc")
+		require.Empty(t, res.Surfaces)
+		require.NotEmpty(t, res.Content)
+	})
+}
+
+func TestIsA2UIMIMEType(t *testing.T) {
+	t.Parallel()
+	require.True(t, IsA2UIMIMEType("application/a2ui+json"))
+	require.True(t, IsA2UIMIMEType("application/json+a2ui"))
+	require.False(t, IsA2UIMIMEType("application/json"))
+	require.False(t, IsA2UIMIMEType("text/plain"))
+}

--- a/internal/agent/tools/mcp_tools_a2ui_test.go
+++ b/internal/agent/tools/mcp_tools_a2ui_test.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitMCPToolResult(t *testing.T) {
+	t.Parallel()
+
+	surface := mcp.A2UISurface{
+		Payload:          testA2UIPayload,
+		URI:              "a2ui://recipe-card",
+		AssistantVisible: true,
+	}
+
+	t.Run("surfaces divert to metadata with provenance", func(t *testing.T) {
+		t.Parallel()
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "Your recipe card",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", true)
+
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, "<a2ui-json>"+testA2UIPayload+"</a2ui-json>", meta.A2UISurfaces[0])
+		require.Equal(t, []string{"recipe"}, meta.MCPSurfaceProvenance)
+		require.Contains(t, content, "Your recipe card")
+		require.True(t, strings.Contains(content, A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, content, "updateComponents")
+	})
+
+	t.Run("no diversion folds the payload back for the model", func(t *testing.T) {
+		t.Parallel()
+		// Channel-originated turns keep the payload so the model can relay it.
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "fallback text",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, "fallback text")
+		require.Contains(t, content, testA2UIPayload)
+	})
+
+	t.Run("user-only payload stays hidden when not diverting", func(t *testing.T) {
+		t.Parallel()
+		userOnly := surface
+		userOnly.AssistantVisible = false
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "fallback text",
+			Surfaces: []mcp.A2UISurface{userOnly},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, "fallback text", content)
+	})
+
+	t.Run("surface without fallback text still gets a placeholder", func(t *testing.T) {
+		t.Parallel()
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{surface},
+		}, "recipe", true)
+
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+	})
+}

--- a/internal/agent/tools/mcp_tools_a2ui_test.go
+++ b/internal/agent/tools/mcp_tools_a2ui_test.go
@@ -14,6 +14,7 @@ func TestSplitMCPToolResult(t *testing.T) {
 	surface := mcp.A2UISurface{
 		Payload:          testA2UIPayload,
 		URI:              "a2ui://recipe-card",
+		RenderForUser:    true,
 		AssistantVisible: true,
 	}
 
@@ -47,8 +48,14 @@ func TestSplitMCPToolResult(t *testing.T) {
 		require.Contains(t, content, testA2UIPayload)
 	})
 
-	t.Run("user-only payload stays hidden when not diverting", func(t *testing.T) {
+	t.Run("user-only payload reaches the model when nothing renders it", func(t *testing.T) {
 		t.Parallel()
+		// divert=false means no chat UI is consuming this turn's surfaces —
+		// a headless `crush run`, or disable_a2ui.
+		// The ["user"] annotation means "the user can already see this", and
+		// here they cannot see anything: the model's reply is the only path
+		// back to them. Withholding the payload left the tool result empty
+		// and the agent replying with nothing at all.
 		userOnly := surface
 		userOnly.AssistantVisible = false
 		content, meta := splitMCPToolResult(mcp.ToolResult{
@@ -58,7 +65,26 @@ func TestSplitMCPToolResult(t *testing.T) {
 		}, "recipe", false)
 
 		require.Empty(t, meta.A2UISurfaces)
-		require.Equal(t, "fallback text", content)
+		require.Contains(t, content, "fallback text")
+		require.Contains(t, content, testA2UIPayload,
+			"a user-audience payload must fold back to the model when no UI renders it")
+	})
+
+	t.Run("user-only surface with no fallback text is not an empty result", func(t *testing.T) {
+		t.Parallel()
+		// The pathological shape: the tool's ONLY content is a ["user"]
+		// surface. Without a renderer this used to produce a completely
+		// empty tool result.
+		userOnly := surface
+		userOnly.AssistantVisible = false
+		content, _ := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{userOnly},
+		}, "recipe", false)
+
+		require.NotEmpty(t, content, "the model must not be handed an empty tool result")
+		require.Contains(t, content, testA2UIPayload)
 	})
 
 	t.Run("surface without fallback text still gets a placeholder", func(t *testing.T) {
@@ -71,5 +97,59 @@ func TestSplitMCPToolResult(t *testing.T) {
 
 		require.Len(t, meta.A2UISurfaces, 1)
 		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+	})
+
+	t.Run("user-only surface renders but stays hidden from the model", func(t *testing.T) {
+		t.Parallel()
+		userOnly := surface
+		userOnly.RenderForUser = true
+		userOnly.AssistantVisible = false
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{userOnly},
+		}, "recipe", true)
+
+		// Renders for the user via metadata, but the model sees a
+		// placeholder, not the JSON.
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.True(t, strings.HasPrefix(content, A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, content, "updateComponents")
+
+		// The model-facing content — what the next agent request's history
+		// carries — holds the placeholder and none of the raw payload.
+		require.NotContains(t, content, testA2UIPayload)
+		require.NotContains(t, content, `"surfaceId"`)
+	})
+
+	t.Run("assistant-only surface reaches the model but never renders", func(t *testing.T) {
+		t.Parallel()
+		assistantOnly := surface
+		assistantOnly.RenderForUser = false
+		assistantOnly.AssistantVisible = true
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{assistantOnly},
+		}, "recipe", true)
+
+		// No surface for the UI; the JSON goes to the model for reasoning.
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, testA2UIPayload)
+	})
+
+	t.Run("assistant-only surface reaches the model when not diverting too", func(t *testing.T) {
+		t.Parallel()
+		assistantOnly := surface
+		assistantOnly.RenderForUser = false
+		assistantOnly.AssistantVisible = true
+		content, meta := splitMCPToolResult(mcp.ToolResult{
+			Type:     "text",
+			Content:  "",
+			Surfaces: []mcp.A2UISurface{assistantOnly},
+		}, "recipe", false)
+
+		require.Empty(t, meta.A2UISurfaces)
+		require.Contains(t, content, testA2UIPayload)
 	})
 }

--- a/internal/agent/tools/read_mcp_resource.go
+++ b/internal/agent/tools/read_mcp_resource.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"strings"
 
 	"charm.land/fantasy"
@@ -27,8 +28,121 @@ type ReadMCPResourcePermissionsParams struct {
 
 const ReadMCPResourceToolName = "read_mcp_resource"
 
+// a2uiMIMEType is the MIME type MCP resource templates use for A2UI surfaces.
+// A2UI payloads are delivered to the UI through response metadata (never to
+// the model): the model gets a compact placeholder instead of the raw JSON,
+// so it cannot echo the payload back and double-render the surface.
+const a2uiMIMEType = mcp.A2UIJSONMIMEType
+
+// ReadMCPResourceResponseMetadata carries the UI-only A2UI surface payload
+// for a resource whose MIME type is application/a2ui+json (or a tool result
+// that embedded one). MCPSurfaceProvenance records which MCP server each
+// surface came from — by slice position — so a later interaction event can
+// route back to the owning server.
+type ReadMCPResourceResponseMetadata struct {
+	A2UISurfaces         []string `json:"a2ui_surfaces,omitempty"`
+	MCPSurfaceProvenance []string `json:"mcp_surface_provenance,omitempty"`
+}
+
+// A2UISurfacePlaceholderPrefix starts every model-facing placeholder that
+// stands in for a diverted A2UI surface. The chat renderer uses it to strip
+// placeholder lines from the tool content it shows the user.
+const A2UISurfacePlaceholderPrefix = "[A2UI surface rendered in the chat UI from "
+
+// splitMCPResourceContents partitions resource contents into model-facing
+// text parts and, when divert is set, UI-only A2UI surface payloads carried
+// in response metadata. divert is false when no chat UI will render the
+// metadata (channel-originated turns, disable_a2ui deployments): the raw
+// payload then stays in the model-facing content so the model can still
+// relay or summarize the data.
+func splitMCPResourceContents(contents []*mcp.ResourceContents, divert bool, provenance string) ([]string, ReadMCPResourceResponseMetadata) {
+	var textParts []string
+	var metadata ReadMCPResourceResponseMetadata
+	for _, content := range contents {
+		if content == nil {
+			continue
+		}
+		text := content.Text
+		if text == "" && len(content.Blob) > 0 {
+			// Blob is a legal delivery for any MIME type, including
+			// application/a2ui+json — normalize it to text here so a
+			// blob-delivered surface cannot slip past the diversion below.
+			text = string(content.Blob)
+		}
+		if text == "" {
+			slog.Debug("MCP resource content missing text/blob", "uri", content.URI)
+			continue
+		}
+		// A2UI surfaces go to the UI via metadata, not the model-facing
+		// content: the chat renderer draws the surface itself, and the
+		// model only ever echoed the raw JSON back, double-rendering the
+		// surface. Both the canonical and legacy MIME spellings match.
+		if divert && mcp.IsA2UIMIMEType(content.MIMEType) {
+			metadata.A2UISurfaces = append(metadata.A2UISurfaces, "<a2ui-json>"+text+"</a2ui-json>")
+			metadata.MCPSurfaceProvenance = append(metadata.MCPSurfaceProvenance, provenance)
+			// The placeholder is a single-line protocol the chat renderer
+			// strips line-wise — a server-controlled URI must not be able
+			// to break out of it with embedded newlines. The injected
+			// width hint is stripped too: servers echo the request URI
+			// verbatim, and a model that re-reads the echoed ?w=N URI
+			// after a terminal resize would freeze the surface at the old
+			// width (a2uiWidthHint respects an existing w=).
+			uri := strings.NewReplacer("\n", " ", "\r", " ").Replace(content.URI)
+			uri = stripA2UIWidthParam(uri)
+			textParts = append(textParts, A2UISurfacePlaceholderPrefix+uri+" — the user can already see it; do not repeat or echo its JSON payload]")
+			continue
+		}
+		textParts = append(textParts, text)
+	}
+	return textParts, metadata
+}
+
 //go:embed read_mcp_resource.md
 var readMCPResourceDescription string
+
+// a2uiWidthHint appends w=N to an A2UI surface URI so the server sizes its
+// pre-rendered geometry to the host's content width. It is a no-op for
+// non-A2UI URIs and for URIs that already carry a width hint (an explicit
+// w= is respected wherever it came from). The /a2ui path suffix is the
+// convention the in-house A2UI resource templates share (cairn,
+// switchboard); the template registry's MIME types would be the
+// protocol-level signal, but templates can legitimately fail to list, so
+// the convention stays the trigger.
+//
+// The URI is parsed only to decide — the hint is appended to the original
+// string, never re-serialized, because MCP servers match URIs textually
+// against their templates.
+func a2uiWidthHint(uri string, width int) string {
+	u, err := url.Parse(uri)
+	if err != nil || !strings.HasSuffix(u.Path, "/a2ui") {
+		return uri
+	}
+	if u.Query().Has("w") {
+		return uri
+	}
+	sep := "?"
+	if u.RawQuery != "" {
+		sep = "&"
+	}
+	return fmt.Sprintf("%s%sw=%d", uri, sep, width)
+}
+
+// stripA2UIWidthParam removes the w= query parameter from a URI for display
+// in the model-facing placeholder. This URI is informational (never
+// fetched), so re-encoding any remaining query parameters is harmless.
+func stripA2UIWidthParam(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil || !u.Query().Has("w") {
+		return uri
+	}
+	q := u.Query()
+	q.Del("w")
+	base, _, _ := strings.Cut(uri, "?")
+	if enc := q.Encode(); enc != "" {
+		return base + "?" + enc
+	}
+	return base
+}
 
 func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Service) fantasy.AgentTool {
 	return fantasy.NewParallelAgentTool(
@@ -69,6 +183,16 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 				return NewPermissionDeniedResponse(), nil
 			}
 
+			// A2UI surface templates (…/a2ui) pre-render their bar
+			// geometry server-side, so pass the UI's content width as
+			// the ?w= hint — the surface then fills the chat card
+			// instead of a fixed default budget. Only when the URI
+			// carries no width of its own and the turn has a UI width
+			// (0 = headless/remote turn).
+			if w := GetContentWidthFromContext(ctx); w > 0 {
+				params.URI = a2uiWidthHint(params.URI, w)
+			}
+
 			contents, err := mcp.ReadResource(ctx, cfg, params.MCPName, params.URI)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
@@ -77,27 +201,27 @@ func NewReadMCPResourceTool(cfg *config.ConfigStore, permissions permission.Serv
 				return fantasy.NewTextResponse(""), nil
 			}
 
-			var textParts []string
-			for _, content := range contents {
-				if content == nil {
-					continue
-				}
-				if content.Text != "" {
-					textParts = append(textParts, content.Text)
-					continue
-				}
-				if len(content.Blob) > 0 {
-					textParts = append(textParts, string(content.Blob))
-					continue
-				}
-				slog.Debug("MCP resource content missing text/blob", "uri", content.URI)
-			}
+			// Divert A2UI payloads to UI-only metadata only when a chat UI
+			// will actually render them: on channel-originated turns the
+			// reply travels back over the channel and the model needs the
+			// payload to relay it, disable_a2ui deployments opted out of
+			// surfaces entirely, and a zero content width means no
+			// interactive UI tagged this turn (headless crush run, remote
+			// clients that predate the wire field).
+			divert := GetChannelFromContext(ctx) == "" &&
+				!cfg.Config().Options.DisableA2UI &&
+				GetContentWidthFromContext(ctx) > 0
+			textParts, metadata := splitMCPResourceContents(contents, divert, params.MCPName)
 
 			if len(textParts) == 0 {
 				return fantasy.NewTextResponse(""), nil
 			}
 
-			return fantasy.NewTextResponse(strings.Join(textParts, "\n")), nil
+			resp := fantasy.NewTextResponse(strings.Join(textParts, "\n"))
+			if len(metadata.A2UISurfaces) > 0 {
+				resp = fantasy.WithResponseMetadata(resp, metadata)
+			}
+			return resp, nil
 		},
 	)
 }

--- a/internal/agent/tools/read_mcp_resource_contents_test.go
+++ b/internal/agent/tools/read_mcp_resource_contents_test.go
@@ -1,0 +1,105 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+const testA2UIPayload = `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+	`{"component":"Text","id":"t","text":"hi"}]}}`
+
+func TestSplitMCPResourceContents(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a2ui text content is diverted to metadata", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, "<a2ui-json>"+testA2UIPayload+"</a2ui-json>", meta.A2UISurfaces[0])
+		require.Equal(t, []string{"test-mcp"}, meta.MCPSurfaceProvenance)
+		require.Len(t, textParts, 1)
+		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, textParts[0], "updateComponents")
+	})
+
+	t.Run("legacy MIME spelling is diverted too", func(t *testing.T) {
+		t.Parallel()
+		_, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "a2ui://form", MIMEType: mcp.A2UILegacyMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Equal(t, []string{"test-mcp"}, meta.MCPSurfaceProvenance)
+	})
+
+	t.Run("a2ui blob content is diverted too", func(t *testing.T) {
+		t.Parallel()
+		// Blob is a legal delivery for any MIME type — a blob-delivered
+		// surface must not leak raw JSON into the model-facing content.
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Blob: []byte(testA2UIPayload)},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Len(t, textParts, 1)
+		require.True(t, strings.HasPrefix(textParts[0], A2UISurfacePlaceholderPrefix))
+		require.NotContains(t, textParts[0], "updateComponents")
+	})
+
+	t.Run("no diversion when no UI renders metadata", func(t *testing.T) {
+		t.Parallel()
+		// Channel-originated and disable_a2ui turns keep the raw payload so
+		// the model can relay or summarize the data.
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, false, "test-mcp")
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, []string{testA2UIPayload}, textParts)
+	})
+
+	t.Run("plain text passes through", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "# hello"},
+		}, true, "test-mcp")
+		require.Empty(t, meta.A2UISurfaces)
+		require.Equal(t, []string{"# hello"}, textParts)
+	})
+
+	t.Run("mixed text and a2ui keeps both", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://artifact/x", MIMEType: "text/markdown", Text: "summary"},
+			{URI: "cairn://artifact/x/a2ui", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, meta.A2UISurfaces, 1)
+		require.Len(t, textParts, 2)
+		require.Equal(t, "summary", textParts[0])
+		require.True(t, strings.HasPrefix(textParts[1], A2UISurfacePlaceholderPrefix))
+	})
+
+	t.Run("placeholder hides the injected width hint", func(t *testing.T) {
+		t.Parallel()
+		// Servers echo the request URI verbatim, ?w=N included; the model
+		// must not learn a width-frozen URI it could reuse after a resize.
+		textParts, _ := splitMCPResourceContents([]*mcp.ResourceContents{
+			{URI: "cairn://run/x/a2ui?w=114", MIMEType: a2uiMIMEType, Text: testA2UIPayload},
+		}, true, "test-mcp")
+		require.Len(t, textParts, 1)
+		require.Contains(t, textParts[0], "cairn://run/x/a2ui ")
+		require.NotContains(t, textParts[0], "w=114")
+	})
+
+	t.Run("nil and empty entries are skipped", func(t *testing.T) {
+		t.Parallel()
+		textParts, meta := splitMCPResourceContents([]*mcp.ResourceContents{
+			nil,
+			{URI: "cairn://artifact/empty"},
+		}, true, "test-mcp")
+		require.Empty(t, meta.A2UISurfaces)
+		require.Empty(t, textParts)
+	})
+}

--- a/internal/agent/tools/read_mcp_resource_test.go
+++ b/internal/agent/tools/read_mcp_resource_test.go
@@ -1,0 +1,85 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestA2UIWidthHint(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		uri   string
+		width int
+		want  string
+	}{
+		{
+			name:  "a2ui run template gets the width",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?w=114",
+		},
+		{
+			name:  "cairn-scheme alias gets the width",
+			uri:   "cairn://run/abc123/a2ui",
+			width: 90,
+			want:  "cairn://run/abc123/a2ui?w=90",
+		},
+		{
+			name:  "artifact and bundle templates get the width",
+			uri:   "mcp://cairn/artifact/PIMfMan7/a2ui",
+			width: 80,
+			want:  "mcp://cairn/artifact/PIMfMan7/a2ui?w=80",
+		},
+		{
+			name:  "an existing width hint is left alone",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui?w=60",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?w=60",
+		},
+		{
+			name:  "a non-width query still gets the width appended",
+			uri:   "mcp://cairn/run/vitkuUpp/a2ui?theme=dark",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp/a2ui?theme=dark&w=114",
+		},
+		{
+			name:  "non-a2ui resources are untouched",
+			uri:   "mcp://cairn/run/vitkuUpp",
+			width: 114,
+			want:  "mcp://cairn/run/vitkuUpp",
+		},
+		{
+			name:  "a2ui-looking substring outside the suffix is untouched",
+			uri:   "mcp://cairn/artifact/a2ui-notes",
+			width: 114,
+			want:  "mcp://cairn/artifact/a2ui-notes",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, a2uiWidthHint(tc.uri, tc.width))
+		})
+	}
+}
+
+func TestStripA2UIWidthParam(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "cairn://run/x/a2ui", stripA2UIWidthParam("cairn://run/x/a2ui?w=114"))
+	require.Equal(t, "cairn://run/x/a2ui?theme=dark", stripA2UIWidthParam("cairn://run/x/a2ui?theme=dark&w=114"))
+	require.Equal(t, "cairn://run/x/a2ui", stripA2UIWidthParam("cairn://run/x/a2ui"))
+	require.Equal(t, "mcp://cairn/artifact/y", stripA2UIWidthParam("mcp://cairn/artifact/y"))
+}
+
+func TestGetContentWidthFromContext(t *testing.T) {
+	t.Parallel()
+
+	require.Zero(t, GetContentWidthFromContext(context.Background()))
+	ctx := context.WithValue(context.Background(), ContentWidthContextKey, 114)
+	require.Equal(t, 114, GetContentWidthFromContext(ctx))
+}

--- a/internal/agent/tools/tools.go
+++ b/internal/agent/tools/tools.go
@@ -15,6 +15,8 @@ type (
 	messageIDContextKey string
 	supportsImagesKey   string
 	modelNameKey        string
+	channelContextKey   string
+	contentWidthKey     string
 )
 
 const (
@@ -26,6 +28,10 @@ const (
 	SupportsImagesContextKey supportsImagesKey = "supports_images"
 	// ModelNameContextKey is the key for the model name in the context.
 	ModelNameContextKey modelNameKey = "model_name"
+	// ChannelContextKey is the key for the channel that originated the turn.
+	ChannelContextKey channelContextKey = "channel"
+	// ContentWidthContextKey is the key for the UI content width hint in cells.
+	ContentWidthContextKey contentWidthKey = "content_width"
 )
 
 // getContextValue is a generic helper that retrieves a typed value from context.
@@ -46,6 +52,11 @@ func GetSessionFromContext(ctx context.Context) string {
 	return getContextValue(ctx, SessionIDContextKey, "")
 }
 
+// GetChannelFromContext retrieves the channel that originated the current turn.
+func GetChannelFromContext(ctx context.Context) string {
+	return getContextValue(ctx, ChannelContextKey, "")
+}
+
 // GetMessageFromContext retrieves the message ID from the context.
 func GetMessageFromContext(ctx context.Context) string {
 	return getContextValue(ctx, MessageIDContextKey, "")
@@ -59,6 +70,12 @@ func GetSupportsImagesFromContext(ctx context.Context) bool {
 // GetModelNameFromContext retrieves the model name from the context.
 func GetModelNameFromContext(ctx context.Context) string {
 	return getContextValue(ctx, ModelNameContextKey, "")
+}
+
+// GetContentWidthFromContext retrieves the UI content width hint in cells,
+// or 0 when no hint was provided for this turn.
+func GetContentWidthFromContext(ctx context.Context) int {
+	return getContextValue(ctx, ContentWidthContextKey, 0)
 }
 
 // NewPermissionDeniedResponse returns a tool response indicating the user

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -94,6 +94,9 @@ func (b *Backend) runAgent(ws *Workspace, msg proto.AgentMessage, accept *agent.
 	}
 	ctx = agent.WithRunCompleteMarker(ctx)
 
+	if msg.ContentWidth > 0 {
+		ctx = agent.WithContentWidth(ctx, msg.ContentWidth)
+	}
 	_, err := ws.AgentCoordinator.RunAccepted(ctx, accept, msg.SessionID, msg.Prompt, proto.AttachmentsToMessage(msg.Attachments)...)
 	if err == nil || errors.Is(err, context.Canceled) {
 		return

--- a/internal/backend/config.go
+++ b/internal/backend/config.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -44,6 +45,19 @@ type MCPResourceContents struct {
 	MIMEType string `json:"mime_type,omitempty"`
 	Text     string `json:"text,omitempty"`
 	Blob     []byte `json:"blob,omitempty"`
+}
+
+// MCPToolCallResult holds the model-facing text and any A2UI surface
+// payloads from an MCP tool call.
+type MCPToolCallResult struct {
+	Content  string               `json:"content"`
+	Surfaces []MCPToolCallSurface `json:"surfaces,omitempty"`
+}
+
+// MCPToolCallSurface is a single A2UI surface payload from a tool call.
+type MCPToolCallSurface struct {
+	Payload string `json:"payload"`
+	URI     string `json:"uri"`
 }
 
 // SetConfigField sets a key/value pair in the config file for the
@@ -295,6 +309,28 @@ func (b *Backend) ReadMCPResource(ctx context.Context, workspaceID, name, uri st
 		}
 	}
 	return result, nil
+}
+
+// CallMCPTool invokes a tool on a named MCP server and returns its text
+// content plus any A2UI surface payload it embedded.
+func (b *Backend) CallMCPTool(ctx context.Context, workspaceID, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	input, err := json.Marshal(args)
+	if err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to encode tool arguments: %w", err)
+	}
+	res, err := mcptools.RunTool(ctx, ws.Cfg, name, toolName, string(input))
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	out := MCPToolCallResult{Content: res.Content}
+	for _, s := range res.Surfaces {
+		out.Surfaces = append(out.Surfaces, MCPToolCallSurface{Payload: s.Payload, URI: s.URI})
+	}
+	return out, nil
 }
 
 // GetMCPPrompt retrieves a prompt from a named MCP server.

--- a/internal/client/config.go
+++ b/internal/client/config.go
@@ -260,6 +260,40 @@ type MCPResourceContents struct {
 	Blob     []byte `json:"blob,omitempty"`
 }
 
+// MCPToolCallResult holds the model-facing text and any A2UI surface
+// payloads from an MCP tool call.
+type MCPToolCallResult struct {
+	Content  string               `json:"content"`
+	Surfaces []MCPToolCallSurface `json:"surfaces,omitempty"`
+}
+
+// MCPToolCallSurface is a single A2UI surface payload from a tool call.
+type MCPToolCallSurface struct {
+	Payload string `json:"payload"`
+	URI     string `json:"uri"`
+}
+
+// CallMCPTool calls a tool on a named MCP server.
+func (c *Client) CallMCPTool(ctx context.Context, id, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/mcp/call-tool", id), nil, jsonBody(struct {
+		Name     string         `json:"name"`
+		ToolName string         `json:"tool_name"`
+		Args     map[string]any `json:"args"`
+	}{Name: name, ToolName: toolName, Args: args}), http.Header{"Content-Type": []string{"application/json"}})
+	if err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to call MCP tool: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return MCPToolCallResult{}, fmt.Errorf("failed to call MCP tool: status code %d", rsp.StatusCode)
+	}
+	var result MCPToolCallResult
+	if err := json.NewDecoder(rsp.Body).Decode(&result); err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to decode MCP tool result: %w", err)
+	}
+	return result, nil
+}
+
 // EnableDockerMCP enables the Docker MCP server on the workspace.
 func (c *Client) EnableDockerMCP(ctx context.Context, id string) error {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/mcp/docker/enable", id), nil, nil, nil)

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -490,12 +490,13 @@ func (c *Client) UpdateAgent(ctx context.Context, id string) error {
 // for completion detection. Pass "" when the caller does not need
 // to distinguish its own turn's terminal event from any concurrent
 // turn on the same session (e.g. interactive TUI usage).
-func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID, prompt string, attachments ...message.Attachment) error {
+func (c *Client) SendMessage(ctx context.Context, id string, sessionID, runID string, contentWidth int, prompt string, attachments ...message.Attachment) error {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/agent", id), nil, jsonBody(proto.AgentMessage{
-		SessionID:   sessionID,
-		RunID:       runID,
-		Prompt:      prompt,
-		Attachments: proto.AttachmentsFromMessage(attachments),
+		SessionID:    sessionID,
+		RunID:        runID,
+		ContentWidth: contentWidth,
+		Prompt:       prompt,
+		Attachments:  proto.AttachmentsFromMessage(attachments),
 	}), http.Header{"Content-Type": []string{"application/json"}})
 	if err != nil {
 		return fmt.Errorf("failed to send message to agent: %w", err)

--- a/internal/client/proto_test.go
+++ b/internal/client/proto_test.go
@@ -97,7 +97,7 @@ func TestSendMessageAcceptsStatusAccepted(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", 0, "hello"))
 }
 
 func TestSendMessageAcceptsStatusOK(t *testing.T) {
@@ -109,7 +109,7 @@ func TestSendMessageAcceptsStatusOK(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", "hello"))
+	require.NoError(t, c.SendMessage(context.Background(), "ws1", "sess1", "", 0, "hello"))
 }
 
 func TestSendMessageDecodesErrorBody(t *testing.T) {
@@ -122,7 +122,7 @@ func TestSendMessageDecodesErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "", "", 0, "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 400")
 	require.Contains(t, err.Error(), "session id is required")
@@ -138,7 +138,7 @@ func TestSendMessageFallsBackOnMalformedErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "sess1", "", 0, "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 500")
 	require.NotContains(t, err.Error(), "not json")
@@ -153,7 +153,7 @@ func TestSendMessageFallsBackOnEmptyErrorBody(t *testing.T) {
 	defer srv.Close()
 
 	c := captureClient(t, srv)
-	err := c.SendMessage(context.Background(), "ws1", "sess1", "", "hello")
+	err := c.SendMessage(context.Background(), "ws1", "sess1", "", 0, "hello")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "status code 500")
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -253,7 +253,7 @@ func runNonInteractive(
 	// loop would exit on whichever RunComplete arrived first for
 	// the same session and drop the queued prompt's output.
 	runID := uuid.New().String()
-	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, prompt); err != nil {
+	if err := c.SendMessage(ctx, ws.ID, sess.ID, runID, 0, prompt); err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -334,6 +334,7 @@ type Options struct {
 	Progress                  *bool        `json:"progress,omitempty" jsonschema:"description=Show indeterminate progress updates during long operations,default=true"`
 	Notifications             string       `json:"notifications,omitempty" jsonschema:"description=Notification style to use. Options: auto (default)\\, native\\, osc\\, bell\\, disabled. Auto selects based on environment: native for local sessions\\, osc for SSH (with automatic OSC 99/777 detection).,enum=auto,enum=native,enum=osc,enum=bell,enum=disabled,default=auto"`
 	DisabledSkills            []string     `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
+	DisableA2UI               bool         `json:"disable_a2ui,omitempty" jsonschema:"description=Disable the A2UI prompt section that invites the model to emit renderable <a2ui-json> UI surfaces in chat,default=false"`
 }
 
 type MCPs map[string]MCPConfig

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -334,7 +334,7 @@ type Options struct {
 	Progress                  *bool        `json:"progress,omitempty" jsonschema:"description=Show indeterminate progress updates during long operations,default=true"`
 	Notifications             string       `json:"notifications,omitempty" jsonschema:"description=Notification style to use. Options: auto (default)\\, native\\, osc\\, bell\\, disabled. Auto selects based on environment: native for local sessions\\, osc for SSH (with automatic OSC 99/777 detection).,enum=auto,enum=native,enum=osc,enum=bell,enum=disabled,default=auto"`
 	DisabledSkills            []string     `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
-	DisableA2UI               bool         `json:"disable_a2ui,omitempty" jsonschema:"description=Disable the A2UI prompt section that invites the model to emit renderable <a2ui-json> UI surfaces in chat,default=false"`
+	DisableA2UI               bool         `json:"disable_a2ui,omitempty" jsonschema:"description=Disable A2UI entirely: drops the prompt section inviting the model to emit renderable <a2ui-json> surfaces and stops advertising the a2ui capability to MCP servers,default=false"`
 }
 
 type MCPs map[string]MCPConfig

--- a/internal/proto/mcp.go
+++ b/internal/proto/mcp.go
@@ -138,6 +138,10 @@ type MCPClientInfo struct {
 	PromptCount   int       `json:"prompt_count,omitempty"`
 	ResourceCount int       `json:"resource_count,omitempty"`
 	ConnectedAt   time.Time `json:"connected_at"`
+	// A2UITools lists the a2ui_* tools the server exposes, so a client can
+	// tell whether an A2UI surface interaction round-trips to the server
+	// without access to the server-side tool registry.
+	A2UITools []string `json:"a2ui_tools,omitempty"`
 }
 
 type MCPPromptArgument struct {

--- a/internal/proto/proto.go
+++ b/internal/proto/proto.go
@@ -142,10 +142,16 @@ func (a AgentInfo) IsZero() bool {
 // remains correct only when no other turns are in flight for the
 // same session.
 type AgentMessage struct {
-	SessionID   string       `json:"session_id"`
-	RunID       string       `json:"run_id,omitempty"`
-	Prompt      string       `json:"prompt"`
-	Attachments []Attachment `json:"attachments,omitempty"`
+	SessionID string `json:"session_id"`
+	RunID     string `json:"run_id,omitempty"`
+	// ContentWidth is the client UI's chat content width hint in cells
+	// (0 when the turn has no interactive UI). It is a per-turn context
+	// value on the server side, so it must travel as an explicit wire
+	// field — context values do not cross the HTTP boundary. See
+	// ShellCommandRequest.TermWidth for the same pattern.
+	ContentWidth int          `json:"content_width,omitempty"`
+	Prompt       string       `json:"prompt"`
+	Attachments  []Attachment `json:"attachments,omitempty"`
 }
 
 // ShellCommandRequest represents a request to run a shell command directly.

--- a/internal/proto/requests.go
+++ b/internal/proto/requests.go
@@ -143,6 +143,13 @@ type MCPReadResourceRequest struct {
 	URI  string `json:"uri"`
 }
 
+// MCPCallToolRequest represents a request to call a tool on an MCP server.
+type MCPCallToolRequest struct {
+	Name     string         `json:"name"`
+	ToolName string         `json:"tool_name"`
+	Args     map[string]any `json:"args"`
+}
+
 // MCPGetPromptRequest represents a request to get an MCP prompt.
 type MCPGetPromptRequest struct {
 	ClientID string            `json:"client_id"`

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -536,6 +536,7 @@ func (c *controllerV1) handleGetWorkspaceMCPStates(w http.ResponseWriter, r *htt
 			PromptCount:   v.Counts.Prompts,
 			ResourceCount: v.Counts.Resources,
 			ConnectedAt:   v.ConnectedAt,
+			A2UITools:     v.A2UITools,
 		}
 	}
 	jsonEncode(w, result)

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -432,6 +432,56 @@ func (c *controllerV1) handleGetWorkspaceMCPPrompts(w http.ResponseWriter, r *ht
 	jsonEncode(w, prompts)
 }
 
+// a2uiCallableTools is the allow-list this route will invoke. The route
+// exists solely for the A2UI surface round-trip, which is not gated on the
+// agent's permission system (a button press is its own consent). Accepting an
+// arbitrary tool name here would turn it into remote execution of any tool on
+// any configured MCP server — file writes, shell-backed tools, network calls —
+// with no permission prompt at all.
+var a2uiCallableTools = map[string]bool{
+	"a2ui_action": true,
+	"a2ui_error":  true,
+}
+
+// handlePostWorkspaceMCPCallTool calls a tool on an MCP server. Only the A2UI
+// round-trip tools are callable; see [a2uiCallableTools].
+//
+//	@Summary		Call MCP tool
+//	@Tags			mcp
+//	@Accept			json
+//	@Produce		json
+//	@Param			id		path		string					true	"Workspace ID"
+//	@Param			request	body		proto.MCPCallToolRequest	true	"MCP call tool request"
+//	@Success		200		{object}	object
+//	@Failure		400		{object}	proto.Error
+//	@Failure		403		{object}	proto.Error
+//	@Failure		404		{object}	proto.Error
+//	@Failure		500		{object}	proto.Error
+//	@Router			/workspaces/{id}/mcp/call-tool [post]
+func (c *controllerV1) handlePostWorkspaceMCPCallTool(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	var req proto.MCPCallToolRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		c.server.logError(r, "Failed to decode request", "error", err)
+		jsonError(w, http.StatusBadRequest, "failed to decode request")
+		return
+	}
+
+	if !a2uiCallableTools[req.ToolName] {
+		c.server.logError(r, "Rejected non-A2UI MCP tool call", "tool", req.ToolName)
+		jsonError(w, http.StatusForbidden, "only the A2UI round-trip tools may be called over this route")
+		return
+	}
+
+	result, err := c.backend.CallMCPTool(r.Context(), id, req.Name, req.ToolName, req.Args)
+	if err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+	jsonEncode(w, result)
+}
+
 // handlePostWorkspaceMCPGetPrompt retrieves a prompt from an MCP server.
 //
 //	@Summary		Get MCP prompt

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -216,6 +216,7 @@ func (s *Server) installHandler() {
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/refresh-tools", c.handlePostWorkspaceMCPRefreshTools)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/read-resource", c.handlePostWorkspaceMCPReadResource)
 	mux.HandleFunc("GET /v1/workspaces/{id}/mcp/prompts", c.handleGetWorkspaceMCPPrompts)
+	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/call-tool", c.handlePostWorkspaceMCPCallTool)
 	mux.HandleFunc("POST /v1/workspaces/{id}/mcp/get-prompt", c.handlePostWorkspaceMCPGetPrompt)
 	mux.HandleFunc("GET /v1/workspaces/{id}/mcp/states", c.handleGetWorkspaceMCPStates)
 	mux.HandleFunc("GET /v1/workspaces/{id}/mcp/pending-auth", c.handleGetWorkspaceMCPPendingAuth)

--- a/internal/skills/builtin/a2ui/SKILL.md
+++ b/internal/skills/builtin/a2ui/SKILL.md
@@ -5,15 +5,30 @@ description: Use when the user asks you to output, speak in, or communicate usin
 
 # A2UI / a2tea Communication Guide
 
-Crush supports rendering rich, interactive terminal UI components embedded directly in your markdown responses using **a2tea** (a bridge to the [A2UI](https://a2ui.org) protocol).
+Crush renders rich, interactive terminal UI from **A2UI** (the [A2UI protocol](https://a2ui.org), via the a2tea bridge). A surface is a compact visual — a status card, an option list, a progress readout, a short form. Most replies should stay prose; reach for a surface only when the structure genuinely helps.
 
-You can emit an A2UI surface when a compact visual genuinely helps — such as a status card, an option list, a progress readout, or a form. Most of your replies should remain prose, but when a visual structure adds value, use A2UI.
+## Two delivery paths — pick the right one
 
-## Wire Format
+There are two ways an A2UI surface reaches the user. **Prefer reading an MCP resource when the data lives on a server**; emit inline JSON only for ad-hoc visuals no server provides.
 
-Embed a single inline `<a2ui-json>{...}</a2ui-json>` block in your response. Inside, provide an A2UI v0.9 payload containing an `updateComponents` message.
+### 1. Read an MCP `/a2ui` resource (preferred for server data)
 
-### Example Payload
+Servers that own data (a todo queue, a bundle, a trace, a dashboard) expose **A2UI resource templates** — URIs ending in `/a2ui` — that render their data as a surface. Read one with `read_mcp_resource`:
+
+```
+read_mcp_resource(mcp_name="todos", uri="todos://queue/<name>/a2ui")
+```
+
+What happens:
+- The host renders the surface for the **user** (audience `user`) and hands **you** a one-line placeholder, e.g. `[A2UI surface rendered in the chat UI from todos://queue/<name>/a2ui — the user can already see it; do not repeat or echo its JSON payload]`.
+- You do **not** receive the surface JSON. **Never re-echo, re-emit, or paraphrase the surface** — the user can already see it. Continue in prose.
+- Resource templates are listed by `list_mcp_resources`. A template with `{id}` is filled by you (e.g. `.../artifact/<id>/a2ui`); one with `{?w}` accepts an optional width hint the host manages — **do not** append `?w=` yourself.
+
+Use this path whenever a server offers an `/a2ui` view of its data. It is richer (server-rendered, sized to the host) and cheaper (no JSON through your context) than reconstructing the same view inline.
+
+### 2. Emit your own inline surface (ad-hoc visuals)
+
+For a visual no server provides, embed a single inline `<a2ui-json>{...}</a2ui-json>` block containing one `updateComponents` message:
 
 ```json
 <a2ui-json>{
@@ -21,121 +36,49 @@ Embed a single inline `<a2ui-json>{...}</a2ui-json>` block in your response. Ins
   "updateComponents": {
     "surfaceId": "s1",
     "components": [
-      {
-        "component": "Card",
-        "id": "root",
-        "child": "col"
-      },
-      {
-        "component": "Column",
-        "id": "col",
-        "children": ["title", "body", "btn-ok"]
-      },
-      {
-        "component": "Text",
-        "id": "title",
-        "variant": "h2",
-        "text": "Build passed"
-      },
-      {
-        "component": "Text",
-        "id": "body",
-        "text": "142 tests, 0 failures."
-      },
-      {
-        "component": "Button",
-        "id": "btn-ok",
-        "child": "btn-ok-label"
-      },
-      {
-        "component": "Text",
-        "id": "btn-ok-label",
-        "text": "Acknowledge"
-      }
+      {"component": "Card", "id": "root", "child": "col"},
+      {"component": "Column", "id": "col", "children": ["title", "body", "btn-ok"]},
+      {"component": "Text", "id": "title", "variant": "h2", "text": "Build passed"},
+      {"component": "Text", "id": "body", "text": "142 tests, 0 failures."},
+      {"component": "Button", "id": "btn-ok", "child": "btn-ok-label"},
+      {"component": "Text", "id": "btn-ok-label", "text": "Acknowledge"}
     ]
   }
 }</a2ui-json>
 ```
 
-## Component Architecture
+This is the **chat-scanned** path: the surface is part of your reply. Use it for summaries, dashboards, and one-shot forms you author yourself.
 
-A2UI components live in a flat list (adjacency list) and reference their children by `id`. The renderer resolves the tree from the root (the component that nothing else references as a child).
+## Component architecture
 
-### Core Catalog (Fully Supported)
+Components live in a **flat adjacency list** and reference children by `id`. The renderer resolves the tree from the root (the component nothing else references as a child).
 
-These components render beautifully with full styling and layout:
-- `Text`: Text display. Options: `text` (string), `variant` (h1-h5, caption).
-- `Card`: A rounded border container. Expects a single `child` ID.
-- `Column`: Lays out children vertically. Expects a `children` array of IDs.
-- `Row`: Lays out children horizontally. Expects a `children` array of IDs.
-- `List`: Lays out children as a list. Expects a `children` array of IDs.
-- `Divider`: A horizontal rule.
-- `Button`: Focusable button. Its label comes from a single `child` ID pointing at a `Text` component (there is no `label` field). When the user presses it, you receive a new message naming the pressed button and carrying the surface's current field values — a button whose id reads as a cancel (e.g. `btn-cancel`, `dismiss`, `close`) just dismisses the form instead.
+### Core catalog (fully supported)
 
-### Input Components (Editable)
+- `Text`: text display. Fields: `text` (string), `variant` (`h1`–`h5`, `caption`; omit for body).
+- `Card`: rounded-border container. Single `child` id.
+- `Column`: lays out `children` (array of ids) vertically.
+- `Row`: lays out `children` horizontally.
+- `List`: lays out `children` as a list (divider between rows).
+- `Divider`: a horizontal rule.
+- `Button`: focusable button. Its label is a single `child` id pointing at a `Text` component — there is **no** `label`/`text` field on `Button`. On press, the surface's current field values come back to you; a button whose id reads as cancel (`btn-cancel`, `dismiss`, `close`) just dismisses the form.
 
-These components render their current values and the user can edit them; their values (keyed by component `id`) are sent back to you when a button on the surface is pressed:
-- `TextField`
-- `CheckBox`
-- `ChoicePicker`
-- `Slider`
-- `DateTimeInput`
+### Input components (editable)
 
-### Media & Layout Placeholders
+Render their current value; the user can edit; values (keyed by component `id`) return when a button on the surface is pressed:
+- `TextField`, `CheckBox`, `ChoicePicker`, `Slider`, `DateTimeInput`
 
-- `Image`, `Icon`, `Video`, `AudioPlayer`: Render as compact one-line placeholders.
-- `Tabs`: Render the title bar and only the *first* tab's content.
-- `Modal`: Renders only its trigger, content stays hidden.
+### Media & layout placeholders
 
-## Best Practices
+- `Image`, `Icon`, `Video`, `AudioPlayer`: compact one-line placeholders.
+- `Tabs`: renders the title bar and only the *first* tab's content.
+- `Modal`: renders only its trigger; content stays hidden.
 
-1. **Keep it compact:** A2UI surfaces should be concise summaries, controls, or dashboards. Use standard markdown fences for code or long logs.
-2. **One surface per block:** Provide all components inside the `components` array of a single `updateComponents` message.
-3. **Link correctly:** Ensure every ID in `child` or `children` corresponds to a component in your array. Dangling IDs will break the render.
-4. **Mix with Markdown:** You can put markdown text before and after the `<a2ui-json>` block.
+## Forms (the submission loop)
 
-## Common Mistakes (Anti-Patterns)
+A form is a surface with input components plus a `Button`. When the user presses the button you receive a message naming the button and carrying the field values keyed by component `id`. A cancel-reading button dismisses without a submission.
 
-These are errors that models frequently make. Read carefully.
-
-### Buttons do NOT have a `text` or `label` field
-
-**NEVER put `text` or `label` on a `Button`** — the A2UI spec has **no** `text`, `label`, or `name` field on `Button` in any schema version. A button's label comes exclusively from its `child` ID pointing at a separate `Text` component. A stray `text`/`label` key is dropped at parse time and the button renders unlabeled.
-
-**Wrong — the label will be empty:**
-```json
-{
-  "component": "Button",
-  "id": "btn",
-  "text": "Submit"
-}
-```
-The `"text"` key is silently ignored and the button renders with no visible label.
-
-**Wrong — `label` is not a real field either:**
-```json
-{
-  "component": "Button",
-  "id": "btn",
-  "label": "Submit"
-}
-```
-
-**Correct — use a child Text component:**
-```json
-{
-  "component": "Button",
-  "id": "btn",
-  "child": "btn-label"
-},
-{
-  "component": "Text",
-  "id": "btn-label",
-  "text": "Submit"
-}
-```
-
-**Complete form template — copy this shape.** Two inputs and two buttons; note how *each* button gets its own child `Text` for its label:
+**Complete form template — copy this shape.** Two inputs, two buttons; each button gets its own child `Text` label:
 
 ```json
 <a2ui-json>{
@@ -157,51 +100,65 @@ The `"text"` key is silently ignored and the button renders with no visible labe
 }</a2ui-json>
 ```
 
-### Every `child` / `children` ID must exist in the components array
+## A2UI over MCP (the contract)
+
+When you build or reason about server-side surfaces, the A2UI-over-MCP contract (https://a2ui.org/guides/a2ui_over_mcp/) governs:
+
+- **MIME type** `application/a2ui+json` (legacy `application/json+a2ui`) identifies a surface, delivered by `resources/read` (an `/a2ui` resource) or by a `tools/call` result carrying an `EmbeddedResource` of that type.
+- **Audience**: a surface annotated `["user"]` renders for the human and its raw JSON is kept out of your context; `["assistant"]` is for your reasoning and is not rendered; empty means both.
+- **Interactivity round-trip**: a surface's `Button` carries an `action` = `{event: {name, context}}`. When the user clicks, the host calls the owning server's `a2ui_action` tool with `{name, context}` (data bindings resolved against surface state) and feeds any returned A2UI payload back into the **same** surface — no agent turn. Render failures go back via an `a2ui_error` tool call.
+- **Width hint**: a server may size pre-rendered geometry (e.g. a flame graph) to an optional `?w=N` hint the **host** appends. Never add `?w=` yourself; only templates declaring `{?w}` accept it.
+
+You normally only *consume* server surfaces (path 1). Build them only when you are authoring an MCP server.
+
+## Best practices
+
+1. **Keep it compact.** Surfaces are concise summaries, controls, or dashboards. Use fenced code blocks for code or long logs.
+2. **One surface per block.** All components inside the `components` array of a single `updateComponents` message.
+3. **Link correctly.** Every `child`/`children` id must exist in your array — a dangling id renders `[a2tea: missing component ...]`.
+4. **Mix with Markdown.** Prose before and after the `<a2ui-json>` block is fine.
+5. **Don't re-emit server surfaces.** If you read an `/a2ui` resource, the user already sees it — move on in prose.
+
+## Common mistakes (anti-patterns)
+
+### Buttons do NOT have a `text` or `label` field
+
+**NEVER put `text`/`label` on a `Button`** — the spec has no such field; the label comes only from a child `Text`. A stray key is dropped and the button renders unlabeled.
+
+**Wrong — the label will be empty:**
+```json
+{"component": "Button", "id": "btn", "text": "Submit"}
+```
+
+**Correct — a child Text component:**
+```json
+{"component": "Button", "id": "btn", "child": "btn-label"},
+{"component": "Text", "id": "btn-label", "text": "Submit"}
+```
+
+### Every `child` / `children` id must exist
 
 **Wrong — dangling reference:**
 ```json
-{
-  "component": "Card",
-  "id": "root",
-  "child": "missing-id"
-}
+{"component": "Card", "id": "root", "child": "missing-id"}
 ```
-There is no component with `id: "missing-id"` in the array, so the card renders `[a2tea: missing component "missing-id"]`.
-
-**Correct:** Always include a matching component for every referenced ID.
+No component `missing-id` exists, so the card renders `[a2tea: missing component "missing-id"]`. Always include a matching component for every referenced id.
 
 ### Do not nest components inline
 
-Components are a **flat list** (adjacency list). Do not embed component objects inside other components.
+Components are a **flat list**; `child` is a **string id**, not an object.
 
 **Wrong — inline nesting:**
 ```json
-{
-  "component": "Card",
-  "id": "root",
-  "child": {
-    "component": "Text",
-    "text": "Hello"
-  }
-}
+{"component": "Card", "id": "root", "child": {"component": "Text", "text": "Hello"}}
 ```
-The `child` field is a **string ID**, not an object. Inline nesting will break the parser.
 
-**Correct:** Define each component separately and link by ID:
+**Correct — define separately, link by id:**
 ```json
-{
-  "component": "Card",
-  "id": "root",
-  "child": "body"
-},
-{
-  "component": "Text",
-  "id": "body",
-  "text": "Hello"
-}
+{"component": "Card", "id": "root", "child": "body"},
+{"component": "Text", "id": "body", "text": "Hello"}
 ```
 
-### Do not put code in an A2UI surface
+### Do not put code in a surface
 
-A2UI surfaces are for compact visual structures. Use standard markdown fenced code blocks (`` ``` ``) for code snippets, command output, or logs. Do not try to render code inside a `Text` component — it will not syntax-highlight.
+A2UI surfaces are for compact visual structure. Use fenced code blocks (`` ``` ``) for code, command output, or logs — a `Text` component will not syntax-highlight.

--- a/internal/skills/builtin/a2ui/SKILL.md
+++ b/internal/skills/builtin/a2ui/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: a2ui
+description: Use when the user asks you to output, speak in, or communicate using the A2UI (a2tea) format, or when you need to understand how to construct A2UI JSON components to render interactive terminal UIs for the user.
+---
+
+# A2UI / a2tea Communication Guide
+
+Crush supports rendering rich, interactive terminal UI components embedded directly in your markdown responses using **a2tea** (a bridge to the [A2UI](https://a2ui.org) protocol).
+
+You can emit an A2UI surface when a compact visual genuinely helps — such as a status card, an option list, a progress readout, or a form. Most of your replies should remain prose, but when a visual structure adds value, use A2UI.
+
+## Wire Format
+
+Embed a single inline `<a2ui-json>{...}</a2ui-json>` block in your response. Inside, provide an A2UI v0.9 payload containing an `updateComponents` message.
+
+### Example Payload
+
+```json
+<a2ui-json>{
+  "version": "v0.9",
+  "updateComponents": {
+    "surfaceId": "s1",
+    "components": [
+      {
+        "component": "Card",
+        "id": "root",
+        "child": "col"
+      },
+      {
+        "component": "Column",
+        "id": "col",
+        "children": ["title", "body", "btn-ok"]
+      },
+      {
+        "component": "Text",
+        "id": "title",
+        "variant": "h2",
+        "text": "Build passed"
+      },
+      {
+        "component": "Text",
+        "id": "body",
+        "text": "142 tests, 0 failures."
+      },
+      {
+        "component": "Button",
+        "id": "btn-ok",
+        "child": "btn-ok-label"
+      },
+      {
+        "component": "Text",
+        "id": "btn-ok-label",
+        "text": "Acknowledge"
+      }
+    ]
+  }
+}</a2ui-json>
+```
+
+## Component Architecture
+
+A2UI components live in a flat list (adjacency list) and reference their children by `id`. The renderer resolves the tree from the root (the component that nothing else references as a child).
+
+### Core Catalog (Fully Supported)
+
+These components render beautifully with full styling and layout:
+- `Text`: Text display. Options: `text` (string), `variant` (h1-h5, caption).
+- `Card`: A rounded border container. Expects a single `child` ID.
+- `Column`: Lays out children vertically. Expects a `children` array of IDs.
+- `Row`: Lays out children horizontally. Expects a `children` array of IDs.
+- `List`: Lays out children as a list. Expects a `children` array of IDs.
+- `Divider`: A horizontal rule.
+- `Button`: Focusable button. Its label comes from a single `child` ID pointing at a `Text` component (there is no `label` field). When the user presses it, you receive a new message naming the pressed button and carrying the surface's current field values — a button whose id reads as a cancel (e.g. `btn-cancel`, `dismiss`, `close`) just dismisses the form instead.
+
+### Input Components (Editable)
+
+These components render their current values and the user can edit them; their values (keyed by component `id`) are sent back to you when a button on the surface is pressed:
+- `TextField`
+- `CheckBox`
+- `ChoicePicker`
+- `Slider`
+- `DateTimeInput`
+
+### Media & Layout Placeholders
+
+- `Image`, `Icon`, `Video`, `AudioPlayer`: Render as compact one-line placeholders.
+- `Tabs`: Render the title bar and only the *first* tab's content.
+- `Modal`: Renders only its trigger, content stays hidden.
+
+## Best Practices
+
+1. **Keep it compact:** A2UI surfaces should be concise summaries, controls, or dashboards. Use standard markdown fences for code or long logs.
+2. **One surface per block:** Provide all components inside the `components` array of a single `updateComponents` message.
+3. **Link correctly:** Ensure every ID in `child` or `children` corresponds to a component in your array. Dangling IDs will break the render.
+4. **Mix with Markdown:** You can put markdown text before and after the `<a2ui-json>` block.
+
+## Common Mistakes (Anti-Patterns)
+
+These are errors that models frequently make. Read carefully.
+
+### Buttons do NOT have a `text` or `label` field
+
+**NEVER put `text` or `label` on a `Button`** — the A2UI spec has **no** `text`, `label`, or `name` field on `Button` in any schema version. A button's label comes exclusively from its `child` ID pointing at a separate `Text` component. A stray `text`/`label` key is dropped at parse time and the button renders unlabeled.
+
+**Wrong — the label will be empty:**
+```json
+{
+  "component": "Button",
+  "id": "btn",
+  "text": "Submit"
+}
+```
+The `"text"` key is silently ignored and the button renders with no visible label.
+
+**Wrong — `label` is not a real field either:**
+```json
+{
+  "component": "Button",
+  "id": "btn",
+  "label": "Submit"
+}
+```
+
+**Correct — use a child Text component:**
+```json
+{
+  "component": "Button",
+  "id": "btn",
+  "child": "btn-label"
+},
+{
+  "component": "Text",
+  "id": "btn-label",
+  "text": "Submit"
+}
+```
+
+**Complete form template — copy this shape.** Two inputs and two buttons; note how *each* button gets its own child `Text` for its label:
+
+```json
+<a2ui-json>{
+  "version": "v0.9",
+  "updateComponents": {
+    "surfaceId": "form",
+    "components": [
+      {"component": "Card", "id": "root", "child": "col"},
+      {"component": "Column", "id": "col", "children": ["name", "email", "actions"]},
+      {"component": "TextField", "id": "name", "label": "Name"},
+      {"component": "TextField", "id": "email", "label": "Email"},
+      {"component": "Row", "id": "actions", "children": ["btn-send", "btn-cancel"]},
+      {"component": "Button", "id": "btn-send", "child": "btn-send-label"},
+      {"component": "Text", "id": "btn-send-label", "text": "Send"},
+      {"component": "Button", "id": "btn-cancel", "child": "btn-cancel-label"},
+      {"component": "Text", "id": "btn-cancel-label", "text": "Cancel"}
+    ]
+  }
+}</a2ui-json>
+```
+
+### Every `child` / `children` ID must exist in the components array
+
+**Wrong — dangling reference:**
+```json
+{
+  "component": "Card",
+  "id": "root",
+  "child": "missing-id"
+}
+```
+There is no component with `id: "missing-id"` in the array, so the card renders `[a2tea: missing component "missing-id"]`.
+
+**Correct:** Always include a matching component for every referenced ID.
+
+### Do not nest components inline
+
+Components are a **flat list** (adjacency list). Do not embed component objects inside other components.
+
+**Wrong — inline nesting:**
+```json
+{
+  "component": "Card",
+  "id": "root",
+  "child": {
+    "component": "Text",
+    "text": "Hello"
+  }
+}
+```
+The `child` field is a **string ID**, not an object. Inline nesting will break the parser.
+
+**Correct:** Define each component separately and link by ID:
+```json
+{
+  "component": "Card",
+  "id": "root",
+  "child": "body"
+},
+{
+  "component": "Text",
+  "id": "body",
+  "text": "Hello"
+}
+```
+
+### Do not put code in an A2UI surface
+
+A2UI surfaces are for compact visual structures. Use standard markdown fenced code blocks (`` ``` ``) for code snippets, command output, or logs. Do not try to render code inside a `Text` component — it will not syntax-highlight.

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -446,6 +446,19 @@ func TestDiscoverBuiltin(t *testing.T) {
 		}
 	}
 	require.True(t, foundHooks, "crush-hooks builtin skill not found")
+
+	var foundA2UI bool
+	for _, s := range discovered {
+		if s.Name == "a2ui" {
+			foundA2UI = true
+			require.Equal(t, "crush://skills/a2ui/SKILL.md", s.SkillFilePath)
+			require.Equal(t, "crush://skills/a2ui", s.Path)
+			require.NotEmpty(t, s.Description)
+			require.NotEmpty(t, s.Instructions)
+			require.True(t, s.Builtin)
+		}
+	}
+	require.True(t, foundA2UI, "a2ui builtin skill not found")
 }
 
 func TestDeduplicate(t *testing.T) {

--- a/internal/swagger/docs.go
+++ b/internal/swagger/docs.go
@@ -1579,6 +1579,169 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaces/{id}/mcp/auth": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Authenticate an MCP server",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MCP name request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPNameRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPAuthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/mcp/auth-url": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Get MCP OAuth authorization URL",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "MCP server name",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPAuthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/mcp/call-tool": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Call MCP tool",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MCP call tool request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPCallToolRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/mcp/docker/disable": {
             "post": {
                 "tags": [
@@ -1688,6 +1851,49 @@ const docTemplate = `{
                         "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/mcp/pending-auth": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Get MCP servers pending OAuth",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/proto.MCPPendingAuthServer"
+                            }
                         }
                     },
                     "404": {
@@ -3492,6 +3698,9 @@ const docTemplate = `{
                 "debug_lsp": {
                     "type": "boolean"
                 },
+                "disable_a2ui": {
+                    "type": "boolean"
+                },
                 "disable_auto_summarize": {
                     "type": "boolean"
                 },
@@ -3678,6 +3887,10 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/proto.Attachment"
                     }
+                },
+                "content_width": {
+                    "description": "ContentWidth is the client UI's chat content width hint in cells\n(0 when the turn has no interactive UI). It is a per-turn context\nvalue on the server side, so it must travel as an explicit wire\nfield — context values do not cross the HTTP boundary. See\nShellCommandRequest.TermWidth for the same pattern.",
+                    "type": "integer"
                 },
                 "prompt": {
                     "type": "string"
@@ -3924,9 +4137,40 @@ const docTemplate = `{
                 }
             }
         },
+        "proto.MCPAuthResponse": {
+            "type": "object",
+            "properties": {
+                "auth_url": {
+                    "description": "AuthURL is the OAuth authorization URL the user must visit, when\nthe flow is still in progress.",
+                    "type": "string"
+                }
+            }
+        },
+        "proto.MCPCallToolRequest": {
+            "type": "object",
+            "properties": {
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tool_name": {
+                    "type": "string"
+                }
+            }
+        },
         "proto.MCPClientInfo": {
             "type": "object",
             "properties": {
+                "a2ui_tools": {
+                    "description": "A2UITools lists the a2ui_* tools the server exposes, so a client can\ntell whether an A2UI surface interaction round-trips to the server\nwithout access to the server-side tool registry.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "connected_at": {
                     "type": "string"
                 },
@@ -3977,6 +4221,17 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.MCPPendingAuthServer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
                     "type": "string"
                 }
             }

--- a/internal/swagger/swagger.json
+++ b/internal/swagger/swagger.json
@@ -1572,6 +1572,169 @@
                 }
             }
         },
+        "/workspaces/{id}/mcp/auth": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Authenticate an MCP server",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MCP name request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPNameRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPAuthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/mcp/auth-url": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Get MCP OAuth authorization URL",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "MCP server name",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPAuthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/mcp/call-tool": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Call MCP tool",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MCP call tool request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPCallToolRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/mcp/docker/disable": {
             "post": {
                 "tags": [
@@ -1681,6 +1844,49 @@
                         "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/mcp/pending-auth": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Get MCP servers pending OAuth",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/proto.MCPPendingAuthServer"
+                            }
                         }
                     },
                     "404": {
@@ -3485,6 +3691,9 @@
                 "debug_lsp": {
                     "type": "boolean"
                 },
+                "disable_a2ui": {
+                    "type": "boolean"
+                },
                 "disable_auto_summarize": {
                     "type": "boolean"
                 },
@@ -3671,6 +3880,10 @@
                     "items": {
                         "$ref": "#/definitions/proto.Attachment"
                     }
+                },
+                "content_width": {
+                    "description": "ContentWidth is the client UI's chat content width hint in cells\n(0 when the turn has no interactive UI). It is a per-turn context\nvalue on the server side, so it must travel as an explicit wire\nfield — context values do not cross the HTTP boundary. See\nShellCommandRequest.TermWidth for the same pattern.",
+                    "type": "integer"
                 },
                 "prompt": {
                     "type": "string"
@@ -3917,9 +4130,40 @@
                 }
             }
         },
+        "proto.MCPAuthResponse": {
+            "type": "object",
+            "properties": {
+                "auth_url": {
+                    "description": "AuthURL is the OAuth authorization URL the user must visit, when\nthe flow is still in progress.",
+                    "type": "string"
+                }
+            }
+        },
+        "proto.MCPCallToolRequest": {
+            "type": "object",
+            "properties": {
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {}
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tool_name": {
+                    "type": "string"
+                }
+            }
+        },
         "proto.MCPClientInfo": {
             "type": "object",
             "properties": {
+                "a2ui_tools": {
+                    "description": "A2UITools lists the a2ui_* tools the server exposes, so a client can\ntell whether an A2UI surface interaction round-trips to the server\nwithout access to the server-side tool registry.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "connected_at": {
                     "type": "string"
                 },
@@ -3970,6 +4214,17 @@
             "type": "object",
             "properties": {
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.MCPPendingAuthServer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
                     "type": "string"
                 }
             }

--- a/internal/swagger/swagger.yaml
+++ b/internal/swagger/swagger.yaml
@@ -370,6 +370,8 @@ definitions:
         type: boolean
       debug_lsp:
         type: boolean
+      disable_a2ui:
+        type: boolean
       disable_auto_summarize:
         type: boolean
       disable_default_providers:
@@ -498,6 +500,14 @@ definitions:
         items:
           $ref: '#/definitions/proto.Attachment'
         type: array
+      content_width:
+        description: |-
+          ContentWidth is the client UI's chat content width hint in cells
+          (0 when the turn has no interactive UI). It is a per-turn context
+          value on the server side, so it must travel as an explicit wire
+          field — context values do not cross the HTTP boundary. See
+          ShellCommandRequest.TermWidth for the same pattern.
+        type: integer
       prompt:
         type: string
       run_id:
@@ -657,8 +667,34 @@ definitions:
       path:
         type: string
     type: object
+  proto.MCPAuthResponse:
+    properties:
+      auth_url:
+        description: |-
+          AuthURL is the OAuth authorization URL the user must visit, when
+          the flow is still in progress.
+        type: string
+    type: object
+  proto.MCPCallToolRequest:
+    properties:
+      args:
+        additionalProperties: {}
+        type: object
+      name:
+        type: string
+      tool_name:
+        type: string
+    type: object
   proto.MCPClientInfo:
     properties:
+      a2ui_tools:
+        description: |-
+          A2UITools lists the a2ui_* tools the server exposes, so a client can
+          tell whether an A2UI surface interaction round-trips to the server
+          without access to the server-side tool registry.
+        items:
+          type: string
+        type: array
       connected_at:
         type: string
       error: {}
@@ -692,6 +728,13 @@ definitions:
   proto.MCPNameRequest:
     properties:
       name:
+        type: string
+    type: object
+  proto.MCPPendingAuthServer:
+    properties:
+      name:
+        type: string
+      url:
         type: string
     type: object
   proto.MCPPrompt:
@@ -2063,6 +2106,113 @@ paths:
       summary: Stop all LSP servers
       tags:
       - lsp
+  /workspaces/{id}/mcp/auth:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: MCP name request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/proto.MCPNameRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/proto.MCPAuthResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Authenticate an MCP server
+      tags:
+      - mcp
+  /workspaces/{id}/mcp/auth-url:
+    get:
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: MCP server name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/proto.MCPAuthResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Get MCP OAuth authorization URL
+      tags:
+      - mcp
+  /workspaces/{id}/mcp/call-tool:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: MCP call tool request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/proto.MCPCallToolRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Call MCP tool
+      tags:
+      - mcp
   /workspaces/{id}/mcp/docker/disable:
     post:
       parameters:
@@ -2143,6 +2293,34 @@ paths:
           schema:
             $ref: '#/definitions/proto.Error'
       summary: Get MCP prompt
+      tags:
+      - mcp
+  /workspaces/{id}/mcp/pending-auth:
+    get:
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/proto.MCPPendingAuthServer'
+            type: array
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Get MCP servers pending OAuth
       tags:
       - mcp
   /workspaces/{id}/mcp/prompts:

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -792,6 +792,25 @@ func (a *AssistantMessageItem) a2uiSurfaceRetired(i int) bool {
 	return a.a2uiRetired[a.a2uiSurfaceIDs[i]]
 }
 
+// HasLiveA2UISurface reports whether this assistant message holds a
+// non-retired surface with the given ID. Surface IDs are only unique within
+// the thing that authored them — an assistant-authored form and an MCP
+// server both commonly use "default" — so callers deciding where a button
+// press should go must ask this before consulting any MCP provenance, or an
+// ID collision routes the user's form submission to an unrelated server.
+func (a *AssistantMessageItem) HasLiveA2UISurface(surfaceID string) bool {
+	if surfaceID == "" {
+		return false
+	}
+	for i, s := range a.a2uiSurfaces {
+		if s == nil || i >= len(a.a2uiSurfaceIDs) || a.a2uiSurfaceIDs[i] != surfaceID {
+			continue
+		}
+		return !a.a2uiRetired[surfaceID]
+	}
+	return false
+}
+
 // RetireA2UISurface retires the live surface with the given A2UI surface ID
 // after a button press (#45): it reads the surface's current field values,
 // revokes its focus, and marks it retired so the form cannot be re-submitted

--- a/internal/ui/chat/a2ui.go
+++ b/internal/ui/chat/a2ui.go
@@ -1,0 +1,1179 @@
+package chat
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"regexp"
+	"slices"
+	"strings"
+	"sync"
+	"unicode"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/glamour/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/event"
+	"github.com/joestump-agent/a2tea/render"
+	a2ui "github.com/tmc/a2ui"
+	"github.com/tmc/a2ui/a2uistream"
+)
+
+// a2uiOpenTag and a2uiCloseTag delimit an inline A2UI block in assistant
+// content — the wire format a2tea scans for.
+const (
+	a2uiOpenTag  = "<a2ui-json>"
+	a2uiCloseTag = "</a2ui-json>"
+)
+
+var (
+	fenceRe = regexp.MustCompile("(?s)```[^\n]*\n.*?```")
+	// inlineCodeRe matches markdown inline code spans on a single line:
+	// double-backtick spans first (their content may hold single backticks),
+	// then single-backtick spans.
+	inlineCodeRe = regexp.MustCompile("``[^\n]*?``|`[^`\n]+`")
+)
+
+// codeReplacement tracks a masked code span for later restoration.
+type codeReplacement struct {
+	placeholder string
+	original    string
+}
+
+// maskMarkdownCode replaces markdown code with unique placeholders so a2tea's
+// markdown-unaware scanner does not extract A2UI from code that is
+// documentation, not live UI. Fenced code blocks are always masked (#6);
+// inline code spans are masked only when they mention A2UI markers (#96) —
+// masking every span would leak placeholders into legitimate surface JSON
+// that happens to contain backticks. Use unmaskMarkdownCode to restore the
+// originals after scanning.
+func maskMarkdownCode(content string) (string, []codeReplacement) {
+	var reps []codeReplacement
+	mask := func(match string) string {
+		p := fmt.Sprintf("\x00CODE%d\x00", len(reps))
+		reps = append(reps, codeReplacement{p, match})
+		return p
+	}
+	if strings.Contains(content, "```") {
+		content = fenceRe.ReplaceAllStringFunc(content, mask)
+	}
+	if strings.Contains(content, "`") {
+		content = inlineCodeRe.ReplaceAllStringFunc(content, func(match string) string {
+			if !mentionsA2UI(match) {
+				return match
+			}
+			return mask(match)
+		})
+	}
+	return content, reps
+}
+
+// a2uiMarkers are the literals a2tea's scanner reacts to: the wire tag and
+// the quoted A2UI message-type keys used for bare-JSON detection. Inline code
+// naming any of these is documentation the scanner must not consume (#96).
+var a2uiMarkers = []string{
+	"a2ui-json",
+	`"createSurface"`,
+	`"updateComponents"`,
+	`"updateDataModel"`,
+	`"deleteSurface"`,
+}
+
+// mentionsA2UI reports whether s contains any marker the a2tea scanner
+// could mistake for live A2UI content.
+func mentionsA2UI(s string) bool {
+	for _, m := range a2uiMarkers {
+		if strings.Contains(s, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// unmaskMarkdownCode restores code spans replaced by maskMarkdownCode.
+func unmaskMarkdownCode(text string, reps []codeReplacement) string {
+	for _, r := range reps {
+		text = strings.ReplaceAll(text, r.placeholder, r.original)
+	}
+	return text
+}
+
+// contentHasA2UI reports whether the assistant content carries any A2UI
+// outside markdown code (fences and inline spans), so the renderer only takes
+// the a2tea path when there is live UI to draw.
+func contentHasA2UI(content string) bool {
+	masked, _ := maskMarkdownCode(content)
+	return a2tea.Contains(masked)
+}
+
+// hasUnclosedA2UITag reports whether content has more opening
+// <a2ui-json> tags than closing </a2ui-json> tags — a truncated block
+// (#5). This catches both a single unclosed block and the rarer case of
+// a complete surface followed by a second truncated block. Only
+// meaningful for finished messages; while streaming the close tag
+// simply hasn't arrived yet.
+func hasUnclosedA2UITag(content string) bool {
+	return strings.Count(content, "<a2ui-json>") > strings.Count(content, "</a2ui-json>")
+}
+
+// contentHasUnclosedA2UI is the gate-level check (markdown code masked) for
+// truncated A2UI blocks in finished messages.
+func contentHasUnclosedA2UI(content string) bool {
+	masked, _ := maskMarkdownCode(content)
+	return hasUnclosedA2UITag(masked)
+}
+
+// a2uiBlockStats summarizes how the a2uistream parser treats the complete
+// <a2ui-json> blocks in content (#7, #168).
+type a2uiBlockStats struct {
+	// dropped counts blocks the parser consumed but produced nothing from —
+	// malformed JSON or objects it doesn't recognize. These lose content and
+	// must alert.
+	dropped int
+	// protocolOnly counts blocks holding only protocol messages
+	// (callFunction/actionResponse): recognized, just not drawable. These get
+	// a quiet notice, not the malformed-content alert.
+	protocolOnly int
+	// unclosed reports an open tag the parser honors as a delimiter that
+	// never got its closing partner — a truncated generation (#5).
+	unclosed bool
+}
+
+// scanA2UIBlocks classifies the tagged blocks in content the way the
+// a2uistream parser does. Both the segmentation and the per-block judgment
+// derive from the parser's own rules, so this check agrees with rendering by
+// construction.
+//
+// Segmentation used to pair tag literals with a blind string scan, which
+// disagreed with the parser when a bare A2UI message's *string content*
+// mentioned the tags — the parser consumes the whole object (tag literals and
+// all) as one message, while the blind scan saw a "block" between the
+// mentions and raised a false alert beside a working surface (#168). This
+// mirrors the parser's pre-tag scan instead: a bare A2UI object opened before
+// a tag swallows it, and only a tag the parser would honor as a delimiter
+// starts a block.
+//
+// Judging each block by re-parsing it also fixes what a single-object
+// unmarshal got wrong in both directions: valid-but-unrecognized JSON
+// ({"foo":1}) is silently dropped by the parser but unmarshals fine (missed
+// alert), while multiple newline-delimited messages render fine but fail a
+// single-object unmarshal (false alert).
+func scanA2UIBlocks(content string) a2uiBlockStats {
+	var stats a2uiBlockStats
+	s := content
+scan:
+	for {
+		tagIdx := strings.Index(s, a2uiOpenTag)
+		if tagIdx < 0 {
+			return stats
+		}
+		// Mirror the parser's scan of the text ahead of the tag for bare
+		// A2UI JSON objects.
+		for from := 0; from < tagIdx; {
+			rel := strings.IndexByte(s[from:tagIdx], '{')
+			if rel < 0 {
+				break
+			}
+			idx := from + rel
+			if !atBareJSONBoundary(s, idx) || !possibleBareA2UIPrefix(s[idx:]) {
+				from = idx + 1
+				continue
+			}
+			end, complete := scanJSONObject(s[idx:])
+			if !complete {
+				// The parser buffers the incomplete object and everything
+				// after it as plain text; the tag never becomes a delimiter.
+				return stats
+			}
+			if acceptedBareA2UIObject(s[idx : idx+end]) {
+				// The parser consumes the object and rescans from after it —
+				// a tag literal inside the object's strings is message
+				// content, not a delimiter.
+				s = s[idx+end:]
+				continue scan
+			}
+			from = idx + 1
+		}
+		rest := s[tagIdx+len(a2uiOpenTag):]
+		j := strings.Index(rest, a2uiCloseTag)
+		if j < 0 {
+			stats.unclosed = true
+			return stats
+		}
+		messages, payloads := classifyA2UIBlock(rest[:j])
+		switch {
+		case messages > 0: // renders — nothing to report
+		case payloads > 0:
+			stats.protocolOnly++
+		default:
+			stats.dropped++
+		}
+		s = rest[j+len(a2uiCloseTag):]
+	}
+}
+
+// classifyA2UIBlock judges one complete tagged block's body with the same
+// parser rendering uses, reporting how many typed (renderable) messages and
+// version-neutral payload objects it yields. A block with payloads but no
+// messages carries only protocol traffic (callFunction/actionResponse);
+// one with neither was dropped entirely.
+func classifyA2UIBlock(body string) (messages, payloads int) {
+	parts, err := a2uistream.ParseAndValidate(a2uiOpenTag+body+a2uiCloseTag, nil)
+	if err != nil {
+		return 0, 0
+	}
+	for _, p := range parts {
+		messages += len(p.Messages)
+		payloads += len(p.Payload)
+	}
+	return messages, payloads
+}
+
+// The helpers below mirror a2uistream's unexported bare-JSON scanning rules
+// so scanA2UIBlocks segments content exactly as the parser does.
+
+// a2uiBareKeys are the JSON keys whose presence as a first key makes an
+// object a bare A2UI message candidate for the parser.
+var a2uiBareKeys = []string{
+	"version",
+	"functionCallId",
+	"actionId",
+	"wantResponse",
+	"createSurface",
+	"updateComponents",
+	"updateDataModel",
+	"deleteSurface",
+	"callFunction",
+	"actionResponse",
+}
+
+// a2uiPayloadKeys are the message-type keys that make the parser actually
+// consume a candidate object (the version-neutral payload check).
+var a2uiPayloadKeys = []string{
+	"createSurface",
+	"updateComponents",
+	"updateDataModel",
+	"deleteSurface",
+	"callFunction",
+	"actionResponse",
+}
+
+// atBareJSONBoundary reports whether an object starting at s[idx] sits at a
+// position the parser treats as a bare-JSON boundary: the start of its
+// buffer, or after whitespace.
+func atBareJSONBoundary(s string, idx int) bool {
+	if idx == 0 {
+		return true
+	}
+	switch s[idx-1] {
+	case ' ', '\t', '\n', '\r':
+		return true
+	default:
+		return false
+	}
+}
+
+// possibleBareA2UIPrefix reports whether s (starting at '{') could open a
+// bare A2UI message: its first key must be one of the keys the parser
+// recognizes.
+func possibleBareA2UIPrefix(s string) bool {
+	if s == "" || s[0] != '{' {
+		return false
+	}
+	i := 1
+	for i < len(s) && isJSONSpace(s[i]) {
+		i++
+	}
+	if i == len(s) {
+		return true
+	}
+	if s[i] != '"' {
+		return false
+	}
+	i++
+	start := i
+	for i < len(s) && isJSONKeyChar(s[i]) {
+		i++
+	}
+	fragment := s[start:i]
+	if i == len(s) || s[i] != '"' {
+		return hasBareA2UIKeyPrefix(fragment)
+	}
+	if !isBareA2UIKey(fragment) {
+		return false
+	}
+	i++
+	for i < len(s) && isJSONSpace(s[i]) {
+		i++
+	}
+	return i == len(s) || s[i] == ':'
+}
+
+func hasBareA2UIKeyPrefix(fragment string) bool {
+	if fragment == "" {
+		return true
+	}
+	for _, key := range a2uiBareKeys {
+		if strings.HasPrefix(key, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func isBareA2UIKey(fragment string) bool {
+	for _, key := range a2uiBareKeys {
+		if key == fragment {
+			return true
+		}
+	}
+	return false
+}
+
+func isJSONKeyChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+func isJSONSpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r':
+		return true
+	default:
+		return false
+	}
+}
+
+// scanJSONObject reports the end of the JSON object starting at s[0] ('{'),
+// tracking strings and escapes so braces (and tag literals) inside string
+// values don't fool the scan. complete is false when the object runs past the
+// end of s.
+func scanJSONObject(s string) (end int, complete bool) {
+	if s == "" || s[0] != '{' {
+		return 0, false
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch c {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// acceptedBareA2UIObject reports whether the parser would consume obj as a
+// bare A2UI message: valid JSON carrying at least one message-type key.
+func acceptedBareA2UIObject(obj string) bool {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(obj), &m); err != nil {
+		return false
+	}
+	for _, key := range a2uiPayloadKeys {
+		if _, ok := m[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// repairA2UIButtons rewrites the raw JSON inside <a2ui-json> blocks to fix a
+// frequent model mistake (#47): a Button carrying its label in a `text` (or
+// `label`) field instead of a child Text component. A2UI's Button has no such
+// field in any schema version, so the label is silently dropped when the block
+// is parsed into typed components — which is why this repair must run on the
+// raw JSON, before a2tea.Scan.
+//
+// The repair is deliberately surgical: only a Button that has a non-empty
+// text/label AND no child is rewritten — a Text component is synthesized from
+// the stray label and the button's child pointed at it. Valid child-based
+// buttons and every other component are left untouched, and a block whose JSON
+// doesn't decode is returned verbatim so the existing error-alert path still
+// applies.
+func repairA2UIButtons(content string) string {
+	if !strings.Contains(content, a2uiOpenTag) {
+		return content
+	}
+	var b strings.Builder
+	s := content
+	for {
+		i := strings.Index(s, a2uiOpenTag)
+		if i < 0 {
+			break
+		}
+		j := strings.Index(s[i+len(a2uiOpenTag):], a2uiCloseTag)
+		if j < 0 {
+			break
+		}
+		body := s[i+len(a2uiOpenTag) : i+len(a2uiOpenTag)+j]
+		b.WriteString(s[:i+len(a2uiOpenTag)])
+		b.WriteString(repairA2UIBody(body))
+		b.WriteString(a2uiCloseTag)
+		s = s[i+len(a2uiOpenTag)+j+len(a2uiCloseTag):]
+	}
+	b.WriteString(s)
+	return b.String()
+}
+
+// repairA2UIBody repairs the JSON body of a single <a2ui-json> block. The body
+// may hold one message object, an array of messages, or several
+// newline-delimited messages — the same forms the a2tea parser accepts. If the
+// body doesn't decode, or no button needs fixing, it is returned unchanged
+// (preserving the author's formatting and the malformed-block alert path).
+func repairA2UIBody(body string) string {
+	dec := json.NewDecoder(strings.NewReader(body))
+	var vals []any
+	for {
+		var v any
+		if err := dec.Decode(&v); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return body
+		}
+		vals = append(vals, v)
+	}
+
+	changed := false
+	for _, v := range vals {
+		switch m := v.(type) {
+		case map[string]any:
+			changed = repairA2UIMessage(m) || changed
+		case []any:
+			for _, e := range m {
+				if mm, ok := e.(map[string]any); ok {
+					changed = repairA2UIMessage(mm) || changed
+				}
+			}
+		}
+	}
+	if !changed {
+		return body
+	}
+
+	out := make([]string, 0, len(vals))
+	for _, v := range vals {
+		enc, err := json.Marshal(v)
+		if err != nil {
+			return body
+		}
+		out = append(out, string(enc))
+	}
+	return strings.Join(out, "\n")
+}
+
+// repairA2UIMessage fixes childless-but-labeled buttons inside one raw A2UI
+// message map, reporting whether it changed anything. For each such button it
+// moves the stray text/label into a new Text component (with a unique id
+// derived from the button's) and points the button's child at it.
+func repairA2UIMessage(msg map[string]any) bool {
+	uc, ok := msg["updateComponents"].(map[string]any)
+	if !ok {
+		return false
+	}
+	comps, ok := uc["components"].([]any)
+	if !ok {
+		return false
+	}
+
+	ids := make(map[string]bool, len(comps))
+	for _, c := range comps {
+		if m, ok := c.(map[string]any); ok {
+			if id, ok := m["id"].(string); ok {
+				ids[id] = true
+			}
+		}
+	}
+
+	var added []any
+	for _, c := range comps {
+		m, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if typ, _ := m["component"].(string); typ != "Button" {
+			continue
+		}
+		switch child := m["child"].(type) {
+		case nil: // absent (or JSON null): childless, repairable
+		case string:
+			if child != "" {
+				continue // valid child-based button: leave untouched
+			}
+		default:
+			continue // e.g. inline-nested object: not ours to rewrite
+		}
+		label, _ := m["text"].(string)
+		if label == "" {
+			label, _ = m["label"].(string)
+		}
+		if label == "" {
+			continue
+		}
+
+		base := "label"
+		if id, _ := m["id"].(string); id != "" {
+			base = id + "-label"
+		}
+		labelID := base
+		for n := 2; ids[labelID]; n++ {
+			labelID = fmt.Sprintf("%s-%d", base, n)
+		}
+		ids[labelID] = true
+
+		m["child"] = labelID
+		delete(m, "text")
+		delete(m, "label")
+		added = append(added, map[string]any{
+			"component": "Text",
+			"id":        labelID,
+			"text":      label,
+		})
+	}
+	if len(added) == 0 {
+		return false
+	}
+	uc["components"] = append(comps, added...)
+	return true
+}
+
+// a2uiThemeStyles builds a2tea render.Styles from the active crush theme so
+// surfaces draw with the same palette as the rest of the chat. Card borders
+// pick up the same border color the old A2UISurface frame used (the theme's
+// visible background), headings and buttons use the brand colors, captions
+// use the muted foreground, and the focused button inverts to a
+// primary-background highlight — matching the dialog selected-item pattern.
+func a2uiThemeStyles(sty *styles.Styles) render.Styles {
+	st := render.DefaultStyles()
+	if sty == nil {
+		return st
+	}
+	st.CardBorder = st.CardBorder.
+		BorderForeground(sty.Messages.A2UISurface.GetBorderTopForeground())
+	st.Heading = st.Heading.Foreground(sty.WorkingGradFromColor)
+	st.Subheading = st.Subheading.Foreground(sty.WorkingGradToColor)
+	st.Caption = st.Caption.Foreground(sty.Dialog.SecondaryText.GetForeground())
+	st.Button = st.Button.Foreground(sty.WorkingGradFromColor)
+	st.ButtonFocused = st.ButtonFocused.
+		Background(sty.Dialog.SelectedItem.GetBackground()).
+		Foreground(sty.Dialog.SelectedItem.GetForeground()).
+		Reverse(false)
+	// Inject Crush's glamour renderer so body-variant Text containing
+	// Markdown (tables, lists, bold, code) renders with the same styling
+	// as the rest of the chat. Rendered output is memoized per
+	// (renderer, text): items holding live surfaces bypass the chat render
+	// caches, so without a memo every repaint re-runs a full glamour parse
+	// per markdown body. The renderer lock is scoped to the Render call —
+	// callers must never hold the same renderer's lock while a surface
+	// View runs (see renderContentWithA2UI), or this hook would deadlock.
+	st.MarkdownRenderer = func(text string, width int) string {
+		renderer := common.MarkdownRenderer(sty, width)
+		if out, ok := a2uiMarkdownMemoGet(renderer, text); ok {
+			return out
+		}
+		mu := common.LockMarkdownRenderer(renderer)
+		mu.Lock()
+		out, err := renderer.Render(text)
+		mu.Unlock()
+		if err != nil {
+			return text
+		}
+		out = strings.TrimSpace(out)
+		a2uiMarkdownMemoPut(renderer, text, out)
+		return out
+	}
+	return st
+}
+
+// a2uiMarkdownMemo caches glamour output for surface body Text. Keyed by the
+// memoized renderer pointer — which already encodes the width and is dropped
+// on theme change via InvalidateMarkdownRendererCache — plus the source text.
+// Bounded crudely: the map resets once it grows past a2uiMarkdownMemoMax.
+var (
+	a2uiMarkdownMemoMu sync.Mutex
+	a2uiMarkdownMemo   = map[a2uiMarkdownMemoKey]string{}
+)
+
+type a2uiMarkdownMemoKey struct {
+	renderer *glamour.TermRenderer
+	text     string
+}
+
+const a2uiMarkdownMemoMax = 512
+
+func a2uiMarkdownMemoGet(r *glamour.TermRenderer, text string) (string, bool) {
+	a2uiMarkdownMemoMu.Lock()
+	defer a2uiMarkdownMemoMu.Unlock()
+	out, ok := a2uiMarkdownMemo[a2uiMarkdownMemoKey{r, text}]
+	return out, ok
+}
+
+func a2uiMarkdownMemoPut(r *glamour.TermRenderer, text, out string) {
+	a2uiMarkdownMemoMu.Lock()
+	defer a2uiMarkdownMemoMu.Unlock()
+	if len(a2uiMarkdownMemo) >= a2uiMarkdownMemoMax {
+		clear(a2uiMarkdownMemo)
+	}
+	a2uiMarkdownMemo[a2uiMarkdownMemoKey{r, text}] = out
+}
+
+// renderA2UILoading renders a "✨ Rendering UI…" placeholder for when an
+// assistant message is still streaming and an unclosed <a2ui-json> tag
+// indicates a surface is being composed. The raw partial JSON is replaced
+// with a styled shimmer that reads as intentional rather than broken.
+func renderA2UILoading(sty *styles.Styles, width int) string {
+	sparkle := lipgloss.NewStyle().
+		Foreground(sty.WorkingGradFromColor).
+		Bold(true).
+		Render("✨")
+	label := lipgloss.NewStyle().
+		Foreground(sty.WorkingLabelColor).
+		Render(" Rendering UI…")
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(sty.WorkingGradFromColor).
+		Padding(0, 1).
+		Width(width).
+		Render(sparkle + label)
+	return box
+}
+
+// syncA2UISurfaces builds — or reuses — the live a2tea models for the
+// scanned parts (#44). Surfaces are keyed by a hash of the scanned source:
+// streaming deltas rebuild them, while pure re-renders (width changes,
+// focus flips, key events) reuse the same models and preserve their
+// interaction state (focus ring position, edited field values). The slice
+// is part-indexed; parts without a renderable surface hold nil.
+func (a *AssistantMessageItem) syncA2UISurfaces(src string, parts []a2tea.Part) {
+	h := fnv64(src)
+	if a.a2uiScanned && a.a2uiSrcHash == h && len(a.a2uiSurfaces) == len(parts) {
+		return
+	}
+	surfaces := make([]render.Model, len(parts))
+	ids := make([]string, len(parts))
+	for i, p := range parts {
+		if len(p.Messages) == 0 {
+			continue
+		}
+		// Render with the crush theme: a2tea's CardBorder picks up the
+		// palette, and crush no longer wraps the surface in its own frame —
+		// a2tea's box is the only one.
+		model, err := a2tea.Render(p.Messages, render.WithStyles(a2uiThemeStyles(a.sty)))
+		if err != nil {
+			// Valid A2UI with nothing to draw (e.g. a bare data-model
+			// update). The render loop skips nil entries; the block-stats
+			// pass decides whether anything needs alerting.
+			continue
+		}
+		if rm, ok := model.(render.Model); ok {
+			surfaces[i] = rm
+			ids[i] = a2uiPartSurfaceID(p.Messages)
+		}
+	}
+	a.a2uiSurfaces = surfaces
+	a.a2uiSurfaceIDs = ids
+	a.a2uiSrcHash = h
+	a.a2uiScanned = true
+	// A rebuild replaces focused models with fresh blurred ones; re-grant
+	// focus when the item is selected so the ring survives streaming.
+	if a.isFocused() {
+		a.focusA2UISurfaces()
+	}
+}
+
+// dropA2UISurfaces discards the live surface models, e.g. when the content
+// no longer scans as A2UI. Retirement marks are kept: they are keyed by
+// surface ID, and a surface that reappears after a rescan was still already
+// submitted (#45).
+func (a *AssistantMessageItem) dropA2UISurfaces() {
+	a.a2uiSurfaces = nil
+	a.a2uiSurfaceIDs = nil
+	a.a2uiSrcHash = 0
+	a.a2uiScanned = false
+}
+
+// a2uiPartSurfaceID extracts the surface ID a scan-part's messages establish:
+// the first updateComponents' surfaceId — the same rule a2tea.Render uses to
+// pick the surface it draws, so the ID here always names the rendered model.
+func a2uiPartSurfaceID(msgs []a2ui.ServerMessage) string {
+	for _, m := range msgs {
+		if m.UpdateComponents != nil {
+			return m.UpdateComponents.SurfaceID
+		}
+	}
+	return ""
+}
+
+// A2UIMessagesFromPayload converts a raw A2UI JSON payload (the body of an
+// MCP-served surface) into the server messages it encodes, so a follow-up
+// payload can be applied to a live surface. The payload is wrapped in the
+// wire tags before scanning because a2tea's scanner treats a bare JSON array
+// of messages as several separate bare objects; the tags make it one block.
+// An error means the payload could not be parsed at all.
+func A2UIMessagesFromPayload(payload string) ([]a2ui.ServerMessage, error) {
+	parts, err := a2tea.Scan(a2uiOpenTag + payload + a2uiCloseTag)
+	if err != nil {
+		return nil, err
+	}
+	var msgs []a2ui.ServerMessage
+	for _, p := range parts {
+		msgs = append(msgs, p.Messages...)
+	}
+	return msgs, nil
+}
+
+// A2UIMessagesSurfaceID reports the surface a batch of server messages
+// targets — the first surfaceId any of them names, whichever payload field
+// carries it. A response to an a2ui_action may update a sibling surface
+// rather than the clicked one, so the payload's own target wins over the
+// surface the interaction came from. Empty means the batch names none.
+func A2UIMessagesSurfaceID(msgs []a2ui.ServerMessage) string {
+	for _, m := range msgs {
+		switch {
+		case m.UpdateComponents != nil:
+			return m.UpdateComponents.SurfaceID
+		case m.CreateSurface != nil:
+			return m.CreateSurface.SurfaceID
+		case m.DeleteSurface != nil:
+			return m.DeleteSurface.SurfaceID
+		case m.UpdateDataModel != nil:
+			return m.UpdateDataModel.SurfaceID
+		}
+	}
+	return ""
+}
+
+// A2UIMessagesDeleteSurface reports whether a batch of server messages
+// deletes a surface. A delete that lands on a surface already gone is the
+// expected end of its life, not a mismatch worth reporting to the server.
+func A2UIMessagesDeleteSurface(msgs []a2ui.ServerMessage) bool {
+	for _, m := range msgs {
+		if m.DeleteSurface != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// a2uiSurfaceRetired reports whether the surface at part-index i has been
+// retired after a submission (#45). Retired surfaces still render (showing
+// their final state) but no longer receive focus or keys.
+func (a *AssistantMessageItem) a2uiSurfaceRetired(i int) bool {
+	if i < 0 || i >= len(a.a2uiSurfaceIDs) {
+		return false
+	}
+	return a.a2uiRetired[a.a2uiSurfaceIDs[i]]
+}
+
+// RetireA2UISurface retires the live surface with the given A2UI surface ID
+// after a button press (#45): it reads the surface's current field values,
+// revokes its focus, and marks it retired so the form cannot be re-submitted
+// — the mark is keyed by surface ID, so it survives streaming rebuilds of
+// the model. It returns the gathered values and whether the surface was
+// found on this item.
+func (a *AssistantMessageItem) RetireA2UISurface(surfaceID string) (map[string]any, bool) {
+	if surfaceID == "" {
+		return nil, false
+	}
+	for i, s := range a.a2uiSurfaces {
+		if s == nil || i >= len(a.a2uiSurfaceIDs) || a.a2uiSurfaceIDs[i] != surfaceID {
+			continue
+		}
+		if a.a2uiRetired[surfaceID] {
+			// Already submitted or dismissed: report not-found so a
+			// duplicate event cannot re-read values from a dead form.
+			return nil, false
+		}
+		var values map[string]any
+		if fv, ok := s.(interface{ FieldValues() map[string]any }); ok {
+			values = fv.FieldValues()
+		}
+		if a.a2uiRetired == nil {
+			a.a2uiRetired = make(map[string]bool)
+		}
+		a.a2uiRetired[surfaceID] = true
+		s.Blur()
+		a.Bump()
+		return values, true
+	}
+	return nil, false
+}
+
+// a2uiCancelWords are the button-name tokens read as "dismiss this form":
+// pressing such a button retires the surface without starting an agent turn
+// (#45). Matched against whole tokens of the button's component ID and its
+// action name, never as substrings, so ids like "notify" or "disclose" do
+// not false-positive.
+var a2uiCancelWords = map[string]bool{
+	"cancel":  true,
+	"dismiss": true,
+	"close":   true,
+	"no":      true,
+}
+
+// A2UIButtonIsCancel reports whether an activated button reads as a cancel /
+// dismiss control. A2UI has no cancel semantics of its own — model-authored
+// buttons typically carry no action at all — so the judgment is by naming
+// convention on the component ID (e.g. "btn-cancel", "dismissBtn") and, when
+// present, the server action's name.
+func A2UIButtonIsCancel(clicked event.ButtonClicked) bool {
+	if a2uiHasCancelToken(clicked.ID) {
+		return true
+	}
+	return clicked.Action != nil && a2uiHasCancelToken(clicked.Action.Name)
+}
+
+// a2uiHasCancelToken tokenizes s on non-alphanumeric and camelCase
+// boundaries and reports whether any token is a cancel word.
+func a2uiHasCancelToken(s string) bool {
+	for _, tok := range a2uiNameTokens(s) {
+		if a2uiCancelWords[tok] {
+			return true
+		}
+	}
+	return false
+}
+
+// a2uiNameTokens splits an identifier-ish name ("btn-cancel", "dismissBtn",
+// "close_form") into lowercase word tokens.
+func a2uiNameTokens(s string) []string {
+	var tokens []string
+	var b strings.Builder
+	flush := func() {
+		if b.Len() > 0 {
+			tokens = append(tokens, strings.ToLower(b.String()))
+			b.Reset()
+		}
+	}
+	var prev rune
+	for _, r := range s {
+		switch {
+		case !unicode.IsLetter(r) && !unicode.IsDigit(r):
+			flush()
+		case unicode.IsUpper(r) && unicode.IsLower(prev):
+			flush()
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
+		prev = r
+	}
+	flush()
+	return tokens
+}
+
+// A2UISubmissionPrompt builds the agent-facing message for an A2UI form
+// submission (#45): which button was pressed on which surface, plus the
+// surface's field values at the moment of submission. Values are keyed by
+// component ID, sorted for determinism, and JSON-encoded so their types
+// (string, bool, number, string list) survive the trip through prose.
+func A2UISubmissionPrompt(clicked event.ButtonClicked, values map[string]any) string {
+	var b strings.Builder
+	b.WriteString("[A2UI form submission] The user pressed the ")
+	fmt.Fprintf(&b, "%q button", clicked.ID)
+	if clicked.Action != nil && clicked.Action.Name != "" {
+		fmt.Fprintf(&b, " (action %q)", clicked.Action.Name)
+	}
+	if clicked.SurfaceID != "" {
+		fmt.Fprintf(&b, " on surface %q", clicked.SurfaceID)
+	}
+	b.WriteString(".")
+	if len(values) > 0 {
+		b.WriteString("\nField values:")
+		for _, k := range slices.Sorted(maps.Keys(values)) {
+			enc, err := json.Marshal(values[k])
+			if err != nil {
+				enc = fmt.Appendf(nil, "%q", fmt.Sprintf("%v", values[k]))
+			}
+			fmt.Fprintf(&b, "\n- %s: %s", k, enc)
+		}
+	}
+	return b.String()
+}
+
+// a2uiSurfaceAt returns the live surface for scan-part i, or nil when the
+// part has none (or the index is stale).
+func (a *AssistantMessageItem) a2uiSurfaceAt(i int) render.Model {
+	if i < 0 || i >= len(a.a2uiSurfaces) {
+		return nil
+	}
+	return a.a2uiSurfaces[i]
+}
+
+// hasLiveA2UISurfaces reports whether the item holds at least one live
+// a2tea surface model. While true, the content-hash render caches are
+// bypassed so surface interaction is never served a frozen frame.
+func (a *AssistantMessageItem) hasLiveA2UISurfaces() bool {
+	for _, s := range a.a2uiSurfaces {
+		if s != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// focusA2UISurfaces grants keyboard focus to the first live, non-retired
+// surface and blurs the rest, honoring the a2tea composition contract of at
+// most one focused child at a time. Retired surfaces (#45) never regain
+// focus — a submitted form must not be re-submittable. render.Surface's
+// Focus returns a nil cmd, so dropping it here loses nothing.
+func (a *AssistantMessageItem) focusA2UISurfaces() {
+	granted := false
+	for i, s := range a.a2uiSurfaces {
+		if s == nil {
+			continue
+		}
+		if !granted && !a.a2uiSurfaceRetired(i) {
+			_ = s.Focus()
+			granted = true
+			continue
+		}
+		s.Blur()
+	}
+}
+
+// blurA2UISurfaces revokes keyboard focus from every live surface.
+func (a *AssistantMessageItem) blurA2UISurfaces() {
+	for _, s := range a.a2uiSurfaces {
+		if s != nil {
+			s.Blur()
+		}
+	}
+}
+
+// focusedA2UISurfaceIndex returns the index of the surface currently
+// holding keyboard focus, or -1 when none does.
+func (a *AssistantMessageItem) focusedA2UISurfaceIndex() int {
+	for i, s := range a.a2uiSurfaces {
+		if s != nil && s.Focused() {
+			return i
+		}
+	}
+	return -1
+}
+
+// updateA2UISurface forwards msg into the surface's Update, stores the
+// returned model back, and bumps the item version so the list re-renders
+// the surface's new state on the next draw.
+func (a *AssistantMessageItem) updateA2UISurface(idx int, msg tea.Msg) tea.Cmd {
+	model, cmd := a.a2uiSurfaces[idx].Update(msg)
+	if rm, ok := model.(render.Model); ok {
+		a.a2uiSurfaces[idx] = rm
+	}
+	a.Bump()
+	return cmd
+}
+
+// a2uiSurfaceWantsKey reports whether a focused surface should consume the
+// key. The whitelist mirrors the keys render.Surface.Update reacts to —
+// forwarding everything would swallow host shortcuts (copy, help, quit)
+// whenever a surface item is selected. While a text-editable component is
+// being edited every key is potential input; Esc stays with the host
+// unless a modal is open to close.
+func a2uiSurfaceWantsKey(s render.Model, key tea.KeyMsg) bool {
+	k := key.String()
+	if k == "esc" {
+		m, ok := s.(interface{ HasOpenModal() bool })
+		return ok && m.HasOpenModal()
+	}
+	if e, ok := s.(interface{ EditingText() bool }); ok && e.EditingText() {
+		return true
+	}
+	switch k {
+	case "tab", "shift+tab", "enter", "space", "up", "down", "left", "right", "h", "l", "backspace":
+		return true
+	}
+	return false
+}
+
+// renderContentWithA2UI renders assistant content that contains A2UI. a2tea
+// scans the content into ordered parts of prose text and typed A2UI messages;
+// crush renders the prose as markdown and hands each part's messages to
+// a2tea.Render, stitching the rendered surface in place.
+//
+// Markdown code (fences, and inline spans naming A2UI markers) is masked
+// before scanning so that A2UI examples in documentation prose are not
+// extracted as live surfaces (#6, #96). If any complete tag
+// pair contains malformed JSON — a block a2tea drops silently — an alert
+// element is appended (#7). An unclosed <a2ui-json> tag (truncated
+// generation) also triggers the alert (#5).
+//
+// This deliberately bypasses the streaming-markdown prefix cache (which assumes
+// a single glamour render per item) and renders each segment directly. The
+// renderer is shared, so each Render call takes its lock — scoped to the call,
+// never held across model.View(): a surface body Text re-enters the same
+// memoized renderer through the a2uiThemeStyles MarkdownRenderer hook, and
+// holding the lock across View would self-deadlock the UI goroutine.
+func (a *AssistantMessageItem) renderContentWithA2UI(content string, width int, finished bool) string {
+	masked, codeReps := maskMarkdownCode(content)
+	// Repair childless-but-labeled buttons on the raw JSON before parsing —
+	// the stray label field is dropped by the typed parser (#47). Runs after
+	// masking so button examples inside fenced code stay verbatim.
+	masked = repairA2UIButtons(masked)
+
+	parts, err := a2tea.Scan(masked)
+	if err != nil {
+		// Not parseable as A2UI — render everything as markdown so nothing is
+		// lost.
+		a.dropA2UISurfaces()
+		return a.renderMarkdown(content, width)
+	}
+
+	// Keep the a2tea models alive on the item (rebuilt only when the source
+	// changed) so the surfaces can receive focus and key input instead of
+	// being frozen to a string (#44).
+	a.syncA2UISurfaces(masked, parts)
+
+	renderer := common.MarkdownRenderer(a.sty, width)
+	mu := common.LockMarkdownRenderer(renderer)
+
+	renderMarkdown := func(text string) string {
+		if strings.TrimSpace(text) == "" {
+			return ""
+		}
+		// Restore masked code before markdown rendering.
+		text = unmaskMarkdownCode(text, codeReps)
+		mu.Lock()
+		out, err := renderer.Render(text)
+		mu.Unlock()
+		if err != nil {
+			return strings.TrimSpace(text)
+		}
+		return trimGlamourMargins(out)
+	}
+
+	var b strings.Builder
+	writeChunk := func(s string) {
+		if s == "" {
+			return
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(s)
+	}
+
+	// a2tea renders its own themed chrome (CardBorder, headings, buttons)
+	// via render.WithStyles — crush no longer wraps the surface in its own
+	// frame. The model is sized to the full content width.
+	for i, p := range parts {
+		writeChunk(renderMarkdown(p.Text))
+		if len(p.Messages) == 0 {
+			continue
+		}
+		model := a.a2uiSurfaceAt(i)
+		if model == nil {
+			// Valid A2UI messages with nothing to draw (e.g. a data-model
+			// update). Not an error worth alarming the user about.
+			continue
+		}
+		// Render from the live model each call: its View reflects the
+		// current focus ring and edited values, not a frozen snapshot.
+		model.SetSize(width, 0)
+		rendered := strings.TrimRight(model.View().Content, "\n")
+		writeChunk(rendered)
+	}
+
+	// While streaming, an unclosed <a2ui-json> tag means the model is
+	// still composing the surface — the parser consumed the raw JSON but
+	// produced no messages, so it doesn't appear in any part. Show a
+	// magical loading placeholder instead of leaving a blank gap.
+	if !finished && hasUnclosedA2UITag(masked) {
+		writeChunk(renderA2UILoading(a.sty, width))
+	}
+
+	// Alert when the parser dropped a complete tagged block (#7) — checked
+	// directly so bare-JSON parts cannot mask the count — or when generation
+	// was truncated mid-block (#5). Blocks carrying only protocol messages
+	// were understood, just not drawable, so they get a quiet notice instead
+	// (#168). Only for finished messages: while streaming, an "unclosed" tag
+	// usually just means the close tag hasn't arrived yet, and flashing a red
+	// alert between flushes that then vanishes reads as a glitch.
+	if finished {
+		stats := scanA2UIBlocks(masked)
+		switch {
+		case stats.dropped > 0 || stats.unclosed:
+			writeChunk(a.renderA2UIAlert(width))
+		case stats.protocolOnly > 0:
+			writeChunk(a.renderA2UIProtocolNotice(width))
+		}
+	}
+
+	return b.String()
+}
+
+// renderTruncatedA2UI handles a finished message whose <a2ui-json> block was
+// never closed — generation was truncated mid-block (#5). The prose before
+// the unclosed tag is rendered as markdown, and the truncated block is
+// surfaced through the standard A2UI alert instead of leaving a wall of raw
+// JSON.
+func (a *AssistantMessageItem) renderTruncatedA2UI(content string, width int) string {
+	// Mask (not strip) markdown code: a fence or inline span containing an
+	// <a2ui-json> example must not be mistaken for the truncation point, but
+	// the code must stay in the rendered prose — stripping deleted it from
+	// the message.
+	masked, codeReps := maskMarkdownCode(content)
+	idx := strings.Index(masked, "<a2ui-json>")
+
+	var b strings.Builder
+	if idx > 0 {
+		prose := unmaskMarkdownCode(masked[:idx], codeReps)
+		if strings.TrimSpace(prose) != "" {
+			b.WriteString(a.renderMarkdown(prose, width))
+		}
+	}
+	if b.Len() > 0 {
+		b.WriteString("\n\n")
+	}
+	b.WriteString(a.renderA2UIAlert(width))
+	return b.String()
+}
+
+// renderA2UIAlert builds an alert element shown when content advertised A2UI but
+// a2tea could not turn it into a surface. Styled in crush's existing
+// error-message language.
+func (a *AssistantMessageItem) renderA2UIAlert(width int) string {
+	inner := max(width-2, 1)
+	tag := a.sty.Messages.ErrorTag.Render("A2UI")
+	title := a.sty.Messages.ErrorTitle.Render("couldn't render a UI block in this message")
+	reason := a.sty.Messages.ErrorDetails.Width(inner).Render(
+		"The A2UI content was malformed or used unsupported components.")
+	return tag + " " + title + "\n\n" + reason
+}
+
+// renderA2UIProtocolNotice is the quiet counterpart to renderA2UIAlert for
+// tagged blocks holding only protocol messages (callFunction/actionResponse):
+// the content was understood, there is simply nothing to draw, so a muted
+// one-liner replaces the misleading malformed-content alert (#168).
+func (a *AssistantMessageItem) renderA2UIProtocolNotice(width int) string {
+	inner := max(width-2, 1)
+	return a.sty.Messages.ErrorDetails.Width(inner).Render(
+		"This message includes A2UI protocol data with nothing to display.")
+}

--- a/internal/ui/chat/a2ui_skill_test.go
+++ b/internal/ui/chat/a2ui_skill_test.go
@@ -1,0 +1,83 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/joestump-agent/a2tea"
+	"github.com/stretchr/testify/require"
+)
+
+// TestA2UISkillExampleRenders guards the builtin a2ui skill's documented
+// wire-format example against drift: every real <a2ui-json> payload embedded
+// in SKILL.md must render through the pinned a2tea as actual content, not an
+// "[a2tea: ...]" placeholder. This caught the Button using a nonexistent
+// "label" field (a2ui Buttons take a child Text ID); if the doc regresses to
+// a payload the renderer can't draw, this fails instead of shipping a broken
+// reference to the model.
+func TestA2UISkillExampleRenders(t *testing.T) {
+	t.Parallel()
+
+	var instructions string
+	for _, s := range skills.DiscoverBuiltin() {
+		if s.Name == "a2ui" {
+			instructions = s.Instructions
+			break
+		}
+	}
+	require.NotEmpty(t, instructions, "a2ui builtin skill not found")
+
+	// SKILL.md mentions <a2ui-json>{...}</a2ui-json> inline as a placeholder as
+	// well as carrying the real example; render only the payloads that
+	// actually describe a surface (an updateComponents message).
+	blocks := extractA2UIBlocks(instructions)
+	var rendered int
+	var all strings.Builder
+	for _, block := range blocks {
+		if !strings.Contains(block, "updateComponents") {
+			continue
+		}
+		parts, err := a2tea.Scan(block)
+		require.NoError(t, err, "documented example must parse as A2UI")
+		for _, p := range parts {
+			if len(p.Messages) == 0 {
+				continue
+			}
+			m, err := a2tea.Render(p.Messages)
+			require.NoError(t, err, "documented example must render")
+			all.WriteString(m.View().Content)
+			rendered++
+		}
+	}
+	require.Positive(t, rendered, "SKILL.md must contain a renderable <a2ui-json> example")
+
+	out := all.String()
+	require.NotContains(t, out, "[a2tea:",
+		"documented example rendered a placeholder (broken wire format): %q", out)
+	// The example's button label and body text must survive to the surface —
+	// the button label in particular only renders if it uses a child Text ID.
+	require.Contains(t, out, "Acknowledge")
+	require.Contains(t, out, "Build passed")
+}
+
+// extractA2UIBlocks returns every <a2ui-json>...</a2ui-json> span (tags
+// included) found in s, in order.
+func extractA2UIBlocks(s string) []string {
+	const open, close = "<a2ui-json>", "</a2ui-json>"
+	var out []string
+	for {
+		i := strings.Index(s, open)
+		if i < 0 {
+			break
+		}
+		j := strings.Index(s[i:], close)
+		if j < 0 {
+			break
+		}
+		end := i + j + len(close)
+		out = append(out, s[i:end])
+		s = s[end:]
+	}
+	return out
+}

--- a/internal/ui/chat/a2ui_surface_host.go
+++ b/internal/ui/chat/a2ui_surface_host.go
@@ -1,0 +1,203 @@
+package chat
+
+import (
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
+)
+
+// a2uiSurfaceHost holds the live a2tea surface models for one message item —
+// an assistant message whose content scanned as A2UI, or a tool result
+// that delivered an MCP A2UI surface. The slice is indexed by
+// scan-part (assistant) or surface (tool result); entries without a
+// renderable surface hold nil.
+//
+// Assistant surfaces stream and rebuild as deltas arrive, so the assistant
+// item keys its models by source hash and retires them on first
+// submission. MCP tool-result surfaces are long-lived app UIs: they build once
+// from a fixed payload, are never retired on interaction, and feed a button
+// back to the owning server. The host carries the shared state and
+// behavior both kinds need; the items own their lifecycle.
+type a2uiSurfaceHost struct {
+	// surfaces holds the live a2tea models so they can receive focus and
+	// key input instead of being frozen to a rendered string.
+	surfaces []render.Model
+	// surfaceIDs holds the A2UI surface ID for each entry (empty where the
+	// part has no renderable surface), so a ButtonClicked event's
+	// SurfaceID can be routed back to the model that emitted it.
+	surfaceIDs []string
+	// surfaceOwners holds the MCP server that served each entry (empty for
+	// chat-scanned surfaces). It is the item-scoped provenance the action
+	// round-trip resolves through, so two servers using the same surface ID
+	// cannot route each other's clicks.
+	surfaceOwners []string
+	// sty themes the surfaces with the crush palette.
+	sty *styles.Styles
+}
+
+// ownerFor returns the MCP server that served the surface at index i, and
+// whether one is known.
+func (h *a2uiSurfaceHost) ownerFor(i int) (string, bool) {
+	if i < 0 || i >= len(h.surfaceOwners) {
+		return "", false
+	}
+	name := h.surfaceOwners[i]
+	return name, name != ""
+}
+
+// drop releases the surface at index i, which the server deleted. The entry
+// is kept (indexes stay parallel to surfaceIDs) but nils out, so hasLive and
+// findByID stop reporting it and it can no longer take focus or keys.
+func (h *a2uiSurfaceHost) drop(i int) {
+	if i < 0 || i >= len(h.surfaces) {
+		return
+	}
+	h.surfaces[i] = nil
+}
+
+// buildSurfaces renders each part's messages into a live a2tea model,
+// returning the surfaces and their IDs. Parts with no messages or nothing
+// to draw (e.g. a bare data-model update) leave nil/empty entries.
+func buildA2UISurfaces(sty *styles.Styles, parts []a2tea.Part) ([]render.Model, []string) {
+	surfaces := make([]render.Model, len(parts))
+	ids := make([]string, len(parts))
+	for i, p := range parts {
+		if len(p.Messages) == 0 {
+			continue
+		}
+		model, err := a2tea.Render(p.Messages, render.WithStyles(a2uiThemeStyles(sty)))
+		if err != nil {
+			continue
+		}
+		if rm, ok := model.(render.Model); ok {
+			surfaces[i] = rm
+			ids[i] = a2uiPartSurfaceID(p.Messages)
+		}
+	}
+	return surfaces, ids
+}
+
+// hasLive reports whether the host holds at least one live surface model.
+// While true, the item's content-hash render caches are bypassed so surface
+// interaction is never served a frozen frame.
+func (h *a2uiSurfaceHost) hasLive() bool {
+	for _, s := range h.surfaces {
+		if s != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// surfaceAt returns the live surface at index i, or nil.
+func (h *a2uiSurfaceHost) surfaceAt(i int) render.Model {
+	if i < 0 || i >= len(h.surfaces) {
+		return nil
+	}
+	return h.surfaces[i]
+}
+
+// focusedIndex returns the index of the surface currently holding keyboard
+// focus, or -1 when none does.
+func (h *a2uiSurfaceHost) focusedIndex() int {
+	for i, s := range h.surfaces {
+		if s != nil && s.Focused() {
+			return i
+		}
+	}
+	return -1
+}
+
+// update forwards msg into surface i's Update and stores the returned model.
+func (h *a2uiSurfaceHost) update(i int, msg tea.Msg) tea.Cmd {
+	model, cmd := h.surfaces[i].Update(msg)
+	if rm, ok := model.(render.Model); ok {
+		h.surfaces[i] = rm
+	}
+	return cmd
+}
+
+// fieldValues reads the surface's current values, if it supports them.
+func (h *a2uiSurfaceHost) fieldValues(i int) map[string]any {
+	s := h.surfaceAt(i)
+	if s == nil {
+		return nil
+	}
+	if fv, ok := s.(interface{ FieldValues() map[string]any }); ok {
+		return fv.FieldValues()
+	}
+	return nil
+}
+
+// surfaceIDFor returns the A2UI surface ID at index i.
+func (h *a2uiSurfaceHost) surfaceIDFor(i int) string {
+	if i < 0 || i >= len(h.surfaceIDs) {
+		return ""
+	}
+	return h.surfaceIDs[i]
+}
+
+// findByID returns the index of the surface with the given A2UI surface ID,
+// or -1.
+func (h *a2uiSurfaceHost) findByID(surfaceID string) int {
+	for i, id := range h.surfaceIDs {
+		if id == surfaceID && h.surfaceAt(i) != nil {
+			return i
+		}
+	}
+	return -1
+}
+
+// focus grants keyboard focus to the surface at index i and blurs the rest,
+// honoring the a2tea composition contract of at most one focused child.
+func (h *a2uiSurfaceHost) focus(i int) {
+	for j, s := range h.surfaces {
+		if s == nil {
+			continue
+		}
+		if j == i {
+			_ = s.Focus()
+		} else {
+			s.Blur()
+		}
+	}
+}
+
+// blurAll revokes keyboard focus from every live surface.
+func (h *a2uiSurfaceHost) blurAll() {
+	for _, s := range h.surfaces {
+		if s != nil {
+			s.Blur()
+		}
+	}
+}
+
+// --- MCP surface provenance registry ---
+
+// a2uiMCPProvenance maps a rendered A2UI surface ID to the MCP server that
+// served it, so a later interaction event (button press, render failure)
+// can route back to the owning server as an a2ui_action / a2ui_error tool
+// call. Entries live for the process lifetime: surface IDs are
+// server-scoped (typically "default"), so re-rendering a surface from the
+// same server simply overwrites the same key. Two servers emitting the SAME
+// surface ID would clobber each other here — the action round-trip should
+// resolve provenance through the owning item before falling back to this
+// registry.
+var a2uiMCPProvenance = csync.NewMap[string, string]()
+
+// registerA2UISurfaceProvenance records that surfaceID came from mcpName.
+// An empty surfaceID or mcpName is not registered.
+func registerA2UISurfaceProvenance(surfaceID, mcpName string) {
+	if surfaceID == "" || mcpName == "" {
+		return
+	}
+	a2uiMCPProvenance.Set(surfaceID, mcpName)
+}
+
+// A2UISurfaceProvenance returns the MCP server that served surfaceID, and
+// whether the surface is MCP-owned at all.
+func A2UISurfaceProvenance(surfaceID string) (string, bool) {
+	return a2uiMCPProvenance.Get(surfaceID)
+}

--- a/internal/ui/chat/a2ui_test.go
+++ b/internal/ui/chat/a2ui_test.go
@@ -1,0 +1,1092 @@
+package chat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/message"
+
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/joestump-agent/a2tea/event"
+	"github.com/joestump-agent/a2tea/render"
+	"github.com/stretchr/testify/require"
+	a2ui "github.com/tmc/a2ui"
+)
+
+// a2uiSurface is an <a2ui-json> block: a card wrapping a single text component.
+const a2uiSurface = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+	`{"component":"Card","id":"root","child":"t"},` +
+	`{"component":"Text","id":"t","text":"Hello from A2UI"}` +
+	`]}}</a2ui-json>`
+
+func TestContentHasA2UI(t *testing.T) {
+	t.Parallel()
+	require.True(t, contentHasA2UI("here you go\n"+a2uiSurface))
+	require.False(t, contentHasA2UI("just a normal ```json\n{}\n``` block"))
+	require.False(t, contentHasA2UI("plain prose"))
+}
+
+// --- Issue #6: fenced code blocks should not render as live surfaces ---
+
+func TestContentHasA2UIIgnoresFencedCode(t *testing.T) {
+	t.Parallel()
+	// A tagged block inside a fenced code block is an example, not live UI.
+	fenced := "Here is an example:\n\n```json\n" + a2uiSurface + "\n```\n\nDone."
+	require.False(t, contentHasA2UI(fenced))
+}
+
+func TestRenderContentWithA2UIFencedCodeNotLiveSurface(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := "Example:\n\n```json\n" + a2uiSurface + "\n```\n\nAnd some text."
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+
+	// The fenced example is rendered as code — the raw tags and JSON are
+	// visible as text, NOT extracted as a live surface.
+	require.Contains(t, plain, "a2ui-json")
+	// No alert — the fenced block is just an example, not a dropped surface.
+	require.NotContains(t, plain, "couldn't render")
+	// The surrounding text is preserved.
+	require.Contains(t, plain, "Example")
+	require.Contains(t, plain, "And some text")
+}
+
+func TestRenderContentWithA2UIRealSurfaceNextToFencedExample(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// A real surface followed by a fenced example: both should render
+	// correctly — the real surface as live, the fenced example as code.
+	content := "Real: " + a2uiSurface + "\n\nExample:\n\n```json\n" + a2uiSurface + "\n```"
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI") // real surface rendered
+}
+
+// --- Issue #96: tag mentions in inline code must not be scanned ---
+
+func TestContentHasA2UIIgnoresInlineCode(t *testing.T) {
+	t.Parallel()
+	// A complete-looking tag pair in inline code is documentation, not live UI.
+	require.False(t, contentHasA2UI("Wrap the payload in `<a2ui-json>` and `</a2ui-json>` tags."))
+	// Double-backtick spans too.
+	require.False(t, contentHasA2UI("Wrap it in ``<a2ui-json>`` and ``</a2ui-json>``."))
+	// A whole example block quoted in one inline span.
+	require.False(t, contentHasA2UI("Like this: `"+a2uiSurface+"`"))
+}
+
+func TestContentHasUnclosedA2UIIgnoresInlineCode(t *testing.T) {
+	t.Parallel()
+	// A lone open tag in inline code is not a truncated block — without this,
+	// renderTruncatedA2UI chops the message at the mention.
+	require.False(t, contentHasUnclosedA2UI("Use the `<a2ui-json>` tag to open a block. More prose."))
+}
+
+func TestRenderContentWithA2UIInlineCodeMentionPreserved(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// The exact repro from #96: prose explaining the format, with the tag pair
+	// in inline code. The scanner used to consume the pair, swallowing the
+	// prose between the mentions and raising a false alert.
+	content := "Wrap the payload in `<a2ui-json>` and `</a2ui-json>` tags, then send it."
+	plain := ansi.Strip(item.renderContentWithA2UI(content, 80, true))
+
+	require.Contains(t, plain, "<a2ui-json>", "the mention must render verbatim")
+	require.Contains(t, plain, "</a2ui-json>")
+	require.Contains(t, plain, "then send it", "prose after the mention must survive")
+	require.NotContains(t, plain, "couldn't render", "a documentation mention is not a dropped block")
+	require.NotContains(t, plain, "\x00", "mask placeholders must not leak")
+}
+
+func TestRenderContentWithA2UIRealSurfaceNextToInlineMention(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// A live surface and an inline-code mention side by side: the surface
+	// renders, the mention stays prose, and no alert fires.
+	content := "I used the `<a2ui-json>` tag:\n\n" + a2uiSurface + "\n\nDone."
+	plain := ansi.Strip(item.renderContentWithA2UI(content, 80, true))
+
+	require.Contains(t, plain, "Hello from A2UI", "the real surface must render")
+	require.Contains(t, plain, "<a2ui-json>", "the inline mention must stay visible prose")
+	require.Contains(t, plain, "Done")
+	require.NotContains(t, plain, "couldn't render")
+}
+
+func TestMaskMarkdownCodeLeavesPlainInlineCodeAlone(t *testing.T) {
+	t.Parallel()
+
+	// Inline code without A2UI markers is not masked — a live surface whose
+	// JSON strings contain backticks must reach the parser byte-for-byte.
+	content := "Run `go test` first. " + a2uiSurface
+	masked, reps := maskMarkdownCode(content)
+	require.Equal(t, content, masked)
+	require.Empty(t, reps)
+}
+
+// --- Issue #5: truncated mid-block should show alert ---
+
+func TestContentHasUnclosedA2UI(t *testing.T) {
+	t.Parallel()
+	require.True(t, contentHasUnclosedA2UI("text <a2ui-json>{\"version\":\"v0"))
+	require.False(t, contentHasUnclosedA2UI("text "+a2uiSurface))
+	require.False(t, contentHasUnclosedA2UI("plain prose"))
+	// Unclosed tag inside a fenced block is not a truncation.
+	require.False(t, contentHasUnclosedA2UI("```json\n<a2ui-json>{bad\n```"))
+	// Complete surface followed by a second truncated block.
+	require.True(t, contentHasUnclosedA2UI(a2uiSurface+"\n\n<a2ui-json>{\"version\":\"v0"))
+}
+
+func TestRenderTruncatedA2UI(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := "Here is a card:\n\n<a2ui-json>{\"version\":\"v0.9\",\"updateComponents"
+	out := item.renderTruncatedA2UI(content, 80)
+	plain := ansi.Strip(out)
+
+	// The prose before the truncated tag is preserved.
+	require.Contains(t, plain, "Here is a card")
+	// The alert is shown.
+	require.Contains(t, plain, "couldn't render")
+	// The raw partial JSON is NOT shown.
+	require.NotContains(t, plain, "updateComponents")
+}
+
+// --- Issue #7: bare JSON should not mask dropped tagged block alert ---
+
+func TestRenderContentWithA2UIMalformedShowsAlert(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// Malformed JSON inside the tags: a2uistream drops it (no messages), so
+	// crush must alert rather than silently losing the block.
+	content := "Look: <a2ui-json>{not valid json}</a2ui-json>"
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "A2UI")
+	require.Contains(t, plain, "couldn't render")
+	// The surrounding prose is still there.
+	require.Contains(t, plain, "Look")
+}
+
+func TestRenderContentWithA2UIMalformedNotMaskedByBareJSON(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// One malformed tagged block + one bare JSON surface. The bare JSON must
+	// not offset the count and suppress the alert for the dropped tagged
+	// block.
+	bareJSON := `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Text","id":"t","text":"bare"}]}}`
+	content := "<a2ui-json>{not valid json}</a2ui-json>\n\n" + bareJSON
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "couldn't render") // the malformed tagged block alerted
+}
+
+// --- Issue #47: childless-but-labeled buttons are repaired on the raw JSON ---
+
+// TestRenderContentWithA2UIRepairsTextOnButton pins the DoD for #47: a model
+// reply carrying the {"component":"Button","text":"Send"} anti-pattern (label
+// in a text field, no child) renders the intended labels — not IDs, not
+// "missing component" placeholders.
+func TestRenderContentWithA2UIRepairsTextOnButton(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `Form: <a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Column","id":"root","children":["btn1","btn2"]},` +
+		`{"component":"Button","id":"btn1","text":"Send"},` +
+		`{"component":"Button","id":"btn2","text":"Cancel"}` +
+		`]}}</a2ui-json>`
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Send", "the button's intended label must render")
+	require.Contains(t, plain, "Cancel", "the second button's label must render")
+	require.NotContains(t, plain, "btn1", "the button must not fall back to its ID")
+	require.NotContains(t, plain, "missing component")
+	require.NotContains(t, plain, "couldn't render")
+}
+
+func TestRepairA2UIButtonsSynthesizesChildText(t *testing.T) {
+	t.Parallel()
+
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Button","id":"btn1","text":"Send"}]}}</a2ui-json>`
+	repaired := repairA2UIButtons(content)
+
+	body := strings.TrimSuffix(strings.TrimPrefix(repaired, "<a2ui-json>"), "</a2ui-json>")
+	var msg struct {
+		UpdateComponents struct {
+			Components []map[string]any `json:"components"`
+		} `json:"updateComponents"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &msg))
+
+	comps := msg.UpdateComponents.Components
+	require.Len(t, comps, 2, "a Text component must be added for the label")
+
+	btn := comps[0]
+	require.Equal(t, "Button", btn["component"])
+	require.Equal(t, "btn1-label", btn["child"], "the button must point at the synthesized Text")
+	require.NotContains(t, btn, "text", "the stray text field must be removed")
+
+	label := comps[1]
+	require.Equal(t, "Text", label["component"])
+	require.Equal(t, "btn1-label", label["id"])
+	require.Equal(t, "Send", label["text"])
+}
+
+func TestRepairA2UIButtonsLabelFieldAndIDCollision(t *testing.T) {
+	t.Parallel()
+
+	// The same anti-pattern with a `label` field instead of `text`, plus an
+	// existing component already occupying the derived label id.
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Text","id":"btn1-label","text":"taken"},` +
+		`{"component":"Button","id":"btn1","label":"Send"}]}}</a2ui-json>`
+	repaired := repairA2UIButtons(content)
+
+	require.Contains(t, repaired, `"child":"btn1-label-2"`, "the synthesized id must not collide")
+	require.Contains(t, repaired, `"id":"btn1-label-2"`)
+	require.NotContains(t, repaired, `"label":"Send"`, "the stray label field must be removed")
+}
+
+// TestRepairA2UIButtonsLeavesValidUntouched pins the surgical guarantee:
+// content whose buttons already use a child Text id passes through repair
+// byte-for-byte unchanged, as does anything else the repair has no business
+// rewriting.
+func TestRepairA2UIButtonsLeavesValidUntouched(t *testing.T) {
+	t.Parallel()
+
+	valid := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Button","id":"btn","child":"lbl"},` +
+		`{"component":"Text","id":"lbl","text":"OK"}]}}</a2ui-json>`
+	require.Equal(t, valid, repairA2UIButtons(valid))
+
+	// A button with BOTH child and text keeps its child (text is the parser's
+	// problem to drop, not ours to rewire).
+	both := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Button","id":"btn","child":"lbl","text":"stray"},` +
+		`{"component":"Text","id":"lbl","text":"OK"}]}}</a2ui-json>`
+	require.Equal(t, both, repairA2UIButtons(both))
+
+	// Inline-nested child (an object, another anti-pattern) is not rewritten;
+	// it stays on the existing error path.
+	nested := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Button","id":"btn","child":{"component":"Text","text":"X"}}]}}</a2ui-json>`
+	require.Equal(t, nested, repairA2UIButtons(nested))
+
+	// The canonical card surface is untouched too.
+	require.Equal(t, "prose "+a2uiSurface, repairA2UIButtons("prose "+a2uiSurface))
+
+	// Plain prose without any block is returned as-is.
+	require.Equal(t, "no blocks here", repairA2UIButtons("no blocks here"))
+}
+
+// TestRepairA2UIButtonsMalformedUnchanged: undecodable JSON passes through
+// verbatim so the existing malformed-block alert still fires downstream.
+func TestRepairA2UIButtonsMalformedUnchanged(t *testing.T) {
+	t.Parallel()
+
+	malformed := `before <a2ui-json>{"component":"Button","text":"Send"</a2ui-json> after`
+	require.Equal(t, malformed, repairA2UIButtons(malformed))
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+	plain := ansi.Strip(item.renderContentWithA2UI(malformed, 80, true))
+	require.Contains(t, plain, "couldn't render", "malformed A2UI must still alert")
+}
+
+// TestRenderContentWithA2UIValidButtonStillRenders: a correctly authored
+// child-based button renders its label with the repair in the path.
+func TestRenderContentWithA2UIValidButtonStillRenders(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Button","id":"btn","child":"lbl"},` +
+		`{"component":"Text","id":"lbl","text":"Acknowledge"}]}}</a2ui-json>`
+	plain := ansi.Strip(item.renderContentWithA2UI(content, 80, true))
+
+	require.Contains(t, plain, "Acknowledge")
+	require.NotContains(t, plain, "couldn't render")
+}
+
+// --- Issue #168: parser-derived segmentation; protocol-only blocks ---
+
+// a2uiDocSurface is a bare A2UI message whose *string content* mentions the
+// wire tags — documentation text inside a live surface. The parser consumes
+// the whole object as one message; the tag literals are content, not
+// delimiters.
+const a2uiDocSurface = `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+	`{"component":"Text","id":"t","text":"Wrap payloads in <a2ui-json> and </a2ui-json> tags"}]}}`
+
+func TestScanA2UIBlocks(t *testing.T) {
+	t.Parallel()
+
+	// A tag pair inside a bare message's JSON string is not a block.
+	require.Equal(t, a2uiBlockStats{}, scanA2UIBlocks(a2uiDocSurface))
+
+	// A lone open-tag literal inside a string is not a truncated block either.
+	lone := `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Text","id":"t","text":"start blocks with <a2ui-json>"}]}}`
+	require.Equal(t, a2uiBlockStats{}, scanA2UIBlocks(lone))
+
+	// Real blocks are still found and judged: rendered, malformed, unclosed.
+	require.Equal(t, a2uiBlockStats{}, scanA2UIBlocks("hi "+a2uiSurface))
+	require.Equal(t, a2uiBlockStats{dropped: 1}, scanA2UIBlocks(`<a2ui-json>{nope}</a2ui-json>`))
+	require.Equal(t, a2uiBlockStats{dropped: 1}, scanA2UIBlocks(`<a2ui-json>{"foo":1}</a2ui-json>`))
+	require.Equal(t, a2uiBlockStats{unclosed: true}, scanA2UIBlocks(`text <a2ui-json>{"version":"v0`))
+
+	// A consumed bare message followed by a real malformed block: the bare
+	// message must not hide the drop.
+	require.Equal(t, a2uiBlockStats{dropped: 1},
+		scanA2UIBlocks(a2uiDocSurface+"\n<a2ui-json>{nope}</a2ui-json>"))
+
+	// Protocol-only block: recognized but not drawable.
+	require.Equal(t, a2uiBlockStats{protocolOnly: 1},
+		scanA2UIBlocks(`<a2ui-json>{"version":"v0.9","callFunction":{"name":"getWeather"}}</a2ui-json>`))
+
+	// An incomplete bare candidate buffers the rest as text — the parser
+	// never honors the tag, so neither do we.
+	require.Equal(t, a2uiBlockStats{},
+		scanA2UIBlocks(`{"updateComponents": "unterminated <a2ui-json>{nope}</a2ui-json>`))
+}
+
+// TestNoAlertForTagLiteralInsideBareJSONString pins the #168 segmentation
+// fix end to end: a working bare surface whose text mentions the tag pair
+// must render without the false "couldn't render" alert the blind tag-pair
+// scan used to raise.
+func TestNoAlertForTagLiteralInsideBareJSONString(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	require.True(t, contentHasA2UI(a2uiDocSurface))
+	plain := ansi.Strip(item.renderContentWithA2UI(a2uiDocSurface, 80, true))
+
+	require.Contains(t, plain, "Wrap payloads in", "the surface must render its text")
+	require.NotContains(t, plain, "couldn't render",
+		"tag literals inside a consumed message's strings must not alert")
+}
+
+// TestProtocolOnlyBlockGetsNoticeNotAlert pins the #168 copy fix: a block
+// carrying only protocol messages was understood — it must show the quiet
+// notice, not the malformed-content alert.
+func TestProtocolOnlyBlockGetsNoticeNotAlert(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `One sec: <a2ui-json>{"version":"v0.9","callFunction":{"name":"getWeather","args":{}}}</a2ui-json>`
+	plain := ansi.Strip(item.renderContentWithA2UI(content, 80, true))
+
+	require.Contains(t, plain, "nothing to display", "the protocol notice must show")
+	require.NotContains(t, plain, "couldn't render",
+		"a recognized protocol-only block is not a malformed block")
+	require.Contains(t, plain, "One sec", "surrounding prose is preserved")
+
+	// While streaming, notices stay quiet like the alert does.
+	streaming := ansi.Strip(item.renderContentWithA2UI(content, 80, false))
+	require.NotContains(t, streaming, "nothing to display")
+}
+
+// TestProtocolOnlyDoesNotMaskMalformedAlert: when both a protocol-only block
+// and a genuinely dropped block are present, the alert wins.
+func TestProtocolOnlyDoesNotMaskMalformedAlert(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `<a2ui-json>{"version":"v0.9","callFunction":{"name":"f"}}</a2ui-json>` +
+		"\n\n<a2ui-json>{nope}</a2ui-json>"
+	plain := ansi.Strip(item.renderContentWithA2UI(content, 80, true))
+
+	require.Contains(t, plain, "couldn't render")
+}
+
+// --- Existing tests ---
+
+func TestRenderContentWithA2UI(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := "Here is a card:\n\n" + a2uiSurface + "\n\nAnything else?"
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+
+	// The A2UI surface renders (text pulled from the card's Text component)...
+	require.Contains(t, plain, "Hello from A2UI")
+	// ...and the surrounding prose is preserved on both sides.
+	require.Contains(t, plain, "Here is a card")
+	require.Contains(t, plain, "Anything else")
+	// The raw A2UI JSON / tags are NOT shown verbatim.
+	require.NotContains(t, plain, "a2ui-json")
+	require.NotContains(t, plain, "updateComponents")
+	// No alert when the surface rendered fine.
+	require.NotContains(t, plain, "couldn't render")
+}
+
+// TestRenderContentWithA2UIThemedContainer asserts the rendered surface is
+// wrapped in the themed A2UISurface container (#46): the surface line sits
+// between the container's vertical border runes, under a top border and above
+// a bottom border. Prose outside the surface stays unboxed.
+func TestRenderContentWithA2UIThemedContainer(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := "Here is a card:\n\n" + a2uiSurface + "\n\nAnything else?"
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+
+	// Container corners from the rounded border are present.
+	require.Contains(t, plain, "╭")
+	require.Contains(t, plain, "╰")
+
+	// The surface content line is enclosed by the container's side borders.
+	var surfaceLine string
+	for _, line := range strings.Split(plain, "\n") {
+		if strings.Contains(line, "Hello from A2UI") {
+			surfaceLine = strings.TrimRight(line, " ")
+			break
+		}
+	}
+	require.NotEmpty(t, surfaceLine, "surface content line not found")
+	require.True(t, strings.HasPrefix(surfaceLine, "│"), "surface line should start with container border: %q", surfaceLine)
+	require.True(t, strings.HasSuffix(surfaceLine, "│"), "surface line should end with container border: %q", surfaceLine)
+
+	// Prose outside the surface is not boxed.
+	for _, line := range strings.Split(plain, "\n") {
+		if strings.Contains(line, "Here is a card") || strings.Contains(line, "Anything else") {
+			require.False(t, strings.Contains(line, "│"), "prose should not be inside the container: %q", line)
+		}
+	}
+}
+
+func TestRenderContentWithA2UIMixedGoodAndBadAlerts(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// One valid surface plus one malformed block: the good one renders AND the
+	// dropped one is still surfaced via an alert (not silently lost).
+	content := "ok: " + a2uiSurface + " bad: <a2ui-json>{nope}</a2ui-json>"
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI") // the good surface rendered
+	require.Contains(t, plain, "couldn't render") // the bad block alerted
+}
+
+// TestDroppedBlockAlert_UnrecognizedValidJSON pins the parser-agreement fix:
+// {"foo":1} is valid JSON — the old single-object unmarshal check passed it —
+// but the A2UI parser silently drops it (no recognized message), so the user
+// lost the block with no alert. The dropped-block check now runs each block
+// through the same parser rendering uses.
+func TestDroppedBlockAlert_UnrecognizedValidJSON(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `Look: <a2ui-json>{"foo": 1}</a2ui-json>`
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "couldn't render",
+		"valid-but-unrecognized JSON is dropped by the parser and must alert")
+}
+
+// TestNoDroppedBlockAlert_MultiMessageBody pins the other direction: a tagged
+// body carrying multiple newline-delimited A2UI messages renders fine, so no
+// alert may appear beside the working surface (the old single-object
+// unmarshal false-positived here).
+func TestNoDroppedBlockAlert_MultiMessageBody(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	body := `{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[{"component":"Text","id":"root","text":"First"}]}}
+{"version":"v0.9","updateDataModel":{"surfaceId":"s","path":"/x","value":"y"}}`
+	content := "Here: <a2ui-json>" + body + "</a2ui-json>"
+
+	// Sanity: the parser really does yield messages for this body.
+	require.Zero(t, scanA2UIBlocks(content).dropped,
+		"multi-message body must not count as dropped")
+
+	out := item.renderContentWithA2UI(content, 80, true)
+	plain := ansi.Strip(out)
+	require.Contains(t, plain, "First", "the surface must render")
+	require.NotContains(t, plain, "couldn't render",
+		"no alert may appear next to a successfully rendered surface")
+}
+
+// TestNoAlertWhileStreaming pins the streaming gate: with one complete
+// surface rendered and a second block still open (its close tag not yet
+// arrived), an unfinished message must NOT flash the alert; the same content
+// on a finished message must show it.
+func TestNoAlertWhileStreaming(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[{"component":"Text","id":"root","text":"Done"}]}}</a2ui-json>
+And a second one: <a2ui-json>{"version":"v0.9","updateComp`
+
+	streaming := ansi.Strip(item.renderContentWithA2UI(content, 80, false))
+	require.Contains(t, streaming, "Done", "the complete surface renders mid-stream")
+	require.NotContains(t, streaming, "couldn't render",
+		"no alert while the close tag simply hasn't arrived yet")
+
+	finished := ansi.Strip(item.renderContentWithA2UI(content, 80, true))
+	require.Contains(t, finished, "couldn't render",
+		"a finished message with a dangling open tag must alert")
+}
+
+// TestRenderTruncatedA2UIPreservesFencedCode pins the fence fix: prose before
+// the truncated block may contain fenced code, which must survive rendering —
+// the old implementation stripped fences from the whole message, deleting the
+// user-visible code block.
+func TestRenderTruncatedA2UIPreservesFencedCode(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := "Example:\n\n```go\nfunc keepMe() {}\n```\n\nForm: <a2ui-json>{\"version\":\"v0.9\",\"updateComp"
+	out := ansi.Strip(item.renderTruncatedA2UI(content, 80))
+
+	require.Contains(t, out, "keepMe", "fenced code before the truncated block must be preserved")
+	require.Contains(t, out, "couldn't render")
+	require.NotContains(t, out, "updateComp", "raw truncated JSON must not leak")
+}
+
+// TestContentCache_FinishedRenderNotServedFromStreamingEntry pins the cache
+// key folding in the finish state: the last streaming delta and the Finish
+// part often carry byte-identical text, so without finish state in the key
+// the no-alert render cached mid-stream would be served forever and the
+// dropped-block alert the finished gate promises could never appear.
+func TestContentCache_FinishedRenderNotServedFromStreamingEntry(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[{"component":"Text","id":"root","text":"Done"}]}}</a2ui-json>
+And a second one: <a2ui-json>{"version":"v0.9","updateComp`
+
+	// Final content delta arrives while the message is still streaming;
+	// the no-alert render lands in the section cache.
+	item.message = &message.Message{
+		ID:    "m-finish-key",
+		Role:  message.Assistant,
+		Parts: []message.ContentPart{message.TextContent{Text: content}},
+	}
+	streaming := ansi.Strip(item.cachedContent(80))
+	require.NotContains(t, streaming, "couldn't render", "no alert while streaming")
+
+	// The Finish part lands with the text unchanged. The finished render
+	// must re-render and alert, not serve the streaming cache entry.
+	item.message = &message.Message{
+		ID:   "m-finish-key",
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: content},
+			message.Finish{Reason: message.FinishReasonEndTurn},
+		},
+	}
+	finished := ansi.Strip(item.cachedContent(80))
+	require.Contains(t, finished, "couldn't render",
+		"finished message with a dangling block must alert even when its text matches the cached streaming render")
+}
+
+// --- Issue #44: keep the surface model live; route focus + keys to it ---
+
+// a2uiTwoButtonForm is a surface with two focusable buttons so Tab moves
+// focus between distinct elements.
+const a2uiTwoButtonForm = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"form","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["b1","b2"]},` +
+	`{"component":"Button","id":"b1","child":"b1t"},` +
+	`{"component":"Text","id":"b1t","text":"Send"},` +
+	`{"component":"Button","id":"b2","child":"b2t"},` +
+	`{"component":"Text","id":"b2t","text":"Cancel"}` +
+	`]}}</a2ui-json>`
+
+// newA2UIFormItem builds a fully-constructed assistant item (version rail,
+// focus rail) whose message carries a two-button A2UI form.
+func newA2UIFormItem(t *testing.T) *AssistantMessageItem {
+	t.Helper()
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:   "a2ui-form",
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "Here is a form:\n\n" + a2uiTwoButtonForm},
+		},
+	}
+	item, ok := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	require.True(t, ok)
+	return item
+}
+
+// firstLiveA2UISurface returns the item's first non-nil surface model.
+func firstLiveA2UISurface(t *testing.T, item *AssistantMessageItem) render.Model {
+	t.Helper()
+	for _, s := range item.a2uiSurfaces {
+		if s != nil {
+			return s
+		}
+	}
+	t.Fatal("item holds no live A2UI surface")
+	return nil
+}
+
+func TestA2UIItemHoldsLiveSurfaceModel(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+
+	require.True(t, item.hasLiveA2UISurfaces(), "rendering must keep the a2tea model, not just its string")
+	surf := firstLiveA2UISurface(t, item)
+	require.False(t, surf.Focused(), "surface starts blurred until the item is selected")
+}
+
+func TestA2UISetFocusedRoutesFocusToSurface(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+
+	require.Equal(t, -1, item.focusedA2UISurfaceIndex())
+	item.SetFocused(true)
+	require.GreaterOrEqual(t, item.focusedA2UISurfaceIndex(), 0, "selecting the item must focus its surface")
+	item.SetFocused(false)
+	require.Equal(t, -1, item.focusedA2UISurfaceIndex(), "deselecting the item must blur its surface")
+}
+
+func TestA2UIHandleKeyEventTabMovesFocus(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	item.SetFocused(true)
+
+	before := item.RawRender(80)
+	v := item.Version()
+
+	handled, _ := item.HandleKeyEvent(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.True(t, handled, "a focused surface must consume tab")
+	require.Greater(t, item.Version(), v, "key handling must bump the item version so the list re-renders")
+
+	after := item.RawRender(80)
+	require.NotEqual(t, before, after, "tab must visibly move the focus indicator")
+
+	// Two buttons: a second tab wraps the ring back to the first.
+	handled, _ = item.HandleKeyEvent(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.True(t, handled)
+	require.Equal(t, before, item.RawRender(80), "tab must cycle back around the two-element ring")
+}
+
+func TestA2UIHandleKeyEventEnterActivatesButton(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	item.SetFocused(true)
+
+	handled, cmd := item.HandleKeyEvent(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.True(t, handled, "enter must reach the surface")
+	require.NotNil(t, cmd, "button activation must emit the ButtonClicked cmd")
+}
+
+func TestA2UIHandleKeyEventIgnoresKeysWhileBlurred(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+
+	handled, _ := item.HandleKeyEvent(tea.KeyPressMsg{Code: tea.KeyTab})
+	require.False(t, handled, "a blurred surface must not consume tab")
+
+	// The copy shortcut still works when the surface is not focused.
+	handled, cmd := item.HandleKeyEvent(tea.KeyPressMsg{Code: 'c', Text: "c"})
+	require.True(t, handled)
+	require.NotNil(t, cmd)
+}
+
+func TestA2UISurfaceModelStableAcrossRenders(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	first := firstLiveA2UISurface(t, item)
+
+	_ = item.RawRender(80) // same width
+	_ = item.RawRender(60) // width change
+	require.Same(t, first, firstLiveA2UISurface(t, item),
+		"re-renders must reuse the live model — rebuilding would drop interaction state")
+}
+
+// TestA2UIClearCacheDropsSurfacesForRestyle pins the theme-swap path: a
+// style change reaches items as clearCache (applyTheme → refreshStyles →
+// InvalidateRenderCaches → ClearItemCaches), and the surface models baked
+// the old theme's render.Styles in at build time. clearCache must drop them
+// so the next render rebuilds the surfaces with the current theme instead
+// of drawing the previous palette next to newly-themed chat.
+func TestA2UIClearCacheDropsSurfacesForRestyle(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	require.True(t, item.hasLiveA2UISurfaces())
+	first := firstLiveA2UISurface(t, item)
+
+	item.clearCache()
+	require.False(t, item.hasLiveA2UISurfaces(),
+		"a style change must drop surface models carrying baked-in styles")
+
+	_ = item.RawRender(80)
+	require.True(t, item.hasLiveA2UISurfaces(), "the next render must rebuild the surfaces")
+	require.NotSame(t, first, firstLiveA2UISurface(t, item),
+		"the rebuilt surface must be a fresh model, not the stale-styled one")
+}
+
+func TestA2UIContentCacheBypassedForLiveSurfaces(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	_ = item.RawRender(80)
+
+	require.True(t, item.hasLiveA2UISurfaces())
+	require.False(t, item.contentSec.valid,
+		"the content-hash cache must not freeze a live surface")
+}
+
+func TestPureTextContentStillCaches(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:    "plain",
+		Role:  message.Assistant,
+		Parts: []message.ContentPart{message.TextContent{Text: "just prose, no UI"}},
+	}
+	item, ok := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	require.True(t, ok)
+
+	_ = item.RawRender(80)
+	require.False(t, item.hasLiveA2UISurfaces())
+	require.True(t, item.contentSec.valid, "pure-text messages must keep the content cache")
+}
+
+// --- Issue #45: turn form submission into an agent turn ---
+
+// a2uiFieldForm is a surface with input components carrying literal values,
+// plus a submit and a cancel button.
+const a2uiFieldForm = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"contact","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["name","subscribe","btn-send","btn-cancel"]},` +
+	`{"component":"TextField","id":"name","label":"Name","value":"Joe"},` +
+	`{"component":"CheckBox","id":"subscribe","value":true},` +
+	`{"component":"Button","id":"btn-send","child":"btn-send-t"},` +
+	`{"component":"Text","id":"btn-send-t","text":"Send"},` +
+	`{"component":"Button","id":"btn-cancel","child":"btn-cancel-t"},` +
+	`{"component":"Text","id":"btn-cancel-t","text":"Cancel"}` +
+	`]}}</a2ui-json>`
+
+// newA2UIFieldFormItem builds an assistant item whose message carries the
+// input-bearing form surface.
+func newA2UIFieldFormItem(t *testing.T) *AssistantMessageItem {
+	t.Helper()
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:   "a2ui-field-form",
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "Fill this in:\n\n" + a2uiFieldForm},
+		},
+	}
+	item, ok := NewAssistantMessageItem(&sty, msg).(*AssistantMessageItem)
+	require.True(t, ok)
+	return item
+}
+
+func TestA2UISubmissionPrompt(t *testing.T) {
+	t.Parallel()
+
+	clicked := event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-send", SurfaceID: "contact"},
+		ID:     "btn-send",
+	}
+
+	// Button only, no field values.
+	require.Equal(t,
+		`[A2UI form submission] The user pressed the "btn-send" button on surface "contact".`,
+		A2UISubmissionPrompt(clicked, nil))
+
+	// Field values are sorted by key and JSON-encoded so their types survive.
+	got := A2UISubmissionPrompt(clicked, map[string]any{
+		"name":      "Joe",
+		"subscribe": true,
+		"count":     float64(3),
+		"tags":      []string{"a", "b"},
+	})
+	require.Equal(t,
+		`[A2UI form submission] The user pressed the "btn-send" button on surface "contact".`+
+			"\nField values:"+
+			"\n- count: 3"+
+			"\n- name: \"Joe\""+
+			"\n- subscribe: true"+
+			"\n- tags: [\"a\",\"b\"]",
+		got)
+
+	// A server-side action's name is included when present.
+	withAction := clicked
+	withAction.Action = &a2ui.EventAction{Name: "submitContact"}
+	require.Equal(t,
+		`[A2UI form submission] The user pressed the "btn-send" button (action "submitContact") on surface "contact".`,
+		A2UISubmissionPrompt(withAction, nil))
+}
+
+func TestA2UIButtonIsCancel(t *testing.T) {
+	t.Parallel()
+
+	cancelIDs := []string{"btn-cancel", "cancel", "dismissBtn", "close_form", "btn-no", "Cancel"}
+	for _, id := range cancelIDs {
+		require.True(t, A2UIButtonIsCancel(event.ButtonClicked{ID: id}), "id %q must read as cancel", id)
+	}
+
+	submitIDs := []string{"btn-send", "submit", "ok", "notify", "disclose", "closest-match"}
+	for _, id := range submitIDs {
+		require.False(t, A2UIButtonIsCancel(event.ButtonClicked{ID: id}), "id %q must not read as cancel", id)
+	}
+
+	// The action name counts too.
+	require.True(t, A2UIButtonIsCancel(event.ButtonClicked{
+		ID:     "btn-2",
+		Action: &a2ui.EventAction{Name: "cancelOrder"},
+	}))
+	require.False(t, A2UIButtonIsCancel(event.ButtonClicked{
+		ID:     "btn-2",
+		Action: &a2ui.EventAction{Name: "placeOrder"},
+	}))
+}
+
+func TestRetireA2UISurfaceCollectsFieldValues(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFieldFormItem(t)
+	_ = item.RawRender(80)
+
+	values, ok := item.RetireA2UISurface("contact")
+	require.True(t, ok, "the surface must be found by its A2UI surface ID")
+	require.Equal(t, "Joe", values["name"], "the TextField literal must be collected")
+	require.Equal(t, true, values["subscribe"], "the CheckBox literal must be collected")
+}
+
+func TestRetireA2UISurfaceBlocksRefocusAndKeys(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+	item.SetFocused(true)
+	require.GreaterOrEqual(t, item.focusedA2UISurfaceIndex(), 0)
+
+	_, ok := item.RetireA2UISurface("form")
+	require.True(t, ok)
+	require.Equal(t, -1, item.focusedA2UISurfaceIndex(), "retiring must blur the surface")
+
+	// Keys no longer reach the retired surface (enter cannot re-submit).
+	handled, _ := item.HandleKeyEvent(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.False(t, handled, "a retired surface must not consume enter")
+
+	// Re-selecting the item must not re-focus the retired surface.
+	item.SetFocused(false)
+	item.SetFocused(true)
+	require.Equal(t, -1, item.focusedA2UISurfaceIndex(), "a retired surface must never regain focus")
+}
+
+func TestRetireA2UISurfaceUnknownID(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIFormItem(t)
+	_ = item.RawRender(80)
+
+	_, ok := item.RetireA2UISurface("nope")
+	require.False(t, ok)
+	_, ok = item.RetireA2UISurface("")
+	require.False(t, ok)
+
+	// The live surface is untouched: it can still be focused.
+	item.SetFocused(true)
+	require.GreaterOrEqual(t, item.focusedA2UISurfaceIndex(), 0)
+}
+
+// --- Single-border + width regression ---
+//
+// A Card surface renders inside exactly one box: a2tea's own CardBorder,
+// themed via render.WithStyles. Crush no longer wraps the surface in an
+// A2UISurface frame. The box must fill exactly `width` with no dangling
+// border fragments.
+
+// TestA2UISurfaceSingleBorder asserts exactly one box is drawn: one top
+// border line and one bottom border line, no nested inner border.
+func TestA2UISurfaceSingleBorder(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	plain := ansi.Strip(item.renderContentWithA2UI(a2uiSurface, 80, true))
+
+	top := strings.Count(plain, "╭")
+	bottom := strings.Count(plain, "╰")
+	require.Equal(t, 1, top, "expected exactly one top border (single box), got %d\n%s", top, plain)
+	require.Equal(t, 1, bottom, "expected exactly one bottom border (single box), got %d\n%s", bottom, plain)
+}
+
+// TestA2UISurfaceFillsWidth asserts the rendered box spans the full content
+// width — no line narrower than the box and, critically, no dangling border
+// fragment wrapped onto its own line (the double-border overflow symptom).
+func TestA2UISurfaceFillsWidth(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	for _, width := range []int{80, 60, 41} {
+		plain := ansi.Strip(item.renderContentWithA2UI(a2uiSurface, width, true))
+		lines := strings.Split(plain, "\n")
+
+		var maxW int
+		for _, ln := range lines {
+			if w := ansi.StringWidth(ln); w > maxW {
+				maxW = w
+			}
+		}
+		require.Equal(t, width, maxW, "width=%d: box must fill the full content width\n%s", width, plain)
+
+		// No line may be a lone border fragment (a right border that wrapped
+		// onto its own line), the visible sign of the double-border overflow.
+		for _, ln := range lines {
+			trimmed := strings.TrimSpace(ln)
+			require.NotEqual(t, "╮", trimmed, "width=%d: dangling top-right border fragment\n%s", width, plain)
+			require.NotEqual(t, "╯", trimmed, "width=%d: dangling bottom-right border fragment\n%s", width, plain)
+			require.NotEqual(t, "─╮", trimmed, "width=%d: wrapped border fragment\n%s", width, plain)
+			require.NotEqual(t, "─╯", trimmed, "width=%d: wrapped border fragment\n%s", width, plain)
+		}
+	}
+}
+
+// --- Streaming loading indicator ---
+
+// TestA2UIStreamingLoadingPlaceholder asserts that an unclosed <a2ui-json>
+// tag during streaming renders a magical "Rendering UI…" placeholder instead
+// of raw partial JSON.
+func TestA2UIStreamingLoadingPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	// Simulate streaming: prose followed by an unclosed <a2ui-json> tag.
+	content := "Here is the trace:\n\n<a2ui-json>{\"version\":\"v0.9\",\"updateComponents\":{\"surfaceId\":\"s\",\"components\":["
+
+	out := ansi.Strip(item.renderContentWithA2UI(content, 80, false))
+
+	require.Contains(t, out, "Here is the trace:", "prose before the unclosed tag should render")
+	require.Contains(t, out, "✨", "loading placeholder should contain the sparkle")
+	require.Contains(t, out, "Rendering UI", "loading placeholder should contain the label")
+	require.NotContains(t, out, `"version"`, "raw partial JSON should not leak into the render")
+	require.NotContains(t, out, `"updateComponents"`, "raw partial JSON should not leak into the render")
+	require.NotContains(t, out, `"surfaceId"`, "raw partial JSON should not leak into the render")
+}
+
+// TestA2UIStreamingLoadingPlaceholderComplete asserts that a complete
+// <a2ui-json> block during streaming renders the surface normally (no
+// loading placeholder).
+func TestA2UIStreamingLoadingPlaceholderComplete(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+
+	content := "Here you go:\n\n" + a2uiSurface
+
+	out := ansi.Strip(item.renderContentWithA2UI(content, 80, false))
+
+	require.Contains(t, out, "Hello from A2UI", "complete surface should render its content")
+	require.NotContains(t, out, "Rendering UI", "complete surface should not show loading placeholder")
+}
+
+// Regression: a markdown-looking body Text rendered at the surface's
+// un-narrowed width re-enters the shared glamour renderer through the
+// a2uiThemeStyles MarkdownRenderer hook. renderContentWithA2UI used to hold
+// that renderer's lock across model.View(), so the hook's Lock() on the same
+// non-reentrant mutex froze the UI goroutine permanently.
+func TestRenderContentWithA2UIMarkdownBodyNoDeadlock(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	item := &AssistantMessageItem{sty: &sty}
+	// Root-level Text (no Card): a2tea passes the full host width to the
+	// markdown hook, matching the outer renderer's width bucket.
+	content := `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		`{"component":"Text","id":"t","text":"This is **bold** markdown"}` +
+		`]}}</a2ui-json>`
+
+	done := make(chan string, 1)
+	go func() {
+		done <- item.renderContentWithA2UI(content, 80, true)
+	}()
+	select {
+	case out := <-done:
+		require.Contains(t, ansi.Strip(out), "bold")
+	case <-time.After(15 * time.Second):
+		t.Fatal("renderContentWithA2UI deadlocked rendering a markdown body Text")
+	}
+}

--- a/internal/ui/chat/a2ui_width.go
+++ b/internal/ui/chat/a2ui_width.go
@@ -1,0 +1,25 @@
+package chat
+
+// a2uiCardChromeWidth is the border+padding chrome a2tea's Card renderer
+// subtracts from its budget (a2tea render/card.go: w := s.width - 4).
+const a2uiCardChromeWidth = 4
+
+// ToolA2UISurfaceWidth returns the interior width, in cells, of a generic
+// tool result's A2UI surface card for a chat viewport of the given width —
+// the number servers pre-rendering bar geometry should size rows to (the
+// ?w= hint read_mcp_resource sends).
+//
+// It mirrors the actual render chain rather than hand-summed constants:
+// the message list reserves one cell for its scrollbar, the tool item and
+// RenderTool each apply cappedMessageWidth, the body is indented by
+// toolBodyLeftPaddingTotal, and a2tea's card chrome takes the rest. Keeping
+// the computation here, next to the constants it depends on, is what stops
+// the hint drifting from the real card interior when the layout changes.
+//
+// Returns 0 (no hint) when the viewport is too small for a meaningful
+// width.
+func ToolA2UISurfaceWidth(chatWidth int) int {
+	listWidth := chatWidth - 1 // scrollbar reservation in model/chat.go SetSize
+	interior := cappedMessageWidth(cappedMessageWidth(listWidth)) - toolBodyLeftPaddingTotal - a2uiCardChromeWidth
+	return max(0, interior)
+}

--- a/internal/ui/chat/a2ui_width_test.go
+++ b/internal/ui/chat/a2ui_width_test.go
@@ -1,0 +1,22 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolA2UISurfaceWidth(t *testing.T) {
+	t.Parallel()
+
+	// Mirror of the real chain: listWidth = chatWidth-1 (scrollbar), two
+	// cappedMessageWidth passes (-2 each, 120/118 caps), tool body indent
+	// (-2), a2tea card chrome (-4).
+	require.Equal(t, 89, ToolA2UISurfaceWidth(100))
+	// Wide viewports saturate at maxTextWidth: min(...,120)-2-2-4 = 112.
+	require.Equal(t, 112, ToolA2UISurfaceWidth(140))
+	require.Equal(t, 112, ToolA2UISurfaceWidth(500))
+	// Degenerate viewports must yield 0 (no hint), never negative.
+	require.Equal(t, 0, ToolA2UISurfaceWidth(0))
+	require.Equal(t, 0, ToolA2UISurfaceWidth(8))
+}

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/list"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/joestump-agent/a2tea/render"
 )
 
 // assistantMessageTruncateFormat is the text shown when an assistant message is
@@ -214,6 +215,32 @@ type AssistantMessageItem struct {
 	// thinking text, which burns CPU and starves the terminal emulator
 	// during long reasoning traces.
 	streamingThinking streamingMarkdown
+
+	// a2uiSurfaces holds the live a2tea models for the A2UI surfaces in
+	// this message so they can receive focus and key input instead of
+	// being frozen to a rendered string. The slice is indexed by
+	// scan-part: parts without a renderable surface hold nil. See
+	// syncA2UISurfaces in a2ui.go.
+	a2uiSurfaces []render.Model
+	// a2uiSurfaceIDs holds the A2UI surface ID for each entry of
+	// a2uiSurfaces (empty where the part has no renderable surface), so a
+	// ButtonClicked event's SurfaceID can be routed back to the model
+	// that emitted it.
+	a2uiSurfaceIDs []string
+	// a2uiRetired marks surfaces (by A2UI surface ID) that were
+	// submitted or dismissed: they still render, but no longer receive
+	// focus or keys, so a form cannot be re-submitted. Keyed by ID
+	// rather than index so the mark survives streaming rebuilds of the
+	// models.
+	a2uiRetired map[string]bool
+	// a2uiSrcHash fingerprints the scanned source the surfaces were
+	// built from, so streaming deltas rebuild them while pure re-renders
+	// (width changes, key events) reuse the same models and keep their
+	// interaction state.
+	a2uiSrcHash uint64
+	// a2uiScanned disambiguates "never scanned" from a source that
+	// hashes to zero.
+	a2uiScanned bool
 }
 
 var _ Expandable = (*AssistantMessageItem)(nil)
@@ -308,9 +335,11 @@ func (a *AssistantMessageItem) Render(width int) string {
 	// per-section srcHash/extra so that any sub-cache change
 	// invalidates this prefix cache without requiring an explicit
 	// drop. Bypass the cache while spinning (RawRender's spinner
-	// suffix changes every animation frame) or while a highlight
-	// range is active (selection drag).
-	useCache := !a.isSpinning() && !a.isHighlighted()
+	// suffix changes every animation frame), while a highlight
+	// range is active (selection drag), or while a live A2UI surface
+	// is present (its focus ring and edits mutate the render without
+	// touching any hashed source text).
+	useCache := !a.isSpinning() && !a.isHighlighted() && !a.hasLiveA2UISurfaces()
 	cappedWidth := cappedMessageWidth(width)
 	key := a.prefixCacheKey(cappedWidth)
 	if useCache {
@@ -528,10 +557,31 @@ func (a *AssistantMessageItem) cachedThinking(width int) string {
 // cachedContent returns the rendered content section.
 func (a *AssistantMessageItem) cachedContent(width int) string {
 	srcHash, extra := a.contentKey()
-	if a.contentSec.hit(width, srcHash, extra) {
+	// A live A2UI surface renders from mutable model state (focus ring,
+	// edited values) that the content hash cannot see — bypass the cache
+	// while one is present so interaction is never served a frozen frame.
+	// Pure-text messages keep the cache.
+	if !a.hasLiveA2UISurfaces() && a.contentSec.hit(width, srcHash, extra) {
 		return a.contentSec.out
 	}
-	out := a.renderMarkdown(a.message.Content().Text, width)
+	text := a.message.Content().Text
+	var out string
+	if contentHasA2UI(text) {
+		// The reply carries an A2UI document — route it through a2tea instead
+		// of rendering the raw JSON as a markdown code block.
+		out = a.renderContentWithA2UI(text, width, a.message.IsFinished())
+	} else if a.message.IsFinished() && contentHasUnclosedA2UI(text) {
+		// Generation was truncated mid-block: an <a2ui-json> tag never got
+		// its closing partner. Show the alert instead of raw partial JSON.
+		a.dropA2UISurfaces()
+		out = a.renderTruncatedA2UI(text, width)
+	} else {
+		a.dropA2UISurfaces()
+		out = a.renderMarkdown(text, width)
+	}
+	if a.hasLiveA2UISurfaces() {
+		return out
+	}
 	a.contentSec.store(width, srcHash, extra, out, 0)
 	return out
 }
@@ -717,6 +767,15 @@ func (a *AssistantMessageItem) clearCache() {
 	a.thinkingHash = 0
 	a.thinkingHashLen = 0
 	a.thinkingHashSample = ""
+	// A2UI surface models bake the theme's render.Styles in at build time
+	// (a2uiThemeStyles), so after a theme swap a kept model would draw the
+	// old palette next to newly-themed chat. Drop them and let the next
+	// render rebuild from the message with the current theme; retirement
+	// marks are keyed by surface ID and survive the rebuild. The cost is
+	// losing in-progress field values on an explicit theme change —
+	// clearCache is only reached via ClearItemCaches (style change) — until
+	// a2tea grows a restyle-in-place.
+	a.dropA2UISurfaces()
 }
 
 // ToggleExpanded advances the F5 thinking view-mode cycle and returns
@@ -794,11 +853,31 @@ func (a *AssistantMessageItem) HandleMouseClick(btn ansi.MouseButton, x, y int) 
 	return a.thinkingBoxHeight > 0 && y < a.thinkingBoxHeight
 }
 
-// HandleKeyEvent implements KeyEventHandler.
+// HandleKeyEvent implements KeyEventHandler. A focused live A2UI surface
+// gets first claim on the keys it understands (Tab/Shift+Tab cycle its
+// focus ring, Enter activates — see a2uiSurfaceWantsKey); every other key
+// falls through, so the copy shortcut keeps working whenever no surface
+// consumes the key.
 func (a *AssistantMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
+	if idx := a.focusedA2UISurfaceIndex(); idx >= 0 && a2uiSurfaceWantsKey(a.a2uiSurfaces[idx], key) {
+		return true, a.updateA2UISurface(idx, key)
+	}
 	if k := key.String(); k == "c" || k == "y" {
 		text := a.message.Content().Text
 		return true, common.CopyToClipboard(text, "Message copied to clipboard")
 	}
 	return false, nil
+}
+
+// SetFocused implements list.Focusable. Besides the base focus bookkeeping
+// it routes focus into any live A2UI surface — a2tea's focus ring (Tab
+// cycling, Enter activation) only engages while the surface model holds
+// focus, so surface focus follows item selection.
+func (a *AssistantMessageItem) SetFocused(focused bool) {
+	a.focusableMessageItem.SetFocused(focused)
+	if focused {
+		a.focusA2UISurfaces()
+	} else {
+		a.blurA2UISurfaces()
+	}
 }

--- a/internal/ui/chat/generic.go
+++ b/internal/ui/chat/generic.go
@@ -2,10 +2,15 @@ package chat
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
 )
 
 // GenericToolMessageItem is a message item that represents an unknown tool call.
@@ -64,10 +69,162 @@ func (g *GenericToolRenderContext) RenderTool(sty *styles.Styles, width int, opt
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
 
 	if opts.Result.Data != "" && strings.HasPrefix(opts.Result.MIMEType, "image/") {
-		body := sty.Tool.Body.Render(toolOutputImageContent(sty, opts.Result.Data, opts.Result.MIMEType))
-		return joinToolParts(header, body)
+		// toolOutputImageContent applies sty.Tool.Body itself — wrapping it
+		// again here double-indented image results.
+		return joinToolParts(header, toolOutputImageContent(sty, opts.Result.Data, opts.Result.MIMEType))
 	}
 
-	body := renderToolResultTextContent(sty, opts.Result.Content, toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}, opts.ExpandedContent)
+	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
+
+	// If the tool result carries an A2UI surface (a read_mcp_resource that
+	// returned application/a2ui+json, or an mcp_* tool whose result
+	// embedded one), render it instead of raw text. The payload arrives via
+	// response metadata — the model only sees a placeholder, so it cannot
+	// echo the JSON back and double-render the surface. Live surface models
+	// render interactively; without them (older persisted results)
+	// fall back to the static snapshot. This is what makes
+	// cairn://artifact/{id}/a2ui and similar resource reads render inline.
+	if opts.Result.Metadata != "" {
+		var meta tools.ReadMCPResourceResponseMetadata
+		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
+			return joinToolParts(header, renderToolA2UIResultBody(sty, meta.A2UISurfaces, opts, widths))
+		}
+	}
+	// Pre-change read_mcp_resource results persisted the raw payload in the
+	// content itself — scan for it so old sessions still render as surfaces.
+	// Scoped to this tool (crush_logs and friends share this renderer and
+	// must keep payload-shaped text as text), and gated on contentHasA2UI so
+	// A2UI examples inside markdown code stay code (#6, #96).
+	if opts.ToolCall.Name == tools.ReadMCPResourceToolName && contentHasA2UI(opts.Result.Content) {
+		surf, err := renderToolA2UI(sty, opts.Result.Content, bodyWidth)
+		if err == nil && surf != "" {
+			return joinToolParts(header, sty.Tool.Body.Render(clampToolA2UI(sty, surf, bodyWidth, opts.ExpandedContent)))
+		}
+	}
+
+	body := renderToolResultTextContent(sty, opts.Result.Content, widths, opts.ExpandedContent)
 	return joinToolParts(header, body)
+}
+
+// renderToolA2UIResultBody renders the metadata-delivered surfaces plus any
+// real text content the resource returned alongside them. When the item
+// carries live surface models (opts.LiveSurfaces) they render
+// interactively; otherwise each surface falls back to a static snapshot.
+// When every surface fails to render, an alert replaces the body — the
+// model-facing placeholder claims the user can already see the surface,
+// which would be false here.
+func renderToolA2UIResultBody(sty *styles.Styles, surfaces []string, opts *ToolRenderOpts, widths toolResultContentWidths) string {
+	var b strings.Builder
+	failed := 0
+	if opts.LiveSurfaces != nil {
+		rendered, liveFailed := opts.LiveSurfaces(widths.Body)
+		b.WriteString(rendered)
+		failed = liveFailed
+	} else {
+		for _, surf := range surfaces {
+			rendered, err := renderToolA2UI(sty, surf, widths.Body)
+			if err != nil || rendered == "" {
+				failed++
+				continue
+			}
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(rendered)
+		}
+	}
+
+	var chunks []string
+	if b.Len() > 0 {
+		chunks = append(chunks, sty.Tool.Body.Render(clampToolA2UI(sty, b.String(), widths.Body, opts.ExpandedContent)))
+	}
+	// Alert on ANY failed surface, not only when all fail: a sibling
+	// surface rendering fine must not hide that another one vanished —
+	// the model was told the user can see every one of them.
+	if failed > 0 {
+		chunks = append(chunks, sty.Tool.Body.Render(renderToolA2UIAlert(sty, widths.Body)))
+	}
+	// Show any real text the resource returned alongside its surfaces — the
+	// model-facing placeholder lines are stripped, the rest belongs to the
+	// user just as much as the surfaces do.
+	if text := stripA2UIPlaceholders(opts.Result.Content); text != "" {
+		chunks = append(chunks, renderToolResultTextContent(sty, text, widths, opts.ExpandedContent))
+	}
+	return strings.Join(chunks, "\n")
+}
+
+// stripA2UIPlaceholders removes the model-facing surface placeholder lines
+// from tool content, leaving only text the user should see.
+func stripA2UIPlaceholders(content string) string {
+	var out []string
+	for _, ln := range strings.Split(content, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(ln), tools.A2UISurfacePlaceholderPrefix) {
+			continue
+		}
+		out = append(out, ln)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+// clampToolA2UI applies the collapsed-height budget every other tool body
+// gets from responseContextHeight. The surface is pre-rendered ANSI, so the
+// clamp slices whole lines and appends the standard truncation footer;
+// expanding the tool result restores the full surface.
+func clampToolA2UI(sty *styles.Styles, body string, width int, expanded bool) string {
+	lines := strings.Split(body, "\n")
+	if expanded || len(lines) <= responseContextHeight {
+		return body
+	}
+	out := append([]string{}, lines[:responseContextHeight]...)
+	out = append(out, sty.Tool.ContentTruncation.
+		Width(width).
+		Render(fmt.Sprintf(assistantMessageTruncateFormat, len(lines)-responseContextHeight)))
+	return strings.Join(out, "\n")
+}
+
+// renderToolA2UIAlert mirrors the assistant path's renderA2UIAlert for tool
+// results: the resource advertised A2UI but a2tea could not draw a surface.
+func renderToolA2UIAlert(sty *styles.Styles, width int) string {
+	inner := max(width-2, 1)
+	tag := sty.Messages.ErrorTag.Render("A2UI")
+	title := sty.Messages.ErrorTitle.Render("couldn't render this resource's UI surface")
+	reason := sty.Messages.ErrorDetails.Width(inner).Render(
+		"The A2UI content was malformed or used unsupported components.")
+	return tag + " " + title + "\n\n" + reason
+}
+
+// renderToolA2UI renders a static (non-interactive) A2UI surface from tool
+// result content. Unlike the live surfaces on AssistantMessageItem, this does
+// not support focus/button interaction — it renders a snapshot of the surface
+// using the same themed styles.
+func renderToolA2UI(sty *styles.Styles, content string, width int) (string, error) {
+	parts, err := a2tea.Scan(content)
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	themedStyles := a2uiThemeStyles(sty)
+	proseStyle := lipgloss.NewStyle().Width(width)
+	for _, p := range parts {
+		// Keep each part's prose, wrapped to the body budget: pre-change
+		// persisted results interleave text with surfaces, and dropping
+		// (or overflowing) it would corrupt content the model saw.
+		if text := strings.TrimSpace(p.Text); text != "" {
+			b.WriteString(proseStyle.Render(text))
+			b.WriteString("\n")
+		}
+		if len(p.Messages) == 0 {
+			continue
+		}
+		model, err := a2tea.Render(p.Messages, render.WithStyles(themedStyles))
+		if err != nil {
+			continue
+		}
+		if rm, ok := model.(render.Model); ok {
+			rm.SetSize(width, 0)
+			b.WriteString(strings.TrimRight(rm.View().Content, "\n"))
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimRight(b.String(), "\n"), nil
 }

--- a/internal/ui/chat/generic_test.go
+++ b/internal/ui/chat/generic_test.go
@@ -1,0 +1,244 @@
+package chat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+const a2uiTestPlaceholder = tools.A2UISurfacePlaceholderPrefix +
+	"mcp://cairn/run/abc123/a2ui — the user can already see it; do not repeat or echo its JSON payload]"
+
+func genericToolOpts(t *testing.T, result *message.ToolResult) *ToolRenderOpts {
+	t.Helper()
+	return genericToolOptsFor(t, tools.ReadMCPResourceToolName, result)
+}
+
+func genericToolOptsFor(t *testing.T, name string, result *message.ToolResult) *ToolRenderOpts {
+	t.Helper()
+	return &ToolRenderOpts{
+		ToolCall: message.ToolCall{
+			ID:       "call-1",
+			Name:     name,
+			Input:    `{"mcp_name":"cairn","uri":"mcp://cairn/run/abc123/a2ui"}`,
+			Finished: true,
+		},
+		Result: result,
+		Status: ToolStatusSuccess,
+	}
+}
+
+// The A2UI payload lives in result metadata (UI-only), not in the content
+// the model sees — the model only gets a placeholder, so it cannot echo the
+// JSON back and double-render the surface.
+func TestGenericToolRendersA2UIFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.NotContains(t, plain, "a2ui-json")
+	require.NotContains(t, plain, "updateComponents")
+	// The model-facing placeholder is not shown to the user.
+	require.NotContains(t, plain, "do not repeat")
+}
+
+// A result with no A2UI metadata renders its text content as before.
+func TestGenericToolNoMetadataRendersText(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "plain resource text",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "plain resource text")
+}
+
+// A mixed resource read (text/markdown alongside application/a2ui+json)
+// shows both the surface and the real text — only the model-facing
+// placeholder lines are stripped.
+func TestGenericToolMetadataMixedContentShowsText(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  "the artifact summary text\n" + a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "the artifact summary text")
+	require.NotContains(t, plain, "do not repeat")
+}
+
+// When every metadata surface fails to render, the user sees an alert — not
+// the model-facing placeholder claiming the surface is already visible.
+func TestGenericToolMetadataAllFailShowsAlert(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{"<a2ui-json>{malformed</a2ui-json>"},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "couldn't render this resource's UI surface")
+	require.NotContains(t, plain, "do not repeat")
+}
+
+// A failed surface next to a healthy sibling still surfaces an alert — the
+// model was told the user can see every surface.
+func TestGenericToolMetadataPartialFailShowsAlert(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiSurface, "<a2ui-json>{malformed</a2ui-json>"},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "couldn't render this resource's UI surface")
+}
+
+// The content-scan fallback exists for pre-change persisted read_mcp_resource
+// results only — other tools sharing the generic renderer must keep
+// payload-shaped text as text.
+func TestGenericToolFallbackScopedToReadMCPResource(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOptsFor(t, "crush_logs", &message.ToolResult{
+		Content: "log line before\n" + a2uiSurface + "\nlog line after",
+	}))
+	plain := ansi.Strip(out)
+
+	// Rendered as text (the raw payload stays visible), not as a surface.
+	require.Contains(t, plain, "log line before")
+	require.NotContains(t, plain, "Hello from A2UI")
+}
+
+// A fenced A2UI example inside a read_mcp_resource result is documentation,
+// not live UI (#6, #96) — the masked scan must not extract it.
+func TestGenericToolFallbackIgnoresFencedExample(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "Example:\n\n```json\n" + a2uiSurface + "\n```\n\nDone.",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Example:")
+	require.NotContains(t, plain, "Hello from A2UI")
+}
+
+// Pre-change persisted results interleave prose with tagged surfaces — the
+// fallback render keeps the prose.
+func TestGenericToolFallbackPreservesProse(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOpts(t, &message.ToolResult{
+		Content: "intro prose\n" + a2uiSurface + "\nfooter prose",
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Hello from A2UI")
+	require.Contains(t, plain, "intro prose")
+	require.Contains(t, plain, "footer prose")
+}
+
+// tallA2UISurface builds a surface whose rendered height exceeds the
+// collapsed tool-body budget.
+func tallA2UISurface(t *testing.T) string {
+	t.Helper()
+	var comps []string
+	var children []string
+	for i := 0; i < 20; i++ {
+		id := string(rune('a' + i%26))
+		id += string(rune('0' + i/26))
+		children = append(children, `"`+id+`"`)
+		comps = append(comps, `{"component":"Text","id":"`+id+`","text":"row `+id+`"}`)
+	}
+	comps = append([]string{
+		`{"component":"Card","id":"root","child":"col"}`,
+		`{"component":"Column","id":"col","children":[` + strings.Join(children, ",") + `]}`,
+	}, comps...)
+	return `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"s","components":[` +
+		strings.Join(comps, ",") + `]}}</a2ui-json>`
+}
+
+// A tall surface honors the same collapsed-height budget as every other tool
+// body, and expanding restores the full surface.
+func TestGenericToolA2UICollapse(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{tallA2UISurface(t)},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &GenericToolRenderContext{}
+
+	collapsed := genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	})
+	out := ansi.Strip(ctx.RenderTool(&sty, 80, collapsed))
+	require.Contains(t, out, "lines hidden")
+
+	expanded := genericToolOpts(t, &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	})
+	expanded.ExpandedContent = true
+	outExpanded := ansi.Strip(ctx.RenderTool(&sty, 80, expanded))
+	require.NotContains(t, outExpanded, "lines hidden")
+	require.Contains(t, outExpanded, "row a0")
+}

--- a/internal/ui/chat/mcp.go
+++ b/internal/ui/chat/mcp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 )
@@ -73,6 +74,19 @@ func (b *MCPToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *T
 	}
 
 	bodyWidth := cappedWidth - toolBodyLeftPaddingTotal
-	body := renderToolResultTextContent(sty, opts.Result.Content, toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}, opts.ExpandedContent)
+	widths := toolResultContentWidths{Body: bodyWidth, Diff: cappedWidth}
+
+	// An MCP tool result can carry an A2UI surface in its metadata: the
+	// server returned an application/a2ui+json EmbeddedResource, diverted
+	// so the model only sees a placeholder. Render the live surface (or
+	// static fallback) instead of raw text.
+	if opts.Result.Metadata != "" {
+		var meta tools.ReadMCPResourceResponseMetadata
+		if err := json.Unmarshal([]byte(opts.Result.Metadata), &meta); err == nil && len(meta.A2UISurfaces) > 0 {
+			return joinToolParts(header, renderToolA2UIResultBody(sty, meta.A2UISurfaces, opts, widths))
+		}
+	}
+
+	body := renderToolResultTextContent(sty, opts.Result.Content, widths, opts.ExpandedContent)
 	return joinToolParts(header, body)
 }

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -248,6 +248,13 @@ func newFocusableMessageItem(v *list.Versioned) *focusableMessageItem {
 	return &focusableMessageItem{version: v}
 }
 
+// isFocused reports the current focus state. It tolerates a nil receiver
+// so helpers can query partially-constructed items (tests build them
+// without the focus rail).
+func (f *focusableMessageItem) isFocused() bool {
+	return f != nil && f.focused
+}
+
 // SetFocused implements MessageItem.
 func (f *focusableMessageItem) SetFocused(focused bool) {
 	if f.focused == focused {

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -1,0 +1,229 @@
+package chat
+
+import (
+	"encoding/json"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/joestump-agent/a2tea"
+	"github.com/joestump-agent/a2tea/render"
+	a2ui "github.com/tmc/a2ui"
+)
+
+// syncToolA2UISurfaces builds — or reuses — the live a2tea models for the
+// surfaces carried in the tool result's metadata. Models are keyed by
+// a hash of the metadata: a re-render with the same result reuses the live
+// models (preserving focus and edited field values), while a result swap
+// (SetResult) rebuilds them. Each surface's provenance is registered so a
+// later interaction routes back to the owning MCP server.
+func (t *baseToolMessageItem) syncToolA2UISurfaces() {
+	if t.result == nil || t.result.Metadata == "" {
+		t.a2ui.surfaces = nil
+		t.a2ui.surfaceIDs = nil
+		t.a2ui.surfaceOwners = nil
+		t.surfaceScanned = false
+		return
+	}
+	var meta tools.ReadMCPResourceResponseMetadata
+	if err := json.Unmarshal([]byte(t.result.Metadata), &meta); err != nil || len(meta.A2UISurfaces) == 0 {
+		t.a2ui.surfaces = nil
+		t.a2ui.surfaceIDs = nil
+		t.a2ui.surfaceOwners = nil
+		t.surfaceScanned = false
+		return
+	}
+	h := fnv64(t.result.Metadata)
+	if t.surfaceScanned && t.surfaceSrcHash == h {
+		return
+	}
+	var surfaces []render.Model
+	var ids []string
+	var owners []string
+	failed := 0
+	for i, surfJSON := range meta.A2UISurfaces {
+		parts, err := a2tea.Scan(surfJSON)
+		if err != nil {
+			failed++
+			continue
+		}
+		built, builtIDs := buildA2UISurfaces(t.sty, parts)
+		payloadLive := 0
+		for j, m := range built {
+			if m == nil {
+				continue
+			}
+			payloadLive++
+			surfaces = append(surfaces, m)
+			id := builtIDs[j]
+			ids = append(ids, id)
+			// Provenance is parallel to A2UISurfaces; a missing or short
+			// slice (older persisted results) means unknown origin. It is
+			// recorded per surface on the item — the round-trip resolves
+			// through that, so two servers sharing a surface ID stay
+			// distinct — and mirrored into the global registry for callers
+			// that only hold an ID.
+			owner := ""
+			if i < len(meta.MCPSurfaceProvenance) {
+				owner = meta.MCPSurfaceProvenance[i]
+				registerA2UISurfaceProvenance(id, owner)
+			}
+			owners = append(owners, owner)
+		}
+		// A payload that scanned but drew nothing (unsupported components,
+		// bare data-model update) failed just like a scan error: the model
+		// was told the user can see it.
+		if payloadLive == 0 {
+			failed++
+		}
+	}
+	t.a2ui.surfaces = surfaces
+	t.a2ui.surfaceIDs = ids
+	t.a2ui.surfaceOwners = owners
+	t.surfaceBuildFailed = failed
+	t.surfaceSrcHash = h
+	t.surfaceScanned = true
+	if t.isFocused() {
+		t.focusToolA2UISurfaces()
+	}
+}
+
+// A2UISurfaceItem is implemented by message items that hold live MCP A2UI
+// surfaces (tool message items carrying an MCP-served payload). It lets the
+// UI model locate a surface by ID, read its input values for an a2ui_action
+// context, and feed a server's response back into the surface.
+type A2UISurfaceItem interface {
+	// HasA2UISurface reports whether the item holds the named surface.
+	HasA2UISurface(surfaceID string) bool
+	// A2UISurfaceIsFocused reports whether the item holds the named surface
+	// AND that surface currently has keyboard focus. Surface IDs are only
+	// unique within a server, so two items can hold the same ID; the
+	// focused one is the one the user is actually interacting with.
+	A2UISurfaceIsFocused(surfaceID string) bool
+	// A2UISurfaceOwner returns the MCP server that served the named
+	// surface, and whether one is known.
+	A2UISurfaceOwner(surfaceID string) (string, bool)
+	// ToolA2UIFieldValues reads the named surface's current input values.
+	ToolA2UIFieldValues(surfaceID string) map[string]any
+	// ApplyToolA2UIUpdate feeds server messages back into the named
+	// surface, reporting whether it still has renderable state.
+	ApplyToolA2UIUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool
+}
+
+// hasToolA2UISurfaces reports whether this item carries live MCP surfaces.
+func (t *baseToolMessageItem) hasToolA2UISurfaces() bool {
+	return t.a2ui.hasLive()
+}
+
+// HasA2UISurface reports whether this item holds the named surface.
+func (t *baseToolMessageItem) HasA2UISurface(surfaceID string) bool {
+	return t.a2ui.findByID(surfaceID) >= 0
+}
+
+// A2UISurfaceIsFocused reports whether this item holds the named surface and
+// that surface currently has keyboard focus.
+func (t *baseToolMessageItem) A2UISurfaceIsFocused(surfaceID string) bool {
+	idx := t.a2ui.findByID(surfaceID)
+	return idx >= 0 && idx == t.a2ui.focusedIndex()
+}
+
+// A2UISurfaceOwner returns the MCP server that served the named surface.
+func (t *baseToolMessageItem) A2UISurfaceOwner(surfaceID string) (string, bool) {
+	return t.a2ui.ownerFor(t.a2ui.findByID(surfaceID))
+}
+
+// ToolA2UIFieldValues reads the named surface's current input values, for
+// building an a2ui_action context.
+func (t *baseToolMessageItem) ToolA2UIFieldValues(surfaceID string) map[string]any {
+	idx := t.a2ui.findByID(surfaceID)
+	return t.a2ui.fieldValues(idx)
+}
+
+// ApplyToolA2UIUpdate feeds a batch of A2UI server messages back into the
+// named surface (the response to an a2ui_action round-trip): the surface
+// updates in place rather than being replaced, preserving focus and edited
+// state the server did not touch. It reports whether the surface still has
+// renderable state afterward (false means the server deleted it).
+func (t *baseToolMessageItem) ApplyToolA2UIUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool {
+	idx := t.a2ui.findByID(surfaceID)
+	s := t.a2ui.surfaceAt(idx)
+	if s == nil {
+		return false
+	}
+	applier, ok := s.(interface {
+		Apply([]a2ui.ServerMessage) bool
+	})
+	if !ok {
+		return false
+	}
+	alive := applier.Apply(msgs)
+	if !alive {
+		// The server deleted the surface. Release the model so it stops
+		// claiming focus and swallowing keys for something that draws
+		// nothing, and re-focus whatever is left.
+		t.a2ui.drop(idx)
+		if t.isFocused() {
+			t.focusToolA2UISurfaces()
+		}
+	}
+	t.Bump()
+	return alive
+}
+
+// focusToolA2UISurfaces grants focus to the first live surface and blurs the
+// rest. MCP surfaces are long-lived app UIs — unlike chat-scanned
+// forms they are never retired on submission, so every live surface is
+// focusable.
+func (t *baseToolMessageItem) focusToolA2UISurfaces() {
+	for i, s := range t.a2ui.surfaces {
+		if s != nil {
+			t.a2ui.focus(i)
+			return
+		}
+	}
+}
+
+// blurToolA2UISurfaces revokes keyboard focus from every live surface.
+func (t *baseToolMessageItem) blurToolA2UISurfaces() {
+	t.a2ui.blurAll()
+}
+
+// renderToolA2UISurfaces renders each live surface from its model at the
+// given width, joined by blank lines. It also reports how many surfaces
+// failed — payloads that never built a model (surfaceBuildFailed) plus live
+// models that drew nothing — so the renderer can show the same alert the
+// static path shows: the model was told the user can see every surface.
+func (t *baseToolMessageItem) renderToolA2UISurfaces(width int) (string, int) {
+	var b strings.Builder
+	failed := t.surfaceBuildFailed
+	for _, s := range t.a2ui.surfaces {
+		if s == nil {
+			continue
+		}
+		s.SetSize(width, 0)
+		rendered := strings.TrimRight(s.View().Content, "\n")
+		if rendered == "" {
+			failed++
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(rendered)
+	}
+	return b.String(), failed
+}
+
+// HandleKeyEvent routes keys to the focused live MCP surface first
+// — Tab/Shift+Tab cycle its focus ring, Enter activates a button,
+// printable keys edit a focused field (see a2uiSurfaceWantsKey) — then falls
+// through to the copy shortcut. A button activation surfaces as an
+// a2uievent.ButtonClicked tea.Cmd, which the UI model routes per the
+// surface's provenance.
+func (t *baseToolMessageItem) handleA2UIKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
+	if idx := t.a2ui.focusedIndex(); idx >= 0 && a2uiSurfaceWantsKey(t.a2ui.surfaces[idx], key) {
+		t.Bump()
+		return true, t.a2ui.update(idx, key)
+	}
+	return false, nil
+}

--- a/internal/ui/chat/tool_a2ui.go
+++ b/internal/ui/chat/tool_a2ui.go
@@ -110,6 +110,31 @@ type A2UISurfaceItem interface {
 	ApplyToolA2UIUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool
 }
 
+// dropToolA2UISurfaces discards the live surface models and the scan state
+// that guards rebuilding them, so the next syncToolA2UISurfaces rebuilds
+// from the result metadata. Provenance and retirement live outside these
+// fields and are unaffected.
+func (t *baseToolMessageItem) dropToolA2UISurfaces() {
+	t.a2ui.surfaces = nil
+	t.a2ui.surfaceIDs = nil
+	t.a2ui.surfaceOwners = nil
+	t.surfaceSrcHash = 0
+	t.surfaceScanned = false
+	t.surfaceBuildFailed = 0
+}
+
+// clearCache drops the rendered strings and the A2UI surface models.
+//
+// The surfaces must go with them: buildA2UISurfaces bakes the theme's
+// render.Styles into each model at build time, and the only caller of
+// clearCache is the theme-change path, so a kept model would keep drawing
+// the previous palette beside newly-themed chat. AssistantMessageItem drops
+// its surfaces here for exactly the same reason.
+func (t *baseToolMessageItem) clearCache() {
+	t.cachedMessageItem.clearCache()
+	t.dropToolA2UISurfaces()
+}
+
 // hasToolA2UISurfaces reports whether this item carries live MCP surfaces.
 func (t *baseToolMessageItem) hasToolA2UISurfaces() bool {
 	return t.a2ui.hasLive()

--- a/internal/ui/chat/tool_a2ui_test.go
+++ b/internal/ui/chat/tool_a2ui_test.go
@@ -148,3 +148,58 @@ func TestMCPToolRendersA2UIFromMetadata(t *testing.T) {
 	require.Contains(t, plain, "Recipe Card")
 	require.NotContains(t, plain, "do not repeat")
 }
+
+// TestToolA2UIClearCacheDropsSurfacesForRestyle pins the theme-change path for
+// tool-result surfaces. buildA2UISurfaces bakes the active theme's
+// render.Styles into each a2tea model, and clearCache is only ever called from
+// the theme-change path (applyTheme -> refreshStyles ->
+// InvalidateRenderCaches -> ClearItemCaches), so a surface kept across it goes
+// on drawing the previous palette beside newly-themed chat. The assistant item
+// has had this drop since the surfaces landed; the tool item did not.
+func TestToolA2UIClearCacheDropsSurfacesForRestyle(t *testing.T) {
+	t.Parallel()
+
+	item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"recipe"}, "mcp_recipe_card")
+	_ = item.RawRender(100)
+	require.True(t, item.hasToolA2UISurfaces(), "surfaces must build on first render")
+	require.True(t, item.surfaceScanned)
+
+	item.clearCache()
+
+	require.False(t, item.surfaceScanned, "the scan guard must reset so the next render rebuilds")
+	require.Zero(t, item.surfaceSrcHash, "a kept hash would short-circuit the rebuild")
+	require.False(t, item.hasToolA2UISurfaces(), "stale themed models must be dropped")
+
+	// The surfaces come back on the next render, now built from current styles.
+	_ = item.RawRender(100)
+	require.True(t, item.hasToolA2UISurfaces(), "surfaces must rebuild after a restyle")
+}
+
+// TestToolRenderDoesNotCacheLiveSurfaceFrame pins that Render never writes a
+// frame containing a live surface into the prefixed-render cache. The surfaces
+// are built inside RawRender, so the hasToolA2UISurfaces() check that guards
+// the cache is still false when Render first consults it — caching there froze
+// the surface's opening frame, and getCachedPrefixedRender keys on
+// (width, prefix) alone, so once the server deleted the surface the dead frame
+// was served for the rest of the item's life.
+func TestToolRenderDoesNotCacheLiveSurfaceFrame(t *testing.T) {
+	t.Parallel()
+
+	// The tool name must not itself contain the surface's text, or the
+	// rendered header would satisfy the replay assertion below.
+	item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"recipe"}, "mcp_recipe_fetch")
+
+	_ = item.Render(100)
+	require.True(t, item.hasToolA2UISurfaces(), "the render must have built a live surface")
+	require.Empty(t, item.prefixedRendered,
+		"a frame holding a live surface must not be cached")
+
+	// Drop the surface the way a server-sent deleteSurface does. With the
+	// frame wrongly cached, the next Render would replay it and keep drawing
+	// the surface that no longer exists.
+	item.dropToolA2UISurfaces()
+	item.result.Metadata = ""
+	out := item.Render(100)
+	require.NotContains(t, ansi.Strip(out), "Recipe Card",
+		"a deleted surface must not be replayed from the cache")
+}

--- a/internal/ui/chat/tool_a2ui_test.go
+++ b/internal/ui/chat/tool_a2ui_test.go
@@ -1,0 +1,150 @@
+package chat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+const a2uiToolSurface = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"card","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["title"]},` +
+	`{"component":"Text","id":"title","variant":"h2","text":"Recipe Card"}]}}` + `</a2ui-json>`
+
+// newA2UIToolItem builds a base tool item whose result metadata carries the
+// given surfaces and provenance — the shape read_mcp_resource and mcp_* tool
+// results produce.
+func newA2UIToolItem(t *testing.T, surfaces, provenance []string, toolName string) *baseToolMessageItem {
+	t.Helper()
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces:         surfaces,
+		MCPSurfaceProvenance: provenance,
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	return newBaseToolMessageItem(&sty, message.ToolCall{
+		ID:       "call-1",
+		Name:     toolName,
+		Input:    `{}`,
+		Finished: true,
+	}, &message.ToolResult{
+		ToolCallID: "call-1",
+		Content:    a2uiTestPlaceholder,
+		Metadata:   string(meta),
+	}, &GenericToolRenderContext{}, false)
+}
+
+func TestToolA2UISurfaces(t *testing.T) {
+	t.Parallel()
+
+	t.Run("metadata surfaces build live models", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+
+		require.True(t, item.hasToolA2UISurfaces())
+		require.Len(t, item.a2ui.surfaces, 1)
+		require.Equal(t, "card", item.a2ui.surfaceIDs[0])
+	})
+
+	t.Run("provenance is registered per surface", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+
+		server, ok := A2UISurfaceProvenance("card")
+		require.True(t, ok)
+		require.Equal(t, "cairn", server)
+	})
+
+	t.Run("missing provenance means unknown origin", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, nil, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.True(t, item.hasToolA2UISurfaces())
+	})
+
+	t.Run("same metadata reuses live models", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		first := item.a2ui.surfaces[0]
+
+		// A re-render with the same result must reuse the model so focus
+		// and edited field values survive.
+		item.syncToolA2UISurfaces()
+		require.Same(t, first, item.a2ui.surfaces[0])
+	})
+
+	t.Run("malformed payload yields no live surface", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{"<a2ui-json>{malformed</a2ui-json>"}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.False(t, item.hasToolA2UISurfaces())
+	})
+
+	t.Run("rendering a live surface draws its content", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		out, failed := item.renderToolA2UISurfaces(80)
+		plain := ansi.Strip(out)
+		require.Contains(t, plain, "Recipe Card")
+		require.NotContains(t, plain, "updateComponents")
+		require.Zero(t, failed)
+	})
+
+	t.Run("a failed sibling payload still alerts next to a live surface", func(t *testing.T) {
+		t.Parallel()
+		// One payload renders, one is malformed: the live path must show
+		// the rendered surface AND the alert — the model was told the
+		// user can see both.
+		item := newA2UIToolItem(t,
+			[]string{a2uiToolSurface, "<a2ui-json>{malformed</a2ui-json>"},
+			[]string{"cairn", "cairn"}, tools.ReadMCPResourceToolName)
+		item.syncToolA2UISurfaces()
+		require.True(t, item.hasToolA2UISurfaces())
+		_, failed := item.renderToolA2UISurfaces(80)
+		require.Equal(t, 1, failed)
+
+		out := ansi.Strip(item.RawRender(100))
+		require.Contains(t, out, "Recipe Card")
+		require.Contains(t, out, "couldn't render this resource's UI surface")
+	})
+
+	t.Run("RawRender renders the surface instead of the placeholder", func(t *testing.T) {
+		t.Parallel()
+		item := newA2UIToolItem(t, []string{a2uiToolSurface}, []string{"cairn"}, tools.ReadMCPResourceToolName)
+		out := ansi.Strip(item.RawRender(100))
+		require.Contains(t, out, "Recipe Card")
+		require.NotContains(t, out, "do not repeat")
+	})
+}
+
+// The MCP tool renderer (mcp_* tools) renders metadata surfaces too, not
+// just read_mcp_resource.
+func TestMCPToolRendersA2UIFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces: []string{a2uiToolSurface},
+	})
+	require.NoError(t, err)
+
+	sty := styles.CharmtonePantera()
+	ctx := &MCPToolRenderContext{}
+	out := ctx.RenderTool(&sty, 80, genericToolOptsFor(t, "mcp_recipe_get_recipe_a2ui", &message.ToolResult{
+		Content:  a2uiTestPlaceholder,
+		Metadata: string(meta),
+	}))
+	plain := ansi.Strip(out)
+
+	require.Contains(t, plain, "Recipe Card")
+	require.NotContains(t, plain, "do not repeat")
+}

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -405,6 +405,11 @@ func (t *baseToolMessageItem) Render(width int) string {
 	// Bypass the cache while spinning (RawRender output is
 	// frame-dependent), while a highlight range is active, or while
 	// live MCP surfaces can change between frames.
+	//
+	// This decides whether the cache may be READ. It is not sufficient for
+	// the write: the surfaces do not exist yet on the first frame — it is
+	// RawRender below that builds them — so the surface check here is
+	// still false at that point and is re-run after RawRender.
 	useCache := !t.isSpinning() && !t.isHighlighted() && !t.hasToolA2UISurfaces()
 	var key uint64
 	switch {
@@ -433,7 +438,14 @@ func (t *baseToolMessageItem) Render(width int) string {
 		lines[i] = prefix + ln
 	}
 	out := strings.Join(lines, "\n")
-	if useCache {
+	// Re-check now that RawRender has built the surfaces. Caching a frame
+	// that contains a live surface freezes it: getCachedPrefixedRender
+	// keys on (width, prefix) alone and ignores Version(), so once the
+	// server deletes the surface — flipping hasToolA2UISurfaces() back to
+	// false and re-enabling the cache — that first frame would be served
+	// again for the rest of the item's life, still drawing the surface
+	// that no longer exists. RawRender guards its own cache the same way.
+	if useCache && !t.hasToolA2UISurfaces() {
 		t.setCachedPrefixedRender(out, width, key)
 	}
 	return out

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -98,6 +98,13 @@ type ToolRenderOpts struct {
 	Compact         bool
 	IsSpinning      bool
 	Status          ToolStatus
+	// LiveSurfaces renders the item's live MCP A2UI surface models at the
+	// given width, and reports how many of the metadata's surfaces failed
+	// to draw. Set only when the result metadata carried renderable
+	// surfaces; nil otherwise, in which case renderers fall back to the
+	// static/text paths. Carried on the opts because the ToolRenderer
+	// interface does not see the owning item.
+	LiveSurfaces func(width int) (string, int)
 }
 
 // IsPending returns true if the tool call is still pending (not finished and
@@ -158,6 +165,20 @@ type baseToolMessageItem struct {
 	sty             *styles.Styles
 	anim            *anim.Anim
 	expandedContent bool
+
+	// a2ui holds the live surface models for an MCP-served A2UI payload:
+	// a read_mcp_resource or mcp_* tool whose result metadata carries
+	// surfaces. They render interactively and, being long-lived app UIs,
+	// are never retired on interaction. Nil for tools without surfaces.
+	// surfaceSrcHash fingerprints the metadata the models were built from
+	// so a re-render with the same metadata reuses the live models (and
+	// their edited values) instead of rebuilding; surfaceBuildFailed
+	// counts payloads that never produced a drawable model, so the
+	// renderer can alert on them.
+	a2ui               a2uiSurfaceHost
+	surfaceSrcHash     uint64
+	surfaceScanned     bool
+	surfaceBuildFailed int
 }
 
 var _ Expandable = (*baseToolMessageItem)(nil)
@@ -191,6 +212,7 @@ func newBaseToolMessageItem(
 		status:                   status,
 		hasCappedWidth:           hasCappedWidth,
 	}
+	t.a2ui.sty = sty
 	t.anim = anim.New(anim.Settings{
 		ID:          toolCall.ID,
 		Size:        15,
@@ -334,9 +356,20 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 		toolItemWidth = cappedMessageWidth(width)
 	}
 
+	// Build or refresh the live MCP surface models from the result
+	// metadata. While surfaces are live the content cache is
+	// bypassed: a surface's View reflects the current focus ring and
+	// edited values, not a frozen frame.
+	t.syncToolA2UISurfaces()
+	liveSurfaces := t.hasToolA2UISurfaces()
+	var liveRender func(width int) (string, int)
+	if liveSurfaces {
+		liveRender = t.renderToolA2UISurfaces
+	}
+
 	content, height, ok := t.getCachedRender(toolItemWidth)
 	// if we are spinning or there is no cache rerender
-	if !ok || t.isSpinning() {
+	if !ok || t.isSpinning() || liveSurfaces {
 		content = t.toolRenderer.RenderTool(t.sty, toolItemWidth, &ToolRenderOpts{
 			ToolCall:        t.toolCall,
 			Result:          t.result,
@@ -345,6 +378,7 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 			Compact:         t.isCompact,
 			IsSpinning:      t.isSpinning(),
 			Status:          t.computeStatus(),
+			LiveSurfaces:    liveRender,
 		})
 
 		// Prepend hook indicator if hooks ran for this tool call.
@@ -355,8 +389,11 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 		}
 
 		height = lipgloss.Height(content)
-		// cache the rendered content
-		t.setCachedRender(content, toolItemWidth, height)
+		// cache the rendered content — but not while surfaces are live:
+		// the next interaction changes the view.
+		if !liveSurfaces {
+			t.setCachedRender(content, toolItemWidth, height)
+		}
 	}
 
 	return t.renderHighlighted(content, toolItemWidth, height)
@@ -366,8 +403,9 @@ func (t *baseToolMessageItem) RawRender(width int) string {
 func (t *baseToolMessageItem) Render(width int) string {
 	// Cache the prefixed output keyed by (width, prefix variant).
 	// Bypass the cache while spinning (RawRender output is
-	// frame-dependent) or while a highlight range is active.
-	useCache := !t.isSpinning() && !t.isHighlighted()
+	// frame-dependent), while a highlight range is active, or while
+	// live MCP surfaces can change between frames.
+	useCache := !t.isSpinning() && !t.isHighlighted() && !t.hasToolA2UISurfaces()
 	var key uint64
 	switch {
 	case t.isCompact:
@@ -416,6 +454,9 @@ func (t *baseToolMessageItem) SetToolCall(tc message.ToolCall) {
 // SetResult sets the tool result associated with this message item.
 func (t *baseToolMessageItem) SetResult(res *message.ToolResult) {
 	t.result = res
+	// New metadata may carry different surfaces; force a rebuild on the
+	// next render while preserving focus/edits when it is unchanged.
+	t.surfaceScanned = false
 	t.clearCache()
 	t.Bump()
 }
@@ -503,13 +544,34 @@ func (t *baseToolMessageItem) HandleMouseClick(btn ansi.MouseButton, x, y int) b
 	return btn == ansi.MouseLeft
 }
 
-// HandleKeyEvent implements KeyEventHandler.
+// HandleKeyEvent implements KeyEventHandler. A focused live MCP surface
+// gets first claim on the keys it understands — Tab/Shift+Tab cycle
+// its focus ring, Enter activates a button (surfacing an
+// a2uievent.ButtonClicked the UI model routes per provenance) — and
+// every other key falls through, so the copy shortcut keeps working
+// whenever no surface consumes the key.
 func (t *baseToolMessageItem) HandleKeyEvent(key tea.KeyMsg) (bool, tea.Cmd) {
+	if handled, cmd := t.handleA2UIKeyEvent(key); handled {
+		return true, cmd
+	}
 	if k := key.String(); k == "c" || k == "y" {
 		text := t.formatToolForCopy()
 		return true, common.CopyToClipboard(text, "Tool content copied to clipboard")
 	}
 	return false, nil
+}
+
+// SetFocused implements MessageItem. Focus also drives the live MCP
+// surfaces: gaining focus grants it to the first live surface,
+// losing focus blurs them all — so the focus ring only ever lives on the
+// selected item.
+func (t *baseToolMessageItem) SetFocused(focused bool) {
+	t.focusableMessageItem.SetFocused(focused)
+	if focused {
+		t.focusToolA2UISurfaces()
+	} else {
+		t.blurToolA2UISurfaces()
+	}
 }
 
 // pendingTool renders a tool that is still in progress with an animation.

--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -428,5 +428,15 @@ func loadMCPResources() []ResourceCompletionValue {
 			})
 		}
 	}
+	for mcpName, mcpTemplates := range mcp.ResourceTemplates() {
+		for _, t := range mcpTemplates {
+			resources = append(resources, ResourceCompletionValue{
+				MCPName:  mcpName,
+				URI:      t.URITemplate,
+				Title:    t.Name,
+				MIMEType: t.MIMEType,
+			})
+		}
+	}
 	return resources
 }

--- a/internal/ui/completions/item.go
+++ b/internal/ui/completions/item.go
@@ -2,6 +2,7 @@ package completions
 
 import (
 	"slices"
+	"strings"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/ui/list"
@@ -21,6 +22,14 @@ type ResourceCompletionValue struct {
 	URI      string
 	Title    string
 	MIMEType string
+}
+
+// IsTemplate reports whether the completion's URI is an unexpanded RFC 6570
+// URI template (it still contains a "{expression}") rather than a concrete,
+// readable resource URI. Templates come from resources/templates/list and
+// cannot be read until their placeholders are filled in.
+func (r ResourceCompletionValue) IsTemplate() bool {
+	return strings.Contains(r.URI, "{")
 }
 
 // CompletionItem represents an item in the completions list.

--- a/internal/ui/completions/item_test.go
+++ b/internal/ui/completions/item_test.go
@@ -1,0 +1,20 @@
+package completions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResourceCompletionValueIsTemplate pins the concrete-vs-template
+// distinction the insertion path relies on: a URI still carrying an RFC 6570
+// placeholder must not be read eagerly (the server would see the literal
+// braces), while a concrete URI must keep the auto-attachment read.
+func TestResourceCompletionValueIsTemplate(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, ResourceCompletionValue{URI: "cairn://run/{id}/a2ui"}.IsTemplate())
+	require.True(t, ResourceCompletionValue{URI: "switchboard://queue/{name}"}.IsTemplate())
+	require.False(t, ResourceCompletionValue{URI: "cairn://run/abc123/a2ui"}.IsTemplate())
+	require.False(t, ResourceCompletionValue{URI: ""}.IsTemplate())
+}

--- a/internal/ui/model/a2ui_action_test.go
+++ b/internal/ui/model/a2ui_action_test.go
@@ -1,0 +1,353 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"charm.land/bubbles/v2/textarea"
+
+	"github.com/charmbracelet/crush/internal/agent/tools"
+	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/chat"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/joestump-agent/a2tea/event"
+	"github.com/stretchr/testify/require"
+	a2ui "github.com/tmc/a2ui"
+)
+
+// a2uiActionWorkspace stubs the workspace calls the A2UI action round-trip
+// touches, recording a2ui_action / a2ui_error calls and serving canned
+// responses.
+type a2uiActionWorkspace struct {
+	workspace.Workspace
+
+	// toolCalls records (name, toolName) pairs in call order.
+	toolCalls [][2]string
+	// lastArgs records the args of the most recent call.
+	lastArgs map[string]any
+	// response is the canned CallMCPTool result.
+	response workspace.MCPToolCallResult
+	// err is returned from CallMCPTool when set.
+	err error
+	// lastPrompt records the content of the most recent AgentRun, so the
+	// fallback path's submission prompt can be asserted on.
+	lastPrompt string
+}
+
+func (w *a2uiActionWorkspace) AgentIsReady() bool     { return true }
+func (w *a2uiActionWorkspace) AgentReadyErr() error   { return nil }
+func (w *a2uiActionWorkspace) Config() *config.Config { return nil }
+
+func (w *a2uiActionWorkspace) AgentRun(_ context.Context, _, content string, _ ...message.Attachment) error {
+	w.lastPrompt = content
+	return nil
+}
+
+func (w *a2uiActionWorkspace) CallMCPTool(_ context.Context, name, toolName string, args map[string]any) (workspace.MCPToolCallResult, error) {
+	w.toolCalls = append(w.toolCalls, [2]string{name, toolName})
+	w.lastArgs = args
+	return w.response, w.err
+}
+
+// a2uiActionForm is an MCP-served surface with a submit button carrying a
+// server-side action, plus a TextField whose value feeds the action context.
+const a2uiActionForm = `{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["start","btn-confirm"]},` +
+	`{"component":"TextField","id":"start","label":"Start","value":"2026-03-20"},` +
+	`{"component":"Button","id":"btn-confirm","child":"btn-confirm-t","action":{"event":{"name":"confirm_booking"}}},` +
+	`{"component":"Text","id":"btn-confirm-t","text":"Confirm"}` +
+	`]}}`
+
+// newA2UIActionUI builds a UI whose chat holds a tool message item carrying
+// an MCP-served A2UI surface with provenance registered to mcpName.
+func newA2UIActionUI(t *testing.T, ws *a2uiActionWorkspace, mcpName string) *UI {
+	t.Helper()
+	m, _ := newA2UIActionUIItem(t, ws, mcpName)
+	return m
+}
+
+// newA2UIActionUIItem is newA2UIActionUI, also handing back the tool item so
+// a test can assert on what the surface actually renders.
+func newA2UIActionUIItem(t *testing.T, ws *a2uiActionWorkspace, mcpName string) (*UI, chat.ToolMessageItem) {
+	t.Helper()
+	com := common.DefaultCommon(ws)
+	m := &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusMain,
+		width:    140,
+		height:   45,
+		session:  &session.Session{ID: "sess-1"},
+	}
+
+	meta, err := json.Marshal(tools.ReadMCPResourceResponseMetadata{
+		A2UISurfaces:         []string{"<a2ui-json>" + a2uiActionForm + "</a2ui-json>"},
+		MCPSurfaceProvenance: []string{mcpName},
+	})
+	require.NoError(t, err)
+
+	item := chat.NewMCPToolMessageItem(com.Styles, message.ToolCall{
+		ID:       "call-1",
+		Name:     "mcp_" + mcpName + "_get_form",
+		Input:    `{}`,
+		Finished: true,
+	}, &message.ToolResult{
+		ToolCallID: "call-1",
+		Content:    "form",
+		Metadata:   string(meta),
+	}, false)
+	m.chat.AppendMessages(item)
+	// Render once so the item builds its live surface models and registers
+	// provenance.
+	_ = item.RawRender(100)
+	return m, item
+}
+
+func TestHandleA2UIButtonClickedMCPSurfaceRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{
+		response: workspace.MCPToolCallResult{Content: "Booking confirmed"},
+	}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
+	t.Cleanup(cleanup)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
+		ID:     "btn-confirm",
+		Action: &a2ui.EventAction{Name: "confirm_booking"},
+	})
+	require.NotNil(t, cmd, "an MCP surface with a2ui_action must round-trip")
+	msg := cmd()
+	result, ok := msg.(a2uiActionResultMsg)
+	require.True(t, ok, "the cmd must produce an a2uiActionResultMsg")
+	require.NoError(t, result.err)
+	require.Equal(t, "booking", result.surfaceID)
+
+	// The server got the action name and the surface's field values as the
+	// context.
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_action"}, ws.toolCalls[0])
+	require.Equal(t, "confirm_booking", ws.lastArgs["name"])
+	ctx, ok := ws.lastArgs["context"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "2026-03-20", ctx["start"])
+
+	// The surface is NOT retired — MCP surfaces are long-lived.
+	_, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.True(t, found, "the surface must stay live after the round-trip")
+}
+
+func TestHandleA2UIButtonClickedMCPSurfaceWithoutActionToolFallsBack(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	// Server serves surfaces but NOT a2ui_action.
+	cleanup := mcptools.SetToolsForTest(srv, "some_other_tool")
+	t.Cleanup(cleanup)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
+		ID:     "btn-confirm",
+		Action: &a2ui.EventAction{Name: "confirm_booking"},
+	})
+	require.NotNil(t, cmd, "fallback must start an agent turn")
+	runCmdTree(cmd)
+
+	require.Empty(t, ws.toolCalls, "no a2ui_action call without the tool")
+
+	// The prompt must carry what the user typed. RetireA2UISurface only
+	// matches assistant items, so an MCP surface's values have to come from
+	// the tool item that holds them — otherwise the whole form is silently
+	// dropped before the agent ever sees it.
+	require.Contains(t, ws.lastPrompt, "2026-03-20",
+		"the fallback submission must carry the surface's field values")
+	require.Contains(t, ws.lastPrompt, "confirm_booking")
+}
+
+func TestHandleA2UIActionResultAppliesSurfacePayload(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m, item := newA2UIActionUIItem(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
+	t.Cleanup(cleanup)
+
+	require.Contains(t, item.RawRender(100), "Confirm", "precondition: the original label renders")
+
+	// A response carrying an A2UI payload updates the surface in place.
+	update := `{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
+		`{"component":"Text","id":"btn-confirm-t","text":"Booked!"}]}}`
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{update},
+	})
+	require.Nil(t, cmd)
+
+	// The update actually reached the live surface — not just "no error".
+	rendered := item.RawRender(100)
+	require.Contains(t, rendered, "Booked!", "the payload must update the surface in place")
+	require.NotContains(t, rendered, "Confirm", "the old label must be replaced")
+
+	// The surface still exists after the in-place update, and the edited
+	// field the server did not touch is preserved.
+	values, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.True(t, found)
+	require.Equal(t, "2026-03-20", values["start"], "untouched field values must survive")
+}
+
+func TestHandleA2UIActionResultInvalidPayloadReportsToServer(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// A malformed payload must round-trip an a2ui_error back to the server:
+	// the command reportA2UIError builds has to actually reach Bubble Tea.
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{`{"version":"v0.9","updateComponents":{`},
+	})
+	require.NotNil(t, cmd, "a malformed payload must produce an a2ui_error command")
+	runCmdTree(cmd)
+
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	// Truncated JSON scans as prose rather than failing outright, so it
+	// lands as INVALID_PAYLOAD (parsed, but no server messages) rather than
+	// INVALID_JSON. Either way it must not be a silent no-op.
+	require.Equal(t, "INVALID_PAYLOAD", ws.lastArgs["code"])
+	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
+}
+
+func TestHandleA2UIActionResultHonorsPayloadSurfaceID(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m, item := newA2UIActionUIItem(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// The server answers the "booking" click by targeting a DIFFERENT
+	// surface. That payload must not be forced onto "booking".
+	update := `{"version":"v0.9","updateComponents":{"surfaceId":"receipt","components":[` +
+		`{"component":"Text","id":"btn-confirm-t","text":"Booked!"}]}}`
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{update},
+	})
+	require.NotNil(t, cmd, "a payload for an unheld surface must be reported back")
+	runCmdTree(cmd)
+
+	require.Contains(t, item.RawRender(100), "Confirm",
+		"a payload aimed at another surface must not corrupt the clicked one")
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	require.Equal(t, "SURFACE_NOT_FOUND", ws.lastArgs["code"])
+	require.Equal(t, "receipt", ws.lastArgs["surfaceId"])
+}
+
+func TestHandleA2UIActionResultDeletedSurfaceGoesAway(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// The server dismisses the form. The surface must be released, not left
+	// behind as a dead widget that still takes focus and swallows keys —
+	// and a delete is not an error worth reporting back.
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		surfaces:  []string{`{"version":"v0.9","deleteSurface":{"surfaceId":"booking"}}`},
+	})
+	runCmdTree(cmd)
+
+	_, found := m.chat.A2UISurfaceFieldValues("booking")
+	require.False(t, found, "a deleted surface must no longer be live")
+	require.Empty(t, ws.toolCalls, "deleting a surface is not an error to report")
+}
+
+func TestHandleA2UIActionResultErrorReports(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+
+	cmd := m.handleA2UIActionResult(a2uiActionResultMsg{
+		surfaceID: "booking",
+		mcpName:   srv,
+		err:       context.DeadlineExceeded,
+	})
+	require.NotNil(t, cmd, "an error must surface as a note")
+}
+
+func TestReportA2UIErrorCallsErrorTool(t *testing.T) {
+	t.Parallel()
+
+	// The MCP tool registry is process-global; a per-test server name keeps
+	// parallel tests from overwriting each other's capabilities.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{}
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_error")
+	t.Cleanup(cleanup)
+
+	// An empty server name exercises the surface-owner resolution path.
+	cmd := m.reportA2UIError("", "booking", "INVALID_JSON", "bad payload")
+	require.NotNil(t, cmd)
+	msg := cmd()
+	require.Nil(t, msg, "a successful a2ui_error call produces no message")
+
+	require.Len(t, ws.toolCalls, 1)
+	require.Equal(t, [2]string{srv, "a2ui_error"}, ws.toolCalls[0])
+	require.Equal(t, "INVALID_JSON", ws.lastArgs["code"])
+	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
+}

--- a/internal/ui/model/a2ui_action_test.go
+++ b/internal/ui/model/a2ui_action_test.go
@@ -37,6 +37,30 @@ type a2uiActionWorkspace struct {
 	// lastPrompt records the content of the most recent AgentRun, so the
 	// fallback path's submission prompt can be asserted on.
 	lastPrompt string
+	// a2uiTools maps an MCP server name to the a2ui_* tools it exposes,
+	// mirroring what a real workspace publishes in ClientInfo.A2UITools.
+	a2uiTools map[string][]string
+}
+
+// serveA2UITools makes the workspace report that mcpName exposes the given
+// a2ui_* tools, the way a connected server's published state would.
+func (w *a2uiActionWorkspace) serveA2UITools(mcpName string, toolNames ...string) {
+	if w.a2uiTools == nil {
+		w.a2uiTools = map[string][]string{}
+	}
+	w.a2uiTools[mcpName] = toolNames
+}
+
+func (w *a2uiActionWorkspace) MCPGetStates() map[string]mcptools.ClientInfo {
+	out := make(map[string]mcptools.ClientInfo, len(w.a2uiTools))
+	for name, toolNames := range w.a2uiTools {
+		out[name] = mcptools.ClientInfo{
+			Name:      name,
+			State:     mcptools.StateConnected,
+			A2UITools: toolNames,
+		}
+	}
+	return out
 }
 
 func (w *a2uiActionWorkspace) AgentIsReady() bool     { return true }
@@ -115,16 +139,15 @@ func newA2UIActionUIItem(t *testing.T, ws *a2uiActionWorkspace, mcpName string) 
 func TestHandleA2UIButtonClickedMCPSurfaceRoundTrips(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{
 		response: workspace.MCPToolCallResult{Content: "Booking confirmed"},
 	}
 	m := newA2UIActionUI(t, ws, srv)
-	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "a2ui_action")
 
 	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
 		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
@@ -155,15 +178,14 @@ func TestHandleA2UIButtonClickedMCPSurfaceRoundTrips(t *testing.T) {
 func TestHandleA2UIButtonClickedMCPSurfaceWithoutActionToolFallsBack(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
 	m := newA2UIActionUI(t, ws, srv)
 	// Server serves surfaces but NOT a2ui_action.
-	cleanup := mcptools.SetToolsForTest(srv, "some_other_tool")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "some_other_tool")
 
 	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
 		Source: event.Source{ComponentID: "btn-confirm", SurfaceID: "booking"},
@@ -187,14 +209,13 @@ func TestHandleA2UIButtonClickedMCPSurfaceWithoutActionToolFallsBack(t *testing.
 func TestHandleA2UIActionResultAppliesSurfacePayload(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
 	m, item := newA2UIActionUIItem(t, ws, srv)
-	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "a2ui_action")
 
 	require.Contains(t, item.RawRender(100), "Confirm", "precondition: the original label renders")
 
@@ -223,14 +244,13 @@ func TestHandleA2UIActionResultAppliesSurfacePayload(t *testing.T) {
 func TestHandleA2UIActionResultInvalidPayloadReportsToServer(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
 	m := newA2UIActionUI(t, ws, srv)
-	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "a2ui_action", "a2ui_error")
 
 	// A malformed payload must round-trip an a2ui_error back to the server:
 	// the command reportA2UIError builds has to actually reach Bubble Tea.
@@ -254,14 +274,13 @@ func TestHandleA2UIActionResultInvalidPayloadReportsToServer(t *testing.T) {
 func TestHandleA2UIActionResultHonorsPayloadSurfaceID(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
 	m, item := newA2UIActionUIItem(t, ws, srv)
-	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "a2ui_action", "a2ui_error")
 
 	// The server answers the "booking" click by targeting a DIFFERENT
 	// surface. That payload must not be forced onto "booking".
@@ -286,14 +305,13 @@ func TestHandleA2UIActionResultHonorsPayloadSurfaceID(t *testing.T) {
 func TestHandleA2UIActionResultDeletedSurfaceGoesAway(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
 	m := newA2UIActionUI(t, ws, srv)
-	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action", "a2ui_error")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "a2ui_action", "a2ui_error")
 
 	// The server dismisses the form. The surface must be released, not left
 	// behind as a dead widget that still takes focus and swallows keys —
@@ -313,8 +331,8 @@ func TestHandleA2UIActionResultDeletedSurfaceGoesAway(t *testing.T) {
 func TestHandleA2UIActionResultErrorReports(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
@@ -331,14 +349,13 @@ func TestHandleA2UIActionResultErrorReports(t *testing.T) {
 func TestReportA2UIErrorCallsErrorTool(t *testing.T) {
 	t.Parallel()
 
-	// The MCP tool registry is process-global; a per-test server name keeps
-	// parallel tests from overwriting each other's capabilities.
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
 	srv := t.Name()
 
 	ws := &a2uiActionWorkspace{}
 	m := newA2UIActionUI(t, ws, srv)
-	cleanup := mcptools.SetToolsForTest(srv, "a2ui_error")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "a2ui_error")
 
 	// An empty server name exercises the surface-owner resolution path.
 	cmd := m.reportA2UIError("", "booking", "INVALID_JSON", "bad payload")
@@ -383,8 +400,7 @@ func TestHandleA2UIButtonClickedAssistantSurfaceWinsOverMCPProvenance(t *testing
 	}
 	// Registers "booking" -> srv in both the item and the global registry.
 	m := newA2UIActionUI(t, ws, srv)
-	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
-	t.Cleanup(cleanup)
+	ws.serveA2UITools(srv, "a2ui_action")
 
 	// The assistant now emits its own form reusing the same surface ID.
 	msg := &message.Message{

--- a/internal/ui/model/a2ui_action_test.go
+++ b/internal/ui/model/a2ui_action_test.go
@@ -369,8 +369,11 @@ func TestReportA2UIErrorCallsErrorTool(t *testing.T) {
 	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
 }
 
-// assistantCollidingForm is an assistant-authored surface reusing the same
-// surface ID an MCP server already owns ("booking").
+// assistantCollidingForm is an assistant-authored surface that happens to use
+// the same surface ID as the MCP-served form above. Surface IDs are only
+// unique within whatever authored them, and both the assistant and MCP
+// servers habitually reuse a small set of names ("default", "form"), so the
+// collision is ordinary rather than contrived.
 const assistantCollidingForm = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
 	`{"component":"Card","id":"root","child":"col"},` +
 	`{"component":"Column","id":"col","children":["who","btn-go"]},` +

--- a/internal/ui/model/a2ui_action_test.go
+++ b/internal/ui/model/a2ui_action_test.go
@@ -351,3 +351,65 @@ func TestReportA2UIErrorCallsErrorTool(t *testing.T) {
 	require.Equal(t, "INVALID_JSON", ws.lastArgs["code"])
 	require.Equal(t, "booking", ws.lastArgs["surfaceId"])
 }
+
+// assistantCollidingForm is an assistant-authored surface reusing the same
+// surface ID an MCP server already owns ("booking").
+const assistantCollidingForm = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"booking","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["who","btn-go"]},` +
+	`{"component":"TextField","id":"who","label":"Who","value":"Joe"},` +
+	`{"component":"Button","id":"btn-go","child":"btn-go-t","action":{"event":{"name":"go"}}},` +
+	`{"component":"Text","id":"btn-go-t","text":"Go"}` +
+	`]}}</a2ui-json>`
+
+// TestHandleA2UIButtonClickedAssistantSurfaceWinsOverMCPProvenance pins that
+// an assistant-authored surface is never routed to an MCP server, even when
+// its ID collides with one that server owns.
+//
+// Assistant items do not implement chat.A2UISurfaceItem and never appear in
+// the global surfaceID->server registry, so both provenance lookups used to
+// resolve the collision in the MCP server's favour: the user's form values
+// were shipped to that server's a2ui_action tool, the surface was never
+// retired, and no agent turn ever started — the button just looked dead.
+func TestHandleA2UIButtonClickedAssistantSurfaceWinsOverMCPProvenance(t *testing.T) {
+	t.Parallel()
+
+	// Surface provenance is recorded in a process-global registry; a
+	// per-test server name keeps parallel tests from clobbering it.
+	srv := t.Name()
+
+	ws := &a2uiActionWorkspace{
+		response: workspace.MCPToolCallResult{Content: "should never be called"},
+	}
+	// Registers "booking" -> srv in both the item and the global registry.
+	m := newA2UIActionUI(t, ws, srv)
+	cleanup := mcptools.SetToolsForTest(srv, "a2ui_action")
+	t.Cleanup(cleanup)
+
+	// The assistant now emits its own form reusing the same surface ID.
+	msg := &message.Message{
+		ID:   "assistant-form",
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "Confirm:\n\n" + assistantCollidingForm},
+		},
+	}
+	item, ok := chat.NewAssistantMessageItem(m.com.Styles, msg).(*chat.AssistantMessageItem)
+	require.True(t, ok)
+	m.chat.AppendMessages(item)
+	_ = item.RawRender(80)
+	require.True(t, m.chat.HasAssistantA2UISurface("booking"),
+		"the assistant item must hold a live surface with the colliding ID")
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-go", SurfaceID: "booking"},
+		ID:     "btn-go",
+		Action: &a2ui.EventAction{Name: "go"},
+	})
+	require.NotNil(t, cmd, "the submission must go somewhere")
+	runCmdTree(cmd)
+
+	require.Empty(t, ws.toolCalls,
+		"an assistant surface must never round-trip to an MCP server")
+	require.NotEmpty(t, ws.lastPrompt, "the submission must start an agent turn")
+}

--- a/internal/ui/model/a2ui_submit_test.go
+++ b/internal/ui/model/a2ui_submit_test.go
@@ -1,0 +1,140 @@
+package model
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/chat"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/joestump-agent/a2tea/event"
+	"github.com/stretchr/testify/require"
+)
+
+// a2uiWorkspace stubs the workspace calls the A2UI submission path touches.
+// The embedded interface panics on anything else, keeping the stub honest.
+type a2uiWorkspace struct {
+	workspace.Workspace
+	prompts []string
+}
+
+func (w *a2uiWorkspace) AgentIsReady() bool     { return true }
+func (w *a2uiWorkspace) AgentReadyErr() error   { return nil }
+func (w *a2uiWorkspace) Config() *config.Config { return nil }
+
+func (w *a2uiWorkspace) AgentRun(_ context.Context, _, prompt string, _ ...message.Attachment) error {
+	w.prompts = append(w.prompts, prompt)
+	return nil
+}
+
+// a2uiSubmitForm carries a submit and a cancel button plus a pre-filled
+// TextField, mirroring the form shape the a2ui skill teaches the model.
+const a2uiSubmitForm = `<a2ui-json>{"version":"v0.9","updateComponents":{"surfaceId":"form","components":[` +
+	`{"component":"Card","id":"root","child":"col"},` +
+	`{"component":"Column","id":"col","children":["name","btn-send","btn-cancel"]},` +
+	`{"component":"TextField","id":"name","label":"Name","value":"Joe"},` +
+	`{"component":"Button","id":"btn-send","child":"btn-send-t"},` +
+	`{"component":"Text","id":"btn-send-t","text":"Send"},` +
+	`{"component":"Button","id":"btn-cancel","child":"btn-cancel-t"},` +
+	`{"component":"Text","id":"btn-cancel-t","text":"Cancel"}` +
+	`]}}</a2ui-json>`
+
+// newA2UISubmitUI builds a UI with an active session and a chat list holding
+// one assistant message with a live A2UI form surface.
+func newA2UISubmitUI(t *testing.T, ws *a2uiWorkspace) *UI {
+	t.Helper()
+	com := common.DefaultCommon(ws)
+	m := &UI{
+		com:      com,
+		status:   NewStatus(com, nil),
+		chat:     NewChat(com, config.ScrollbarDefault),
+		textarea: textarea.New(),
+		state:    uiChat,
+		focus:    uiFocusMain,
+		width:    140,
+		height:   45,
+		session:  &session.Session{ID: "sess-1"},
+	}
+	msg := &message.Message{
+		ID:   "a2ui-msg",
+		Role: message.Assistant,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "Fill this in:\n\n" + a2uiSubmitForm},
+		},
+	}
+	item, ok := chat.NewAssistantMessageItem(com.Styles, msg).(*chat.AssistantMessageItem)
+	require.True(t, ok)
+	m.chat.AppendMessages(item)
+	// Render once so the item builds its live surface models.
+	_ = item.RawRender(80)
+	return m
+}
+
+// runCmdTree executes a cmd (and any tea.BatchMsg it fans out into),
+// collecting the produced messages.
+func runCmdTree(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var msgs []tea.Msg
+		for _, c := range batch {
+			msgs = append(msgs, runCmdTree(c)...)
+		}
+		return msgs
+	}
+	return []tea.Msg{msg}
+}
+
+func TestHandleA2UIButtonClickedStartsAgentTurn(t *testing.T) {
+	t.Parallel()
+
+	ws := &a2uiWorkspace{}
+	m := newA2UISubmitUI(t, ws)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-send", SurfaceID: "form"},
+		ID:     "btn-send",
+	})
+	require.NotNil(t, cmd, "a submit button must start a turn")
+	runCmdTree(cmd)
+
+	require.Len(t, ws.prompts, 1, "exactly one agent turn must start")
+	prompt := ws.prompts[0]
+	require.Contains(t, prompt, `"btn-send"`, "the prompt must name the pressed button")
+	require.Contains(t, prompt, `"form"`, "the prompt must name the surface")
+	require.True(t, strings.Contains(prompt, `name: "Joe"`),
+		"the prompt must carry the collected field values, got: %q", prompt)
+
+	// The surface is retired: a second click of the same surface finds no
+	// live surface, and the submission goes out with the button identity
+	// only (never blocked, never re-reading stale values).
+	_, ok := m.chat.RetireA2UISurface("form")
+	require.False(t, ok, "the surface must be retired after submission")
+}
+
+func TestHandleA2UIButtonClickedCancelDismissesWithoutTurn(t *testing.T) {
+	t.Parallel()
+
+	ws := &a2uiWorkspace{}
+	m := newA2UISubmitUI(t, ws)
+
+	cmd := m.handleA2UIButtonClicked(event.ButtonClicked{
+		Source: event.Source{ComponentID: "btn-cancel", SurfaceID: "form"},
+		ID:     "btn-cancel",
+	})
+	require.Nil(t, cmd, "a cancel button must not start a turn")
+	require.Empty(t, ws.prompts)
+
+	// Cancel still retires the surface so it cannot be re-submitted.
+	_, ok := m.chat.RetireA2UISurface("form")
+	require.False(t, ok, "cancel must retire the surface")
+}

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -16,6 +16,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/clipperhouse/displaywidth"
 	"github.com/clipperhouse/uax29/v2/words"
+	a2ui "github.com/tmc/a2ui"
 )
 
 // Constants for multi-click detection.
@@ -796,6 +797,80 @@ func (m *Chat) MessageItem(id string) chat.MessageItem {
 		return nil
 	}
 	return item
+}
+
+// RetireA2UISurface finds the assistant message holding the live A2UI
+// surface with the given ID, reads its current field values, and retires the
+// surface so the form cannot be re-submitted. It reports the gathered
+// values and whether a matching surface was found.
+func (m *Chat) RetireA2UISurface(surfaceID string) (map[string]any, bool) {
+	for i := range m.list.Len() {
+		item, ok := m.list.ItemAt(i).(*chat.AssistantMessageItem)
+		if !ok {
+			continue
+		}
+		if values, ok := item.RetireA2UISurface(surfaceID); ok {
+			return values, true
+		}
+	}
+	return nil, false
+}
+
+// a2uiSurfaceItem locates the chat item holding the named MCP surface.
+// Surface IDs are only unique within a server — invoking the same tool twice
+// appends two items carrying the same ID — so the focused surface wins: that
+// is the one the user is actually interacting with. Only when nothing is
+// focused does it fall back to the first match.
+func (m *Chat) a2uiSurfaceItem(surfaceID string) (chat.A2UISurfaceItem, bool) {
+	var first chat.A2UISurfaceItem
+	for i := range m.list.Len() {
+		item, ok := m.list.ItemAt(i).(chat.A2UISurfaceItem)
+		if !ok || !item.HasA2UISurface(surfaceID) {
+			continue
+		}
+		if item.A2UISurfaceIsFocused(surfaceID) {
+			return item, true
+		}
+		if first == nil {
+			first = item
+		}
+	}
+	return first, first != nil
+}
+
+// A2UISurfaceOwner returns the MCP server that served the named surface,
+// resolved through the item that owns it rather than the global
+// surfaceID-keyed registry, so two servers using the same surface ID cannot
+// route each other's interactions.
+func (m *Chat) A2UISurfaceOwner(surfaceID string) (string, bool) {
+	item, ok := m.a2uiSurfaceItem(surfaceID)
+	if !ok {
+		return "", false
+	}
+	return item.A2UISurfaceOwner(surfaceID)
+}
+
+// A2UISurfaceFieldValues reads the named MCP surface's current input values,
+// for building an a2ui_action context. It reports whether a tool item held
+// the surface.
+func (m *Chat) A2UISurfaceFieldValues(surfaceID string) (map[string]any, bool) {
+	item, ok := m.a2uiSurfaceItem(surfaceID)
+	if !ok {
+		return nil, false
+	}
+	return item.ToolA2UIFieldValues(surfaceID), true
+}
+
+// ApplyA2UISurfaceUpdate feeds a batch of A2UI server messages back into the
+// named MCP surface (the response to an a2ui_action round-trip). It reports
+// whether the surface still has renderable state afterward — false means no
+// item held it, or the server deleted it.
+func (m *Chat) ApplyA2UISurfaceUpdate(surfaceID string, msgs []a2ui.ServerMessage) bool {
+	item, ok := m.a2uiSurfaceItem(surfaceID)
+	if !ok {
+		return false
+	}
+	return item.ApplyToolA2UIUpdate(surfaceID, msgs)
 }
 
 // ToggleExpandedSelectedItem expands the selected message item if it is expandable.

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -816,6 +816,22 @@ func (m *Chat) RetireA2UISurface(surfaceID string) (map[string]any, bool) {
 	return nil, false
 }
 
+// HasAssistantA2UISurface reports whether a live assistant-authored surface
+// carries the given ID. Assistant items do not implement A2UISurfaceItem and
+// are absent from the MCP provenance registry, so without this check a
+// surface ID an assistant happens to share with an MCP server (both default
+// to "default") resolves as MCP-owned and the user's submission is shipped
+// to that server instead of starting an agent turn.
+func (m *Chat) HasAssistantA2UISurface(surfaceID string) bool {
+	for i := range m.list.Len() {
+		item, ok := m.list.ItemAt(i).(*chat.AssistantMessageItem)
+		if ok && item.HasLiveA2UISurface(surfaceID) {
+			return true
+		}
+	}
+	return false
+}
+
 // a2uiSurfaceItem locates the chat item holding the named MCP surface.
 // Surface IDs are only unique within a server — invoking the same tool twice
 // appends two items carrying the same ID — so the focused surface wins: that

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -5073,7 +5073,7 @@ func (m *UI) handleA2UIButtonClicked(clicked a2uievent.ButtonClicked) tea.Cmd {
 		}
 	}
 	if isMCP && clicked.Action != nil {
-		if mcp.HasTool(mcpName, "a2ui_action") {
+		if m.mcpServesTool(mcpName, "a2ui_action") {
 			return m.runA2UIAction(mcpName, clicked)
 		}
 		// The server serves surfaces but not the action round-trip: keep
@@ -5088,6 +5088,24 @@ func (m *UI) handleA2UIButtonClicked(clicked a2uievent.ButtonClicked) tea.Cmd {
 		values, _ = m.chat.A2UISurfaceFieldValues(clicked.SurfaceID)
 	}
 	return m.sendMessage(chat.A2UISubmissionPrompt(clicked, values))
+}
+
+// mcpServesTool reports whether the named MCP server exposes toolName.
+//
+// It reads the workspace's published MCP state rather than mcp.HasTool: that
+// registry is only populated in the process that owns the MCP sessions, so
+// in client/server mode it is permanently empty and every HasTool gate is
+// false — which silently disabled the whole A2UI action round-trip on a
+// remote client and left its /mcp/call-tool route unreachable.
+func (m *UI) mcpServesTool(mcpName, toolName string) bool {
+	if mcpName == "" {
+		return false
+	}
+	info, ok := m.com.Workspace.MCPGetStates()[mcpName]
+	if !ok {
+		return false
+	}
+	return info.ServesA2UITool(toolName)
 }
 
 // a2uiActionResultMsg carries the outcome of an a2ui_action round-trip back
@@ -5207,7 +5225,7 @@ func (m *UI) reportA2UIError(mcpName, surfaceID, code, message string) tea.Cmd {
 			mcpName, ok = chat.A2UISurfaceProvenance(surfaceID)
 		}
 	}
-	if !ok || !mcp.HasTool(mcpName, "a2ui_error") {
+	if !ok || !m.mcpServesTool(mcpName, "a2ui_error") {
 		return nil
 	}
 	args := map[string]any{"code": code, "message": message, "surfaceId": surfaceID}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -5057,9 +5057,20 @@ func (m *UI) handleA2UIButtonClicked(clicked a2uievent.ButtonClicked) tea.Cmd {
 	// claims it: surface IDs are server-scoped (typically "default"), so two
 	// servers would otherwise clobber each other in that registry and route
 	// one another's clicks.
-	mcpName, isMCP := m.chat.A2UISurfaceOwner(clicked.SurfaceID)
-	if !isMCP {
-		mcpName, isMCP = chat.A2UISurfaceProvenance(clicked.SurfaceID)
+	//
+	// An assistant-authored surface is never MCP-owned, whatever the
+	// registry says: assistant items do not implement chat.A2UISurfaceItem,
+	// and the global registry is keyed by surface ID alone — so an
+	// assistant surface sharing an ID with a server's ("default" on both
+	// sides is the common case) would otherwise ship the user's form
+	// submission to that server instead of starting an agent turn.
+	var mcpName string
+	var isMCP bool
+	if !m.chat.HasAssistantA2UISurface(clicked.SurfaceID) {
+		mcpName, isMCP = m.chat.A2UISurfaceOwner(clicked.SurfaceID)
+		if !isMCP {
+			mcpName, isMCP = chat.A2UISurfaceProvenance(clicked.SurfaceID)
+		}
 	}
 	if isMCP && clicked.Action != nil {
 		if mcp.HasTool(mcpName, "a2ui_action") {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -28,6 +28,9 @@ import (
 	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/agent/hyper"
+	a2uievent "github.com/joestump-agent/a2tea/event"
+
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	agenttools "github.com/charmbracelet/crush/internal/agent/tools"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
@@ -802,6 +805,21 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sendMessageMsg:
 		cmds = append(cmds, m.sendMessage(msg.Content, msg.Attachments...))
+
+	case a2uievent.ButtonClicked:
+		// A button on a live A2UI surface was activated: retire the
+		// surface and, unless the button reads as a cancel, turn the
+		// submission into a new agent turn.
+		if cmd := m.handleA2UIButtonClicked(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+
+	case a2uiActionResultMsg:
+		// An a2ui_action round-trip returned: update the originating
+		// surface in place (or land plain text) without an agent turn.
+		if cmd := m.handleA2UIActionResult(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 
 	case userCommandsLoadedMsg:
 		m.customCommands = msg.Commands
@@ -2669,6 +2687,13 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		case uiFocusMain:
 			switch {
 			case key.Matches(msg, m.keyMap.Tab):
+				// A selected live A2UI surface consumes Tab for its own
+				// focus ring; pane switching applies only when no
+				// item claims the key.
+				if ok, cmd := m.chat.HandleKeyMsg(msg); ok {
+					cmds = append(cmds, cmd)
+					break
+				}
 				m.focus = uiFocusEditor
 				m.sidebarScrollbarVisible = false
 				cmds = append(cmds, m.textarea.Focus())
@@ -4037,6 +4062,12 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 
 	// Capture session ID to avoid race with main goroutine updating m.session.
 	sessionID := m.session.ID
+	// The turn's content width hint: tools that read width-sensitive remote
+	// content (A2UI surfaces with server-pre-rendered bar geometry) get the
+	// surface card's interior width so the server sizes its rows to fill
+	// the card. The chat package owns the computation — it must track the
+	// real render chain, not constants copied here.
+	contentWidth := chat.ToolA2UISurfaceWidth(m.layout.main.Dx())
 	// Optimistically mark the agent busy: the prompt we are about to submit
 	// either starts a run or is enqueued behind one. This keeps esc pressed
 	// right after enter routing to cancelAgent instead of reading a stale
@@ -4051,7 +4082,7 @@ func (m *UI) sendMessage(content string, attachments ...message.Attachment) tea.
 		// been accepted (HTTP 202) or synchronously with a validation
 		// or transport error. Run failures and cancellation surface
 		// through SSE-derived events, not this return value.
-		err := m.com.Workspace.AgentRun(context.Background(), sessionID, content, attachments...)
+		err := m.com.Workspace.AgentRun(agent.WithContentWidth(context.Background(), contentWidth), sessionID, content, attachments...)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			return util.InfoMsg{
 				Type: util.InfoTypeError,
@@ -4993,4 +5024,187 @@ func renderLogo(t *styles.Styles, compact, hyper bool, width int) string {
 		Width:        width,
 		Hyper:        hyper,
 	})
+}
+
+// handleA2UIButtonClicked turns an activated A2UI button into an agent turn.
+// The surface that emitted the event is retired first — its field
+// values are read and it stops accepting focus and keys, so the form cannot
+// be re-submitted. A button that reads as a cancel (see
+// chat.A2UIButtonIsCancel) only dismisses; any other button starts a new
+// turn carrying the button and the gathered field values, through the same
+// prompt path a typed message uses (sendMessage → AgentRun, which enqueues
+// behind a running turn).
+//
+// The retire lookup may miss — e.g. the message content was rescanned and
+// the surface rebuilt without an ID — in which case the submission still
+// goes out with just the button identity rather than being dropped.
+func (m *UI) handleA2UIButtonClicked(clicked a2uievent.ButtonClicked) tea.Cmd {
+	// A cancel/dismiss button only ever dismisses the surface locally —
+	// it never starts an agent turn nor round-trips to an MCP server.
+	// Checked first, before any provenance branch.
+	if chat.A2UIButtonIsCancel(clicked) {
+		m.chat.RetireA2UISurface(clicked.SurfaceID)
+		return nil
+	}
+	// MCP-served surface: route the interaction back to the owning server
+	// when it speaks the action round-trip, instead of starting an agent
+	// turn. The button press is itself the consent, so the a2ui_action
+	// call is not gated on permission. The surface is long-lived — it is
+	// NOT retired, and a surface payload in the response updates it in
+	// place.
+	// Provenance resolves through the item that owns the surface, falling
+	// back to the global surfaceID-keyed registry only when no live item
+	// claims it: surface IDs are server-scoped (typically "default"), so two
+	// servers would otherwise clobber each other in that registry and route
+	// one another's clicks.
+	mcpName, isMCP := m.chat.A2UISurfaceOwner(clicked.SurfaceID)
+	if !isMCP {
+		mcpName, isMCP = chat.A2UISurfaceProvenance(clicked.SurfaceID)
+	}
+	if isMCP && clicked.Action != nil {
+		if mcp.HasTool(mcpName, "a2ui_action") {
+			return m.runA2UIAction(mcpName, clicked)
+		}
+		// The server serves surfaces but not the action round-trip: keep
+		// today's behavior so a dumb server still works.
+	}
+	// RetireA2UISurface only matches assistant items, so an MCP surface's
+	// values must be read from the tool item that holds it — otherwise the
+	// fallback submits the button identity with everything the user typed
+	// silently dropped.
+	values, ok := m.chat.RetireA2UISurface(clicked.SurfaceID)
+	if !ok {
+		values, _ = m.chat.A2UISurfaceFieldValues(clicked.SurfaceID)
+	}
+	return m.sendMessage(chat.A2UISubmissionPrompt(clicked, values))
+}
+
+// a2uiActionResultMsg carries the outcome of an a2ui_action round-trip back
+// to the UI so the surface updates in place (or a plain-text reply lands as
+// tool output) without an agent turn.
+type a2uiActionResultMsg struct {
+	surfaceID string
+	mcpName   string
+	// surfaces holds any A2UI payloads the response embedded, applied to
+	// the surface in place. content holds plain text from the response.
+	surfaces []string
+	content  string
+	err      error
+}
+
+// runA2UIAction calls the owning server's a2ui_action tool with the
+// button's action name and the surface's resolved input values as the
+// context. The call runs off the UI goroutine; the result returns as an
+// a2uiActionResultMsg.
+func (m *UI) runA2UIAction(mcpName string, clicked a2uievent.ButtonClicked) tea.Cmd {
+	values, _ := m.chat.A2UISurfaceFieldValues(clicked.SurfaceID)
+	if values == nil {
+		values = map[string]any{}
+	}
+	args := map[string]any{
+		"name":    clicked.Action.Name,
+		"context": values,
+	}
+	surfaceID := clicked.SurfaceID
+	return func() tea.Msg {
+		res, err := m.com.Workspace.CallMCPTool(context.Background(), mcpName, "a2ui_action", args)
+		if err != nil {
+			return a2uiActionResultMsg{surfaceID: surfaceID, mcpName: mcpName, err: err}
+		}
+		out := a2uiActionResultMsg{surfaceID: surfaceID, mcpName: mcpName, content: res.Content}
+		for _, s := range res.Surfaces {
+			out.surfaces = append(out.surfaces, s.Payload)
+		}
+		return out
+	}
+}
+
+// handleA2UIActionResult applies an a2ui_action response: any A2UI payload
+// updates the originating surface in place (the surface stays live), and any
+// plain text lands as an informational note. A transport/server error is
+// surfaced as an error note — the surface is left untouched.
+func (m *UI) handleA2UIActionResult(msg a2uiActionResultMsg) tea.Cmd {
+	if msg.err != nil {
+		return util.ReportError(fmt.Errorf("A2UI action failed: %w", msg.err))
+	}
+	var cmds []tea.Cmd
+	for _, payload := range msg.surfaces {
+		if cmd := m.applyA2UIPayloadToSurface(msg.mcpName, msg.surfaceID, payload); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	if msg.content != "" {
+		cmds = append(cmds, util.ReportInfo(msg.content))
+	}
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
+}
+
+// applyA2UIPayloadToSurface scans an A2UI payload and feeds its server
+// messages into the surface the payload targets, which updates in place. A
+// payload that does not scan, or that targets a surface nothing holds, is
+// reported back to the owning server as an a2ui_error when it exposes that
+// tool. clickedID is the surface the interaction came from — the fallback
+// target for a payload that declares no surface of its own — and mcpName is
+// the server that sent it, which is who any error is reported to.
+func (m *UI) applyA2UIPayloadToSurface(mcpName, clickedID, payload string) tea.Cmd {
+	msgs, err := chat.A2UIMessagesFromPayload(payload)
+	if err != nil {
+		return m.reportA2UIError(mcpName, clickedID, "INVALID_JSON",
+			"Failed to parse A2UI payload.")
+	}
+	if len(msgs) == 0 {
+		// The payload parsed but carried no server messages — it scanned
+		// as prose, not A2UI. Applying it would be a silent no-op, which
+		// looks to the user like a dead button.
+		return m.reportA2UIError(mcpName, clickedID, "INVALID_PAYLOAD",
+			"Payload carried no A2UI server messages.")
+	}
+	// Honor the surface the payload itself declares: a server may answer an
+	// action by updating a sibling surface, not the clicked one. Forcing
+	// every payload onto the clicked ID would corrupt that surface instead.
+	target := chat.A2UIMessagesSurfaceID(msgs)
+	if target == "" {
+		target = clickedID
+	}
+	if !m.chat.ApplyA2UISurfaceUpdate(target, msgs) {
+		// Either nothing holds that surface, or the server just deleted
+		// it. A delete is the expected end of a surface's life; a payload
+		// aimed at a surface we never had is a real mismatch worth
+		// reporting back.
+		if !chat.A2UIMessagesDeleteSurface(msgs) {
+			return m.reportA2UIError(mcpName, target, "SURFACE_NOT_FOUND",
+				fmt.Sprintf("No live surface %q to apply the payload to.", target))
+		}
+	}
+	return nil
+}
+
+// reportA2UIError reports a render failure to mcpName via its a2ui_error
+// tool, when it exposes one. Otherwise the failure is only shown to the user
+// (the existing render-failure alert path). mcpName may be empty when the
+// caller only holds a surface ID, in which case the owner is resolved from
+// the surface — item-scoped first, same as the action path, because the
+// global registry is keyed by surface ID alone and two servers sharing an ID
+// clobber each other there.
+func (m *UI) reportA2UIError(mcpName, surfaceID, code, message string) tea.Cmd {
+	ok := mcpName != ""
+	if !ok {
+		if mcpName, ok = m.chat.A2UISurfaceOwner(surfaceID); !ok {
+			mcpName, ok = chat.A2UISurfaceProvenance(surfaceID)
+		}
+	}
+	if !ok || !mcp.HasTool(mcpName, "a2ui_error") {
+		return nil
+	}
+	args := map[string]any{"code": code, "message": message, "surfaceId": surfaceID}
+	return func() tea.Msg {
+		_, err := m.com.Workspace.CallMCPTool(context.Background(), mcpName, "a2ui_error", args)
+		if err != nil {
+			return util.InfoMsg{Type: util.InfoTypeError, Msg: fmt.Sprintf("A2UI error report failed: %v", err)}
+		}
+		return nil
+	}
 }

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -913,6 +913,14 @@ func quickStyle(o quickStyleOpts) Styles {
 	s.Messages.ThinkingFooterTitle = muted
 	s.Messages.ThinkingFooterDuration = subtle
 
+	// A2UI surface container. a2tea renders its chrome with terminal
+	// defaults, so a subtle themed frame makes surfaces read as part of
+	// the chat (like the thinking box) rather than plain output.
+	s.Messages.A2UISurface = base.
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(o.bgMostVisible).
+		Padding(0, 1)
+
 	// Text selection.
 	s.TextSelection = lipgloss.NewStyle().Foreground(o.onPrimary).Background(o.primary)
 

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -312,6 +312,10 @@ type Styles struct {
 		AssistantInfoProvider  lipgloss.Style
 		AssistantInfoDuration  lipgloss.Style
 		AssistantCanceled      lipgloss.Style // Italic "Canceled" footer
+
+		// A2UISurface is the themed container wrapped around rendered A2UI
+		// surfaces so they read as part of the chat.
+		A2UISurface lipgloss.Style
 	}
 
 	// Tool - styles for tool call rendering

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -436,6 +437,24 @@ func (w *AppWorkspace) ReadMCPResource(ctx context.Context, name, uri string) ([
 
 func (w *AppWorkspace) ListMCPPrompts(context.Context) ([]commands.MCPPrompt, error) {
 	return commands.LoadMCPPrompts()
+}
+
+// CallMCPTool invokes a tool on a named MCP server and returns its text
+// content plus any A2UI surface payload it embedded.
+func (w *AppWorkspace) CallMCPTool(ctx context.Context, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	input, err := json.Marshal(args)
+	if err != nil {
+		return MCPToolCallResult{}, fmt.Errorf("failed to encode tool arguments: %w", err)
+	}
+	res, err := mcptools.RunTool(ctx, w.store, name, toolName, string(input))
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	out := MCPToolCallResult{Content: res.Content}
+	for _, s := range res.Surfaces {
+		out.Surfaces = append(out.Surfaces, MCPToolCallSurface{Payload: s.Payload, URI: s.URI})
+	}
+	return out, nil
 }
 
 func (w *AppWorkspace) GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error) {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -657,6 +657,7 @@ func (w *ClientWorkspace) MCPGetStates() map[string]mcp.ClientInfo {
 				Resources: v.ResourceCount,
 			},
 			ConnectedAt: v.ConnectedAt,
+			A2UITools:   v.A2UITools,
 		}
 	}
 	return result

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/app"
@@ -228,7 +229,11 @@ func (w *ClientWorkspace) AgentRun(ctx context.Context, sessionID, prompt string
 	// completion detection (it observes message events directly),
 	// so passing an empty RunID is correct here: it skips the
 	// correlator stamping path without functional consequences.
-	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", prompt, attachments...)
+	//
+	// The content-width hint rides the context locally but cannot cross
+	// the HTTP boundary as a context value, so it is lifted onto the wire
+	// message here and re-attached server-side (backend.runAgent).
+	return w.client.SendMessage(ctx, w.workspaceID(), sessionID, "", agent.ContentWidthFromContext(ctx), prompt, attachments...)
 }
 
 func (w *ClientWorkspace) AgentRunShellCommand(ctx context.Context, sessionID, command string, termWidth int, _ func(string), _ bool) (proto.ShellCommandResponse, error) {
@@ -716,6 +721,20 @@ func (w *ClientWorkspace) ListMCPPrompts(ctx context.Context) ([]commands.MCPPro
 
 func (w *ClientWorkspace) GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error) {
 	return w.client.GetMCPPrompt(context.Background(), w.workspaceID(), clientID, promptID, args)
+}
+
+// CallMCPTool invokes a tool on a named MCP server via the server and
+// returns its text content plus any A2UI surface payload it embedded.
+func (w *ClientWorkspace) CallMCPTool(ctx context.Context, name, toolName string, args map[string]any) (MCPToolCallResult, error) {
+	res, err := w.client.CallMCPTool(ctx, w.workspaceID(), name, toolName, args)
+	if err != nil {
+		return MCPToolCallResult{}, err
+	}
+	out := MCPToolCallResult{Content: res.Content}
+	for _, s := range res.Surfaces {
+		out.Surfaces = append(out.Surfaces, MCPToolCallSurface{Payload: s.Payload, URI: s.URI})
+	}
+	return out, nil
 }
 
 func (w *ClientWorkspace) EnableDockerMCP(ctx context.Context) error {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -224,6 +224,12 @@ type Workspace interface {
 	RefreshMCPTools(ctx context.Context, name string)
 	ReadMCPResource(ctx context.Context, name, uri string) ([]MCPResourceContents, error)
 	ListMCPPrompts(ctx context.Context) ([]commands.MCPPrompt, error)
+	// CallMCPTool invokes a tool on a named MCP server and returns its
+	// text content plus any A2UI surface payload it embedded. It backs the
+	// A2UI action round-trip: a button press on an MCP-served surface
+	// routes back to the owning server as an a2ui_action (or a render
+	// failure as an a2ui_error) without an agent turn.
+	CallMCPTool(ctx context.Context, name, toolName string, args map[string]any) (MCPToolCallResult, error)
 	GetMCPPrompt(clientID, promptID string, args map[string]string) (string, error)
 	EnableDockerMCP(ctx context.Context) error
 	DisableDockerMCP() error
@@ -242,4 +248,19 @@ type MCPResourceContents struct {
 	MIMEType string `json:"mime_type,omitempty"`
 	Text     string `json:"text,omitempty"`
 	Blob     []byte `json:"blob,omitempty"`
+}
+
+// MCPToolCallResult holds the model-facing text and any A2UI surface
+// payloads from an MCP tool call.
+type MCPToolCallResult struct {
+	// Content is the result's text (its TextContent, joined).
+	Content string `json:"content"`
+	// Surfaces carries any A2UI surface payloads the result embedded.
+	Surfaces []MCPToolCallSurface `json:"surfaces,omitempty"`
+}
+
+// MCPToolCallSurface is a single A2UI surface payload from a tool call.
+type MCPToolCallSurface struct {
+	Payload string `json:"payload"`
+	URI     string `json:"uri"`
 }

--- a/schema.json
+++ b/schema.json
@@ -574,7 +574,24 @@
         },
         "disable_a2ui": {
           "type": "boolean",
-          "description": "Disable the A2UI prompt section that invites the model to emit renderable \u003ca2ui-json\u003e UI surfaces in chat",
+          "description": "Disable A2UI entirely: drops the prompt section inviting the model to emit renderable \u003ca2ui-json\u003e surfaces and stops advertising the a2ui capability to MCP servers",
+          "default": false
+        },
+        "allowed_commands": {
+          "items": {
+            "type": "string",
+            "examples": [
+              "ssh",
+              "curl",
+              "scp"
+            ]
+          },
+          "type": "array",
+          "description": "List of commands to allow that are normally banned. Only affects the exact-command block list; package-manager argument blocks (e.g. 'apt install') are unaffected. Allowed commands still require permission approval."
+        },
+        "allow_all_commands": {
+          "type": "boolean",
+          "description": "Remove all command restrictions from the bash tool",
           "default": false
         }
       },

--- a/schema.json
+++ b/schema.json
@@ -576,23 +576,6 @@
           "type": "boolean",
           "description": "Disable A2UI entirely: drops the prompt section inviting the model to emit renderable \u003ca2ui-json\u003e surfaces and stops advertising the a2ui capability to MCP servers",
           "default": false
-        },
-        "allowed_commands": {
-          "items": {
-            "type": "string",
-            "examples": [
-              "ssh",
-              "curl",
-              "scp"
-            ]
-          },
-          "type": "array",
-          "description": "List of commands to allow that are normally banned. Only affects the exact-command block list; package-manager argument blocks (e.g. 'apt install') are unaffected. Allowed commands still require permission approval."
-        },
-        "allow_all_commands": {
-          "type": "boolean",
-          "description": "Remove all command restrictions from the bash tool",
-          "default": false
         }
       },
       "additionalProperties": false,

--- a/schema.json
+++ b/schema.json
@@ -571,6 +571,11 @@
           },
           "type": "array",
           "description": "List of skill names to disable and hide from the agent"
+        },
+        "disable_a2ui": {
+          "type": "boolean",
+          "description": "Disable the A2UI prompt section that invites the model to emit renderable \u003ca2ui-json\u003e UI surfaces in chat",
+          "default": false
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
> [!NOTE]
> **WIP / draft.** Charm folks know this is coming — opening as a draft so the team can look at the approach while the last gaps below are closed. Per the [contributing guide](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md), the feature conversation happened out-of-band with the maintainers rather than in a Discussion.

## TL;DR ✨

- 🖼️ **Assistant replies can draw real UI.** An `<a2ui-json>` block in a reply renders as a live [A2UI](https://a2ui.org) v0.9 surface (cards, lists, inputs, buttons) via [a2tea](https://github.com/joestump-agent/a2tea) — not a wall of JSON.
- ⌨️ **Surfaces are interactive.** Tab cycles a focused surface's focus ring, inputs take edits, and a button press becomes a normal agent turn carrying the form's values. Cancel-style buttons just dismiss.
- 🔌 **MCP servers can serve surfaces too**: `application/a2ui+json` resources and embedded tool-result surfaces render inline; the raw payload is diverted to UI-only response metadata so the model only ever sees a placeholder (no echo/double-render). Audience annotations are honored.
- 🔁 **Interactions round-trip.** A button on an MCP-served surface calls the owning server's `a2ui_action` tool (errors report via `a2ui_error`) over a new allow-listed `/mcp/call-tool` route, updating the surface in place — no agent turn, no permission prompt beyond the press itself.
- 📐 **Width-aware.** MCP resource templates are discovered eagerly (`resources/templates/list`), surface URIs get a `?w=` hint, and the UI's content width rides each turn across the client/server boundary (and into sub-agents).
- 🧠 New `a2ui` builtin skill + prompt section teaching the model when (and when not) to emit surfaces; opt out entirely with `options.disable_a2ui`.
- Two emojis were the contractual minimum for this description, so you'd know a robot wrote it. I chose to exceed expectations. 🤖

## What this is

Sometimes prose isn't the best answer. This PR teaches Crush to render A2UI documents as actual chat elements:

```text
<a2ui-json>{"version":"v0.9","updateComponents":{...}}</a2ui-json>

        …becomes…

╭──────────────────────────────╮
│ Build passed                 │
│ 142 tests, 0 failures.       │
│ ──────────────────────────── │
│ [ Details ]  [ Re-run ]      │
╰──────────────────────────────╯
```

Parsing/rendering is handled by [a2tea](https://github.com/joestump-agent/a2tea) (pinned at `v0.1.0`), which speaks the real A2UI v0.9 protocol and themes its chrome from the host. Prose around a surface still renders as Markdown; malformed or truncated blocks degrade to a visible alert instead of silently disappearing.

Diff shape: **62 files, +6,069/−76** — about half of it tests. New code is concentrated in `internal/ui/chat/a2ui*.go`, `internal/ui/chat/tool_a2ui.go`, and `internal/agent/tools/mcp/`; the rest is narrow integration seams (config option, prompt template, workspace/proto/server plumbing for the action round-trip and the width hint).

## How this branch was made

This is the fork's `feat/a2ui` branch rebased onto current `main` (`v0.88.1`). Because much of the fork's other work has already landed here (channels, MCP lifecycle, OAuth, attachment fixes), a naive rebase would have replayed ~130 commits of duplicate lineage — so the A2UI payload was re-landed as one squashed commit on a fresh branch cut from `main`, and the duplicated/fork-only commits were dropped. The full reviewed history lives in the fork PRs below.

## History: fork PRs this squashes

Foundation (rendering, skill, prompt, alerts):
- https://github.com/joestump-agent/crush/pull/1 · https://github.com/joestump-agent/crush/pull/2 · https://github.com/joestump-agent/crush/pull/3 · https://github.com/joestump-agent/crush/pull/4 — first a2tea rendering + config-gated prompt
- https://github.com/joestump-agent/crush/pull/10 — fenced-code, truncated-block, and alert-masking edge cases
- https://github.com/joestump-agent/crush/pull/11 — `a2ui` builtin skill + test coverage
- https://github.com/joestump-agent/crush/pull/12 · https://github.com/joestump-agent/crush/pull/95 — skill correctness + anti-patterns
- https://github.com/joestump-agent/crush/pull/14 — README feature docs
- https://github.com/joestump-agent/crush/pull/145 — alerts agree with the parser, gate on finished, keep fences
- https://github.com/joestump-agent/crush/pull/151 — a2tea pin bump
- https://github.com/joestump-agent/crush/pull/171 — foundational interactive A2UI: themed container, button repair, live surfaces, form submission

A2UI over MCP (resource + tool-result surfaces, round-trip, width):
- https://github.com/joestump-agent/crush/pull/216 — drop the double border, fill the content width
- https://github.com/joestump-agent/crush/pull/230 — render MCP resource surfaces inline + Markdown body text
- https://github.com/joestump-agent/crush/pull/231 — resource-template registry hygiene + review findings
- https://github.com/joestump-agent/crush/pull/232 — size resource surfaces to the chat content width (the `?w=` hint + width-across-the-wire plumbing)
- https://github.com/joestump-agent/crush/pull/233 — detect and render A2UI payloads from tool results
- https://github.com/joestump-agent/crush/pull/235 — route surface interactions back as `a2ui_action` calls
- https://github.com/joestump-agent/crush/pull/244 — respect A2UI audience annotations for LLM visibility

Design issues driving the work:
- https://github.com/joestump-agent/crush/issues/43 (epic: make rendered A2UI interactive) → https://github.com/joestump-agent/crush/issues/44, https://github.com/joestump-agent/crush/issues/45, https://github.com/joestump-agent/crush/issues/47
- https://github.com/joestump-agent/crush/issues/217 (epic: A2UI over MCP) → https://github.com/joestump-agent/crush/issues/219, https://github.com/joestump-agent/crush/issues/221, https://github.com/joestump-agent/crush/issues/222

## How it was verified

- `go build ./...`, `go vet ./...` clean (modulo the pre-existing `internal/csync` vet finding on `main`).
- `golangci-lint run` (repo config): **0 issues**; `gofumpt -l .` clean.
- `go test ./...`: green across the repo **except `TestCoderAgent`** — see below.
- `schema.json` regenerated (`go run . schema`) for the new `disable_a2ui` option.

## Known gaps before "Ready for review" (why this is a draft)

- **`TestCoderAgent` VCR cassettes need re-recording**: the system prompt now advertises the `a2ui` builtin skill, so the recorded request bodies no longer match. Re-recording needs live provider keys; will be done before marking ready.
- **Swagger spec intentionally not regenerated**: `task swag` currently also picks up drift from routes that predate this PR (e.g. `/mcp/auth`), so the committed spec doesn't include the new `/workspaces/{id}/mcp/call-tool` route yet. Happy to regenerate here or leave it for the next docs pass — maintainer's call.
- The metadata-diversion guard has a **channel-originated-turn arm that is inert upstream** (nothing marks a turn as channel-originated on `main` yet); it becomes live if/when channel-turn attribution lands.
- `capabilities.a2ui` advertisement at MCP initialize (fork [#243](https://github.com/joestump-agent/crush/pull/243)) is deliberately **not** included — it tracks a moving part of the A2UI-over-MCP contract and can follow separately.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features). — *discussed with the maintainers out-of-band; they know this PR is coming.*

🤖 Posted on behalf of `@joestump` by [`claude-fable-5`](https://openrouter.ai/anthropic/claude-fable-5) using [Claude Code](https://claude.ai).
