### PR TITLE
feat(herdr): Herdr compat improvements: overhaul agent state reporting and pane integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,12 +626,13 @@ the agent finishes its turn. They're only sent when the terminal window isn't
 focused _and_ your terminal supports reporting the focus state.
 
 ```bash
-# Choose auto, native, osc, bell, or disabled.
+# Choose auto, native, osc, bell, herdr, or disabled.
 option notifications disabled
 ```
 
 `auto` uses native notifications locally and OSC notifications over SSH when
-supported.
+supported. `herdr` surfaces toasts in herdr's own UI and only works when Crush
+runs inside a herdr pane; outside one it falls back to OSC.
 
 ### Initialization
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -483,7 +483,7 @@ String Keys:
   data-directory string            directory for project data and state
   initialize-as string             context filename created by crush init
   notifications string             notification style: auto, native, osc, bell,
-                                   or disabled
+                                   herdr, or disabled
   attribution-trailer-style string attribution trailer: none, co-authored-by,
                                    or assisted-by
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -231,11 +231,15 @@ func (app *App) RunCompletions() *pubsub.Broker[notify.RunComplete] {
 
 // ReportCurrentSession tells herdr which session the user is now
 // viewing so the pane can show its title and persist a resumable
-// reference. Safe to call when not running inside a herdr pane; the
-// underlying client is nil-safe. Call this whenever the active
-// session changes (load, new, or select). An empty sessionID clears
-// the presentation (landing screen).
+// reference. A no-op when not running inside a herdr pane. Call this
+// whenever the active session changes (load, new, or select). An
+// empty sessionID clears the presentation (landing screen).
 func (app *App) ReportCurrentSession(ctx context.Context, sessionID string) {
+	// Outside a herdr pane there is nothing to report to, so the
+	// title lookup would be a database read for no one.
+	if app.herdrClient == nil {
+		return
+	}
 	var title string
 	if sessionID != "" {
 		sess, err := app.Sessions.Get(ctx, sessionID)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -147,10 +147,12 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 	// Start herdr integration when running inside a herdr pane.
 	app.herdrClient = herdr.Init()
 	herdr.BridgeLocal(ctx, app.herdrClient, herdr.BridgeSources{
-		PermRequests:      app.Permissions,
-		PermNotifications: app.Permissions,
-		RunCompletions:    app.runCompletions,
-		Messages:          app.Messages,
+		PermRequests:          app.Permissions,
+		PermNotifications:     app.Permissions,
+		RunCompletions:        app.runCompletions,
+		Messages:              app.Messages,
+		Questions:             app.Questions,
+		QuestionNotifications: app.Questions,
 	})
 
 	// Release the shared database connection on shutdown. The pool

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -153,6 +153,7 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 		Messages:              app.Messages,
 		Questions:             app.Questions,
 		QuestionNotifications: app.Questions,
+		Notifications:         app.agentNotifications,
 	})
 
 	// Release the shared database connection on shutdown. The pool

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -154,7 +154,11 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 		Questions:             app.Questions,
 		QuestionNotifications: app.Questions,
 		Notifications:         app.agentNotifications,
+		Sessions:              app.Sessions,
 	})
+	if model, ok := cfg.Models[config.SelectedModelTypeLarge]; ok {
+		app.herdrClient.ReportModel(model.Model)
+	}
 
 	// Release the shared database connection on shutdown. The pool
 	// closes the underlying *sql.DB when the last reference is released.
@@ -226,12 +230,22 @@ func (app *App) RunCompletions() *pubsub.Broker[notify.RunComplete] {
 }
 
 // ReportCurrentSession tells herdr which session the user is now
-// viewing so it can persist a resumable reference for the pane. Safe
-// to call when not running inside a herdr pane; the underlying client
-// is nil-safe. Call this whenever the active session changes (load,
-// new, or select).
-func (app *App) ReportCurrentSession(sessionID string) {
-	app.herdrClient.SetSessionID(sessionID)
+// viewing so the pane can show its title and persist a resumable
+// reference. Safe to call when not running inside a herdr pane; the
+// underlying client is nil-safe. Call this whenever the active
+// session changes (load, new, or select). An empty sessionID clears
+// the presentation (landing screen).
+func (app *App) ReportCurrentSession(ctx context.Context, sessionID string) {
+	var title string
+	if sessionID != "" {
+		sess, err := app.Sessions.Get(ctx, sessionID)
+		if err != nil {
+			slog.Debug("Failed to look up session title for herdr", "session_id", sessionID, "error", err)
+		} else {
+			title = sess.Title
+		}
+	}
+	app.herdrClient.SetSession(sessionID, title)
 }
 
 // resolveSession resolves which session to use for a non-interactive run
@@ -340,7 +354,7 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 	app.Permissions.AutoApproveSession(sess.ID)
 
 	// Report session identity to herdr.
-	app.ReportCurrentSession(sess.ID)
+	app.ReportCurrentSession(ctx, sess.ID)
 
 	type response struct {
 		result *fantasy.AgentResult

--- a/internal/app/report_current_session_test.go
+++ b/internal/app/report_current_session_test.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReportCurrentSession_NoLookupWithoutHerdr pins that the
+// session-title lookup only happens when a herdr client is attached.
+// The title exists solely to feed herdr's pane metadata, and
+// ReportCurrentSession runs on every session load, new and select, so
+// outside a herdr pane the read is pure overhead.
+func TestReportCurrentSession_NoLookupWithoutHerdr(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockSessionService{sessions: []session.Session{{ID: "s1", Title: "Title"}}}
+	app := newTestApp(mock)
+	require.Nil(t, app.herdrClient)
+
+	app.ReportCurrentSession(t.Context(), "s1")
+
+	require.Empty(t, mock.gets)
+}

--- a/internal/app/resolve_session_test.go
+++ b/internal/app/resolve_session_test.go
@@ -16,6 +16,9 @@ import (
 type mockSessionService struct {
 	sessions []session.Session
 	created  []session.Session
+	// gets records every Get lookup, so tests can assert that a
+	// caller did not read a session it had no use for.
+	gets []string
 }
 
 func (m *mockSessionService) Subscribe(context.Context) <-chan pubsub.Event[session.Session] {
@@ -37,6 +40,7 @@ func (m *mockSessionService) CreateTaskSession(context.Context, string, string, 
 }
 
 func (m *mockSessionService) Get(_ context.Context, id string) (session.Session, error) {
+	m.gets = append(m.gets, id)
 	for _, s := range m.sessions {
 		if s.ID == id {
 			return s, nil

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -35,6 +35,7 @@ import (
 	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/server"
 	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/shell"
 	"github.com/charmbracelet/crush/internal/skills"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	ui "github.com/charmbracelet/crush/internal/ui/model"
@@ -855,6 +856,12 @@ func startDetachedServer(cmd *cobra.Command, hostURL *url.URL) error {
 	// DETACHED_PROCESS on windows) is what truly detaches the child from
 	// this process's lifetime.
 	c := exec.CommandContext(context.Background(), exe, cmdArgs...)
+
+	// Strip herdr pane-ownership vars as defense in depth: even if the
+	// server ever skipped herdr.Disable, without these it cannot
+	// attach to or release this pane's agent authority.
+	c.Env = shell.WithoutHerdrEnv(os.Environ())
+
 	stdoutPath := filepath.Join(chDir, "stdout.log")
 	stderrPath := filepath.Join(chDir, "stderr.log")
 	detachProcess(c)

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -266,7 +266,12 @@ func runNonInteractive(
 
 	// Start herdr integration when running inside a herdr pane.
 	hc := herdr.Init()
-	hc.SetSessionID(sess.ID)
+	hc.SetSession(sess.ID, sess.Title)
+	if ws.Config != nil {
+		if model, ok := ws.Config.Models[config.SelectedModelTypeLarge]; ok {
+			hc.ReportModel(model.Model)
+		}
+	}
 	defer hc.Close()
 
 	defer func() {

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/herdr"
 	crushlog "github.com/charmbracelet/crush/internal/log"
 	"github.com/charmbracelet/crush/internal/server"
 	"github.com/charmbracelet/x/term"
@@ -28,6 +29,12 @@ var serverCmd = &cobra.Command{
 	Use:   "server",
 	Short: "Start the Crush server",
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		// The server hosts workspaces on behalf of clients and must
+		// never claim the pane of the terminal that launched it:
+		// reporting would fight the client's own reports, and
+		// shutdown would release the client's agent authority.
+		herdr.Disable()
+
 		dataDir, err := cmd.Flags().GetString("data-dir")
 		if err != nil {
 			return fmt.Errorf("failed to get data directory: %v", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -332,7 +332,7 @@ type Options struct {
 	InitializeAs              string       `json:"initialize_as,omitempty" jsonschema:"description=Name of the context file to create/update during project initialization,default=AGENTS.md,example=AGENTS.md,example=CRUSH.md,example=CLAUDE.md,example=docs/LLMs.md"`
 	AutoLSP                   *bool        `json:"auto_lsp,omitempty" jsonschema:"description=Automatically setup LSPs based on root markers,default=true"`
 	Progress                  *bool        `json:"progress,omitempty" jsonschema:"description=Show indeterminate progress updates during long operations,default=true"`
-	Notifications             string       `json:"notifications,omitempty" jsonschema:"description=Notification style to use. Options: auto (default)\\, native\\, osc\\, bell\\, herdr\\, disabled. Auto selects based on environment: native for local sessions\\, osc for SSH (with automatic OSC 99/777 detection). Herdr surfaces toasts in herdr's UI and requires running inside a herdr pane.,enum=auto,enum=native,enum=osc,enum=bell,enum=herdr,enum=disabled,default=auto"`
+	Notifications             string       `json:"notifications,omitempty" jsonschema:"description=Notification style to use. Options: auto (default)\\, native\\, osc\\, bell\\, herdr\\, disabled. Auto selects based on environment: native for local sessions\\, osc for SSH (with automatic OSC 99/777 detection). Herdr surfaces toasts in herdr's own UI and only works when Crush runs inside a herdr pane; outside one it falls back to OSC.,enum=auto,enum=native,enum=osc,enum=bell,enum=herdr,enum=disabled,default=auto"`
 	DisabledSkills            []string     `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -332,7 +332,7 @@ type Options struct {
 	InitializeAs              string       `json:"initialize_as,omitempty" jsonschema:"description=Name of the context file to create/update during project initialization,default=AGENTS.md,example=AGENTS.md,example=CRUSH.md,example=CLAUDE.md,example=docs/LLMs.md"`
 	AutoLSP                   *bool        `json:"auto_lsp,omitempty" jsonschema:"description=Automatically setup LSPs based on root markers,default=true"`
 	Progress                  *bool        `json:"progress,omitempty" jsonschema:"description=Show indeterminate progress updates during long operations,default=true"`
-	Notifications             string       `json:"notifications,omitempty" jsonschema:"description=Notification style to use. Options: auto (default)\\, native\\, osc\\, bell\\, disabled. Auto selects based on environment: native for local sessions\\, osc for SSH (with automatic OSC 99/777 detection).,enum=auto,enum=native,enum=osc,enum=bell,enum=disabled,default=auto"`
+	Notifications             string       `json:"notifications,omitempty" jsonschema:"description=Notification style to use. Options: auto (default)\\, native\\, osc\\, bell\\, herdr\\, disabled. Auto selects based on environment: native for local sessions\\, osc for SSH (with automatic OSC 99/777 detection). Herdr surfaces toasts in herdr's UI and requires running inside a herdr pane.,enum=auto,enum=native,enum=osc,enum=bell,enum=herdr,enum=disabled,default=auto"`
 	DisabledSkills            []string     `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
 }
 

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -84,6 +84,14 @@ type AssistantMessage struct {
 	// known. Kept fresh on every assistant message so the pane's
 	// model token self-heals after a mid-session model switch.
 	Model string
+	// Finished marks the terminal snapshot of an assistant message
+	// (a finish part is set, e.g. stop or canceled). A finished
+	// message is output, not ongoing activity, so it must not arm
+	// runActive: the bridge consumes the messages broker and the
+	// runCompletions broker on separate goroutines, and a finished
+	// snapshot processed after its turn's RunComplete would
+	// otherwise re-arm runActive and strand the pane in working.
+	Finished bool
 }
 
 func (AssistantMessage) herdrEvent() {}
@@ -367,7 +375,7 @@ func (c *Client) HandleEvent(ev Event) {
 	case RunStarted:
 		c.onRunStarted(e.SessionID)
 	case AssistantMessage:
-		c.onAssistantMessage(e.SessionID, e.Model)
+		c.onAssistantMessage(e.SessionID, e.Model, e.Finished)
 	case RunComplete:
 		c.onRunComplete(e.SessionID)
 	case PermissionRequested:
@@ -510,13 +518,23 @@ func (c *Client) onRunStarted(sessionID string) {
 	c.recomputeLocked()
 }
 
-func (c *Client) onAssistantMessage(sessionID, model string) {
+func (c *Client) onAssistantMessage(sessionID, model string, finished bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if !c.acceptLifecycleLocked(sessionID) {
 		return
 	}
-	c.runActive = true
+	// A finished message is the turn's terminal snapshot, not a
+	// sign of ongoing work. Arming runActive here could land after
+	// the turn's RunComplete (the two travel on separate brokers,
+	// so their delivery order is not serialized) and strand the
+	// pane in working — the ESC-cancel path is exactly that: the
+	// cancelled assistant's finished update races the cancelled
+	// RunComplete. Only RunComplete clears the flag, so skipping
+	// the arm can never cause a premature idle.
+	if !finished {
+		c.runActive = true
+	}
 	if model != "" {
 		c.pres.model = model
 		c.reportMetadataLocked()

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -101,6 +101,12 @@ type PermissionRequested struct {
 	// ToolCallID identifies the tool call awaiting approval. It
 	// pairs the block with the PermissionResolved that ends it.
 	ToolCallID string
+	// ToolName is the tool asking for approval ("bash", "edit").
+	ToolName string
+	// Description is the request's human-readable detail (the
+	// command, the file). Free-form and possibly multi-line; the
+	// client reduces it to a single capped line.
+	Description string
 }
 
 func (PermissionRequested) herdrEvent() {}
@@ -361,7 +367,7 @@ func (c *Client) HandleEvent(ev Event) {
 	case RunComplete:
 		c.onRunComplete(e.SessionID)
 	case PermissionRequested:
-		c.onPermissionRequest(e.ToolCallID)
+		c.onPermissionRequest(e.ToolCallID, e.ToolName, e.Description)
 	case PermissionResolved:
 		c.onPermissionResolved(e.ToolCallID)
 	case QuestionAsked:
@@ -518,15 +524,35 @@ func (c *Client) onRunComplete(sessionID string) {
 	c.recomputeLocked()
 }
 
-func (c *Client) onPermissionRequest(toolCallID string) {
+func (c *Client) onPermissionRequest(toolCallID, toolName, description string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	// A permission request implies a run is active, even if no
 	// assistant message has arrived yet (e.g. tool calls that fire
 	// before any text output).
 	c.runActive = true
-	c.setExclusiveBlockLocked(blockKey{reason: blockPermission, id: toolCallID}, "")
+	c.setExclusiveBlockLocked(
+		blockKey{reason: blockPermission, id: toolCallID},
+		permissionBlockMessage(toolName, description),
+	)
 	c.recomputeLocked()
+}
+
+// permissionBlockMessage renders the reason a permission prompt is
+// waiting. The tool name leads because it is always short and always
+// present; the description carries the specifics (the command, the
+// path) and only its first line is usable, since herdr's text fields
+// are single-line and capped. Truncation cuts the tail, so the tool
+// name survives even for a long description.
+func permissionBlockMessage(toolName, description string) string {
+	msg := "Permission required"
+	if toolName = strings.TrimSpace(toolName); toolName != "" {
+		msg = "Permission: " + toolName
+	}
+	if detail := firstLine(description); detail != "" {
+		msg += " - " + detail
+	}
+	return truncateBlockMessage(msg)
 }
 
 func (c *Client) onPermissionResolved(toolCallID string) {

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -43,6 +44,17 @@ const (
 	blockQuestion   blockReason = "question"
 	blockAuth       blockReason = "auth"
 )
+
+// blockKey identifies one outstanding block. The id correlates a
+// block with the event that resolves it: the tool call id for
+// permissions, the batch id for questions. Reasons that carry no
+// correlation id (auth) use the empty string. Keying on the id keeps
+// a resolution for one request from clearing a block raised by
+// another, and makes a re-delivered resolution idempotent.
+type blockKey struct {
+	reason blockReason
+	id     string
+}
 
 // subSessionSeparator separates the parent message id from the tool
 // call id in agent-tool sub-session ids
@@ -85,19 +97,30 @@ func (RunComplete) herdrEvent() {}
 
 // PermissionRequested indicates the agent is waiting for user approval.
 // Transitions to blocked.
-type PermissionRequested struct{}
+type PermissionRequested struct {
+	// ToolCallID identifies the tool call awaiting approval. It
+	// pairs the block with the PermissionResolved that ends it.
+	ToolCallID string
+}
 
 func (PermissionRequested) herdrEvent() {}
 
 // PermissionResolved indicates a permission decision was made.
 // Transitions back to working if a run is active, idle otherwise.
-type PermissionResolved struct{}
+type PermissionResolved struct {
+	// ToolCallID identifies the tool call whose approval was
+	// decided. Only that tool call's block is cleared.
+	ToolCallID string
+}
 
 func (PermissionResolved) herdrEvent() {}
 
 // QuestionAsked indicates the question tool is waiting for the user
 // to answer. Transitions to blocked.
 type QuestionAsked struct {
+	// BatchID identifies the question batch. It pairs the block
+	// with the QuestionResolved that ends it.
+	BatchID string
 	// Text is the blocked message, derived from the first
 	// question's text and truncated to herdr's text-field cap by
 	// Translate.
@@ -109,7 +132,11 @@ func (QuestionAsked) herdrEvent() {}
 // QuestionResolved indicates a pending question was answered or
 // cancelled. Transitions back to working if a run is active, idle
 // otherwise.
-type QuestionResolved struct{}
+type QuestionResolved struct {
+	// BatchID identifies the resolved question batch. Only that
+	// batch's block is cleared.
+	BatchID string
+}
 
 func (QuestionResolved) herdrEvent() {}
 
@@ -179,13 +206,14 @@ type Client struct {
 	state   string
 	message string
 	// runActive tracks an in-flight agent turn, summarizing tracks
-	// context compaction. Blocks record reasons the agent is waiting
-	// on the user; blockOrder keeps them oldest-first so the newest
-	// block's message can be picked for the report.
+	// context compaction. Blocks record the outstanding reasons the
+	// agent is waiting on the user, keyed by reason and request id;
+	// blockOrder keeps them oldest-first so the newest block's
+	// message can be picked for the report.
 	runActive   bool
 	summarizing bool
-	blocks      map[blockReason]string
-	blockOrder  []blockReason
+	blocks      map[blockKey]string
+	blockOrder  []blockKey
 	seq         uint64
 	// pres holds the complete desired pane presentation (session
 	// title, session id, model); reportedPres holds the last set
@@ -267,7 +295,7 @@ func newFromEnv() *Client {
 		socketPath: socketPath,
 		paneID:     paneID,
 		state:      stateIdle,
-		blocks:     make(map[blockReason]string),
+		blocks:     make(map[blockKey]string),
 		seq:        uint64(time.Now().UnixNano()),
 		snd:        newUnixSender(socketPath),
 	}
@@ -333,13 +361,13 @@ func (c *Client) HandleEvent(ev Event) {
 	case RunComplete:
 		c.onRunComplete(e.SessionID)
 	case PermissionRequested:
-		c.onPermissionRequest()
+		c.onPermissionRequest(e.ToolCallID)
 	case PermissionResolved:
-		c.onPermissionResolved()
+		c.onPermissionResolved(e.ToolCallID)
 	case QuestionAsked:
-		c.onQuestionAsked(e.Text)
+		c.onQuestionAsked(e.BatchID, e.Text)
 	case QuestionResolved:
-		c.onQuestionResolved()
+		c.onQuestionResolved(e.BatchID)
 	case AuthRequired:
 		c.onAuthRequired(e.ProviderID)
 	case SummarizeStarted:
@@ -486,43 +514,43 @@ func (c *Client) onRunComplete(sessionID string) {
 	// the 401 that raised the prompt. Successful re-auth publishes
 	// no event, so this is the only reliable point to drop the
 	// block without leaking a permanent blocked state.
-	c.clearBlockLocked(blockAuth)
+	c.clearBlockLocked(blockKey{reason: blockAuth})
 	c.recomputeLocked()
 }
 
-func (c *Client) onPermissionRequest() {
+func (c *Client) onPermissionRequest(toolCallID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	// A permission request implies a run is active, even if no
 	// assistant message has arrived yet (e.g. tool calls that fire
 	// before any text output).
 	c.runActive = true
-	c.setBlockLocked(blockPermission, "")
+	c.setExclusiveBlockLocked(blockKey{reason: blockPermission, id: toolCallID}, "")
 	c.recomputeLocked()
 }
 
-func (c *Client) onPermissionResolved() {
+func (c *Client) onPermissionResolved(toolCallID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.clearBlockLocked(blockPermission)
+	c.clearBlockLocked(blockKey{reason: blockPermission, id: toolCallID})
 	c.recomputeLocked()
 }
 
-func (c *Client) onQuestionAsked(text string) {
+func (c *Client) onQuestionAsked(batchID, text string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	// A question implies a run is active, even if no assistant
 	// message has arrived yet: the tool can only block on user
 	// input mid-turn.
 	c.runActive = true
-	c.setBlockLocked(blockQuestion, text)
+	c.setExclusiveBlockLocked(blockKey{reason: blockQuestion, id: batchID}, text)
 	c.recomputeLocked()
 }
 
-func (c *Client) onQuestionResolved() {
+func (c *Client) onQuestionResolved(batchID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.clearBlockLocked(blockQuestion)
+	c.clearBlockLocked(blockKey{reason: blockQuestion, id: batchID})
 	c.recomputeLocked()
 }
 
@@ -537,7 +565,7 @@ func (c *Client) onAuthRequired(providerID string) {
 	if providerID != "" {
 		msg = "Re-authentication required: " + providerID
 	}
-	c.setBlockLocked(blockAuth, truncateBlockMessage(msg))
+	c.setBlockLocked(blockKey{reason: blockAuth}, truncateBlockMessage(msg))
 	c.recomputeLocked()
 }
 
@@ -579,27 +607,53 @@ func (c *Client) onSessionUpdated(sessionID, title string) {
 	c.reportMetadataLocked()
 }
 
-// setBlockLocked records a reason the agent is waiting on the user.
-// Must be called with c.mu held.
-func (c *Client) setBlockLocked(reason blockReason, message string) {
+// setBlockLocked records one outstanding reason the agent is waiting
+// on the user. Re-setting a key it already holds keeps that key's
+// position in blockOrder: only genuinely new blocks become the
+// newest, so a re-delivered request cannot jump ahead of a block
+// raised after it. Must be called with c.mu held.
+func (c *Client) setBlockLocked(key blockKey, message string) {
 	if c.blocks == nil {
-		c.blocks = make(map[blockReason]string)
+		c.blocks = make(map[blockKey]string)
 	}
-	if _, ok := c.blocks[reason]; !ok {
-		c.blockOrder = append(c.blockOrder, reason)
+	if _, ok := c.blocks[key]; !ok {
+		c.blockOrder = append(c.blockOrder, key)
 	}
-	c.blocks[reason] = message
+	c.blocks[key] = message
 }
 
-// clearBlockLocked drops a block reason. Must be called with c.mu held.
-func (c *Client) clearBlockLocked(reason blockReason) {
-	if _, ok := c.blocks[reason]; !ok {
+// setExclusiveBlockLocked records a block whose reason can only ever
+// have one instance outstanding, dropping any older block that
+// shares the reason. Both prompting services serialize their
+// requests — the permission service behind a request mutex
+// (internal/permission/permission.go), the question service behind a
+// single pending slot (internal/question/question.go) — so an older
+// block with the same reason belongs to a request that has already
+// returned. That includes the requests cancelled by a turn interrupt,
+// which publish no resolution at all and would otherwise leave the
+// pane blocked forever. Must be called with c.mu held.
+func (c *Client) setExclusiveBlockLocked(key blockKey, message string) {
+	kept := c.blockOrder[:0]
+	for _, k := range c.blockOrder {
+		if k.reason == key.reason && k.id != key.id {
+			delete(c.blocks, k)
+			continue
+		}
+		kept = append(kept, k)
+	}
+	c.blockOrder = kept
+	c.setBlockLocked(key, message)
+}
+
+// clearBlockLocked drops one block. Must be called with c.mu held.
+func (c *Client) clearBlockLocked(key blockKey) {
+	if _, ok := c.blocks[key]; !ok {
 		return
 	}
-	delete(c.blocks, reason)
-	for i, r := range c.blockOrder {
-		if r == reason {
-			c.blockOrder = append(c.blockOrder[:i], c.blockOrder[i+1:]...)
+	delete(c.blocks, key)
+	for i, k := range c.blockOrder {
+		if k == key {
+			c.blockOrder = slices.Delete(c.blockOrder, i, i+1)
 			break
 		}
 	}

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -191,7 +191,9 @@ type SessionUpdated struct {
 func (SessionUpdated) herdrEvent() {}
 
 // sender abstracts the transport layer for reporting state to herdr.
-// Production uses a Unix socket; tests use a recorder.
+// Production uses a Unix socket; tests use a recorder. Every call is
+// made with Client.mu held, so implementations never see concurrent
+// use and need not be thread-safe themselves.
 type sender interface {
 	send(req reportRequest) error
 	close()
@@ -337,6 +339,8 @@ func (c *Client) Close() {
 		return
 	}
 	c.releaseAgent()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.snd.close()
 }
 
@@ -436,25 +440,28 @@ func (c *Client) ReportModel(model string) {
 }
 
 // maxNotificationBodyLength is herdr's 240-character cap on the
-// notification.show body field. The title uses the same 80-character
-// text-field cap as block messages.
+// notification.show body field, the one text field that is not
+// bound by the generic maxTextFieldLength cap.
 const maxNotificationBodyLength = 240
 
 // Notify sends a notification.show request so herdr surfaces a toast
 // in its own UI. The request carries no pane id, source, or seq: it
 // is a global herdr UI notification, not a pane-scoped report, so it
-// bypasses the state machinery and goes straight to the sender.
-// Best-effort and fire-and-forget, like state reports. Safe to call
-// on a nil client.
+// skips the state machinery and neither reads nor writes client
+// state. It still takes c.mu, because that is what gives sender
+// implementations their single-threaded contract. Best-effort and
+// fire-and-forget, like state reports. Safe to call on a nil client.
 func (c *Client) Notify(title, body string) {
 	if c == nil {
 		return
 	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	_ = c.snd.send(reportRequest{
 		ID:     fmt.Sprintf("crush:notify:%d", time.Now().UnixNano()),
 		Method: "notification.show",
 		Params: notificationParams{
-			Title: truncateBlockMessage(title),
+			Title: truncateText(title),
 			Body:  truncateRunes(body, maxNotificationBodyLength),
 		},
 	})
@@ -561,7 +568,7 @@ func permissionBlockMessage(toolName, description string) string {
 	if detail := firstLine(description); detail != "" {
 		msg += " - " + detail
 	}
-	return truncateBlockMessage(msg)
+	return truncateText(msg)
 }
 
 func (c *Client) onPermissionResolved(toolCallID string) {
@@ -600,7 +607,7 @@ func (c *Client) onAuthRequired(providerID string) {
 	if providerID != "" {
 		msg = "Re-authentication required: " + providerID
 	}
-	c.setBlockLocked(blockKey{reason: blockAuth}, truncateBlockMessage(msg))
+	c.setBlockLocked(blockKey{reason: blockAuth}, truncateText(msg))
 	c.recomputeLocked()
 }
 
@@ -769,11 +776,11 @@ func (c *Client) newMetadataRequestLocked() reportRequest {
 	c.seq++
 	tokens := map[string]*string{"session": nil}
 	if c.pres.session != "" {
-		session := truncateBlockMessage(c.pres.session)
+		session := truncateText(c.pres.session)
 		tokens["session"] = &session
 	}
 	if c.pres.model != "" {
-		model := truncateBlockMessage(c.pres.model)
+		model := truncateText(c.pres.model)
 		tokens["model"] = &model
 	}
 	return reportRequest{
@@ -782,7 +789,7 @@ func (c *Client) newMetadataRequestLocked() reportRequest {
 		Params: metadataParams{
 			PaneID: c.paneID,
 			Source: "crush",
-			Title:  truncateBlockMessage(c.pres.title),
+			Title:  truncateText(c.pres.title),
 			Tokens: tokens,
 			Seq:    c.seq,
 		},

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -30,6 +30,18 @@ const (
 	stateBlocked = "blocked"
 )
 
+// blockReason identifies a cause that keeps the agent waiting on the
+// user. The reported state is derived from the set of active blocks
+// plus the run/summarize flags, so overlapping blocks only clear once
+// every one of them is resolved.
+type blockReason string
+
+const (
+	blockPermission blockReason = "permission"
+	blockQuestion   blockReason = "question"
+	blockAuth       blockReason = "auth"
+)
+
 // Event is the herdr-specific event vocabulary. Each type maps to a
 // distinct state transition in the agent lifecycle. Callers translate
 // from proto or domain types into these before calling HandleEvent.
@@ -82,11 +94,24 @@ type Client struct {
 	socketPath string
 	paneID     string
 
-	mu        sync.Mutex
+	mu sync.Mutex
+	// sessionID is the current top-level session, sent along with
+	// every state report.
 	sessionID string
-	state     string
-	runActive bool
-	seq       uint64
+	// state and message hold the last reported pair; reports are
+	// deduplicated on both so a changed blocked reason still reaches
+	// herdr.
+	state   string
+	message string
+	// runActive tracks an in-flight agent turn, summarizing tracks
+	// context compaction. Blocks record reasons the agent is waiting
+	// on the user; blockOrder keeps them oldest-first so the newest
+	// block's message can be picked for the report.
+	runActive   bool
+	summarizing bool
+	blocks      map[blockReason]string
+	blockOrder  []blockReason
+	seq         uint64
 
 	snd sender
 }
@@ -134,6 +159,7 @@ func newFromEnv() *Client {
 		socketPath: socketPath,
 		paneID:     paneID,
 		state:      stateIdle,
+		blocks:     make(map[blockReason]string),
 		seq:        uint64(time.Now().UnixNano()),
 		snd:        newUnixSender(socketPath),
 	}
@@ -222,10 +248,8 @@ func (c *Client) onAssistantMessage(sessionID string) {
 	if sessionID != "" {
 		c.sessionID = sessionID
 	}
-	if !c.runActive {
-		c.runActive = true
-		c.reportLocked(stateWorking)
-	}
+	c.runActive = true
+	c.recomputeLocked()
 }
 
 func (c *Client) onRunComplete(sessionID string) {
@@ -235,7 +259,7 @@ func (c *Client) onRunComplete(sessionID string) {
 	if sessionID != "" {
 		c.sessionID = sessionID
 	}
-	c.reportLocked(stateIdle)
+	c.recomputeLocked()
 }
 
 func (c *Client) onPermissionRequest() {
@@ -244,29 +268,71 @@ func (c *Client) onPermissionRequest() {
 	// A permission request implies a run is active, even if no
 	// assistant message has arrived yet (e.g. tool calls that fire
 	// before any text output).
-	if !c.runActive {
-		c.runActive = true
-	}
-	c.reportLocked(stateBlocked)
+	c.runActive = true
+	c.setBlockLocked(blockPermission, "")
+	c.recomputeLocked()
 }
 
 func (c *Client) onPermissionResolved() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.runActive {
-		c.reportLocked(stateWorking)
-	} else {
-		c.reportLocked(stateIdle)
-	}
+	c.clearBlockLocked(blockPermission)
+	c.recomputeLocked()
 }
 
 func (c *Client) onSummarizing() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if !c.runActive {
-		c.runActive = true
+	// Compaction currently maps onto runActive so a following
+	// RunComplete still returns the pane to idle. TODO-3 replaces
+	// this with explicit summarize start/finish events that drive
+	// the summarizing flag instead.
+	c.runActive = true
+	c.recomputeLocked()
+}
+
+// setBlockLocked records a reason the agent is waiting on the user.
+// Must be called with c.mu held.
+func (c *Client) setBlockLocked(reason blockReason, message string) {
+	if c.blocks == nil {
+		c.blocks = make(map[blockReason]string)
 	}
-	c.reportLocked(stateWorking)
+	if _, ok := c.blocks[reason]; !ok {
+		c.blockOrder = append(c.blockOrder, reason)
+	}
+	c.blocks[reason] = message
+}
+
+// clearBlockLocked drops a block reason. Must be called with c.mu held.
+func (c *Client) clearBlockLocked(reason blockReason) {
+	if _, ok := c.blocks[reason]; !ok {
+		return
+	}
+	delete(c.blocks, reason)
+	for i, r := range c.blockOrder {
+		if r == reason {
+			c.blockOrder = append(c.blockOrder[:i], c.blockOrder[i+1:]...)
+			break
+		}
+	}
+}
+
+// recomputeLocked derives the reported state from the active blocks
+// and the run/summarize flags, then reports it. Must be called with
+// c.mu held. Blocks outrank everything: as long as any block is
+// active the pane is blocked, carrying the newest block's message.
+func (c *Client) recomputeLocked() {
+	var state, message string
+	switch {
+	case len(c.blocks) > 0:
+		state = stateBlocked
+		message = c.blocks[c.blockOrder[len(c.blockOrder)-1]]
+	case c.runActive || c.summarizing:
+		state = stateWorking
+	default:
+		state = stateIdle
+	}
+	c.reportLocked(state, message)
 }
 
 // newRequestLocked builds a seq-stamped JSON-RPC request to herdr.
@@ -291,13 +357,14 @@ func (c *Client) newRequestLocked(method, idPrefix, state string) reportRequest 
 }
 
 // reportLocked sends a pane.report_agent request to herdr. Must be
-// called with c.mu held. Skips redundant reports when the state has
-// not changed.
-func (c *Client) reportLocked(state string) {
-	if state == c.state {
+// called with c.mu held. Skips redundant reports when neither the
+// state nor the message has changed.
+func (c *Client) reportLocked(state, message string) {
+	if state == c.state && message == c.message {
 		return
 	}
 	c.state = state
+	c.message = message
 	c.snd.send(c.newRequestLocked("pane.report_agent", "report", state))
 }
 

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -359,16 +359,31 @@ func (c *Client) HandleEvent(ev Event) {
 // session event fires on a plain switch, so the title must be pushed
 // here. An empty id (landing screen) clears both the title and the
 // session token.
+//
+// A switch to a different session also resets the lifecycle flags.
+// They describe the session being left, whose terminal events
+// acceptLifecycleLocked drops from this point on, so nothing else
+// could ever clear them: switching sessions mid-run would strand the
+// pane in working forever. The cost is that a run still going in the
+// session we left reports idle until it emits its next assistant
+// message, which is transient and self-healing. Blocks survive the
+// switch: they are not session-scoped, and a dialog raised by any
+// session still waits on the user.
 func (c *Client) SetSession(id, title string) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if id != c.sessionID {
+		c.runActive = false
+		c.summarizing = false
+	}
 	c.sessionID = id
 	c.pres.title = title
 	c.pres.session = id
 	c.reportMetadataLocked()
+	c.recomputeLocked()
 }
 
 // ReportModel records the active model id for the pane's model

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -68,6 +68,10 @@ func (RunStarted) herdrEvent() {}
 // to working if not already active.
 type AssistantMessage struct {
 	SessionID string
+	// Model is the id of the model that produced the message, when
+	// known. Kept fresh on every assistant message so the pane's
+	// model token self-heals after a mid-session model switch.
+	Model string
 }
 
 func (AssistantMessage) herdrEvent() {}
@@ -142,6 +146,17 @@ type SummarizeFinished struct {
 
 func (SummarizeFinished) herdrEvent() {}
 
+// SessionUpdated carries a session's current title. Not a state
+// transition: it refreshes the pane's presentation metadata when the
+// current session's title changes (auto-titling, rename). Events for
+// any session other than the authoritative current one are ignored.
+type SessionUpdated struct {
+	SessionID string
+	Title     string
+}
+
+func (SessionUpdated) herdrEvent() {}
+
 // sender abstracts the transport layer for reporting state to herdr.
 // Production uses a Unix socket; tests use a recorder.
 type sender interface {
@@ -172,8 +187,24 @@ type Client struct {
 	blocks      map[blockReason]string
 	blockOrder  []blockReason
 	seq         uint64
+	// pres holds the complete desired pane presentation (session
+	// title, session id, model); reportedPres holds the last set
+	// sent. herdr treats presentation fields as replace-all per
+	// source, so every metadata report carries the complete set and
+	// identical sets are deduplicated.
+	pres         presentation
+	reportedPres presentation
 
 	snd sender
+}
+
+// presentation is the pane metadata crush reports to herdr. All
+// fields are strings so the zero value is a valid, comparable
+// "nothing to show" state.
+type presentation struct {
+	title   string
+	session string
+	model   string
 }
 
 // defaultClient is the process-wide herdr client. Initialized once
@@ -298,7 +329,7 @@ func (c *Client) HandleEvent(ev Event) {
 	case RunStarted:
 		c.onRunStarted(e.SessionID)
 	case AssistantMessage:
-		c.onAssistantMessage(e.SessionID)
+		c.onAssistantMessage(e.SessionID, e.Model)
 	case RunComplete:
 		c.onRunComplete(e.SessionID)
 	case PermissionRequested:
@@ -315,20 +346,44 @@ func (c *Client) HandleEvent(ev Event) {
 		c.onSummarizeStarted(e.SessionID)
 	case SummarizeFinished:
 		c.onSummarizeFinished(e.SessionID)
+	case SessionUpdated:
+		c.onSessionUpdated(e.SessionID, e.Title)
 	}
 }
 
-// SetSessionID sets the session ID for reporting. This is the
+// SetSession sets the session ID for reporting. This is the
 // authoritative current session: lifecycle events for any other
 // top-level session are ignored afterwards. Call this when the
-// session is created or resolved, before events start flowing.
-func (c *Client) SetSessionID(id string) {
+// session is created or resolved, before events start flowing. The
+// title refreshes the pane's presentation metadata immediately: no
+// session event fires on a plain switch, so the title must be pushed
+// here. An empty id (landing screen) clears both the title and the
+// session token.
+func (c *Client) SetSession(id, title string) {
 	if c == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.sessionID = id
+	c.pres.title = title
+	c.pres.session = id
+	c.reportMetadataLocked()
+}
+
+// ReportModel records the active model id for the pane's model
+// token. Called at startup from the loaded config and refreshed from
+// assistant messages afterwards. An empty model is ignored: crush
+// always has a configured model, so clearing the token is never
+// meaningful.
+func (c *Client) ReportModel(model string) {
+	if c == nil || model == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pres.model = model
+	c.reportMetadataLocked()
 }
 
 // acceptLifecycleLocked applies the session scoping shared by all
@@ -365,13 +420,17 @@ func (c *Client) onRunStarted(sessionID string) {
 	c.recomputeLocked()
 }
 
-func (c *Client) onAssistantMessage(sessionID string) {
+func (c *Client) onAssistantMessage(sessionID, model string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if !c.acceptLifecycleLocked(sessionID) {
 		return
 	}
 	c.runActive = true
+	if model != "" {
+		c.pres.model = model
+		c.reportMetadataLocked()
+	}
 	c.recomputeLocked()
 }
 
@@ -462,6 +521,24 @@ func (c *Client) onSummarizeFinished(sessionID string) {
 	c.recomputeLocked()
 }
 
+// onSessionUpdated refreshes the pane title when the current
+// session's title changes. Title events for any other session
+// (background auto-titling of task sessions, sub-sessions) must not
+// clobber the presentation, and with no current session known there
+// is nothing to attach a title to.
+func (c *Client) onSessionUpdated(sessionID, title string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if sessionID == "" || strings.Contains(sessionID, subSessionSeparator) {
+		return
+	}
+	if c.sessionID == "" || sessionID != c.sessionID {
+		return
+	}
+	c.pres.title = title
+	c.reportMetadataLocked()
+}
+
 // setBlockLocked records a reason the agent is waiting on the user.
 // Must be called with c.mu held.
 func (c *Client) setBlockLocked(reason blockReason, message string) {
@@ -541,11 +618,55 @@ func (c *Client) reportLocked(state, message string) {
 	c.snd.send(c.newRequestLocked("pane.report_agent", "report", state, message))
 }
 
-// reportRequest is the JSON-RPC envelope sent to herdr.
+// reportMetadataLocked sends a pane.report_metadata request to
+// herdr. Must be called with c.mu held. Skips redundant reports when
+// the complete presentation set is unchanged.
+func (c *Client) reportMetadataLocked() {
+	if c.pres == c.reportedPres {
+		return
+	}
+	c.reportedPres = c.pres
+	c.snd.send(c.newMetadataRequestLocked())
+}
+
+// newMetadataRequestLocked builds a seq-stamped pane.report_metadata
+// request carrying the complete presentation set. Must be called
+// with c.mu held. herdr treats presentation fields as replace-all
+// per source but merges tokens per key, so the title is always sent
+// (omitted when empty, which clears it) and the session token is
+// always sent (null when empty, which clears it). The model token is
+// omitted until known so it is never cleared accidentally.
+func (c *Client) newMetadataRequestLocked() reportRequest {
+	c.seq++
+	tokens := map[string]*string{"session": nil}
+	if c.pres.session != "" {
+		session := truncateBlockMessage(c.pres.session)
+		tokens["session"] = &session
+	}
+	if c.pres.model != "" {
+		model := truncateBlockMessage(c.pres.model)
+		tokens["model"] = &model
+	}
+	return reportRequest{
+		ID:     fmt.Sprintf("crush:metadata:%d", time.Now().UnixNano()),
+		Method: "pane.report_metadata",
+		Params: metadataParams{
+			PaneID: c.paneID,
+			Source: "crush",
+			Title:  truncateBlockMessage(c.pres.title),
+			Tokens: tokens,
+			Seq:    c.seq,
+		},
+	}
+}
+
+// reportRequest is the JSON-RPC envelope sent to herdr. Params is
+// method-specific: reportParams for agent state, metadataParams for
+// pane presentation.
 type reportRequest struct {
-	ID     string       `json:"id"`
-	Method string       `json:"method"`
-	Params reportParams `json:"params"`
+	ID     string `json:"id"`
+	Method string `json:"method"`
+	Params any    `json:"params"`
 }
 
 // reportParams carries the agent state payload. Message is the
@@ -560,6 +681,18 @@ type reportParams struct {
 	Message        string `json:"message"`
 	Seq            uint64 `json:"seq"`
 	AgentSessionID string `json:"agent_session_id"`
+}
+
+// metadataParams carries the pane presentation payload. Title is
+// omitted when empty: herdr's presentation fields are replace-all
+// per source, so omission clears it. Tokens merge per key; a null
+// value clears that token.
+type metadataParams struct {
+	PaneID string             `json:"pane_id"`
+	Source string             `json:"source"`
+	Title  string             `json:"title,omitempty"`
+	Tokens map[string]*string `json:"tokens"`
+	Seq    uint64             `json:"seq"`
 }
 
 // unixSender sends JSON-RPC requests over a Unix domain socket using

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -466,7 +466,8 @@ func (c *Client) Notify(title, body string) {
 // run must not drive the pane state nor overwrite the reported
 // session id. Events from a different top-level session than the
 // current one are stale and ignored as well. While no session is
-// known, the first scoped event establishes it. Must be called with
+// known, the first scoped event establishes it, for the reported
+// session id and the presentation token alike. Must be called with
 // c.mu held.
 func (c *Client) acceptLifecycleLocked(sessionID string) bool {
 	if strings.Contains(sessionID, subSessionSeparator) {
@@ -478,7 +479,15 @@ func (c *Client) acceptLifecycleLocked(sessionID string) bool {
 		return true
 	}
 	if c.sessionID == "" {
+		// The learned id rides on every state report from here on,
+		// so the session token has to move with it: both name the
+		// current session, and writing them together is what keeps
+		// pane.report_agent and pane.report_metadata from
+		// disagreeing. The title is unknown here; it arrives with
+		// the SetSession call that follows the session load.
 		c.sessionID = sessionID
+		c.pres.session = sessionID
+		c.reportMetadataLocked()
 		return true
 	}
 	return sessionID == c.sessionID

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -82,13 +82,24 @@ type PermissionResolved struct{}
 
 func (PermissionResolved) herdrEvent() {}
 
-// Summarizing indicates the agent is compacting context. Transitions
-// to working if not already active.
-type Summarizing struct {
+// SummarizeStarted indicates context compaction began. Transitions to
+// working until a matching SummarizeFinished arrives. Compaction never
+// publishes a RunComplete, so it must not ride on runActive: that is
+// what left the pane stuck in working after a /compact.
+type SummarizeStarted struct {
 	SessionID string
 }
 
-func (Summarizing) herdrEvent() {}
+func (SummarizeStarted) herdrEvent() {}
+
+// SummarizeFinished indicates context compaction ended, whether by
+// success, error, or user cancel. Transitions back to working if a
+// run is still active (auto-compaction mid-turn), idle otherwise.
+type SummarizeFinished struct {
+	SessionID string
+}
+
+func (SummarizeFinished) herdrEvent() {}
 
 // sender abstracts the transport layer for reporting state to herdr.
 // Production uses a Unix socket; tests use a recorder.
@@ -234,8 +245,10 @@ func (c *Client) HandleEvent(ev Event) {
 		c.onPermissionRequest()
 	case PermissionResolved:
 		c.onPermissionResolved()
-	case Summarizing:
-		c.onSummarizing(e.SessionID)
+	case SummarizeStarted:
+		c.onSummarizeStarted(e.SessionID)
+	case SummarizeFinished:
+		c.onSummarizeFinished(e.SessionID)
 	}
 }
 
@@ -314,17 +327,23 @@ func (c *Client) onPermissionResolved() {
 	c.recomputeLocked()
 }
 
-func (c *Client) onSummarizing(sessionID string) {
+func (c *Client) onSummarizeStarted(sessionID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if !c.acceptLifecycleLocked(sessionID) {
 		return
 	}
-	// Compaction currently maps onto runActive so a following
-	// RunComplete still returns the pane to idle. TODO-3 replaces
-	// this with explicit summarize start/finish events that drive
-	// the summarizing flag instead.
-	c.runActive = true
+	c.summarizing = true
+	c.recomputeLocked()
+}
+
+func (c *Client) onSummarizeFinished(sessionID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.acceptLifecycleLocked(sessionID) {
+		return
+	}
+	c.summarizing = false
 	c.recomputeLocked()
 }
 

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -181,7 +182,20 @@ type Client struct {
 var (
 	defaultClient *Client
 	initOnce      sync.Once
+	// disabled, when set, makes Init return nil forever after. Set
+	// via Disable before the first Init call.
+	disabled atomic.Bool
 )
+
+// Disable permanently disables the herdr integration for this
+// process: Init returns nil and no socket connection is ever made.
+// The crush server hosts workspaces on behalf of clients and must
+// never claim the pane of the terminal that launched it, so it calls
+// this at startup. Call before the first Init; an already-created
+// client is not closed.
+func Disable() {
+	disabled.Store(true)
+}
 
 // Init returns the process-wide herdr Client, creating it on first
 // call from environment variables. Returns nil when Crush is not
@@ -194,6 +208,10 @@ func Init() *Client {
 }
 
 func newFromEnv() *Client {
+	if disabled.Load() {
+		slog.Debug("Herdr integration disabled for this process")
+		return nil
+	}
 	if os.Getenv("HERDR_ENV") != "1" {
 		return nil
 	}

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -55,6 +55,14 @@ type Event interface {
 	herdrEvent()
 }
 
+// RunStarted indicates the user submitted a prompt. Transitions to
+// working immediately, before the first assistant output arrives.
+type RunStarted struct {
+	SessionID string
+}
+
+func (RunStarted) herdrEvent() {}
+
 // AssistantMessage indicates the agent produced output. Transitions
 // to working if not already active.
 type AssistantMessage struct {
@@ -269,6 +277,8 @@ func (c *Client) HandleEvent(ev Event) {
 		return
 	}
 	switch e := ev.(type) {
+	case RunStarted:
+		c.onRunStarted(e.SessionID)
 	case AssistantMessage:
 		c.onAssistantMessage(e.SessionID)
 	case RunComplete:
@@ -325,6 +335,16 @@ func (c *Client) acceptLifecycleLocked(sessionID string) bool {
 		return true
 	}
 	return sessionID == c.sessionID
+}
+
+func (c *Client) onRunStarted(sessionID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.acceptLifecycleLocked(sessionID) {
+		return
+	}
+	c.runActive = true
+	c.recomputeLocked()
 }
 
 func (c *Client) onAssistantMessage(sessionID string) {

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -222,7 +222,7 @@ func (c *Client) registerInitial() {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.snd.send(c.newRequestLocked("pane.report_agent", "init", stateIdle))
+	c.snd.send(c.newRequestLocked("pane.report_agent", "init", stateIdle, ""))
 }
 
 // Close releases the agent's authority on the pane and shuts down
@@ -242,7 +242,7 @@ func (c *Client) Close() {
 func (c *Client) releaseAgent() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	req := c.newRequestLocked("pane.release_agent", "release", "")
+	req := c.newRequestLocked("pane.release_agent", "release", "", "")
 	if err := dialSend(c.socketPath, req); err != nil {
 		slog.Debug("Herdr release_agent failed", "error", err)
 	}
@@ -434,9 +434,10 @@ func (c *Client) recomputeLocked() {
 // newRequestLocked builds a seq-stamped JSON-RPC request to herdr.
 // Must be called with c.mu held. Every request increments c.seq so
 // herdr accepts it as strictly newer than the last (see
-// registerInitial for why monotonic seq matters). State is empty for
-// requests that carry no agent state, such as pane.release_agent.
-func (c *Client) newRequestLocked(method, idPrefix, state string) reportRequest {
+// registerInitial for why monotonic seq matters). State and message
+// are empty for requests that carry no agent state, such as
+// pane.release_agent.
+func (c *Client) newRequestLocked(method, idPrefix, state, message string) reportRequest {
 	c.seq++
 	return reportRequest{
 		ID:     fmt.Sprintf("crush:%s:%d", idPrefix, time.Now().UnixNano()),
@@ -446,6 +447,7 @@ func (c *Client) newRequestLocked(method, idPrefix, state string) reportRequest 
 			Source:         "crush",
 			Agent:          "crush",
 			State:          state,
+			Message:        message,
 			Seq:            c.seq,
 			AgentSessionID: c.sessionID,
 		},
@@ -461,7 +463,7 @@ func (c *Client) reportLocked(state, message string) {
 	}
 	c.state = state
 	c.message = message
-	c.snd.send(c.newRequestLocked("pane.report_agent", "report", state))
+	c.snd.send(c.newRequestLocked("pane.report_agent", "report", state, message))
 }
 
 // reportRequest is the JSON-RPC envelope sent to herdr.
@@ -471,12 +473,16 @@ type reportRequest struct {
 	Params reportParams `json:"params"`
 }
 
-// reportParams carries the agent state payload.
+// reportParams carries the agent state payload. Message is the
+// human-readable reason the agent is blocked (e.g. the question
+// text); it is sent on every report so herdr always has a complete
+// (state, message) snapshot, and is empty when nothing is pending.
 type reportParams struct {
 	PaneID         string `json:"pane_id"`
 	Source         string `json:"source"`
 	Agent          string `json:"agent"`
 	State          string `json:"state"`
+	Message        string `json:"message"`
 	Seq            uint64 `json:"seq"`
 	AgentSessionID string `json:"agent_session_id"`
 }

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -386,6 +386,31 @@ func (c *Client) ReportModel(model string) {
 	c.reportMetadataLocked()
 }
 
+// maxNotificationBodyLength is herdr's 240-character cap on the
+// notification.show body field. The title uses the same 80-character
+// text-field cap as block messages.
+const maxNotificationBodyLength = 240
+
+// Notify sends a notification.show request so herdr surfaces a toast
+// in its own UI. The request carries no pane id, source, or seq: it
+// is a global herdr UI notification, not a pane-scoped report, so it
+// bypasses the state machinery and goes straight to the sender.
+// Best-effort and fire-and-forget, like state reports. Safe to call
+// on a nil client.
+func (c *Client) Notify(title, body string) {
+	if c == nil {
+		return
+	}
+	_ = c.snd.send(reportRequest{
+		ID:     fmt.Sprintf("crush:notify:%d", time.Now().UnixNano()),
+		Method: "notification.show",
+		Params: notificationParams{
+			Title: truncateBlockMessage(title),
+			Body:  truncateRunes(body, maxNotificationBodyLength),
+		},
+	})
+}
+
 // acceptLifecycleLocked applies the session scoping shared by all
 // lifecycle events and reports whether the event should be processed.
 // Events from agent-tool sub-sessions are always ignored: a sub-agent
@@ -693,6 +718,14 @@ type metadataParams struct {
 	Title  string             `json:"title,omitempty"`
 	Tokens map[string]*string `json:"tokens"`
 	Seq    uint64             `json:"seq"`
+}
+
+// notificationParams carries the notification.show payload. Title is
+// required and capped at 80 characters; body is optional, capped at
+// 240, and omitted when empty so herdr shows a title-only toast.
+type notificationParams struct {
+	Title string `json:"title"`
+	Body  string `json:"body,omitempty"`
 }
 
 // unixSender sends JSON-RPC requests over a Unix domain socket using

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -82,6 +82,24 @@ type PermissionResolved struct{}
 
 func (PermissionResolved) herdrEvent() {}
 
+// QuestionAsked indicates the question tool is waiting for the user
+// to answer. Transitions to blocked.
+type QuestionAsked struct {
+	// Text is the blocked message, derived from the first
+	// question's text and truncated to herdr's text-field cap by
+	// Translate.
+	Text string
+}
+
+func (QuestionAsked) herdrEvent() {}
+
+// QuestionResolved indicates a pending question was answered or
+// cancelled. Transitions back to working if a run is active, idle
+// otherwise.
+type QuestionResolved struct{}
+
+func (QuestionResolved) herdrEvent() {}
+
 // SummarizeStarted indicates context compaction began. Transitions to
 // working until a matching SummarizeFinished arrives. Compaction never
 // publishes a RunComplete, so it must not ride on runActive: that is
@@ -245,6 +263,10 @@ func (c *Client) HandleEvent(ev Event) {
 		c.onPermissionRequest()
 	case PermissionResolved:
 		c.onPermissionResolved()
+	case QuestionAsked:
+		c.onQuestionAsked(e.Text)
+	case QuestionResolved:
+		c.onQuestionResolved()
 	case SummarizeStarted:
 		c.onSummarizeStarted(e.SessionID)
 	case SummarizeFinished:
@@ -324,6 +346,24 @@ func (c *Client) onPermissionResolved() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.clearBlockLocked(blockPermission)
+	c.recomputeLocked()
+}
+
+func (c *Client) onQuestionAsked(text string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// A question implies a run is active, even if no assistant
+	// message has arrived yet: the tool can only block on user
+	// input mid-turn.
+	c.runActive = true
+	c.setBlockLocked(blockQuestion, text)
+	c.recomputeLocked()
+}
+
+func (c *Client) onQuestionResolved() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.clearBlockLocked(blockQuestion)
 	c.recomputeLocked()
 }
 

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -41,6 +42,11 @@ const (
 	blockQuestion   blockReason = "question"
 	blockAuth       blockReason = "auth"
 )
+
+// subSessionSeparator separates the parent message id from the tool
+// call id in agent-tool sub-session ids
+// ("<messageID>$$<toolCallID>", see session.CreateAgentToolSessionID).
+const subSessionSeparator = "$$"
 
 // Event is the herdr-specific event vocabulary. Each type maps to a
 // distinct state transition in the agent lifecycle. Callers translate
@@ -78,7 +84,9 @@ func (PermissionResolved) herdrEvent() {}
 
 // Summarizing indicates the agent is compacting context. Transitions
 // to working if not already active.
-type Summarizing struct{}
+type Summarizing struct {
+	SessionID string
+}
 
 func (Summarizing) herdrEvent() {}
 
@@ -227,11 +235,13 @@ func (c *Client) HandleEvent(ev Event) {
 	case PermissionResolved:
 		c.onPermissionResolved()
 	case Summarizing:
-		c.onSummarizing()
+		c.onSummarizing(e.SessionID)
 	}
 }
 
-// SetSessionID sets the session ID for reporting. Call this when the
+// SetSessionID sets the session ID for reporting. This is the
+// authoritative current session: lifecycle events for any other
+// top-level session are ignored afterwards. Call this when the
 // session is created or resolved, before events start flowing.
 func (c *Client) SetSessionID(id string) {
 	if c == nil {
@@ -242,11 +252,35 @@ func (c *Client) SetSessionID(id string) {
 	c.sessionID = id
 }
 
+// acceptLifecycleLocked applies the session scoping shared by all
+// lifecycle events and reports whether the event should be processed.
+// Events from agent-tool sub-sessions are always ignored: a sub-agent
+// run must not drive the pane state nor overwrite the reported
+// session id. Events from a different top-level session than the
+// current one are stale and ignored as well. While no session is
+// known, the first scoped event establishes it. Must be called with
+// c.mu held.
+func (c *Client) acceptLifecycleLocked(sessionID string) bool {
+	if strings.Contains(sessionID, subSessionSeparator) {
+		return false
+	}
+	if sessionID == "" {
+		// The event carries no session; accept it so the state
+		// transition still happens, but there is nothing to learn.
+		return true
+	}
+	if c.sessionID == "" {
+		c.sessionID = sessionID
+		return true
+	}
+	return sessionID == c.sessionID
+}
+
 func (c *Client) onAssistantMessage(sessionID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if sessionID != "" {
-		c.sessionID = sessionID
+	if !c.acceptLifecycleLocked(sessionID) {
+		return
 	}
 	c.runActive = true
 	c.recomputeLocked()
@@ -255,10 +289,10 @@ func (c *Client) onAssistantMessage(sessionID string) {
 func (c *Client) onRunComplete(sessionID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.runActive = false
-	if sessionID != "" {
-		c.sessionID = sessionID
+	if !c.acceptLifecycleLocked(sessionID) {
+		return
 	}
+	c.runActive = false
 	c.recomputeLocked()
 }
 
@@ -280,9 +314,12 @@ func (c *Client) onPermissionResolved() {
 	c.recomputeLocked()
 }
 
-func (c *Client) onSummarizing() {
+func (c *Client) onSummarizing(sessionID string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if !c.acceptLifecycleLocked(sessionID) {
+		return
+	}
 	// Compaction currently maps onto runActive so a following
 	// RunComplete still returns the pane to idle. TODO-3 replaces
 	// this with explicit summarize start/finish events that drive

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -100,6 +100,20 @@ type QuestionResolved struct{}
 
 func (QuestionResolved) herdrEvent() {}
 
+// AuthRequired indicates the agent hit an authentication error and is
+// waiting for the user to re-authenticate. Transitions to blocked
+// until the run that needed auth completes: re-auth resolution
+// publishes no event, so the block's lifetime is tied to the run to
+// avoid leaking a permanent blocked state.
+type AuthRequired struct {
+	// ProviderID names the provider needing re-authentication, when
+	// known. Client/server mode does not carry it on the wire, so
+	// it may be empty.
+	ProviderID string
+}
+
+func (AuthRequired) herdrEvent() {}
+
 // SummarizeStarted indicates context compaction began. Transitions to
 // working until a matching SummarizeFinished arrives. Compaction never
 // publishes a RunComplete, so it must not ride on runActive: that is
@@ -267,6 +281,8 @@ func (c *Client) HandleEvent(ev Event) {
 		c.onQuestionAsked(e.Text)
 	case QuestionResolved:
 		c.onQuestionResolved()
+	case AuthRequired:
+		c.onAuthRequired(e.ProviderID)
 	case SummarizeStarted:
 		c.onSummarizeStarted(e.SessionID)
 	case SummarizeFinished:
@@ -328,6 +344,12 @@ func (c *Client) onRunComplete(sessionID string) {
 		return
 	}
 	c.runActive = false
+	// The run that needed re-authentication is over, one way or
+	// another: the auth wait happened inside it, or it ended with
+	// the 401 that raised the prompt. Successful re-auth publishes
+	// no event, so this is the only reliable point to drop the
+	// block without leaking a permanent blocked state.
+	c.clearBlockLocked(blockAuth)
 	c.recomputeLocked()
 }
 
@@ -364,6 +386,21 @@ func (c *Client) onQuestionResolved() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.clearBlockLocked(blockQuestion)
+	c.recomputeLocked()
+}
+
+func (c *Client) onAuthRequired(providerID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// An auth prompt implies a run is active: the coordinator only
+	// requests re-authentication from within a failed or waiting
+	// turn.
+	c.runActive = true
+	msg := "Re-authentication required"
+	if providerID != "" {
+		msg = "Re-authentication required: " + providerID
+	}
+	c.setBlockLocked(blockAuth, truncateBlockMessage(msg))
 	c.recomputeLocked()
 }
 

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -1,6 +1,8 @@
 package herdr
 
 import (
+	"slices"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,10 +11,13 @@ import (
 // recordingSender captures state transitions without connecting to a
 // real Unix socket.
 type recordingSender struct {
+	mu     sync.Mutex
 	states []string
 }
 
 func (r *recordingSender) send(req reportRequest) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.states = append(r.states, req.Params.State)
 	return nil
 }
@@ -31,7 +36,10 @@ func newTestClient() *Client {
 
 // reportedStates returns the states recorded by the test sender.
 func reportedStates(c *Client) []string {
-	return c.snd.(*recordingSender).states
+	rec := c.snd.(*recordingSender)
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	return slices.Clone(rec.states)
 }
 
 func TestBasicLifecycle(t *testing.T) {
@@ -187,6 +195,91 @@ func TestSubSessionSummarizeEventsIgnored(t *testing.T) {
 	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
 }
 
+func TestQuestionBlockAndUnblock(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// Start working.
+	c.HandleEvent(AssistantMessage{SessionID: "sess-1"})
+
+	// A question blocks, carrying its text as the blocked message.
+	c.HandleEvent(QuestionAsked{Text: "Which file should I edit?"})
+	assert.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+	assert.Equal(t, "Which file should I edit?", c.message)
+
+	// Answering the question returns to working (run still active).
+	c.HandleEvent(QuestionResolved{})
+	assert.Equal(t, []string{stateWorking, stateBlocked, stateWorking}, reportedStates(c))
+	assert.Empty(t, c.message)
+
+	// Run complete returns to idle.
+	c.HandleEvent(RunComplete{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking, stateBlocked, stateWorking, stateIdle}, reportedStates(c))
+}
+
+func TestQuestionBeforeAssistantMessage(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A question can only be asked mid-turn, so it implies an active
+	// run even when no assistant message has arrived yet.
+	c.HandleEvent(QuestionAsked{Text: "Proceed?"})
+	assert.Equal(t, []string{stateBlocked}, reportedStates(c))
+
+	// Resolving the question returns to working, not idle.
+	c.HandleEvent(QuestionResolved{})
+	assert.Equal(t, []string{stateBlocked, stateWorking}, reportedStates(c))
+}
+
+func TestOverlappingPermissionAndQuestionBlocks(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A permission prompt opens, then a question arrives while the
+	// permission is still pending.
+	c.HandleEvent(AssistantMessage{SessionID: "sess-1"})
+	c.HandleEvent(PermissionRequested{})
+	c.HandleEvent(QuestionAsked{Text: "Pick an option"})
+	// The state stays blocked but the message changed from the
+	// permission's empty one to the question's text, and dedup is
+	// on the (state, message) pair: a second blocked report goes
+	// out.
+	assert.Equal(t, []string{stateWorking, stateBlocked, stateBlocked}, reportedStates(c))
+	// The newest block's message wins.
+	assert.Equal(t, "Pick an option", c.message)
+
+	// Resolving only the permission leaves the pane blocked, with
+	// the question's message unchanged, so nothing new is reported.
+	c.HandleEvent(PermissionResolved{})
+	assert.Equal(t, []string{stateWorking, stateBlocked, stateBlocked}, reportedStates(c))
+	assert.Equal(t, "Pick an option", c.message)
+
+	// Resolving the question finally unblocks.
+	c.HandleEvent(QuestionResolved{})
+	assert.Equal(t, []string{stateWorking, stateBlocked, stateBlocked, stateWorking}, reportedStates(c))
+}
+
+func TestQuestionBlockOutranksRunComplete(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A run starts and a question opens mid-turn.
+	c.HandleEvent(AssistantMessage{SessionID: "sess-1"})
+	c.HandleEvent(QuestionAsked{Text: "Proceed?"})
+	assert.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+
+	// A run completion arriving while the question is still pending
+	// (e.g. the turn errored out) must not drop the pane to idle:
+	// the block wins until it is resolved.
+	c.HandleEvent(RunComplete{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+
+	// With the run already finished, resolving the question lands
+	// on idle rather than working.
+	c.HandleEvent(QuestionResolved{})
+	assert.Equal(t, []string{stateWorking, stateBlocked, stateIdle}, reportedStates(c))
+}
+
 func TestDedupSkipsRedundantState(t *testing.T) {
 	t.Parallel()
 	c := newTestClient()
@@ -195,6 +288,22 @@ func TestDedupSkipsRedundantState(t *testing.T) {
 	c.HandleEvent(AssistantMessage{SessionID: "s1"})
 	c.HandleEvent(AssistantMessage{SessionID: "s1"})
 	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+}
+
+func TestDedupReportsChangedBlockMessage(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A repeated block with a different message must still reach
+	// herdr: dedup is on the (state, message) pair, not state alone.
+	c.HandleEvent(QuestionAsked{Text: "First question"})
+	c.HandleEvent(QuestionAsked{Text: "Second question"})
+	assert.Equal(t, []string{stateBlocked, stateBlocked}, reportedStates(c))
+	assert.Equal(t, "Second question", c.message)
+
+	// An identical repeat is deduplicated.
+	c.HandleEvent(QuestionAsked{Text: "Second question"})
+	assert.Equal(t, []string{stateBlocked, stateBlocked}, reportedStates(c))
 }
 
 func TestSummarizeStartFinishReturnsToIdle(t *testing.T) {
@@ -276,6 +385,8 @@ func TestNilClientSafe(t *testing.T) {
 	c.HandleEvent(RunComplete{SessionID: "s1"})
 	c.HandleEvent(PermissionRequested{})
 	c.HandleEvent(PermissionResolved{})
+	c.HandleEvent(QuestionAsked{Text: "Proceed?"})
+	c.HandleEvent(QuestionResolved{})
 	c.HandleEvent(SummarizeStarted{SessionID: "s1"})
 	c.HandleEvent(SummarizeFinished{SessionID: "s1"})
 }

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -1,7 +1,7 @@
 package herdr
 
 import (
-	"slices"
+	"encoding/json"
 	"sync"
 	"testing"
 
@@ -11,14 +11,14 @@ import (
 // recordingSender captures state transitions without connecting to a
 // real Unix socket.
 type recordingSender struct {
-	mu     sync.Mutex
-	states []string
+	mu       sync.Mutex
+	requests []reportRequest
 }
 
 func (r *recordingSender) send(req reportRequest) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.states = append(r.states, req.Params.State)
+	r.requests = append(r.requests, req)
 	return nil
 }
 
@@ -27,7 +27,7 @@ func (r *recordingSender) close() {}
 // newTestClient creates a Client that records state transitions
 // without connecting to a real Unix socket.
 func newTestClient() *Client {
-	rec := &recordingSender{states: make([]string, 0, 16)}
+	rec := &recordingSender{requests: make([]reportRequest, 0, 16)}
 	return &Client{
 		state: stateIdle,
 		snd:   rec,
@@ -39,7 +39,32 @@ func reportedStates(c *Client) []string {
 	rec := c.snd.(*recordingSender)
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
-	return slices.Clone(rec.states)
+	states := make([]string, 0, len(rec.requests))
+	for _, req := range rec.requests {
+		states = append(states, req.Params.State)
+	}
+	return states
+}
+
+// reportedMessages returns the messages recorded by the test sender.
+func reportedMessages(c *Client) []string {
+	rec := c.snd.(*recordingSender)
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	messages := make([]string, 0, len(rec.requests))
+	for _, req := range rec.requests {
+		messages = append(messages, req.Params.Message)
+	}
+	return messages
+}
+
+// lastRequest returns the most recent request recorded by the test
+// sender.
+func lastRequest(c *Client) reportRequest {
+	rec := c.snd.(*recordingSender)
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	return rec.requests[len(rec.requests)-1]
 }
 
 func TestBasicLifecycle(t *testing.T) {
@@ -306,6 +331,66 @@ func TestDedupReportsChangedBlockMessage(t *testing.T) {
 	assert.Equal(t, []string{stateBlocked, stateBlocked}, reportedStates(c))
 }
 
+func TestReportCarriesBlockMessage(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// Every report carries the current block message on the wire so
+	// herdr can show what the agent is waiting on.
+	c.HandleEvent(AssistantMessage{SessionID: "sess-1"})
+	c.HandleEvent(QuestionAsked{Text: "Which file should I edit?"})
+	assert.Equal(t,
+		[]string{"", "Which file should I edit?"},
+		reportedMessages(c))
+	req := lastRequest(c)
+	assert.Equal(t, stateBlocked, req.Params.State)
+	assert.Equal(t, "Which file should I edit?", req.Params.Message)
+
+	// Resolving the block clears the message on the very next
+	// report; herdr must not keep showing the stale question.
+	c.HandleEvent(QuestionResolved{})
+	req = lastRequest(c)
+	assert.Equal(t, stateWorking, req.Params.State)
+	assert.Empty(t, req.Params.Message)
+}
+
+func TestPermissionBlockSendsEmptyMessage(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A question leaves its text as the block message; a permission
+	// prompt then takes over with an empty one. The empty message
+	// must go out on the wire, not be dropped, so herdr clears the
+	// stale question text while the state stays blocked.
+	c.HandleEvent(QuestionAsked{Text: "Pick an option"})
+	c.HandleEvent(PermissionRequested{})
+	assert.Equal(t,
+		[]string{"Pick an option", ""},
+		reportedMessages(c))
+	req := lastRequest(c)
+	assert.Equal(t, stateBlocked, req.Params.State)
+	assert.Empty(t, req.Params.Message)
+}
+
+func TestReportRequestAlwaysIncludesMessageKey(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// The message key must be present in the marshaled JSON even
+	// when empty: each report is a complete (state, message)
+	// snapshot, so herdr never has to guess whether a missing key
+	// means "clear" or "keep the last value".
+	c.HandleEvent(AssistantMessage{SessionID: "sess-1"})
+	raw, err := json.Marshal(lastRequest(c))
+	assert.NoError(t, err)
+	assert.Contains(t, string(raw), `"message":""`)
+
+	c.HandleEvent(QuestionAsked{Text: "Proceed?"})
+	raw, err = json.Marshal(lastRequest(c))
+	assert.NoError(t, err)
+	assert.Contains(t, string(raw), `"message":"Proceed?"`)
+}
+
 func TestSummarizeStartFinishReturnsToIdle(t *testing.T) {
 	t.Parallel()
 	c := newTestClient()
@@ -393,14 +478,14 @@ func TestNilClientSafe(t *testing.T) {
 
 func TestRegisterInitial(t *testing.T) {
 	t.Parallel()
-	rec := &recordingSender{states: make([]string, 0, 16)}
+	rec := &recordingSender{requests: make([]reportRequest, 0, 16)}
 	c := &Client{
 		state: stateIdle,
 		seq:   100,
 		snd:   rec,
 	}
 	c.registerInitial()
-	assert.Equal(t, []string{stateIdle}, rec.states)
+	assert.Equal(t, []string{stateIdle}, reportedStates(c))
 	// seq must strictly increase so herdr accepts the report.
 	assert.Equal(t, uint64(101), c.seq)
 }

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -305,6 +305,85 @@ func TestQuestionBlockOutranksRunComplete(t *testing.T) {
 	assert.Equal(t, []string{stateWorking, stateBlocked, stateIdle}, reportedStates(c))
 }
 
+func TestAuthBlockAndUnblock(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A run starts and hits an auth error mid-turn (e.g. a revoked
+	// OAuth refresh token): the pane blocks on re-authentication.
+	c.HandleEvent(AssistantMessage{SessionID: "sess-1"})
+	c.HandleEvent(AuthRequired{ProviderID: "hyper"})
+	assert.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+	assert.Equal(t, "Re-authentication required: hyper", lastRequest(c).Params.Message)
+
+	// The run that needed auth completes — one way or another, the
+	// auth wait is over. Re-auth success publishes no event, so the
+	// completion is what clears the block.
+	c.HandleEvent(RunComplete{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking, stateBlocked, stateIdle}, reportedStates(c))
+	assert.Empty(t, lastRequest(c).Params.Message)
+}
+
+func TestAuthBlockWithoutProvider(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// Client/server mode carries no provider id on the wire, so the
+	// message falls back to the generic text.
+	c.HandleEvent(AuthRequired{})
+	assert.Equal(t, []string{stateBlocked}, reportedStates(c))
+	assert.Equal(t, "Re-authentication required", lastRequest(c).Params.Message)
+}
+
+func TestAuthBlockBeforeAssistantMessage(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// The 401 can arrive before any assistant output. The block
+	// still reports, and the completing run lands on idle.
+	c.HandleEvent(AuthRequired{ProviderID: "hyper"})
+	assert.Equal(t, []string{stateBlocked}, reportedStates(c))
+
+	c.HandleEvent(RunComplete{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateBlocked, stateIdle}, reportedStates(c))
+}
+
+func TestAuthBlockOverlapsPermissionBlock(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A permission prompt and an auth prompt can both be open; the
+	// newest block's message wins.
+	c.HandleEvent(PermissionRequested{})
+	c.HandleEvent(AuthRequired{ProviderID: "hyper"})
+	assert.Equal(t, "Re-authentication required: hyper", lastRequest(c).Params.Message)
+
+	// Resolving the permission keeps the pane blocked on auth. The
+	// (state, message) pair is unchanged, so nothing new is sent.
+	c.HandleEvent(PermissionResolved{})
+	assert.Equal(t, []string{stateBlocked, stateBlocked}, reportedStates(c))
+
+	// Run completion clears the auth block and returns to idle.
+	c.HandleEvent(RunComplete{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateBlocked, stateBlocked, stateIdle}, reportedStates(c))
+}
+
+func TestSubSessionRunCompleteKeepsAuthBlock(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	c.HandleEvent(AssistantMessage{SessionID: "sess-1"})
+	c.HandleEvent(AuthRequired{ProviderID: "hyper"})
+
+	// A sub-agent's run completion is session-filtered, so it must
+	// not clear the top-level auth block.
+	c.HandleEvent(RunComplete{SessionID: "msg-1$$call-1"})
+	assert.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+
+	c.HandleEvent(RunComplete{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking, stateBlocked, stateIdle}, reportedStates(c))
+}
+
 func TestDedupSkipsRedundantState(t *testing.T) {
 	t.Parallel()
 	c := newTestClient()
@@ -472,6 +551,7 @@ func TestNilClientSafe(t *testing.T) {
 	c.HandleEvent(PermissionResolved{})
 	c.HandleEvent(QuestionAsked{Text: "Proceed?"})
 	c.HandleEvent(QuestionResolved{})
+	c.HandleEvent(AuthRequired{ProviderID: "hyper"})
 	c.HandleEvent(SummarizeStarted{SessionID: "s1"})
 	c.HandleEvent(SummarizeFinished{SessionID: "s1"})
 }

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -620,3 +620,19 @@ func TestInitDisabledUnderTest(t *testing.T) {
 	t.Setenv("HERDR_PANE_ID", "test:pane")
 	assert.Nil(t, newFromEnv())
 }
+
+// TestDisable verifies newFromEnv returns nil once Disable was
+// called, even with a complete, valid-looking environment. Mutates
+// process-global state, so it cannot run in parallel; the flag is
+// restored on exit.
+func TestDisable(t *testing.T) {
+	old := disabled.Swap(false)
+	defer disabled.Store(old)
+
+	t.Setenv("HERDR_ENV", "1")
+	t.Setenv("HERDR_SOCKET_PATH", "/tmp/does-not-matter.sock")
+	t.Setenv("HERDR_PANE_ID", "test:pane")
+
+	Disable()
+	assert.Nil(t, newFromEnv())
+}

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -2,6 +2,7 @@ package herdr
 
 import (
 	"encoding/json"
+	"strings"
 	"sync"
 	"testing"
 
@@ -35,27 +36,48 @@ func newTestClient() *Client {
 }
 
 // reportedStates returns the states recorded by the test sender.
+// Metadata requests carry no state and are skipped.
 func reportedStates(c *Client) []string {
 	rec := c.snd.(*recordingSender)
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
 	states := make([]string, 0, len(rec.requests))
 	for _, req := range rec.requests {
-		states = append(states, req.Params.State)
+		if p, ok := req.Params.(reportParams); ok {
+			states = append(states, p.State)
+		}
 	}
 	return states
 }
 
 // reportedMessages returns the messages recorded by the test sender.
+// Metadata requests carry no message and are skipped.
 func reportedMessages(c *Client) []string {
 	rec := c.snd.(*recordingSender)
 	rec.mu.Lock()
 	defer rec.mu.Unlock()
 	messages := make([]string, 0, len(rec.requests))
 	for _, req := range rec.requests {
-		messages = append(messages, req.Params.Message)
+		if p, ok := req.Params.(reportParams); ok {
+			messages = append(messages, p.Message)
+		}
 	}
 	return messages
+}
+
+// reportedMetadata returns the metadata params recorded by the test
+// sender.
+func reportedMetadata(c *Client) []metadataParams {
+	rec := c.snd.(*recordingSender)
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	var out []metadataParams
+	for _, req := range rec.requests {
+		if p, ok := req.Params.(metadataParams); ok {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // lastRequest returns the most recent request recorded by the test
@@ -157,8 +179,8 @@ func TestSessionIDPropagation(t *testing.T) {
 	t.Parallel()
 	c := newTestClient()
 
-	// SetSessionID before events.
-	c.SetSessionID("early-session")
+	// SetSession before events.
+	c.SetSession("early-session", "Early")
 	assert.Equal(t, "early-session", c.sessionID)
 
 	// Events for the current session drive the state.
@@ -181,7 +203,7 @@ func TestSessionIDLearnedFromFirstEvent(t *testing.T) {
 	t.Parallel()
 	c := newTestClient()
 
-	// With no SetSessionID call, the first top-level lifecycle event
+	// With no SetSession call, the first top-level lifecycle event
 	// establishes the session.
 	c.HandleEvent(AssistantMessage{SessionID: "s1"})
 	assert.Equal(t, "s1", c.sessionID)
@@ -191,9 +213,9 @@ func TestSessionIDLearnedFromFirstEvent(t *testing.T) {
 	c.HandleEvent(RunComplete{SessionID: "s2"})
 	assert.Equal(t, []string{stateWorking}, reportedStates(c))
 
-	// SetSessionID re-points the client at the new session (session
+	// SetSession re-points the client at the new session (session
 	// switch); events for the old one are now the stale ones.
-	c.SetSessionID("s2")
+	c.SetSession("s2", "S2")
 	c.HandleEvent(RunComplete{SessionID: "s1"})
 	assert.Equal(t, []string{stateWorking}, reportedStates(c))
 	c.HandleEvent(RunComplete{SessionID: "s2"})
@@ -229,7 +251,7 @@ func TestSubSessionNeverEstablishesSessionID(t *testing.T) {
 	t.Parallel()
 	c := newTestClient()
 
-	// A sub-session event arriving before any SetSessionID must be
+	// A sub-session event arriving before any SetSession must be
 	// ignored rather than learned as the current session.
 	c.HandleEvent(RunComplete{SessionID: "msg-1$$tc-1"})
 	assert.Empty(t, c.sessionID)
@@ -352,14 +374,14 @@ func TestAuthBlockAndUnblock(t *testing.T) {
 	c.HandleEvent(AssistantMessage{SessionID: "sess-1"})
 	c.HandleEvent(AuthRequired{ProviderID: "hyper"})
 	assert.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
-	assert.Equal(t, "Re-authentication required: hyper", lastRequest(c).Params.Message)
+	assert.Equal(t, "Re-authentication required: hyper", lastRequest(c).Params.(reportParams).Message)
 
 	// The run that needed auth completes — one way or another, the
 	// auth wait is over. Re-auth success publishes no event, so the
 	// completion is what clears the block.
 	c.HandleEvent(RunComplete{SessionID: "sess-1"})
 	assert.Equal(t, []string{stateWorking, stateBlocked, stateIdle}, reportedStates(c))
-	assert.Empty(t, lastRequest(c).Params.Message)
+	assert.Empty(t, lastRequest(c).Params.(reportParams).Message)
 }
 
 func TestAuthBlockWithoutProvider(t *testing.T) {
@@ -370,7 +392,7 @@ func TestAuthBlockWithoutProvider(t *testing.T) {
 	// message falls back to the generic text.
 	c.HandleEvent(AuthRequired{})
 	assert.Equal(t, []string{stateBlocked}, reportedStates(c))
-	assert.Equal(t, "Re-authentication required", lastRequest(c).Params.Message)
+	assert.Equal(t, "Re-authentication required", lastRequest(c).Params.(reportParams).Message)
 }
 
 func TestAuthBlockBeforeAssistantMessage(t *testing.T) {
@@ -394,7 +416,7 @@ func TestAuthBlockOverlapsPermissionBlock(t *testing.T) {
 	// newest block's message wins.
 	c.HandleEvent(PermissionRequested{})
 	c.HandleEvent(AuthRequired{ProviderID: "hyper"})
-	assert.Equal(t, "Re-authentication required: hyper", lastRequest(c).Params.Message)
+	assert.Equal(t, "Re-authentication required: hyper", lastRequest(c).Params.(reportParams).Message)
 
 	// Resolving the permission keeps the pane blocked on auth. The
 	// (state, message) pair is unchanged, so nothing new is sent.
@@ -460,15 +482,15 @@ func TestReportCarriesBlockMessage(t *testing.T) {
 		[]string{"", "Which file should I edit?"},
 		reportedMessages(c))
 	req := lastRequest(c)
-	assert.Equal(t, stateBlocked, req.Params.State)
-	assert.Equal(t, "Which file should I edit?", req.Params.Message)
+	assert.Equal(t, stateBlocked, req.Params.(reportParams).State)
+	assert.Equal(t, "Which file should I edit?", req.Params.(reportParams).Message)
 
 	// Resolving the block clears the message on the very next
 	// report; herdr must not keep showing the stale question.
 	c.HandleEvent(QuestionResolved{})
 	req = lastRequest(c)
-	assert.Equal(t, stateWorking, req.Params.State)
-	assert.Empty(t, req.Params.Message)
+	assert.Equal(t, stateWorking, req.Params.(reportParams).State)
+	assert.Empty(t, req.Params.(reportParams).Message)
 }
 
 func TestPermissionBlockSendsEmptyMessage(t *testing.T) {
@@ -485,8 +507,8 @@ func TestPermissionBlockSendsEmptyMessage(t *testing.T) {
 		[]string{"Pick an option", ""},
 		reportedMessages(c))
 	req := lastRequest(c)
-	assert.Equal(t, stateBlocked, req.Params.State)
-	assert.Empty(t, req.Params.Message)
+	assert.Equal(t, stateBlocked, req.Params.(reportParams).State)
+	assert.Empty(t, req.Params.(reportParams).Message)
 }
 
 func TestReportRequestAlwaysIncludesMessageKey(t *testing.T) {
@@ -582,7 +604,7 @@ func TestNilClientSafe(t *testing.T) {
 	t.Parallel()
 	var c *Client
 	// These should not panic on a nil receiver.
-	c.SetSessionID("s1")
+	c.SetSession("s1", "S1")
 	c.HandleEvent(AssistantMessage{SessionID: "s1"})
 	c.HandleEvent(RunComplete{SessionID: "s1"})
 	c.HandleEvent(PermissionRequested{})
@@ -592,6 +614,188 @@ func TestNilClientSafe(t *testing.T) {
 	c.HandleEvent(AuthRequired{ProviderID: "hyper"})
 	c.HandleEvent(SummarizeStarted{SessionID: "s1"})
 	c.HandleEvent(SummarizeFinished{SessionID: "s1"})
+	c.HandleEvent(SessionUpdated{SessionID: "s1", Title: "S1"})
+	c.ReportModel("model-1")
+}
+
+func TestSetSessionReportsMetadata(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A session switch publishes the complete presentation set:
+	// title plus the session token. herdr's presentation fields are
+	// replace-all per source, so every report carries both.
+	c.SetSession("s1", "My Title")
+	meta := reportedMetadata(c)
+	assert.Len(t, meta, 1)
+	assert.Equal(t, "My Title", meta[0].Title)
+	if assert.NotNil(t, meta[0].Tokens["session"]) {
+		assert.Equal(t, "s1", *meta[0].Tokens["session"])
+	}
+	assert.NotContains(t, meta[0].Tokens, "model")
+	assert.Equal(t, "pane.report_metadata", lastRequest(c).Method)
+
+	// Identical reports are deduplicated.
+	c.SetSession("s1", "My Title")
+	assert.Len(t, reportedMetadata(c), 1)
+
+	// A switch to another session refreshes title and token.
+	c.SetSession("s2", "Other Title")
+	meta = reportedMetadata(c)
+	assert.Len(t, meta, 2)
+	assert.Equal(t, "Other Title", meta[1].Title)
+	if assert.NotNil(t, meta[1].Tokens["session"]) {
+		assert.Equal(t, "s2", *meta[1].Tokens["session"])
+	}
+
+	// The session id still rides along on state reports.
+	assert.Equal(t, "s2", c.sessionID)
+}
+
+func TestSetSessionClearRemovesPresentation(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// Landing on the session picker (empty id) clears the title
+	// (omitted, replace-all) and the session token (explicit null,
+	// tokens merge per key).
+	c.SetSession("s1", "My Title")
+	c.SetSession("", "")
+	meta := reportedMetadata(c)
+	assert.Len(t, meta, 2)
+	assert.Empty(t, meta[1].Title)
+	assert.Nil(t, meta[1].Tokens["session"])
+
+	raw, err := json.Marshal(lastRequest(c))
+	assert.NoError(t, err)
+	assert.NotContains(t, string(raw), `"title"`)
+	assert.Contains(t, string(raw), `"session":null`)
+}
+
+func TestReportModel(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// The model token merges with the rest of the set; before any
+	// session is known the session token goes out as null.
+	c.ReportModel("model-1")
+	meta := reportedMetadata(c)
+	assert.Len(t, meta, 1)
+	if assert.NotNil(t, meta[0].Tokens["model"]) {
+		assert.Equal(t, "model-1", *meta[0].Tokens["model"])
+	}
+	assert.Nil(t, meta[0].Tokens["session"])
+
+	// Dedup, then a model change re-reports the complete set.
+	c.ReportModel("model-1")
+	assert.Len(t, reportedMetadata(c), 1)
+	c.SetSession("s1", "T")
+	c.ReportModel("model-2")
+	meta = reportedMetadata(c)
+	assert.Len(t, meta, 3)
+	assert.Equal(t, "T", meta[2].Title)
+	if assert.NotNil(t, meta[2].Tokens["model"]) {
+		assert.Equal(t, "model-2", *meta[2].Tokens["model"])
+	}
+	if assert.NotNil(t, meta[2].Tokens["session"]) {
+		assert.Equal(t, "s1", *meta[2].Tokens["session"])
+	}
+
+	// An empty model never clears the token.
+	c.ReportModel("")
+	assert.Len(t, reportedMetadata(c), 3)
+}
+
+func TestAssistantMessageRefreshesModelToken(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// The model riding on assistant output keeps the token fresh
+	// after a mid-session model switch, in both run modes.
+	c.HandleEvent(AssistantMessage{SessionID: "s1", Model: "model-1"})
+	meta := reportedMetadata(c)
+	assert.Len(t, meta, 1)
+	if assert.NotNil(t, meta[0].Tokens["model"]) {
+		assert.Equal(t, "model-1", *meta[0].Tokens["model"])
+	}
+
+	// Same model: deduped. New model: re-reported. Empty model: no
+	// change.
+	c.HandleEvent(AssistantMessage{SessionID: "s1", Model: "model-1"})
+	assert.Len(t, reportedMetadata(c), 1)
+	c.HandleEvent(AssistantMessage{SessionID: "s1", Model: "model-2"})
+	assert.Len(t, reportedMetadata(c), 2)
+	c.HandleEvent(AssistantMessage{SessionID: "s1", Model: ""})
+	assert.Len(t, reportedMetadata(c), 2)
+}
+
+func TestSessionUpdatedRefreshesTitle(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// Auto-titling and renames arrive as session events; only the
+	// authoritative current session may touch the pane title.
+	c.SetSession("s1", "Old Title")
+	c.HandleEvent(SessionUpdated{SessionID: "s1", Title: "New Title"})
+	meta := reportedMetadata(c)
+	assert.Len(t, meta, 2)
+	assert.Equal(t, "New Title", meta[1].Title)
+
+	// Events for other sessions, sub-sessions, and empty ids are
+	// ignored, as are events while no current session is known.
+	c.HandleEvent(SessionUpdated{SessionID: "s2", Title: "Wrong"})
+	c.HandleEvent(SessionUpdated{SessionID: "msg-1$$tc-1", Title: "Sub"})
+	c.HandleEvent(SessionUpdated{SessionID: "", Title: "Empty"})
+	assert.Len(t, reportedMetadata(c), 2)
+
+	c2 := newTestClient()
+	c2.HandleEvent(SessionUpdated{SessionID: "s1", Title: "Unanchored"})
+	assert.Empty(t, reportedMetadata(c2))
+}
+
+func TestSessionUpdatedTruncatesLongTitle(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// herdr caps text fields at 80 characters; the cut must stay
+	// rune-safe.
+	long := strings.Repeat("é", 100)
+	c.SetSession("s1", long)
+	meta := reportedMetadata(c)
+	assert.Len(t, meta, 1)
+	assert.Equal(t, strings.Repeat("é", 80), meta[0].Title)
+}
+
+func TestMetadataSeqStrictlyIncreases(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+	c.seq = 100
+
+	// State and metadata reports share one seq space; herdr drops
+	// any report whose seq is not strictly greater than the last.
+	c.HandleEvent(AssistantMessage{SessionID: "s1", Model: "m"})
+	c.SetSession("s1", "T")
+	c.HandleEvent(RunComplete{SessionID: "s1"})
+
+	rec := c.snd.(*recordingSender)
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	var prev uint64
+	for i, req := range rec.requests {
+		var seq uint64
+		switch p := req.Params.(type) {
+		case reportParams:
+			seq = p.Seq
+		case metadataParams:
+			seq = p.Seq
+		default:
+			t.Fatalf("unexpected params type %T", req.Params)
+		}
+		if i > 0 {
+			assert.Greater(t, seq, prev)
+		}
+		prev = seq
+	}
 }
 
 func TestRegisterInitial(t *testing.T) {

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -685,7 +685,7 @@ func TestPermissionBlockMessage(t *testing.T) {
 			t.Parallel()
 			got := permissionBlockMessage(tt.toolName, tt.description)
 			assert.Equal(t, tt.want, got)
-			assert.LessOrEqual(t, utf8.RuneCountInString(got), maxBlockMessageLength)
+			assert.LessOrEqual(t, utf8.RuneCountInString(got), maxTextFieldLength)
 		})
 	}
 }
@@ -1128,7 +1128,7 @@ func TestNotifyTruncation(t *testing.T) {
 	c.Notify(strings.Repeat("é", 100), strings.Repeat("b", 300))
 
 	p := lastRequest(c).Params.(notificationParams)
-	assert.Len(t, []rune(p.Title), maxBlockMessageLength)
+	assert.Len(t, []rune(p.Title), maxTextFieldLength)
 	assert.Len(t, []rune(p.Body), maxNotificationBodyLength)
 }
 
@@ -1151,4 +1151,59 @@ func TestNotifyNilClient(t *testing.T) {
 	t.Parallel()
 	var c *Client
 	assert.NotPanics(t, func() { c.Notify("Done", "") })
+}
+
+// unsyncSender is a sender with no internal locking, unlike
+// recordingSender. It encodes the contract that every sender call is
+// made with Client.mu held: a plain slice append from two goroutines
+// trips the race detector the moment that stops being true.
+type unsyncSender struct {
+	requests []reportRequest
+}
+
+func (u *unsyncSender) send(req reportRequest) error {
+	u.requests = append(u.requests, req)
+	return nil
+}
+
+func (u *unsyncSender) close() {}
+
+// TestSenderCallsAreSerialized drives notifications concurrently with
+// state events. Notify is the one send that reads and writes no
+// client state, which is what made it tempting to leave outside the
+// mutex; run under -race, an unsynchronized sender shows it cannot
+// be. Fails as a data race, not an assertion, if the lock goes away.
+func TestSenderCallsAreSerialized(t *testing.T) {
+	t.Parallel()
+	c := &Client{state: stateIdle, snd: &unsyncSender{}}
+
+	const (
+		notifiers = 4
+		rounds    = 100
+	)
+	var wg sync.WaitGroup
+	for range notifiers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range rounds {
+				c.Notify("Done", "turn complete")
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range rounds {
+			c.HandleEvent(AssistantMessage{SessionID: "s1"})
+			c.HandleEvent(QuestionAsked{BatchID: "b1", Text: "pick one"})
+			c.HandleEvent(QuestionResolved{BatchID: "b1"})
+			c.HandleEvent(RunComplete{SessionID: "s1"})
+		}
+	}()
+	wg.Wait()
+
+	// Every notification is sent unconditionally; state reports are
+	// deduplicated, so only the notifications have an exact count.
+	assert.GreaterOrEqual(t, len(c.snd.(*unsyncSender).requests), notifiers*rounds)
 }

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -331,12 +332,11 @@ func TestOverlappingPermissionAndQuestionBlocks(t *testing.T) {
 	// A permission prompt opens, then a question arrives while the
 	// permission is still pending.
 	c.HandleEvent(AssistantMessage{SessionID: "sess-1"})
-	c.HandleEvent(PermissionRequested{})
+	c.HandleEvent(PermissionRequested{ToolName: "bash"})
 	c.HandleEvent(QuestionAsked{Text: "Pick an option"})
 	// The state stays blocked but the message changed from the
-	// permission's empty one to the question's text, and dedup is
-	// on the (state, message) pair: a second blocked report goes
-	// out.
+	// permission's text to the question's, and dedup is on the
+	// (state, message) pair: a second blocked report goes out.
 	assert.Equal(t, []string{stateWorking, stateBlocked, stateBlocked}, reportedStates(c))
 	// The newest block's message wins.
 	assert.Equal(t, "Pick an option", c.message)
@@ -581,22 +581,78 @@ func TestReportCarriesBlockMessage(t *testing.T) {
 	assert.Empty(t, req.Params.(reportParams).Message)
 }
 
-func TestPermissionBlockSendsEmptyMessage(t *testing.T) {
+func TestPermissionBlockSendsToolMessage(t *testing.T) {
 	t.Parallel()
 	c := newTestClient()
 
 	// A question leaves its text as the block message; a permission
-	// prompt then takes over with an empty one. The empty message
-	// must go out on the wire, not be dropped, so herdr clears the
-	// stale question text while the state stays blocked.
+	// prompt then takes over with its own. The replacement must go
+	// out on the wire, not be dropped by dedup, so herdr never shows
+	// the stale question text while the state stays blocked.
 	c.HandleEvent(QuestionAsked{Text: "Pick an option"})
-	c.HandleEvent(PermissionRequested{})
+	c.HandleEvent(PermissionRequested{
+		ToolName:    "bash",
+		Description: "Execute command: git push",
+	})
 	assert.Equal(t,
-		[]string{"Pick an option", ""},
+		[]string{"Pick an option", "Permission: bash - Execute command: git push"},
 		reportedMessages(c))
 	req := lastRequest(c)
 	assert.Equal(t, stateBlocked, req.Params.(reportParams).State)
-	assert.Empty(t, req.Params.(reportParams).Message)
+}
+
+func TestPermissionBlockMessage(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("x", 200)
+	tests := []struct {
+		name        string
+		toolName    string
+		description string
+		want        string
+	}{
+		{
+			name:        "tool and description",
+			toolName:    "edit",
+			description: "Create file /tmp/a.go",
+			want:        "Permission: edit - Create file /tmp/a.go",
+		},
+		{
+			name:     "tool only",
+			toolName: "bash",
+			want:     "Permission: bash",
+		},
+		{
+			name:        "description only",
+			description: "Fetch content from URL: https://example.com",
+			want:        "Permission required - Fetch content from URL: https://example.com",
+		},
+		{
+			name: "neither",
+			want: "Permission required",
+		},
+		{
+			// Descriptions embed commands, which can span lines.
+			// herdr's text fields are single-line.
+			name:        "multi-line description keeps the first line",
+			toolName:    "bash",
+			description: "Execute command: cat <<EOF\nhello\nEOF",
+			want:        "Permission: bash - Execute command: cat <<EOF",
+		},
+		{
+			name:        "long description is truncated to herdr's cap",
+			toolName:    "bash",
+			description: long,
+			want:        "Permission: bash - " + strings.Repeat("x", 80-len("Permission: bash - ")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := permissionBlockMessage(tt.toolName, tt.description)
+			assert.Equal(t, tt.want, got)
+			assert.LessOrEqual(t, utf8.RuneCountInString(got), maxBlockMessageLength)
+		})
+	}
 }
 
 func TestReportRequestAlwaysIncludesMessageKey(t *testing.T) {

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -165,18 +165,26 @@ func TestSubSessionNeverEstablishesSessionID(t *testing.T) {
 	assert.Empty(t, reportedStates(c))
 }
 
-func TestSubSessionSummarizingIgnored(t *testing.T) {
+func TestSubSessionSummarizeEventsIgnored(t *testing.T) {
 	t.Parallel()
 	c := newTestClient()
 
 	// Auto-compaction inside a sub-agent session must not start a
 	// working report the main session never clears.
-	c.HandleEvent(Summarizing{SessionID: "msg-1$$tc-1"})
+	c.HandleEvent(SummarizeStarted{SessionID: "msg-1$$tc-1"})
 	assert.Empty(t, reportedStates(c))
 
-	// A summarize event for the main session is accepted.
-	c.HandleEvent(Summarizing{SessionID: "sess-1"})
+	// A summarize event for the main session is accepted, and its
+	// finish returns the pane to idle.
+	c.HandleEvent(SummarizeStarted{SessionID: "sess-1"})
 	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+	c.HandleEvent(SummarizeFinished{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+
+	// A sub-session finish arriving while idle must not drive any
+	// state change either.
+	c.HandleEvent(SummarizeFinished{SessionID: "msg-1$$tc-1"})
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
 }
 
 func TestDedupSkipsRedundantState(t *testing.T) {
@@ -189,17 +197,53 @@ func TestDedupSkipsRedundantState(t *testing.T) {
 	assert.Equal(t, []string{stateWorking}, reportedStates(c))
 }
 
-func TestSummarizingTriggersWorking(t *testing.T) {
+func TestSummarizeStartFinishReturnsToIdle(t *testing.T) {
 	t.Parallel()
 	c := newTestClient()
 
-	// Summarizing event should trigger working.
-	c.HandleEvent(Summarizing{})
+	// Regression: compaction never publishes a RunComplete, so the
+	// summarize lifecycle must return the pane to idle by itself.
+	c.HandleEvent(SummarizeStarted{SessionID: "s1"})
 	assert.Equal(t, []string{stateWorking}, reportedStates(c))
 
-	// Second summarizing should not trigger another state change.
-	c.HandleEvent(Summarizing{})
+	// Repeated starts are deduplicated.
+	c.HandleEvent(SummarizeStarted{SessionID: "s1"})
 	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+
+	// Finishing the compaction returns the pane to idle.
+	c.HandleEvent(SummarizeFinished{SessionID: "s1"})
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+}
+
+func TestSummarizeDuringRunStaysWorking(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// Auto-compaction fires mid-turn (agent.go:1194): a run is
+	// already active when the summarize starts.
+	c.HandleEvent(AssistantMessage{SessionID: "s1"})
+	c.HandleEvent(SummarizeStarted{SessionID: "s1"})
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+
+	// Finishing the compaction must not drop the pane to idle while
+	// the turn that triggered it is still running.
+	c.HandleEvent(SummarizeFinished{SessionID: "s1"})
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+
+	// The turn's completion finally lands on idle.
+	c.HandleEvent(RunComplete{SessionID: "s1"})
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+}
+
+func TestSummarizeFinishWithoutStartIsNoop(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A finish without a matching start (e.g. a stale summary
+	// message deleted during session cleanup) must not report
+	// anything: idle is already the current state.
+	c.HandleEvent(SummarizeFinished{SessionID: "s1"})
+	assert.Empty(t, reportedStates(c))
 }
 
 func TestBlockOutranksRunComplete(t *testing.T) {
@@ -232,7 +276,8 @@ func TestNilClientSafe(t *testing.T) {
 	c.HandleEvent(RunComplete{SessionID: "s1"})
 	c.HandleEvent(PermissionRequested{})
 	c.HandleEvent(PermissionResolved{})
-	c.HandleEvent(Summarizing{})
+	c.HandleEvent(SummarizeStarted{SessionID: "s1"})
+	c.HandleEvent(SummarizeFinished{SessionID: "s1"})
 }
 
 func TestRegisterInitial(t *testing.T) {

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -840,3 +840,53 @@ func TestDisable(t *testing.T) {
 	Disable()
 	assert.Nil(t, newFromEnv())
 }
+
+// TestNotify verifies a toast goes out as a notification.show request
+// carrying the title and body.
+func TestNotify(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	c.Notify("Done", "turn complete")
+
+	req := lastRequest(c)
+	assert.Equal(t, "notification.show", req.Method)
+	p, ok := req.Params.(notificationParams)
+	assert.True(t, ok)
+	assert.Equal(t, "Done", p.Title)
+	assert.Equal(t, "turn complete", p.Body)
+}
+
+// TestNotifyTruncation verifies the title and body respect herdr's
+// 80/240-character caps, rune-safe.
+func TestNotifyTruncation(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	c.Notify(strings.Repeat("é", 100), strings.Repeat("b", 300))
+
+	p := lastRequest(c).Params.(notificationParams)
+	assert.Len(t, []rune(p.Title), maxBlockMessageLength)
+	assert.Len(t, []rune(p.Body), maxNotificationBodyLength)
+}
+
+// TestNotifyOmitsEmptyBody verifies a title-only toast leaves the
+// body key out of the wire payload entirely.
+func TestNotifyOmitsEmptyBody(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	c.Notify("Done", "")
+
+	data, err := json.Marshal(lastRequest(c).Params)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "body")
+}
+
+// TestNotifyNilClient verifies Notify is safe on a nil client, like
+// the other public methods.
+func TestNotifyNilClient(t *testing.T) {
+	t.Parallel()
+	var c *Client
+	assert.NotPanics(t, func() { c.Notify("Done", "") })
+}

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -118,6 +118,27 @@ func TestSummarizingTriggersWorking(t *testing.T) {
 	assert.Equal(t, []string{stateWorking}, reportedStates(c))
 }
 
+func TestBlockOutranksRunComplete(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A run starts and a permission prompt opens mid-turn.
+	c.HandleEvent(AssistantMessage{SessionID: "sess-1"})
+	c.HandleEvent(PermissionRequested{})
+	assert.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+
+	// A run completion arriving while the block is still pending
+	// (e.g. the turn was cancelled) must not drop the pane to idle:
+	// the block wins until it is resolved.
+	c.HandleEvent(RunComplete{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+
+	// With the run already finished, resolving the block lands on
+	// idle rather than working.
+	c.HandleEvent(PermissionResolved{})
+	assert.Equal(t, []string{stateWorking, stateBlocked, stateIdle}, reportedStates(c))
+}
+
 func TestNilClientSafe(t *testing.T) {
 	t.Parallel()
 	var c *Client

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -214,12 +214,20 @@ func TestSessionIDLearnedFromFirstEvent(t *testing.T) {
 	assert.Equal(t, []string{stateWorking}, reportedStates(c))
 
 	// SetSession re-points the client at the new session (session
-	// switch); events for the old one are now the stale ones.
+	// switch). The run flag described the session we left, so the
+	// switch clears it and the pane drops to idle; events for the
+	// old session are now the stale ones.
 	c.SetSession("s2", "S2")
-	c.HandleEvent(RunComplete{SessionID: "s1"})
-	assert.Equal(t, []string{stateWorking}, reportedStates(c))
-	c.HandleEvent(RunComplete{SessionID: "s2"})
 	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+	c.HandleEvent(RunComplete{SessionID: "s1"})
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+	c.HandleEvent(RunStarted{SessionID: "s2"})
+	c.HandleEvent(RunComplete{SessionID: "s2"})
+	assert.Equal(
+		t,
+		[]string{stateWorking, stateIdle, stateWorking, stateIdle},
+		reportedStates(c),
+	)
 }
 
 func TestSubSessionEventsIgnored(t *testing.T) {
@@ -650,6 +658,84 @@ func TestSetSessionReportsMetadata(t *testing.T) {
 
 	// The session id still rides along on state reports.
 	assert.Equal(t, "s2", c.sessionID)
+}
+
+func TestSetSessionClearsStaleRunState(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A run is in flight in s1 when the user switches to s2. The
+	// old session's RunComplete is dropped by the session gate, so
+	// the switch itself has to clear the run flag or the pane stays
+	// working forever.
+	c.SetSession("s1", "S1")
+	c.HandleEvent(RunStarted{SessionID: "s1"})
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+
+	c.SetSession("s2", "S2")
+	assert.False(t, c.runActive)
+	assert.False(t, c.summarizing)
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+
+	// The stale terminal event changes nothing, and a fresh turn in
+	// s2 still drives the pane normally.
+	c.HandleEvent(RunComplete{SessionID: "s1"})
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+	c.HandleEvent(RunStarted{SessionID: "s2"})
+	c.HandleEvent(RunComplete{SessionID: "s2"})
+	assert.Equal(
+		t,
+		[]string{stateWorking, stateIdle, stateWorking, stateIdle},
+		reportedStates(c),
+	)
+}
+
+func TestSetSessionClearsStaleSummarizing(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// Compaction is per-session too: its SummarizeFinished would be
+	// gated out after the switch.
+	c.SetSession("s1", "S1")
+	c.HandleEvent(SummarizeStarted{SessionID: "s1"})
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+
+	c.SetSession("s2", "S2")
+	assert.False(t, c.summarizing)
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+}
+
+func TestSetSessionSameIDKeepsRunState(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// Re-asserting the same session (reconnect, reload) is not a
+	// switch and must not interrupt the in-flight run.
+	c.SetSession("s1", "S1")
+	c.HandleEvent(RunStarted{SessionID: "s1"})
+	c.SetSession("s1", "S1 renamed")
+	assert.True(t, c.runActive)
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+}
+
+func TestSetSessionKeepsBlocks(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// Blocks are not session-scoped: the dialog is still on screen
+	// after the switch, so the pane stays blocked.
+	c.SetSession("s1", "S1")
+	c.HandleEvent(QuestionAsked{Text: "Proceed?"})
+	assert.Equal(t, []string{stateBlocked}, reportedStates(c))
+
+	c.SetSession("s2", "S2")
+	assert.Equal(t, []string{stateBlocked}, reportedStates(c))
+	assert.Equal(t, []string{"Proceed?"}, reportedMessages(c))
+
+	// Resolving it lands on idle, since the run it belonged to is
+	// no longer being tracked.
+	c.HandleEvent(QuestionResolved{})
+	assert.Equal(t, []string{stateBlocked, stateIdle}, reportedStates(c))
 }
 
 func TestSetSessionClearRemovesPresentation(t *testing.T) {

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -141,6 +141,42 @@ func TestRunStartedSessionGating(t *testing.T) {
 	assert.Equal(t, []string{stateWorking}, reportedStates(c))
 }
 
+func TestFinishedAssistantMessageAfterRunCompleteStaysIdle(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// The ESC-cancel race: the cancelled assistant's finished
+	// update travels on the messages broker while the cancelled
+	// RunComplete travels on the runCompletions broker, so the
+	// finished snapshot can be handled after the turn already
+	// ended. It must not re-arm the run; that would strand the
+	// pane in working with nothing left to clear it.
+	c.HandleEvent(RunStarted{SessionID: "sess-1"})
+	c.HandleEvent(RunComplete{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+
+	c.HandleEvent(AssistantMessage{SessionID: "sess-1", Finished: true})
+	assert.False(t, c.runActive)
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+}
+
+func TestFinishedAssistantMessageMidRunKeepsWorking(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A finished snapshot processed while the turn is still
+	// active (the common ordering) must not clear the run either:
+	// only RunComplete does. Skipping the arm is what makes the
+	// finished snapshot a no-op for the state machine.
+	c.HandleEvent(RunStarted{SessionID: "sess-1"})
+	c.HandleEvent(AssistantMessage{SessionID: "sess-1", Finished: true})
+	assert.True(t, c.runActive)
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+
+	c.HandleEvent(RunComplete{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+}
+
 func TestPermissionBlockAndUnblock(t *testing.T) {
 	t.Parallel()
 	c := newTestClient()

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -80,6 +80,44 @@ func TestBasicLifecycle(t *testing.T) {
 	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
 }
 
+func TestRunStartedReportsWorkingImmediately(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// The prompt submission itself flips the pane to working; no
+	// assistant output is required first.
+	c.HandleEvent(RunStarted{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+
+	// The first assistant message changes nothing (deduped), and
+	// the run's completion returns to idle.
+	c.HandleEvent(AssistantMessage{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+	c.HandleEvent(RunComplete{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+}
+
+func TestRunStartedSessionGating(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A sub-agent's prompt (agent-tool sub-session) must not drive
+	// the pane nor establish the session id.
+	c.HandleEvent(RunStarted{SessionID: "msg-1$$tc-1"})
+	assert.Empty(t, c.sessionID)
+	assert.Empty(t, reportedStates(c))
+
+	// The main session's prompt is accepted and learned.
+	c.HandleEvent(RunStarted{SessionID: "sess-1"})
+	assert.Equal(t, "sess-1", c.sessionID)
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+
+	// A prompt for a different top-level session is stale and
+	// ignored.
+	c.HandleEvent(RunStarted{SessionID: "other-session"})
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+}
+
 func TestPermissionBlockAndUnblock(t *testing.T) {
 	t.Parallel()
 	c := newTestClient()

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -90,9 +90,93 @@ func TestSessionIDPropagation(t *testing.T) {
 	c.SetSessionID("early-session")
 	assert.Equal(t, "early-session", c.sessionID)
 
-	// RunComplete also updates session ID.
-	c.HandleEvent(RunComplete{SessionID: "final-session"})
-	assert.Equal(t, "final-session", c.sessionID)
+	// Events for the current session drive the state.
+	c.HandleEvent(AssistantMessage{SessionID: "early-session"})
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+
+	// A lifecycle event for a different session is ignored: it must
+	// neither overwrite the authoritative session id nor change the
+	// reported state.
+	c.HandleEvent(RunComplete{SessionID: "other-session"})
+	assert.Equal(t, "early-session", c.sessionID)
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+
+	// An event for the current session is accepted.
+	c.HandleEvent(RunComplete{SessionID: "early-session"})
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+}
+
+func TestSessionIDLearnedFromFirstEvent(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// With no SetSessionID call, the first top-level lifecycle event
+	// establishes the session.
+	c.HandleEvent(AssistantMessage{SessionID: "s1"})
+	assert.Equal(t, "s1", c.sessionID)
+
+	// Events for other sessions are then ignored.
+	c.HandleEvent(AssistantMessage{SessionID: "s2"})
+	c.HandleEvent(RunComplete{SessionID: "s2"})
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+
+	// SetSessionID re-points the client at the new session (session
+	// switch); events for the old one are now the stale ones.
+	c.SetSessionID("s2")
+	c.HandleEvent(RunComplete{SessionID: "s1"})
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+	c.HandleEvent(RunComplete{SessionID: "s2"})
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+}
+
+func TestSubSessionEventsIgnored(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// Main session starts a run.
+	c.HandleEvent(AssistantMessage{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+
+	// A sub-agent (agent tool) run publishes its own lifecycle events
+	// on the shared broker with ids of the form
+	// "messageID$$toolCallID". Its messages must not corrupt the
+	// reported session id.
+	c.HandleEvent(AssistantMessage{SessionID: "msg-1$$tc-1"})
+	assert.Equal(t, "sess-1", c.sessionID)
+
+	// Its RunComplete must not drop the pane to idle while the main
+	// run is still going.
+	c.HandleEvent(RunComplete{SessionID: "msg-1$$tc-1"})
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
+
+	// The main run's completion still lands on idle.
+	c.HandleEvent(RunComplete{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
+}
+
+func TestSubSessionNeverEstablishesSessionID(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A sub-session event arriving before any SetSessionID must be
+	// ignored rather than learned as the current session.
+	c.HandleEvent(RunComplete{SessionID: "msg-1$$tc-1"})
+	assert.Empty(t, c.sessionID)
+	assert.Empty(t, reportedStates(c))
+}
+
+func TestSubSessionSummarizingIgnored(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// Auto-compaction inside a sub-agent session must not start a
+	// working report the main session never clears.
+	c.HandleEvent(Summarizing{SessionID: "msg-1$$tc-1"})
+	assert.Empty(t, reportedStates(c))
+
+	// A summarize event for the main session is accepted.
+	c.HandleEvent(Summarizing{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking}, reportedStates(c))
 }
 
 func TestDedupSkipsRedundantState(t *testing.T) {

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -352,6 +352,86 @@ func TestOverlappingPermissionAndQuestionBlocks(t *testing.T) {
 	assert.Equal(t, []string{stateWorking, stateBlocked, stateBlocked, stateWorking}, reportedStates(c))
 }
 
+func TestPermissionResolutionIsCorrelatedByToolCall(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	c.HandleEvent(RunStarted{SessionID: "sess-1"})
+	c.HandleEvent(PermissionRequested{ToolCallID: "tc-1"})
+	assert.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+
+	// A resolution for a different tool call must not unblock the
+	// open prompt. A PreToolUse hook that pre-approves a parallel
+	// tool call publishes exactly such a granted notification
+	// without ever raising a prompt of its own.
+	c.HandleEvent(PermissionResolved{ToolCallID: "tc-2"})
+	assert.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+
+	// The matching resolution does.
+	c.HandleEvent(PermissionResolved{ToolCallID: "tc-1"})
+	assert.Equal(t, []string{stateWorking, stateBlocked, stateWorking}, reportedStates(c))
+}
+
+func TestQuestionResolutionIsCorrelatedByBatch(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	c.HandleEvent(RunStarted{SessionID: "sess-1"})
+	c.HandleEvent(QuestionAsked{BatchID: "b2", Text: "Second batch"})
+	assert.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+
+	// A late resolution for an earlier batch, reordered past the
+	// new request by the bridge's per-broker goroutines, must not
+	// unblock the batch now on screen.
+	c.HandleEvent(QuestionResolved{BatchID: "b1"})
+	assert.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+
+	c.HandleEvent(QuestionResolved{BatchID: "b2"})
+	assert.Equal(t, []string{stateWorking, stateBlocked, stateWorking}, reportedStates(c))
+}
+
+func TestNewPromptSupersedesStaleBlock(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A turn cancelled while a prompt is open publishes no
+	// resolution, so the block outlives the request that raised it
+	// and keeps outranking the run's completion.
+	c.HandleEvent(RunStarted{SessionID: "sess-1"})
+	c.HandleEvent(PermissionRequested{ToolCallID: "tc-1"})
+	c.HandleEvent(RunComplete{SessionID: "sess-1"})
+	assert.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+
+	// The permission service serializes its requests, so the next
+	// one proves the stale request is over: it takes the old
+	// block's place instead of piling up next to it.
+	c.HandleEvent(RunStarted{SessionID: "sess-1"})
+	c.HandleEvent(PermissionRequested{ToolCallID: "tc-2"})
+	c.HandleEvent(PermissionResolved{ToolCallID: "tc-2"})
+	assert.Equal(t,
+		[]string{stateWorking, stateBlocked, stateWorking},
+		reportedStates(c),
+	)
+	c.mu.Lock()
+	assert.Empty(t, c.blocks)
+	c.mu.Unlock()
+}
+
+func TestNewestBlockMessageWins(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// Each request is a distinct block key, so the message always
+	// tracks the most recent prompt rather than whichever reason
+	// happened to be recorded first.
+	c.HandleEvent(QuestionAsked{BatchID: "b1", Text: "First question"})
+	c.HandleEvent(PermissionRequested{ToolCallID: "tc-1"})
+	c.HandleEvent(QuestionAsked{BatchID: "b2", Text: "Second question"})
+	c.mu.Lock()
+	assert.Equal(t, "Second question", c.message)
+	c.mu.Unlock()
+}
+
 func TestQuestionBlockOutranksRunComplete(t *testing.T) {
 	t.Parallel()
 	c := newTestClient()

--- a/internal/herdr/client_test.go
+++ b/internal/herdr/client_test.go
@@ -231,6 +231,41 @@ func TestSessionIDLearnedFromFirstEvent(t *testing.T) {
 	)
 }
 
+func TestLearnedSessionIDReachesMetadataToken(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	// A prompt's RunStarted can beat the SetSession that follows the
+	// session load: sendMessage batches loadSession and AgentRun as
+	// concurrent commands (internal/ui/model/ui.go). The id learned
+	// from the event rides on every state report from then on, so the
+	// metadata token must name that session too, not stay on the
+	// empty value the landing screen wrote.
+	c.SetSession("s1", "S1")
+	c.SetSession("", "")
+	c.HandleEvent(RunStarted{SessionID: "s2"})
+
+	params, ok := lastRequest(c).Params.(reportParams)
+	if assert.True(t, ok) {
+		assert.Equal(t, "s2", params.AgentSessionID)
+	}
+	meta := reportedMetadata(c)
+	if assert.Len(t, meta, 3) && assert.NotNil(t, meta[2].Tokens["session"]) {
+		assert.Equal(t, "s2", *meta[2].Tokens["session"])
+	}
+
+	// The SetSession that eventually lands only adds the title: the
+	// token it carries already matches.
+	c.SetSession("s2", "S2")
+	meta = reportedMetadata(c)
+	if assert.Len(t, meta, 4) {
+		assert.Equal(t, "S2", meta[3].Title)
+		if assert.NotNil(t, meta[3].Tokens["session"]) {
+			assert.Equal(t, "s2", *meta[3].Tokens["session"])
+		}
+	}
+}
+
 func TestSubSessionEventsIgnored(t *testing.T) {
 	t.Parallel()
 	c := newTestClient()
@@ -933,22 +968,27 @@ func TestAssistantMessageRefreshesModelToken(t *testing.T) {
 	c := newTestClient()
 
 	// The model riding on assistant output keeps the token fresh
-	// after a mid-session model switch, in both run modes.
+	// after a mid-session model switch, in both run modes. The
+	// session is known up front here, as it is in production, so
+	// every further metadata report comes from the model alone.
+	c.SetSession("s1", "S1")
+	assert.Len(t, reportedMetadata(c), 1)
+
 	c.HandleEvent(AssistantMessage{SessionID: "s1", Model: "model-1"})
 	meta := reportedMetadata(c)
-	assert.Len(t, meta, 1)
-	if assert.NotNil(t, meta[0].Tokens["model"]) {
-		assert.Equal(t, "model-1", *meta[0].Tokens["model"])
+	assert.Len(t, meta, 2)
+	if assert.NotNil(t, meta[1].Tokens["model"]) {
+		assert.Equal(t, "model-1", *meta[1].Tokens["model"])
 	}
 
 	// Same model: deduped. New model: re-reported. Empty model: no
 	// change.
 	c.HandleEvent(AssistantMessage{SessionID: "s1", Model: "model-1"})
-	assert.Len(t, reportedMetadata(c), 1)
+	assert.Len(t, reportedMetadata(c), 2)
 	c.HandleEvent(AssistantMessage{SessionID: "s1", Model: "model-2"})
-	assert.Len(t, reportedMetadata(c), 2)
+	assert.Len(t, reportedMetadata(c), 3)
 	c.HandleEvent(AssistantMessage{SessionID: "s1", Model: ""})
-	assert.Len(t, reportedMetadata(c), 2)
+	assert.Len(t, reportedMetadata(c), 3)
 }
 
 func TestSessionUpdatedRefreshesTitle(t *testing.T) {

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -37,7 +37,7 @@ func Translate(ev any) Event {
 		if len(e.Payload.Questions) > 0 {
 			text = e.Payload.Questions[0].Text
 		}
-		return QuestionAsked{BatchID: e.Payload.ID, Text: truncateText(text)}
+		return QuestionAsked{BatchID: e.Payload.ID, Text: truncateText(firstLine(text))}
 	case pubsub.Event[question.Notification]:
 		return QuestionResolved{BatchID: e.Payload.BatchID}
 	case pubsub.Event[notify.Notification]:
@@ -84,7 +84,7 @@ func Translate(ev any) Event {
 		if len(e.Payload.Questions) > 0 {
 			text = e.Payload.Questions[0].Question
 		}
-		return QuestionAsked{BatchID: e.Payload.ID, Text: truncateText(text)}
+		return QuestionAsked{BatchID: e.Payload.ID, Text: truncateText(firstLine(text))}
 	case pubsub.Event[proto.QuestionNotification]:
 		return QuestionResolved{BatchID: e.Payload.BatchID}
 	case pubsub.Event[proto.AgentEvent]:

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -37,7 +37,7 @@ func Translate(ev any) Event {
 		if len(e.Payload.Questions) > 0 {
 			text = e.Payload.Questions[0].Text
 		}
-		return QuestionAsked{BatchID: e.Payload.ID, Text: truncateBlockMessage(text)}
+		return QuestionAsked{BatchID: e.Payload.ID, Text: truncateText(text)}
 	case pubsub.Event[question.Notification]:
 		return QuestionResolved{BatchID: e.Payload.BatchID}
 	case pubsub.Event[notify.Notification]:
@@ -84,7 +84,7 @@ func Translate(ev any) Event {
 		if len(e.Payload.Questions) > 0 {
 			text = e.Payload.Questions[0].Question
 		}
-		return QuestionAsked{BatchID: e.Payload.ID, Text: truncateBlockMessage(text)}
+		return QuestionAsked{BatchID: e.Payload.ID, Text: truncateText(text)}
 	case pubsub.Event[proto.QuestionNotification]:
 		return QuestionResolved{BatchID: e.Payload.BatchID}
 	case pubsub.Event[proto.AgentEvent]:
@@ -120,14 +120,16 @@ func permissionNotification(toolCallID string, granted, denied bool) Event {
 	return PermissionResolved{ToolCallID: toolCallID}
 }
 
-// maxBlockMessageLength is herdr's 80-character cap on report text
-// fields. Block messages must stay under it.
-const maxBlockMessageLength = 80
+// maxTextFieldLength is herdr's 80-rune cap on report text fields.
+// It applies to every string crush sends except the notification
+// body: the agent report's blocked-reason message, the notification
+// title, and the pane presentation's title and token values.
+const maxTextFieldLength = 80
 
-// truncateBlockMessage caps a blocked-reason message at herdr's
-// text-field limit, keeping the cut rune-safe.
-func truncateBlockMessage(s string) string {
-	return truncateRunes(s, maxBlockMessageLength)
+// truncateText caps a text field at herdr's limit, keeping the cut
+// rune-safe.
+func truncateText(s string) string {
+	return truncateRunes(s, maxTextFieldLength)
 }
 
 // truncateRunes caps s at max runes, keeping the cut rune-safe.

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -60,10 +60,10 @@ func Translate(ev any) Event {
 		case proto.Assistant:
 			return AssistantMessage{SessionID: e.Payload.SessionID, Model: e.Payload.Model}
 		case proto.User:
-			// Same exclusions as the domain mapping: bang-mode
-			// shell records and session-cleanup deletions start
-			// no run.
-			if e.Type == pubsub.DeletedEvent || hasShellCommandPart(e.Payload.Parts) {
+			// Same exclusions as the domain mapping: only a
+			// creation starts a run. Bang-mode shell records,
+			// session-cleanup deletions and updates do not.
+			if e.Type != pubsub.CreatedEvent || hasShellCommandPart(e.Payload.Parts) {
 				return nil
 			}
 			return RunStarted{SessionID: e.Payload.SessionID}
@@ -150,7 +150,8 @@ func firstLine(s string) string {
 }
 
 // translateMessage maps a domain message event to a herdr event.
-// A user message marks prompt submission, the real start of a turn.
+// Creating a user message marks prompt submission, the real start of
+// a turn.
 // Compaction never publishes a RunComplete, so the summary message's
 // lifecycle doubles as the compaction signal: an unfinished summary
 // message means compaction is running, a finished one means it
@@ -172,11 +173,14 @@ func translateMessage(eventType pubsub.EventType, msg message.Message) Event {
 		return AssistantMessage{SessionID: msg.SessionID, Model: msg.Model}
 	}
 	if msg.Role == message.User {
+		// Only the creation of a user message starts a turn.
 		// Bang-mode shell commands are persisted as user messages
 		// (shell.PersistOutput) but start no agent run, and session
-		// cleanup deletes user messages; neither may report
-		// working. Only a real prompt submission does.
-		if eventType == pubsub.DeletedEvent || len(msg.ShellCommands()) > 0 {
+		// cleanup deletes user messages. Updates are excluded for
+		// the same reason: re-arming runActive outside a real
+		// submission produces no matching RunComplete and strands
+		// the pane in working.
+		if eventType != pubsub.CreatedEvent || len(msg.ShellCommands()) > 0 {
 			return nil
 		}
 		return RunStarted{SessionID: msg.SessionID}

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -132,13 +132,15 @@ func truncateText(s string) string {
 	return truncateRunes(s, maxTextFieldLength)
 }
 
-// truncateRunes caps s at max runes, keeping the cut rune-safe.
-func truncateRunes(s string, max int) string {
+// truncateRunes caps s at limit runes, keeping the cut rune-safe. The
+// parameter is limit rather than max so the body does not shadow the
+// builtin.
+func truncateRunes(s string, limit int) string {
 	r := []rune(s)
-	if len(r) <= max {
+	if len(r) <= limit {
 		return s
 	}
-	return string(r[:max])
+	return string(r[:limit])
 }
 
 // firstLine reduces free-form text to a single trimmed line. herdr's

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/pubsub"
+	"github.com/charmbracelet/crush/internal/question"
 )
 
 // Translate converts a pub/sub event (domain or proto) into a herdr
@@ -25,6 +26,14 @@ func Translate(ev any) Event {
 		return PermissionRequested{}
 	case pubsub.Event[permission.PermissionNotification]:
 		return PermissionResolved{}
+	case pubsub.Event[question.Request]:
+		var text string
+		if len(e.Payload.Questions) > 0 {
+			text = e.Payload.Questions[0].Text
+		}
+		return QuestionAsked{Text: truncateBlockMessage(text)}
+	case pubsub.Event[question.Notification]:
+		return QuestionResolved{}
 
 	// Proto types (client/server mode). proto.Message carries no
 	// IsSummaryMessage flag, so compaction is not detectable on the
@@ -41,10 +50,32 @@ func Translate(ev any) Event {
 		return PermissionRequested{}
 	case pubsub.Event[proto.PermissionNotification]:
 		return PermissionResolved{}
+	case pubsub.Event[proto.QuestionRequest]:
+		var text string
+		if len(e.Payload.Questions) > 0 {
+			text = e.Payload.Questions[0].Question
+		}
+		return QuestionAsked{Text: truncateBlockMessage(text)}
+	case pubsub.Event[proto.QuestionNotification]:
+		return QuestionResolved{}
 
 	default:
 		return nil
 	}
+}
+
+// maxBlockMessageLength is herdr's 80-character cap on report text
+// fields. Block messages must stay under it.
+const maxBlockMessageLength = 80
+
+// truncateBlockMessage caps a blocked-reason message at herdr's
+// text-field limit, keeping the cut rune-safe.
+func truncateBlockMessage(s string) string {
+	r := []rune(s)
+	if len(r) <= maxBlockMessageLength {
+		return s
+	}
+	return string(r[:maxBlockMessageLength])
 }
 
 // translateMessage maps a domain message event to a herdr event.
@@ -77,14 +108,23 @@ type permNotificationSubscriber interface {
 	SubscribeNotifications(context.Context) <-chan pubsub.Event[permission.PermissionNotification]
 }
 
+// questionNotificationSubscriber is the subset of the question
+// service needed by BridgeLocal to subscribe to resolution
+// notifications.
+type questionNotificationSubscriber interface {
+	SubscribeNotifications(context.Context) <-chan pubsub.Event[question.Notification]
+}
+
 // BridgeSources groups the pub/sub sources that BridgeLocal subscribes
 // to. Adding a new event type means adding a field here rather than
 // growing the function signature.
 type BridgeSources struct {
-	PermRequests      pubsub.Subscriber[permission.PermissionRequest]
-	PermNotifications permNotificationSubscriber
-	RunCompletions    pubsub.Subscriber[notify.RunComplete]
-	Messages          pubsub.Subscriber[message.Message]
+	PermRequests          pubsub.Subscriber[permission.PermissionRequest]
+	PermNotifications     permNotificationSubscriber
+	RunCompletions        pubsub.Subscriber[notify.RunComplete]
+	Messages              pubsub.Subscriber[message.Message]
+	Questions             pubsub.Subscriber[question.Request]
+	QuestionNotifications questionNotificationSubscriber
 }
 
 // BridgeLocal subscribes to local pub/sub brokers and forwards
@@ -114,6 +154,12 @@ func BridgeLocal(ctx context.Context, c *Client, src BridgeSources) {
 	})
 	go forward(ctx, c, func(subCtx context.Context) <-chan pubsub.Event[message.Message] {
 		return src.Messages.Subscribe(subCtx)
+	})
+	go forward(ctx, c, func(subCtx context.Context) <-chan pubsub.Event[question.Request] {
+		return src.Questions.Subscribe(subCtx)
+	})
+	go forward(ctx, c, func(subCtx context.Context) <-chan pubsub.Event[question.Notification] {
+		return src.QuestionNotifications.SubscribeNotifications(subCtx)
 	})
 }
 

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/question"
+	"github.com/charmbracelet/crush/internal/session"
 )
 
 // Translate converts a pub/sub event (domain or proto) into a herdr
@@ -42,6 +43,8 @@ func Translate(ev any) Event {
 			return AuthRequired{ProviderID: e.Payload.ProviderID}
 		}
 		return nil
+	case pubsub.Event[session.Session]:
+		return translateSession(e.Type, e.Payload.ID, e.Payload.Title)
 
 	// Proto types (client/server mode). proto.Message carries no
 	// IsSummaryMessage flag, so compaction is not detectable on the
@@ -50,7 +53,7 @@ func Translate(ev any) Event {
 	case pubsub.Event[proto.Message]:
 		switch e.Payload.Role {
 		case proto.Assistant:
-			return AssistantMessage{SessionID: e.Payload.SessionID}
+			return AssistantMessage{SessionID: e.Payload.SessionID, Model: e.Payload.Model}
 		case proto.User:
 			// Same exclusions as the domain mapping: bang-mode
 			// shell records and session-cleanup deletions start
@@ -84,6 +87,8 @@ func Translate(ev any) Event {
 			return AuthRequired{}
 		}
 		return nil
+	case pubsub.Event[proto.Session]:
+		return translateSession(e.Type, e.Payload.ID, e.Payload.Title)
 
 	default:
 		return nil
@@ -124,7 +129,7 @@ func translateMessage(eventType pubsub.EventType, msg message.Message) Event {
 		}
 	}
 	if msg.Role == message.Assistant {
-		return AssistantMessage{SessionID: msg.SessionID}
+		return AssistantMessage{SessionID: msg.SessionID, Model: msg.Model}
 	}
 	if msg.Role == message.User {
 		// Bang-mode shell commands are persisted as user messages
@@ -137,6 +142,17 @@ func translateMessage(eventType pubsub.EventType, msg message.Message) Event {
 		return RunStarted{SessionID: msg.SessionID}
 	}
 	return nil
+}
+
+// translateSession maps a session event (domain or proto) to a
+// presentation refresh. Deletions carry no presentation value: when
+// the current session is deleted the UI switches away and SetSession
+// clears the metadata instead.
+func translateSession(eventType pubsub.EventType, id, title string) Event {
+	if eventType == pubsub.DeletedEvent {
+		return nil
+	}
+	return SessionUpdated{SessionID: id, Title: title}
 }
 
 // hasShellCommandPart reports whether a proto message carries a
@@ -175,6 +191,7 @@ type BridgeSources struct {
 	Questions             pubsub.Subscriber[question.Request]
 	QuestionNotifications questionNotificationSubscriber
 	Notifications         pubsub.Subscriber[notify.Notification]
+	Sessions              pubsub.Subscriber[session.Session]
 }
 
 // BridgeLocal subscribes to local pub/sub brokers and forwards
@@ -213,6 +230,9 @@ func BridgeLocal(ctx context.Context, c *Client, src BridgeSources) {
 	})
 	go forward(ctx, c, func(subCtx context.Context) <-chan pubsub.Event[notify.Notification] {
 		return src.Notifications.Subscribe(subCtx)
+	})
+	go forward(ctx, c, func(subCtx context.Context) <-chan pubsub.Event[session.Session] {
+		return src.Sessions.Subscribe(subCtx)
 	})
 }
 

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -34,6 +34,14 @@ func Translate(ev any) Event {
 		return QuestionAsked{Text: truncateBlockMessage(text)}
 	case pubsub.Event[question.Notification]:
 		return QuestionResolved{}
+	case pubsub.Event[notify.Notification]:
+		// Only re-authentication blocks the pane; every other
+		// notification type is informational. AWS SSO is handled
+		// transparently by its own dialog flow and never blocks.
+		if e.Payload.Type == notify.TypeReAuthenticate {
+			return AuthRequired{ProviderID: e.Payload.ProviderID}
+		}
+		return nil
 
 	// Proto types (client/server mode). proto.Message carries no
 	// IsSummaryMessage flag, so compaction is not detectable on the
@@ -58,6 +66,15 @@ func Translate(ev any) Event {
 		return QuestionAsked{Text: truncateBlockMessage(text)}
 	case pubsub.Event[proto.QuestionNotification]:
 		return QuestionResolved{}
+	case pubsub.Event[proto.AgentEvent]:
+		// The server wraps notify.Notification into proto.AgentEvent
+		// with the domain type string, so re_authenticate arrives
+		// here in client/server mode. ProviderID does not cross the
+		// wire, so the block message carries no provider name.
+		if notify.Type(e.Payload.Type) == notify.TypeReAuthenticate {
+			return AuthRequired{}
+		}
+		return nil
 
 	default:
 		return nil
@@ -125,6 +142,7 @@ type BridgeSources struct {
 	Messages              pubsub.Subscriber[message.Message]
 	Questions             pubsub.Subscriber[question.Request]
 	QuestionNotifications questionNotificationSubscriber
+	Notifications         pubsub.Subscriber[notify.Notification]
 }
 
 // BridgeLocal subscribes to local pub/sub brokers and forwards
@@ -160,6 +178,9 @@ func BridgeLocal(ctx context.Context, c *Client, src BridgeSources) {
 	})
 	go forward(ctx, c, func(subCtx context.Context) <-chan pubsub.Event[question.Notification] {
 		return src.QuestionNotifications.SubscribeNotifications(subCtx)
+	})
+	go forward(ctx, c, func(subCtx context.Context) <-chan pubsub.Event[notify.Notification] {
+		return src.Notifications.Subscribe(subCtx)
 	})
 }
 

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -48,8 +48,17 @@ func Translate(ev any) Event {
 	// wire; client/server mode simply never reports a summarizing
 	// state.
 	case pubsub.Event[proto.Message]:
-		if e.Payload.Role == proto.Assistant {
+		switch e.Payload.Role {
+		case proto.Assistant:
 			return AssistantMessage{SessionID: e.Payload.SessionID}
+		case proto.User:
+			// Same exclusions as the domain mapping: bang-mode
+			// shell records and session-cleanup deletions start
+			// no run.
+			if e.Type == pubsub.DeletedEvent || hasShellCommandPart(e.Payload.Parts) {
+				return nil
+			}
+			return RunStarted{SessionID: e.Payload.SessionID}
 		}
 		return nil
 	case pubsub.Event[proto.RunComplete]:
@@ -96,6 +105,7 @@ func truncateBlockMessage(s string) string {
 }
 
 // translateMessage maps a domain message event to a herdr event.
+// A user message marks prompt submission, the real start of a turn.
 // Compaction never publishes a RunComplete, so the summary message's
 // lifecycle doubles as the compaction signal: an unfinished summary
 // message means compaction is running, a finished one means it
@@ -116,7 +126,29 @@ func translateMessage(eventType pubsub.EventType, msg message.Message) Event {
 	if msg.Role == message.Assistant {
 		return AssistantMessage{SessionID: msg.SessionID}
 	}
+	if msg.Role == message.User {
+		// Bang-mode shell commands are persisted as user messages
+		// (shell.PersistOutput) but start no agent run, and session
+		// cleanup deletes user messages; neither may report
+		// working. Only a real prompt submission does.
+		if eventType == pubsub.DeletedEvent || len(msg.ShellCommands()) > 0 {
+			return nil
+		}
+		return RunStarted{SessionID: msg.SessionID}
+	}
 	return nil
+}
+
+// hasShellCommandPart reports whether a proto message carries a
+// bang-mode shell command part. proto.Message has no ShellCommands
+// helper like the domain type, so check the parts directly.
+func hasShellCommandPart(parts []proto.ContentPart) bool {
+	for _, p := range parts {
+		if _, ok := p.(proto.ShellCommand); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // permNotificationSubscriber is the subset of the permission service

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -24,17 +24,17 @@ func Translate(ev any) Event {
 	case pubsub.Event[notify.RunComplete]:
 		return RunComplete{SessionID: e.Payload.SessionID}
 	case pubsub.Event[permission.PermissionRequest]:
-		return PermissionRequested{}
+		return PermissionRequested{ToolCallID: e.Payload.ToolCallID}
 	case pubsub.Event[permission.PermissionNotification]:
-		return PermissionResolved{}
+		return permissionNotification(e.Payload.ToolCallID, e.Payload.Granted, e.Payload.Denied)
 	case pubsub.Event[question.Request]:
 		var text string
 		if len(e.Payload.Questions) > 0 {
 			text = e.Payload.Questions[0].Text
 		}
-		return QuestionAsked{Text: truncateBlockMessage(text)}
+		return QuestionAsked{BatchID: e.Payload.ID, Text: truncateBlockMessage(text)}
 	case pubsub.Event[question.Notification]:
-		return QuestionResolved{}
+		return QuestionResolved{BatchID: e.Payload.BatchID}
 	case pubsub.Event[notify.Notification]:
 		// Only re-authentication blocks the pane; every other
 		// notification type is informational. AWS SSO is handled
@@ -67,17 +67,17 @@ func Translate(ev any) Event {
 	case pubsub.Event[proto.RunComplete]:
 		return RunComplete{SessionID: e.Payload.SessionID}
 	case pubsub.Event[proto.PermissionRequest]:
-		return PermissionRequested{}
+		return PermissionRequested{ToolCallID: e.Payload.ToolCallID}
 	case pubsub.Event[proto.PermissionNotification]:
-		return PermissionResolved{}
+		return permissionNotification(e.Payload.ToolCallID, e.Payload.Granted, e.Payload.Denied)
 	case pubsub.Event[proto.QuestionRequest]:
 		var text string
 		if len(e.Payload.Questions) > 0 {
 			text = e.Payload.Questions[0].Question
 		}
-		return QuestionAsked{Text: truncateBlockMessage(text)}
+		return QuestionAsked{BatchID: e.Payload.ID, Text: truncateBlockMessage(text)}
 	case pubsub.Event[proto.QuestionNotification]:
-		return QuestionResolved{}
+		return QuestionResolved{BatchID: e.Payload.BatchID}
 	case pubsub.Event[proto.AgentEvent]:
 		// The server wraps notify.Notification into proto.AgentEvent
 		// with the domain type string, so re_authenticate arrives
@@ -93,6 +93,22 @@ func Translate(ev any) Event {
 	default:
 		return nil
 	}
+}
+
+// permissionNotification maps a permission notification to a herdr
+// event. Only a granted or denied notification ends the wait: the
+// permission service also publishes a flagless notification the
+// moment a request *starts*, before publishing the request itself
+// (permissionService.Request). Treating that marker as a resolution
+// is unsafe because local mode consumes the request broker and the
+// notification broker on separate goroutines, so the clear can land
+// after the set and leave the pane reporting working while the
+// prompt is still on screen.
+func permissionNotification(toolCallID string, granted, denied bool) Event {
+	if !granted && !denied {
+		return nil
+	}
+	return PermissionResolved{ToolCallID: toolCallID}
 }
 
 // maxBlockMessageLength is herdr's 80-character cap on report text

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -45,7 +45,7 @@ func Translate(ev any) Event {
 		return PermissionResolved{}
 	case pubsub.Event[proto.AgentEvent]:
 		if e.Payload.Type == proto.AgentEventTypeSummarize && !e.Payload.Done {
-			return Summarizing{}
+			return Summarizing{SessionID: e.Payload.Message.SessionID}
 		}
 		return nil
 
@@ -61,7 +61,7 @@ func translateMessage(isAssistant bool, sessionID string, isSummary bool) Event 
 		return nil
 	}
 	if isSummary {
-		return Summarizing{}
+		return Summarizing{SessionID: sessionID}
 	}
 	return AssistantMessage{SessionID: sessionID}
 }

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -102,11 +102,16 @@ const maxBlockMessageLength = 80
 // truncateBlockMessage caps a blocked-reason message at herdr's
 // text-field limit, keeping the cut rune-safe.
 func truncateBlockMessage(s string) string {
+	return truncateRunes(s, maxBlockMessageLength)
+}
+
+// truncateRunes caps s at max runes, keeping the cut rune-safe.
+func truncateRunes(s string, max int) string {
 	r := []rune(s)
-	if len(r) <= maxBlockMessageLength {
+	if len(r) <= max {
 		return s
 	}
-	return string(r[:maxBlockMessageLength])
+	return string(r[:max])
 }
 
 // translateMessage maps a domain message event to a herdr event.

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -18,11 +18,7 @@ func Translate(ev any) Event {
 	switch e := ev.(type) {
 	// Domain types (TUI / local headless).
 	case pubsub.Event[message.Message]:
-		return translateMessage(
-			e.Payload.Role == message.Assistant,
-			e.Payload.SessionID,
-			e.Payload.IsSummaryMessage,
-		)
+		return translateMessage(e.Type, e.Payload)
 	case pubsub.Event[notify.RunComplete]:
 		return RunComplete{SessionID: e.Payload.SessionID}
 	case pubsub.Event[permission.PermissionRequest]:
@@ -30,40 +26,49 @@ func Translate(ev any) Event {
 	case pubsub.Event[permission.PermissionNotification]:
 		return PermissionResolved{}
 
-	// Proto types (client/server mode).
+	// Proto types (client/server mode). proto.Message carries no
+	// IsSummaryMessage flag, so compaction is not detectable on the
+	// wire; client/server mode simply never reports a summarizing
+	// state.
 	case pubsub.Event[proto.Message]:
-		return translateMessage(
-			e.Payload.Role == proto.Assistant,
-			e.Payload.SessionID,
-			false,
-		)
+		if e.Payload.Role == proto.Assistant {
+			return AssistantMessage{SessionID: e.Payload.SessionID}
+		}
+		return nil
 	case pubsub.Event[proto.RunComplete]:
 		return RunComplete{SessionID: e.Payload.SessionID}
 	case pubsub.Event[proto.PermissionRequest]:
 		return PermissionRequested{}
 	case pubsub.Event[proto.PermissionNotification]:
 		return PermissionResolved{}
-	case pubsub.Event[proto.AgentEvent]:
-		if e.Payload.Type == proto.AgentEventTypeSummarize && !e.Payload.Done {
-			return Summarizing{SessionID: e.Payload.Message.SessionID}
-		}
-		return nil
 
 	default:
 		return nil
 	}
 }
 
-// translateMessage is the shared message-mapping logic for both domain
-// and proto message types.
-func translateMessage(isAssistant bool, sessionID string, isSummary bool) Event {
-	if !isAssistant {
-		return nil
+// translateMessage maps a domain message event to a herdr event.
+// Compaction never publishes a RunComplete, so the summary message's
+// lifecycle doubles as the compaction signal: an unfinished summary
+// message means compaction is running, a finished one means it
+// completed or errored (sessionAgent.Summarize calls AddFinish on
+// both paths), and a deleted one means the user cancelled (the
+// cancel path removes the summary message).
+func translateMessage(eventType pubsub.EventType, msg message.Message) Event {
+	if msg.IsSummaryMessage {
+		switch {
+		case eventType == pubsub.DeletedEvent:
+			return SummarizeFinished{SessionID: msg.SessionID}
+		case msg.IsFinished():
+			return SummarizeFinished{SessionID: msg.SessionID}
+		default:
+			return SummarizeStarted{SessionID: msg.SessionID}
+		}
 	}
-	if isSummary {
-		return Summarizing{SessionID: sessionID}
+	if msg.Role == message.Assistant {
+		return AssistantMessage{SessionID: msg.SessionID}
 	}
-	return AssistantMessage{SessionID: sessionID}
+	return nil
 }
 
 // permNotificationSubscriber is the subset of the permission service

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -2,6 +2,7 @@ package herdr
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/charmbracelet/crush/internal/agent/notify"
@@ -24,7 +25,11 @@ func Translate(ev any) Event {
 	case pubsub.Event[notify.RunComplete]:
 		return RunComplete{SessionID: e.Payload.SessionID}
 	case pubsub.Event[permission.PermissionRequest]:
-		return PermissionRequested{ToolCallID: e.Payload.ToolCallID}
+		return PermissionRequested{
+			ToolCallID:  e.Payload.ToolCallID,
+			ToolName:    e.Payload.ToolName,
+			Description: e.Payload.Description,
+		}
 	case pubsub.Event[permission.PermissionNotification]:
 		return permissionNotification(e.Payload.ToolCallID, e.Payload.Granted, e.Payload.Denied)
 	case pubsub.Event[question.Request]:
@@ -67,7 +72,11 @@ func Translate(ev any) Event {
 	case pubsub.Event[proto.RunComplete]:
 		return RunComplete{SessionID: e.Payload.SessionID}
 	case pubsub.Event[proto.PermissionRequest]:
-		return PermissionRequested{ToolCallID: e.Payload.ToolCallID}
+		return PermissionRequested{
+			ToolCallID:  e.Payload.ToolCallID,
+			ToolName:    e.Payload.ToolName,
+			Description: e.Payload.Description,
+		}
 	case pubsub.Event[proto.PermissionNotification]:
 		return permissionNotification(e.Payload.ToolCallID, e.Payload.Granted, e.Payload.Denied)
 	case pubsub.Event[proto.QuestionRequest]:
@@ -128,6 +137,16 @@ func truncateRunes(s string, max int) string {
 		return s
 	}
 	return string(r[:max])
+}
+
+// firstLine reduces free-form text to a single trimmed line. herdr's
+// text fields are single-line, so anything past the first newline is
+// dropped rather than sent as an embedded break.
+func firstLine(s string) string {
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
 }
 
 // translateMessage maps a domain message event to a herdr event.

--- a/internal/herdr/translate.go
+++ b/internal/herdr/translate.go
@@ -58,7 +58,7 @@ func Translate(ev any) Event {
 	case pubsub.Event[proto.Message]:
 		switch e.Payload.Role {
 		case proto.Assistant:
-			return AssistantMessage{SessionID: e.Payload.SessionID, Model: e.Payload.Model}
+			return AssistantMessage{SessionID: e.Payload.SessionID, Model: e.Payload.Model, Finished: e.Payload.IsFinished()}
 		case proto.User:
 			// Same exclusions as the domain mapping: only a
 			// creation starts a run. Bang-mode shell records,
@@ -174,7 +174,7 @@ func translateMessage(eventType pubsub.EventType, msg message.Message) Event {
 		}
 	}
 	if msg.Role == message.Assistant {
-		return AssistantMessage{SessionID: msg.SessionID, Model: msg.Model}
+		return AssistantMessage{SessionID: msg.SessionID, Model: msg.Model, Finished: msg.IsFinished()}
 	}
 	if msg.Role == message.User {
 		// Only the creation of a user message starts a turn.

--- a/internal/herdr/translate_integration_test.go
+++ b/internal/herdr/translate_integration_test.go
@@ -83,6 +83,65 @@ func TestSummaryMessageLifecycleIntegration(t *testing.T) {
 	)
 }
 
+// TestUserMessageRunStartedIntegration pins the prompt-submission
+// contract between message.Service and Translate that the early
+// working report relies on: creating a user message means a turn
+// started, while a bang-mode shell record (also a user message)
+// means no run. Drives a real SQLite-backed message service and
+// asserts the resulting client state sequence.
+func TestUserMessageRunStartedIntegration(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	conn, err := db.Connect(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	q := db.New(conn)
+	sess, err := session.NewService(q, conn).Create(ctx, "test")
+	require.NoError(t, err)
+
+	svc := message.NewService(q, message.WithDebounce(0))
+	ch := svc.Subscribe(ctx)
+
+	c := newTestClient()
+	c.SetSessionID(sess.ID)
+
+	// drain pops one published event and forwards its translation.
+	drain := func() {
+		t.Helper()
+		select {
+		case ev := <-ch:
+			if hev := Translate(ev); hev != nil {
+				c.HandleEvent(hev)
+			}
+		default:
+			t.Fatal("expected a published message event")
+		}
+	}
+
+	// Prompt submission flips the pane to working before any
+	// assistant output exists (agent.go:713).
+	_, err = svc.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role:  message.User,
+		Parts: []message.ContentPart{message.TextContent{Text: "hi"}},
+	})
+	require.NoError(t, err)
+	drain() // CreatedEvent -> RunStarted.
+
+	// A bang-mode shell command persists a user message but starts
+	// no run (shell.PersistOutput).
+	_, err = svc.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.ShellCommand{Command: "ls", Output: "file.go", ExitCode: 0},
+		},
+	})
+	require.NoError(t, err)
+	drain() // CreatedEvent -> nil.
+
+	require.Equal(t, []string{stateWorking}, reportedStates(c))
+}
+
 // TestTranslateDomainDeletedNonSummary guards the boundary of the
 // delete mapping: deleting a regular assistant message (session
 // cleanup) is not a compaction signal and keeps its pre-existing

--- a/internal/herdr/translate_integration_test.go
+++ b/internal/herdr/translate_integration_test.go
@@ -242,11 +242,12 @@ func TestPermissionRequestPublishOrderIntegration(t *testing.T) {
 	granted := make(chan bool, 1)
 	go func() {
 		ok, err := svc.Request(ctx, permission.CreatePermissionRequest{
-			SessionID:  "s1",
-			ToolCallID: "tc-1",
-			ToolName:   "bash",
-			Action:     "execute",
-			Path:       dir,
+			SessionID:   "s1",
+			ToolCallID:  "tc-1",
+			ToolName:    "bash",
+			Action:      "execute",
+			Description: "Execute command: ls",
+			Path:        dir,
 		})
 		assert.NoError(t, err)
 		granted <- ok
@@ -272,6 +273,12 @@ func TestPermissionRequestPublishOrderIntegration(t *testing.T) {
 	deliver(req)
 	deliver(announce)
 	require.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+	// The real service's payload reaches herdr as the blocked
+	// reason, so the pane shows what crush is waiting on.
+	require.Equal(t,
+		"Permission: bash - Execute command: ls",
+		lastRequest(c).Params.(reportParams).Message,
+	)
 
 	require.True(t, svc.Grant(req.Payload))
 	deliver(<-notifications)

--- a/internal/herdr/translate_integration_test.go
+++ b/internal/herdr/translate_integration_test.go
@@ -88,9 +88,10 @@ func TestSummaryMessageLifecycleIntegration(t *testing.T) {
 // TestUserMessageRunStartedIntegration pins the prompt-submission
 // contract between message.Service and Translate that the early
 // working report relies on: creating a user message means a turn
-// started, while a bang-mode shell record (also a user message)
-// means no run. Drives a real SQLite-backed message service and
-// asserts the resulting client state sequence.
+// started, while a bang-mode shell record (also a user message) and
+// an update to an existing prompt mean no run. Drives a real
+// SQLite-backed message service and asserts the resulting client
+// state sequence.
 func TestUserMessageRunStartedIntegration(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
@@ -123,7 +124,7 @@ func TestUserMessageRunStartedIntegration(t *testing.T) {
 
 	// Prompt submission flips the pane to working before any
 	// assistant output exists (agent.go:713).
-	_, err = svc.Create(ctx, sess.ID, message.CreateMessageParams{
+	prompt, err := svc.Create(ctx, sess.ID, message.CreateMessageParams{
 		Role:  message.User,
 		Parts: []message.ContentPart{message.TextContent{Text: "hi"}},
 	})
@@ -141,7 +142,14 @@ func TestUserMessageRunStartedIntegration(t *testing.T) {
 	require.NoError(t, err)
 	drain() // CreatedEvent -> nil.
 
-	require.Equal(t, []string{stateWorking}, reportedStates(c))
+	// Update publishes an UpdatedEvent for whatever message it is
+	// handed. Revising an existing prompt is not a submission, so it
+	// must not re-arm working once the turn has ended.
+	c.HandleEvent(RunComplete{SessionID: sess.ID})
+	require.NoError(t, svc.Update(ctx, prompt))
+	drain() // UpdatedEvent -> nil.
+
+	require.Equal(t, []string{stateWorking, stateIdle}, reportedStates(c))
 }
 
 // TestTranslateDomainDeletedNonSummary guards the boundary of the

--- a/internal/herdr/translate_integration_test.go
+++ b/internal/herdr/translate_integration_test.go
@@ -1,0 +1,97 @@
+package herdr
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/db"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/pubsub"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSummaryMessageLifecycleIntegration pins the contract between
+// message.Service's publish behaviour and Translate that the
+// compaction fix relies on: an unfinished summary message means
+// compaction started, a finished one means it completed or errored,
+// and a deleted one means it was cancelled. Drives a real
+// SQLite-backed message service through both the success and the
+// cancel paths of sessionAgent.Summarize and asserts the translated
+// herdr events plus the resulting client state sequence.
+func TestSummaryMessageLifecycleIntegration(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	conn, err := db.Connect(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	q := db.New(conn)
+	sess, err := session.NewService(q, conn).Create(ctx, "test")
+	require.NoError(t, err)
+
+	// Zero debounce so every Update publishes synchronously.
+	svc := message.NewService(q, message.WithDebounce(0))
+	ch := svc.Subscribe(ctx)
+
+	c := newTestClient()
+	c.SetSessionID(sess.ID)
+
+	// drain pops one published event and forwards its translation.
+	drain := func() {
+		t.Helper()
+		select {
+		case ev := <-ch:
+			if hev := Translate(ev); hev != nil {
+				c.HandleEvent(hev)
+			}
+		default:
+			t.Fatal("expected a published message event")
+		}
+	}
+
+	// Success path: create, stream content, finish (agent.go:1387,
+	// 1450).
+	msg, err := svc.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role:             message.Assistant,
+		IsSummaryMessage: true,
+	})
+	require.NoError(t, err)
+	drain() // CreatedEvent -> SummarizeStarted.
+
+	msg.AppendContent("summary text")
+	require.NoError(t, svc.Update(ctx, msg))
+	drain() // UpdatedEvent, unfinished -> SummarizeStarted (deduped).
+
+	msg.AddFinish(message.FinishReasonEndTurn, "", "")
+	require.NoError(t, svc.Update(ctx, msg))
+	drain() // UpdatedEvent, finished -> SummarizeFinished.
+
+	// Cancel path: create, then delete (agent.go:1437-1440).
+	cancelMsg, err := svc.Create(ctx, sess.ID, message.CreateMessageParams{
+		Role:             message.Assistant,
+		IsSummaryMessage: true,
+	})
+	require.NoError(t, err)
+	drain() // CreatedEvent -> SummarizeStarted.
+
+	require.NoError(t, svc.Delete(ctx, cancelMsg.ID))
+	drain() // DeletedEvent -> SummarizeFinished.
+
+	require.Equal(t,
+		[]string{stateWorking, stateIdle, stateWorking, stateIdle},
+		reportedStates(c),
+	)
+}
+
+// TestTranslateDomainDeletedNonSummary guards the boundary of the
+// delete mapping: deleting a regular assistant message (session
+// cleanup) is not a compaction signal and keeps its pre-existing
+// translation.
+func TestTranslateDomainDeletedNonSummary(t *testing.T) {
+	t.Parallel()
+	ev := pubsub.Event[message.Message]{
+		Type:    pubsub.DeletedEvent,
+		Payload: message.Message{Role: message.Assistant, SessionID: "s1"},
+	}
+	require.Equal(t, AssistantMessage{SessionID: "s1"}, Translate(ev))
+}

--- a/internal/herdr/translate_integration_test.go
+++ b/internal/herdr/translate_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/session"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,7 +35,7 @@ func TestSummaryMessageLifecycleIntegration(t *testing.T) {
 	ch := svc.Subscribe(ctx)
 
 	c := newTestClient()
-	c.SetSessionID(sess.ID)
+	c.SetSession(sess.ID, sess.Title)
 
 	// drain pops one published event and forwards its translation.
 	drain := func() {
@@ -104,7 +105,7 @@ func TestUserMessageRunStartedIntegration(t *testing.T) {
 	ch := svc.Subscribe(ctx)
 
 	c := newTestClient()
-	c.SetSessionID(sess.ID)
+	c.SetSession(sess.ID, sess.Title)
 
 	// drain pops one published event and forwards its translation.
 	drain := func() {
@@ -153,4 +154,65 @@ func TestTranslateDomainDeletedNonSummary(t *testing.T) {
 		Payload: message.Message{Role: message.Assistant, SessionID: "s1"},
 	}
 	require.Equal(t, AssistantMessage{SessionID: "s1"}, Translate(ev))
+}
+
+// TestSessionTitleChangeIntegration pins the contract between
+// session.Service's publish behaviour and Translate that the pane
+// title refresh relies on: a rename (or auto-title, which shares the
+// same UpdatedEvent path) publishes the session with its new title,
+// and only the current session's event updates the pane metadata.
+// Drives a real SQLite-backed session service.
+func TestSessionTitleChangeIntegration(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	conn, err := db.Connect(ctx, t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	q := db.New(conn)
+	svc := session.NewService(q, conn)
+	sess, err := svc.Create(ctx, "Untitled Session")
+	require.NoError(t, err)
+	other, err := svc.Create(ctx, "Other Session")
+	require.NoError(t, err)
+
+	ch := svc.Subscribe(ctx)
+
+	c := newTestClient()
+	c.SetSession(sess.ID, "Untitled Session")
+
+	// drain pops one published event and forwards its translation.
+	drain := func() {
+		t.Helper()
+		select {
+		case ev := <-ch:
+			if hev := Translate(ev); hev != nil {
+				c.HandleEvent(hev)
+			}
+		default:
+			t.Fatal("expected a published session event")
+		}
+	}
+
+	// The two Creates published events for sessions that are not the
+	// current one (the client's SetSession predates them but the
+	// subscription started after, so nothing is drained for them).
+
+	// A title change on a background session must not touch the
+	// pane.
+	require.NoError(t, svc.Rename(ctx, other.ID, "Background Title"))
+	drain() // UpdatedEvent -> SessionUpdated, gated away.
+	meta := reportedMetadata(c)
+	require.Len(t, meta, 1)
+	require.Equal(t, "Untitled Session", meta[0].Title)
+
+	// A rename of the current session refreshes the pane title.
+	require.NoError(t, svc.Rename(ctx, sess.ID, "Generated Title"))
+	drain() // UpdatedEvent -> SessionUpdated, applied.
+	meta = reportedMetadata(c)
+	require.Len(t, meta, 2)
+	require.Equal(t, "Generated Title", meta[1].Title)
+	if assert.NotNil(t, meta[1].Tokens["session"]) {
+		assert.Equal(t, sess.ID, *meta[1].Tokens["session"])
+	}
 }

--- a/internal/herdr/translate_integration_test.go
+++ b/internal/herdr/translate_integration_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/charmbracelet/crush/internal/db"
 	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/stretchr/testify/assert"
@@ -215,4 +216,68 @@ func TestSessionTitleChangeIntegration(t *testing.T) {
 	if assert.NotNil(t, meta[1].Tokens["session"]) {
 		assert.Equal(t, sess.ID, *meta[1].Tokens["session"])
 	}
+}
+
+// TestPermissionRequestPublishOrderIntegration pins the contract
+// between permission.Service's publish behaviour and Translate that
+// the blocked report relies on. The service announces a request on
+// the notification broker before publishing the request itself, and
+// BridgeLocal consumes the two brokers on separate goroutines, so
+// the announcement may reach the client after the request does. It
+// must not unblock the pane; only the granted or denied notification
+// may. Drives a real permission service through a full
+// request/grant cycle and replays both events in the adverse order.
+func TestPermissionRequestPublishOrderIntegration(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	dir := t.TempDir()
+	svc := permission.NewPermissionService(dir, false, nil)
+	requests := svc.Subscribe(ctx)
+	notifications := svc.SubscribeNotifications(ctx)
+
+	c := newTestClient()
+	c.SetSession("s1", "Test")
+	c.HandleEvent(RunStarted{SessionID: "s1"})
+
+	granted := make(chan bool, 1)
+	go func() {
+		ok, err := svc.Request(ctx, permission.CreatePermissionRequest{
+			SessionID:  "s1",
+			ToolCallID: "tc-1",
+			ToolName:   "bash",
+			Action:     "execute",
+			Path:       dir,
+		})
+		assert.NoError(t, err)
+		granted <- ok
+	}()
+
+	// deliver forwards one event exactly as BridgeLocal's forward
+	// goroutines do.
+	deliver := func(ev any) {
+		t.Helper()
+		if hev := Translate(ev); hev != nil {
+			c.HandleEvent(hev)
+		}
+	}
+
+	announce := <-notifications
+	require.Equal(t, "tc-1", announce.Payload.ToolCallID)
+	require.False(t, announce.Payload.Granted)
+	require.False(t, announce.Payload.Denied)
+	req := <-requests
+
+	// Adverse order: the request blocks the pane, then the
+	// announcement of that same request arrives late.
+	deliver(req)
+	deliver(announce)
+	require.Equal(t, []string{stateWorking, stateBlocked}, reportedStates(c))
+
+	require.True(t, svc.Grant(req.Payload))
+	deliver(<-notifications)
+	require.True(t, <-granted)
+	require.Equal(t,
+		[]string{stateWorking, stateBlocked, stateWorking},
+		reportedStates(c),
+	)
 }

--- a/internal/herdr/translate_test.go
+++ b/internal/herdr/translate_test.go
@@ -253,6 +253,38 @@ func TestTranslateDomainQuestionRequestTruncatesMessage(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestTranslateDomainQuestionRequestFirstLinesMessage(t *testing.T) {
+	t.Parallel()
+	// Question text is model-generated free-form; herdr's text
+	// fields are single-line, so anything past the first newline
+	// is dropped and the remainder trimmed.
+	ev := pubsub.Event[question.Request]{
+		Payload: question.Request{
+			ID: "b1",
+			Questions: []question.Question{
+				{Text: "  Which file should I edit?\nAnd why?\r\nMore detail"},
+			},
+		},
+	}
+	want := QuestionAsked{BatchID: "b1", Text: "Which file should I edit?"}
+	assert.Equal(t, want, Translate(ev))
+}
+
+func TestTranslateDomainQuestionRequestFirstLineStillTruncated(t *testing.T) {
+	t.Parallel()
+	// First-lining runs before the cap, so a long first line is
+	// still cut at 80 runes.
+	ev := pubsub.Event[question.Request]{
+		Payload: question.Request{
+			Questions: []question.Question{
+				{Text: strings.Repeat("界", 100) + "\nignored"},
+			},
+		},
+	}
+	want := QuestionAsked{Text: strings.Repeat("界", maxTextFieldLength)}
+	assert.Equal(t, want, Translate(ev))
+}
+
 func TestTranslateDomainQuestionNotification(t *testing.T) {
 	t.Parallel()
 	ev := pubsub.Event[question.Notification]{
@@ -430,6 +462,34 @@ func TestTranslateProtoQuestionRequest(t *testing.T) {
 		},
 	}
 	assert.Equal(t, QuestionAsked{BatchID: "b1", Text: "Pick an option"}, Translate(ev))
+}
+
+func TestTranslateProtoQuestionRequestFirstLinesMessage(t *testing.T) {
+	t.Parallel()
+	// Same single-line contract as the domain path: text past the
+	// first newline is dropped and the remainder trimmed.
+	ev := pubsub.Event[proto.QuestionRequest]{
+		Payload: proto.QuestionRequest{
+			ID: "b1",
+			Questions: []proto.QuestionItem{
+				{Question: " Pick an option\nExplanations follow"},
+			},
+		},
+	}
+	assert.Equal(t, QuestionAsked{BatchID: "b1", Text: "Pick an option"}, Translate(ev))
+}
+
+func TestTranslateProtoQuestionRequestFirstLineStillTruncated(t *testing.T) {
+	t.Parallel()
+	ev := pubsub.Event[proto.QuestionRequest]{
+		Payload: proto.QuestionRequest{
+			Questions: []proto.QuestionItem{
+				{Question: strings.Repeat("a", 100) + "\r\nignored"},
+			},
+		},
+	}
+	want := QuestionAsked{Text: strings.Repeat("a", maxTextFieldLength)}
+	assert.Equal(t, want, Translate(ev))
 }
 
 func TestTranslateProtoQuestionNotification(t *testing.T) {

--- a/internal/herdr/translate_test.go
+++ b/internal/herdr/translate_test.go
@@ -139,9 +139,17 @@ func TestTranslateDomainRunComplete(t *testing.T) {
 func TestTranslateDomainPermissionRequest(t *testing.T) {
 	t.Parallel()
 	ev := pubsub.Event[permission.PermissionRequest]{
-		Payload: permission.PermissionRequest{ToolName: "bash", ToolCallID: "tc-1"},
+		Payload: permission.PermissionRequest{
+			ToolName:    "bash",
+			ToolCallID:  "tc-1",
+			Description: "Execute command: ls",
+		},
 	}
-	assert.Equal(t, PermissionRequested{ToolCallID: "tc-1"}, Translate(ev))
+	assert.Equal(t, PermissionRequested{
+		ToolCallID:  "tc-1",
+		ToolName:    "bash",
+		Description: "Execute command: ls",
+	}, Translate(ev))
 }
 
 func TestTranslateDomainPermissionNotification(t *testing.T) {
@@ -313,9 +321,17 @@ func TestTranslateProtoRunComplete(t *testing.T) {
 func TestTranslateProtoPermissionRequest(t *testing.T) {
 	t.Parallel()
 	ev := pubsub.Event[proto.PermissionRequest]{
-		Payload: proto.PermissionRequest{ToolName: "bash", ToolCallID: "tc-1"},
+		Payload: proto.PermissionRequest{
+			ToolName:    "bash",
+			ToolCallID:  "tc-1",
+			Description: "Execute command: ls",
+		},
 	}
-	assert.Equal(t, PermissionRequested{ToolCallID: "tc-1"}, Translate(ev))
+	assert.Equal(t, PermissionRequested{
+		ToolCallID:  "tc-1",
+		ToolName:    "bash",
+		Description: "Execute command: ls",
+	}, Translate(ev))
 }
 
 func TestTranslateProtoPermissionNotification(t *testing.T) {

--- a/internal/herdr/translate_test.go
+++ b/internal/herdr/translate_test.go
@@ -1,13 +1,18 @@
 package herdr
 
 import (
+	"context"
+	"slices"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/pubsub"
+	"github.com/charmbracelet/crush/internal/question"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -102,6 +107,55 @@ func TestTranslateDomainPermissionNotification(t *testing.T) {
 	assert.Equal(t, PermissionResolved{}, Translate(ev))
 }
 
+func TestTranslateDomainQuestionRequest(t *testing.T) {
+	t.Parallel()
+	ev := pubsub.Event[question.Request]{
+		Payload: question.Request{
+			SessionID: "s1",
+			Questions: []question.Question{
+				{Text: "Which file should I edit?"},
+				{Text: "And why?"},
+			},
+		},
+	}
+	// The blocked message is the first question's text.
+	assert.Equal(t, QuestionAsked{Text: "Which file should I edit?"}, Translate(ev))
+}
+
+func TestTranslateDomainQuestionRequestEmptyQuestions(t *testing.T) {
+	t.Parallel()
+	// A request without questions still blocks, just without a
+	// message.
+	ev := pubsub.Event[question.Request]{
+		Payload: question.Request{SessionID: "s1"},
+	}
+	assert.Equal(t, QuestionAsked{}, Translate(ev))
+}
+
+func TestTranslateDomainQuestionRequestTruncatesMessage(t *testing.T) {
+	t.Parallel()
+	// herdr caps text fields at 80 characters; the cut must be
+	// rune-safe.
+	ev := pubsub.Event[question.Request]{
+		Payload: question.Request{
+			Questions: []question.Question{
+				{Text: strings.Repeat("界", 100)},
+			},
+		},
+	}
+	got := Translate(ev)
+	want := QuestionAsked{Text: strings.Repeat("界", maxBlockMessageLength)}
+	assert.Equal(t, want, got)
+}
+
+func TestTranslateDomainQuestionNotification(t *testing.T) {
+	t.Parallel()
+	ev := pubsub.Event[question.Notification]{
+		Payload: question.Notification{BatchID: "b1"},
+	}
+	assert.Equal(t, QuestionResolved{}, Translate(ev))
+}
+
 // Proto type translation.
 
 func TestTranslateProtoAssistantMessage(t *testing.T) {
@@ -144,6 +198,27 @@ func TestTranslateProtoPermissionNotification(t *testing.T) {
 	assert.Equal(t, PermissionResolved{}, Translate(ev))
 }
 
+func TestTranslateProtoQuestionRequest(t *testing.T) {
+	t.Parallel()
+	ev := pubsub.Event[proto.QuestionRequest]{
+		Payload: proto.QuestionRequest{
+			SessionID: "s1",
+			Questions: []proto.QuestionItem{
+				{Question: "Pick an option"},
+			},
+		},
+	}
+	assert.Equal(t, QuestionAsked{Text: "Pick an option"}, Translate(ev))
+}
+
+func TestTranslateProtoQuestionNotification(t *testing.T) {
+	t.Parallel()
+	ev := pubsub.Event[proto.QuestionNotification]{
+		Payload: proto.QuestionNotification{BatchID: "b1"},
+	}
+	assert.Equal(t, QuestionResolved{}, Translate(ev))
+}
+
 func TestTranslateProtoAgentEventIgnored(t *testing.T) {
 	t.Parallel()
 	// proto.Message carries no IsSummaryMessage flag and nothing
@@ -171,4 +246,88 @@ func TestTranslateProtoSessionIgnored(t *testing.T) {
 func TestTranslateUnknownReturnsNil(t *testing.T) {
 	t.Parallel()
 	assert.Nil(t, Translate("not an event"))
+}
+
+// Bridge wiring.
+
+// brokerSubscriber adapts a pubsub.Broker to the plain subscriber
+// fields of BridgeSources.
+type brokerSubscriber[T any] struct {
+	b *pubsub.Broker[T]
+}
+
+func (s brokerSubscriber[T]) Subscribe(ctx context.Context) <-chan pubsub.Event[T] {
+	return s.b.Subscribe(ctx)
+}
+
+// permStub adapts brokers to the permission sources of BridgeSources.
+type permStub struct {
+	brokerSubscriber[permission.PermissionRequest]
+	notifications *pubsub.Broker[permission.PermissionNotification]
+}
+
+func (s permStub) SubscribeNotifications(ctx context.Context) <-chan pubsub.Event[permission.PermissionNotification] {
+	return s.notifications.Subscribe(ctx)
+}
+
+// questionStub adapts brokers to the question sources of
+// BridgeSources.
+type questionStub struct {
+	brokerSubscriber[question.Request]
+	notifications *pubsub.Broker[question.Notification]
+}
+
+func (s questionStub) SubscribeNotifications(ctx context.Context) <-chan pubsub.Event[question.Notification] {
+	return s.notifications.Subscribe(ctx)
+}
+
+func TestBridgeLocalForwardsQuestionEvents(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	perms := permStub{
+		brokerSubscriber: brokerSubscriber[permission.PermissionRequest]{pubsub.NewBroker[permission.PermissionRequest]()},
+		notifications:    pubsub.NewBroker[permission.PermissionNotification](),
+	}
+	questions := questionStub{
+		brokerSubscriber: brokerSubscriber[question.Request]{pubsub.NewBroker[question.Request]()},
+		notifications:    pubsub.NewBroker[question.Notification](),
+	}
+	src := BridgeSources{
+		PermRequests:          perms,
+		PermNotifications:     perms,
+		RunCompletions:        brokerSubscriber[notify.RunComplete]{pubsub.NewBroker[notify.RunComplete]()},
+		Messages:              brokerSubscriber[message.Message]{pubsub.NewBroker[message.Message]()},
+		Questions:             questions,
+		QuestionNotifications: questions,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	BridgeLocal(ctx, c, src)
+
+	// Wait until the bridge has subscribed before publishing so no
+	// event is lost.
+	assert.Eventually(t, func() bool {
+		return questions.b.GetSubscriberCount() > 0 &&
+			questions.notifications.GetSubscriberCount() > 0
+	}, time.Second, time.Millisecond)
+
+	// A published question request blocks the pane, carrying the
+	// first question's text.
+	questions.b.Publish(pubsub.CreatedEvent, question.Request{
+		Questions: []question.Question{{Text: "Pick an option"}},
+	})
+	assert.Eventually(t, func() bool {
+		return slices.Equal(reportedStates(c), []string{stateBlocked})
+	}, time.Second, time.Millisecond)
+	c.mu.Lock()
+	assert.Equal(t, "Pick an option", c.message)
+	c.mu.Unlock()
+
+	// Its resolution notification unblocks it.
+	questions.notifications.Publish(pubsub.CreatedEvent, question.Notification{BatchID: "b1"})
+	assert.Eventually(t, func() bool {
+		return slices.Equal(reportedStates(c), []string{stateBlocked, stateWorking})
+	}, time.Second, time.Millisecond)
 }

--- a/internal/herdr/translate_test.go
+++ b/internal/herdr/translate_test.go
@@ -27,6 +27,26 @@ func TestTranslateDomainAssistantMessage(t *testing.T) {
 	assert.Equal(t, AssistantMessage{SessionID: "s1", Model: "model-1"}, Translate(ev))
 }
 
+func TestTranslateDomainFinishedAssistantMessage(t *testing.T) {
+	t.Parallel()
+	// A finished assistant message is the turn's terminal snapshot
+	// (ESC-cancel coalesces one with FinishReasonCanceled); it must
+	// map with Finished set so the client does not treat it as
+	// ongoing activity.
+	ev := pubsub.Event[message.Message]{
+		Type: pubsub.UpdatedEvent,
+		Payload: message.Message{
+			Role:      message.Assistant,
+			SessionID: "s1",
+			Model:     "model-1",
+			Parts: []message.ContentPart{
+				message.Finish{Reason: message.FinishReasonCanceled},
+			},
+		},
+	}
+	assert.Equal(t, AssistantMessage{SessionID: "s1", Model: "model-1", Finished: true}, Translate(ev))
+}
+
 func TestTranslateDomainSummaryMessageStarted(t *testing.T) {
 	t.Parallel()
 	// An unfinished summary message (created or mid-stream update)
@@ -278,6 +298,21 @@ func TestTranslateProtoAssistantMessage(t *testing.T) {
 		Payload: proto.Message{Role: proto.Assistant, SessionID: "s1", Model: "model-1"},
 	}
 	assert.Equal(t, AssistantMessage{SessionID: "s1", Model: "model-1"}, Translate(ev))
+}
+
+func TestTranslateProtoFinishedAssistantMessage(t *testing.T) {
+	t.Parallel()
+	ev := pubsub.Event[proto.Message]{
+		Payload: proto.Message{
+			Role:      proto.Assistant,
+			SessionID: "s1",
+			Model:     "model-1",
+			Parts: []proto.ContentPart{
+				proto.Finish{Reason: proto.FinishReasonCanceled},
+			},
+		},
+	}
+	assert.Equal(t, AssistantMessage{SessionID: "s1", Model: "model-1", Finished: true}, Translate(ev))
 }
 
 func TestTranslateProtoNonAssistantIgnored(t *testing.T) {

--- a/internal/herdr/translate_test.go
+++ b/internal/herdr/translate_test.go
@@ -30,7 +30,7 @@ func TestTranslateDomainSummaryMessage(t *testing.T) {
 			IsSummaryMessage: true,
 		},
 	}
-	assert.Equal(t, Summarizing{}, Translate(ev))
+	assert.Equal(t, Summarizing{SessionID: "s1"}, Translate(ev))
 }
 
 func TestTranslateDomainNonAssistantIgnored(t *testing.T) {
@@ -111,11 +111,12 @@ func TestTranslateProtoSummarizing(t *testing.T) {
 	t.Parallel()
 	ev := pubsub.Event[proto.AgentEvent]{
 		Payload: proto.AgentEvent{
-			Type: proto.AgentEventTypeSummarize,
-			Done: false,
+			Type:    proto.AgentEventTypeSummarize,
+			Message: proto.Message{SessionID: "s1"},
+			Done:    false,
 		},
 	}
-	assert.Equal(t, Summarizing{}, Translate(ev))
+	assert.Equal(t, Summarizing{SessionID: "s1"}, Translate(ev))
 }
 
 func TestTranslateProtoSummarizeDoneIgnored(t *testing.T) {

--- a/internal/herdr/translate_test.go
+++ b/internal/herdr/translate_test.go
@@ -21,16 +21,53 @@ func TestTranslateDomainAssistantMessage(t *testing.T) {
 	assert.Equal(t, AssistantMessage{SessionID: "s1"}, Translate(ev))
 }
 
-func TestTranslateDomainSummaryMessage(t *testing.T) {
+func TestTranslateDomainSummaryMessageStarted(t *testing.T) {
 	t.Parallel()
+	// An unfinished summary message (created or mid-stream update)
+	// means compaction is running.
+	for _, eventType := range []pubsub.EventType{pubsub.CreatedEvent, pubsub.UpdatedEvent} {
+		ev := pubsub.Event[message.Message]{
+			Type: eventType,
+			Payload: message.Message{
+				Role:             message.Assistant,
+				SessionID:        "s1",
+				IsSummaryMessage: true,
+			},
+		}
+		assert.Equal(t, SummarizeStarted{SessionID: "s1"}, Translate(ev))
+	}
+}
+
+func TestTranslateDomainSummaryMessageFinished(t *testing.T) {
+	t.Parallel()
+	// Success and error both AddFinish on the summary message.
 	ev := pubsub.Event[message.Message]{
+		Type: pubsub.UpdatedEvent,
+		Payload: message.Message{
+			Role:             message.Assistant,
+			SessionID:        "s1",
+			IsSummaryMessage: true,
+			Parts: []message.ContentPart{
+				message.Finish{Reason: message.FinishReasonEndTurn},
+			},
+		},
+	}
+	assert.Equal(t, SummarizeFinished{SessionID: "s1"}, Translate(ev))
+}
+
+func TestTranslateDomainSummaryMessageDeleted(t *testing.T) {
+	t.Parallel()
+	// The cancel path deletes the summary message, so a DeletedEvent
+	// for one also means compaction is over.
+	ev := pubsub.Event[message.Message]{
+		Type: pubsub.DeletedEvent,
 		Payload: message.Message{
 			Role:             message.Assistant,
 			SessionID:        "s1",
 			IsSummaryMessage: true,
 		},
 	}
-	assert.Equal(t, Summarizing{SessionID: "s1"}, Translate(ev))
+	assert.Equal(t, SummarizeFinished{SessionID: "s1"}, Translate(ev))
 }
 
 func TestTranslateDomainNonAssistantIgnored(t *testing.T) {
@@ -107,24 +144,15 @@ func TestTranslateProtoPermissionNotification(t *testing.T) {
 	assert.Equal(t, PermissionResolved{}, Translate(ev))
 }
 
-func TestTranslateProtoSummarizing(t *testing.T) {
+func TestTranslateProtoAgentEventIgnored(t *testing.T) {
 	t.Parallel()
+	// proto.Message carries no IsSummaryMessage flag and nothing
+	// publishes AgentEventTypeSummarize, so proto agent events never
+	// map to a herdr event.
 	ev := pubsub.Event[proto.AgentEvent]{
 		Payload: proto.AgentEvent{
 			Type:    proto.AgentEventTypeSummarize,
 			Message: proto.Message{SessionID: "s1"},
-			Done:    false,
-		},
-	}
-	assert.Equal(t, Summarizing{SessionID: "s1"}, Translate(ev))
-}
-
-func TestTranslateProtoSummarizeDoneIgnored(t *testing.T) {
-	t.Parallel()
-	ev := pubsub.Event[proto.AgentEvent]{
-		Payload: proto.AgentEvent{
-			Type: proto.AgentEventTypeSummarize,
-			Done: true,
 		},
 	}
 	assert.Nil(t, Translate(ev))

--- a/internal/herdr/translate_test.go
+++ b/internal/herdr/translate_test.go
@@ -83,6 +83,50 @@ func TestTranslateDomainNonAssistantIgnored(t *testing.T) {
 	assert.Nil(t, Translate(ev))
 }
 
+func TestTranslateDomainUserMessage(t *testing.T) {
+	t.Parallel()
+	// A user message marks prompt submission, the real start of a
+	// turn.
+	ev := pubsub.Event[message.Message]{
+		Type: pubsub.CreatedEvent,
+		Payload: message.Message{
+			Role:      message.User,
+			SessionID: "s1",
+			Parts:     []message.ContentPart{message.TextContent{Text: "hi"}},
+		},
+	}
+	assert.Equal(t, RunStarted{SessionID: "s1"}, Translate(ev))
+}
+
+func TestTranslateDomainUserMessageShellCommandIgnored(t *testing.T) {
+	t.Parallel()
+	// Bang-mode shell commands are persisted as user messages
+	// (shell.PersistOutput) but start no agent run; mapping them
+	// would leave the pane stuck in working.
+	ev := pubsub.Event[message.Message]{
+		Type: pubsub.CreatedEvent,
+		Payload: message.Message{
+			Role:      message.User,
+			SessionID: "s1",
+			Parts: []message.ContentPart{
+				message.ShellCommand{Command: "ls", Output: "file.go", ExitCode: 0},
+			},
+		},
+	}
+	assert.Nil(t, Translate(ev))
+}
+
+func TestTranslateDomainUserMessageDeletedIgnored(t *testing.T) {
+	t.Parallel()
+	// Session cleanup deletes user messages; a deletion must not
+	// report working.
+	ev := pubsub.Event[message.Message]{
+		Type:    pubsub.DeletedEvent,
+		Payload: message.Message{Role: message.User, SessionID: "s1"},
+	}
+	assert.Nil(t, Translate(ev))
+}
+
 func TestTranslateDomainRunComplete(t *testing.T) {
 	t.Parallel()
 	ev := pubsub.Event[notify.RunComplete]{
@@ -198,6 +242,45 @@ func TestTranslateProtoAssistantMessage(t *testing.T) {
 func TestTranslateProtoNonAssistantIgnored(t *testing.T) {
 	t.Parallel()
 	ev := pubsub.Event[proto.Message]{
+		Payload: proto.Message{Role: proto.System, SessionID: "s1"},
+	}
+	assert.Nil(t, Translate(ev))
+}
+
+func TestTranslateProtoUserMessage(t *testing.T) {
+	t.Parallel()
+	ev := pubsub.Event[proto.Message]{
+		Type: pubsub.CreatedEvent,
+		Payload: proto.Message{
+			Role:      proto.User,
+			SessionID: "s1",
+			Parts:     []proto.ContentPart{proto.TextContent{Text: "hi"}},
+		},
+	}
+	assert.Equal(t, RunStarted{SessionID: "s1"}, Translate(ev))
+}
+
+func TestTranslateProtoUserMessageShellCommandIgnored(t *testing.T) {
+	t.Parallel()
+	// Bang-mode shell records cross the wire with their
+	// ShellCommand part; they start no run.
+	ev := pubsub.Event[proto.Message]{
+		Type: pubsub.CreatedEvent,
+		Payload: proto.Message{
+			Role:      proto.User,
+			SessionID: "s1",
+			Parts: []proto.ContentPart{
+				proto.ShellCommand{Command: "ls", Output: "file.go", ExitCode: 0},
+			},
+		},
+	}
+	assert.Nil(t, Translate(ev))
+}
+
+func TestTranslateProtoUserMessageDeletedIgnored(t *testing.T) {
+	t.Parallel()
+	ev := pubsub.Event[proto.Message]{
+		Type:    pubsub.DeletedEvent,
 		Payload: proto.Message{Role: proto.User, SessionID: "s1"},
 	}
 	assert.Nil(t, Translate(ev))

--- a/internal/herdr/translate_test.go
+++ b/internal/herdr/translate_test.go
@@ -229,7 +229,7 @@ func TestTranslateDomainQuestionRequestTruncatesMessage(t *testing.T) {
 		},
 	}
 	got := Translate(ev)
-	want := QuestionAsked{Text: strings.Repeat("界", maxBlockMessageLength)}
+	want := QuestionAsked{Text: strings.Repeat("界", maxTextFieldLength)}
 	assert.Equal(t, want, got)
 }
 

--- a/internal/herdr/translate_test.go
+++ b/internal/herdr/translate_test.go
@@ -156,6 +156,35 @@ func TestTranslateDomainQuestionNotification(t *testing.T) {
 	assert.Equal(t, QuestionResolved{}, Translate(ev))
 }
 
+func TestTranslateDomainReAuthenticateNotification(t *testing.T) {
+	t.Parallel()
+	ev := pubsub.Event[notify.Notification]{
+		Payload: notify.Notification{
+			Type:       notify.TypeReAuthenticate,
+			ProviderID: "hyper",
+		},
+	}
+	assert.Equal(t, AuthRequired{ProviderID: "hyper"}, Translate(ev))
+}
+
+func TestTranslateDomainOtherNotificationsIgnored(t *testing.T) {
+	t.Parallel()
+	// Only re-authentication blocks the pane; the remaining
+	// notification types are informational or own their dialog
+	// flows (AWS SSO).
+	for _, typ := range []notify.Type{
+		notify.TypeAgentFinished,
+		notify.TypeAgentError,
+		notify.TypeAWSSSOAuth,
+		notify.TypeAWSSSOAuthResult,
+	} {
+		ev := pubsub.Event[notify.Notification]{
+			Payload: notify.Notification{Type: typ},
+		}
+		assert.Nil(t, Translate(ev))
+	}
+}
+
 // Proto type translation.
 
 func TestTranslateProtoAssistantMessage(t *testing.T) {
@@ -219,11 +248,24 @@ func TestTranslateProtoQuestionNotification(t *testing.T) {
 	assert.Equal(t, QuestionResolved{}, Translate(ev))
 }
 
+func TestTranslateProtoReAuthenticateAgentEvent(t *testing.T) {
+	t.Parallel()
+	// The server wraps notify.Notification into proto.AgentEvent
+	// with the domain type string, so re_authenticate arrives as a
+	// raw agent event type. ProviderID does not cross the wire.
+	ev := pubsub.Event[proto.AgentEvent]{
+		Payload: proto.AgentEvent{
+			Type: proto.AgentEventType(notify.TypeReAuthenticate),
+		},
+	}
+	assert.Equal(t, AuthRequired{}, Translate(ev))
+}
+
 func TestTranslateProtoAgentEventIgnored(t *testing.T) {
 	t.Parallel()
 	// proto.Message carries no IsSummaryMessage flag and nothing
-	// publishes AgentEventTypeSummarize, so proto agent events never
-	// map to a herdr event.
+	// publishes AgentEventTypeSummarize, so summarize agent events
+	// never map to a herdr event.
 	ev := pubsub.Event[proto.AgentEvent]{
 		Payload: proto.AgentEvent{
 			Type:    proto.AgentEventTypeSummarize,
@@ -300,6 +342,7 @@ func TestBridgeLocalForwardsQuestionEvents(t *testing.T) {
 		Messages:              brokerSubscriber[message.Message]{pubsub.NewBroker[message.Message]()},
 		Questions:             questions,
 		QuestionNotifications: questions,
+		Notifications:         brokerSubscriber[notify.Notification]{pubsub.NewBroker[notify.Notification]()},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -330,4 +373,58 @@ func TestBridgeLocalForwardsQuestionEvents(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return slices.Equal(reportedStates(c), []string{stateBlocked, stateWorking})
 	}, time.Second, time.Millisecond)
+}
+
+func TestBridgeLocalForwardsAuthNotification(t *testing.T) {
+	t.Parallel()
+	c := newTestClient()
+
+	perms := permStub{
+		brokerSubscriber: brokerSubscriber[permission.PermissionRequest]{pubsub.NewBroker[permission.PermissionRequest]()},
+		notifications:    pubsub.NewBroker[permission.PermissionNotification](),
+	}
+	questions := questionStub{
+		brokerSubscriber: brokerSubscriber[question.Request]{pubsub.NewBroker[question.Request]()},
+		notifications:    pubsub.NewBroker[question.Notification](),
+	}
+	notifications := pubsub.NewBroker[notify.Notification]()
+	src := BridgeSources{
+		PermRequests:          perms,
+		PermNotifications:     perms,
+		RunCompletions:        brokerSubscriber[notify.RunComplete]{pubsub.NewBroker[notify.RunComplete]()},
+		Messages:              brokerSubscriber[message.Message]{pubsub.NewBroker[message.Message]()},
+		Questions:             questions,
+		QuestionNotifications: questions,
+		Notifications:         brokerSubscriber[notify.Notification]{notifications},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	BridgeLocal(ctx, c, src)
+
+	// Wait until the bridge has subscribed before publishing so no
+	// event is lost.
+	assert.Eventually(t, func() bool {
+		return notifications.GetSubscriberCount() > 0
+	}, time.Second, time.Millisecond)
+
+	// A re-authentication notification blocks the pane, naming the
+	// provider.
+	notifications.Publish(pubsub.CreatedEvent, notify.Notification{
+		Type:       notify.TypeReAuthenticate,
+		ProviderID: "hyper",
+	})
+	assert.Eventually(t, func() bool {
+		return slices.Equal(reportedStates(c), []string{stateBlocked})
+	}, time.Second, time.Millisecond)
+	c.mu.Lock()
+	assert.Equal(t, "Re-authentication required: hyper", c.message)
+	c.mu.Unlock()
+
+	// Other notification types pass through without a report.
+	notifications.Publish(pubsub.CreatedEvent, notify.Notification{
+		Type: notify.TypeAgentFinished,
+	})
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, []string{stateBlocked}, reportedStates(c))
 }

--- a/internal/herdr/translate_test.go
+++ b/internal/herdr/translate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/question"
+	"github.com/charmbracelet/crush/internal/session"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,9 +22,9 @@ import (
 func TestTranslateDomainAssistantMessage(t *testing.T) {
 	t.Parallel()
 	ev := pubsub.Event[message.Message]{
-		Payload: message.Message{Role: message.Assistant, SessionID: "s1"},
+		Payload: message.Message{Role: message.Assistant, SessionID: "s1", Model: "model-1"},
 	}
-	assert.Equal(t, AssistantMessage{SessionID: "s1"}, Translate(ev))
+	assert.Equal(t, AssistantMessage{SessionID: "s1", Model: "model-1"}, Translate(ev))
 }
 
 func TestTranslateDomainSummaryMessageStarted(t *testing.T) {
@@ -234,9 +235,9 @@ func TestTranslateDomainOtherNotificationsIgnored(t *testing.T) {
 func TestTranslateProtoAssistantMessage(t *testing.T) {
 	t.Parallel()
 	ev := pubsub.Event[proto.Message]{
-		Payload: proto.Message{Role: proto.Assistant, SessionID: "s1"},
+		Payload: proto.Message{Role: proto.Assistant, SessionID: "s1", Model: "model-1"},
 	}
-	assert.Equal(t, AssistantMessage{SessionID: "s1"}, Translate(ev))
+	assert.Equal(t, AssistantMessage{SessionID: "s1", Model: "model-1"}, Translate(ev))
 }
 
 func TestTranslateProtoNonAssistantIgnored(t *testing.T) {
@@ -358,12 +359,45 @@ func TestTranslateProtoAgentEventIgnored(t *testing.T) {
 	assert.Nil(t, Translate(ev))
 }
 
-func TestTranslateProtoSessionIgnored(t *testing.T) {
+func TestTranslateDomainSession(t *testing.T) {
 	t.Parallel()
-	ev := pubsub.Event[proto.Session]{
+
+	// Created and updated sessions carry the title for the pane
+	// presentation; deletions are left to the SetSession clear
+	// path when the UI switches away.
+	created := pubsub.Event[session.Session]{
+		Type:    pubsub.CreatedEvent,
+		Payload: session.Session{ID: "s1", Title: "My Title"},
+	}
+	assert.Equal(t, SessionUpdated{SessionID: "s1", Title: "My Title"}, Translate(created))
+
+	updated := pubsub.Event[session.Session]{
+		Type:    pubsub.UpdatedEvent,
+		Payload: session.Session{ID: "s1", Title: "Renamed"},
+	}
+	assert.Equal(t, SessionUpdated{SessionID: "s1", Title: "Renamed"}, Translate(updated))
+
+	deleted := pubsub.Event[session.Session]{
+		Type:    pubsub.DeletedEvent,
+		Payload: session.Session{ID: "s1"},
+	}
+	assert.Nil(t, Translate(deleted))
+}
+
+func TestTranslateProtoSession(t *testing.T) {
+	t.Parallel()
+
+	updated := pubsub.Event[proto.Session]{
+		Type:    pubsub.UpdatedEvent,
+		Payload: proto.Session{ID: "s1", Title: "My Title"},
+	}
+	assert.Equal(t, SessionUpdated{SessionID: "s1", Title: "My Title"}, Translate(updated))
+
+	deleted := pubsub.Event[proto.Session]{
+		Type:    pubsub.DeletedEvent,
 		Payload: proto.Session{ID: "s1"},
 	}
-	assert.Nil(t, Translate(ev))
+	assert.Nil(t, Translate(deleted))
 }
 
 // Unknown types.
@@ -426,6 +460,7 @@ func TestBridgeLocalForwardsQuestionEvents(t *testing.T) {
 		Questions:             questions,
 		QuestionNotifications: questions,
 		Notifications:         brokerSubscriber[notify.Notification]{pubsub.NewBroker[notify.Notification]()},
+		Sessions:              brokerSubscriber[session.Session]{pubsub.NewBroker[session.Session]()},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -479,6 +514,7 @@ func TestBridgeLocalForwardsAuthNotification(t *testing.T) {
 		Questions:             questions,
 		QuestionNotifications: questions,
 		Notifications:         brokerSubscriber[notify.Notification]{notifications},
+		Sessions:              brokerSubscriber[session.Session]{pubsub.NewBroker[session.Session]()},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/herdr/translate_test.go
+++ b/internal/herdr/translate_test.go
@@ -128,6 +128,23 @@ func TestTranslateDomainUserMessageDeletedIgnored(t *testing.T) {
 	assert.Nil(t, Translate(ev))
 }
 
+func TestTranslateDomainUserMessageUpdatedIgnored(t *testing.T) {
+	t.Parallel()
+	// Only a creation is a prompt submission. message.Service.Update
+	// publishes an UpdatedEvent for whatever message it is handed, so
+	// mapping updates would let a future edit-the-prompt feature
+	// re-arm runActive with no matching RunComplete.
+	ev := pubsub.Event[message.Message]{
+		Type: pubsub.UpdatedEvent,
+		Payload: message.Message{
+			Role:      message.User,
+			SessionID: "s1",
+			Parts:     []message.ContentPart{message.TextContent{Text: "hi"}},
+		},
+	}
+	assert.Nil(t, Translate(ev))
+}
+
 func TestTranslateDomainRunComplete(t *testing.T) {
 	t.Parallel()
 	ev := pubsub.Event[notify.RunComplete]{
@@ -306,6 +323,22 @@ func TestTranslateProtoUserMessageDeletedIgnored(t *testing.T) {
 	ev := pubsub.Event[proto.Message]{
 		Type:    pubsub.DeletedEvent,
 		Payload: proto.Message{Role: proto.User, SessionID: "s1"},
+	}
+	assert.Nil(t, Translate(ev))
+}
+
+func TestTranslateProtoUserMessageUpdatedIgnored(t *testing.T) {
+	t.Parallel()
+	// The server preserves the domain event type on the wire
+	// (messageToProto), so the creation-only rule has to hold here
+	// too.
+	ev := pubsub.Event[proto.Message]{
+		Type: pubsub.UpdatedEvent,
+		Payload: proto.Message{
+			Role:      proto.User,
+			SessionID: "s1",
+			Parts:     []proto.ContentPart{proto.TextContent{Text: "hi"}},
+		},
 	}
 	assert.Nil(t, Translate(ev))
 }

--- a/internal/herdr/translate_test.go
+++ b/internal/herdr/translate_test.go
@@ -139,23 +139,37 @@ func TestTranslateDomainRunComplete(t *testing.T) {
 func TestTranslateDomainPermissionRequest(t *testing.T) {
 	t.Parallel()
 	ev := pubsub.Event[permission.PermissionRequest]{
-		Payload: permission.PermissionRequest{ToolName: "bash"},
+		Payload: permission.PermissionRequest{ToolName: "bash", ToolCallID: "tc-1"},
 	}
-	assert.Equal(t, PermissionRequested{}, Translate(ev))
+	assert.Equal(t, PermissionRequested{ToolCallID: "tc-1"}, Translate(ev))
 }
 
 func TestTranslateDomainPermissionNotification(t *testing.T) {
 	t.Parallel()
-	ev := pubsub.Event[permission.PermissionNotification]{
-		Payload: permission.PermissionNotification{Granted: true},
+	granted := pubsub.Event[permission.PermissionNotification]{
+		Payload: permission.PermissionNotification{ToolCallID: "tc-1", Granted: true},
 	}
-	assert.Equal(t, PermissionResolved{}, Translate(ev))
+	assert.Equal(t, PermissionResolved{ToolCallID: "tc-1"}, Translate(granted))
+
+	denied := pubsub.Event[permission.PermissionNotification]{
+		Payload: permission.PermissionNotification{ToolCallID: "tc-1", Denied: true},
+	}
+	assert.Equal(t, PermissionResolved{ToolCallID: "tc-1"}, Translate(denied))
+
+	// The permission service publishes a flagless notification when
+	// a request starts, before publishing the request itself. It is
+	// not a resolution and must not unblock the pane.
+	marker := pubsub.Event[permission.PermissionNotification]{
+		Payload: permission.PermissionNotification{ToolCallID: "tc-1"},
+	}
+	assert.Nil(t, Translate(marker))
 }
 
 func TestTranslateDomainQuestionRequest(t *testing.T) {
 	t.Parallel()
 	ev := pubsub.Event[question.Request]{
 		Payload: question.Request{
+			ID:        "b1",
 			SessionID: "s1",
 			Questions: []question.Question{
 				{Text: "Which file should I edit?"},
@@ -164,7 +178,8 @@ func TestTranslateDomainQuestionRequest(t *testing.T) {
 		},
 	}
 	// The blocked message is the first question's text.
-	assert.Equal(t, QuestionAsked{Text: "Which file should I edit?"}, Translate(ev))
+	want := QuestionAsked{BatchID: "b1", Text: "Which file should I edit?"}
+	assert.Equal(t, want, Translate(ev))
 }
 
 func TestTranslateDomainQuestionRequestEmptyQuestions(t *testing.T) {
@@ -198,7 +213,7 @@ func TestTranslateDomainQuestionNotification(t *testing.T) {
 	ev := pubsub.Event[question.Notification]{
 		Payload: question.Notification{BatchID: "b1"},
 	}
-	assert.Equal(t, QuestionResolved{}, Translate(ev))
+	assert.Equal(t, QuestionResolved{BatchID: "b1"}, Translate(ev))
 }
 
 func TestTranslateDomainReAuthenticateNotification(t *testing.T) {
@@ -298,30 +313,39 @@ func TestTranslateProtoRunComplete(t *testing.T) {
 func TestTranslateProtoPermissionRequest(t *testing.T) {
 	t.Parallel()
 	ev := pubsub.Event[proto.PermissionRequest]{
-		Payload: proto.PermissionRequest{ToolName: "bash"},
+		Payload: proto.PermissionRequest{ToolName: "bash", ToolCallID: "tc-1"},
 	}
-	assert.Equal(t, PermissionRequested{}, Translate(ev))
+	assert.Equal(t, PermissionRequested{ToolCallID: "tc-1"}, Translate(ev))
 }
 
 func TestTranslateProtoPermissionNotification(t *testing.T) {
 	t.Parallel()
-	ev := pubsub.Event[proto.PermissionNotification]{
-		Payload: proto.PermissionNotification{Granted: true},
+	granted := pubsub.Event[proto.PermissionNotification]{
+		Payload: proto.PermissionNotification{ToolCallID: "tc-1", Granted: true},
 	}
-	assert.Equal(t, PermissionResolved{}, Translate(ev))
+	assert.Equal(t, PermissionResolved{ToolCallID: "tc-1"}, Translate(granted))
+
+	// The server forwards the permission service's flagless
+	// request marker too; it is not a resolution on the wire
+	// either.
+	marker := pubsub.Event[proto.PermissionNotification]{
+		Payload: proto.PermissionNotification{ToolCallID: "tc-1"},
+	}
+	assert.Nil(t, Translate(marker))
 }
 
 func TestTranslateProtoQuestionRequest(t *testing.T) {
 	t.Parallel()
 	ev := pubsub.Event[proto.QuestionRequest]{
 		Payload: proto.QuestionRequest{
+			ID:        "b1",
 			SessionID: "s1",
 			Questions: []proto.QuestionItem{
 				{Question: "Pick an option"},
 			},
 		},
 	}
-	assert.Equal(t, QuestionAsked{Text: "Pick an option"}, Translate(ev))
+	assert.Equal(t, QuestionAsked{BatchID: "b1", Text: "Pick an option"}, Translate(ev))
 }
 
 func TestTranslateProtoQuestionNotification(t *testing.T) {
@@ -329,7 +353,7 @@ func TestTranslateProtoQuestionNotification(t *testing.T) {
 	ev := pubsub.Event[proto.QuestionNotification]{
 		Payload: proto.QuestionNotification{BatchID: "b1"},
 	}
-	assert.Equal(t, QuestionResolved{}, Translate(ev))
+	assert.Equal(t, QuestionResolved{BatchID: "b1"}, Translate(ev))
 }
 
 func TestTranslateProtoReAuthenticateAgentEvent(t *testing.T) {
@@ -477,6 +501,7 @@ func TestBridgeLocalForwardsQuestionEvents(t *testing.T) {
 	// A published question request blocks the pane, carrying the
 	// first question's text.
 	questions.b.Publish(pubsub.CreatedEvent, question.Request{
+		ID:        "b1",
 		Questions: []question.Question{{Text: "Pick an option"}},
 	})
 	assert.Eventually(t, func() bool {
@@ -486,7 +511,8 @@ func TestBridgeLocalForwardsQuestionEvents(t *testing.T) {
 	assert.Equal(t, "Pick an option", c.message)
 	c.mu.Unlock()
 
-	// Its resolution notification unblocks it.
+	// Its resolution notification, correlated by batch id, unblocks
+	// it.
 	questions.notifications.Publish(pubsub.CreatedEvent, question.Notification{BatchID: "b1"})
 	assert.Eventually(t, func() bool {
 		return slices.Equal(reportedStates(c), []string{stateBlocked, stateWorking})

--- a/internal/oauth/mcp/handler.go
+++ b/internal/oauth/mcp/handler.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/charmbracelet/crush/internal/oauth"
@@ -422,6 +423,10 @@ type authFlight struct {
 	once   sync.Once
 	result *auth.AuthorizationResult
 	err    error
+	// refs counts the callers sharing this flight: the creator plus every
+	// joiner waiting on the same redirect. Tests use it to wait for all
+	// concurrent callers to arrive before letting the redirect land.
+	refs atomic.Int64
 }
 
 // settle records the outcome of the flight and wakes everyone waiting on
@@ -443,12 +448,15 @@ func (r *callbackReceiver) begin() (*authFlight, bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.flight != nil {
+		r.flight.refs.Add(1)
 		return r.flight, false, nil
 	}
 	if err := r.bindLocked(); err != nil {
 		return nil, false, err
 	}
-	r.flight = &authFlight{done: make(chan struct{})}
+	flight := &authFlight{done: make(chan struct{})}
+	flight.refs.Store(1)
+	r.flight = flight
 	return r.flight, true, nil
 }
 
@@ -622,6 +630,7 @@ func (r *callbackReceiver) fetchAuthorizationCode(ctx context.Context, args *aut
 // releases the callback listener once the flow is done, so the port is
 // free again as soon as the authorization completes (or is abandoned).
 func (r *callbackReceiver) await(ctx context.Context, flight *authFlight, owned bool) (*auth.AuthorizationResult, error) {
+	defer flight.refs.Add(-1)
 	select {
 	case <-flight.done:
 		if owned {

--- a/internal/oauth/mcp/handler_test.go
+++ b/internal/oauth/mcp/handler_test.go
@@ -552,12 +552,19 @@ func TestCallbackReceiver_ConcurrentAuthorizeOpensOneTab(t *testing.T) {
 
 	base := serveReceiver(t, r)
 
-	// Stand in for the browser: record the open, then redirect back as the
-	// authorization server would once the user consents.
+	// Stand in for the browser: record the open, but hold the redirect
+	// until every caller has joined the flight. Releasing it immediately
+	// would let a fast settle retire the flight before the slowest caller
+	// arrives, and that late caller would open a second tab.
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+
 	var opens atomic.Int64
 	r.handler = &Handler{openURL: func(string) error {
 		opens.Add(1)
 		go func() {
+			<-release
 			resp, gerr := http.Get(base + callbackPath + "?code=abc&state=xyz") //nolint:noctx
 			if gerr == nil {
 				resp.Body.Close()
@@ -577,6 +584,15 @@ func TestCallbackReceiver_ConcurrentAuthorizeOpensOneTab(t *testing.T) {
 			errs <- ferr
 		})
 	}
+
+	// Every caller must be parked on the same flight before the redirect
+	// lands, or the opens==1 assertion below is left to the scheduler.
+	require.Eventually(t, func() bool {
+		flight := r.current()
+		return flight != nil && flight.refs.Load() == callers
+	}, 5*time.Second, time.Millisecond, "all callers must join the in-flight authorization")
+	releaseOnce.Do(func() { close(release) })
+
 	wg.Wait()
 	close(results)
 	close(errs)

--- a/internal/shell/run.go
+++ b/internal/shell/run.go
@@ -258,18 +258,19 @@ func withNonInteractiveEnv(env []string) []string {
 // so agents can report state over its Unix socket API. Subprocesses
 // must not inherit these: a child process that calls herdr.Init()
 // would attach to the parent's pane and, on exit, release its agent
-// authority — making the status vanish. Stripping them here closes
-// that gap for every command the bash tool runs.
+// authority — making the status vanish. Stripping them closes that
+// gap for every command the bash tool runs and for the detached
+// crush server (see startDetachedServer).
 var herdrEnvVars = []string{
 	"HERDR_ENV",
 	"HERDR_SOCKET_PATH",
 	"HERDR_PANE_ID",
 }
 
-// withoutHerdrEnv returns env with all HERDR_* variables removed.
+// WithoutHerdrEnv returns env with all HERDR_* variables removed.
 // The returned slice is a new allocation safe to use concurrently
 // with the input.
-func withoutHerdrEnv(env []string) []string {
+func WithoutHerdrEnv(env []string) []string {
 	strip := make(map[string]bool, len(herdrEnvVars))
 	for _, k := range herdrEnvVars {
 		strip[k] = true

--- a/internal/shell/run.go
+++ b/internal/shell/run.go
@@ -254,22 +254,28 @@ func withNonInteractiveEnv(env []string) []string {
 	return append(result, nonInteractiveEnvVars...)
 }
 
-// herdrEnvVars are the environment variables herdr injects into panes
-// so agents can report state over its Unix socket API. Subprocesses
-// must not inherit these: a child process that calls herdr.Init()
-// would attach to the parent's pane and, on exit, release its agent
-// authority — making the status vanish. Stripping them closes that
-// gap for every command the bash tool runs and for the detached
-// crush server (see startDetachedServer).
+// herdrEnvVars are the herdr pane-ownership environment variables: the
+// ones that let a process attach to a pane and report agent state over
+// herdr's Unix socket API. Subprocesses must not inherit these: a child
+// that calls herdr.Init() would attach to the parent's pane and, on
+// exit, release its agent authority — making the status vanish.
+// Stripping them closes that gap for every command the bash tool runs
+// and for the detached crush server (see startDetachedServer).
+//
+// herdr injects other HERDR_* variables (HERDR_TAB_ID,
+// HERDR_WORKSPACE_ID) that only describe where a process is running.
+// They confer no authority, so they are deliberately not listed here —
+// a child that shells out to herdr still knows its own workspace.
 var herdrEnvVars = []string{
 	"HERDR_ENV",
 	"HERDR_SOCKET_PATH",
 	"HERDR_PANE_ID",
 }
 
-// WithoutHerdrEnv returns env with all HERDR_* variables removed.
-// The returned slice is a new allocation safe to use concurrently
-// with the input.
+// WithoutHerdrEnv returns env with the herdr pane-ownership variables
+// (HERDR_ENV, HERDR_SOCKET_PATH, HERDR_PANE_ID) removed. Purely
+// informational vars such as HERDR_TAB_ID are left alone. The returned
+// slice is a new allocation safe to use concurrently with the input.
 func WithoutHerdrEnv(env []string) []string {
 	strip := make(map[string]bool, len(herdrEnvVars))
 	for _, k := range herdrEnvVars {

--- a/internal/shell/run_test.go
+++ b/internal/shell/run_test.go
@@ -318,7 +318,7 @@ func TestWithoutHerdrEnv_StripsAllVars(t *testing.T) {
 		"PATH=/usr/bin",
 		"HOME=/home/user",
 	}
-	result := withoutHerdrEnv(env)
+	result := WithoutHerdrEnv(env)
 	for _, e := range result {
 		if strings.HasPrefix(e, "HERDR_") {
 			t.Errorf("herdr var not stripped: %s", e)
@@ -334,7 +334,7 @@ func TestWithoutHerdrEnv_StripsAllVars(t *testing.T) {
 
 func TestWithoutHerdrEnv_EmptyInput(t *testing.T) {
 	t.Parallel()
-	result := withoutHerdrEnv(nil)
+	result := WithoutHerdrEnv(nil)
 	if len(result) != 0 {
 		t.Errorf("expected empty result for nil input, got %v", result)
 	}
@@ -343,7 +343,7 @@ func TestWithoutHerdrEnv_EmptyInput(t *testing.T) {
 func TestWithoutHerdrEnv_SliceIndependence(t *testing.T) {
 	t.Parallel()
 	env := []string{"HERDR_ENV=1", "FOO=bar"}
-	result := withoutHerdrEnv(env)
+	result := WithoutHerdrEnv(env)
 	env[1] = "FOO=baz"
 	for _, e := range result {
 		if e == "FOO=baz" {

--- a/internal/shell/run_test.go
+++ b/internal/shell/run_test.go
@@ -309,26 +309,30 @@ func TestWithNonInteractiveEnv_SliceIndependence(t *testing.T) {
 	}
 }
 
-func TestWithoutHerdrEnv_StripsAllVars(t *testing.T) {
+// WithoutHerdrEnv strips the pane-ownership vars and nothing else:
+// HERDR_TAB_ID / HERDR_WORKSPACE_ID confer no authority over a pane, so
+// a child that shells out to herdr keeps its bearings.
+func TestWithoutHerdrEnv_StripsPaneOwnershipVars(t *testing.T) {
 	t.Parallel()
 	env := []string{
 		"HERDR_ENV=1",
 		"HERDR_SOCKET_PATH=/tmp/herdr.sock",
 		"HERDR_PANE_ID=wA:p1",
+		"HERDR_TAB_ID=t1",
+		"HERDR_WORKSPACE_ID=wA",
 		"PATH=/usr/bin",
 		"HOME=/home/user",
 	}
 	result := WithoutHerdrEnv(env)
-	for _, e := range result {
-		if strings.HasPrefix(e, "HERDR_") {
-			t.Errorf("herdr var not stripped: %s", e)
+	for _, e := range env[:3] {
+		if slices.Contains(result, e) {
+			t.Errorf("pane-ownership var not stripped: %s", e)
 		}
 	}
-	if !slices.Contains(result, "PATH=/usr/bin") {
-		t.Error("non-herdr var PATH was incorrectly removed")
-	}
-	if !slices.Contains(result, "HOME=/home/user") {
-		t.Error("non-herdr var HOME was incorrectly removed")
+	for _, e := range env[3:] {
+		if !slices.Contains(result, e) {
+			t.Errorf("var was incorrectly removed: %s", e)
+		}
 	}
 }
 

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -97,7 +97,7 @@ func NewShell(opts *Options) *Shell {
 	// Strip herdr pane-ownership vars so subprocesses (including test
 	// binaries and nested crush instances) can't attach to or release
 	// the parent pane's agent authority.
-	env = withoutHerdrEnv(env)
+	env = WithoutHerdrEnv(env)
 
 	// Allow tools to detect execution by Crush.
 	env = append(env, CrushEnvMarkers()...)

--- a/internal/ui/dialog/notifications.go
+++ b/internal/ui/dialog/notifications.go
@@ -33,6 +33,7 @@ var AllNotificationStyles = []NotificationStyle{
 	{ID: "native", Title: "Native", Description: "Use system notifications (macOS/Linux/Windows)"},
 	{ID: "osc", Title: "OSC", Description: "Use terminal OSC escape sequences"},
 	{ID: "bell", Title: "Bell", Description: "Use terminal bell character"},
+	{ID: "herdr", Title: "Herdr", Description: "Surface toasts in herdr's UI (inside a herdr pane)"},
 	{ID: "disabled", Title: "Disabled", Description: "Turn off notifications"},
 }
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -37,6 +37,7 @@ import (
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/event"
 	"github.com/charmbracelet/crush/internal/fsext"
+	"github.com/charmbracelet/crush/internal/herdr"
 	"github.com/charmbracelet/crush/internal/history"
 	"github.com/charmbracelet/crush/internal/home"
 	"github.com/charmbracelet/crush/internal/lsp"
@@ -589,6 +590,13 @@ func selectNotificationBackend(caps common.Capabilities, cfg *config.Config) not
 		case "bell":
 			slog.Debug("Using bell backend (user preference)")
 			return notification.NewBellBackend()
+		case "herdr":
+			if client := herdr.Init(); client != nil {
+				slog.Debug("Using herdr backend (user preference)")
+				return notification.NewHerdrBackend(client)
+			}
+			slog.Debug("Herdr backend unavailable outside a herdr pane; using OSC backend", "osc99_supported", caps.OSC99Notifications)
+			return notification.NewOSCBackend(notification.Icon, caps.OSC99Notifications)
 		case "disabled":
 			slog.Debug("Notifications disabled (user preference)")
 			return notification.NoopBackend{}

--- a/internal/ui/notification/herdr.go
+++ b/internal/ui/notification/herdr.go
@@ -1,0 +1,38 @@
+package notification
+
+import (
+	"log/slog"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// HerdrNotifier is the subset of the herdr client the HerdrBackend
+// needs. Defined here so tests can substitute a fake.
+type HerdrNotifier interface {
+	Notify(title, body string)
+}
+
+// HerdrBackend surfaces Crush toasts in herdr's own UI via its
+// notification.show socket API. It is only useful when Crush runs
+// inside a herdr pane; backend selection falls back to OSC when it
+// does not.
+type HerdrBackend struct {
+	client HerdrNotifier
+}
+
+// NewHerdrBackend creates a backend that reports toasts to herdr.
+func NewHerdrBackend(client HerdrNotifier) *HerdrBackend {
+	return &HerdrBackend{client: client}
+}
+
+// Send returns a [tea.Cmd] that asks herdr to show the toast. The
+// herdr client enqueues the request on its socket writer without
+// blocking, so the command completes immediately.
+func (b *HerdrBackend) Send(n Notification) tea.Cmd {
+	slog.Debug("Sending herdr notification", "title", n.Title, "message", n.Message)
+
+	return func() tea.Msg {
+		b.client.Notify(n.Title, n.Message)
+		return nil
+	}
+}

--- a/internal/ui/notification/herdr_test.go
+++ b/internal/ui/notification/herdr_test.go
@@ -1,0 +1,30 @@
+package notification_test
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/ui/notification"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeHerdrNotifier struct {
+	calls []struct{ title, body string }
+}
+
+func (f *fakeHerdrNotifier) Notify(title, body string) {
+	f.calls = append(f.calls, struct{ title, body string }{title, body})
+}
+
+func TestHerdrBackend_Send(t *testing.T) {
+	t.Parallel()
+	fake := &fakeHerdrNotifier{}
+	backend := notification.NewHerdrBackend(fake)
+
+	cmd := backend.Send(notification.Notification{Title: "Done", Message: "turn complete"})
+	require.NotNil(t, cmd)
+	cmd()
+
+	require.Len(t, fake.calls, 1)
+	require.Equal(t, "Done", fake.calls[0].title)
+	require.Equal(t, "turn complete", fake.calls[0].body)
+}

--- a/internal/ui/notification/notification.go
+++ b/internal/ui/notification/notification.go
@@ -7,11 +7,13 @@
 //     falling back to OSC 777 (urxvt extension, widely supported). Used for SSH sessions.
 //   - BellBackend: Triggers the terminal bell character (\x07), causing an audible
 //     beep or visual flash. Works in virtually all terminals but provides no message text.
+//   - HerdrBackend: Surfaces toasts in herdr's own UI via its notification.show
+//     socket API. Only useful when Crush runs inside a herdr pane.
 //   - NoopBackend: A no-op backend that silently discards notifications. Used when
 //     notifications are disabled or no suitable backend is available.
 //
 // Backend selection is based on terminal capabilities, environment, and user config:
-//   - Users can explicitly set notifications in crush.json (auto/native/osc/bell/disabled)
+//   - Users can explicitly set notifications in crush.json (auto/native/osc/bell/herdr/disabled)
 //   - Auto mode: SSH sessions use OSC backend (auto-detects OSC 99 vs 777)
 //   - Auto mode: Local sessions use native OS notifications
 //   - If focus events are not supported in local sessions, notifications are disabled (NoopBackend)

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -77,7 +77,7 @@ func (w *AppWorkspace) ParseAgentToolSessionID(sessionID string) (string, string
 // is irrelevant in single-client local mode, but herdr still needs
 // to know which session is live to support agent resume.
 func (w *AppWorkspace) SetCurrentSession(ctx context.Context, sessionID string) error {
-	w.app.ReportCurrentSession(sessionID)
+	w.app.ReportCurrentSession(ctx, sessionID)
 	return nil
 }
 

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -90,7 +90,7 @@ func NewClientWorkspace(c *client.Client, ws proto.Workspace) *ClientWorkspace {
 	states := protoToSkillStates(ws.Skills)
 	mgr := skills.NewManager(nil, nil, states, skills.WithGlobalMirror())
 	subCtx, subCancel := context.WithCancel(context.Background())
-	return &ClientWorkspace{
+	w := &ClientWorkspace{
 		client:      c,
 		ws:          ws,
 		skills:      mgr,
@@ -98,6 +98,20 @@ func NewClientWorkspace(c *client.Client, ws proto.Workspace) *ClientWorkspace {
 		subCancel:   subCancel,
 		subDone:     make(chan struct{}),
 		herdrClient: herdr.Init(),
+	}
+	w.reportModel()
+	return w
+}
+
+// reportModel pushes the configured large model id to herdr's pane
+// metadata. Best-effort: the model token is also refreshed from
+// every assistant message, so a missed update self-heals on the
+// next turn.
+func (w *ClientWorkspace) reportModel() {
+	if cfg := w.Config(); cfg != nil {
+		if model, ok := cfg.Models[config.SelectedModelTypeLarge]; ok {
+			w.herdrClient.ReportModel(model.Model)
+		}
 	}
 }
 
@@ -115,6 +129,7 @@ func (w *ClientWorkspace) refreshWorkspace() {
 	w.mu.Lock()
 	w.ws = *updated
 	w.mu.Unlock()
+	w.reportModel()
 }
 
 // cached returns a snapshot of the cached workspace.
@@ -188,7 +203,19 @@ func (w *ClientWorkspace) ParseAgentToolSessionID(sessionID string) (string, str
 // are propagated to the caller; the TUI logs and ignores them since
 // the presence record is a hint, not correctness-critical state.
 func (w *ClientWorkspace) SetCurrentSession(ctx context.Context, sessionID string) error {
-	w.herdrClient.SetSessionID(sessionID)
+	// Resolve the title so herdr's pane metadata reflects the
+	// session immediately: no session event fires on a plain
+	// switch. A lookup failure still reports the session id; the
+	// title catches up on the next session event.
+	var title string
+	if sessionID != "" {
+		if sess, err := w.GetSession(ctx, sessionID); err == nil {
+			title = sess.Title
+		} else {
+			slog.Debug("Failed to look up session title for herdr", "session_id", sessionID, "error", err)
+		}
+	}
+	w.herdrClient.SetSession(sessionID, title)
 	w.mu.Lock()
 	w.lastSession = sessionID
 	w.mu.Unlock()

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -206,16 +206,20 @@ func (w *ClientWorkspace) SetCurrentSession(ctx context.Context, sessionID strin
 	// Resolve the title so herdr's pane metadata reflects the
 	// session immediately: no session event fires on a plain
 	// switch. A lookup failure still reports the session id; the
-	// title catches up on the next session event.
-	var title string
-	if sessionID != "" {
-		if sess, err := w.GetSession(ctx, sessionID); err == nil {
-			title = sess.Title
-		} else {
-			slog.Debug("Failed to look up session title for herdr", "session_id", sessionID, "error", err)
+	// title catches up on the next session event. Outside a herdr
+	// pane the lookup has no consumer, so skip the round trip —
+	// this runs on every switch and on every reconnect re-assert.
+	if w.herdrClient != nil {
+		var title string
+		if sessionID != "" {
+			if sess, err := w.GetSession(ctx, sessionID); err == nil {
+				title = sess.Title
+			} else {
+				slog.Debug("Failed to look up session title for herdr", "session_id", sessionID, "error", err)
+			}
 		}
+		w.herdrClient.SetSession(sessionID, title)
 	}
-	w.herdrClient.SetSession(sessionID, title)
 	w.mu.Lock()
 	w.lastSession = sessionID
 	w.mu.Unlock()

--- a/internal/workspace/client_workspace_test.go
+++ b/internal/workspace/client_workspace_test.go
@@ -945,3 +945,35 @@ func TestClientWorkspace_RecoveryCreateIsBounded(t *testing.T) {
 		t.Fatal("recoverWorkspace blocked on an unresponsive server")
 	}
 }
+
+// TestClientWorkspace_SetCurrentSessionSkipsTitleLookup pins that the
+// herdr session-title lookup only runs when a herdr client is
+// attached. The title has no other consumer, and SetCurrentSession
+// runs on every session switch and on every reconnect re-assert, so
+// for the majority of users — who are not inside a herdr pane — a
+// switch must cost exactly one presence call and nothing else.
+func TestClientWorkspace_SetCurrentSessionSkipsTitleLookup(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var calls []string
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls = append(calls, r.Method+" "+r.URL.Path)
+		mu.Unlock()
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	c, err := client.NewClient(t.TempDir(), "tcp", u.Host)
+	require.NoError(t, err)
+	ws := NewClientWorkspace(c, proto.Workspace{ID: "ws-1"})
+	require.Nil(t, ws.herdrClient, "herdr is inert under test")
+
+	require.NoError(t, ws.SetCurrentSession(t.Context(), "S1"))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []string{"POST /v1/workspaces/ws-1/current-session"}, calls)
+}

--- a/schema.json
+++ b/schema.json
@@ -560,7 +560,7 @@
             "herdr",
             "disabled"
           ],
-          "description": "Notification style to use. Options: auto (default), native, osc, bell, herdr, disabled. Auto selects based on environment: native for local sessions, osc for SSH (with automatic OSC 99/777 detection). Herdr surfaces toasts in herdr's UI and requires running inside a herdr pane.",
+          "description": "Notification style to use. Options: auto (default), native, osc, bell, herdr, disabled. Auto selects based on environment: native for local sessions, osc for SSH (with automatic OSC 99/777 detection). Herdr surfaces toasts in herdr's own UI and only works when Crush runs inside a herdr pane; outside one it falls back to OSC.",
           "default": "auto"
         },
         "disabled_skills": {

--- a/schema.json
+++ b/schema.json
@@ -557,9 +557,10 @@
             "native",
             "osc",
             "bell",
+            "herdr",
             "disabled"
           ],
-          "description": "Notification style to use. Options: auto (default), native, osc, bell, disabled. Auto selects based on environment: native for local sessions, osc for SSH (with automatic OSC 99/777 detection).",
+          "description": "Notification style to use. Options: auto (default), native, osc, bell, herdr, disabled. Auto selects based on environment: native for local sessions, osc for SSH (with automatic OSC 99/777 detection). Herdr surfaces toasts in herdr's UI and requires running inside a herdr pane.",
           "default": "auto"
         },
         "disabled_skills": {


### PR DESCRIPTION
This PR makes Crush work better inside [Herdr](https://herdr.dev/). Crush now reliably tells Herdr what it's doing — working, waiting on you, or idle — without getting stuck in the wrong state when you switch sessions, compact context, run sub-agents, or need to re-authenticate. When Crush is blocked, Herdr shows what it's waiting on (a permission prompt, a question, or a sign-in). Crush also shares the current session title and model with Herdr, updates them as they change, and can now send its toast notifications straight to Herdr's UI (opt-in).

Closes #3539

Note: This PR also fixes an unrelated flaky test that existed in `main` via commit [207c17c](https://github.com/charmbracelet/crush/pull/3541/commits/207c17ce8e81d4851f074663e3f1dc6f90a1a16e).

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

### AI Disclosure

Planning and Implementation: Kimi K3 (max)
Review and fixes: Opus 5 (x-high) + Copilot

Manual testing by me.