### PR TITLE
fix(shell): bound the wait when killing a background job

### DIFF
--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -336,8 +336,10 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 					break waitLoop
 				case <-ctx.Done():
 					// Incoming context was cancelled before we moved to background
-					// Kill the shell and return error
-					bgManager.Kill(bgShell.ID)
+					// Kill the shell and return error. The cancelled context
+					// is passed on purpose: the shell still gets signalled,
+					// and there is nobody left to wait for it.
+					bgManager.Kill(ctx, bgShell.ID)
 					return fantasy.ToolResponse{}, ctx.Err()
 				}
 			}

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -80,7 +80,7 @@ func TestBashTool_CustomAutoBackgroundThreshold(t *testing.T) {
 	require.Contains(t, resp.Content, "moved to background")
 
 	bgManager := shell.GetBackgroundShellManager()
-	require.NoError(t, bgManager.Kill(meta.ShellID))
+	require.NoError(t, bgManager.Kill(context.Background(), meta.ShellID))
 }
 
 type recordingPermissionService struct {

--- a/internal/agent/tools/job_kill.go
+++ b/internal/agent/tools/job_kill.go
@@ -48,7 +48,7 @@ func NewJobKillTool() fantasy.AgentTool {
 				Description: bgShell.Description,
 			}
 
-			err := bgManager.Kill(params.ShellID)
+			err := bgManager.Kill(ctx, params.ShellID)
 			if err != nil {
 				return fantasy.NewTextErrorResponse(err.Error()), nil
 			}

--- a/internal/agent/tools/job_test.go
+++ b/internal/agent/tools/job_test.go
@@ -34,7 +34,7 @@ func TestBackgroundShell_Integration(t *testing.T) {
 	require.Empty(t, stderr)
 
 	// Clean up
-	bgManager.Kill(bgShell.ID)
+	bgManager.Kill(context.Background(), bgShell.ID)
 }
 
 func TestBackgroundShell_Kill(t *testing.T) {
@@ -49,7 +49,7 @@ func TestBackgroundShell_Kill(t *testing.T) {
 	require.NoError(t, err)
 
 	// Kill it
-	err = bgManager.Kill(bgShell.ID)
+	err = bgManager.Kill(context.Background(), bgShell.ID)
 	require.NoError(t, err)
 
 	// Verify it's gone
@@ -70,7 +70,7 @@ func TestBackgroundShell_MultipleOutputCalls(t *testing.T) {
 	bgManager := shell.GetBackgroundShellManager()
 	bgShell, err := bgManager.Start(ctx, workingDir, nil, "echo 'step 1' && echo 'step 2' && echo 'step 3'", "")
 	require.NoError(t, err)
-	defer bgManager.Kill(bgShell.ID)
+	defer bgManager.Kill(context.Background(), bgShell.ID)
 
 	// Check that we can call GetOutput multiple times while running
 	for range 5 {
@@ -110,7 +110,7 @@ func TestBackgroundShell_EmptyOutput(t *testing.T) {
 	bgManager := shell.GetBackgroundShellManager()
 	bgShell, err := bgManager.Start(ctx, workingDir, nil, "sleep 0.1", "")
 	require.NoError(t, err)
-	defer bgManager.Kill(bgShell.ID)
+	defer bgManager.Kill(context.Background(), bgShell.ID)
 
 	// Wait for completion
 	bgShell.Wait()
@@ -132,7 +132,7 @@ func TestBackgroundShell_ExitCode(t *testing.T) {
 	bgManager := shell.GetBackgroundShellManager()
 	bgShell, err := bgManager.Start(ctx, workingDir, nil, "echo 'failing' && exit 42", "")
 	require.NoError(t, err)
-	defer bgManager.Kill(bgShell.ID)
+	defer bgManager.Kill(context.Background(), bgShell.ID)
 
 	// Wait for completion
 	bgShell.Wait()
@@ -160,7 +160,7 @@ func TestBackgroundShell_WithBlockFuncs(t *testing.T) {
 	bgManager := shell.GetBackgroundShellManager()
 	bgShell, err := bgManager.Start(ctx, workingDir, blockFuncs, "curl example.com", "")
 	require.NoError(t, err)
-	defer bgManager.Kill(bgShell.ID)
+	defer bgManager.Kill(context.Background(), bgShell.ID)
 
 	// Wait for completion
 	bgShell.Wait()
@@ -189,7 +189,7 @@ func TestBackgroundShell_StdoutAndStderr(t *testing.T) {
 	bgManager := shell.GetBackgroundShellManager()
 	bgShell, err := bgManager.Start(ctx, workingDir, nil, "echo 'stdout message' && echo 'stderr message' >&2", "")
 	require.NoError(t, err)
-	defer bgManager.Kill(bgShell.ID)
+	defer bgManager.Kill(context.Background(), bgShell.ID)
 
 	// Wait for completion
 	bgShell.Wait()
@@ -211,7 +211,7 @@ func TestBackgroundShell_ConcurrentAccess(t *testing.T) {
 	bgManager := shell.GetBackgroundShellManager()
 	bgShell, err := bgManager.Start(ctx, workingDir, nil, "for i in 1 2 3 4 5; do echo \"line $i\"; sleep 0.05; done", "")
 	require.NoError(t, err)
-	defer bgManager.Kill(bgShell.ID)
+	defer bgManager.Kill(context.Background(), bgShell.ID)
 
 	// Access output concurrently from multiple goroutines
 	done := make(chan struct{})
@@ -277,7 +277,7 @@ func TestBackgroundShell_List(t *testing.T) {
 
 	// Clean up
 	for _, sh := range shells {
-		bgManager.Kill(sh.ID)
+		bgManager.Kill(context.Background(), sh.ID)
 	}
 }
 
@@ -305,7 +305,7 @@ func TestBackgroundShell_AutoBackground(t *testing.T) {
 		require.Empty(t, stderr)
 
 		// Clean up
-		bgManager.Kill(bgShell.ID)
+		bgManager.Kill(context.Background(), bgShell.ID)
 	})
 
 	// Test that a long command stays in background
@@ -314,7 +314,7 @@ func TestBackgroundShell_AutoBackground(t *testing.T) {
 		bgManager := shell.GetBackgroundShellManager()
 		bgShell, err := bgManager.Start(ctx, workingDir, nil, "sleep 20 && echo '20 seconds completed'", "")
 		require.NoError(t, err)
-		defer bgManager.Kill(bgShell.ID)
+		defer bgManager.Kill(context.Background(), bgShell.ID)
 
 		// Wait threshold time
 		time.Sleep(5 * time.Second)

--- a/internal/shell/background.go
+++ b/internal/shell/background.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -17,7 +18,17 @@ const (
 	MaxBackgroundJobs = 50
 	// CompletedJobRetentionMinutes is how long to keep completed jobs before auto-cleanup (8 hours)
 	CompletedJobRetentionMinutes = 8 * 60
+	// killGrace bounds how long Kill waits for a cancelled shell to finish.
+	// The exec handler escalates from SIGINT to SIGKILL after
+	// defaultKillTimeout, so the grace has to outlast that to give a
+	// well-behaved job time to exit on its own.
+	killGrace = defaultKillTimeout + 3*time.Second
 )
+
+// ErrKillEscaped reports that a killed job left a process behind. It means
+// the process detached itself into its own session, so the process-group
+// kill could not reach it.
+var ErrKillEscaped = errors.New("a process outlived the kill and is still running")
 
 // syncBuffer is a thread-safe wrapper around bytes.Buffer.
 type syncBuffer struct {
@@ -143,16 +154,30 @@ func (m *BackgroundShellManager) Remove(id string) error {
 	return nil
 }
 
-// Kill terminates a background shell by ID.
-func (m *BackgroundShellManager) Kill(id string) error {
+// Kill terminates a background shell by ID. It returns once the shell has
+// finished or once killGrace has elapsed, whichever comes first: a process
+// that put itself in a new session survives the process-group kill and
+// keeps the shell's output pipe open, which would otherwise leave this
+// blocked for as long as that process runs.
+func (m *BackgroundShellManager) Kill(ctx context.Context, id string) error {
 	shell, ok := m.shells.Take(id)
 	if !ok {
 		return fmt.Errorf("background shell not found: %s", id)
 	}
 
 	shell.cancel()
-	<-shell.done
-	return nil
+
+	timer := time.NewTimer(killGrace)
+	defer timer.Stop()
+
+	select {
+	case <-shell.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return fmt.Errorf("background shell %s: %w", id, ErrKillEscaped)
+	}
 }
 
 // BackgroundShellInfo contains information about a background shell.

--- a/internal/shell/background_test.go
+++ b/internal/shell/background_test.go
@@ -71,7 +71,7 @@ func TestBackgroundShellManager_Get(t *testing.T) {
 	}
 
 	// Clean up
-	manager.Kill(bgShell.ID)
+	manager.Kill(context.Background(), bgShell.ID)
 }
 
 func TestBackgroundShellManager_Kill(t *testing.T) {
@@ -88,7 +88,7 @@ func TestBackgroundShellManager_Kill(t *testing.T) {
 	}
 
 	// Kill it
-	err = manager.Kill(bgShell.ID)
+	err = manager.Kill(context.Background(), bgShell.ID)
 	if err != nil {
 		t.Errorf("failed to kill background shell: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestBackgroundShellManager_KillNonExistent(t *testing.T) {
 
 	manager := newBackgroundShellManager()
 
-	err := manager.Kill("non-existent-id")
+	err := manager.Kill(context.Background(), "non-existent-id")
 	if err == nil {
 		t.Error("expected error when killing non-existent shell")
 	}
@@ -132,7 +132,7 @@ func TestBackgroundShell_IsDone(t *testing.T) {
 	require.Eventually(t, bgShell.IsDone, 5*time.Second, 50*time.Millisecond, "expected shell to be done")
 
 	// Clean up
-	manager.Kill(bgShell.ID)
+	manager.Kill(context.Background(), bgShell.ID)
 }
 
 func TestBackgroundShell_WithBlockFuncs(t *testing.T) {
@@ -166,7 +166,7 @@ func TestBackgroundShell_WithBlockFuncs(t *testing.T) {
 	}
 
 	// Clean up
-	manager.Kill(bgShell.ID)
+	manager.Kill(context.Background(), bgShell.ID)
 }
 
 func TestBackgroundShellManager_List(t *testing.T) {
@@ -213,8 +213,8 @@ func TestBackgroundShellManager_List(t *testing.T) {
 	}
 
 	// Clean up
-	manager.Kill(bgShell1.ID)
-	manager.Kill(bgShell2.ID)
+	manager.Kill(context.Background(), bgShell1.ID)
+	manager.Kill(context.Background(), bgShell2.ID)
 }
 
 func TestBackgroundShellManager_KillAll(t *testing.T) {
@@ -327,4 +327,61 @@ func TestBackgroundShell_WaitContext_Canceled(t *testing.T) {
 	cancel()
 
 	require.False(t, bgShell.WaitContext(ctx))
+}
+
+func TestBackgroundShellManager_KillReturnsWhenShellNeverFinishes(t *testing.T) {
+	t.Parallel()
+
+	// A shell whose goroutine never finishes, which is what a process that
+	// escaped into its own session leaves behind: it holds the output pipe
+	// open, so ExecStream never returns.
+	_, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	stuck := &BackgroundShell{ID: "STUCK", done: make(chan struct{}), cancel: cancel}
+
+	manager := newBackgroundShellManager()
+	manager.shells.Set(stuck.ID, stuck)
+
+	errc := make(chan error, 1)
+	go func() { errc <- manager.Kill(t.Context(), stuck.ID) }()
+
+	select {
+	case err := <-errc:
+		require.ErrorIs(t, err, ErrKillEscaped)
+	case <-time.After(killGrace + 10*time.Second):
+		t.Fatal("Kill never returned for a shell that does not finish")
+	}
+
+	_, tracked := manager.Get(stuck.ID)
+	require.False(t, tracked, "a killed shell must not stay tracked")
+}
+
+func TestBackgroundShellManager_KillReportsNoErrorOnCleanExit(t *testing.T) {
+	t.Parallel()
+
+	manager := newBackgroundShellManager()
+	bgShell, err := manager.Start(t.Context(), t.TempDir(), nil, "sleep 30", "sleeper")
+	require.NoError(t, err)
+
+	start := time.Now()
+	require.NoError(t, manager.Kill(t.Context(), bgShell.ID))
+	require.Less(t, time.Since(start), killGrace, "a job that exits must not wait out the grace")
+}
+
+func TestBackgroundShellManager_KillStopsWaitingOnCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	_, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	stuck := &BackgroundShell{ID: "STUCK", done: make(chan struct{}), cancel: cancel}
+
+	manager := newBackgroundShellManager()
+	manager.shells.Set(stuck.ID, stuck)
+
+	ctx, cancelCaller := context.WithCancel(t.Context())
+	cancelCaller()
+
+	start := time.Now()
+	require.ErrorIs(t, manager.Kill(ctx, stuck.ID), context.Canceled)
+	require.Less(t, time.Since(start), killGrace, "a canceled caller must not wait out the grace")
 }

--- a/internal/shell/background_unix_test.go
+++ b/internal/shell/background_unix_test.go
@@ -1,0 +1,65 @@
+//go:build !windows
+
+package shell
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBackgroundShellManager_KillWithEscapedProcess drives the real case
+// behind the bounded wait: a job whose child moves itself into a new
+// session survives the process-group kill and holds the shell's output
+// pipe open, so the shell goroutine never finishes.
+func TestBackgroundShellManager_KillWithEscapedProcess(t *testing.T) {
+	t.Parallel()
+
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 is needed to detach a process into its own session")
+	}
+
+	pidFile := filepath.Join(t.TempDir(), "escaped.pid")
+	command := fmt.Sprintf(
+		`%s -c 'import subprocess,sys,time; p=subprocess.Popen(["sleep","120"], start_new_session=True); open(sys.argv[1],"w").write(str(p.pid)); time.sleep(120)' %s`,
+		python, pidFile,
+	)
+
+	manager := newBackgroundShellManager()
+	bgShell, err := manager.Start(t.Context(), t.TempDir(), nil, command, "escapes its process group")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		_, statErr := os.Stat(pidFile)
+		return statErr == nil
+	}, 20*time.Second, 100*time.Millisecond, "detached child never started")
+
+	t.Cleanup(func() {
+		raw, readErr := os.ReadFile(pidFile)
+		if readErr != nil {
+			return
+		}
+		if pid, convErr := strconv.Atoi(strings.TrimSpace(string(raw))); convErr == nil {
+			_ = syscall.Kill(pid, syscall.SIGKILL)
+		}
+	})
+
+	errc := make(chan error, 1)
+	go func() { errc <- manager.Kill(t.Context(), bgShell.ID) }()
+
+	select {
+	case err := <-errc:
+		require.ErrorIs(t, err, ErrKillEscaped)
+	case <-time.After(killGrace + 30*time.Second):
+		t.Fatal("Kill never returned while a detached process held the output pipe")
+	}
+}


### PR DESCRIPTION
## What

`job_kill` never returns when the background job started a process that put itself in a new session, so the tool call hangs and the agent sits there

## Why it happened

`Kill` waits on `<-shell.done` with no bound ([background.go:154](https://github.com/charmbracelet/crush/blob/75791b88/internal/shell/background.go#L154)). That channel closes when `ExecStream` returns, and `ExecStream` cannot return: the exec handler passes a plain `io.Writer` as the command's stdout, so `os/exec` sets up a pipe and `cmd.Wait` waits for every writer of that pipe to close. The exec handler's SIGKILL goes to the process group ([exec_unix.go:68](https://github.com/charmbracelet/crush/blob/75791b88/internal/shell/exec_unix.go#L68)), which a process in its own session is no longer part of, so it keeps the pipe open and the wait never ends

Confirmed by process state at the moment `Kill` was still blocked:

```
Kill still blocked after 20s
direct child (python) still alive: false
escaped grandchild (sleep) still alive: true
```

So the job's own process does die. The one that escaped is what holds the wait open. This part the issue has backwards, it puts the hang on the job not responding to cancel

## Fix

Bound the wait in `Kill`, the way `KillAll` already bounds its own, and take a context so a cancelled caller stops waiting. A job that exits returns nil as before. A job that leaves a process behind returns `ErrKillEscaped`, so the tool tells the model what actually happened instead of hanging

Closes #3404

## Proof

Same scenario, a background job whose child detaches with `start_new_session`:

```
$ go test ./internal/shell -run TestBaseKillHangs          # main
    job_kill hung: Kill has not returned after 30.001346083s
--- FAIL: TestBaseKillHangs (30.70s)

$ go test ./internal/shell -run TestBackgroundShellManager_KillWithEscapedProcess
--- PASS: TestBackgroundShellManager_KillWithEscapedProcess (5.10s)
ok      github.com/charmbracelet/crush/internal/shell    5.509s
```

## Tests

`TestBackgroundShellManager_KillWithEscapedProcess` runs the real case end to end and cleans up the detached process, skipped on Windows and where python3 is missing. Three unit tests cover the rest: a shell that never finishes returns `ErrKillEscaped` and stops being tracked, a job that exits still returns nil well inside the grace, and a cancelled caller returns `context.Canceled` without waiting it out

`go test -race ./internal/shell/... ./internal/agent/tools/...` passes, `GOOS=windows go build ./...` and golangci-lint v2.11 clean
