### PR TITLE
fix: send hyper api key when fetching provider catalog

### DIFF
--- a/internal/config/hyper.go
+++ b/internal/config/hyper.go
@@ -39,6 +39,12 @@ func (s *hyperSync) Init(client hyperClient, path string, autoupdate bool) {
 	s.init.Store(true)
 }
 
+// SetClient replaces the HTTP client used for fetching. This is used
+// before Refetch to ensure the latest credentials are used.
+func (s *hyperSync) SetClient(client hyperClient) {
+	s.client = client
+}
+
 func (s *hyperSync) Get(ctx context.Context) (catwalk.Provider, error) {
 	if !s.init.Load() {
 		panic("called Get before Init")
@@ -47,58 +53,93 @@ func (s *hyperSync) Get(ctx context.Context) (catwalk.Provider, error) {
 	// The result and the error are memoized together so that every caller
 	// sees the same outcome, not just the one that won the once.
 	s.once.Do(func() {
-		if !s.autoupdate {
-			slog.Info("Using embedded Hyper provider")
-			s.result = hyper.Embedded()
-			return
-		}
-
-		cached, etag, cachedErr := s.cache.Get()
-		if cached.ID == "" || cachedErr != nil {
-			// if cached file is empty, default to embedded provider
-			cached = hyper.Embedded()
-		}
-
-		slog.Info("Fetching Hyper provider")
-		result, err := s.client.Get(ctx, etag)
-		if errors.Is(err, context.DeadlineExceeded) {
-			slog.Warn("Hyper provider not updated in time")
-			s.result = cached
-			return
-		}
-		if errors.Is(err, catwalk.ErrNotModified) {
-			slog.Info("Hyper provider not modified")
-			s.result = cached
-			return
-		}
-		if err != nil {
-			slog.Warn("Could not fetch the Hyper provider", "error", err)
-			s.result = cached
-			return
-		}
-		if len(result.Models) == 0 {
-			slog.Warn("Hyper did not return any models")
-			s.result = cached
-			return
-		}
-
-		// The provider is usable from here on. A cache write failure only
-		// costs the next run a refresh, so it is reported alongside a valid
-		// result rather than in place of one.
-		s.result = result
-		s.err = s.cache.Store(result)
+		s.fetch(ctx)
 	})
 	return s.result, s.err
+}
+
+// Refetch resets the memoized result and re-fetches the Hyper provider.
+// Must not be called concurrently with Get.
+func (s *hyperSync) Refetch(ctx context.Context) (catwalk.Provider, error) {
+	if !s.init.Load() {
+		panic("called Refetch before Init")
+	}
+	s.once = sync.Once{}
+	s.once.Do(func() {
+		s.fetch(ctx)
+	})
+	return s.result, s.err
+}
+
+// fetch performs the actual Hyper provider fetch. It is called from both
+// Get (via sync.Once) and Refetch (after resetting sync.Once).
+func (s *hyperSync) fetch(ctx context.Context) {
+	s.err = nil
+	if !s.autoupdate {
+		slog.Info("Using embedded Hyper provider")
+		s.result = hyper.Embedded()
+		return
+	}
+
+	cached, etag, cachedErr := s.cache.Get()
+	if cached.ID == "" || cachedErr != nil {
+		// if cached file is empty, default to embedded provider
+		cached = hyper.Embedded()
+	}
+
+	slog.Info("Fetching Hyper provider")
+	result, err := s.client.Get(ctx, etag)
+	if errors.Is(err, context.DeadlineExceeded) {
+		slog.Warn("Hyper provider not updated in time")
+		s.result = cached
+		return
+	}
+	if errors.Is(err, catwalk.ErrNotModified) {
+		slog.Info("Hyper provider not modified")
+		s.result = cached
+		return
+	}
+	if err != nil {
+		slog.Warn("Could not fetch the Hyper provider", "error", err)
+		s.result = cached
+		return
+	}
+	if len(result.Models) == 0 {
+		slog.Warn("Hyper did not return any models")
+		s.result = cached
+		return
+	}
+
+	// The provider is usable from here on. A cache write failure only
+	// costs the next run a refresh, so it is reported alongside a valid
+	// result rather than in place of one.
+	s.result = result
+	s.err = s.cache.Store(result)
 }
 
 var _ hyperClient = realHyperClient{}
 
 type realHyperClient struct {
-	baseURL string
+	baseURL      string
+	resolveKey   func() string
+	refreshToken func(context.Context) error
 }
 
 // Get implements hyperClient.
 func (r realHyperClient) Get(ctx context.Context, etag string) (catwalk.Provider, error) {
+	result, err := r.doGet(ctx, etag)
+	if err != nil && isHTTPUnauthorized(err) && r.refreshToken != nil {
+		slog.Info("Received 401 fetching Hyper provider, refreshing token and retrying")
+		if refreshErr := r.refreshToken(ctx); refreshErr != nil {
+			slog.Warn("Failed to refresh Hyper token", "error", refreshErr)
+			return result, err
+		}
+		result, err = r.doGet(ctx, "")
+	}
+	return result, err
+}
+
+func (r realHyperClient) doGet(ctx context.Context, etag string) (catwalk.Provider, error) {
 	var result catwalk.Provider
 	req, err := http.NewRequestWithContext(
 		ctx,
@@ -110,6 +151,9 @@ func (r realHyperClient) Get(ctx context.Context, etag string) (catwalk.Provider
 		return result, fmt.Errorf("could not create request: %w", err)
 	}
 	xetag.Request(req, etag)
+	if apiKey := r.resolveKey(); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
@@ -122,6 +166,10 @@ func (r realHyperClient) Get(ctx context.Context, etag string) (catwalk.Provider
 		return result, catwalk.ErrNotModified
 	}
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		return result, errUnauthorized
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return result, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
@@ -131,4 +179,12 @@ func (r realHyperClient) Get(ctx context.Context, etag string) (catwalk.Provider
 	}
 
 	return result, nil
+}
+
+// errUnauthorized is a sentinel for HTTP 401 responses from the Hyper API.
+var errUnauthorized = errors.New("unauthorized")
+
+// isHTTPUnauthorized reports whether err is or wraps errUnauthorized.
+func isHTTPUnauthorized(err error) bool {
+	return errors.Is(err, errUnauthorized)
 }

--- a/internal/config/hyper_test.go
+++ b/internal/config/hyper_test.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"charm.land/catwalk/pkg/catwalk"
@@ -202,4 +205,112 @@ func TestHyperSync_GetCacheStoreError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to create directory for provider cache")
 	require.Equal(t, "Hyper", provider.Name) // Provider is still returned.
+}
+
+func TestRealHyperClient_RetryOn401(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	expectedProvider := catwalk.Provider{
+		Name: "Hyper",
+		ID:   "hyper",
+		Models: []catwalk.Model{
+			{ID: "model-1", Name: "Model 1"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		if n == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expectedProvider) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	refreshCalled := false
+	client := realHyperClient{
+		baseURL:      server.URL,
+		resolveKey:   func() string { return "test-key" },
+		refreshToken: func(ctx context.Context) error { refreshCalled = true; return nil },
+	}
+
+	provider, err := client.Get(t.Context(), "")
+	require.NoError(t, err)
+	require.Equal(t, "Hyper", provider.Name)
+	require.True(t, refreshCalled, "token refresher should have been called")
+	require.Equal(t, int32(2), callCount.Load(), "should have made two requests")
+}
+
+func TestRealHyperClient_NoRetryWithoutRefresher(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := realHyperClient{
+		baseURL:    server.URL,
+		resolveKey: func() string { return "test-key" },
+	}
+
+	_, err := client.Get(t.Context(), "")
+	require.ErrorIs(t, err, errUnauthorized)
+	require.Equal(t, int32(1), callCount.Load(), "should not retry without refresher")
+}
+
+func TestRealHyperClient_RefreshFailureReturnsOriginalError(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := realHyperClient{
+		baseURL:      server.URL,
+		resolveKey:   func() string { return "test-key" },
+		refreshToken: func(ctx context.Context) error { return errors.New("refresh failed") },
+	}
+
+	_, err := client.Get(t.Context(), "")
+	require.ErrorIs(t, err, errUnauthorized)
+	require.Equal(t, int32(1), callCount.Load(), "should not retry when refresh fails")
+}
+
+func TestRealHyperClient_SuccessWithoutRetry(t *testing.T) {
+	t.Parallel()
+
+	expectedProvider := catwalk.Provider{
+		Name: "Hyper",
+		ID:   "hyper",
+		Models: []catwalk.Model{
+			{ID: "model-1", Name: "Model 1"},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(expectedProvider) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	refreshCalled := false
+	client := realHyperClient{
+		baseURL:      server.URL,
+		resolveKey:   func() string { return "test-key" },
+		refreshToken: func(ctx context.Context) error { refreshCalled = true; return nil },
+	}
+
+	provider, err := client.Get(t.Context(), "")
+	require.NoError(t, err)
+	require.Equal(t, "Hyper", provider.Name)
+	require.False(t, refreshCalled, "refresher should not be called on success")
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -103,8 +103,11 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 	// Load known providers, this loads the config from catwalk. A failed
 	// refresh still yields the cached or embedded catalog, so only an empty
 	// list is fatal: starting up without providers is worse than starting
-	// up with slightly stale ones.
-	providers, err := Providers(cfg)
+	// up with slightly stale ones. Pass a Hyper token refresher so the
+	// catalog fetch can retry on 401.
+	providers, err := Providers(cfg, func(ctx context.Context) error {
+		return store.RefreshOAuthToken(ctx, ScopeGlobal, "hyper")
+	})
 	if err != nil {
 		if len(providers) == 0 {
 			return nil, err

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -89,6 +89,27 @@ func UpdateProviders(pathOrURL string) error {
 	return nil
 }
 
+// resolveHyperAPIKey returns the Hyper API key from the environment or
+// the raw config value. The env var takes precedence.
+func resolveHyperAPIKey(cfg *Config) string {
+	if key := os.Getenv("HYPER_API_KEY"); key != "" {
+		return key
+	}
+	if cfg == nil || cfg.Providers == nil {
+		return ""
+	}
+	pc, ok := cfg.Providers.Get("hyper")
+	if !ok {
+		return ""
+	}
+	return pc.APIKey
+}
+
+// HyperTokenRefresher is a function that refreshes the Hyper OAuth
+// token. It is passed to Providers so the catalog fetch can retry on
+// 401 without relying on package-global state.
+type HyperTokenRefresher func(context.Context) error
+
 // UpdateHyper updates the Hyper provider information from a specified URL.
 func UpdateHyper(pathOrURL string) error {
 	var provider catwalk.Provider
@@ -98,7 +119,10 @@ func UpdateHyper(pathOrURL string) error {
 	case pathOrURL == "embedded":
 		provider = hyper.Embedded()
 	case strings.HasPrefix(pathOrURL, "http://") || strings.HasPrefix(pathOrURL, "https://"):
-		client := realHyperClient{baseURL: pathOrURL}
+		client := realHyperClient{
+			baseURL:    pathOrURL,
+			resolveKey: func() string { return resolveHyperAPIKey(nil) },
+		}
 		var err error
 		provider, err = client.Get(context.Background(), "")
 		if err != nil {
@@ -143,7 +167,7 @@ var (
 // using the returned list. A refresh that simply could not reach the network
 // is not an error at all: the cached or embedded catalog is a sound answer, so
 // those are logged and the fallback is returned.
-func Providers(cfg *Config) ([]catwalk.Provider, error) {
+func Providers(cfg *Config, opts ...HyperTokenRefresher) ([]catwalk.Provider, error) {
 	providerOnce.Do(func() {
 		var wg sync.WaitGroup
 		providers := csync.NewSlice[catwalk.Provider]()
@@ -184,7 +208,16 @@ func Providers(cfg *Config) ([]catwalk.Provider, error) {
 				return
 			}
 			path := cachePathFor("hyper")
-			hyperSyncer.Init(realHyperClient{baseURL: hyper.BaseURL()}, path, autoupdate)
+			cfgSnapshot := cfg
+			var refresher func(context.Context) error
+			if len(opts) > 0 {
+				refresher = opts[0]
+			}
+			hyperSyncer.Init(realHyperClient{
+				baseURL:      hyper.BaseURL(),
+				resolveKey:   func() string { return resolveHyperAPIKey(cfgSnapshot) },
+				refreshToken: refresher,
+			}, path, autoupdate)
 
 			// As above: keep whatever provider we were handed. The syncer
 			// already falls back to the cached or embedded copy, so an
@@ -209,6 +242,21 @@ func Providers(cfg *Config) ([]catwalk.Provider, error) {
 		providerErr = errors.Join(catwalkErr, hyperErr)
 	})
 	return providerList, providerErr
+}
+
+// UpdateProviderInList replaces a provider in the memoized provider list
+// returned by Providers(). This is used after re-fetching a single
+// provider (e.g. Hyper after OAuth) so that all callers of Providers()
+// see the updated entry without needing to reset sync.Once.
+func UpdateProviderInList(provider catwalk.Provider) {
+	for i, p := range providerList {
+		if p.ID == provider.ID {
+			providerList[i] = provider
+			return
+		}
+	}
+	// Provider not found in list; prepend it.
+	providerList = append([]catwalk.Provider{provider}, providerList...)
 }
 
 type cache[T any] struct {

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -181,6 +181,66 @@ func (s *ConfigStore) KnownProviders() []catwalk.Provider {
 	return s.knownProviders
 }
 
+// RefetchHyperProvider re-fetches the Hyper provider catalog from the
+// remote API and updates the in-memory known providers list and config.
+// This is called after OAuth authentication completes so the latest
+// models are available without restarting.
+func (s *ConfigStore) RefetchHyperProvider(ctx context.Context) error {
+	// Build a fresh client that reads the API key from the live config,
+	// not the stale snapshot captured at startup. The syncer's original
+	// client closes over the startup config and would send an expired
+	// token after OAuth re-authentication.
+	freshClient := realHyperClient{
+		baseURL:    hyperp.BaseURL(),
+		resolveKey: func() string { return resolveHyperAPIKey(s.Config()) },
+	}
+	hyperSyncer.SetClient(freshClient)
+
+	hyperProvider, err := hyperSyncer.Refetch(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to refetch Hyper provider: %w", err)
+	}
+	if hyperProvider.ID == "" {
+		return nil
+	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	// Replace or insert the Hyper entry in knownProviders.
+	found := false
+	for i, p := range s.knownProviders {
+		if string(p.ID) == string(hyperProvider.ID) {
+			s.knownProviders[i] = hyperProvider
+			found = true
+			break
+		}
+	}
+	if !found {
+		s.knownProviders = append([]catwalk.Provider{hyperProvider}, s.knownProviders...)
+	}
+
+	// Update the Hyper provider config with the refreshed model list
+	// and endpoint. Use cloneForWrite so readers always see a consistent
+	// snapshot (the store's contract forbids in-place config mutation).
+	nc := s.config.cloneForWrite()
+	if pc, ok := nc.Providers.Get(string(hyperProvider.ID)); ok {
+		pc.Models = hyperProvider.Models
+		if hyperProvider.APIEndpoint != "" {
+			pc.BaseURL = hyperProvider.APIEndpoint
+		}
+		nc.Providers.Set(string(hyperProvider.ID), pc)
+	}
+	s.setConfig(nc)
+
+	// Also update the memoized provider list so callers of
+	// config.Providers() (e.g. the models dialog) see fresh data.
+	UpdateProviderInList(hyperProvider)
+
+	s.SetupAgents()
+	return nil
+}
+
 // SetupAgents configures the coder and task agents on the config.
 func (s *ConfigStore) SetupAgents() {
 	s.Config().SetupAgents()
@@ -540,33 +600,40 @@ func (s *ConfigStore) SetProviderAPIKey(scope Scope, providerID string, apiKey a
 	if exists {
 		setKeyOrToken()
 		cfg.Providers.Set(providerID, providerConfig)
-		return nil
-	}
-
-	var foundProvider *catwalk.Provider
-	for _, p := range s.knownProviders {
-		if string(p.ID) == providerID {
-			foundProvider = &p
-			break
-		}
-	}
-
-	if foundProvider != nil {
-		providerConfig = ProviderConfig{
-			ID:           providerID,
-			Name:         foundProvider.Name,
-			BaseURL:      foundProvider.APIEndpoint,
-			Type:         foundProvider.Type,
-			Disable:      false,
-			ExtraHeaders: make(map[string]string),
-			ExtraParams:  make(map[string]string),
-			Models:       foundProvider.Models,
-		}
-		setKeyOrToken()
 	} else {
-		return fmt.Errorf("provider with ID %s not found in known providers", providerID)
+		var foundProvider *catwalk.Provider
+		for _, p := range s.knownProviders {
+			if string(p.ID) == providerID {
+				foundProvider = &p
+				break
+			}
+		}
+
+		if foundProvider != nil {
+			providerConfig = ProviderConfig{
+				ID:           providerID,
+				Name:         foundProvider.Name,
+				BaseURL:      foundProvider.APIEndpoint,
+				Type:         foundProvider.Type,
+				Disable:      false,
+				ExtraHeaders: make(map[string]string),
+				ExtraParams:  make(map[string]string),
+				Models:       foundProvider.Models,
+			}
+			setKeyOrToken()
+		} else {
+			return fmt.Errorf("provider with ID %s not found in known providers", providerID)
+		}
+		cfg.Providers.Set(providerID, providerConfig)
 	}
-	cfg.Providers.Set(providerID, providerConfig)
+
+	// After authenticating with Hyper, re-fetch the provider catalog so
+	// the latest models are available without restarting.
+	if providerID == "hyper" {
+		if refetchErr := s.RefetchHyperProvider(context.Background()); refetchErr != nil {
+			slog.Warn("Failed to refetch Hyper provider after auth", "error", refetchErr)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
- [x] Make sure we're refreshing the Hyper tokens if expired.
- [x] Make sure we're re-fetching the catalog after authenticating via OAuth dialog.