### PR TITLE
fix(copilot): import a token any Copilot client left on disk

### DIFF
--- a/internal/oauth/copilot/disk.go
+++ b/internal/oauth/copilot/disk.go
@@ -2,11 +2,23 @@ package copilot
 
 import (
 	"encoding/json"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
+	"strings"
 )
 
+const (
+	githubHost = "github.com"
+	// crushAppKey is the apps.json entry written by a client authenticating
+	// as us.
+	crushAppKey = githubHost + ":" + clientID
+)
+
+// RefreshTokenFromDisk returns a GitHub OAuth token that a Copilot client
+// already stored on this machine, if one is there.
 func RefreshTokenFromDisk() (string, bool) {
 	data, err := os.ReadFile(tokenFilePath())
 	if err != nil {
@@ -20,8 +32,23 @@ func RefreshTokenFromDisk() (string, bool) {
 	if err := json.Unmarshal(data, &content); err != nil {
 		return "", false
 	}
-	if app, ok := content["github.com:Iv1.b507a08c87ecfe98"]; ok {
+
+	if app, ok := content[crushAppKey]; ok && app.OAuthToken != "" {
 		return app.OAuthToken, true
+	}
+
+	// Every client keys its entry by host and its own app id, so a token
+	// written by any of them works against api.github.com just as well as
+	// one written under our id. Enterprise hosts are skipped: their tokens
+	// are not valid against the public API. Keys are sorted so a file
+	// holding several entries always resolves to the same one.
+	for _, key := range slices.Sorted(maps.Keys(content)) {
+		if key != githubHost && !strings.HasPrefix(key, githubHost+":") {
+			continue
+		}
+		if token := content[key].OAuthToken; token != "" {
+			return token, true
+		}
 	}
 	return "", false
 }

--- a/internal/oauth/copilot/disk_test.go
+++ b/internal/oauth/copilot/disk_test.go
@@ -1,0 +1,129 @@
+package copilot
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeAppsJSON points the token lookup at a temporary home and seeds
+// apps.json with body. It cannot be parallel: t.Setenv forbids it.
+func writeAppsJSON(t *testing.T, body string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", dir)
+	} else {
+		t.Setenv("HOME", dir)
+	}
+
+	path := tokenFilePath()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+}
+
+func TestRefreshTokenFromDisk(t *testing.T) {
+	tests := []struct {
+		name  string
+		body  string
+		want  string
+		found bool
+	}{
+		{
+			name:  "our own app id",
+			body:  `{"github.com:Iv1.b507a08c87ecfe98":{"user":"bob","oauth_token":"gho_ours"}}`,
+			want:  "gho_ours",
+			found: true,
+		},
+		{
+			name:  "another client's app id",
+			body:  `{"github.com:Iv23liAbCdEfGh":{"user":"bob","oauth_token":"gho_theirs"}}`,
+			want:  "gho_theirs",
+			found: true,
+		},
+		{
+			name:  "host without an app id",
+			body:  `{"github.com":{"user":"bob","oauth_token":"gho_plain"}}`,
+			want:  "gho_plain",
+			found: true,
+		},
+		{
+			name: "our app id wins over another client's",
+			body: `{"github.com:Iv23liAbCdEfGh":{"oauth_token":"gho_theirs"},
+			        "github.com:Iv1.b507a08c87ecfe98":{"oauth_token":"gho_ours"}}`,
+			want:  "gho_ours",
+			found: true,
+		},
+		{
+			name: "several foreign entries resolve to the first by key",
+			body: `{"github.com:Iv50zzz":{"oauth_token":"gho_z"},
+			        "github.com:Iv10aaa":{"oauth_token":"gho_a"}}`,
+			want:  "gho_a",
+			found: true,
+		},
+		{
+			name:  "enterprise host is not used against the public API",
+			body:  `{"tenant.ghe.com:Iv1.b507a08c87ecfe98":{"oauth_token":"gho_ghe"}}`,
+			found: false,
+		},
+		{
+			name:  "lookalike host is rejected",
+			body:  `{"github.com.evil.example:Iv1.x":{"oauth_token":"gho_evil"}}`,
+			found: false,
+		},
+		{
+			name:  "entry without a token is skipped",
+			body:  `{"github.com:Iv23liAbCdEfGh":{"user":"bob","oauth_token":""}}`,
+			found: false,
+		},
+		{
+			name:  "malformed file",
+			body:  `not json`,
+			found: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeAppsJSON(t, tt.body)
+
+			token, ok := RefreshTokenFromDisk()
+
+			require.Equal(t, tt.found, ok)
+			require.Equal(t, tt.want, token)
+		})
+	}
+}
+
+func TestRefreshTokenFromDiskIsStableAcrossCalls(t *testing.T) {
+	writeAppsJSON(t, `{"github.com:Iv50zzz":{"oauth_token":"gho_z"},
+	                   "github.com:Iv10aaa":{"oauth_token":"gho_a"},
+	                   "github.com:Iv30mmm":{"oauth_token":"gho_m"}}`)
+
+	first, ok := RefreshTokenFromDisk()
+	require.True(t, ok)
+
+	for range 20 {
+		again, ok := RefreshTokenFromDisk()
+		require.True(t, ok)
+		require.Equal(t, first, again, "map iteration order must not leak into the choice")
+	}
+}
+
+func TestRefreshTokenFromDiskWithoutFile(t *testing.T) {
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", dir)
+	} else {
+		t.Setenv("HOME", dir)
+	}
+
+	token, ok := RefreshTokenFromDisk()
+
+	require.False(t, ok)
+	require.Empty(t, token)
+}


### PR DESCRIPTION
## What

crush only picks up a Copilot token from `~/.config/github-copilot/apps.json` when copilot.vim wrote it. A token any other Copilot client left there is ignored, so login starts a device flow with a perfectly good credential sitting on disk

## Why it happened

`RefreshTokenFromDisk` ([disk.go:23](https://github.com/charmbracelet/crush/blob/75791b88/internal/oauth/copilot/disk.go#L23)) looks up one hardcoded key, `github.com:Iv1.b507a08c87ecfe98`. Clients key their entry by host plus their own app id, so any other id, and the plain `github.com` form, miss. `crush login copilot` ([login.go:149](https://github.com/charmbracelet/crush/blob/75791b88/internal/cmd/login.go#L149)) and the copilot model switch in the TUI ([ui.go:2209](https://github.com/charmbracelet/crush/blob/75791b88/internal/ui/model/ui.go#L2209)) both fall through to the device flow when that lookup comes back empty

codecompanion.nvim, avante.nvim and jcode all match on the host part of the key rather than one app id

## Fix

Keep preferring our own app id, then fall back to any `github.com` entry that carries a token. Keys are sorted so a file with several entries always resolves to the same one instead of following map order. Enterprise hosts stay excluded, since a `ghe.com` token is not valid against api.github.com

Related to #3399

## Proof

`apps.json` holding one entry from another client:

```
$ cat $HOME/.config/github-copilot/apps.json
{"github.com:Iv23liOtherClient":{"user":"octocat","oauth_token":"gho_token_written_by_another_client"}}

$ crush login copilot          # v0.88.1
Requesting device code from GitHub...

The following code should be on clipboard already:

B810-3318

$ crush login copilot          # this branch
Found existing GitHub Copilot token on disk. Using it to authenticate...
   ERROR  Unable to refresh token from disk: copilot token request failed: 401 Unauthorized - {
     "message": "Bad credentials",
```

The 401 is the placeholder token in the fixture. The point is which branch runs: before, the credential on disk is invisible and you get a device code

## Tests

`TestRefreshTokenFromDisk` covers our app id, a foreign app id, the bare `github.com` key, our id winning when both are present, a `ghe.com` entry being skipped, a `github.com.evil.example` lookalike being rejected, an empty token being passed over, and a malformed file. `TestRefreshTokenFromDiskIsStableAcrossCalls` pins the ordering. Three of them fail on `main`

`go test -race ./internal/oauth/...` and golangci-lint v2.11 clean

One correction on the issue: its main claim is that the device-flow poller fires early. It cannot, `ticker.Reset` only runs after the response lands, so every gap is at least the mandated interval plus the round trip, and the 1s deltas in the capture look like whole-second timestamps. This fixes the other half it reports, that a token placed in `apps.json` is not picked up, so I have left it open
