### PR TITLE
test(config): stop inherited provider keys from failing the suite

### DIFF
--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -37,10 +38,21 @@ func TestMain(m *testing.M) {
 	os.Exit(exitVal)
 }
 
-// inheritedCredentialEnvNames returns the names in environ that a test
-// process must not inherit. CRUSH_ prefixed variables count because
+// Provider configuration is resolved from the environment on every load,
+// so anything below can silently steer a test. The suffixes cover the
+// per-provider variables the provider registry declares, which are mostly
+// but not all named *_API_KEY: huggingface uses HF_TOKEN and scaleway uses
+// SCW_SECRET_KEY. The prefixes cover the credential chains load.go reads
+// directly for Bedrock, Azure and Vertex AI. CRUSH_ is here because
 // PushPopCrushEnv copies CRUSH_FOO over FOO on every load, so clearing
 // HYPER_API_KEY alone leaves CRUSH_HYPER_API_KEY to reinstate it.
+var (
+	credentialEnvSuffixes = []string{"_API_KEY", "_API_ENDPOINT", "_TOKEN", "_SECRET_KEY"}
+	credentialEnvPrefixes = []string{"CRUSH_", "AWS_", "AZURE_", "VERTEXAI_"}
+)
+
+// inheritedCredentialEnvNames returns the names in environ that a test
+// process must not inherit.
 func inheritedCredentialEnvNames(environ []string) []string {
 	var names []string
 	for _, ev := range environ {
@@ -48,7 +60,13 @@ func inheritedCredentialEnvNames(environ []string) []string {
 		if !ok {
 			continue
 		}
-		if strings.HasSuffix(name, "_API_KEY") || strings.HasPrefix(name, "CRUSH_") {
+		suffixed := slices.ContainsFunc(credentialEnvSuffixes, func(s string) bool {
+			return strings.HasSuffix(name, s)
+		})
+		prefixed := slices.ContainsFunc(credentialEnvPrefixes, func(p string) bool {
+			return strings.HasPrefix(name, p)
+		})
+		if suffixed || prefixed {
 			names = append(names, name)
 		}
 	}
@@ -61,19 +79,34 @@ func TestInheritedCredentialEnvNames(t *testing.T) {
 	names := inheritedCredentialEnvNames([]string{
 		"PATH=/usr/bin",
 		"HOME=/home/dev",
-		"HYPER_API_KEY=live-key",
-		"CRUSH_HYPER_API_KEY=live-key",
-		"VENICE_API_KEY=live-key",
-		"CRUSH_GLOBAL_CONFIG=/home/dev/.config/crush",
+		"TOKEN=not-suffixed",
 		"API_KEY_SUFFIXED_WRONG=x",
 		"MALFORMED",
+		"HYPER_API_KEY=live",
+		"VENICE_API_KEY=live",
+		"CRUSH_HYPER_API_KEY=live",
+		"CRUSH_GLOBAL_CONFIG=/home/dev/.config/crush",
+		"HF_TOKEN=live",
+		"SCW_SECRET_KEY=live",
+		"ANTHROPIC_API_ENDPOINT=https://proxy.example",
+		"AWS_PROFILE=work",
+		"AWS_BEARER_TOKEN_BEDROCK=live",
+		"AZURE_OPENAI_API_VERSION=2026-01-01",
+		"VERTEXAI_PROJECT=my-project",
 	})
 
 	require.ElementsMatch(t, []string{
 		"HYPER_API_KEY",
-		"CRUSH_HYPER_API_KEY",
 		"VENICE_API_KEY",
+		"CRUSH_HYPER_API_KEY",
 		"CRUSH_GLOBAL_CONFIG",
+		"HF_TOKEN",
+		"SCW_SECRET_KEY",
+		"ANTHROPIC_API_ENDPOINT",
+		"AWS_PROFILE",
+		"AWS_BEARER_TOKEN_BEDROCK",
+		"AZURE_OPENAI_API_VERSION",
+		"VERTEXAI_PROJECT",
 	}, names)
 }
 

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -25,8 +25,64 @@ import (
 func TestMain(m *testing.M) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
 
+	// Drop credentials inherited from the developer's shell. They resolve
+	// into provider configs on every load, so a real key silently replaces
+	// the value a test asserts on and the failure diff prints the key.
+	// Tests that need one set it themselves with t.Setenv.
+	for _, name := range inheritedCredentialEnvNames(os.Environ()) {
+		os.Unsetenv(name)
+	}
+
 	exitVal := m.Run()
 	os.Exit(exitVal)
+}
+
+// inheritedCredentialEnvNames returns the names in environ that a test
+// process must not inherit. CRUSH_ prefixed variables count because
+// PushPopCrushEnv copies CRUSH_FOO over FOO on every load, so clearing
+// HYPER_API_KEY alone leaves CRUSH_HYPER_API_KEY to reinstate it.
+func inheritedCredentialEnvNames(environ []string) []string {
+	var names []string
+	for _, ev := range environ {
+		name, _, ok := strings.Cut(ev, "=")
+		if !ok {
+			continue
+		}
+		if strings.HasSuffix(name, "_API_KEY") || strings.HasPrefix(name, "CRUSH_") {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func TestInheritedCredentialEnvNames(t *testing.T) {
+	t.Parallel()
+
+	names := inheritedCredentialEnvNames([]string{
+		"PATH=/usr/bin",
+		"HOME=/home/dev",
+		"HYPER_API_KEY=live-key",
+		"CRUSH_HYPER_API_KEY=live-key",
+		"VENICE_API_KEY=live-key",
+		"CRUSH_GLOBAL_CONFIG=/home/dev/.config/crush",
+		"API_KEY_SUFFIXED_WRONG=x",
+		"MALFORMED",
+	})
+
+	require.ElementsMatch(t, []string{
+		"HYPER_API_KEY",
+		"CRUSH_HYPER_API_KEY",
+		"VENICE_API_KEY",
+		"CRUSH_GLOBAL_CONFIG",
+	}, names)
+}
+
+// TestMainClearedInheritedCredentials is deliberately not parallel: it reads
+// process-wide state, and t.Setenv in other tests is confined to the
+// sequential pass.
+func TestMainClearedInheritedCredentials(t *testing.T) {
+	require.Empty(t, inheritedCredentialEnvNames(os.Environ()),
+		"TestMain must clear inherited credentials before any test runs")
 }
 
 func TestConfig_LoadFromBytes(t *testing.T) {


### PR DESCRIPTION
## What

`go test ./internal/config` fails if you have a Hyper key in your shell, and the failure diff prints that key to the terminal

## Why it happened

`TestRefreshOAuthToken_StalePeerBorrowsRotatedRefreshToken` refreshes a token, and persisting it goes through `SetConfigFields`, which auto-reloads. The reload resolves `HYPER_API_KEY` from the environment and puts it back over the access token the refresh had just applied. `CRUSH_HYPER_API_KEY` breaks it the same way, since `PushPopCrushEnv` ([load.go:182](<https://github.com/charmbracelet/crush/blob/75791b88/internal/config/load.go#L182>)) copies `CRUSH_FOO` over `FOO` on every load

## Fix

`TestMain` drops inherited credentials before running anything. Tests that need one keep setting it with `t.Setenv`

Matching is by suffix, `_API_KEY`, `_API_ENDPOINT`, `_TOKEN`, `_SECRET_KEY`, and by prefix, `CRUSH_`, `AWS_`, `AZURE_`, `VERTEXAI_`. The suffixes catch the per-provider variables the registry declares, which are mostly but not all named `*_API_KEY`: huggingface uses `HF_TOKEN` and scaleway uses `SCW_SECRET_KEY`. The prefixes catch the credential chains `load.go` reads directly for Bedrock, Azure and Vertex AI

Closes charmbracelet/crush#3448

## Proof

```
$ CRUSH_HYPER_API_KEY=totally-fake-not-a-real-key go test ./internal/config -run TestRefreshOAuthToken_StalePeerBorrowsRotatedRefreshToken
--- FAIL: TestRefreshOAuthToken_StalePeerBorrowsRotatedRefreshToken (1.43s)
                expected: "at4"
                actual  : "totally-fake-not-a-real-key"
FAIL

$ CRUSH_HYPER_API_KEY=totally-fake-not-a-real-key go test ./internal/config -run TestRefreshOAuthToken_StalePeerBorrowsRotatedRefreshToken
ok      github.com/charmbracelet/crush/internal/config  1.802s
```

`HYPER_API_KEY` on its own reproduces it too

## Tests

`TestInheritedCredentialEnvNames` pins which names get dropped, including that a bare `TOKEN`, a `MALFORMED` entry and `API_KEY_SUFFIXED_WRONG` are left alone. `TestMainClearedInheritedCredentials` asserts nothing survived into the test process

`go test -race ./internal/config/...` and golangci-lint v2.11 clean

The issue also names two Venice tests, but neither exists on `main` anymore, so only the Hyper case still reproduces