### PR TITLE
feat: enable contextcheck linter and warn on dropped pubsub events

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,7 @@ version: "2"
 linters:
   enable:
     - bodyclose
+    - contextcheck
     # - exhaustive
     # - goconst
     # - godot
@@ -41,6 +42,29 @@ linters:
         text: "SA1019.*interp.ExecHandler"
         linters:
           - staticcheck
+      # The config system intentionally uses background context for
+      # file I/O operations that must complete regardless of request
+      # cancellation (atomic writes, lock acquisition, auto-reload).
+      # Threading request-scoped context through would require changing
+      # every exported ConfigStore method — a breaking API change.
+      - path: internal/config/
+        linters:
+          - contextcheck
+      # Backend interface methods (CreateWorkspace, SetConfigField,
+      # SendMessage, etc.) don't accept context — adding it would be a
+      # breaking change to the client-server protocol.
+      - path: internal/server/
+        linters:
+          - contextcheck
+      # Workspace methods cascade into the config system and do
+      # best-effort refresh after mutations.
+      - path: internal/workspace/
+        linters:
+          - contextcheck
+      # Backend config/event handlers cascade into the config system.
+      - path: internal/backend/
+        linters:
+          - contextcheck
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1260,7 +1260,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		// A dropped prompt carrying a RunID must still publish its
 		// terminal cancelled RunComplete so a caller waiting on that
 		// RunID does not hang.
-		a.publishCanceledQueueDrops(canceledRunIDDrops)
+		a.publishCanceledQueueDrops(canceledRunIDDrops) //nolint:contextcheck // must deliver cancelled-run notifications after run ctx is gone
 	}
 	if len(queuedMessages) == 0 {
 		// No queued work. Clear the cancel mark only when no accepted

--- a/internal/agent/agenttest/coordinator.go
+++ b/internal/agent/agenttest/coordinator.go
@@ -37,7 +37,7 @@ func NewCoordinator(
 	sessions session.Service,
 	messages message.Service,
 ) (agent.Coordinator, error) {
-	cfg, err := config.Init(workingDir, "", false)
+	cfg, err := config.Init(workingDir, "", false) //nolint:contextcheck // test helper; Init is a startup call with no request context
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -251,7 +251,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 				bgManager := shell.GetBackgroundShellManager()
 				bgManager.Cleanup()
 				// Use background context so it continues after tool returns
-				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+				bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description) //nolint:contextcheck // intentional: background shell must outlive the tool call
 				if err != nil {
 					return fantasy.ToolResponse{}, fmt.Errorf("error starting background shell: %w", err)
 				}
@@ -306,7 +306,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 			// Start with detached context so it can survive if moved to background
 			bgManager := shell.GetBackgroundShellManager()
 			bgManager.Cleanup()
-			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description)
+			bgShell, err := bgManager.Start(context.Background(), execWorkingDir, blockFuncs(), params.Command, params.Description) //nolint:contextcheck // intentional: shell may auto-background, must survive context cancellation
 			if err != nil {
 				return fantasy.ToolResponse{}, fmt.Errorf("error starting shell: %w", err)
 			}

--- a/internal/agent/tools/lsp_restart.go
+++ b/internal/agent/tools/lsp_restart.go
@@ -49,7 +49,7 @@ func NewLSPRestartTool(lspManager *lsp.Manager) fantasy.AgentTool {
 			var mu sync.Mutex
 			var wg sync.WaitGroup
 			for name, client := range clientsToRestart {
-				wg.Go(func() {
+				wg.Go(func() { //nolint:contextcheck // LSP server restart outlives the request
 					if err := client.Restart(); err != nil {
 						slog.Error("Failed to restart LSP client", "name", name, "error", err)
 						mu.Lock()

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -493,7 +493,7 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 	// all or the token is structurally invalid (empty access token).
 	if m.OAuth && m.Type == config.MCPHttp && !hasUsableToken(m.OAuthToken) {
 		if m.OAuthToken != nil {
-			clearOAuthToken(cfg, name)
+			clearOAuthToken(cfg, name) //nolint:contextcheck // best-effort token cleanup; config write cascades to lockConfig
 		}
 		updateState(name, StateNeedsAuth, nil, nil, Counts{})
 		clearMCPData(name)
@@ -511,7 +511,7 @@ func initClient(ctx context.Context, cfg *config.ConfigStore, name string, m con
 		// StateError.
 		if m.OAuth && m.Type == config.MCPHttp && isOAuthInitErr(err) {
 			if m.OAuthToken != nil {
-				clearOAuthToken(cfg, name)
+				clearOAuthToken(cfg, name) //nolint:contextcheck // best-effort token cleanup; config write cascades to lockConfig
 			}
 			updateState(name, StateNeedsAuth, nil, nil, Counts{})
 			slog.Info("MCP OAuth token is no longer valid, re-authentication required", "name", name, "error", err)
@@ -709,7 +709,7 @@ func getOrRenewClient(ctx context.Context, cfg *config.ConfigStore, name string)
 		// re-authenticate instead of leaving it in an error state.
 		if m.OAuth && m.Type == config.MCPHttp {
 			if m.OAuthToken != nil && isOAuthInitErr(err) {
-				clearOAuthToken(cfg, name)
+				clearOAuthToken(cfg, name) //nolint:contextcheck // best-effort token cleanup; config write cascades to lockConfig
 			}
 			updateState(name, StateNeedsAuth, nil, nil, Counts{})
 			slog.Info("MCP OAuth session expired, re-authentication required", "name", name, "error", err)
@@ -934,7 +934,7 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 
 	session, err := client.Connect(mcpCtx, transport, nil)
 	if err != nil {
-		err = maybeStdioErr(err, transport)
+		err = maybeStdioErr(err, transport) //nolint:contextcheck // pure error formatting, no I/O
 		updateState(name, StateError, maybeTimeoutErr(err, timeout), nil, Counts{})
 		slog.Error("MCP client failed to initialize", "error", err, "name", name)
 		cancel()
@@ -1037,7 +1037,7 @@ func createTransport(ctx context.Context, cfg *config.ConfigStore, name string, 
 		// (and the client registration/endpoints needed to refresh it)
 		// on every exchange and refresh via this saver.
 		if m.OAuth {
-			tokenSaver := func(tok *oauth.Token) {
+			tokenSaver := func(tok *oauth.Token) { //nolint:contextcheck // OAuth SDK callback; no context parameter available
 				if err := cfg.SetConfigField(config.ScopeGlobal, fmt.Sprintf("mcp.%s.oauth_token", name), tok); err != nil {
 					slog.Warn("Failed to persist MCP OAuth token", "name", name, "error", err)
 				} else {
@@ -1067,7 +1067,7 @@ func createTransport(ctx context.Context, cfg *config.ConfigStore, name string, 
 
 			// Normalize trailing slash for PRM discovery compatibility.
 			normalizedURL := strings.TrimSuffix(url, "/")
-			oauthHandler, oauthErr := mcpoauth.NewHandler(name, normalizedURL, m.OAuthToken, preregistered, tokenSaver, mcpoauth.IsInteractive(ctx), m.OAuthCallbackPort)
+			oauthHandler, oauthErr := mcpoauth.NewHandler(name, normalizedURL, m.OAuthToken, preregistered, tokenSaver, mcpoauth.IsInteractive(ctx), m.OAuthCallbackPort) //nolint:contextcheck // port binding is near-instant
 			if oauthErr != nil {
 				return nil, nil, fmt.Errorf("failed to create OAuth handler for mcp %q: %w", name, oauthErr)
 			}
@@ -1112,7 +1112,7 @@ func createTransport(ctx context.Context, cfg *config.ConfigStore, name string, 
 		// injects bearer tokens and handles 401-triggered authorization.
 		// Based on Bruno Krugel's oauthRoundTripper from PR #3396.
 		if m.OAuth {
-			tokenSaver := func(tok *oauth.Token) {
+			tokenSaver := func(tok *oauth.Token) { //nolint:contextcheck // OAuth SDK callback; no context parameter available
 				if err := cfg.SetConfigField(config.ScopeGlobal, fmt.Sprintf("mcp.%s.oauth_token", name), tok); err != nil {
 					slog.Warn("Failed to persist MCP OAuth token", "name", name, "error", err)
 				} else {
@@ -1138,7 +1138,7 @@ func createTransport(ctx context.Context, cfg *config.ConfigStore, name string, 
 
 			// Normalize trailing slash for PRM discovery compatibility.
 			normalizedURL := strings.TrimSuffix(url, "/")
-			handler, oauthErr := mcpoauth.NewHandler(name, normalizedURL, m.OAuthToken, preregistered, tokenSaver, mcpoauth.IsInteractive(ctx), m.OAuthCallbackPort)
+			handler, oauthErr := mcpoauth.NewHandler(name, normalizedURL, m.OAuthToken, preregistered, tokenSaver, mcpoauth.IsInteractive(ctx), m.OAuthCallbackPort) //nolint:contextcheck // port binding is near-instant
 			if oauthErr != nil {
 				return nil, nil, fmt.Errorf("failed to create OAuth handler for mcp %q: %w", name, oauthErr)
 			}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -39,6 +39,7 @@ import (
 	"github.com/charmbracelet/crush/internal/skills"
 	"github.com/charmbracelet/crush/internal/ui/anim"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/ui/util"
 	"github.com/charmbracelet/crush/internal/update"
 	"github.com/charmbracelet/crush/internal/version"
 	"github.com/charmbracelet/x/ansi"
@@ -127,7 +128,7 @@ func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr
 		runCompletions:     pubsub.NewBroker[notify.RunComplete](),
 	}
 
-	app.setupEvents()
+	app.setupEvents() //nolint:contextcheck // derives its own lifecycle context from app.globalCtx
 
 	// Initialize clipboard support. This is best-effort; if it fails
 	// (e.g., headless environment), clipboard operations will return nil.
@@ -480,7 +481,7 @@ func (app *App) restoreModelFromSession(ctx context.Context, sessionID string) e
 		Model:    lastMsg.Model,
 	})
 	if _, ok := cfg.Models[config.SelectedModelTypeSmall]; !ok {
-		smallModel := app.GetDefaultSmallModel(lastMsg.Provider)
+		smallModel := app.GetDefaultSmallModel(lastMsg.Provider) //nolint:contextcheck // Providers uses sync.Once; ctx is moot after first call
 		app.config.OverridePreferredModel(config.SelectedModelTypeSmall, smallModel)
 	}
 	if err := app.AgentCoordinator.UpdateModels(ctx); err != nil {
@@ -537,7 +538,7 @@ func (app *App) overrideModelsForNonInteractive(ctx context.Context, largeModel,
 
 	case largeModel != "":
 		// No small model specified, but large model was - use provider's default.
-		smallCfg := app.GetDefaultSmallModel(largeProviderID)
+		smallCfg := app.GetDefaultSmallModel(largeProviderID) //nolint:contextcheck // Providers uses sync.Once; ctx is moot after first call
 		app.config.OverridePreferredModel(config.SelectedModelTypeSmall, smallCfg)
 	}
 
@@ -718,6 +719,33 @@ func (app *App) Subscribe(program *tea.Program) {
 		return nil
 	})
 	defer app.tuiWG.Done()
+
+	// Monitor for dropped pubsub events and warn the user so they know
+	// the display may be stale (e.g. during heavy LLM streaming).
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		lastDrop := app.events.DropCount()
+		lastMustDeliver := app.events.MustDeliverDropCount()
+		for {
+			select {
+			case <-tuiCtx.Done():
+				return
+			case <-ticker.C:
+				curDrop := app.events.DropCount()
+				curMustDeliver := app.events.MustDeliverDropCount()
+				dropped := (curDrop - lastDrop) + (curMustDeliver - lastMustDeliver)
+				lastDrop = curDrop
+				lastMustDeliver = curMustDeliver
+				if dropped > 0 {
+					program.Send(util.NewWarnMsg(fmt.Sprintf(
+						"UI could not keep up — %d event(s) dropped. The display may be out of date.",
+						dropped,
+					)))
+				}
+			}
+		}
+	}()
 
 	events := app.events.Subscribe(tuiCtx)
 	for {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -275,7 +275,7 @@ func runNonInteractive(
 	// Start herdr integration when running inside a herdr pane.
 	hc := herdr.Init()
 	hc.SetSessionID(sess.ID)
-	defer hc.Close()
+	defer hc.Close() //nolint:contextcheck // cleanup defer; no request context available
 
 	defer func() {
 		if progress && stderrTTY {

--- a/internal/herdr/client.go
+++ b/internal/herdr/client.go
@@ -361,7 +361,7 @@ func (s *unixSender) writeLoop(ctx context.Context) {
 			if !ok {
 				return
 			}
-			if err := dialSend(s.socketPath, req); err != nil {
+			if err := dialSend(s.socketPath, req); err != nil { //nolint:contextcheck // dialSend uses its own 500ms timeout
 				slog.Debug("Herdr report failed", "error", err)
 			}
 		case <-ctx.Done():

--- a/internal/lsp/manager.go
+++ b/internal/lsp/manager.go
@@ -111,7 +111,7 @@ func (s *Manager) Start(ctx context.Context, path string) {
 
 	var wg sync.WaitGroup
 	for name, server := range s.manager.GetServers() {
-		wg.Go(func() {
+		wg.Go(func() { //nolint:contextcheck // LSP server outlives any single request
 			s.startServer(name, path, server)
 		})
 	}

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -263,7 +263,7 @@ func (s *service) Update(ctx context.Context, msg Message) error {
 	// be picked up by the next Update or by Flush.
 	if p.timer == nil && !p.flushing {
 		id := msg.ID
-		p.timer = time.AfterFunc(s.debounce, func() {
+		p.timer = time.AfterFunc(s.debounce, func() { //nolint:contextcheck // detached context prevents stranded writes when stream is cancelled
 			// Detached from caller ctx so a cancelled stream context
 			// does not strand the buffered write.
 			_ = s.flushOne(context.Background(), id, false)

--- a/internal/oauth/mcp/handler.go
+++ b/internal/oauth/mcp/handler.go
@@ -581,7 +581,7 @@ func (r *callbackReceiver) handleCallback(w http.ResponseWriter, req *http.Reque
 }
 
 func (r *callbackReceiver) fetchAuthorizationCode(ctx context.Context, args *auth.AuthorizationArgs) (*auth.AuthorizationResult, error) {
-	flight, owned, err := r.begin()
+	flight, owned, err := r.begin() //nolint:contextcheck // localhost port binding is near-instant
 	if err != nil {
 		return nil, err
 	}
@@ -625,7 +625,7 @@ func (r *callbackReceiver) await(ctx context.Context, flight *authFlight, owned 
 	select {
 	case <-flight.done:
 		if owned {
-			r.release()
+			r.release() //nolint:contextcheck // HTTP server shutdown uses its own 2s timeout
 		}
 		if flight.err != nil {
 			slog.Error("MCP OAuth authorization failed", "error", flight.err)
@@ -639,7 +639,7 @@ func (r *callbackReceiver) await(ctx context.Context, flight *authFlight, owned 
 			// Abandoning the tab we opened; make sure nobody keeps
 			// waiting on a redirect that is no longer coming.
 			flight.settle(nil, ctx.Err())
-			r.release()
+			r.release() //nolint:contextcheck // HTTP server shutdown uses its own 2s timeout
 		}
 		return nil, ctx.Err()
 	}


### PR DESCRIPTION

## Summary

Two improvements in one PR:

### 1. Enable `contextcheck` linter

Adds the [`contextcheck`](https://github.com/kkHAIKE/contextcheck) linter to `.golangci.yml` to catch missing `context.Context` propagation at lint time — preventing bugs like the grep regex fallback hanging indefinitely on cancelled requests (#1855).

**Strategy:**
- **4 packages excluded** (`config`, `server`, `workspace`, `backend`) where threading context through would require breaking changes to exported APIs and the client-server protocol.
- **23 intentional `context.Background()` sites** annotated with documented `//nolint:contextcheck` directives — each with a comment explaining why detached context is correct (background shells, LSP lifecycle, OAuth callbacks, debounce timers, cancelled-run notifications, etc.).

### 2. Warn user when pubsub events are dropped

The pubsub broker already tracks drop counts (`DropCount()`, `MustDeliverDropCount()`) but never surfaces them to the user. During heavy LLM streaming, a slow TUI consumer can cause events to be silently dropped.

This adds a goroutine in `App.Subscribe` that polls the drop counters every 2s. If any events were dropped since the last check, it sends a warning toast:

> ⚠ UI could not keep up — N event(s) dropped. The display may be out of date.

## Test plan

- [x] `golangci-lint run` — 0 issues
- [x] `go build ./...` — passes
- [x] `go test ./...` — all packages pass


💘 Generated with Crush