### PR TITLE
fix(config): honor global data dir for provider cache

### DIFF
--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -19,7 +18,6 @@ import (
 	"charm.land/catwalk/pkg/embedded"
 	"github.com/charmbracelet/crush/internal/agent/hyper"
 	"github.com/charmbracelet/crush/internal/csync"
-	"github.com/charmbracelet/crush/internal/home"
 	"github.com/charmbracelet/x/etag"
 )
 
@@ -33,25 +31,9 @@ var (
 	providerErr  error
 )
 
-// file to cache provider data
+// cachePathFor returns the path to a provider catalog cache file.
 func cachePathFor(name string) string {
-	xdgDataHome := os.Getenv("XDG_DATA_HOME")
-	if xdgDataHome != "" {
-		return filepath.Join(xdgDataHome, appName, name+".json")
-	}
-
-	// return the path to the main data directory
-	// for windows, it should be in `%LOCALAPPDATA%/crush/`
-	// for linux and macOS, it should be in `$HOME/.local/share/crush/`
-	if runtime.GOOS == "windows" {
-		localAppData := os.Getenv("LOCALAPPDATA")
-		if localAppData == "" {
-			localAppData = filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Local")
-		}
-		return filepath.Join(localAppData, appName, name+".json")
-	}
-
-	return filepath.Join(home.Dir(), ".local", "share", appName, name+".json")
+	return filepath.Join(filepath.Dir(GlobalConfigData()), name+".json")
 }
 
 // UpdateProviders updates the Catwalk providers list from a specified source.

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -274,36 +274,48 @@ func TestCache_GetInvalidJSON(t *testing.T) {
 
 func TestCachePathFor(t *testing.T) {
 	tests := []struct {
-		name        string
-		xdgDataHome string
-		expected    string
+		name            string
+		cacheName       string
+		crushGlobalData string
+		xdgDataHome     string
+		expected        string
 	}{
 		{
-			name:        "with XDG_DATA_HOME",
+			name:            "CRUSH_GLOBAL_DATA providers cache",
+			cacheName:       "providers",
+			crushGlobalData: "/isolated/data",
+			xdgDataHome:     "/custom/data",
+			expected:        "/isolated/data/providers.json",
+		},
+		{
+			name:            "CRUSH_GLOBAL_DATA Hyper cache",
+			cacheName:       "hyper",
+			crushGlobalData: "/isolated/data",
+			expected:        "/isolated/data/hyper.json",
+		},
+		{
+			name:        "XDG_DATA_HOME",
+			cacheName:   "providers",
 			xdgDataHome: "/custom/data",
 			expected:    "/custom/data/crush/providers.json",
 		},
 		{
-			name:        "without XDG_DATA_HOME",
-			xdgDataHome: "",
-			expected:    "", // Will use platform-specific default.
+			name:      "platform default",
+			cacheName: "providers",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.xdgDataHome != "" {
-				t.Setenv("XDG_DATA_HOME", tt.xdgDataHome)
-			} else {
-				t.Setenv("XDG_DATA_HOME", "")
-			}
+			t.Setenv("CRUSH_GLOBAL_DATA", tt.crushGlobalData)
+			t.Setenv("XDG_DATA_HOME", tt.xdgDataHome)
 
-			result := cachePathFor("providers")
+			result := cachePathFor(tt.cacheName)
 			if tt.expected != "" {
 				require.Equal(t, tt.expected, filepath.ToSlash(result))
 			} else {
 				require.Contains(t, result, "crush")
-				require.Contains(t, result, "providers.json")
+				require.Contains(t, result, tt.cacheName+".json")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- resolve provider catalog cache files through the same global data path used by the rest of Crush
- keep `providers.json` and `hyper.json` inside `CRUSH_GLOBAL_DATA` during isolated runs
- cover the override precedence, both catalog files, XDG data paths, and platform defaults

## Root cause

`cachePathFor` independently reconstructed the platform data directory instead of using `GlobalConfigData`. As a result, it understood `XDG_DATA_HOME` and platform defaults but skipped the higher-priority `CRUSH_GLOBAL_DATA` override. Provider auto-refreshes therefore updated the developer's real catalog files even when the rest of the run was redirected to an isolated data directory.

The cache path now uses the directory containing `GlobalConfigData`, keeping the existing XDG and platform-specific behavior while also honoring Crush's explicit data override.

Fixes #3530

## Testing

- `go test ./internal/config -count=1`
- `go vet ./internal/config`
- `go test ./... -count=1`
- `git diff --check`