### PR TITLE
feat: ctrl+end to go to the bottom and follow

### DIFF
--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -228,6 +228,13 @@ func (m *Chat) Draw(scr uv.Screen, area uv.Rectangle) {
 	}
 
 	rendered := m.list.Render()
+	// If we're in follow mode but the render revealed we're no longer at
+	// the bottom (e.g. streaming content grew an item), re-anchor and
+	// re-render so the view stays pinned to the end.
+	if m.follow && !m.list.AtBottom() {
+		m.list.ScrollToBottom()
+		rendered = m.list.Render()
+	}
 	method, ok := scr.WidthMethod().(ansi.Method)
 	if !ok {
 		// Width method isn't an ansi.Method (unlikely in practice — both
@@ -616,6 +623,15 @@ func (m *Chat) ScrollToTopAndAnimate() tea.Cmd {
 // restart any paused animations that are now visible.
 func (m *Chat) ScrollToBottomAndAnimate() tea.Cmd {
 	return tea.Batch(m.ScrollToBottom(), m.RestartPausedVisibleAnimations())
+}
+
+// ScrollToBottomAndSelectLast scrolls the chat view to the bottom, selects
+// the last item, and returns a command to restart any paused animations that
+// are now visible.
+func (m *Chat) ScrollToBottomAndSelectLast() tea.Cmd {
+	cmd := m.ScrollToBottomAndAnimate()
+	m.SelectLast()
+	return cmd
 }
 
 // ScrollByAndAnimate scrolls the chat view by the given number of line deltas and returns

--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -43,6 +43,7 @@ type KeyMap struct {
 		HalfPageUp     key.Binding
 		Home           key.Binding
 		End            key.Binding
+		EndFollow      key.Binding
 		Copy           key.Binding
 		ClearHighlight key.Binding
 		Expand         key.Binding
@@ -236,6 +237,9 @@ func DefaultKeyMap() KeyMap {
 	km.Chat.End = key.NewBinding(
 		key.WithKeys("G", "end"),
 		key.WithHelp("G", "end"),
+	)
+	km.Chat.EndFollow = key.NewBinding(
+		key.WithKeys("ctrl+end"),
 	)
 	km.Chat.Copy = key.NewBinding(
 		key.WithKeys("c", "y", "C", "Y"),

--- a/internal/ui/model/layout_test.go
+++ b/internal/ui/model/layout_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/ui/chat"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	uv "github.com/charmbracelet/ultraviolet"
 )
 
 // testMessageItem is a minimal chat item used to populate the chat list
@@ -26,6 +27,28 @@ func (m testMessageItem) Version() uint64      { return 0 }
 func (m testMessageItem) Finished() bool       { return true }
 
 var _ chat.MessageItem = testMessageItem{}
+
+// mutableMessageItem is a test message item whose rendered height can grow
+// over time, simulating streaming content that increases the item's height.
+type mutableMessageItem struct {
+	id      string
+	lines   int
+	version uint64
+}
+
+func (m *mutableMessageItem) ID() string { return m.id }
+func (m *mutableMessageItem) Render(width int) string {
+	lines := make([]string, m.lines)
+	for i := range lines {
+		lines[i] = "line"
+	}
+	return strings.Join(lines, "\n")
+}
+func (m *mutableMessageItem) RawRender(width int) string { return m.Render(width) }
+func (m *mutableMessageItem) Version() uint64            { return m.version }
+func (m *mutableMessageItem) Finished() bool             { return false }
+
+var _ chat.MessageItem = (*mutableMessageItem)(nil)
 
 // newTestUI builds a focused uiChat model with dynamic textarea sizing enabled.
 // It intentionally keeps dependencies minimal so layout behavior can be tested
@@ -118,6 +141,87 @@ func TestHandleTextareaHeightChange_FollowModeStaysAtBottom(t *testing.T) {
 	}
 	if !u.chat.AtBottom() {
 		t.Fatal("expected chat to remain at bottom after editor resize in follow mode")
+	}
+}
+
+func TestScrollByDown_EnablesFollowAtBottom(t *testing.T) {
+	t.Parallel()
+
+	// Use enough messages to make the chat scrollable so AtBottom/Follow
+	// assertions are meaningful.
+	u := newTestUI()
+
+	msgs := make([]chat.MessageItem, 0, 60)
+	for i := range 60 {
+		msgs = append(msgs, testMessageItem{
+			id:   "m-" + strconv.Itoa(i),
+			text: "message " + strconv.Itoa(i),
+		})
+	}
+	u.chat.SetMessages(msgs...)
+	u.updateLayoutAndSize()
+
+	// Start at the top with follow disabled, simulating a user that
+	// scrolled up to read earlier messages.
+	u.chat.ScrollToTop()
+	if u.chat.Follow() {
+		t.Fatal("expected follow mode to be disabled after scrolling to top")
+	}
+
+	// Scroll down in small increments (like mouse wheel ticks) until we
+	// reach the bottom. Follow mode should re-enable once the bottom is
+	// reached so the view sticks to new content.
+	for range 200 {
+		if u.chat.AtBottom() {
+			break
+		}
+		u.chat.ScrollBy(3)
+	}
+
+	if !u.chat.AtBottom() {
+		t.Fatal("expected chat to be at bottom after scrolling down")
+	}
+	if !u.chat.Follow() {
+		t.Fatal("expected follow mode to be enabled after scrolling to bottom")
+	}
+}
+
+func TestFollowStaysAtBottomWhenContentGrows(t *testing.T) {
+	t.Parallel()
+
+	u := newTestUI()
+
+	// Create enough static messages to make the chat scrollable, plus one
+	// mutable item at the end that will grow (simulating streaming).
+	msgs := make([]chat.MessageItem, 0, 60)
+	for i := range 59 {
+		msgs = append(msgs, testMessageItem{
+			id:   "m-" + strconv.Itoa(i),
+			text: "message " + strconv.Itoa(i),
+		})
+	}
+	streaming := &mutableMessageItem{id: "streaming", lines: 1, version: 1}
+	msgs = append(msgs, streaming)
+	u.chat.SetMessages(msgs...)
+	u.updateLayoutAndSize()
+
+	// Start at the bottom in follow mode.
+	u.chat.ScrollToBottom()
+	if !u.chat.AtBottom() {
+		t.Fatal("expected chat to start at bottom")
+	}
+
+	// Simulate streaming: grow the last item's height.
+	streaming.lines = 20
+	streaming.version++
+
+	// Trigger a draw (which renders the list and updates cached heights).
+	// The follow re-anchor in Draw should keep us pinned to the bottom.
+	scr := uv.NewScreenBuffer(u.width, u.height)
+	u.chat.Draw(scr, u.layout.main)
+
+	if !u.chat.AtBottom() {
+		t.Fatal("expected chat to remain at bottom after streaming content grew while following")
 	}
 }
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1720,10 +1720,9 @@ func (m *UI) updateSessionMessage(msg message.Message) tea.Cmd {
 
 	m.chat.AppendMessages(items...)
 	if m.chat.Follow() {
-		if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
+		if cmd := m.chat.ScrollToBottomAndSelectLast(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
-		m.chat.SelectLast()
 	}
 
 	return tea.Sequence(cmds...)
@@ -1813,10 +1812,9 @@ func (m *UI) handleChildSessionMessage(event pubsub.Event[message.Message]) tea.
 	m.chat.UpdateNestedToolIDs(toolCallID)
 
 	if m.chat.Follow() {
-		if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
+		if cmd := m.chat.ScrollToBottomAndSelectLast(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
-		m.chat.SelectLast()
 	}
 
 	return tea.Sequence(cmds...)
@@ -2328,6 +2326,13 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			m.detailsOpen = !m.detailsOpen
 			m.updateLayoutAndSize()
 			return true
+		case key.Matches(msg, m.keyMap.Chat.EndFollow):
+			if m.state == uiChat && m.hasSession() {
+				if cmd := m.chat.ScrollToBottomAndSelectLast(); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
+				return true
+			}
 		case key.Matches(msg, m.keyMap.Chat.TogglePills):
 			if m.state == uiChat && m.hasSession() {
 				if cmd := m.togglePillsExpanded(); cmd != nil {
@@ -2745,10 +2750,9 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				}
 				m.chat.SelectFirst()
 			case key.Matches(msg, m.keyMap.Chat.End):
-				if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
+				if cmd := m.chat.ScrollToBottomAndSelectLast(); cmd != nil {
 					cmds = append(cmds, cmd)
 				}
-				m.chat.SelectLast()
 			default:
 				if ok, cmd := m.chat.HandleKeyMsg(msg); ok {
 					cmds = append(cmds, cmd)
@@ -3162,7 +3166,7 @@ func (m *UI) FullHelp() [][]key.Binding {
 			k.ToggleYolo,
 		)
 		if hasSession {
-			mainBinds = append(mainBinds, k.Chat.NewSession)
+			mainBinds = append(mainBinds, k.Chat.NewSession, k.Chat.EndFollow)
 		}
 
 		binds = append(binds, mainBinds)
@@ -3216,6 +3220,7 @@ func (m *UI) FullHelp() [][]key.Binding {
 					k.Chat.HalfPageDown,
 					k.Chat.Home,
 					k.Chat.End,
+					k.Chat.EndFollow,
 					k.Chat.FocusSidebar,
 				},
 				[]key.Binding{


### PR DESCRIPTION
## What?

Adds `ctrl+end` (stolen from Claude Code, up to suggestions) keybind that returns to the end of the chat and starts following the stream


## Why?

A lot of complaints were in Discord regarding the scrolling and how it is impossible to return and start following the chat, except by chance