### PR TITLE
feat(session): restore last used provider/model from session

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -328,6 +328,14 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 
 	if continueSessionID != "" || useLast {
 		slog.Info("Continuing session for non-interactive run", "session_id", sess.ID)
+		// If no explicit model override was requested, restore the
+		// model/provider from the last assistant message in the
+		// session, provided it is still available.
+		if largeModel == "" && smallModel == "" {
+			if err := app.restoreModelFromSession(ctx, sess.ID); err != nil {
+				slog.Warn("Failed to restore model from session", "error", err)
+			}
+		}
 	} else {
 		slog.Info("Created session for non-interactive run", "session_id", sess.ID)
 	}
@@ -430,6 +438,54 @@ func (app *App) UpdateAgentModel(ctx context.Context) error {
 		return fmt.Errorf("agent configuration is missing")
 	}
 	return app.AgentCoordinator.UpdateModels(ctx)
+}
+
+// restoreModelFromSession reads the last assistant message in the
+// session and, if it used a different provider/model than the current
+// config, overrides the preferred model in-memory (non-persistent)
+// provided the provider/model is still available. This ensures that
+// continuing a session uses the same model that produced the last
+// response.
+func (app *App) restoreModelFromSession(ctx context.Context, sessionID string) error {
+	lastMsg, err := app.Messages.GetLastAssistantMessage(ctx, sessionID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("failed to get last assistant message: %w", err)
+	}
+	if lastMsg.Provider == "" || lastMsg.Model == "" {
+		return nil
+	}
+
+	cfg := app.config.Config()
+	currentLarge := cfg.Models[config.SelectedModelTypeLarge]
+	if currentLarge.Provider == lastMsg.Provider && currentLarge.Model == lastMsg.Model {
+		return nil
+	}
+
+	if !cfg.IsModelAvailable(lastMsg.Provider, lastMsg.Model) {
+		slog.Debug("Skipping model restoration: provider/model not available",
+			"provider", lastMsg.Provider,
+			"model", lastMsg.Model)
+		return nil
+	}
+
+	app.config.OverridePreferredModel(config.SelectedModelTypeLarge, config.SelectedModel{
+		Provider: lastMsg.Provider,
+		Model:    lastMsg.Model,
+	})
+	if _, ok := cfg.Models[config.SelectedModelTypeSmall]; !ok {
+		smallModel := app.GetDefaultSmallModel(lastMsg.Provider)
+		app.config.OverridePreferredModel(config.SelectedModelTypeSmall, smallModel)
+	}
+	if err := app.AgentCoordinator.UpdateModels(ctx); err != nil {
+		return fmt.Errorf("failed to update agent models: %w", err)
+	}
+	slog.Info("Restored model from session",
+		"provider", lastMsg.Provider,
+		"model", lastMsg.Model)
+	return nil
 }
 
 // overrideModelsForNonInteractive parses the model strings and temporarily

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -238,6 +238,14 @@ func runNonInteractive(
 	}
 	if continueSessionID != "" || useLast {
 		slog.Info("Continuing session for non-interactive run", "session_id", sess.ID)
+		// If no explicit model override was requested, restore the
+		// model/provider from the last assistant message in the
+		// session, provided it is still available.
+		if largeModel == "" && smallModel == "" {
+			if err := restoreModelFromSession(ctx, c, ws, sess.ID); err != nil {
+				slog.Warn("Failed to restore model from session", "error", err)
+			}
+		}
 	} else {
 		slog.Info("Created session for non-interactive run", "session_id", sess.ID)
 	}
@@ -523,6 +531,63 @@ func overrideModels(
 		} else if sm != nil {
 			if err := c.UpdatePreferredModel(ctx, ws.ID, config.ScopeWorkspace, config.SelectedModelTypeSmall, *sm); err != nil {
 				return fmt.Errorf("failed to set small model: %w", err)
+			}
+		}
+	}
+
+	return c.UpdateAgent(ctx, ws.ID)
+}
+
+// restoreModelFromSession reads the last assistant message in the
+// session and, if it used a different provider/model than the current
+// config, updates the preferred model on the server provided the
+// provider/model is still available. This ensures that continuing a
+// session uses the same model that produced the last response.
+func restoreModelFromSession(ctx context.Context, c *client.Client, ws *proto.Workspace, sessionID string) error {
+	msgs, err := c.ListMessages(ctx, ws.ID, sessionID)
+	if err != nil {
+		return fmt.Errorf("failed to list messages: %w", err)
+	}
+
+	var lastAssistant *proto.Message
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == proto.Assistant && !msgs[i].IsSummaryMessage {
+			lastAssistant = &msgs[i]
+			break
+		}
+	}
+	if lastAssistant == nil || lastAssistant.Provider == "" || lastAssistant.Model == "" {
+		return nil
+	}
+
+	cfg := ws.Config
+	currentLarge := cfg.Models[config.SelectedModelTypeLarge]
+	if currentLarge.Provider == lastAssistant.Provider && currentLarge.Model == lastAssistant.Model {
+		return nil
+	}
+
+	if !cfg.IsModelAvailable(lastAssistant.Provider, lastAssistant.Model) {
+		slog.Debug("Skipping model restoration: provider/model not available",
+			"provider", lastAssistant.Provider,
+			"model", lastAssistant.Model)
+		return nil
+	}
+
+	selectedModel := config.SelectedModel{
+		Provider: lastAssistant.Provider,
+		Model:    lastAssistant.Model,
+	}
+	if err := c.UpdatePreferredModel(ctx, ws.ID, config.ScopeWorkspace, config.SelectedModelTypeLarge, selectedModel); err != nil {
+		return fmt.Errorf("failed to set large model: %w", err)
+	}
+
+	if _, ok := cfg.Models[config.SelectedModelTypeSmall]; !ok {
+		sm, err := c.GetDefaultSmallModel(ctx, ws.ID, lastAssistant.Provider)
+		if err != nil {
+			slog.Warn("Failed to get default small model", "error", err)
+		} else if sm != nil {
+			if err := c.UpdatePreferredModel(ctx, ws.ID, config.ScopeWorkspace, config.SelectedModelTypeSmall, *sm); err != nil {
+				slog.Warn("Failed to set small model during session restore", "error", err)
 			}
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -732,6 +732,21 @@ func (c *Config) GetModel(provider, model string) *catwalk.Model {
 	return nil
 }
 
+// IsModelAvailable returns true if the provider is enabled and the model
+// exists in its catalog. Unlike GetModel, it rejects disabled providers.
+func (c *Config) IsModelAvailable(provider, model string) bool {
+	providerConfig, ok := c.Providers.Get(provider)
+	if !ok || providerConfig.Disable {
+		return false
+	}
+	for _, m := range providerConfig.Models {
+		if m.ID == model {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Config) GetProviderForModel(modelType SelectedModelType) *ProviderConfig {
 	model, ok := c.Models[modelType]
 	if !ok {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -11,10 +11,10 @@ import (
 )
 
 type DBTX interface {
-	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
 	PrepareContext(context.Context, string) (*sql.Stmt, error)
-	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
-	QueryRowContext(context.Context, string, ...any) *sql.Row
+	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
 func New(db DBTX) *Queries {
@@ -62,6 +62,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.getHourDayHeatmapStmt, err = db.PrepareContext(ctx, getHourDayHeatmap); err != nil {
 		return nil, fmt.Errorf("error preparing query GetHourDayHeatmap: %w", err)
+	}
+	if q.getLastAssistantMessageBySessionStmt, err = db.PrepareContext(ctx, getLastAssistantMessageBySession); err != nil {
+		return nil, fmt.Errorf("error preparing query GetLastAssistantMessageBySession: %w", err)
 	}
 	if q.getLastSessionStmt, err = db.PrepareContext(ctx, getLastSession); err != nil {
 		return nil, fmt.Errorf("error preparing query GetLastSession: %w", err)
@@ -203,6 +206,11 @@ func (q *Queries) Close() error {
 	if q.getHourDayHeatmapStmt != nil {
 		if cerr := q.getHourDayHeatmapStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getHourDayHeatmapStmt: %w", cerr)
+		}
+	}
+	if q.getLastAssistantMessageBySessionStmt != nil {
+		if cerr := q.getLastAssistantMessageBySessionStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getLastAssistantMessageBySessionStmt: %w", cerr)
 		}
 	}
 	if q.getLastSessionStmt != nil {
@@ -362,87 +370,89 @@ func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, ar
 }
 
 type Queries struct {
-	db                             DBTX
-	tx                             *sql.Tx
-	createFileStmt                 *sql.Stmt
-	createMessageStmt              *sql.Stmt
-	createSessionStmt              *sql.Stmt
-	deleteFileStmt                 *sql.Stmt
-	deleteMessageStmt              *sql.Stmt
-	deleteSessionStmt              *sql.Stmt
-	deleteSessionFilesStmt         *sql.Stmt
-	deleteSessionMessagesStmt      *sql.Stmt
-	getAverageResponseTimeStmt     *sql.Stmt
-	getFileStmt                    *sql.Stmt
-	getFileByPathAndSessionStmt    *sql.Stmt
-	getFileReadStmt                *sql.Stmt
-	getHourDayHeatmapStmt          *sql.Stmt
-	getLastSessionStmt             *sql.Stmt
-	getMessageStmt                 *sql.Stmt
-	getRecentActivityStmt          *sql.Stmt
-	getSessionByIDStmt             *sql.Stmt
-	getToolUsageStmt               *sql.Stmt
-	getTotalStatsStmt              *sql.Stmt
-	getUsageByDayStmt              *sql.Stmt
-	getUsageByDayOfWeekStmt        *sql.Stmt
-	getUsageByHourStmt             *sql.Stmt
-	getUsageByModelStmt            *sql.Stmt
-	listAllUserMessagesStmt        *sql.Stmt
-	listFilesByPathStmt            *sql.Stmt
-	listFilesBySessionStmt         *sql.Stmt
-	listLatestSessionFilesStmt     *sql.Stmt
-	listMessagesBySessionStmt      *sql.Stmt
-	listNewFilesStmt               *sql.Stmt
-	listSessionReadFilesStmt       *sql.Stmt
-	listSessionsStmt               *sql.Stmt
-	listUserMessagesBySessionStmt  *sql.Stmt
-	recordFileReadStmt             *sql.Stmt
-	renameSessionStmt              *sql.Stmt
-	updateMessageStmt              *sql.Stmt
-	updateSessionStmt              *sql.Stmt
-	updateSessionTitleAndUsageStmt *sql.Stmt
+	db                                   DBTX
+	tx                                   *sql.Tx
+	createFileStmt                       *sql.Stmt
+	createMessageStmt                    *sql.Stmt
+	createSessionStmt                    *sql.Stmt
+	deleteFileStmt                       *sql.Stmt
+	deleteMessageStmt                    *sql.Stmt
+	deleteSessionStmt                    *sql.Stmt
+	deleteSessionFilesStmt               *sql.Stmt
+	deleteSessionMessagesStmt            *sql.Stmt
+	getAverageResponseTimeStmt           *sql.Stmt
+	getFileStmt                          *sql.Stmt
+	getFileByPathAndSessionStmt          *sql.Stmt
+	getFileReadStmt                      *sql.Stmt
+	getHourDayHeatmapStmt                *sql.Stmt
+	getLastAssistantMessageBySessionStmt *sql.Stmt
+	getLastSessionStmt                   *sql.Stmt
+	getMessageStmt                       *sql.Stmt
+	getRecentActivityStmt                *sql.Stmt
+	getSessionByIDStmt                   *sql.Stmt
+	getToolUsageStmt                     *sql.Stmt
+	getTotalStatsStmt                    *sql.Stmt
+	getUsageByDayStmt                    *sql.Stmt
+	getUsageByDayOfWeekStmt              *sql.Stmt
+	getUsageByHourStmt                   *sql.Stmt
+	getUsageByModelStmt                  *sql.Stmt
+	listAllUserMessagesStmt              *sql.Stmt
+	listFilesByPathStmt                  *sql.Stmt
+	listFilesBySessionStmt               *sql.Stmt
+	listLatestSessionFilesStmt           *sql.Stmt
+	listMessagesBySessionStmt            *sql.Stmt
+	listNewFilesStmt                     *sql.Stmt
+	listSessionReadFilesStmt             *sql.Stmt
+	listSessionsStmt                     *sql.Stmt
+	listUserMessagesBySessionStmt        *sql.Stmt
+	recordFileReadStmt                   *sql.Stmt
+	renameSessionStmt                    *sql.Stmt
+	updateMessageStmt                    *sql.Stmt
+	updateSessionStmt                    *sql.Stmt
+	updateSessionTitleAndUsageStmt       *sql.Stmt
 }
 
 func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 	return &Queries{
-		db:                             tx,
-		tx:                             tx,
-		createFileStmt:                 q.createFileStmt,
-		createMessageStmt:              q.createMessageStmt,
-		createSessionStmt:              q.createSessionStmt,
-		deleteFileStmt:                 q.deleteFileStmt,
-		deleteMessageStmt:              q.deleteMessageStmt,
-		deleteSessionStmt:              q.deleteSessionStmt,
-		deleteSessionFilesStmt:         q.deleteSessionFilesStmt,
-		deleteSessionMessagesStmt:      q.deleteSessionMessagesStmt,
-		getAverageResponseTimeStmt:     q.getAverageResponseTimeStmt,
-		getFileStmt:                    q.getFileStmt,
-		getFileByPathAndSessionStmt:    q.getFileByPathAndSessionStmt,
-		getFileReadStmt:                q.getFileReadStmt,
-		getHourDayHeatmapStmt:          q.getHourDayHeatmapStmt,
-		getLastSessionStmt:             q.getLastSessionStmt,
-		getMessageStmt:                 q.getMessageStmt,
-		getRecentActivityStmt:          q.getRecentActivityStmt,
-		getSessionByIDStmt:             q.getSessionByIDStmt,
-		getToolUsageStmt:               q.getToolUsageStmt,
-		getTotalStatsStmt:              q.getTotalStatsStmt,
-		getUsageByDayStmt:              q.getUsageByDayStmt,
-		getUsageByDayOfWeekStmt:        q.getUsageByDayOfWeekStmt,
-		getUsageByHourStmt:             q.getUsageByHourStmt,
-		getUsageByModelStmt:            q.getUsageByModelStmt,
-		listAllUserMessagesStmt:        q.listAllUserMessagesStmt,
-		listFilesByPathStmt:            q.listFilesByPathStmt,
-		listFilesBySessionStmt:         q.listFilesBySessionStmt,
-		listLatestSessionFilesStmt:     q.listLatestSessionFilesStmt,
-		listMessagesBySessionStmt:      q.listMessagesBySessionStmt,
-		listNewFilesStmt:               q.listNewFilesStmt,
-		listSessionReadFilesStmt:       q.listSessionReadFilesStmt,
-		listSessionsStmt:               q.listSessionsStmt,
-		listUserMessagesBySessionStmt:  q.listUserMessagesBySessionStmt,
-		recordFileReadStmt:             q.recordFileReadStmt,
-		renameSessionStmt:              q.renameSessionStmt,
-		updateMessageStmt:              q.updateMessageStmt,
-		updateSessionStmt:              q.updateSessionStmt,
-		updateSessionTitleAndUsageStmt: q.updateSessionTitleAndUsageStmt,
+		db:                                   tx,
+		tx:                                   tx,
+		createFileStmt:                       q.createFileStmt,
+		createMessageStmt:                    q.createMessageStmt,
+		createSessionStmt:                    q.createSessionStmt,
+		deleteFileStmt:                       q.deleteFileStmt,
+		deleteMessageStmt:                    q.deleteMessageStmt,
+		deleteSessionStmt:                    q.deleteSessionStmt,
+		deleteSessionFilesStmt:               q.deleteSessionFilesStmt,
+		deleteSessionMessagesStmt:            q.deleteSessionMessagesStmt,
+		getAverageResponseTimeStmt:           q.getAverageResponseTimeStmt,
+		getFileStmt:                          q.getFileStmt,
+		getFileByPathAndSessionStmt:          q.getFileByPathAndSessionStmt,
+		getFileReadStmt:                      q.getFileReadStmt,
+		getHourDayHeatmapStmt:                q.getHourDayHeatmapStmt,
+		getLastAssistantMessageBySessionStmt: q.getLastAssistantMessageBySessionStmt,
+		getLastSessionStmt:                   q.getLastSessionStmt,
+		getMessageStmt:                       q.getMessageStmt,
+		getRecentActivityStmt:                q.getRecentActivityStmt,
+		getSessionByIDStmt:                   q.getSessionByIDStmt,
+		getToolUsageStmt:                     q.getToolUsageStmt,
+		getTotalStatsStmt:                    q.getTotalStatsStmt,
+		getUsageByDayStmt:                    q.getUsageByDayStmt,
+		getUsageByDayOfWeekStmt:              q.getUsageByDayOfWeekStmt,
+		getUsageByHourStmt:                   q.getUsageByHourStmt,
+		getUsageByModelStmt:                  q.getUsageByModelStmt,
+		listAllUserMessagesStmt:              q.listAllUserMessagesStmt,
+		listFilesByPathStmt:                  q.listFilesByPathStmt,
+		listFilesBySessionStmt:               q.listFilesBySessionStmt,
+		listLatestSessionFilesStmt:           q.listLatestSessionFilesStmt,
+		listMessagesBySessionStmt:            q.listMessagesBySessionStmt,
+		listNewFilesStmt:                     q.listNewFilesStmt,
+		listSessionReadFilesStmt:             q.listSessionReadFilesStmt,
+		listSessionsStmt:                     q.listSessionsStmt,
+		listUserMessagesBySessionStmt:        q.listUserMessagesBySessionStmt,
+		recordFileReadStmt:                   q.recordFileReadStmt,
+		renameSessionStmt:                    q.renameSessionStmt,
+		updateMessageStmt:                    q.updateMessageStmt,
+		updateSessionStmt:                    q.updateSessionStmt,
+		updateSessionTitleAndUsageStmt:       q.updateSessionTitleAndUsageStmt,
 	}
 }

--- a/internal/db/messages.sql.go
+++ b/internal/db/messages.sql.go
@@ -83,6 +83,32 @@ func (q *Queries) DeleteSessionMessages(ctx context.Context, sessionID string) e
 	return err
 }
 
+const getLastAssistantMessageBySession = `-- name: GetLastAssistantMessageBySession :one
+SELECT id, session_id, role, parts, model, created_at, updated_at, finished_at, provider, is_summary_message
+FROM messages
+WHERE session_id = ? AND role = 'assistant' AND is_summary_message = 0
+ORDER BY created_at DESC
+LIMIT 1
+`
+
+func (q *Queries) GetLastAssistantMessageBySession(ctx context.Context, sessionID string) (Message, error) {
+	row := q.queryRow(ctx, q.getLastAssistantMessageBySessionStmt, getLastAssistantMessageBySession, sessionID)
+	var i Message
+	err := row.Scan(
+		&i.ID,
+		&i.SessionID,
+		&i.Role,
+		&i.Parts,
+		&i.Model,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.FinishedAt,
+		&i.Provider,
+		&i.IsSummaryMessage,
+	)
+	return i, err
+}
+
 const getMessage = `-- name: GetMessage :one
 SELECT id, session_id, role, parts, model, created_at, updated_at, finished_at, provider, is_summary_message
 FROM messages

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -22,6 +22,7 @@ type Querier interface {
 	GetFileByPathAndSession(ctx context.Context, arg GetFileByPathAndSessionParams) (File, error)
 	GetFileRead(ctx context.Context, arg GetFileReadParams) (ReadFile, error)
 	GetHourDayHeatmap(ctx context.Context) ([]GetHourDayHeatmapRow, error)
+	GetLastAssistantMessageBySession(ctx context.Context, sessionID string) (Message, error)
 	GetLastSession(ctx context.Context) (Session, error)
 	GetMessage(ctx context.Context, id string) (Message, error)
 	GetRecentActivity(ctx context.Context) ([]GetRecentActivityRow, error)

--- a/internal/db/sql/messages.sql
+++ b/internal/db/sql/messages.sql
@@ -53,3 +53,10 @@ SELECT *
 FROM messages
 WHERE role = 'user'
 ORDER BY created_at DESC;
+
+-- name: GetLastAssistantMessageBySession :one
+SELECT *
+FROM messages
+WHERE session_id = ? AND role = 'assistant' AND is_summary_message = 0
+ORDER BY created_at DESC
+LIMIT 1;

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -51,6 +51,7 @@ type Service interface {
 	List(ctx context.Context, sessionID string) ([]Message, error)
 	ListUserMessages(ctx context.Context, sessionID string) ([]Message, error)
 	ListAllUserMessages(ctx context.Context) ([]Message, error)
+	GetLastAssistantMessage(ctx context.Context, sessionID string) (Message, error)
 	Delete(ctx context.Context, id string) error
 	DeleteSessionMessages(ctx context.Context, sessionID string) error
 
@@ -496,6 +497,14 @@ func (s *service) ListAllUserMessages(ctx context.Context) ([]Message, error) {
 		}
 	}
 	return messages, nil
+}
+
+func (s *service) GetLastAssistantMessage(ctx context.Context, sessionID string) (Message, error) {
+	dbMessage, err := s.q.GetLastAssistantMessageBySession(ctx, sessionID)
+	if err != nil {
+		return Message{}, err
+	}
+	return s.fromDBItem(dbMessage)
 }
 
 func (s *service) fromDBItem(item db.Message) (Message, error) {

--- a/internal/proto/message.go
+++ b/internal/proto/message.go
@@ -21,14 +21,15 @@ type CreateMessageParams struct {
 
 // Message represents a message in the proto layer.
 type Message struct {
-	ID        string        `json:"id"`
-	Role      MessageRole   `json:"role"`
-	SessionID string        `json:"session_id"`
-	Parts     []ContentPart `json:"parts"`
-	Model     string        `json:"model"`
-	Provider  string        `json:"provider"`
-	CreatedAt int64         `json:"created_at"`
-	UpdatedAt int64         `json:"updated_at"`
+	ID               string        `json:"id"`
+	Role             MessageRole   `json:"role"`
+	SessionID        string        `json:"session_id"`
+	Parts            []ContentPart `json:"parts"`
+	Model            string        `json:"model"`
+	Provider         string        `json:"provider"`
+	CreatedAt        int64         `json:"created_at"`
+	UpdatedAt        int64         `json:"updated_at"`
+	IsSummaryMessage bool          `json:"is_summary_message,omitempty"`
 }
 
 // MessageRole represents the role of a message sender.

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -267,13 +267,14 @@ func fileToProto(f history.File) proto.File {
 
 func messageToProto(m message.Message) proto.Message {
 	msg := proto.Message{
-		ID:        m.ID,
-		SessionID: m.SessionID,
-		Role:      proto.MessageRole(m.Role),
-		Model:     m.Model,
-		Provider:  m.Provider,
-		CreatedAt: m.CreatedAt,
-		UpdatedAt: m.UpdatedAt,
+		ID:               m.ID,
+		SessionID:        m.SessionID,
+		Role:             proto.MessageRole(m.Role),
+		Model:            m.Model,
+		Provider:         m.Provider,
+		CreatedAt:        m.CreatedAt,
+		UpdatedAt:        m.UpdatedAt,
+		IsSummaryMessage: m.IsSummaryMessage,
 	}
 
 	for _, p := range m.Parts {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -770,6 +770,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if cmd := m.setSessionMessages(msgs); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+		if cmd := m.restoreModelFromSession(msgs); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 		if cmd := m.autoExpandPillsIfReasonable(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
@@ -2170,6 +2173,69 @@ func (m *UI) fetchHyperCredits() tea.Cmd {
 		}
 		return creditsUpdatedMsg{credits: credits}
 	}
+}
+
+// restoreModelFromSession checks the last assistant message in the
+// loaded session and, if it used a different provider/model than the
+// current config, restores that model/provider provided it is still
+// available. Returns a tea.Cmd that rebuilds the agent models if a
+// switch was made, or nil if no switch was needed.
+func (m *UI) restoreModelFromSession(msgs []message.Message) tea.Cmd {
+	var lastAssistant *message.Message
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role == message.Assistant && !msgs[i].IsSummaryMessage {
+			lastAssistant = &msgs[i]
+			break
+		}
+	}
+	if lastAssistant == nil || lastAssistant.Provider == "" || lastAssistant.Model == "" {
+		return nil
+	}
+
+	cfg := m.com.Config()
+	if cfg == nil {
+		return nil
+	}
+
+	currentLarge := cfg.Models[config.SelectedModelTypeLarge]
+	if currentLarge.Provider == lastAssistant.Provider && currentLarge.Model == lastAssistant.Model {
+		return nil
+	}
+
+	if !cfg.IsModelAvailable(lastAssistant.Provider, lastAssistant.Model) {
+		slog.Debug("Skipping model restoration: provider/model not available",
+			"provider", lastAssistant.Provider,
+			"model", lastAssistant.Model)
+		return nil
+	}
+
+	selectedModel := config.SelectedModel{
+		Provider: lastAssistant.Provider,
+		Model:    lastAssistant.Model,
+	}
+	if err := m.com.Workspace.UpdatePreferredModel(config.ScopeGlobal, config.SelectedModelTypeLarge, selectedModel); err != nil {
+		slog.Error("Failed to restore model from session", "error", err)
+		return nil
+	}
+
+	m.applyThemeForProvider(lastAssistant.Provider)
+
+	if _, ok := cfg.Models[config.SelectedModelTypeSmall]; !ok {
+		smallModel := m.com.Workspace.GetDefaultSmallModel(lastAssistant.Provider)
+		if err := m.com.Workspace.UpdatePreferredModel(config.ScopeGlobal, config.SelectedModelTypeSmall, smallModel); err != nil {
+			slog.Error("Failed to set small model during session restore", "error", err)
+		}
+	}
+
+	return m.updateAgentModelCmd(func() tea.Msg {
+		if err := m.com.Workspace.UpdateAgentModel(context.TODO()); err != nil {
+			return util.ReportError(err)
+		}
+		slog.Info("Restored model from session",
+			"provider", lastAssistant.Provider,
+			"model", lastAssistant.Model)
+		return nil
+	})
 }
 
 // handleSelectModel performs the model selection after any provider

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -1275,13 +1275,14 @@ func protoToFile(f proto.File) history.File {
 
 func protoToMessage(m proto.Message) message.Message {
 	msg := message.Message{
-		ID:        m.ID,
-		SessionID: m.SessionID,
-		Role:      message.MessageRole(m.Role),
-		Model:     m.Model,
-		Provider:  m.Provider,
-		CreatedAt: m.CreatedAt,
-		UpdatedAt: m.UpdatedAt,
+		ID:               m.ID,
+		SessionID:        m.SessionID,
+		Role:             message.MessageRole(m.Role),
+		Model:            m.Model,
+		Provider:         m.Provider,
+		CreatedAt:        m.CreatedAt,
+		UpdatedAt:        m.UpdatedAt,
+		IsSummaryMessage: m.IsSummaryMessage,
 	}
 
 	for _, p := range m.Parts {


### PR DESCRIPTION
When continuing or loading a session, the provider and model are now restored to the last ones used in that session. If the provider/model is no longer available this is a noöp. This covers interactive mode, `crush run`, and client-server.

Funny enough, it fixes a bunch of other annoying behavior around model selection as well.