### PR TITLE
fix(server): send client environment into bash tool

### DIFF
--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -167,7 +167,7 @@ func coderAgent(r *vcr.Recorder, env fakeEnv, large, small fantasy.LanguageModel
 	}
 
 	allTools := []fantasy.AgentTool{
-		tools.NewBashTool(env.permissions, env.workingDir, cfg.Config().Options.Attribution, modelName),
+		tools.NewBashTool(env.permissions, env.workingDir, cfg.Config().Options.Attribution, modelName, nil),
 		tools.NewDownloadTool(env.permissions, env.workingDir, r.GetDefaultClient()),
 		tools.NewEditTool(nil, env.permissions, env.history, *env.filetracker, env.workingDir),
 		tools.NewMultiEditTool(nil, env.permissions, env.history, *env.filetracker, env.workingDir),

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -123,6 +123,7 @@ type coordinator struct {
 	notify      pubsub.Publisher[notify.Notification]
 	runComplete pubsub.Publisher[notify.RunComplete]
 	interactive bool
+	env         []string
 
 	currentAgent SessionAgent
 	agents       map[string]SessionAgent
@@ -151,6 +152,11 @@ type CoordinatorOptions struct {
 	RunComplete pubsub.Publisher[notify.RunComplete]
 	Skills      *skills.Manager
 	Interactive bool
+	// Env is the client's environment (as sent by the connecting client).
+	// It is merged with the server's os.Environ() when the bash tool
+	// spawns shells so that client-side variables like TMUX and TMUX_PANE
+	// are visible to agent commands.
+	Env []string
 }
 
 func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, error) {
@@ -183,6 +189,7 @@ func NewCoordinator(ctx context.Context, opts CoordinatorOptions) (Coordinator, 
 		activeSkills: activeSkills,
 		skillTracker: skillTracker,
 		interactive:  opts.Interactive,
+		env:          opts.Env,
 	}
 
 	agentCfg, ok := opts.Config.Config().Agents[config.AgentCoder]
@@ -714,7 +721,7 @@ func (c *coordinator) buildTools(ctx context.Context, agent config.Agent, isSubA
 
 	allTools = append(
 		allTools,
-		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Options.Attribution, modelID),
+		tools.NewBashTool(c.permissions, c.cfg.WorkingDir(), c.cfg.Config().Options.Attribution, modelID, c.env),
 		tools.NewCrushInfoTool(c.cfg, c.lspManager, c.allSkills, c.activeSkills, c.skillTracker),
 		tools.NewCrushLogsTool(logFile),
 		tools.NewJobOutputTool(),

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -197,13 +197,14 @@ func blockFuncs() []shell.BlockFunc {
 
 func NewBashTool(permissions permission.Service, workingDir string, attribution *config.Attribution, modelID string, env []string) fantasy.AgentTool {
 	// When the client's env is available (server mode), merge it with the
-	// server's os.Environ() so subprocesses inherit both. The client env
-	// takes precedence for duplicate keys, matching backend/agent.go.
+	// server's os.Environ() so subprocesses inherit both. The server env
+	// takes precedence for duplicate keys so that remote deployments use
+	// the machine's own PATH, HOME, and other system variables.
 	// In local mode env is nil, so shellEnv stays nil and NewShell falls
 	// back to os.Environ() on its own.
 	var shellEnv []string
 	if env != nil {
-		shellEnv = append(os.Environ(), env...)
+		shellEnv = append(env, os.Environ()...)
 	}
 	return fantasy.NewAgentTool(
 		BashToolName,

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -7,6 +7,7 @@ import (
 	_ "embed"
 	"fmt"
 	"html/template"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -194,7 +195,16 @@ func blockFuncs() []shell.BlockFunc {
 	}
 }
 
-func NewBashTool(permissions permission.Service, workingDir string, attribution *config.Attribution, modelID string) fantasy.AgentTool {
+func NewBashTool(permissions permission.Service, workingDir string, attribution *config.Attribution, modelID string, env []string) fantasy.AgentTool {
+	// When the client's env is available (server mode), merge it with the
+	// server's os.Environ() so subprocesses inherit both. The client env
+	// takes precedence for duplicate keys, matching backend/agent.go.
+	// In local mode env is nil, so shellEnv stays nil and NewShell falls
+	// back to os.Environ() on its own.
+	var shellEnv []string
+	if env != nil {
+		shellEnv = append(os.Environ(), env...)
+	}
 	return fantasy.NewAgentTool(
 		BashToolName,
 		string(bashDescription(attribution, modelID)),
@@ -251,7 +261,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 				bgManager := shell.GetBackgroundShellManager()
 				bgManager.Cleanup()
 				// Use background context so it continues after tool returns
-				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+				bgShell, err := bgManager.StartWithEnv(context.Background(), execWorkingDir, shellEnv, blockFuncs(), params.Command, params.Description)
 				if err != nil {
 					return fantasy.ToolResponse{}, fmt.Errorf("error starting background shell: %w", err)
 				}
@@ -306,7 +316,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 			// Start with detached context so it can survive if moved to background
 			bgManager := shell.GetBackgroundShellManager()
 			bgManager.Cleanup()
-			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+			bgShell, err := bgManager.StartWithEnv(context.Background(), execWorkingDir, shellEnv, blockFuncs(), params.Command, params.Description)
 			if err != nil {
 				return fantasy.ToolResponse{}, fmt.Errorf("error starting shell: %w", err)
 			}

--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -117,7 +117,7 @@ func (m *recordingPermissionService) SubscribeNotifications(ctx context.Context)
 func newBashToolForTest(workingDir string) fantasy.AgentTool {
 	permissions := &mockBashPermissionService{Broker: pubsub.NewBroker[permission.PermissionRequest]()}
 	attribution := &config.Attribution{TrailerStyle: config.TrailerStyleNone}
-	return NewBashTool(permissions, workingDir, attribution, "test-model")
+	return NewBashTool(permissions, workingDir, attribution, "test-model", nil)
 }
 
 func newBashToolWithRecordingPerms(workingDir string, allow bool) (fantasy.AgentTool, *recordingPermissionService) {
@@ -126,7 +126,7 @@ func newBashToolWithRecordingPerms(workingDir string, allow bool) (fantasy.Agent
 		allow:  allow,
 	}
 	attribution := &config.Attribution{TrailerStyle: config.TrailerStyleNone}
-	return NewBashTool(perms, workingDir, attribution, "test-model"), perms
+	return NewBashTool(perms, workingDir, attribution, "test-model", nil), perms
 }
 
 func TestBashTool_ChainedCommandsRequirePermission(t *testing.T) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -68,6 +68,13 @@ type App struct {
 
 	config *config.ConfigStore
 
+	// env is the client's environment (sent by the connecting client in
+	// client/server mode). It is merged with os.Environ() when spawning
+	// agent shells so that client-side variables like TMUX and TMUX_PANE
+	// are visible to the bash tool. In local mode this is nil, which
+	// causes NewShell to fall back to os.Environ() (already correct).
+	env []string
+
 	serviceEventsWG *sync.WaitGroup
 	eventsCtx       context.Context
 	events          *pubsub.Broker[tea.Msg]
@@ -94,7 +101,7 @@ type App struct {
 // per-workspace skill discovery results computed by the caller; the
 // caller is responsible for constructing it (typically via
 // skills.NewManager + skills.DiscoverFromConfig).
-func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr *skills.Manager) (*App, error) {
+func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr *skills.Manager, env []string) (*App, error) {
 	q := db.New(conn)
 	sessions := session.NewService(q, conn)
 	messages := message.NewService(q)
@@ -125,6 +132,8 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 		tuiWG:              &sync.WaitGroup{},
 		agentNotifications: pubsub.NewBroker[notify.Notification](),
 		runCompletions:     pubsub.NewBroker[notify.RunComplete](),
+
+		env: env,
 	}
 
 	app.setupEvents()
@@ -634,6 +643,7 @@ func (app *App) initCoderAgent(ctx context.Context, interactive bool) error {
 		RunComplete: app.runCompletions,
 		Skills:      app.Skills,
 		Interactive: interactive,
+		Env:         app.env,
 	})
 	if err != nil {
 		slog.Error("Failed to create coder agent", "err", err)

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -262,7 +262,7 @@ func (b *Backend) RunShellCommand(ctx context.Context, workspaceID string, req p
 	result, err := shell.RunAndPersist(ctx, shell.RunOptions{
 		Command:   req.Command,
 		Cwd:       ws.Path,
-		Env:       append(os.Environ(), ws.Env...),
+		Env:       append(ws.Env, os.Environ()...),
 		TermWidth: req.TermWidth,
 	}, persist)
 	if err != nil {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -440,7 +440,7 @@ func (b *Backend) CreateWorkspace(args proto.Workspace) (*Workspace, proto.Works
 		skills.WithWorkingDir(discoveryCfg.WorkingDir),
 	)
 
-	appWorkspace, err := app.New(b.ctx, conn, cfg, skillsMgr)
+	appWorkspace, err := app.New(b.ctx, conn, cfg, skillsMgr, args.Env)
 	if err != nil {
 		return nil, proto.Workspace{}, fmt.Errorf("failed to create app workspace: %w", err)
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -306,7 +306,7 @@ func setupLocalWorkspace(cmd *cobra.Command) (workspace.Workspace, func(), error
 		skills.WithWorkingDir(discoveryCfg.WorkingDir),
 	)
 
-	appInstance, err := app.New(ctx, conn, store, skillsMgr)
+	appInstance, err := app.New(ctx, conn, store, skillsMgr, nil)
 	if err != nil {
 		_ = conn.Close()
 		slog.Error("Failed to create app instance", "error", err)

--- a/internal/shell/background.go
+++ b/internal/shell/background.go
@@ -86,7 +86,15 @@ func GetBackgroundShellManager() *BackgroundShellManager {
 }
 
 // Start creates and starts a new background shell with the given command.
+// Start creates and starts a new background shell with the given command.
+// If env is nil, the shell inherits os.Environ().
 func (m *BackgroundShellManager) Start(ctx context.Context, workingDir string, blockFuncs []BlockFunc, command string, description string) (*BackgroundShell, error) {
+	return m.StartWithEnv(ctx, workingDir, nil, blockFuncs, command, description)
+}
+
+// StartWithEnv is like Start but allows the caller to supply an explicit
+// environment. If env is nil, the shell inherits os.Environ().
+func (m *BackgroundShellManager) StartWithEnv(ctx context.Context, workingDir string, env []string, blockFuncs []BlockFunc, command string, description string) (*BackgroundShell, error) {
 	// Check job limit
 	if m.shells.Len() >= MaxBackgroundJobs {
 		return nil, fmt.Errorf("maximum number of background jobs (%d) reached. Please terminate or wait for some jobs to complete", MaxBackgroundJobs)
@@ -96,6 +104,7 @@ func (m *BackgroundShellManager) Start(ctx context.Context, workingDir string, b
 
 	shell := NewShell(&Options{
 		WorkingDir: workingDir,
+		Env:        env,
 		BlockFuncs: blockFuncs,
 	})
 


### PR DESCRIPTION
This revision makes sure the server running the bash tool gets the env vars from the client's environment. The client's vars get merged with the server, with the server's vars taking precedence.