### PR TITLE
telemetry: differentiate invocation types

### DIFF
--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -17,9 +17,10 @@ const (
 	endpoint = "https://data.charm.land"
 	key      = "phc_4zt4VgDWLqbYnJYEwLRxFoaTL2noNrQij0C6E8k3I0V"
 
-	nonInteractiveAttrName      = "NonInteractive"
-	continueSessionByIDAttrName = "ContinueSessionByID"
-	continueLastSessionAttrName = "ContinueLastSession"
+	nonInteractiveAttrName       = "NonInteractive"
+	nonInteractiveNestedAttrName = "NonInteractiveNested"
+	continueSessionByIDAttrName  = "ContinueSessionByID"
+	continueLastSessionAttrName  = "ContinueLastSession"
 )
 
 var (
@@ -32,11 +33,14 @@ var (
 			Set("SHELL", filepath.Base(os.Getenv("SHELL"))).
 			Set("Version", version.Version).
 			Set("GoVersion", runtime.Version()).
-			Set(nonInteractiveAttrName, false)
+			Set(nonInteractiveAttrName, false).
+			Set(nonInteractiveNestedAttrName, false)
 )
 
 func SetNonInteractive(nonInteractive bool) {
-	baseProps = baseProps.Set(nonInteractiveAttrName, nonInteractive)
+	baseProps = baseProps.
+		Set(nonInteractiveAttrName, nonInteractive).
+		Set(nonInteractiveNestedAttrName, nonInteractive && os.Getenv("CRUSH") == "1")
 }
 
 func SetContinueBySessionID(continueBySessionID bool) {

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -10,6 +10,60 @@ import (
 	"github.com/posthog/posthog-go"
 )
 
+func TestSetNonInteractive(t *testing.T) {
+	originalNonInteractive := baseProps[nonInteractiveAttrName]
+	originalNonInteractiveNested := baseProps[nonInteractiveNestedAttrName]
+	t.Cleanup(func() {
+		baseProps = baseProps.
+			Set(nonInteractiveAttrName, originalNonInteractive).
+			Set(nonInteractiveNestedAttrName, originalNonInteractiveNested)
+	})
+
+	tests := []struct {
+		name                     string
+		nonInteractive           bool
+		crush                    string
+		wantNonInteractiveNested bool
+	}{
+		{
+			name: "interactive direct invocation",
+		},
+		{
+			name:           "non-interactive direct invocation",
+			nonInteractive: true,
+		},
+		{
+			name:  "interactive nested invocation",
+			crush: "1",
+		},
+		{
+			name:                     "non-interactive nested invocation",
+			nonInteractive:           true,
+			crush:                    "1",
+			wantNonInteractiveNested: true,
+		},
+		{
+			name:           "non-interactive invocation with unrecognized marker",
+			nonInteractive: true,
+			crush:          "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CRUSH", tt.crush)
+			SetNonInteractive(tt.nonInteractive)
+
+			if got := baseProps[nonInteractiveAttrName]; got != tt.nonInteractive {
+				t.Errorf("%s = %v, want %v", nonInteractiveAttrName, got, tt.nonInteractive)
+			}
+			if got := baseProps[nonInteractiveNestedAttrName]; got != tt.wantNonInteractiveNested {
+				t.Errorf("%s = %v, want %v", nonInteractiveNestedAttrName, got, tt.wantNonInteractiveNested)
+			}
+		})
+	}
+}
+
 func TestError(t *testing.T) {
 	t.Run("returns early when client is nil", func(t *testing.T) {
 		// This test verifies that when the PostHog client is not initialized


### PR DESCRIPTION
I suspect lots of `crush run` is just from people telling their interactive Crush to use `crush run` for write-capable subagents, since our built in subagents are currently hobbled.

This checks for nesting on startup by looking for an env var the shell tool already sets for all shell invocations. If `crush run` sees the env var, it knows it's a non-interactive instance launched by another possibly interactive, possibly noninteractive instance.