### PR TITLE
fix: preserve provider type overrides

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -292,7 +292,7 @@ func (c *Config) configureProviders(ctx context.Context, store *ConfigStore, env
 		prepared.BaseURL = p.APIEndpoint
 		prepared.APIKey = p.APIKey
 		prepared.APIKeyTemplate = p.APIKey // Store original template for re-resolution
-		prepared.Type = p.Type
+		prepared.Type = cmp.Or(config.Type, p.Type)
 		prepared.Models = p.Models
 		prepared.ExtraHeaders = headers
 		if prepared.ExtraParams == nil {

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -404,6 +404,7 @@ func TestConfig_configureProviders(t *testing.T) {
 	knownProviders := []catwalk.Provider{
 		{
 			ID:          "openai",
+			Type:        catwalk.TypeOpenAI,
 			APIKey:      "$OPENAI_API_KEY",
 			APIEndpoint: "https://api.openai.com/v1",
 			Models: []catwalk.Model{{
@@ -425,12 +426,14 @@ func TestConfig_configureProviders(t *testing.T) {
 	// We want to make sure that we keep the configured API key as a placeholder
 	pc, _ := cfg.Providers.Get("openai")
 	require.Equal(t, "$OPENAI_API_KEY", pc.APIKey)
+	require.Equal(t, catwalk.TypeOpenAI, pc.Type)
 }
 
 func TestConfig_configureProvidersWithOverride(t *testing.T) {
 	knownProviders := []catwalk.Provider{
 		{
 			ID:          "openai",
+			Type:        catwalk.TypeOpenAI,
 			APIKey:      "$OPENAI_API_KEY",
 			APIEndpoint: "https://api.openai.com/v1",
 			Models: []catwalk.Model{{
@@ -445,6 +448,7 @@ func TestConfig_configureProvidersWithOverride(t *testing.T) {
 	cfg.Providers.Set("openai", ProviderConfig{
 		APIKey:  "xyz",
 		BaseURL: "https://api.openai.com/v2",
+		Type:    catwalk.TypeAnthropic,
 		Models: []catwalk.Model{
 			{
 				ID:   "test-model",
@@ -469,6 +473,7 @@ func TestConfig_configureProvidersWithOverride(t *testing.T) {
 	pc, _ := cfg.Providers.Get("openai")
 	require.Equal(t, "xyz", pc.APIKey)
 	require.Equal(t, "https://api.openai.com/v2", pc.BaseURL)
+	require.Equal(t, catwalk.TypeAnthropic, pc.Type)
 	require.Len(t, pc.Models, 2)
 	require.Equal(t, "Updated", pc.Models[0].Name)
 }


### PR DESCRIPTION
## Summary

- preserve an explicit provider `type` when enriching a known provider from Catwalk
- keep the Catwalk provider type as the fallback when users omit `type`
- cover both the explicit override and fallback behavior with regression assertions

## Root cause

Provider configuration starts from the user's values, but the Catwalk enrichment path unconditionally replaced `prepared.Type` with the catalog type. This caused known provider IDs to ignore an explicitly configured compatible protocol and send requests to the wrong endpoint shape.

## Impact

Users can configure a known provider ID with a different compatible protocol without that choice being silently overwritten. Existing configurations that omit `type` continue to use the catalog default.

Fixes #3504

## Validation

- `go test ./internal/config -run '^TestConfig_configureProviders(WithOverride)?$' -count=1`
- `golangci-lint v2.11.4 run --path-mode=abs --config=.golangci.yml --timeout=5m --new-from-rev=origin/main ./internal/config/...`

I also ran `go test -p 2 ./... -count=1` on Windows. The changed `internal/config` package and the other Windows-compatible packages passed; the remaining failures were existing Bash/WSL integration tests whose temporary Windows script paths were not visible inside WSL.
