### PR TITLE
chore: normalize line endings to `lf` via `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+* text=auto eol=lf
 *.golden linguist-generated=true -text
 .github/crush-schema.json linguist-generated=true
 internal/agent/hyper/provider.json linguist-generated=true


### PR DESCRIPTION
## Why
The repository stores files with LF, but on Windows `core.autocrlf=true` checks them out as CRLF. As a result, diff tools report files as "differing only in line separators", and git status can flag untouched files as modified with an empty diff. This is pure line-ending noise that gets in the way of reviewing real changes.

## What
Add `* text=auto eol=lf` to `.gitattributes` so all text files are normalized to LF

## Impact
- No more line-ending-only diffs
- Consistent line endings across contributors and platforms
