### PR TITLE
fix(ui): don't probe for kitty graphics under tmux

### DIFF
--- a/internal/ui/common/capabilities.go
+++ b/internal/ui/common/capabilities.go
@@ -84,15 +84,17 @@ func QueryCmd(env uv.Environ) tea.Cmd {
 	sb.WriteString(notification.OSC99QuerySequence())
 
 	// Queries that should only be sent to "smart" normal terminals.
-	shouldQueryFor := shouldQueryCapabilities(env)
-	if shouldQueryFor {
+	if shouldQueryCapabilities(env) {
 		sb.WriteString(ansi.RequestNameVersion)
 		sb.WriteString(ansi.WindowOp(14)) // Window size in pixels
-		kittyReq := ansi.KittyGraphics([]byte("AAAA"), "i=31", "s=1", "v=1", "a=q", "t=d", "f=24")
-		if _, isTmux := env.LookupEnv("TMUX"); isTmux {
-			kittyReq = ansi.TmuxPassthrough(kittyReq)
+		// Skip the Kitty graphics query under tmux. The reply is an APC
+		// sequence, and tmux's key parser has no APC branch, so unless the
+		// whole reply lands in a single read tmux forwards its printable
+		// bytes to the pane as ordinary keys and "Gi=31;OK" is typed into
+		// the editor.
+		if _, isTmux := env.LookupEnv("TMUX"); !isTmux {
+			sb.WriteString(ansi.KittyGraphics([]byte("AAAA"), "i=31", "s=1", "v=1", "a=q", "t=d", "f=24"))
 		}
-		sb.WriteString(kittyReq)
 	}
 
 	return tea.Raw(sb.String())

--- a/internal/ui/common/capabilities_test.go
+++ b/internal/ui/common/capabilities_test.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// tmuxPassthroughPrefix opens the DCS wrapper ansi.TmuxPassthrough emits.
+const tmuxPassthroughPrefix = "\x1bPtmux;"
+
+func queryString(t *testing.T, env uv.Environ) string {
+	t.Helper()
+	msg, ok := QueryCmd(env)().(tea.RawMsg)
+	require.True(t, ok, "QueryCmd should emit a tea.RawMsg")
+	raw, ok := msg.Msg.(string)
+	require.True(t, ok, "tea.RawMsg should carry a string")
+	return raw
+}
+
+func TestQueryCmdSkipsKittyGraphicsUnderTmux(t *testing.T) {
+	t.Parallel()
+
+	// tmux cannot forward the APC reply to the pane, so the query must not
+	// be sent at all. Otherwise the reply is typed into the editor.
+	raw := queryString(t, uv.Environ{
+		"TERM=xterm-256color",
+		"TERM_PROGRAM=tmux",
+		"TMUX=/tmp/tmux-1000/default,1234,0",
+	})
+
+	require.NotContains(t, raw, "_Gi=31")
+	require.NotContains(t, raw, tmuxPassthroughPrefix)
+	require.Contains(t, raw, ansi.RequestPrimaryDeviceAttributes)
+	require.Contains(t, raw, ansi.RequestNameVersion)
+}
+
+func TestQueryCmdSendsKittyGraphicsOutsideTmux(t *testing.T) {
+	t.Parallel()
+
+	raw := queryString(t, uv.Environ{
+		"TERM=xterm-kitty",
+		"TERM_PROGRAM=kitty",
+	})
+
+	require.Contains(t, raw, "_Gi=31")
+	require.NotContains(t, raw, tmuxPassthroughPrefix)
+}


### PR DESCRIPTION
## What

Running crush inside tmux under kitty types `Gi=31;OK` into the editor on startup. That string is crush's own capability probe coming back at it

## Why it happened

`QueryCmd` ([capabilities.go:91](https://github.com/charmbracelet/crush/blob/649c3b1f/internal/ui/common/capabilities.go#L91)) sends the kitty graphics query wrapped in tmux passthrough, so the outer terminal answers with `\x1b_Gi=31;OK\x1b\`. tmux's key parser has no APC branch, so unless the whole reply lands in a single read it degrades into Alt+`_`, the printable run `Gi=31;OK`, and Alt+`\`, and the printables reach the pane as keystrokes. `shouldQueryCapabilities` returns true for tmux, so the probe goes out in the first place

## Fix

Skip the kitty graphics query in `QueryCmd` when `TMUX` is set. XTVERSION and the pixel-size query still go out, since tmux answers those itself

Closes #3500

## Proof

Ran crush inside tmux on a pty, then played back the exact reply kitty sends. The harness only injects a reply if crush actually asked, matching what a real terminal does:

```
$ python3 repro_3500.py ./crush-main          # v0.88.1
crush emitted the kitty graphics probe through tmux : True
prompt before kitty's reply                         : '> Ready...'
prompt after kitty's reply                          : '> Gi=31;OK'
verdict                                             : REPRODUCED

$ python3 repro_3500.py ./crush-patched
crush emitted the kitty graphics probe through tmux : False
prompt before kitty's reply                         : '> Ready?'
prompt after kitty's reply                          : '> Ready?'
verdict                                             : clean
```

Script: https://gist.github.com/olifarhaan/0fafcd38a80a0c2f4786a7dab603ef36

By hand, on kitty: `tmux new-session crush`, and the prompt reads `Gi=31;OK` before this change and stays empty after

## Tests

`TestQueryCmdSkipsKittyGraphicsUnderTmux` fails on `main`:

```
"...\x1bPtmux;\x1b\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\x1b\\\x1b\\" should not contain "_Gi=31"
```

`go test -race ./internal/ui/...` and golangci-lint v2.11 both clean
