### PR TITLE
feat(ui): add ability to pop and edit queued messages

### DIFF
--- a/internal/agent/accepted_run_test.go
+++ b/internal/agent/accepted_run_test.go
@@ -216,16 +216,3 @@ func TestPersistCanceledTurn_SucceedsWithCanceledContext(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, msgs, 2)
 }
-
-func TestClearPendingCancel(t *testing.T) {
-	t.Parallel()
-	sa, _ := newCancelTestAgent(t)
-
-	accept := sa.BeginAccepted("sid")
-	defer accept.Close()
-	sa.Cancel("sid")
-	require.True(t, sa.hasPendingCancel("sid"))
-
-	sa.clearPendingCancel("sid")
-	require.False(t, sa.hasPendingCancel("sid"))
-}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -222,15 +222,25 @@ type sessionAgent struct {
 	// cancel. It is only raised by Cancel when acceptedRuns > 0, so an
 	// idle Escape never records a mark.
 	cancelMark *csync.Map[string, uint64]
+	// handoffs counts in-flight session handoffs: a finished turn (or the
+	// Summarize tail) that has stopped being observable as busy but has
+	// not yet handed the session over to the queued call it promoted. A
+	// count > 0 makes the dispatch decision in Run treat the session as
+	// busy for newly submitted prompts, so a submission landing in the
+	// transition is queued behind the promotion instead of swapping
+	// itself in front of it. It is mutated under acceptedMu, like the
+	// other dispatch counters.
+	handoffs *csync.Map[string, int]
 	// dispatchMuCreate guards lazy creation of per-session entries in
 	// dispatchMu so two goroutines can't race to lock different mutex
 	// instances for the same session.
 	dispatchMuCreate sync.Mutex
-	// acceptedMu serializes increments/decrements of acceptedRuns and
-	// the assignment of accept sequence numbers from acceptSeqGen. It
-	// is separate from dispatchMu so AcceptedRun.Close (which may run
-	// while Run holds dispatchMu for the same session) does not
-	// deadlock by re-entering the dispatch lock.
+	// acceptedMu serializes increments/decrements of the dispatch
+	// counters (acceptedRuns, handoffs) and the assignment of accept
+	// sequence numbers from acceptSeqGen. It is separate from dispatchMu
+	// so AcceptedRun.Close (which may run while Run holds dispatchMu for
+	// the same session) does not deadlock by re-entering the dispatch
+	// lock.
 	acceptedMu sync.Mutex
 	// acceptSeqGen is the monotonic source of accept sequence numbers.
 	// Each BeginAccepted increments it under acceptedMu and stamps the
@@ -276,6 +286,7 @@ func NewSessionAgent(
 		dispatchMu:           csync.NewMap[string, *sync.Mutex](),
 		acceptedRuns:         csync.NewMap[string, int](),
 		cancelMark:           csync.NewMap[string, uint64](),
+		handoffs:             csync.NewMap[string, int](),
 	}
 }
 
@@ -352,6 +363,57 @@ func (a *sessionAgent) endAccepted(sessionID string) {
 		return
 	}
 	a.acceptedRuns.Set(sessionID, count-1)
+}
+
+// beginHandoff records that a finished turn (or the Summarize tail) has
+// started handing the session over to whatever is queued for it. It must
+// be called before the handoff stops being observable as busy, i.e.
+// before activeRequests is released, so no dispatch decision can see the
+// session as idle-with-a-queue while the handoff is choosing a prompt to
+// promote.
+//
+// The ticket exists because the handoff is invisible in that window: the
+// finished turn's activeRequests entry is gone, the promoted call is no
+// longer in the queue, and the dispatch decision consults only those two
+// pieces of state. A submission landing there would take Run's
+// idle-with-queue branch, swap itself into the queue and start the *new*
+// head — running it ahead of the call the handoff already promoted and
+// inverting the strictly-oldest-first order that branch exists to
+// guarantee. While the ticket is held such a submission is queued
+// instead, so it lands behind the promotion.
+func (a *sessionAgent) beginHandoff(sessionID string) {
+	a.acceptedMu.Lock()
+	defer a.acceptedMu.Unlock()
+	count, _ := a.handoffs.Get(sessionID)
+	a.handoffs.Set(sessionID, count+1)
+}
+
+// endHandoff releases the ticket taken by beginHandoff. It is called by
+// the promoted call itself, from its dispatch decision under the session
+// dispatch mutex, and by a handoff that found nothing to promote. Every
+// beginHandoff is paired with exactly one of those two releases: a
+// promoted call always reaches its dispatch decision (it was validated
+// when it was first dispatched, and Run's only earlier return releases
+// the ticket too).
+func (a *sessionAgent) endHandoff(sessionID string) {
+	a.acceptedMu.Lock()
+	defer a.acceptedMu.Unlock()
+	count, ok := a.handoffs.Get(sessionID)
+	if !ok || count <= 1 {
+		a.handoffs.Del(sessionID)
+		return
+	}
+	a.handoffs.Set(sessionID, count-1)
+}
+
+// handoffInFlight reports whether a handoff has promoted (or is about to
+// promote) a queued call for this session that has not yet reached its
+// dispatch decision.
+func (a *sessionAgent) handoffInFlight(sessionID string) bool {
+	a.acceptedMu.Lock()
+	defer a.acceptedMu.Unlock()
+	count, _ := a.handoffs.Get(sessionID)
+	return count > 0
 }
 
 // sessionMu returns the per-session dispatch mutex, creating it on first
@@ -646,6 +708,15 @@ func ValidateCall(call SessionAgentCall) error {
 
 func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *fantasy.AgentResult, retErr error) {
 	if err := ValidateCall(call); err != nil {
+		if call.dequeued {
+			// A promoted call carries the handoff ticket taken for it, and
+			// this is the one path that returns before the dispatch
+			// decision releases it. Releasing it here keeps a structurally
+			// invalid promotion (unreachable today: queued calls were
+			// validated when they were first dispatched) from leaving the
+			// session permanently undispatchable.
+			a.endHandoff(call.SessionID)
+		}
 		return nil, err
 	}
 
@@ -668,6 +739,16 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	// runs on the same session.
 	sessMu := a.sessionMu(call.SessionID)
 	sessMu.Lock()
+
+	if call.dequeued {
+		// This call is the promotion a handoff reserved a ticket for, and
+		// it has now reached the dispatch decision under the same mutex
+		// the handoff promoted it under: the transition is over, so
+		// release the ticket. Releasing it here — rather than when Run
+		// returns — keeps the window closed for exactly as long as it is
+		// open.
+		a.endHandoff(call.SessionID)
+	}
 
 	if call.Accepted != nil && a.canceledBySeq(call.SessionID, call.Accepted.seq) {
 		// Cancel-on-entry: a cancel arrived while this accepted run was
@@ -698,12 +779,19 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		return nil, nil
 	}
 
-	if a.IsSessionBusy(call.SessionID) {
-		// Busy: an earlier prompt is active. Queue this call so it is
-		// folded into (or sequenced after) the active turn, and release any
-		// accept reservation. A Cancel arriving after this point sees the
-		// active entry and ends that turn; this queued call survives the
-		// cancel and waits for the next handoff.
+	// A handoff in flight counts as busy for a newly submitted prompt: the
+	// session is mid-transition to a call that was promoted out of the
+	// queue, and the swap branch below would start the new queue head
+	// ahead of it. Promoted calls themselves ignore the ticket (their own
+	// is already released above): they are ahead of the queue, and the
+	// activeRequests check is what keeps two runs from starting.
+	if a.IsSessionBusy(call.SessionID) || (!call.dequeued && a.handoffInFlight(call.SessionID)) {
+		// Busy: an earlier prompt is active, or a finished turn is handing
+		// the session to a prompt it promoted out of the queue. Queue this
+		// call so it is folded into (or sequenced after) that turn, and
+		// release any accept reservation. A Cancel arriving after this
+		// point sees the active entry and ends that turn; this queued call
+		// survives the cancel and waits for the next handoff.
 		//
 		// enqueueCall strips OnComplete: the caller that supplied the hook
 		// (typically coordinator.Run) has its own retry/coalesce scope that
@@ -1337,6 +1425,13 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		}
 	}
 
+	// Take the handoff ticket before releasing the active request: from
+	// here until the promoted call reaches its dispatch decision the
+	// session is observably idle, and the ticket is the only thing that
+	// tells a submission landing in that window to queue behind the
+	// promotion instead of swapping itself in front of it.
+	a.beginHandoff(call.SessionID)
+
 	// Release active request before publishing the notification.
 	// TUI handlers poll IsSessionBusy() and only re-evaluate when a
 	// tea.Msg arrives, so the cleanup must precede the notify or
@@ -1387,6 +1482,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		if inFlight == 0 {
 			a.cancelMark.Del(call.SessionID)
 		}
+		// Nothing was promoted, so no dispatch decision is coming to
+		// release the handoff ticket: this is where the transition ends.
+		a.endHandoff(call.SessionID)
 		mu.Unlock()
 		return result, err
 	}
@@ -1575,6 +1673,13 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		return err
 	}
 
+	// Take the handoff ticket before releasing the active request: the
+	// tail is the same kind of transition as the completion handoff in
+	// Run, and a submission landing between the release below and the
+	// promoted call's dispatch decision must queue behind the promotion
+	// rather than swap itself ahead of it.
+	a.beginHandoff(sessionID)
+
 	// Release the active request before processing queued messages so that
 	// Run() does not see the session as busy.
 	a.activeRequests.Del(sessionID)
@@ -1594,6 +1699,9 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	mu.Lock()
 	queuedMessages, ok := a.messageQueue.Get(sessionID)
 	if !ok || len(queuedMessages) == 0 {
+		// Nothing was promoted, so no dispatch decision is coming to
+		// release the handoff ticket.
+		a.endHandoff(sessionID)
 		mu.Unlock()
 		return nil
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -407,6 +407,18 @@ func (a *sessionAgent) enqueueCall(call SessionAgentCall) {
 // path still balances the caller's reservation exactly once and
 // acceptedRuns never dips to 0 across the swap, keeping the session
 // observable to a concurrent Cancel.
+//
+// The accept reservation is the only thing it inherits. In particular
+// the head keeps the nil OnComplete enqueueCall gave it, rather than
+// borrowing call's hook: the coordinator's hook only buffers the payload
+// and publishes it after Run returns, so routing the head's terminal
+// event through it would hold that event back until every prompt behind
+// the head — call's own included — had finished, publishing it out of
+// execution order. With the hook left nil the head's terminal publishes
+// to the broker the moment its turn ends, under the head's own RunID.
+// Run records the swap on the context instead (MarkRunRequeued) so the
+// dispatch boundary stops attributing this invocation's outcome to
+// call.RunID.
 func (a *sessionAgent) swapWithQueueHead(call SessionAgentCall) SessionAgentCall {
 	a.enqueueCall(call)
 	queued, _ := a.messageQueue.Get(call.SessionID)
@@ -733,8 +745,20 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	// Calls the internal promotion paths dequeued (call.dequeued) are
 	// already ahead of the queue; swapping them back in would rotate the
 	// queue and invert the very order this branch exists to preserve.
+	// That also means only the dispatched (top-level) call can swap, so
+	// the requeue recorded below always describes the RunID the
+	// dispatcher is waiting on.
 	if !call.dequeued && a.QueuedPrompts(call.SessionID) > 0 {
 		call = a.swapWithQueueHead(call)
+		// This invocation now runs the queue head, not the prompt it was
+		// dispatched with: that prompt is queued and publishes its own
+		// terminal event when it runs. Tell the dispatch boundary
+		// (backend.runAgent), which otherwise reads this invocation's
+		// error as its own run's failure and both reports it under the
+		// still-queued RunID and publishes a terminal event for a prompt
+		// that has not run — which the prompt's own turn would later
+		// publish a second time.
+		MarkRunRequeued(ctx, call.RunID)
 	}
 
 	// Idle: become the active run. Register the cancel func before dropping

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -58,6 +58,10 @@ const (
 	largeContextWindowThreshold = 200_000
 	largeContextWindowBuffer    = 20_000
 	smallContextWindowRatio     = 0.2
+
+	// summarizeKeySuffix distinguishes a session's summarize entry from
+	// its regular run entry in activeRequests.
+	summarizeKeySuffix = "-summarize"
 )
 
 var userAgent = fmt.Sprintf("Charm-Crush/%s (https://charm.land/crush)", version.Version)
@@ -125,6 +129,12 @@ type SessionAgentCall struct {
 	// paths treat as covered by any present mark, preserving the
 	// pre-sequence behavior.
 	acceptSeq uint64
+	// dequeued marks a call that Run itself pulled out of the session
+	// queue and handed back to Run (the completion handoff and the
+	// summarize tail). Such a call is already ahead of everything still
+	// queued, so the dispatch decision must run it rather than swap it
+	// behind the queue again. It is meaningless on a queued call.
+	dequeued bool
 	// OnAuthRefresh, when non-nil, is called by fantasy when a stream
 	// fails with an authentication error (HTTP 401). The callback should
 	// refresh credentials and return nil on success, in which case
@@ -384,6 +394,30 @@ func (a *sessionAgent) enqueueCall(call SessionAgentCall) {
 	queued.Accepted = nil
 	existing = append(existing, queued)
 	a.messageQueue.Set(call.SessionID, existing)
+}
+
+// swapWithQueueHead sends call to the tail of its session's queue and
+// returns the call at the head, which Run then executes in call's place.
+// Callers must hold the session's dispatch mutex and must only call this
+// for a session whose queue is non-empty, which also guarantees the queue
+// is left non-empty (call itself is in it).
+//
+// The returned call inherits call's accept reservation — queued calls
+// carry none, enqueueCall strips it — so the single Close in Run's idle
+// path still balances the caller's reservation exactly once and
+// acceptedRuns never dips to 0 across the swap, keeping the session
+// observable to a concurrent Cancel.
+func (a *sessionAgent) swapWithQueueHead(call SessionAgentCall) SessionAgentCall {
+	a.enqueueCall(call)
+	queued, _ := a.messageQueue.Get(call.SessionID)
+	head := queued[0]
+	// Reslicing from the front is safe for lock-free queue readers
+	// (QueuedPrompts, QueuedPromptsList): a later append writes past the
+	// end of the original slice, never into a window a reader that
+	// captured the pre-swap header is still ranging over.
+	a.messageQueue.Set(call.SessionID, queued[1:])
+	head.Accepted = call.Accepted
+	return head
 }
 
 // drainQueueForStep partitions the session's queued calls for the current
@@ -686,6 +720,36 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		}
 		sessMu.Unlock()
 		return nil, nil
+	}
+
+	// Idle, but prompts are already queued for this session. A canceled
+	// turn leaves its queue intact (see Cancel), so this is the state the
+	// user restarts the agent from after "esc esc". Becoming the active
+	// run for this call would jump it ahead of every prompt already
+	// waiting, so hand it to the tail of the queue and take the queue
+	// head as this invocation's turn instead: submissions then execute
+	// strictly oldest-first, with the rest of the queue (this caller's
+	// prompt last) draining behind the head through the completion
+	// handoff below.
+	//
+	// The swap runs under the same lock as the busy check, so the
+	// promoted head is registered in activeRequests before the lock is
+	// dropped: two concurrent submissions to an idle session with a queue
+	// still start exactly one run.
+	//
+	// The head's queued accept sequence is deliberately not re-checked
+	// against the session's cancel mark. A cancel ends the turn in
+	// progress and never discards queued prompts, so a mark recorded
+	// while the head sat in the queue must not poison it now that the
+	// user has explicitly restarted the agent — the same reasoning that
+	// hands the completion handoff's dequeued call a fresh accept
+	// reservation above the mark.
+	//
+	// Calls the internal promotion paths dequeued (call.dequeued) are
+	// already ahead of the queue; swapping them back in would rotate the
+	// queue and invert the very order this branch exists to preserve.
+	if !call.dequeued && a.QueuedPrompts(call.SessionID) > 0 {
+		call = a.swapWithQueueHead(call)
 	}
 
 	// Idle: become the active run. Register the cancel func before dropping
@@ -1331,6 +1395,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		}
 	}
 	firstQueuedMessage := queuedMessages[0]
+	// Mark the promotion so the recursive Run executes this call instead
+	// of swapping it behind the prompts still queued after it.
+	firstQueuedMessage.dequeued = true
 	a.messageQueue.Set(call.SessionID, queuedMessages[1:])
 	// Reserve a fresh accept for the dequeued prompt before dropping the
 	// lock so acceptedRuns > 0 across the handoff into the recursive
@@ -1500,6 +1567,9 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 		return nil
 	}
 	firstQueuedMessage := queuedMessages[0]
+	// Mark the promotion so Run executes this call instead of swapping it
+	// behind the prompts still queued after it.
+	firstQueuedMessage.dequeued = true
 	a.messageQueue.Set(sessionID, queuedMessages[1:])
 	_, qErr := a.Run(ctx, firstQueuedMessage)
 	return qErr
@@ -2008,7 +2078,7 @@ func (a *sessionAgent) Cancel(sessionID string) {
 	}
 
 	// Also check for summarize requests.
-	if ac, ok := a.activeRequests.Get(sessionID + "-summarize"); ok && ac != nil {
+	if ac, ok := a.activeRequests.Get(sessionID + summarizeKeySuffix); ok && ac != nil {
 		slog.Debug("Summarize cancellation initiated", "session_id", sessionID)
 		ac.cancel()
 	}
@@ -2050,13 +2120,31 @@ func (a *sessionAgent) ClearQueue(sessionID string) {
 // discards each canceled session's queue, which publishes the terminal
 // cancelled RunComplete a non-interactive caller (e.g. `crush run`)
 // blocking on a queued prompt's RunID needs in order to exit.
+//
+// The teardown set is the union of sessions with an active request and
+// sessions that merely hold a queue: Cancel is turn-scoped, so a canceled
+// session goes idle with its queue intact, and that state — no active
+// request, non-empty queue — is the common one after "esc esc". Keying
+// only on activeRequests would return early (nothing busy) or skip such a
+// session entirely, and its queued RunIDs would never see a terminal
+// event. Keys are normalized to real session IDs so ClearQueue cannot be
+// handed a synthetic "<id>-summarize" key, on which it is a silent no-op.
 func (a *sessionAgent) CancelAll() {
-	if !a.IsBusy() {
+	teardown := make(map[string]struct{})
+	for key := range a.activeRequests.Seq2() {
+		teardown[strings.TrimSuffix(key, summarizeKeySuffix)] = struct{}{}
+	}
+	for sessionID, queued := range a.messageQueue.Seq2() {
+		if len(queued) > 0 {
+			teardown[sessionID] = struct{}{}
+		}
+	}
+	if len(teardown) == 0 {
 		return
 	}
-	for key := range a.activeRequests.Seq2() {
-		a.Cancel(key) // key is sessionID
-		a.ClearQueue(key)
+	for sessionID := range teardown {
+		a.Cancel(sessionID)
+		a.ClearQueue(sessionID)
 	}
 
 	timeout := time.After(5 * time.Second)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -161,7 +161,7 @@ type SessionAgent interface {
 	IsBusy() bool
 	QueuedPrompts(sessionID string) int
 	QueuedPromptsList(sessionID string) []string
-	ClearQueue(sessionID string)
+	ClearQueue(sessionID string) []QueuedMessage
 	PopQueuedMessage(sessionID string) (QueuedMessage, bool)
 	Summarize(context.Context, string, fantasy.ProviderOptions, func(context.Context, *fantasy.ProviderError) error) error
 	Model() Model
@@ -496,17 +496,20 @@ func (a *sessionAgent) publishCanceledQueueDrops(drops []SessionAgentCall) {
 	}
 }
 
-// clearQueueAndNotify removes all queued prompts for the session and
-// publishes a terminal cancelled RunComplete for any that carried a RunID,
-// so callers waiting on those RunIDs (e.g. `crush run`) are not left
-// hanging when their queued prompt is discarded without running.
-func (a *sessionAgent) clearQueueAndNotify(sessionID string) {
-	queued, ok := a.messageQueue.Get(sessionID)
-	a.messageQueue.Del(sessionID)
-	if !ok {
-		return
+// queuedMessageOf copies the frontend-safe content out of a queued call:
+// prompt text and attachments, with the attachment bytes cloned so the
+// caller owns them and can hand them to the editor without aliasing a
+// queued call the agent may still be holding.
+func queuedMessageOf(call SessionAgentCall) QueuedMessage {
+	attachments := make([]message.Attachment, len(call.Attachments))
+	for i, attachment := range call.Attachments {
+		attachments[i] = attachment
+		attachments[i].Content = append([]byte(nil), attachment.Content...)
 	}
-	a.publishCanceledQueueDrops(queued)
+	return QueuedMessage{
+		Prompt:      call.Prompt,
+		Attachments: attachments,
+	}
 }
 
 // PopQueuedMessage atomically removes the newest queued call for sessionID.
@@ -537,16 +540,8 @@ func (a *sessionAgent) PopQueuedMessage(sessionID string) (QueuedMessage, bool) 
 	}
 	mu.Unlock()
 
-	attachments := make([]message.Attachment, len(popped.Attachments))
-	for i, attachment := range popped.Attachments {
-		attachments[i] = attachment
-		attachments[i].Content = append([]byte(nil), attachment.Content...)
-	}
 	a.publishCanceledQueueDrops([]SessionAgentCall{popped})
-	return QueuedMessage{
-		Prompt:      popped.Prompt,
-		Attachments: attachments,
-	}, true
+	return queuedMessageOf(popped), true
 }
 
 // canceledBySeq reports whether an accepted handle or queued call with
@@ -2098,11 +2093,37 @@ func (a *sessionAgent) Cancel(sessionID string) {
 	}
 }
 
-func (a *sessionAgent) ClearQueue(sessionID string) {
-	if a.QueuedPrompts(sessionID) > 0 {
-		slog.Debug("Clearing queued prompts", "session_id", sessionID)
-		a.clearQueueAndNotify(sessionID)
+// ClearQueue atomically removes every prompt queued for sessionID and
+// returns what it removed, oldest to newest, so a caller that is taking
+// the queue off the agent (Escape in the TUI) can hand the prompts back
+// to the user instead of destroying them. The returned messages carry
+// their attachments and own the attachment bytes.
+//
+// The removal holds the per-session dispatch mutex, like PopQueuedMessage:
+// the returned content is acted upon, so the drain must be atomic against
+// the run handoff and the PrepareStep drain — a message reported as
+// drained must never also be started. Terminal events are published after
+// the lock is dropped, so a RunID-bearing prompt discarded without ever
+// running still emits exactly one cancelled RunComplete and leaves no
+// `crush run` caller hanging.
+func (a *sessionAgent) ClearQueue(sessionID string) []QueuedMessage {
+	mu := a.sessionMu(sessionID)
+	mu.Lock()
+	queued, ok := a.messageQueue.Get(sessionID)
+	if !ok || len(queued) == 0 {
+		mu.Unlock()
+		return nil
 	}
+	a.messageQueue.Del(sessionID)
+	mu.Unlock()
+
+	slog.Debug("Clearing queued prompts", "session_id", sessionID, "count", len(queued))
+	drained := make([]QueuedMessage, len(queued))
+	for i, call := range queued {
+		drained[i] = queuedMessageOf(call)
+	}
+	a.publishCanceledQueueDrops(queued)
+	return drained
 }
 
 // CancelAll is the shutdown path: the process or workspace is going away,
@@ -2134,6 +2155,8 @@ func (a *sessionAgent) CancelAll() {
 	}
 	for sessionID := range teardown {
 		a.Cancel(sessionID)
+		// The drained prompts are deliberately discarded: nothing is
+		// left to hand them back to at shutdown.
 		a.ClearQueue(sessionID)
 	}
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -549,16 +549,6 @@ func (a *sessionAgent) PopQueuedMessage(sessionID string) (QueuedMessage, bool) 
 	}, true
 }
 
-// clearPendingCancel removes any pending-cancel mark for sessionID. It
-// takes the per-session dispatch lock so it is ordered against Cancel
-// and the dispatch handoff.
-func (a *sessionAgent) clearPendingCancel(sessionID string) {
-	mu := a.sessionMu(sessionID)
-	mu.Lock()
-	defer mu.Unlock()
-	a.cancelMark.Del(sessionID)
-}
-
 // canceledBySeq reports whether an accepted handle or queued call with
 // the given accept sequence is covered by a pending cancel for the
 // session. Callers must hold the session's dispatch mutex. A tracked

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -492,7 +493,13 @@ func (a *sessionAgent) PopQueuedMessage(sessionID string) (QueuedMessage, bool) 
 	if last == 0 {
 		a.messageQueue.Del(sessionID)
 	} else {
-		a.messageQueue.Set(sessionID, queued[:last])
+		// Clone instead of reslicing: queue readers (QueuedPrompts,
+		// QueuedPromptsList) run without the dispatch mutex and can be
+		// ranging over a slice header captured before this pop. A bare
+		// queued[:last] keeps the original array and its spare capacity,
+		// so the next enqueueCall would append in place over index last —
+		// the very element such a reader is still reading.
+		a.messageQueue.Set(sessionID, slices.Clone(queued[:last]))
 	}
 	mu.Unlock()
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -59,8 +59,6 @@ const (
 	largeContextWindowBuffer    = 20_000
 	smallContextWindowRatio     = 0.2
 
-	// summarizeKeySuffix distinguishes a session's summarize entry from
-	// its regular run entry in activeRequests.
 	summarizeKeySuffix = "-summarize"
 )
 
@@ -143,7 +141,8 @@ type SessionAgentCall struct {
 	OnAuthRefresh func(ctx context.Context, err *fantasy.ProviderError) error
 }
 
-// QueuedMessage is the frontend-safe content of a queued agent call.
+// QueuedMessage is the frontend-safe portion of a SessionAgentCall (prompt
+// and attachments, with the attachment bytes owned by the caller).
 type QueuedMessage struct {
 	Prompt      string
 	Attachments []message.Attachment
@@ -406,9 +405,9 @@ func (a *sessionAgent) endHandoff(sessionID string) {
 	a.handoffs.Set(sessionID, count-1)
 }
 
-// handoffInFlight reports whether a handoff has promoted (or is about to
-// promote) a queued call for this session that has not yet reached its
-// dispatch decision.
+// handoffInFlight reports whether a queued call for this session has been
+// promoted (or is about to be) but has not yet reached its dispatch
+// decision.
 func (a *sessionAgent) handoffInFlight(sessionID string) bool {
 	a.acceptedMu.Lock()
 	defer a.acceptedMu.Unlock()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1317,6 +1317,15 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		}
 		// If the agent wasn't done...
 		if len(currentAssistant.ToolCalls()) > 0 {
+			// Re-queue the continuation under the per-session dispatch
+			// mutex. Every other queue read-modify-write (the dispatch
+			// decision, the PrepareStep drain, ClearQueue, and both
+			// promotions) holds it, so an unlocked append here can be
+			// lost to a concurrent drain that read the queue before the
+			// append and wrote after it — or resurrect a prompt that
+			// drain removed.
+			mu := a.sessionMu(call.SessionID)
+			mu.Lock()
 			existing, ok := a.messageQueue.Get(call.SessionID)
 			if !ok {
 				existing = []SessionAgentCall{}
@@ -1324,6 +1333,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			call.Prompt = fmt.Sprintf("The previous session was interrupted because it got too long, the initial user request was: `%s`", call.Prompt)
 			existing = append(existing, call)
 			a.messageQueue.Set(call.SessionID, existing)
+			mu.Unlock()
 		}
 	}
 
@@ -1570,9 +1580,21 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	a.activeRequests.Del(sessionID)
 	cancel()
 
-	// Process any messages that were queued while summarizing.
+	// Process any messages that were queued while summarizing. The
+	// dequeue holds the per-session dispatch mutex because the release
+	// above makes the session read idle: a submission landing here takes
+	// Run's idle-with-queue branch, which swaps itself into the queue and
+	// starts the head. An unlocked read/promote/write would write this
+	// stale snapshot back over that swap, dropping the new submission
+	// (never run, never restored, and no terminal RunComplete for its
+	// RunID, so a `crush run` waiter hangs) and re-queueing a head that
+	// is already running — which then runs a second time and publishes a
+	// second terminal event for its RunID.
+	mu := a.sessionMu(sessionID)
+	mu.Lock()
 	queuedMessages, ok := a.messageQueue.Get(sessionID)
 	if !ok || len(queuedMessages) == 0 {
+		mu.Unlock()
 		return nil
 	}
 	firstQueuedMessage := queuedMessages[0]
@@ -1580,6 +1602,7 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	// behind the prompts still queued after it.
 	firstQueuedMessage.dequeued = true
 	a.messageQueue.Set(sessionID, queuedMessages[1:])
+	mu.Unlock()
 	_, qErr := a.Run(ctx, firstQueuedMessage)
 	return qErr
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -392,31 +392,28 @@ func (a *sessionAgent) enqueueCall(call SessionAgentCall) {
 // prevents a cancel recorded between the drain and the check from being
 // observed inconsistently.
 //
-// Calls covered by a pending cancel are dropped; the dropped ones that
-// carry a RunID are returned in canceledWithRunID so the caller can
-// publish their terminal cancelled RunComplete (a caller waiting on that
-// RunID, e.g. `crush run`, would otherwise hang). Uncanceled calls without
-// a RunID are returned in fold to be folded into the active turn,
-// preserving the existing follow-up behavior. Uncanceled calls that carry
-// a RunID are left in the queue so each runs as its own turn via the
-// recursive run path and publishes its own RunComplete, giving every
-// RunID-bearing prompt an explicit lifecycle instead of being silently
-// absorbed into another turn. fold is processed by the caller without the
-// lock held.
-func (a *sessionAgent) drainQueueForStep(sessionID string) (fold, canceledWithRunID []SessionAgentCall) {
+// Queued calls without a RunID are returned in fold to be folded into the
+// active turn, preserving the existing follow-up behavior. Two kinds of
+// call are left in the queue instead:
+//
+//   - Calls carrying a RunID, so each runs as its own turn via the
+//     recursive run path and publishes its own RunComplete, giving every
+//     RunID-bearing prompt an explicit lifecycle instead of being silently
+//     absorbed into another turn.
+//   - Calls covered by a pending cancel. A cancel ends the turn in
+//     progress; it never discards queued prompts. Folding such a call into
+//     that turn would destroy it along with the turn, so it stays queued
+//     for a later handoff (or for the user to pop and edit).
+//
+// fold is processed by the caller without the lock held.
+func (a *sessionAgent) drainQueueForStep(sessionID string) (fold []SessionAgentCall) {
 	dispatchLock := a.sessionMu(sessionID)
 	dispatchLock.Lock()
 	defer dispatchLock.Unlock()
 	queuedCalls, _ := a.messageQueue.Get(sessionID)
 	var keep []SessionAgentCall
 	for _, queued := range queuedCalls {
-		if a.canceledBySeq(sessionID, queued.acceptSeq) {
-			if queued.RunID != "" {
-				canceledWithRunID = append(canceledWithRunID, queued)
-			}
-			continue
-		}
-		if queued.RunID != "" {
+		if queued.RunID != "" || a.canceledBySeq(sessionID, queued.acceptSeq) {
 			keep = append(keep, queued)
 			continue
 		}
@@ -427,14 +424,14 @@ func (a *sessionAgent) drainQueueForStep(sessionID string) (fold, canceledWithRu
 	} else {
 		a.messageQueue.Set(sessionID, keep)
 	}
-	return fold, canceledWithRunID
+	return fold
 }
 
 // publishCanceledQueueDrops emits a terminal cancelled RunComplete for
 // every dropped queued call that carries a RunID. A queued prompt removed
-// from the queue without ever running — covered by a pending cancel, or
-// cleared by Cancel/ClearQueue — would otherwise leave a caller blocked on
-// that RunID: `crush run` ignores live message events and exits only on a
+// from the queue without ever running — cleared by ClearQueue, or popped
+// back into the editor — would otherwise leave a caller blocked on that
+// RunID: `crush run` ignores live message events and exits only on a
 // RunComplete whose RunID matches. Calls without a RunID had no such waiter
 // and are dropped silently as before. A detached, bounded context keeps the
 // must-deliver publish alive even when the run context that triggered the
@@ -531,6 +528,11 @@ func (a *sessionAgent) clearPendingCancel(sessionID string) {
 // preserving the pre-sequence behavior. The mark is not consumed: it
 // stays so every sibling handle it covers observes the same cancel, and
 // a later handle (higher seq) ignores it regardless.
+//
+// Coverage means "do not start this run as part of the canceled turn": a
+// covered handle cancels on entry, and a covered queued call is left in
+// the queue rather than folded into the turn being canceled. It never
+// means the queued prompt is discarded.
 func (a *sessionAgent) canceledBySeq(sessionID string, seq uint64) bool {
 	mark, ok := a.cancelMark.Get(sessionID)
 	if !ok || mark == 0 {
@@ -620,12 +622,12 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 
 	// Serialize the dispatch decision (cancel-on-entry | queued | active)
 	// against a concurrent Cancel. Cancel takes the same per-session lock, so
-	// every cancel observes at least one of: a cancel mark, an activeRequests
-	// entry, or a messageQueue entry it then clears. Holding the lock across
-	// the busy check and the active registration also makes them atomic, so
-	// two concurrent in-process callers — a burst of channel events, or a
-	// channel event racing a typed prompt — cannot both pass the busy check
-	// and start two runs on the same session.
+	// every cancel observes at least one of: a cancel mark or an
+	// activeRequests entry. Holding the lock across the busy check and the
+	// active registration also makes them atomic, so two concurrent
+	// in-process callers — a burst of channel events, or a channel event
+	// racing a typed prompt — cannot both pass the busy check and start two
+	// runs on the same session.
 	sessMu := a.sessionMu(call.SessionID)
 	sessMu.Lock()
 
@@ -662,7 +664,8 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		// Busy: an earlier prompt is active. Queue this call so it is
 		// folded into (or sequenced after) the active turn, and release any
 		// accept reservation. A Cancel arriving after this point sees the
-		// active entry and clears the queue.
+		// active entry and ends that turn; this queued call survives the
+		// cancel and waits for the next handoff.
 		//
 		// enqueueCall strips OnComplete: the caller that supplied the hook
 		// (typically coordinator.Run) has its own retry/coalesce scope that
@@ -855,19 +858,16 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 			// Use latest tools (updated by SetTools when MCP tools change).
 			prepared.Tools = a.tools.Copy()
 
-			// Drain queued follow-up prompts for this step. Calls covered
-			// by a cancel recorded while they sat in the queue are dropped:
-			// a cancel that arrived after a prompt was queued must not let
-			// it run as part of this step. Coverage is per-call by accept
-			// sequence so a follow-up queued after the cancel (higher seq)
-			// is not dropped. A dropped prompt carrying a RunID still gets
-			// its terminal cancelled RunComplete so a caller waiting on it
-			// does not hang. Uncanceled prompts without a RunID are folded
-			// into this turn; uncanceled prompts with a RunID are left
-			// queued so each runs as its own turn (with its own
-			// RunComplete) via the recursive run path below.
-			fold, canceledRunIDs := a.drainQueueForStep(call.SessionID)
-			a.publishCanceledQueueDrops(canceledRunIDs)
+			// Drain queued follow-up prompts for this step. Prompts
+			// without a RunID are folded into this turn. Two kinds stay
+			// queued: prompts carrying a RunID, so each runs as its own
+			// turn (with its own RunComplete) via the recursive run path
+			// below, and prompts covered by a cancel recorded while they
+			// sat in the queue — a cancel ends the turn in progress, so
+			// folding those prompts into it would destroy them with it.
+			// Coverage is per-call by accept sequence, so a follow-up
+			// queued after the cancel (higher seq) is still folded.
+			fold := a.drainQueueForStep(call.SessionID)
 			for _, queued := range fold {
 				userMessage, createErr := a.createUserMessage(callContext, queued)
 				if createErr != nil {
@@ -1269,40 +1269,20 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	// against a concurrent Cancel. activeRequests for this session was
 	// just deleted above, so without the lock there is a window in
 	// which the session looks idle and a cancel becomes a no-op that
-	// fails to stop the queued prompt. Holding the lock lets us observe
-	// a pending cancel recorded against the session and drop the queue
-	// instead of running it, and (for the recursion) hand a fresh
-	// accept reservation to the dequeued call so acceptedRuns stays > 0
-	// across the recursive Run's own dispatch handoff — keeping the
-	// session observable to Cancel for the entire transition and
-	// closing the dequeue -> re-register window.
+	// fails to stop the queued prompt. Holding the lock lets us hand a
+	// fresh accept reservation to the dequeued call so acceptedRuns
+	// stays > 0 across the recursive Run's own dispatch handoff —
+	// keeping the session observable to Cancel for the entire
+	// transition and closing the dequeue -> re-register window.
+	//
+	// A cancel mark recorded for this session does not discard queued
+	// prompts: cancellation ends the turn in progress, and this turn is
+	// already finished. A cancel that lands inside the handoff window
+	// covers the fresh reservation below, so the recursive Run cancels
+	// that one prompt on entry; anything still queued stays queued.
 	mu := a.sessionMu(call.SessionID)
 	mu.Lock()
 	queuedMessages, _ := a.messageQueue.Get(call.SessionID)
-	if mark, ok := a.cancelMark.Get(call.SessionID); ok && mark > 0 && len(queuedMessages) > 0 {
-		// A cancel was recorded for this session (e.g. it arrived while
-		// this run was active and follow-ups had been queued). Drop the
-		// queued prompts it covers (accept sequence at or below the
-		// mark, or untracked); keep any queued after the cancel (higher
-		// sequence) so they still run.
-		var kept []SessionAgentCall
-		var canceledRunIDDrops []SessionAgentCall
-		for _, q := range queuedMessages {
-			if q.acceptSeq == 0 || q.acceptSeq <= mark {
-				if q.RunID != "" {
-					canceledRunIDDrops = append(canceledRunIDDrops, q)
-				}
-				continue
-			}
-			kept = append(kept, q)
-		}
-		queuedMessages = kept
-		a.messageQueue.Set(call.SessionID, kept)
-		// A dropped prompt carrying a RunID must still publish its
-		// terminal cancelled RunComplete so a caller waiting on that
-		// RunID does not hang.
-		a.publishCanceledQueueDrops(canceledRunIDDrops)
-	}
 	if len(queuedMessages) == 0 {
 		// No queued work. Clear the cancel mark only when no accepted
 		// run remains in flight that it might still cover; otherwise a
@@ -1993,13 +1973,20 @@ func summaryCompletionTokens(usage fantasy.Usage, summaryMessage message.Message
 	return approxTokenCount(summaryMessage.Content().Text) + approxTokenCount(summaryMessage.ReasoningContent().String())
 }
 
+// Cancel stops the session's current work: the active request (and an
+// active summarize) plus any run that is dispatched but has not yet
+// become active. It deliberately leaves the message queue alone —
+// cancellation ends the turn in progress, it does not discard prompts
+// the user queued behind it. Queued prompts stay queued (and remain
+// editable through PopQueuedMessage) until a turn completes and hands
+// off to them; use ClearQueue to discard them.
 func (a *sessionAgent) Cancel(sessionID string) {
 	// Serialize against the dispatch handoff in Run so the accepted ->
 	// (cancel-on-entry | queued | active) transition is atomic against
 	// this cancel. Every cancel observes at least one of: an active
-	// request, an accepted run (recorded as a pending cancel), or a
-	// queue entry it then clears. If none of those hold, an idle Escape
-	// is a true no-op and must not poison the next prompt.
+	// request or an accepted run (recorded as a pending cancel). If
+	// neither holds, an idle Escape is a true no-op and must not poison
+	// the next prompt.
 	mu := a.sessionMu(sessionID)
 	mu.Lock()
 	defer mu.Unlock()
@@ -2042,11 +2029,6 @@ func (a *sessionAgent) Cancel(sessionID string) {
 		existing, _ := a.cancelMark.Get(sessionID)
 		a.cancelMark.Set(sessionID, max(existing, mark))
 	}
-
-	if a.QueuedPrompts(sessionID) > 0 {
-		slog.Debug("Clearing queued prompts", "session_id", sessionID)
-		a.clearQueueAndNotify(sessionID)
-	}
 }
 
 func (a *sessionAgent) ClearQueue(sessionID string) {
@@ -2056,12 +2038,18 @@ func (a *sessionAgent) ClearQueue(sessionID string) {
 	}
 }
 
+// CancelAll is the shutdown path: the process or workspace is going away,
+// so queued prompts cannot run later. Unlike Cancel, it therefore also
+// discards each canceled session's queue, which publishes the terminal
+// cancelled RunComplete a non-interactive caller (e.g. `crush run`)
+// blocking on a queued prompt's RunID needs in order to exit.
 func (a *sessionAgent) CancelAll() {
 	if !a.IsBusy() {
 		return
 	}
 	for key := range a.activeRequests.Seq2() {
 		a.Cancel(key) // key is sessionID
+		a.ClearQueue(key)
 	}
 
 	timeout := time.After(5 * time.Second)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -132,6 +132,12 @@ type SessionAgentCall struct {
 	OnAuthRefresh func(ctx context.Context, err *fantasy.ProviderError) error
 }
 
+// QueuedMessage is the frontend-safe content of a queued agent call.
+type QueuedMessage struct {
+	Prompt      string
+	Attachments []message.Attachment
+}
+
 type SessionAgent interface {
 	Run(context.Context, SessionAgentCall) (*fantasy.AgentResult, error)
 	BeginAccepted(sessionID string) *AcceptedRun
@@ -145,6 +151,7 @@ type SessionAgent interface {
 	QueuedPrompts(sessionID string) int
 	QueuedPromptsList(sessionID string) []string
 	ClearQueue(sessionID string)
+	PopQueuedMessage(sessionID string) (QueuedMessage, bool)
 	Summarize(context.Context, string, fantasy.ProviderOptions, func(context.Context, *fantasy.ProviderError) error) error
 	Model() Model
 	GenerateTitle(ctx context.Context, sessionID, userPrompt string)
@@ -468,6 +475,40 @@ func (a *sessionAgent) clearQueueAndNotify(sessionID string) {
 		return
 	}
 	a.publishCanceledQueueDrops(queued)
+}
+
+// PopQueuedMessage atomically removes the newest queued call for sessionID.
+// Queue order is oldest-to-newest, so removing the final element preserves
+// the order of all remaining calls. The returned content does not expose
+// agent-only dispatch state and owns its attachment byte slices.
+func (a *sessionAgent) PopQueuedMessage(sessionID string) (QueuedMessage, bool) {
+	mu := a.sessionMu(sessionID)
+	mu.Lock()
+	queued, ok := a.messageQueue.Get(sessionID)
+	if !ok || len(queued) == 0 {
+		mu.Unlock()
+		return QueuedMessage{}, false
+	}
+
+	last := len(queued) - 1
+	popped := queued[last]
+	if last == 0 {
+		a.messageQueue.Del(sessionID)
+	} else {
+		a.messageQueue.Set(sessionID, queued[:last])
+	}
+	mu.Unlock()
+
+	attachments := make([]message.Attachment, len(popped.Attachments))
+	for i, attachment := range popped.Attachments {
+		attachments[i] = attachment
+		attachments[i].Content = append([]byte(nil), attachment.Content...)
+	}
+	a.publishCanceledQueueDrops([]SessionAgentCall{popped})
+	return QueuedMessage{
+		Prompt:      popped.Prompt,
+		Attachments: attachments,
+	}, true
 }
 
 // clearPendingCancel removes any pending-cancel mark for sessionID. It

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -104,7 +104,7 @@ type Coordinator interface {
 	IsBusy() bool
 	QueuedPrompts(sessionID string) int
 	QueuedPromptsList(sessionID string) []string
-	ClearQueue(sessionID string)
+	ClearQueue(sessionID string) []QueuedMessage
 	PopQueuedMessage(sessionID string) (QueuedMessage, bool)
 	Summarize(context.Context, string) error
 	Model() Model
@@ -1190,8 +1190,8 @@ func (c *coordinator) CancelAll() {
 	c.currentAgent.CancelAll()
 }
 
-func (c *coordinator) ClearQueue(sessionID string) {
-	c.currentAgent.ClearQueue(sessionID)
+func (c *coordinator) ClearQueue(sessionID string) []QueuedMessage {
+	return c.currentAgent.ClearQueue(sessionID)
 }
 
 func (c *coordinator) PopQueuedMessage(sessionID string) (QueuedMessage, bool) {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -105,6 +105,7 @@ type Coordinator interface {
 	QueuedPrompts(sessionID string) int
 	QueuedPromptsList(sessionID string) []string
 	ClearQueue(sessionID string)
+	PopQueuedMessage(sessionID string) (QueuedMessage, bool)
 	Summarize(context.Context, string) error
 	Model() Model
 	UpdateModels(ctx context.Context) error
@@ -1191,6 +1192,10 @@ func (c *coordinator) CancelAll() {
 
 func (c *coordinator) ClearQueue(sessionID string) {
 	c.currentAgent.ClearQueue(sessionID)
+}
+
+func (c *coordinator) PopQueuedMessage(sessionID string) (QueuedMessage, bool) {
+	return c.currentAgent.PopQueuedMessage(sessionID)
 }
 
 func (c *coordinator) IsBusy() bool {

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -24,6 +24,7 @@ type mockSessionAgent struct {
 	cancelled []string
 	popped    QueuedMessage
 	popOK     bool
+	drained   []QueuedMessage
 }
 
 func (m *mockSessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy.AgentResult, error) {
@@ -46,7 +47,7 @@ func (m *mockSessionAgent) IsSessionBusy(sessionID string) bool         { return
 func (m *mockSessionAgent) IsBusy() bool                                { return false }
 func (m *mockSessionAgent) QueuedPrompts(sessionID string) int          { return 0 }
 func (m *mockSessionAgent) QueuedPromptsList(sessionID string) []string { return nil }
-func (m *mockSessionAgent) ClearQueue(sessionID string)                 {}
+func (m *mockSessionAgent) ClearQueue(sessionID string) []QueuedMessage { return m.drained }
 func (m *mockSessionAgent) PopQueuedMessage(sessionID string) (QueuedMessage, bool) {
 	return m.popped, m.popOK
 }
@@ -66,6 +67,16 @@ func TestCoordinatorPopQueuedMessage(t *testing.T) {
 	got, ok := c.PopQueuedMessage("session")
 	require.True(t, ok)
 	require.Equal(t, want, got)
+}
+
+func TestCoordinatorClearQueue(t *testing.T) {
+	t.Parallel()
+
+	want := []QueuedMessage{{Prompt: "oldest"}, {Prompt: "newest"}}
+	mock := &mockSessionAgent{drained: want}
+	c := &coordinator{currentAgent: mock}
+
+	require.Equal(t, want, c.ClearQueue("session"))
 }
 
 // newTestCoordinator creates a minimal coordinator for unit testing runSubAgent.

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -22,6 +22,8 @@ type mockSessionAgent struct {
 	model     Model
 	runFunc   func(ctx context.Context, call SessionAgentCall) (*fantasy.AgentResult, error)
 	cancelled []string
+	popped    QueuedMessage
+	popOK     bool
 }
 
 func (m *mockSessionAgent) Run(ctx context.Context, call SessionAgentCall) (*fantasy.AgentResult, error) {
@@ -45,10 +47,26 @@ func (m *mockSessionAgent) IsBusy() bool                                { return
 func (m *mockSessionAgent) QueuedPrompts(sessionID string) int          { return 0 }
 func (m *mockSessionAgent) QueuedPromptsList(sessionID string) []string { return nil }
 func (m *mockSessionAgent) ClearQueue(sessionID string)                 {}
+func (m *mockSessionAgent) PopQueuedMessage(sessionID string) (QueuedMessage, bool) {
+	return m.popped, m.popOK
+}
+
 func (m *mockSessionAgent) Summarize(context.Context, string, fantasy.ProviderOptions, func(context.Context, *fantasy.ProviderError) error) error {
 	return nil
 }
 func (m *mockSessionAgent) GenerateTitle(context.Context, string, string) {}
+
+func TestCoordinatorPopQueuedMessage(t *testing.T) {
+	t.Parallel()
+
+	want := QueuedMessage{Prompt: "queued"}
+	mock := &mockSessionAgent{popped: want, popOK: true}
+	c := &coordinator{currentAgent: mock}
+
+	got, ok := c.PopQueuedMessage("session")
+	require.True(t, ok)
+	require.Equal(t, want, got)
+}
 
 // newTestCoordinator creates a minimal coordinator for unit testing runSubAgent.
 func newTestCoordinator(t *testing.T, env fakeEnv, providerID string, providerCfg config.ProviderConfig) *coordinator {

--- a/internal/agent/dispatch_cancel_test.go
+++ b/internal/agent/dispatch_cancel_test.go
@@ -129,11 +129,14 @@ func TestRun_BusyWithPendingCancelTakesCancelOnEntry(t *testing.T) {
 	assert.Equal(t, message.FinishReasonCanceled, msgs[1].FinishReason())
 }
 
-// TestRun_PrepareStepDrainSkipsQueuedOnPendingCancel verifies that the
-// queue drain inside PrepareStep skips queued follow-up prompts when a
-// cancel has been recorded for the session: the queued prompt must not
-// be folded into the active turn as an extra user message.
-func TestRun_PrepareStepDrainSkipsQueuedOnPendingCancel(t *testing.T) {
+// TestRun_PrepareStepDrainKeepsQueuedOnPendingCancel verifies that the
+// queue drain inside PrepareStep does not fold queued follow-up prompts
+// into the active turn when a cancel has been recorded for the session:
+// that turn is the one being canceled, so folding would destroy the
+// prompt with it. The prompt stays queued and runs as its own turn
+// through the completion handoff instead — cancellation never discards
+// queued work.
+func TestRun_PrepareStepDrainKeepsQueuedOnPendingCancel(t *testing.T) {
 	t.Parallel()
 	sa, env := newStreamTestAgent(t)
 
@@ -143,6 +146,13 @@ func TestRun_PrepareStepDrainSkipsQueuedOnPendingCancel(t *testing.T) {
 	// A follow-up prompt sits queued for the session.
 	sa.enqueueCall(SessionAgentCall{SessionID: sess.ID, Prompt: "queued-followup"})
 	// A cancel was recorded for the session while it sat in the queue.
+	// Mirror production ordering: Cancel raises the mark to the latest
+	// accept sequence assigned so far, so any reservation created after
+	// the cancel — including the one the completion handoff hands to the
+	// dequeued prompt — sits strictly above the mark.
+	sa.acceptedMu.Lock()
+	sa.acceptSeqGen = 1
+	sa.acceptedMu.Unlock()
 	sa.cancelMark.Set(sess.ID, 1)
 
 	result, err := sa.Run(t.Context(), SessionAgentCall{
@@ -152,20 +162,27 @@ func TestRun_PrepareStepDrainSkipsQueuedOnPendingCancel(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	// Only the main prompt produced a user message; the queued
-	// follow-up was skipped, not folded into the turn.
+	// The queued follow-up was not folded into the main turn: it ran as
+	// its own turn after it, so its user message follows the main turn's
+	// assistant message instead of preceding it.
 	msgs, err := env.messages.List(t.Context(), sess.ID)
 	require.NoError(t, err)
-	var userMsgs []message.Message
-	for _, m := range msgs {
+	roles := make([]message.MessageRole, len(msgs))
+	prompts := make([]string, 0, 2)
+	for i, m := range msgs {
+		roles[i] = m.Role
 		if m.Role == message.User {
-			userMsgs = append(userMsgs, m)
+			prompts = append(prompts, m.Content().String())
 		}
 	}
-	require.Len(t, userMsgs, 1, "queued follow-up must not create a user message")
-	assert.Equal(t, "main", userMsgs[0].Content().String())
+	require.Equal(t,
+		[]message.MessageRole{message.User, message.Assistant, message.User, message.Assistant},
+		roles,
+		"the queued follow-up must run as its own turn, not be folded into the canceled one")
+	require.Equal(t, []string{"main", "queued-followup"}, prompts)
 
-	// The queue was drained and the pending cancel consumed.
+	// The queue drained through the handoff and the pending cancel is
+	// consumed.
 	require.Equal(t, 0, sa.QueuedPrompts(sess.ID))
 	require.False(t, sa.hasPendingCancel(sess.ID))
 }

--- a/internal/agent/dispatch_cancel_test.go
+++ b/internal/agent/dispatch_cancel_test.go
@@ -185,8 +185,6 @@ func TestRun_PrepareStepDrainKeepsQueuedOnPendingCancel(t *testing.T) {
 		"the queued follow-up must run as its own turn, not be folded into the canceled one")
 	require.Equal(t, []string{"queued-followup", "main"}, prompts)
 
-	// The queue drained through the handoff and the pending cancel is
-	// consumed.
 	require.Equal(t, 0, sa.QueuedPrompts(sess.ID))
 	require.False(t, sa.hasPendingCancel(sess.ID))
 }

--- a/internal/agent/dispatch_cancel_test.go
+++ b/internal/agent/dispatch_cancel_test.go
@@ -130,12 +130,16 @@ func TestRun_BusyWithPendingCancelTakesCancelOnEntry(t *testing.T) {
 }
 
 // TestRun_PrepareStepDrainKeepsQueuedOnPendingCancel verifies that the
-// queue drain inside PrepareStep does not fold queued follow-up prompts
-// into the active turn when a cancel has been recorded for the session:
-// that turn is the one being canceled, so folding would destroy the
-// prompt with it. The prompt stays queued and runs as its own turn
-// through the completion handoff instead — cancellation never discards
-// queued work.
+// queue drain inside PrepareStep does not fold a cancel-covered queued
+// prompt into the turn being canceled — folding would destroy the prompt
+// along with that turn. It stays queued and runs as its own turn instead,
+// so cancellation never discards queued work.
+//
+// The new submission ("main") lands on a session that is idle with a
+// non-empty queue, so the dispatch decision swaps it behind the queue:
+// the queued follow-up runs first as its own turn and "main" runs last.
+// Both prompts therefore get their own user/assistant pair; a fold would
+// instead produce two user messages under one assistant.
 func TestRun_PrepareStepDrainKeepsQueuedOnPendingCancel(t *testing.T) {
 	t.Parallel()
 	sa, env := newStreamTestAgent(t)
@@ -162,9 +166,9 @@ func TestRun_PrepareStepDrainKeepsQueuedOnPendingCancel(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	// The queued follow-up was not folded into the main turn: it ran as
-	// its own turn after it, so its user message follows the main turn's
-	// assistant message instead of preceding it.
+	// Each prompt produced its own user/assistant pair, oldest first: the
+	// queued follow-up was neither folded into a turn nor overtaken by the
+	// prompt submitted after it.
 	msgs, err := env.messages.List(t.Context(), sess.ID)
 	require.NoError(t, err)
 	roles := make([]message.MessageRole, len(msgs))
@@ -179,7 +183,7 @@ func TestRun_PrepareStepDrainKeepsQueuedOnPendingCancel(t *testing.T) {
 		[]message.MessageRole{message.User, message.Assistant, message.User, message.Assistant},
 		roles,
 		"the queued follow-up must run as its own turn, not be folded into the canceled one")
-	require.Equal(t, []string{"main", "queued-followup"}, prompts)
+	require.Equal(t, []string{"queued-followup", "main"}, prompts)
 
 	// The queue drained through the handoff and the pending cancel is
 	// consumed.

--- a/internal/agent/queued_runid_test.go
+++ b/internal/agent/queued_runid_test.go
@@ -18,7 +18,9 @@ import (
 // gatedStreamModel streams a single text part followed by a clean finish,
 // but blocks the very first Stream call until its gate is released. That
 // lets a test hold a run "active" (past PrepareStep, inside Stream) just
-// long enough to enqueue a follow-up prompt behind the busy session.
+// long enough to enqueue a follow-up prompt behind the busy session. If
+// the run context is canceled while the gate is held, Stream fails with
+// the context error, the way a real provider call does.
 // Subsequent Stream calls (e.g. the recursive run draining the queue)
 // proceed immediately.
 type gatedStreamModel struct {
@@ -44,6 +46,7 @@ func (m *gatedStreamModel) Stream(ctx context.Context, call fantasy.Call) (fanta
 		select {
 		case <-m.gate:
 		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 	}
 	text := m.text
@@ -178,4 +181,119 @@ func TestRun_QueuedRunIDPromptRunsRecursivelyAndPublishesRunComplete(t *testing.
 	}
 	require.Equal(t, 2, assistants, "the active turn and the recursive turn each produce one assistant message")
 	require.Equal(t, 1, follows, "the follow-up prompt is its own user turn")
+}
+
+// TestRun_CancelKeepsQueuedPromptsForEditing is the end-to-end proof for
+// issue #3558: with a turn active and prompts queued behind it, "esc esc"
+// must cancel the active turn and nothing else. Before this, Cancel called
+// clearQueueAndNotify, so cancelling destroyed every queued prompt — the
+// data loss the pop feature exists to prevent. The canceled turn returns
+// through the error path (before the completion handoff), so the queue is
+// left intact, in order, for the user to pop and edit; still-queued
+// prompts are not reported as cancelled to a waiting caller, because they
+// have not been discarded.
+func TestRun_CancelKeepsQueuedPromptsForEditing(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	broker := pubsub.NewBroker[notify.RunComplete]()
+	t.Cleanup(broker.Shutdown)
+
+	large := &gatedStreamModel{
+		text:    "done",
+		gate:    make(chan struct{}),
+		entered: make(chan struct{}),
+	}
+	small := &finishStreamModel{text: "title"}
+
+	sa := NewSessionAgent(SessionAgentOptions{
+		LargeModel:  Model{Model: large, CatwalkCfg: catwalk.Model{ContextWindow: 200000, DefaultMaxTokens: 10000}},
+		SmallModel:  Model{Model: small, CatwalkCfg: catwalk.Model{ContextWindow: 200000, DefaultMaxTokens: 10000}},
+		IsYolo:      true,
+		Sessions:    env.sessions,
+		Messages:    env.messages,
+		RunComplete: broker,
+	}).(*sessionAgent)
+
+	sess, err := env.sessions.Create(t.Context(), "session")
+	require.NoError(t, err)
+
+	subCtx, subCancel := context.WithCancel(t.Context())
+	defer subCancel()
+	ch := broker.Subscribe(subCtx)
+
+	// Start the main turn; it blocks inside Stream once active.
+	mainDone := make(chan error, 1)
+	go func() {
+		_, runErr := sa.Run(t.Context(), SessionAgentCall{
+			SessionID: sess.ID,
+			RunID:     "run-main",
+			Prompt:    "main",
+		})
+		mainDone <- runErr
+	}()
+	select {
+	case <-large.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("main run never entered Stream")
+	}
+	require.True(t, sa.IsSessionBusy(sess.ID))
+
+	// The user queues two prompts behind the busy turn: one typed in the
+	// TUI (no RunID) and one submitted by a non-interactive caller.
+	for _, queued := range []SessionAgentCall{
+		{SessionID: sess.ID, Prompt: "queued-one"},
+		{SessionID: sess.ID, RunID: "run-two", Prompt: "queued-two"},
+	} {
+		res, runErr := sa.Run(t.Context(), queued)
+		require.NoError(t, runErr)
+		require.Nil(t, res, "a busy-session prompt must enqueue and return (nil, nil)")
+	}
+	require.Equal(t, 2, sa.QueuedPrompts(sess.ID))
+
+	// esc esc.
+	sa.Cancel(sess.ID)
+	require.ErrorIs(t, <-mainDone, context.Canceled,
+		"the active turn must end canceled")
+
+	// The queue survived the cancel, in its original order, and the
+	// newest entry is still poppable for editing.
+	require.Equal(t, []string{"queued-one", "queued-two"}, sa.QueuedPromptsList(sess.ID),
+		"cancelling must not discard queued prompts")
+	popped, ok := sa.PopQueuedMessage(sess.ID)
+	require.True(t, ok)
+	require.Equal(t, "queued-two", popped.Prompt)
+	require.Equal(t, []string{"queued-one"}, sa.QueuedPromptsList(sess.ID))
+
+	// Neither queued prompt ran: only the canceled main turn produced
+	// messages.
+	msgs, err := env.messages.List(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	require.Equal(t, message.User, msgs[0].Role)
+	require.Equal(t, "main", msgs[0].Content().String())
+	require.Equal(t, message.Assistant, msgs[1].Role)
+	require.Equal(t, message.FinishReasonCanceled, msgs[1].FinishReason())
+
+	// Exactly two terminal events: the canceled main turn, and the popped
+	// prompt (a pop does discard it, so its waiting caller is released).
+	// A prompt that merely sat in the queue across the cancel publishes
+	// nothing.
+	got := map[string]notify.RunComplete{}
+	deadline := time.After(5 * time.Second)
+	for len(got) < 2 {
+		select {
+		case ev := <-ch:
+			got[ev.Payload.RunID] = ev.Payload
+		case <-deadline:
+			t.Fatalf("timed out waiting for terminal events; got %v", got)
+		}
+	}
+	require.True(t, got["run-main"].Cancelled, "the active turn must report cancelled")
+	require.True(t, got["run-two"].Cancelled, "the popped prompt must release its caller")
+	select {
+	case extra := <-ch:
+		t.Fatalf("unexpected extra terminal event: %+v", extra.Payload)
+	case <-time.After(200 * time.Millisecond):
+	}
 }

--- a/internal/agent/queued_runid_test.go
+++ b/internal/agent/queued_runid_test.go
@@ -297,3 +297,94 @@ func TestRun_CancelKeepsQueuedPromptsForEditing(t *testing.T) {
 	case <-time.After(200 * time.Millisecond):
 	}
 }
+
+// TestRun_IdleWithQueueRunsSubmissionsOldestFirst covers restarting the
+// agent after "esc esc": cancellation is turn-scoped, so the session is
+// left idle with its queue intact, and the prompt the user sends to get
+// going again must run *behind* what is already queued. Keying the
+// dispatch decision on IsSessionBusy alone made the new prompt the active
+// run, so it overtook every queued prompt and they drained after it.
+//
+// Each prompt carries a RunID, so none of them can be folded into another
+// turn: every one runs as its own turn and owes exactly one terminal
+// RunComplete. The order of those events is the contract — a caller
+// waiting on the new submission's RunID must not be released before the
+// prompts queued ahead of it have completed.
+func TestRun_IdleWithQueueRunsSubmissionsOldestFirst(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	broker := pubsub.NewBroker[notify.RunComplete]()
+	t.Cleanup(broker.Shutdown)
+
+	model := &finishStreamModel{text: "done"}
+	sa := NewSessionAgent(SessionAgentOptions{
+		LargeModel:  Model{Model: model, CatwalkCfg: catwalk.Model{ContextWindow: 200000, DefaultMaxTokens: 10000}},
+		SmallModel:  Model{Model: model, CatwalkCfg: catwalk.Model{ContextWindow: 200000, DefaultMaxTokens: 10000}},
+		IsYolo:      true,
+		Sessions:    env.sessions,
+		Messages:    env.messages,
+		RunComplete: broker,
+	}).(*sessionAgent)
+
+	sess, err := env.sessions.Create(t.Context(), "session")
+	require.NoError(t, err)
+
+	subCtx, subCancel := context.WithCancel(t.Context())
+	defer subCancel()
+	ch := broker.Subscribe(subCtx)
+
+	// Two prompts survived a cancel and sit queued on an idle session.
+	sa.enqueueCall(SessionAgentCall{SessionID: sess.ID, RunID: "run-one", Prompt: "queued-one"})
+	sa.enqueueCall(SessionAgentCall{SessionID: sess.ID, RunID: "run-two", Prompt: "queued-two"})
+	require.False(t, sa.IsSessionBusy(sess.ID))
+
+	// The user restarts the agent with a new prompt.
+	_, err = sa.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		RunID:     "run-new",
+		Prompt:    "new",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, 0, sa.QueuedPrompts(sess.ID), "the whole queue must have drained")
+
+	msgs, err := env.messages.List(t.Context(), sess.ID)
+	require.NoError(t, err)
+	roles := make([]message.MessageRole, len(msgs))
+	prompts := make([]string, 0, 3)
+	for i, m := range msgs {
+		roles[i] = m.Role
+		if m.Role == message.User {
+			prompts = append(prompts, m.Content().String())
+		}
+	}
+	require.Equal(t, []string{"queued-one", "queued-two", "new"}, prompts,
+		"queued prompts must run in order, with the new submission last")
+	require.Equal(t, []message.MessageRole{
+		message.User, message.Assistant,
+		message.User, message.Assistant,
+		message.User, message.Assistant,
+	}, roles, "each prompt runs as its own turn")
+
+	// One terminal event per RunID, in execution order.
+	var order []string
+	deadline := time.After(5 * time.Second)
+	for len(order) < 3 {
+		select {
+		case ev := <-ch:
+			require.Empty(t, ev.Payload.Error)
+			require.False(t, ev.Payload.Cancelled)
+			order = append(order, ev.Payload.RunID)
+		case <-deadline:
+			t.Fatalf("timed out waiting for terminal events; got %v", order)
+		}
+	}
+	require.Equal(t, []string{"run-one", "run-two", "run-new"}, order,
+		"the new submission's RunID must not complete before the prompts queued ahead of it")
+	select {
+	case extra := <-ch:
+		t.Fatalf("unexpected extra terminal event: %+v", extra.Payload)
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/internal/agent/queued_runid_test.go
+++ b/internal/agent/queued_runid_test.go
@@ -185,9 +185,7 @@ func TestRun_QueuedRunIDPromptRunsRecursivelyAndPublishesRunComplete(t *testing.
 
 // TestRun_CancelKeepsQueuedPromptsForEditing is the end-to-end proof for
 // issue #3558: with a turn active and prompts queued behind it, "esc esc"
-// must cancel the active turn and nothing else. Before this, Cancel called
-// clearQueueAndNotify, so cancelling destroyed every queued prompt — the
-// data loss the pop feature exists to prevent. The canceled turn returns
+// must cancel the active turn and nothing else. The canceled turn returns
 // through the error path (before the completion handoff), so the queue is
 // left intact, in order, for the user to pop and edit; still-queued
 // prompts are not reported as cancelled to a waiting caller, because they
@@ -222,7 +220,6 @@ func TestRun_CancelKeepsQueuedPromptsForEditing(t *testing.T) {
 	defer subCancel()
 	ch := broker.Subscribe(subCtx)
 
-	// Start the main turn; it blocks inside Stream once active.
 	mainDone := make(chan error, 1)
 	go func() {
 		_, runErr := sa.Run(t.Context(), SessionAgentCall{
@@ -256,8 +253,7 @@ func TestRun_CancelKeepsQueuedPromptsForEditing(t *testing.T) {
 	require.ErrorIs(t, <-mainDone, context.Canceled,
 		"the active turn must end canceled")
 
-	// The queue survived the cancel, in its original order, and the
-	// newest entry is still poppable for editing.
+	// The newest entry is still poppable for editing.
 	require.Equal(t, []string{"queued-one", "queued-two"}, sa.QueuedPromptsList(sess.ID),
 		"cancelling must not discard queued prompts")
 	popped, ok := sa.PopQueuedMessage(sess.ID)
@@ -302,8 +298,9 @@ func TestRun_CancelKeepsQueuedPromptsForEditing(t *testing.T) {
 // agent after "esc esc": cancellation is turn-scoped, so the session is
 // left idle with its queue intact, and the prompt the user sends to get
 // going again must run *behind* what is already queued. Keying the
-// dispatch decision on IsSessionBusy alone made the new prompt the active
-// run, so it overtook every queued prompt and they drained after it.
+// dispatch decision on IsSessionBusy alone would make the new prompt the
+// active run, overtaking every queued prompt and leaving them to drain
+// after it.
 //
 // Each prompt carries a RunID, so none of them can be folded into another
 // turn: every one runs as its own turn and owes exactly one terminal
@@ -339,7 +336,6 @@ func TestRun_IdleWithQueueRunsSubmissionsOldestFirst(t *testing.T) {
 	sa.enqueueCall(SessionAgentCall{SessionID: sess.ID, RunID: "run-two", Prompt: "queued-two"})
 	require.False(t, sa.IsSessionBusy(sess.ID))
 
-	// The user restarts the agent with a new prompt.
 	_, err = sa.Run(t.Context(), SessionAgentCall{
 		SessionID: sess.ID,
 		RunID:     "run-new",
@@ -488,7 +484,6 @@ func TestRun_SubmissionDuringCompletionHandoffRunsAfterTheQueue(t *testing.T) {
 	defer subCancel()
 	ch := broker.Subscribe(subCtx)
 
-	// Turn one is active, parked inside Stream.
 	firstDone := make(chan error, 1)
 	go func() {
 		_, runErr := sa.Run(t.Context(), SessionAgentCall{
@@ -640,8 +635,8 @@ func TestRun_SwappedHeadFailureIsNotAttributedToTheRequeuedSubmission(t *testing
 	sa.enqueueCall(SessionAgentCall{SessionID: sess.ID, RunID: "run-a", Prompt: "queued"})
 	require.False(t, sa.IsSessionBusy(sess.ID))
 
-	// The user restarts the agent with a new prompt, dispatched the way
-	// backend.runAgent does it.
+	// Dispatched the way backend.runAgent does it: the RunID and run-complete
+	// marker live on the ctx.
 	ctx := WithRunCompleteMarker(WithRunID(t.Context(), "run-b"))
 	_, err = sa.Run(ctx, SessionAgentCall{
 		SessionID: sess.ID,

--- a/internal/agent/queued_runid_test.go
+++ b/internal/agent/queued_runid_test.go
@@ -389,6 +389,194 @@ func TestRun_IdleWithQueueRunsSubmissionsOldestFirst(t *testing.T) {
 	}
 }
 
+// TestRun_HandoffInFlightQueuesSubmissionBehindThePromotion pins the
+// dispatch decision for the window a session handoff opens. A finished
+// turn (and the Summarize tail) releases its activeRequests entry before
+// it promotes the queue head, so the session reads idle for the whole
+// transition while the promoted call is neither active nor in the queue.
+// A submission landing there took the idle-with-queue branch and swapped
+// itself in, starting the *new* head ahead of the call already promoted;
+// it must be queued at the tail instead, with nothing new started.
+func TestRun_HandoffInFlightQueuesSubmissionBehindThePromotion(t *testing.T) {
+	t.Parallel()
+
+	sa, env := newStreamTestAgent(t)
+	sess, err := env.sessions.Create(t.Context(), "session")
+	require.NoError(t, err)
+
+	// The state a handoff leaves behind: one prompt still queued, the
+	// promoted call on its way into Run, and no active request.
+	sa.enqueueCall(SessionAgentCall{SessionID: sess.ID, RunID: "run-queued", Prompt: "queued"})
+	sa.beginHandoff(sess.ID)
+	require.False(t, sa.IsSessionBusy(sess.ID))
+
+	res, err := sa.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		RunID:     "run-new",
+		Prompt:    "new",
+	})
+	require.NoError(t, err)
+	require.Nil(t, res, "a submission landing in the handoff window must enqueue and return (nil, nil)")
+	require.Equal(t, []string{"queued", "new"}, sa.QueuedPromptsList(sess.ID),
+		"the submission must land behind the queue instead of swapping itself ahead of the promoted call")
+	require.False(t, sa.IsSessionBusy(sess.ID), "no run may start inside the handoff window")
+	msgs, err := env.messages.List(t.Context(), sess.ID)
+	require.NoError(t, err)
+	require.Empty(t, msgs, "the queued submission must not have started a turn")
+
+	// The promoted call releases the ticket at its own dispatch decision.
+	// With the transition over, the next submission takes the swap branch
+	// again and the queue drains oldest-first — proving the ticket, not
+	// some other state, is what gated the window.
+	sa.endHandoff(sess.ID)
+	require.False(t, sa.handoffInFlight(sess.ID))
+
+	_, err = sa.Run(t.Context(), SessionAgentCall{
+		SessionID: sess.ID,
+		RunID:     "run-last",
+		Prompt:    "last",
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, sa.QueuedPrompts(sess.ID), "the whole queue must have drained")
+
+	msgs, err = env.messages.List(t.Context(), sess.ID)
+	require.NoError(t, err)
+	prompts := make([]string, 0, 3)
+	for _, m := range msgs {
+		if m.Role == message.User {
+			prompts = append(prompts, m.Content().String())
+		}
+	}
+	require.Equal(t, []string{"queued", "new", "last"}, prompts,
+		"the prompt queued during the window keeps its place ahead of the newer submission")
+}
+
+// TestRun_SubmissionDuringCompletionHandoffRunsAfterTheQueue drives the
+// real completion handoff with a submission landing inside it. The
+// finished turn promotes the queue head and only then enters the
+// recursive Run, so between those two points the session is observably
+// idle with a queue: a submission that wins the dispatch mutex there used
+// to swap itself in and start the next head, and the promoted call then
+// found the session busy and was re-queued *behind* the submission —
+// execution order inverted to Q3, X, Q2 with the oldest queued prompt
+// last. Both prompts and both terminal events must stay oldest-first.
+func TestRun_SubmissionDuringCompletionHandoffRunsAfterTheQueue(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	broker := pubsub.NewBroker[notify.RunComplete]()
+	t.Cleanup(broker.Shutdown)
+
+	large := &gatedStreamModel{
+		text:    "done",
+		gate:    make(chan struct{}),
+		entered: make(chan struct{}),
+	}
+	sa := NewSessionAgent(SessionAgentOptions{
+		LargeModel:  Model{Model: large, CatwalkCfg: catwalk.Model{ContextWindow: 200000, DefaultMaxTokens: 10000}},
+		SmallModel:  Model{Model: &finishStreamModel{text: "title"}, CatwalkCfg: catwalk.Model{ContextWindow: 200000, DefaultMaxTokens: 10000}},
+		IsYolo:      true,
+		Sessions:    env.sessions,
+		Messages:    env.messages,
+		RunComplete: broker,
+	}).(*sessionAgent)
+
+	sess, err := env.sessions.Create(t.Context(), "session")
+	require.NoError(t, err)
+
+	subCtx, subCancel := context.WithCancel(t.Context())
+	defer subCancel()
+	ch := broker.Subscribe(subCtx)
+
+	// Turn one is active, parked inside Stream.
+	firstDone := make(chan error, 1)
+	go func() {
+		_, runErr := sa.Run(t.Context(), SessionAgentCall{
+			SessionID: sess.ID,
+			RunID:     "run-one",
+			Prompt:    "active",
+		})
+		firstDone <- runErr
+	}()
+	select {
+	case <-large.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the first run never entered Stream")
+	}
+	require.True(t, sa.IsSessionBusy(sess.ID))
+
+	// Two RunID-bearing prompts queue up behind it, so neither can be
+	// folded into another turn.
+	sa.enqueueCall(SessionAgentCall{SessionID: sess.ID, RunID: "run-two", Prompt: "queued-two"})
+	sa.enqueueCall(SessionAgentCall{SessionID: sess.ID, RunID: "run-three", Prompt: "queued-three"})
+
+	// Hold the dispatch mutex so the handoff parks on it, and dispatch the
+	// submission so it parks on it too. When the lock is released either
+	// of them may win it: the submission must end up behind the queue in
+	// both interleavings.
+	mu := sa.sessionMu(sess.ID)
+	mu.Lock()
+	newDone := make(chan error, 1)
+	go func() {
+		_, runErr := sa.Run(t.Context(), SessionAgentCall{
+			SessionID: sess.ID,
+			RunID:     "run-new",
+			Prompt:    "new",
+		})
+		newDone <- runErr
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	// Let turn one finish. It releases its active request and then parks
+	// on the dispatch mutex, which is exactly the window under test.
+	close(large.gate)
+	require.Eventually(t, func() bool {
+		return !sa.IsSessionBusy(sess.ID)
+	}, 10*time.Second, 10*time.Millisecond,
+		"the first turn never reached its completion handoff")
+
+	mu.Unlock()
+	require.NoError(t, <-newDone)
+	select {
+	case runErr := <-firstDone:
+		require.NoError(t, runErr)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the handoff never drained the queue")
+	}
+	require.Equal(t, 0, sa.QueuedPrompts(sess.ID), "the whole queue must have drained")
+
+	msgs, err := env.messages.List(t.Context(), sess.ID)
+	require.NoError(t, err)
+	prompts := make([]string, 0, 4)
+	for _, m := range msgs {
+		if m.Role == message.User {
+			prompts = append(prompts, m.Content().String())
+		}
+	}
+	require.Equal(t, []string{"active", "queued-two", "queued-three", "new"}, prompts,
+		"a submission landing in the handoff window must run after the prompts already queued")
+
+	var order []string
+	deadline := time.After(10 * time.Second)
+	for len(order) < 4 {
+		select {
+		case ev := <-ch:
+			require.Empty(t, ev.Payload.Error)
+			require.False(t, ev.Payload.Cancelled)
+			order = append(order, ev.Payload.RunID)
+		case <-deadline:
+			t.Fatalf("timed out waiting for terminal events; got %v", order)
+		}
+	}
+	require.Equal(t, []string{"run-one", "run-two", "run-three", "run-new"}, order,
+		"the submission's RunID must not complete before the prompts queued ahead of it")
+	select {
+	case extra := <-ch:
+		t.Fatalf("unexpected extra terminal event: %+v", extra.Payload)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
 // errStreamModel fails every Stream call with a fixed error, the way a
 // provider that rejects the request does. PrepareStep has already created
 // the assistant message by then, so the turn takes Run's stream-error

--- a/internal/agent/queued_runid_test.go
+++ b/internal/agent/queued_runid_test.go
@@ -388,3 +388,102 @@ func TestRun_IdleWithQueueRunsSubmissionsOldestFirst(t *testing.T) {
 	case <-time.After(200 * time.Millisecond):
 	}
 }
+
+// errStreamModel fails every Stream call with a fixed error, the way a
+// provider that rejects the request does. PrepareStep has already created
+// the assistant message by then, so the turn takes Run's stream-error
+// branch and publishes an errored terminal event.
+type errStreamModel struct {
+	err error
+}
+
+func (m *errStreamModel) Provider() string { return "fake" }
+func (m *errStreamModel) Model() string    { return "fake-model" }
+
+func (m *errStreamModel) Generate(ctx context.Context, call fantasy.Call) (*fantasy.Response, error) {
+	return nil, m.err
+}
+
+func (m *errStreamModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+	return nil, m.err
+}
+
+func (m *errStreamModel) GenerateObject(ctx context.Context, call fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *errStreamModel) StreamObject(ctx context.Context, call fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+// TestRun_SwappedHeadFailureIsNotAttributedToTheRequeuedSubmission pins
+// the attribution contract of the FIFO swap: when a submission to an idle
+// session with a queue is requeued behind the queue head and the head's
+// turn then fails, the failure belongs to the head's RunID alone. The
+// submission's prompt has not run, so it must get no terminal event yet —
+// otherwise its `crush run` waiter would exit on a foreign prompt's error
+// and the prompt would publish a second terminal event for the same RunID
+// when its own turn finally ran.
+func TestRun_SwappedHeadFailureIsNotAttributedToTheRequeuedSubmission(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	broker := pubsub.NewBroker[notify.RunComplete]()
+	t.Cleanup(broker.Shutdown)
+
+	streamErr := errors.New("provider rejected the request")
+	sa := NewSessionAgent(SessionAgentOptions{
+		LargeModel:  Model{Model: &errStreamModel{err: streamErr}, CatwalkCfg: catwalk.Model{ContextWindow: 200000, DefaultMaxTokens: 10000}},
+		SmallModel:  Model{Model: &finishStreamModel{text: "title"}, CatwalkCfg: catwalk.Model{ContextWindow: 200000, DefaultMaxTokens: 10000}},
+		IsYolo:      true,
+		Sessions:    env.sessions,
+		Messages:    env.messages,
+		RunComplete: broker,
+	}).(*sessionAgent)
+
+	sess, err := env.sessions.Create(t.Context(), "session")
+	require.NoError(t, err)
+
+	subCtx, subCancel := context.WithCancel(t.Context())
+	defer subCancel()
+	ch := broker.Subscribe(subCtx)
+
+	// A prompt survived a cancel and sits queued on an idle session.
+	sa.enqueueCall(SessionAgentCall{SessionID: sess.ID, RunID: "run-a", Prompt: "queued"})
+	require.False(t, sa.IsSessionBusy(sess.ID))
+
+	// The user restarts the agent with a new prompt, dispatched the way
+	// backend.runAgent does it.
+	ctx := WithRunCompleteMarker(WithRunID(t.Context(), "run-b"))
+	_, err = sa.Run(ctx, SessionAgentCall{
+		SessionID: sess.ID,
+		RunID:     "run-b",
+		Prompt:    "new",
+	})
+	require.ErrorIs(t, err, streamErr, "the promoted head's failure propagates to the caller")
+
+	// The caller's own prompt never ran: it is still queued, and the
+	// dispatcher must be told so it does not report the head's failure
+	// under run-b.
+	require.Equal(t, []string{"new"}, sa.QueuedPromptsList(sess.ID),
+		"the requeued submission must still be queued after the head failed")
+	ranID, requeued := RequeuedRun(ctx)
+	require.True(t, requeued, "the swap must record that the dispatched prompt was requeued")
+	require.Equal(t, "run-a", ranID, "the invocation's outcome belongs to the promoted head")
+
+	// Exactly one terminal event, errored, for the head's RunID.
+	select {
+	case ev := <-ch:
+		require.Equal(t, "run-a", ev.Payload.RunID,
+			"the failed turn's terminal event must carry the RunID of the prompt that ran")
+		require.Contains(t, ev.Payload.Error, streamErr.Error())
+		require.False(t, ev.Payload.Cancelled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the promoted head published no terminal RunComplete; its waiter would hang")
+	}
+	select {
+	case extra := <-ch:
+		t.Fatalf("terminal event for a prompt that has not run: %+v", extra.Payload)
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/internal/agent/run_complete_test.go
+++ b/internal/agent/run_complete_test.go
@@ -514,3 +514,80 @@ func TestCancelAll_ShutdownDiscardsQueueAndNotifies(t *testing.T) {
 	require.Equal(t, 0, a.QueuedPrompts(sessionID),
 		"shutdown must discard queued prompts it can no longer run")
 }
+
+// TestCancelAll_ShutdownDiscardsQueueOnIdleSession is the same shutdown
+// contract for the state Cancel actually leaves behind. Cancel is
+// turn-scoped: it ends the active turn and keeps the queue, so after
+// "esc esc" the session has *no* active request and a non-empty queue.
+// Keying the teardown on activeRequests alone made CancelAll return
+// early (nothing is busy) and the queued RunIDs never got a terminal
+// event, hanging any caller blocking on one.
+func TestCancelAll_ShutdownDiscardsQueueOnIdleSession(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	broker := pubsub.NewBroker[notify.RunComplete]()
+	t.Cleanup(broker.Shutdown)
+
+	a := NewSessionAgent(SessionAgentOptions{
+		Sessions:    env.sessions,
+		Messages:    env.messages,
+		RunComplete: broker,
+	}).(*sessionAgent)
+
+	subCtx, subCancel := context.WithCancel(t.Context())
+	defer subCancel()
+	ch := broker.Subscribe(subCtx)
+
+	const sessionID = "cancel-all-idle"
+	a.messageQueue.Set(sessionID, []SessionAgentCall{
+		{SessionID: sessionID, RunID: "run-queued", Prompt: "queued", acceptSeq: 1},
+	})
+	require.False(t, a.IsBusy())
+
+	a.CancelAll()
+
+	requireSingleCancelledRunComplete(t, ch, sessionID, "run-queued")
+	require.Equal(t, 0, a.QueuedPrompts(sessionID),
+		"shutdown must discard the queue of a session left idle by a cancel")
+}
+
+// TestCancelAll_SummarizeKeyClearsSessionQueue guards the key
+// normalization: a summarizing session is tracked in activeRequests under
+// the synthetic "<id>-summarize" key, while its queue is stored under the
+// real session ID. Passing the synthetic key straight to ClearQueue makes
+// it a silent no-op, so the queued RunID would never be notified.
+func TestCancelAll_SummarizeKeyClearsSessionQueue(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	broker := pubsub.NewBroker[notify.RunComplete]()
+	t.Cleanup(broker.Shutdown)
+
+	a := NewSessionAgent(SessionAgentOptions{
+		Sessions:    env.sessions,
+		Messages:    env.messages,
+		RunComplete: broker,
+	}).(*sessionAgent)
+
+	subCtx, subCancel := context.WithCancel(t.Context())
+	defer subCancel()
+	ch := broker.Subscribe(subCtx)
+
+	const sessionID = "cancel-all-summarize"
+	summarizeKey := sessionID + summarizeKeySuffix
+	// Releasing the active entry mirrors Summarize's cleanup, so
+	// CancelAll's busy-wait finishes immediately.
+	a.activeRequests.Set(summarizeKey, &activeCancel{
+		cancel: func() { a.activeRequests.Del(summarizeKey) },
+	})
+	a.messageQueue.Set(sessionID, []SessionAgentCall{
+		{SessionID: sessionID, RunID: "run-queued", Prompt: "queued", acceptSeq: 1},
+	})
+
+	a.CancelAll()
+
+	requireSingleCancelledRunComplete(t, ch, sessionID, "run-queued")
+	require.Equal(t, 0, a.QueuedPrompts(sessionID),
+		"the summarize key must be normalized to the session whose queue it owns")
+}

--- a/internal/agent/run_complete_test.go
+++ b/internal/agent/run_complete_test.go
@@ -401,9 +401,8 @@ func requireNoRunComplete(t *testing.T, ch <-chan pubsub.Event[notify.RunComplet
 // the queue by the explicit ClearQueue path (which routes through
 // publishCanceledQueueDrops) must emit exactly one cancelled RunComplete
 // on the broker for its RunID. A queued prompt without a RunID is dropped
-// silently. This is the coverage the earlier drain test lacked: it
-// asserted the returned bookkeeping slice, not the published event a
-// `crush run` caller awaits.
+// silently. The assertions observe the published event a `crush run`
+// caller awaits.
 func TestClearQueue_QueuedRunIDPromptPublishesCancelledRunComplete(t *testing.T) {
 	t.Parallel()
 
@@ -742,9 +741,9 @@ func TestCancelAll_ShutdownDiscardsQueueAndNotifies(t *testing.T) {
 // contract for the state Cancel actually leaves behind. Cancel is
 // turn-scoped: it ends the active turn and keeps the queue, so after
 // "esc esc" the session has *no* active request and a non-empty queue.
-// Keying the teardown on activeRequests alone made CancelAll return
-// early (nothing is busy) and the queued RunIDs never got a terminal
-// event, hanging any caller blocking on one.
+// Keying the teardown on activeRequests alone would make CancelAll return
+// early (nothing is busy), leaving the queued RunIDs without a terminal
+// event and hanging any caller blocking on one.
 func TestCancelAll_ShutdownDiscardsQueueOnIdleSession(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/run_complete_test.go
+++ b/internal/agent/run_complete_test.go
@@ -244,6 +244,53 @@ func TestPopQueuedMessage_NewestFirstWithAttachments(t *testing.T) {
 	require.Equal(t, QueuedMessage{}, empty)
 }
 
+// TestPopQueuedMessage_DoesNotAliasQueueBackingArray verifies that the
+// queue left behind by a pop does not share its backing array with the
+// pre-pop queue. QueuedPrompts/QueuedPromptsList read the queue without
+// the per-session dispatch mutex, so a reader can be ranging over a slice
+// header captured before the pop; if the pop merely resliced, the next
+// enqueueCall would append in place over the popped index and mutate that
+// reader's window (a torn read of a multi-word struct under -race).
+func TestPopQueuedMessage_DoesNotAliasQueueBackingArray(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	a := NewSessionAgent(SessionAgentOptions{
+		Sessions: env.sessions,
+		Messages: env.messages,
+	}).(*sessionAgent)
+
+	const sessionID = "pop-alias"
+	a.messageQueue.Set(sessionID, []SessionAgentCall{
+		{SessionID: sessionID, Prompt: "oldest"},
+		{SessionID: sessionID, Prompt: "newest"},
+	})
+	// Stand in for a concurrent QueuedPromptsList: it holds the slice
+	// header as it was before the pop, spare capacity included.
+	beforePop, ok := a.messageQueue.Get(sessionID)
+	require.True(t, ok)
+
+	popped, ok := a.PopQueuedMessage(sessionID)
+	require.True(t, ok)
+	require.Equal(t, "newest", popped.Prompt)
+
+	a.enqueueCall(SessionAgentCall{SessionID: sessionID, Prompt: "requeued"})
+
+	require.Equal(t, []string{"oldest", "newest"}, promptsOf(beforePop),
+		"an enqueue after a pop must not write into a pre-pop reader's window")
+	require.Equal(t, []string{"oldest", "requeued"},
+		a.QueuedPromptsList(sessionID),
+		"the live queue must keep the surviving prompt and the new one")
+}
+
+func promptsOf(calls []SessionAgentCall) []string {
+	prompts := make([]string, len(calls))
+	for i, call := range calls {
+		prompts[i] = call.Prompt
+	}
+	return prompts
+}
+
 func TestPopQueuedMessage_RunIDPublishesCancelledRunComplete(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/run_complete_test.go
+++ b/internal/agent/run_complete_test.go
@@ -316,7 +316,7 @@ func TestPopQueuedMessage_RunIDPublishesCancelledRunComplete(t *testing.T) {
 	popped, ok := a.PopQueuedMessage(sessionID)
 	require.True(t, ok)
 	require.Equal(t, "queued", popped.Prompt)
-	requireSingleCancelledRunComplete(t, ch, sessionID, "queued-run")
+	requireCancelledRunCompletes(t, ch, sessionID, "queued-run")
 }
 
 // TestRunCompletePublisher_MustDeliverOverTakesPublish exercises the
@@ -349,26 +349,36 @@ func TestRunCompletePublisher_MustDeliverOverTakesPublish(t *testing.T) {
 	}
 }
 
-// requireSingleCancelledRunComplete reads exactly one RunComplete from ch,
-// asserts it is the cancelled terminal event for runID, and verifies no
-// second event arrives. This observes the published pubsub event rather
-// than internal bookkeeping, which is the contract a `crush run` caller
-// blocking on the broker actually relies on.
-func requireSingleCancelledRunComplete(t *testing.T, ch <-chan pubsub.Event[notify.RunComplete], sessionID, runID string) {
+// requireCancelledRunCompletes reads exactly len(runIDs) RunCompletes from
+// ch, asserts each is a cancelled terminal event for one of runIDs, that
+// every runID appears exactly once, and that no further event arrives. It
+// observes the published pubsub events rather than internal bookkeeping,
+// which is the contract a `crush run` caller blocking on the broker
+// actually relies on. Arrival order is not asserted: the contract is that
+// every dropped prompt releases its own caller.
+func requireCancelledRunCompletes(t *testing.T, ch <-chan pubsub.Event[notify.RunComplete], sessionID string, runIDs ...string) {
 	t.Helper()
-	select {
-	case ev := <-ch:
-		require.Equal(t, runID, ev.Payload.RunID,
-			"the published RunComplete must carry the dropped queued prompt's RunID")
-		require.Equal(t, sessionID, ev.Payload.SessionID)
-		require.True(t, ev.Payload.Cancelled,
-			"a dropped queued prompt must publish a cancelled RunComplete")
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for the cancelled RunComplete")
+	seen := make(map[string]struct{}, len(runIDs))
+	for range runIDs {
+		select {
+		case ev := <-ch:
+			require.Equal(t, sessionID, ev.Payload.SessionID)
+			require.True(t, ev.Payload.Cancelled,
+				"a dropped queued prompt must publish a cancelled RunComplete")
+			require.NotContains(t, seen, ev.Payload.RunID,
+				"a dropped queued prompt must publish exactly one cancelled RunComplete")
+			seen[ev.Payload.RunID] = struct{}{}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for cancelled RunCompletes: want %v, got %d", runIDs, len(seen))
+		}
+	}
+	for _, runID := range runIDs {
+		require.Contains(t, seen, runID,
+			"every dropped queued prompt must publish a cancelled RunComplete carrying its own RunID")
 	}
 	select {
 	case extra := <-ch:
-		t.Fatalf("expected exactly one RunComplete, got a second: %+v", extra.Payload)
+		t.Fatalf("expected exactly %d RunComplete(s), got another: %+v", len(runIDs), extra.Payload)
 	case <-time.After(100 * time.Millisecond):
 	}
 }
@@ -423,10 +433,49 @@ func TestClearQueue_QueuedRunIDPromptPublishesCancelledRunComplete(t *testing.T)
 		[]string{drained[0].Prompt, drained[1].Prompt},
 		"the drain must report every removed prompt, RunID-bearing or not")
 
-	requireSingleCancelledRunComplete(t, ch, sessionID, "run-queued")
+	requireCancelledRunCompletes(t, ch, sessionID, "run-queued")
 
 	_, ok := a.messageQueue.Get(sessionID)
 	require.False(t, ok, "ClearQueue must clear the queue")
+}
+
+// TestClearQueue_PublishesCancelledRunCompleteForEveryRunIDBearingDrop
+// pins the loop in publishCanceledQueueDrops rather than its first
+// iteration: one drain removes the whole queue, so it can retire any
+// number of RunID-bearing prompts at once — a burst of scripted
+// `crush run` submissions taken off the queue by a single Escape. Each of
+// those callers blocks until a RunComplete carrying its own RunID
+// arrives, so publishing only the first drop leaves every caller behind
+// it hanging until connection teardown. The interleaved RunID-less prompt
+// must not consume a publish of its own.
+func TestClearQueue_PublishesCancelledRunCompleteForEveryRunIDBearingDrop(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	broker := pubsub.NewBroker[notify.RunComplete]()
+	t.Cleanup(broker.Shutdown)
+
+	a := NewSessionAgent(SessionAgentOptions{
+		Sessions:    env.sessions,
+		Messages:    env.messages,
+		RunComplete: broker,
+	}).(*sessionAgent)
+
+	subCtx, subCancel := context.WithCancel(t.Context())
+	defer subCancel()
+	ch := broker.Subscribe(subCtx)
+
+	const sessionID = "clear-many-queued-runids"
+	a.messageQueue.Set(sessionID, []SessionAgentCall{
+		{SessionID: sessionID, RunID: "run-a", Prompt: "first", acceptSeq: 1},
+		{SessionID: sessionID, Prompt: "no-runid", acceptSeq: 2},
+		{SessionID: sessionID, RunID: "run-b", Prompt: "second", acceptSeq: 3},
+	})
+
+	require.Len(t, a.ClearQueue(sessionID), 3,
+		"the drain must report every removed prompt, RunID-bearing or not")
+
+	requireCancelledRunCompletes(t, ch, sessionID, "run-a", "run-b")
 }
 
 // TestClearQueue_DrainsInOrderWithOwnedAttachments pins the
@@ -675,7 +724,7 @@ func TestCancelAll_ShutdownDiscardsQueueAndNotifies(t *testing.T) {
 
 	a.CancelAll()
 
-	requireSingleCancelledRunComplete(t, ch, sessionID, "run-queued")
+	requireCancelledRunCompletes(t, ch, sessionID, "run-queued")
 	require.Equal(t, 0, a.QueuedPrompts(sessionID),
 		"shutdown must discard queued prompts it can no longer run")
 }
@@ -712,7 +761,7 @@ func TestCancelAll_ShutdownDiscardsQueueOnIdleSession(t *testing.T) {
 
 	a.CancelAll()
 
-	requireSingleCancelledRunComplete(t, ch, sessionID, "run-queued")
+	requireCancelledRunCompletes(t, ch, sessionID, "run-queued")
 	require.Equal(t, 0, a.QueuedPrompts(sessionID),
 		"shutdown must discard the queue of a session left idle by a cancel")
 }
@@ -752,7 +801,7 @@ func TestCancelAll_SummarizeKeyClearsSessionQueue(t *testing.T) {
 
 	a.CancelAll()
 
-	requireSingleCancelledRunComplete(t, ch, sessionID, "run-queued")
+	requireCancelledRunCompletes(t, ch, sessionID, "run-queued")
 	require.Equal(t, 0, a.QueuedPrompts(sessionID),
 		"the summarize key must be normalized to the session whose queue it owns")
 }

--- a/internal/agent/run_complete_test.go
+++ b/internal/agent/run_complete_test.go
@@ -387,13 +387,13 @@ func requireNoRunComplete(t *testing.T, ch <-chan pubsub.Event[notify.RunComplet
 }
 
 // TestClearQueue_QueuedRunIDPromptPublishesCancelledRunComplete proves the
-// terminal-event behavior end-to-end: a RunID-bearing prompt discarded
-// from the queue by the explicit ClearQueue path (which routes through
-// clearQueueAndNotify -> publishCanceledQueueDrops) must emit exactly one
-// cancelled RunComplete on the broker for its RunID. A queued prompt
-// without a RunID is dropped silently. This is the coverage the earlier
-// drain test lacked: it asserted the returned bookkeeping slice, not the
-// published event a `crush run` caller awaits.
+// terminal-event behavior end-to-end: a RunID-bearing prompt removed from
+// the queue by the explicit ClearQueue path (which routes through
+// publishCanceledQueueDrops) must emit exactly one cancelled RunComplete
+// on the broker for its RunID. A queued prompt without a RunID is dropped
+// silently. This is the coverage the earlier drain test lacked: it
+// asserted the returned bookkeeping slice, not the published event a
+// `crush run` caller awaits.
 func TestClearQueue_QueuedRunIDPromptPublishesCancelledRunComplete(t *testing.T) {
 	t.Parallel()
 
@@ -417,12 +417,111 @@ func TestClearQueue_QueuedRunIDPromptPublishesCancelledRunComplete(t *testing.T)
 		{SessionID: sessionID, RunID: "run-queued", Prompt: "queued", acceptSeq: 2},
 	})
 
-	a.ClearQueue(sessionID)
+	drained := a.ClearQueue(sessionID)
+	require.Len(t, drained, 2)
+	require.Equal(t, []string{"no-runid", "queued"},
+		[]string{drained[0].Prompt, drained[1].Prompt},
+		"the drain must report every removed prompt, RunID-bearing or not")
 
 	requireSingleCancelledRunComplete(t, ch, sessionID, "run-queued")
 
 	_, ok := a.messageQueue.Get(sessionID)
 	require.False(t, ok, "ClearQueue must clear the queue")
+}
+
+// TestClearQueue_DrainsInOrderWithOwnedAttachments pins the
+// drain-and-return contract the Escape gesture depends on: the clear
+// reports every message it removed, oldest to newest, with attachments
+// whose bytes the caller owns, and it deletes the queue map entry. An
+// empty queue drains to nothing.
+func TestClearQueue_DrainsInOrderWithOwnedAttachments(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	a := NewSessionAgent(SessionAgentOptions{
+		Sessions: env.sessions,
+		Messages: env.messages,
+	}).(*sessionAgent)
+
+	const sessionID = "clear-drain"
+	content := []byte("oldest content")
+	a.messageQueue.Set(sessionID, []SessionAgentCall{
+		{
+			SessionID: sessionID,
+			Prompt:    "oldest",
+			Attachments: []message.Attachment{{
+				FilePath: "/tmp/oldest.txt",
+				FileName: "oldest.txt",
+				MimeType: "text/plain",
+				Content:  content,
+			}},
+		},
+		{SessionID: sessionID, Prompt: "middle"},
+		{SessionID: sessionID, Prompt: "newest"},
+	})
+
+	drained := a.ClearQueue(sessionID)
+	require.Len(t, drained, 3)
+	require.Equal(t, []string{"oldest", "middle", "newest"},
+		[]string{drained[0].Prompt, drained[1].Prompt, drained[2].Prompt},
+		"the drain must preserve queue order, oldest to newest")
+	require.Equal(t, []message.Attachment{{
+		FilePath: "/tmp/oldest.txt",
+		FileName: "oldest.txt",
+		MimeType: "text/plain",
+		Content:  []byte("oldest content"),
+	}}, drained[0].Attachments)
+
+	content[0] = 'X'
+	require.Equal(t, []byte("oldest content"), drained[0].Attachments[0].Content,
+		"the drained attachment content must not alias the queued call")
+
+	_, ok := a.messageQueue.Get(sessionID)
+	require.False(t, ok, "the drain must delete the queue map entry")
+	require.Nil(t, a.ClearQueue(sessionID), "draining an empty queue returns nothing")
+}
+
+// TestClearQueue_HoldsSessionDispatchMutex pins the synchronization the
+// returned payload requires: the drain removes messages the caller then
+// acts on, so it must be atomic against the run handoff and the
+// PrepareStep drain — a message reported as drained can never also have
+// been started. The pre-drain implementation returned nothing and skipped
+// the mutex, which was unobservable only because the content was thrown
+// away.
+func TestClearQueue_HoldsSessionDispatchMutex(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	a := NewSessionAgent(SessionAgentOptions{
+		Sessions: env.sessions,
+		Messages: env.messages,
+	}).(*sessionAgent)
+
+	const sessionID = "clear-dispatch-mutex"
+	a.messageQueue.Set(sessionID, []SessionAgentCall{
+		{SessionID: sessionID, Prompt: "queued"},
+	})
+
+	mu := a.sessionMu(sessionID)
+	mu.Lock()
+	done := make(chan []QueuedMessage, 1)
+	go func() { done <- a.ClearQueue(sessionID) }()
+
+	select {
+	case <-done:
+		mu.Unlock()
+		t.Fatal("ClearQueue drained the queue without the session dispatch mutex")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	mu.Unlock()
+	select {
+	case drained := <-done:
+		require.Len(t, drained, 1)
+		require.Equal(t, "queued", drained[0].Prompt)
+	case <-time.After(5 * time.Second):
+		t.Fatal("ClearQueue never completed after the dispatch mutex was released")
+	}
 }
 
 // TestCancel_PreservesQueuedPrompts is the regression test for issue

--- a/internal/agent/run_complete_test.go
+++ b/internal/agent/run_complete_test.go
@@ -553,8 +553,17 @@ func TestClearQueue_HoldsSessionDispatchMutex(t *testing.T) {
 
 	mu := a.sessionMu(sessionID)
 	mu.Lock()
+	started := make(chan struct{})
 	done := make(chan []QueuedMessage, 1)
-	go func() { done <- a.ClearQueue(sessionID) }()
+	go func() {
+		close(started)
+		done <- a.ClearQueue(sessionID)
+	}()
+	// Without waiting for the goroutine to reach the call, the negative
+	// window below is satisfied by a goroutine that was never scheduled —
+	// which is exactly what happens under -race load, and it would pass with
+	// the mutex removed.
+	<-started
 
 	select {
 	case <-done:

--- a/internal/agent/run_complete_test.go
+++ b/internal/agent/run_complete_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/crush/internal/agent/notify"
+	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/stretchr/testify/require"
 )
@@ -188,6 +189,88 @@ func TestDrainQueueForStep_ReportsCanceledRunIDDrops(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, kept, 1, "the uncanceled RunID prompt stays queued")
 	require.Equal(t, "run-survives", kept[0].RunID)
+}
+
+func TestPopQueuedMessage_NewestFirstWithAttachments(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	a := NewSessionAgent(SessionAgentOptions{
+		Sessions: env.sessions,
+		Messages: env.messages,
+	}).(*sessionAgent)
+
+	const sessionID = "pop-newest"
+	content := []byte("newest content")
+	a.messageQueue.Set(sessionID, []SessionAgentCall{
+		{SessionID: sessionID, Prompt: "oldest"},
+		{
+			SessionID: sessionID,
+			Prompt:    "newest",
+			Attachments: []message.Attachment{{
+				FilePath: "/tmp/newest.txt",
+				FileName: "newest.txt",
+				MimeType: "text/plain",
+				Content:  content,
+			}},
+		},
+	})
+
+	popped, ok := a.PopQueuedMessage(sessionID)
+	require.True(t, ok)
+	require.Equal(t, "newest", popped.Prompt)
+	require.Equal(t, []message.Attachment{{
+		FilePath: "/tmp/newest.txt",
+		FileName: "newest.txt",
+		MimeType: "text/plain",
+		Content:  []byte("newest content"),
+	}}, popped.Attachments)
+
+	content[0] = 'X'
+	require.Equal(t, []byte("newest content"), popped.Attachments[0].Content,
+		"the returned attachment content must not alias the queued call")
+	remaining, ok := a.messageQueue.Get(sessionID)
+	require.True(t, ok)
+	require.Len(t, remaining, 1)
+	require.Equal(t, "oldest", remaining[0].Prompt)
+
+	last, ok := a.PopQueuedMessage(sessionID)
+	require.True(t, ok)
+	require.Equal(t, "oldest", last.Prompt)
+	_, ok = a.messageQueue.Get(sessionID)
+	require.False(t, ok, "popping the last call must remove the queue map entry")
+
+	empty, ok := a.PopQueuedMessage(sessionID)
+	require.False(t, ok)
+	require.Equal(t, QueuedMessage{}, empty)
+}
+
+func TestPopQueuedMessage_RunIDPublishesCancelledRunComplete(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	broker := pubsub.NewBroker[notify.RunComplete]()
+	t.Cleanup(broker.Shutdown)
+	a := NewSessionAgent(SessionAgentOptions{
+		Sessions:    env.sessions,
+		Messages:    env.messages,
+		RunComplete: broker,
+	}).(*sessionAgent)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	ch := broker.Subscribe(ctx)
+	const sessionID = "pop-runid"
+	a.messageQueue.Set(sessionID, []SessionAgentCall{{
+		SessionID: sessionID,
+		RunID:     "queued-run",
+		Prompt:    "queued",
+	}})
+
+	popped, ok := a.PopQueuedMessage(sessionID)
+	require.True(t, ok)
+	require.Equal(t, "queued", popped.Prompt)
+	requireSingleCancelledRunComplete(t, ch, sessionID, "queued-run")
 }
 
 // TestRunCompletePublisher_MustDeliverOverTakesPublish exercises the

--- a/internal/agent/run_complete_test.go
+++ b/internal/agent/run_complete_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -61,12 +62,12 @@ func TestSessionAgentRun_QueueStripsOnComplete(t *testing.T) {
 
 // TestDrainQueueForStep_FiltersUnderDispatchLock verifies that the queue
 // drain evaluates the per-session cancel mark while holding the dispatch
-// mutex (canceledBySeq's documented precondition). Queued calls at or
-// below the cancel high-water mark are dropped, calls queued after the
-// cancel (higher seq) are folded, untracked enqueues (seq == 0) are
-// dropped whenever any mark is present, and the queue is cleared. These
-// calls carry no RunID, so all foldable survivors are returned for
-// folding (the existing follow-up behavior).
+// mutex (canceledBySeq's documented precondition). Calls queued after the
+// cancel (higher seq) are folded into the active turn; calls at or below
+// the cancel high-water mark — and untracked enqueues (seq == 0) whenever
+// any mark is present — stay in the queue in their original order. A
+// cancel ends the turn in progress, so folding a covered prompt into that
+// turn would destroy it; discarding it would lose it outright.
 func TestDrainQueueForStep_FiltersUnderDispatchLock(t *testing.T) {
 	t.Parallel()
 
@@ -86,16 +87,18 @@ func TestDrainQueueForStep_FiltersUnderDispatchLock(t *testing.T) {
 	// Cancel high-water mark at seq 2: seq <= 2 and seq == 0 are covered.
 	a.cancelMark.Set(sessionID, 2)
 
-	fold, canceledWithRunID := a.drainQueueForStep(sessionID)
+	fold := a.drainQueueForStep(sessionID)
 
 	require.Len(t, fold, 1,
 		"only the follow-up queued after the cancel (seq > mark) must be folded")
 	require.Equal(t, "after", fold[0].Prompt)
-	require.Empty(t, canceledWithRunID,
-		"no dropped call carried a RunID, so none need a terminal RunComplete")
 
-	_, ok := a.messageQueue.Get(sessionID)
-	require.False(t, ok, "drain must clear the session message queue when nothing is kept")
+	kept, ok := a.messageQueue.Get(sessionID)
+	require.True(t, ok, "cancel-covered prompts must survive the drain")
+	require.Len(t, kept, 3)
+	require.Equal(t, []string{"below", "at-mark", "untracked"},
+		[]string{kept[0].Prompt, kept[1].Prompt, kept[2].Prompt},
+		"the surviving prompts must keep their original order")
 }
 
 // TestDrainQueueForStep_NoMarkFoldsAllNonRunID verifies that with no
@@ -115,9 +118,8 @@ func TestDrainQueueForStep_NoMarkFoldsAllNonRunID(t *testing.T) {
 		{SessionID: sessionID, Prompt: "b", acceptSeq: 5},
 	})
 
-	fold, canceledWithRunID := a.drainQueueForStep(sessionID)
+	fold := a.drainQueueForStep(sessionID)
 	require.Len(t, fold, 2, "no cancel mark means all non-RunID queued calls are folded")
-	require.Empty(t, canceledWithRunID)
 }
 
 // TestDrainQueueForStep_KeepsRunIDPromptsQueued is the core of fix 2: a
@@ -143,11 +145,10 @@ func TestDrainQueueForStep_KeepsRunIDPromptsQueued(t *testing.T) {
 		{SessionID: sessionID, RunID: "run-b", Prompt: "keep-me-too", acceptSeq: 3},
 	})
 
-	fold, canceledWithRunID := a.drainQueueForStep(sessionID)
+	fold := a.drainQueueForStep(sessionID)
 
 	require.Len(t, fold, 1, "only the non-RunID prompt is folded into the active turn")
 	require.Equal(t, "fold-me", fold[0].Prompt)
-	require.Empty(t, canceledWithRunID)
 
 	kept, ok := a.messageQueue.Get(sessionID)
 	require.True(t, ok, "RunID-bearing prompts must remain queued for the recursive run path")
@@ -156,12 +157,12 @@ func TestDrainQueueForStep_KeepsRunIDPromptsQueued(t *testing.T) {
 	require.Equal(t, "run-b", kept[1].RunID)
 }
 
-// TestDrainQueueForStep_ReportsCanceledRunIDDrops verifies that a queued
-// prompt carrying a RunID that is dropped because a cancel covers it is
-// reported in canceledWithRunID so the caller can publish its terminal
-// cancelled RunComplete. A canceled prompt without a RunID is dropped
-// silently as before.
-func TestDrainQueueForStep_ReportsCanceledRunIDDrops(t *testing.T) {
+// TestDrainQueueForStep_KeepsCanceledPromptsQueued verifies that a cancel
+// covering a queued prompt never removes it: the drain leaves it queued
+// (RunID or not) so it survives the canceled turn, stays visible in the
+// queue pill, and remains poppable. Only prompts queued after the cancel
+// are folded into the active turn.
+func TestDrainQueueForStep_KeepsCanceledPromptsQueued(t *testing.T) {
 	t.Parallel()
 
 	env := testEnv(t)
@@ -178,17 +179,15 @@ func TestDrainQueueForStep_ReportsCanceledRunIDDrops(t *testing.T) {
 	})
 	a.cancelMark.Set(sessionID, 2)
 
-	fold, canceledWithRunID := a.drainQueueForStep(sessionID)
+	fold := a.drainQueueForStep(sessionID)
 
-	require.Empty(t, fold, "no uncanceled non-RunID prompts to fold")
-	require.Len(t, canceledWithRunID, 1,
-		"only the dropped RunID-bearing prompt needs a terminal RunComplete")
-	require.Equal(t, "run-canceled", canceledWithRunID[0].RunID)
+	require.Empty(t, fold, "a cancel-covered prompt must not be folded into the canceled turn")
 
 	kept, ok := a.messageQueue.Get(sessionID)
 	require.True(t, ok)
-	require.Len(t, kept, 1, "the uncanceled RunID prompt stays queued")
-	require.Equal(t, "run-survives", kept[0].RunID)
+	require.Len(t, kept, 3, "cancellation must not remove queued prompts")
+	require.Equal(t, []string{"canceled", "canceled-no-runid", "survives"},
+		[]string{kept[0].Prompt, kept[1].Prompt, kept[2].Prompt})
 }
 
 func TestPopQueuedMessage_NewestFirstWithAttachments(t *testing.T) {
@@ -327,15 +326,28 @@ func requireSingleCancelledRunComplete(t *testing.T, ch <-chan pubsub.Event[noti
 	}
 }
 
-// TestCancel_QueuedRunIDPromptPublishesCancelledRunComplete proves the
-// terminal-event behavior end-to-end: a RunID-bearing prompt sitting in
-// the queue that is canceled while queued (via the public Cancel path,
-// which routes through clearQueueAndNotify -> publishCanceledQueueDrops)
-// must emit exactly one cancelled RunComplete on the broker for its
-// RunID. A queued prompt without a RunID is dropped silently. This is the
-// coverage the earlier drain test lacked: it asserted the returned
-// bookkeeping slice, not the published event a `crush run` caller awaits.
-func TestCancel_QueuedRunIDPromptPublishesCancelledRunComplete(t *testing.T) {
+// requireNoRunComplete asserts nothing is published on ch. A queued prompt
+// that is still queued has not been discarded, so it must not report a
+// terminal cancelled RunComplete: a `crush run` caller blocking on that
+// RunID would exit as canceled while its prompt was still pending.
+func requireNoRunComplete(t *testing.T, ch <-chan pubsub.Event[notify.RunComplete]) {
+	t.Helper()
+	select {
+	case ev := <-ch:
+		t.Fatalf("expected no RunComplete for a still-queued prompt, got %+v", ev.Payload)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestClearQueue_QueuedRunIDPromptPublishesCancelledRunComplete proves the
+// terminal-event behavior end-to-end: a RunID-bearing prompt discarded
+// from the queue by the explicit ClearQueue path (which routes through
+// clearQueueAndNotify -> publishCanceledQueueDrops) must emit exactly one
+// cancelled RunComplete on the broker for its RunID. A queued prompt
+// without a RunID is dropped silently. This is the coverage the earlier
+// drain test lacked: it asserted the returned bookkeeping slice, not the
+// published event a `crush run` caller awaits.
+func TestClearQueue_QueuedRunIDPromptPublishesCancelledRunComplete(t *testing.T) {
 	t.Parallel()
 
 	env := testEnv(t)
@@ -352,28 +364,27 @@ func TestCancel_QueuedRunIDPromptPublishesCancelledRunComplete(t *testing.T) {
 	defer subCancel()
 	ch := broker.Subscribe(subCtx)
 
-	const sessionID = "cancel-queued-runid"
+	const sessionID = "clear-queued-runid"
 	a.messageQueue.Set(sessionID, []SessionAgentCall{
 		{SessionID: sessionID, Prompt: "no-runid", acceptSeq: 1},
 		{SessionID: sessionID, RunID: "run-queued", Prompt: "queued", acceptSeq: 2},
 	})
 
-	a.Cancel(sessionID)
+	a.ClearQueue(sessionID)
 
 	requireSingleCancelledRunComplete(t, ch, sessionID, "run-queued")
 
 	_, ok := a.messageQueue.Get(sessionID)
-	require.False(t, ok, "Cancel must clear the queue")
+	require.False(t, ok, "ClearQueue must clear the queue")
 }
 
-// TestDrainQueueForStep_DroppedRunIDPublishesCancelledRunComplete drives
-// the production drain sequence (drainQueueForStep then
-// publishCanceledQueueDrops, mirroring the PrepareStep handoff) and
-// asserts the dropped RunID-bearing prompt actually publishes exactly one
-// cancelled RunComplete on the broker. The companion bookkeeping test
-// covers the returned slice; this one covers the observable terminal
-// event.
-func TestDrainQueueForStep_DroppedRunIDPublishesCancelledRunComplete(t *testing.T) {
+// TestCancel_PreservesQueuedPrompts is the regression test for issue
+// #3558: Escape must cancel the turn in progress without discarding
+// queued prompts. It drives the public Cancel path with an active request
+// and an accepted follow-up so both cancel branches fire, then asserts the
+// queue is untouched — order, count, and RunID-bearing entries — and that
+// no queued prompt was reported as cancelled to a waiting `crush run`.
+func TestCancel_PreservesQueuedPrompts(t *testing.T) {
 	t.Parallel()
 
 	env := testEnv(t)
@@ -390,16 +401,69 @@ func TestDrainQueueForStep_DroppedRunIDPublishesCancelledRunComplete(t *testing.
 	defer subCancel()
 	ch := broker.Subscribe(subCtx)
 
-	const sessionID = "drain-drop-runid"
+	const sessionID = "cancel-preserves-queue"
+	var activeCanceled atomic.Bool
+	a.activeRequests.Set(sessionID, &activeCancel{cancel: func() { activeCanceled.Store(true) }})
+	accept := a.BeginAccepted(sessionID)
+	defer accept.Close()
 	a.messageQueue.Set(sessionID, []SessionAgentCall{
-		{SessionID: sessionID, RunID: "run-dropped", Prompt: "dropped", acceptSeq: 1},
-		{SessionID: sessionID, Prompt: "dropped-no-runid", acceptSeq: 1},
+		{SessionID: sessionID, Prompt: "first", acceptSeq: 1},
+		{SessionID: sessionID, RunID: "run-queued", Prompt: "second", acceptSeq: 2},
 	})
-	a.cancelMark.Set(sessionID, 2)
 
-	_, canceledWithRunID := a.drainQueueForStep(sessionID)
-	require.Len(t, canceledWithRunID, 1)
-	a.publishCanceledQueueDrops(canceledWithRunID)
+	a.Cancel(sessionID)
 
-	requireSingleCancelledRunComplete(t, ch, sessionID, "run-dropped")
+	require.True(t, activeCanceled.Load(), "the active turn must still be canceled")
+	require.True(t, a.hasPendingCancel(sessionID),
+		"the accepted-but-not-active follow-up must still be covered")
+
+	queued, ok := a.messageQueue.Get(sessionID)
+	require.True(t, ok, "Cancel must not delete the queue")
+	require.Len(t, queued, 2, "Cancel must not discard queued prompts")
+	require.Equal(t, "first", queued[0].Prompt)
+	require.Equal(t, "second", queued[1].Prompt)
+	require.Equal(t, "run-queued", queued[1].RunID)
+	require.Equal(t, 2, a.QueuedPrompts(sessionID))
+
+	requireNoRunComplete(t, ch)
+}
+
+// TestCancelAll_ShutdownDiscardsQueueAndNotifies covers the one place that
+// still discards queued prompts implicitly: shutdown. Cancel keeps the
+// queue because a queued prompt can still run later, but CancelAll runs
+// when the workspace is going away, so every queued RunID must receive its
+// terminal cancelled RunComplete or a `crush run` caller blocking on it
+// would never exit.
+func TestCancelAll_ShutdownDiscardsQueueAndNotifies(t *testing.T) {
+	t.Parallel()
+
+	env := testEnv(t)
+	broker := pubsub.NewBroker[notify.RunComplete]()
+	t.Cleanup(broker.Shutdown)
+
+	a := NewSessionAgent(SessionAgentOptions{
+		Sessions:    env.sessions,
+		Messages:    env.messages,
+		RunComplete: broker,
+	}).(*sessionAgent)
+
+	subCtx, subCancel := context.WithCancel(t.Context())
+	defer subCancel()
+	ch := broker.Subscribe(subCtx)
+
+	const sessionID = "cancel-all-shutdown"
+	// Releasing the active entry mirrors processRequest's deferred
+	// cleanup, so CancelAll's busy-wait finishes immediately.
+	a.activeRequests.Set(sessionID, &activeCancel{
+		cancel: func() { a.activeRequests.Del(sessionID) },
+	})
+	a.messageQueue.Set(sessionID, []SessionAgentCall{
+		{SessionID: sessionID, RunID: "run-queued", Prompt: "queued", acceptSeq: 1},
+	})
+
+	a.CancelAll()
+
+	requireSingleCancelledRunComplete(t, ch, sessionID, "run-queued")
+	require.Equal(t, 0, a.QueuedPrompts(sessionID),
+		"shutdown must discard queued prompts it can no longer run")
 }

--- a/internal/agent/run_complete_test.go
+++ b/internal/agent/run_complete_test.go
@@ -524,6 +524,72 @@ func TestClearQueue_HoldsSessionDispatchMutex(t *testing.T) {
 	}
 }
 
+// TestSummarize_QueuePromotionHoldsSessionDispatchMutex pins the
+// synchronization of the promotion at the end of Summarize. The tail
+// releases the active request first, so the session reads idle for the
+// whole promotion: a submission landing in that window takes Run's
+// idle-with-queue branch, which swaps the submission into the queue and
+// starts the queue head. Promoting without the dispatch mutex writes the
+// tail's stale pre-swap snapshot back over that swap — the submission is
+// wiped from the queue (never run, no terminal RunComplete for its RunID)
+// and the head, already active, is re-queued and runs a second time.
+func TestSummarize_QueuePromotionHoldsSessionDispatchMutex(t *testing.T) {
+	t.Parallel()
+
+	sa, env := newStreamTestAgent(t)
+
+	sess, err := env.sessions.Create(t.Context(), "session")
+	require.NoError(t, err)
+	// Summarize returns early on an empty session.
+	_, err = env.messages.Create(t.Context(), sess.ID, message.CreateMessageParams{
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "history"},
+		},
+	})
+	require.NoError(t, err)
+
+	sa.enqueueCall(SessionAgentCall{SessionID: sess.ID, Prompt: "queued"})
+
+	mu := sa.sessionMu(sess.ID)
+	mu.Lock()
+
+	done := make(chan error, 1)
+	go func() { done <- sa.Summarize(context.WithoutCancel(t.Context()), sess.ID, nil, nil) }()
+
+	// Persisting the summary on the session is the last step before the
+	// tail, so once it lands the only work left is the promotion.
+	require.Eventually(t, func() bool {
+		s, err := env.sessions.Get(t.Context(), sess.ID)
+		return err == nil && s.SummaryMessageID != ""
+	}, 10*time.Second, 10*time.Millisecond,
+		"summarize never reached its queue-promotion tail")
+
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 1, sa.QueuedPrompts(sess.ID),
+		"the summarize tail dequeued the queue head without the session dispatch mutex")
+
+	mu.Unlock()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Summarize never completed after the dispatch mutex was released")
+	}
+
+	require.Equal(t, 0, sa.QueuedPrompts(sess.ID),
+		"the queued prompt must be promoted once the lock is available")
+	msgs, err := env.messages.List(t.Context(), sess.ID)
+	require.NoError(t, err)
+	var ranQueued bool
+	for _, msg := range msgs {
+		if msg.Role == message.User && msg.Content().String() == "queued" {
+			ranQueued = true
+		}
+	}
+	require.True(t, ranQueued, "the promoted prompt must have run as its own turn")
+}
+
 // TestCancel_PreservesQueuedPrompts is the regression test for issue
 // #3558: Escape must cancel the turn in progress without discarding
 // queued prompts. It drives the public Cancel path with an active request

--- a/internal/agent/run_marker.go
+++ b/internal/agent/run_marker.go
@@ -7,27 +7,36 @@ import (
 
 // runCompleteMarkerKey is the unexported context key carrying a
 // [runCompleteMarker] from the dispatch boundary (backend.runAgent)
-// down into the coordinator. It lets the dispatcher learn whether the
-// coordinator already published the authoritative terminal
-// notify.RunComplete for the run, so a fallback terminal event is only
-// emitted when one is actually missing (e.g. an error returned before
-// sessionAgent.Run ever executed). It avoids a breaking change to the
-// Coordinator interface.
+// down into the coordinator and the session agent. It lets the
+// dispatcher learn what happened to the run it dispatched — whether the
+// authoritative terminal notify.RunComplete was already published, and
+// whether the run's prompt was requeued so that the outcome it is
+// handed belongs to a different prompt — so it only publishes a
+// fallback terminal event when one is actually missing for its own run
+// (e.g. an error returned before sessionAgent.Run ever executed). It
+// avoids a breaking change to the Coordinator interface.
 type runCompleteMarkerKey struct{}
 
-// runCompleteMarker records whether a terminal RunComplete has been
-// published for a run. It is shared by pointer through the context so
-// a publish deep in the call stack is observable by the dispatcher
-// after the call returns.
+// runCompleteMarker records what became of a dispatched run. It is
+// shared by pointer through the context so a publish (or a requeue)
+// deep in the call stack is observable by the dispatcher after the call
+// returns.
 type runCompleteMarker struct {
 	published atomic.Bool
+	// requeuedTo is non-nil when sessionAgent.Run swapped the
+	// dispatched prompt into the session's message queue and ran a
+	// prompt already queued ahead of it instead (see
+	// swapWithQueueHead). It holds that prompt's RunID, which may be
+	// empty, so the pointer — not the string — is the signal.
+	requeuedTo atomic.Pointer[string]
 }
 
 // WithRunCompleteMarker returns ctx carrying a fresh marker the
 // coordinator can flag via [MarkRunCompletePublished] once it emits the
-// run's terminal RunComplete. Callers read the result with
-// [RunCompletePublished]. Attaching the marker is optional: code paths
-// without one simply skip the dedup signal.
+// run's terminal RunComplete, and the session agent can flag via
+// [MarkRunRequeued] when it requeues the run's prompt. Callers read the
+// results with [RunCompletePublished] and [RequeuedRun]. Attaching the
+// marker is optional: code paths without one simply skip the signals.
 func WithRunCompleteMarker(ctx context.Context) context.Context {
 	return context.WithValue(ctx, runCompleteMarkerKey{}, &runCompleteMarker{})
 }
@@ -40,6 +49,32 @@ func MarkRunCompletePublished(ctx context.Context) {
 	if m, ok := ctx.Value(runCompleteMarkerKey{}).(*runCompleteMarker); ok {
 		m.published.Store(true)
 	}
+}
+
+// MarkRunRequeued records that the prompt dispatched with ctx was
+// requeued behind its session's message queue and that this invocation
+// ran the already-queued prompt identified by ranRunID in its place.
+// The dispatcher reads it with [RequeuedRun] to keep attribution
+// straight: the outcome it is handed belongs to ranRunID, while ctx's
+// own run is still queued and owes its own terminal event when it runs.
+// It is a no-op when no marker is present.
+func MarkRunRequeued(ctx context.Context, ranRunID string) {
+	if m, ok := ctx.Value(runCompleteMarkerKey{}).(*runCompleteMarker); ok {
+		m.requeuedTo.Store(&ranRunID)
+	}
+}
+
+// RequeuedRun reports whether [MarkRunRequeued] was called on ctx's
+// marker and, if so, the RunID of the prompt the invocation ran instead
+// of ctx's own (empty when that prompt carried none). It returns
+// ("", false) when no marker is present.
+func RequeuedRun(ctx context.Context) (string, bool) {
+	if m, ok := ctx.Value(runCompleteMarkerKey{}).(*runCompleteMarker); ok {
+		if ran := m.requeuedTo.Load(); ran != nil {
+			return *ran, true
+		}
+	}
+	return "", false
 }
 
 // RunCompletePublished reports whether [MarkRunCompletePublished] was

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -234,6 +234,21 @@ func (b *Backend) QueuedPromptsList(workspaceID, sessionID string) ([]string, er
 	return ws.AgentCoordinator.QueuedPromptsList(sessionID), nil
 }
 
+// PopQueuedMessage removes and returns the newest queued message for a session.
+func (b *Backend) PopQueuedMessage(workspaceID, sessionID string) (agent.QueuedMessage, bool, error) {
+	ws, err := b.GetWorkspace(workspaceID)
+	if err != nil {
+		return agent.QueuedMessage{}, false, err
+	}
+
+	if ws.AgentCoordinator == nil {
+		return agent.QueuedMessage{}, false, nil
+	}
+
+	queued, ok := ws.AgentCoordinator.PopQueuedMessage(sessionID)
+	return queued, ok, nil
+}
+
 // GetDefaultSmallModel returns the default small model for a provider.
 func (b *Backend) GetDefaultSmallModel(workspaceID, providerID string) (config.SelectedModel, error) {
 	ws, err := b.GetWorkspace(workspaceID)

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -259,7 +259,9 @@ func (b *Backend) QueuedPromptsList(workspaceID, sessionID string) ([]string, er
 	return ws.AgentCoordinator.QueuedPromptsList(sessionID), nil
 }
 
-// PopQueuedMessage removes and returns the newest queued message for a session.
+// PopQueuedMessage removes and returns the newest queued message for a
+// session. A workspace with no coordinator has no queue, so it reports
+// an empty pop rather than an error.
 func (b *Backend) PopQueuedMessage(workspaceID, sessionID string) (agent.QueuedMessage, bool, error) {
 	ws, err := b.GetWorkspace(workspaceID)
 	if err != nil {

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -83,7 +83,14 @@ func (b *Backend) SendMessage(workspaceID string, msg proto.AgentMessage) error 
 // agent.WithRunID so the coordinator can stamp the terminal
 // notify.RunComplete event with that correlator. A run-complete marker
 // is also attached so the coordinator can report whether it published
-// the terminal event, letting runAgent avoid a duplicate fallback.
+// the terminal event, letting runAgent avoid a duplicate fallback, and
+// so sessionAgent.Run can report that it requeued this prompt behind the
+// session's queue and ran a queued one in its place. A requeued
+// dispatch's error belongs to the prompt that actually ran, so it is
+// reported under that prompt's RunID and no fallback terminal event is
+// emitted: the run that failed published its own inside Run, and
+// msg.RunID's prompt is still queued, owing exactly one terminal event
+// when its own turn ends.
 func (b *Backend) runAgent(ws *Workspace, msg proto.AgentMessage, accept *agent.AcceptedRun) {
 	defer ws.runWG.Done()
 	defer accept.Close()
@@ -99,17 +106,30 @@ func (b *Backend) runAgent(ws *Workspace, msg proto.AgentMessage, accept *agent.
 		return
 	}
 
+	// A requeued dispatch ran a prompt that was already queued (the
+	// FIFO swap in sessionAgent.Run), so err describes that prompt's
+	// turn. Attribute the failure to it: `crush run` treats an error
+	// event matching its RunID as fatal, and msg.RunID's prompt has not
+	// run yet.
+	errRunID := msg.RunID
+	ranID, requeued := agent.RequeuedRun(ctx)
+	if requeued {
+		errRunID = ranID
+	}
+
 	ws.AgentNotifications().Publish(pubsub.CreatedEvent, notify.Notification{
 		SessionID: msg.SessionID,
-		RunID:     msg.RunID,
+		RunID:     errRunID,
 		Type:      notify.TypeAgentError,
 		Message:   err.Error(),
 	})
 
 	// Reliable terminal fallback. Only needed when a RunID waiter
-	// exists and the coordinator has not already emitted the run's
-	// terminal RunComplete; otherwise this would be a duplicate.
-	if msg.RunID == "" || agent.RunCompletePublished(ctx) {
+	// exists, this run's prompt is the one that ran, and the coordinator
+	// has not already emitted the run's terminal RunComplete; otherwise
+	// this would be a duplicate — or, for a requeued prompt, a terminal
+	// event for a turn that has not happened.
+	if msg.RunID == "" || requeued || agent.RunCompletePublished(ctx) {
 		return
 	}
 	if rc := ws.RunCompletions(); rc != nil {

--- a/internal/backend/agent.go
+++ b/internal/backend/agent.go
@@ -206,17 +206,22 @@ func (b *Backend) QueuedPrompts(workspaceID, sessionID string) (int, error) {
 	return ws.AgentCoordinator.QueuedPrompts(sessionID), nil
 }
 
-// ClearQueue clears the prompt queue for the session.
-func (b *Backend) ClearQueue(workspaceID, sessionID string) error {
+// ClearQueue clears the prompt queue for the session and returns the
+// messages it removed, oldest to newest, so a caller can restore them
+// instead of losing them. A workspace with no coordinator has no queue,
+// so it reports an empty drain rather than an error — the same shape
+// PopQueuedMessage uses.
+func (b *Backend) ClearQueue(workspaceID, sessionID string) ([]agent.QueuedMessage, error) {
 	ws, err := b.GetWorkspace(workspaceID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if ws.AgentCoordinator != nil {
-		ws.AgentCoordinator.ClearQueue(sessionID)
+	if ws.AgentCoordinator == nil {
+		return nil, nil
 	}
-	return nil
+
+	return ws.AgentCoordinator.ClearQueue(sessionID), nil
 }
 
 // QueuedPromptsList returns the list of queued prompt strings for a

--- a/internal/backend/agent_runcomplete_test.go
+++ b/internal/backend/agent_runcomplete_test.go
@@ -44,10 +44,13 @@ func (c *errorCoordinator) IsSessionBusy(string) bool                         { 
 func (c *errorCoordinator) QueuedPrompts(string) int                          { return 0 }
 func (c *errorCoordinator) QueuedPromptsList(string) []string                 { return nil }
 func (c *errorCoordinator) ClearQueue(string)                                 {}
-func (c *errorCoordinator) Summarize(context.Context, string) error           { return nil }
-func (c *errorCoordinator) Model() agent.Model                                { return agent.Model{} }
-func (c *errorCoordinator) UpdateModels(context.Context) error                { return nil }
-func (c *errorCoordinator) GenerateTitle(context.Context, string, string)     {}
+func (c *errorCoordinator) PopQueuedMessage(string) (agent.QueuedMessage, bool) {
+	return agent.QueuedMessage{}, false
+}
+func (c *errorCoordinator) Summarize(context.Context, string) error       { return nil }
+func (c *errorCoordinator) Model() agent.Model                            { return agent.Model{} }
+func (c *errorCoordinator) UpdateModels(context.Context) error            { return nil }
+func (c *errorCoordinator) GenerateTitle(context.Context, string, string) {}
 
 // insertRunCompleteWorkspace installs a workspace backed by a real
 // app.App (so the runCompletions broker exists) with the given

--- a/internal/backend/agent_runcomplete_test.go
+++ b/internal/backend/agent_runcomplete_test.go
@@ -8,6 +8,7 @@ import (
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/agent"
+	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/app"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/proto"
@@ -20,9 +21,15 @@ import (
 // the run-complete marker on the context before returning, simulating a
 // real coordinator that already published the run's authoritative
 // terminal RunComplete (so runAgent must not emit a duplicate fallback).
+// When requeued is true it instead stamps the requeue marker with
+// ranRunID, simulating sessionAgent.Run's FIFO swap: the dispatched
+// prompt went back into the session queue and the error belongs to the
+// queued prompt that ran in its place.
 type errorCoordinator struct {
 	err           error
 	markPublished bool
+	requeued      bool
+	ranRunID      string
 }
 
 func (c *errorCoordinator) Run(ctx context.Context, sessionID, prompt string, attachments ...message.Attachment) (*fantasy.AgentResult, error) {
@@ -32,6 +39,9 @@ func (c *errorCoordinator) Run(ctx context.Context, sessionID, prompt string, at
 func (c *errorCoordinator) RunAccepted(ctx context.Context, accept *agent.AcceptedRun, sessionID, prompt string, attachments ...message.Attachment) (*fantasy.AgentResult, error) {
 	if c.markPublished {
 		agent.MarkRunCompletePublished(ctx)
+	}
+	if c.requeued {
+		agent.MarkRunRequeued(ctx, c.ranRunID)
 	}
 	return nil, c.err
 }
@@ -161,6 +171,50 @@ func TestRunAgent_CancellationPublishesNoErrorTerminal(t *testing.T) {
 	select {
 	case ev := <-ch:
 		t.Fatalf("cancellation must not publish a terminal RunComplete: %+v", ev.Payload)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// TestRunAgent_RequeuedRunAttributesErrorToTheRunThatRan covers the FIFO
+// swap's dispatch contract: when sessionAgent.Run requeues the
+// dispatched prompt behind the session's queue and runs a queued prompt
+// instead, the error it returns belongs to that queued prompt. runAgent
+// must report it under that prompt's RunID and publish no terminal
+// RunComplete for the dispatched one, which is still queued and owes
+// exactly one terminal event when its own turn ends. Attributing either
+// event to the dispatched RunID makes its `crush run` waiter exit on a
+// foreign prompt's failure and yields a second terminal event for that
+// RunID once the prompt actually runs.
+func TestRunAgent_RequeuedRunAttributesErrorToTheRunThatRan(t *testing.T) {
+	t.Parallel()
+	b, _ := newTestBackend(t)
+	runErr := errors.New("provider rejected the request")
+	ws := insertRunCompleteWorkspace(t, b, context.Background(),
+		&errorCoordinator{err: runErr, requeued: true, ranRunID: "run-a"})
+
+	subCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	terminals := ws.RunCompletions().Subscribe(subCtx)
+	notifications := ws.AgentNotifications().Subscribe(subCtx)
+
+	err := b.SendMessage(ws.ID, proto.AgentMessage{SessionID: "S1", RunID: "run-b", Prompt: "hi"})
+	require.NoError(t, err)
+
+	ws.runWG.Wait()
+
+	select {
+	case ev := <-notifications:
+		require.Equal(t, notify.TypeAgentError, ev.Payload.Type)
+		require.Equal(t, "run-a", ev.Payload.RunID,
+			"the error must be attributed to the prompt that actually ran")
+		require.Equal(t, runErr.Error(), ev.Payload.Message)
+	case <-time.After(2 * time.Second):
+		t.Fatal("no agent error notification published for the failed turn")
+	}
+
+	select {
+	case ev := <-terminals:
+		t.Fatalf("terminal RunComplete published for a prompt that has not run: %+v", ev.Payload)
 	case <-time.After(200 * time.Millisecond):
 	}
 }

--- a/internal/backend/agent_runcomplete_test.go
+++ b/internal/backend/agent_runcomplete_test.go
@@ -43,7 +43,7 @@ func (c *errorCoordinator) IsBusy() bool                                      { 
 func (c *errorCoordinator) IsSessionBusy(string) bool                         { return false }
 func (c *errorCoordinator) QueuedPrompts(string) int                          { return 0 }
 func (c *errorCoordinator) QueuedPromptsList(string) []string                 { return nil }
-func (c *errorCoordinator) ClearQueue(string)                                 {}
+func (c *errorCoordinator) ClearQueue(string) []agent.QueuedMessage           { return nil }
 func (c *errorCoordinator) PopQueuedMessage(string) (agent.QueuedMessage, bool) {
 	return agent.QueuedMessage{}, false
 }

--- a/internal/backend/agent_test.go
+++ b/internal/backend/agent_test.go
@@ -53,7 +53,7 @@ func (c *blockingCoordinator) IsBusy() bool                                     
 func (c *blockingCoordinator) IsSessionBusy(string) bool                         { return false }
 func (c *blockingCoordinator) QueuedPrompts(string) int                          { return 0 }
 func (c *blockingCoordinator) QueuedPromptsList(string) []string                 { return nil }
-func (c *blockingCoordinator) ClearQueue(string)                                 {}
+func (c *blockingCoordinator) ClearQueue(string) []agent.QueuedMessage           { return nil }
 func (c *blockingCoordinator) PopQueuedMessage(string) (agent.QueuedMessage, bool) {
 	return agent.QueuedMessage{}, false
 }
@@ -125,6 +125,52 @@ func TestPopQueuedMessageEmptyAndErrors(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, found)
 	require.Equal(t, agent.QueuedMessage{}, got)
+}
+
+type clearCoordinator struct {
+	agent.Coordinator
+	drained []agent.QueuedMessage
+}
+
+func (c *clearCoordinator) ClearQueue(string) []agent.QueuedMessage {
+	return c.drained
+}
+
+func TestClearQueue(t *testing.T) {
+	t.Parallel()
+	b, _ := newTestBackend(t)
+	want := []agent.QueuedMessage{
+		{Prompt: "oldest"},
+		{
+			Prompt: "newest",
+			Attachments: []message.Attachment{{
+				FileName: "notes.txt",
+				MimeType: "text/plain",
+				Content:  []byte("content"),
+			}},
+		},
+	}
+	ws := insertAgentWorkspace(t, b, &clearCoordinator{drained: want})
+
+	got, err := b.ClearQueue(ws.ID, "S1")
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestClearQueueEmptyAndErrors(t *testing.T) {
+	t.Parallel()
+	b, _ := newTestBackend(t)
+
+	drained, err := b.ClearQueue("missing", "S1")
+	require.ErrorIs(t, err, ErrWorkspaceNotFound)
+	require.Nil(t, drained)
+
+	// No coordinator means no queue: an empty drain, not an error, so the
+	// same user action behaves identically in client/server mode.
+	ws := insertAgentWorkspace(t, b, nil)
+	drained, err = b.ClearQueue(ws.ID, "S1")
+	require.NoError(t, err)
+	require.Nil(t, drained)
 }
 
 func TestSendMessage_WorkspaceNotFound(t *testing.T) {

--- a/internal/backend/agent_test.go
+++ b/internal/backend/agent_test.go
@@ -54,10 +54,13 @@ func (c *blockingCoordinator) IsSessionBusy(string) bool                        
 func (c *blockingCoordinator) QueuedPrompts(string) int                          { return 0 }
 func (c *blockingCoordinator) QueuedPromptsList(string) []string                 { return nil }
 func (c *blockingCoordinator) ClearQueue(string)                                 {}
-func (c *blockingCoordinator) Summarize(context.Context, string) error           { return nil }
-func (c *blockingCoordinator) Model() agent.Model                                { return agent.Model{} }
-func (c *blockingCoordinator) UpdateModels(context.Context) error                { return nil }
-func (c *blockingCoordinator) GenerateTitle(context.Context, string, string)     {}
+func (c *blockingCoordinator) PopQueuedMessage(string) (agent.QueuedMessage, bool) {
+	return agent.QueuedMessage{}, false
+}
+func (c *blockingCoordinator) Summarize(context.Context, string) error       { return nil }
+func (c *blockingCoordinator) Model() agent.Model                            { return agent.Model{} }
+func (c *blockingCoordinator) UpdateModels(context.Context) error            { return nil }
+func (c *blockingCoordinator) GenerateTitle(context.Context, string, string) {}
 
 // insertAgentWorkspace installs a synthetic workspace with the given
 // coordinator (or none) and a workspace run context, mirroring the
@@ -78,6 +81,50 @@ func insertAgentWorkspace(t *testing.T, b *Backend, coord agent.Coordinator) *Wo
 	b.pathIndex[ws.resolvedPath] = ws.ID
 	b.mu.Unlock()
 	return ws
+}
+
+type popCoordinator struct {
+	agent.Coordinator
+	message agent.QueuedMessage
+	found   bool
+}
+
+func (c *popCoordinator) PopQueuedMessage(string) (agent.QueuedMessage, bool) {
+	return c.message, c.found
+}
+
+func TestPopQueuedMessage(t *testing.T) {
+	t.Parallel()
+	b, _ := newTestBackend(t)
+	want := agent.QueuedMessage{
+		Prompt: "queued",
+		Attachments: []message.Attachment{{
+			FileName: "notes.txt",
+			MimeType: "text/plain",
+			Content:  []byte("content"),
+		}},
+	}
+	ws := insertAgentWorkspace(t, b, &popCoordinator{message: want, found: true})
+
+	got, found, err := b.PopQueuedMessage(ws.ID, "S1")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, want, got)
+}
+
+func TestPopQueuedMessageEmptyAndErrors(t *testing.T) {
+	t.Parallel()
+	b, _ := newTestBackend(t)
+
+	_, found, err := b.PopQueuedMessage("missing", "S1")
+	require.ErrorIs(t, err, ErrWorkspaceNotFound)
+	require.False(t, found)
+
+	ws := insertAgentWorkspace(t, b, nil)
+	got, found, err := b.PopQueuedMessage(ws.ID, "S1")
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Equal(t, agent.QueuedMessage{}, got)
 }
 
 func TestSendMessage_WorkspaceNotFound(t *testing.T) {

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -441,17 +441,35 @@ func (c *Client) GetAgentSessionQueuedPrompts(ctx context.Context, id string, se
 	return count, nil
 }
 
-// ClearAgentSessionQueuedPrompts clears the queued prompts for a session.
-func (c *Client) ClearAgentSessionQueuedPrompts(ctx context.Context, id string, sessionID string) error {
+// ClearAgentSessionQueuedPrompts clears the queued prompts for a session and
+// returns the messages the server removed, oldest to newest. Because the
+// clear is destructive server-side, an error here may be raised after the
+// messages were already removed.
+func (c *Client) ClearAgentSessionQueuedPrompts(ctx context.Context, id string, sessionID string) ([]agent.QueuedMessage, error) {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/agent/sessions/%s/prompts/clear", id, sessionID), nil, nil, nil)
 	if err != nil {
-		return fmt.Errorf("failed to clear session agent queued prompts: %w", err)
+		return nil, fmt.Errorf("failed to clear session agent queued prompts: %w", err)
 	}
 	defer rsp.Body.Close()
 	if rsp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to clear session agent queued prompts: status code %d", rsp.StatusCode)
+		return nil, fmt.Errorf("failed to clear session agent queued prompts: status code %d", rsp.StatusCode)
 	}
-	return nil
+
+	var result proto.ClearQueueResponse
+	if err := json.NewDecoder(rsp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode cleared session agent queued prompts: %w", err)
+	}
+	if len(result.Messages) == 0 {
+		return nil, nil
+	}
+	drained := make([]agent.QueuedMessage, len(result.Messages))
+	for i, queued := range result.Messages {
+		drained[i] = agent.QueuedMessage{
+			Prompt:      queued.Prompt,
+			Attachments: proto.AttachmentsToMessage(queued.Attachments),
+		}
+	}
+	return drained, nil
 }
 
 // PopAgentSessionQueuedMessage removes and returns the newest queued message.

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/proto"
@@ -451,6 +452,30 @@ func (c *Client) ClearAgentSessionQueuedPrompts(ctx context.Context, id string, 
 		return fmt.Errorf("failed to clear session agent queued prompts: status code %d", rsp.StatusCode)
 	}
 	return nil
+}
+
+// PopAgentSessionQueuedMessage removes and returns the newest queued message.
+func (c *Client) PopAgentSessionQueuedMessage(ctx context.Context, id, sessionID string) (agent.QueuedMessage, bool, error) {
+	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/agent/sessions/%s/prompts/pop", id, sessionID), nil, nil, nil)
+	if err != nil {
+		return agent.QueuedMessage{}, false, fmt.Errorf("failed to pop session agent queued message: %w", err)
+	}
+	defer rsp.Body.Close()
+	if rsp.StatusCode != http.StatusOK {
+		return agent.QueuedMessage{}, false, fmt.Errorf("failed to pop session agent queued message: status code %d", rsp.StatusCode)
+	}
+
+	var result proto.PopQueuedMessageResponse
+	if err := json.NewDecoder(rsp.Body).Decode(&result); err != nil {
+		return agent.QueuedMessage{}, false, fmt.Errorf("failed to decode popped session agent queued message: %w", err)
+	}
+	if !result.Found {
+		return agent.QueuedMessage{}, false, nil
+	}
+	return agent.QueuedMessage{
+		Prompt:      result.Message.Prompt,
+		Attachments: proto.AttachmentsToMessage(result.Message.Attachments),
+	}, result.Found, nil
 }
 
 // GetAgentInfo retrieves the agent status for a workspace.

--- a/internal/client/proto.go
+++ b/internal/client/proto.go
@@ -472,7 +472,8 @@ func (c *Client) ClearAgentSessionQueuedPrompts(ctx context.Context, id string, 
 	return drained, nil
 }
 
-// PopAgentSessionQueuedMessage removes and returns the newest queued message.
+// PopAgentSessionQueuedMessage removes and returns the newest queued message
+// for a session; the boolean reports whether the queue held one.
 func (c *Client) PopAgentSessionQueuedMessage(ctx context.Context, id, sessionID string) (agent.QueuedMessage, bool, error) {
 	rsp, err := c.post(ctx, fmt.Sprintf("/workspaces/%s/agent/sessions/%s/prompts/pop", id, sessionID), nil, nil, nil)
 	if err != nil {

--- a/internal/client/proto_test.go
+++ b/internal/client/proto_test.go
@@ -9,10 +9,66 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/proto"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPopAgentSessionQueuedMessage(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/workspaces/ws1/agent/sessions/sess1/prompts/pop", r.URL.Path)
+		require.NoError(t, json.NewEncoder(w).Encode(proto.PopQueuedMessageResponse{
+			Found: true,
+			Message: proto.QueuedMessage{
+				Prompt: "queued",
+				Attachments: []proto.Attachment{{
+					FileName: "notes.txt",
+					MimeType: "text/plain",
+					Content:  []byte("content"),
+				}},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	c := captureClient(t, srv)
+	got, found, err := c.PopAgentSessionQueuedMessage(context.Background(), "ws1", "sess1")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "queued", got.Prompt)
+	require.Equal(t, "notes.txt", got.Attachments[0].FileName)
+	require.Equal(t, []byte("content"), got.Attachments[0].Content)
+}
+
+func TestPopAgentSessionQueuedMessageEmptyAndError(t *testing.T) {
+	t.Parallel()
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(proto.PopQueuedMessageResponse{}))
+		}))
+		defer srv.Close()
+
+		got, found, err := captureClient(t, srv).PopAgentSessionQueuedMessage(context.Background(), "ws1", "sess1")
+		require.NoError(t, err)
+		require.False(t, found)
+		require.Equal(t, agent.QueuedMessage{}, got)
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		_, _, err := captureClient(t, srv).PopAgentSessionQueuedMessage(context.Background(), "ws1", "sess1")
+		require.Error(t, err)
+	})
+}
 
 func TestSendEventAfterContextCancelIsIdempotent(t *testing.T) {
 	t.Parallel()

--- a/internal/client/proto_test.go
+++ b/internal/client/proto_test.go
@@ -70,6 +70,63 @@ func TestPopAgentSessionQueuedMessageEmptyAndError(t *testing.T) {
 	})
 }
 
+func TestClearAgentSessionQueuedPrompts(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/workspaces/ws1/agent/sessions/sess1/prompts/clear", r.URL.Path)
+		require.NoError(t, json.NewEncoder(w).Encode(proto.ClearQueueResponse{
+			Messages: []proto.QueuedMessage{
+				{Prompt: "oldest"},
+				{
+					Prompt: "newest",
+					Attachments: []proto.Attachment{{
+						FileName: "notes.txt",
+						MimeType: "text/plain",
+						Content:  []byte("content"),
+					}},
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	drained, err := captureClient(t, srv).ClearAgentSessionQueuedPrompts(context.Background(), "ws1", "sess1")
+	require.NoError(t, err)
+	require.Len(t, drained, 2)
+	require.Equal(t, []string{"oldest", "newest"},
+		[]string{drained[0].Prompt, drained[1].Prompt})
+	require.Equal(t, "notes.txt", drained[1].Attachments[0].FileName)
+	require.Equal(t, []byte("content"), drained[1].Attachments[0].Content)
+}
+
+func TestClearAgentSessionQueuedPromptsEmptyAndError(t *testing.T) {
+	t.Parallel()
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(proto.ClearQueueResponse{}))
+		}))
+		defer srv.Close()
+
+		drained, err := captureClient(t, srv).ClearAgentSessionQueuedPrompts(context.Background(), "ws1", "sess1")
+		require.NoError(t, err)
+		require.Nil(t, drained, "an empty drain must match the local path's nil")
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		drained, err := captureClient(t, srv).ClearAgentSessionQueuedPrompts(context.Background(), "ws1", "sess1")
+		require.Error(t, err)
+		require.Nil(t, drained)
+	})
+}
+
 func TestSendEventAfterContextCancelIsIdempotent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/proto/agent.go
+++ b/internal/proto/agent.go
@@ -5,6 +5,18 @@ import (
 	"errors"
 )
 
+// QueuedMessage is the transport-safe content of a queued agent call.
+type QueuedMessage struct {
+	Prompt      string       `json:"prompt"`
+	Attachments []Attachment `json:"attachments"`
+}
+
+// PopQueuedMessageResponse distinguishes an empty queue from an empty message.
+type PopQueuedMessageResponse struct {
+	Found   bool          `json:"found"`
+	Message QueuedMessage `json:"message"`
+}
+
 // AgentEventType represents the type of agent event.
 type AgentEventType string
 

--- a/internal/proto/agent.go
+++ b/internal/proto/agent.go
@@ -17,6 +17,13 @@ type PopQueuedMessageResponse struct {
 	Message QueuedMessage `json:"message"`
 }
 
+// ClearQueueResponse carries the messages a queue clear removed, oldest to
+// newest, so the caller can hand them back to the user instead of losing
+// them.
+type ClearQueueResponse struct {
+	Messages []QueuedMessage `json:"messages"`
+}
+
 // AgentEventType represents the type of agent event.
 type AgentEventType string
 

--- a/internal/proto/agent.go
+++ b/internal/proto/agent.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 )
 
-// QueuedMessage is the transport-safe content of a queued agent call.
+// QueuedMessage is the JSON-safe form of agent.QueuedMessage.
 type QueuedMessage struct {
 	Prompt      string       `json:"prompt"`
 	Attachments []Attachment `json:"attachments"`

--- a/internal/server/agent_cancel_test.go
+++ b/internal/server/agent_cancel_test.go
@@ -76,12 +76,26 @@ func (s *runCoordinator) IsSessionBusy(string) bool {
 func (s *runCoordinator) QueuedPrompts(string) int          { return 0 }
 func (s *runCoordinator) QueuedPromptsList(string) []string { return nil }
 func (s *runCoordinator) ClearQueue(string)                 {}
+func (s *runCoordinator) PopQueuedMessage(string) (agent.QueuedMessage, bool) {
+	return agent.QueuedMessage{}, false
+}
+
 func (s *runCoordinator) Summarize(context.Context, string) error {
 	return nil
 }
 func (s *runCoordinator) Model() agent.Model                            { return agent.Model{} }
 func (s *runCoordinator) UpdateModels(context.Context) error            { return nil }
 func (s *runCoordinator) GenerateTitle(context.Context, string, string) {}
+
+type popRunCoordinator struct {
+	*runCoordinator
+	message agent.QueuedMessage
+	found   bool
+}
+
+func (s *popRunCoordinator) PopQueuedMessage(string) (agent.QueuedMessage, bool) {
+	return s.message, s.found
+}
 
 func (s *runCoordinator) capturedCtx() context.Context {
 	s.mu.Lock()
@@ -120,6 +134,57 @@ func postAgent(t *testing.T, c *controllerV1, ctx context.Context, wsID, session
 	rec := httptest.NewRecorder()
 	c.handlePostWorkspaceAgent(rec, req)
 	return rec
+}
+
+func TestPostWorkspaceAgentSessionPromptPop(t *testing.T) {
+	t.Parallel()
+	want := agent.QueuedMessage{
+		Prompt: "queued",
+		Attachments: []message.Attachment{{
+			FilePath: "/tmp/notes.txt",
+			FileName: "notes.txt",
+			MimeType: "text/plain",
+			Content:  []byte("content"),
+		}},
+	}
+	coord := &popRunCoordinator{
+		runCoordinator: newRunCoordinator(func(context.Context) error { return nil }),
+		message:        want,
+		found:          true,
+	}
+	c, wsID := buildAgentWorkspace(t, coord)
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.SetPathValue("id", wsID)
+	req.SetPathValue("sid", "S1")
+	rec := httptest.NewRecorder()
+
+	c.handlePostWorkspaceAgentSessionPromptPop(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got proto.PopQueuedMessageResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	require.True(t, got.Found)
+	require.Equal(t, want.Prompt, got.Message.Prompt)
+	require.Equal(t, want.Attachments, proto.AttachmentsToMessage(got.Message.Attachments))
+}
+
+func TestPostWorkspaceAgentSessionPromptPopEmpty(t *testing.T) {
+	t.Parallel()
+	coord := &popRunCoordinator{
+		runCoordinator: newRunCoordinator(func(context.Context) error { return nil }),
+	}
+	c, wsID := buildAgentWorkspace(t, coord)
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.SetPathValue("id", wsID)
+	req.SetPathValue("sid", "S1")
+	rec := httptest.NewRecorder()
+
+	c.handlePostWorkspaceAgentSessionPromptPop(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got proto.PopQueuedMessageResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	require.False(t, got.Found)
 }
 
 // TestPostAgent_ReturnsOKOnContextCanceled verifies that when another

--- a/internal/server/agent_cancel_test.go
+++ b/internal/server/agent_cancel_test.go
@@ -73,9 +73,9 @@ func (s *runCoordinator) IsBusy() bool  { return false }
 func (s *runCoordinator) IsSessionBusy(string) bool {
 	return false
 }
-func (s *runCoordinator) QueuedPrompts(string) int          { return 0 }
-func (s *runCoordinator) QueuedPromptsList(string) []string { return nil }
-func (s *runCoordinator) ClearQueue(string)                 {}
+func (s *runCoordinator) QueuedPrompts(string) int                { return 0 }
+func (s *runCoordinator) QueuedPromptsList(string) []string       { return nil }
+func (s *runCoordinator) ClearQueue(string) []agent.QueuedMessage { return nil }
 func (s *runCoordinator) PopQueuedMessage(string) (agent.QueuedMessage, bool) {
 	return agent.QueuedMessage{}, false
 }
@@ -95,6 +95,15 @@ type popRunCoordinator struct {
 
 func (s *popRunCoordinator) PopQueuedMessage(string) (agent.QueuedMessage, bool) {
 	return s.message, s.found
+}
+
+type clearRunCoordinator struct {
+	*runCoordinator
+	drained []agent.QueuedMessage
+}
+
+func (s *clearRunCoordinator) ClearQueue(string) []agent.QueuedMessage {
+	return s.drained
 }
 
 func (s *runCoordinator) capturedCtx() context.Context {
@@ -185,6 +194,60 @@ func TestPostWorkspaceAgentSessionPromptPopEmpty(t *testing.T) {
 	var got proto.PopQueuedMessageResponse
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
 	require.False(t, got.Found)
+}
+
+func TestPostWorkspaceAgentSessionPromptClear(t *testing.T) {
+	t.Parallel()
+	want := []agent.QueuedMessage{
+		{Prompt: "oldest"},
+		{
+			Prompt: "newest",
+			Attachments: []message.Attachment{{
+				FilePath: "/tmp/notes.txt",
+				FileName: "notes.txt",
+				MimeType: "text/plain",
+				Content:  []byte("content"),
+			}},
+		},
+	}
+	coord := &clearRunCoordinator{
+		runCoordinator: newRunCoordinator(func(context.Context) error { return nil }),
+		drained:        want,
+	}
+	c, wsID := buildAgentWorkspace(t, coord)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", nil)
+	req.SetPathValue("id", wsID)
+	req.SetPathValue("sid", "S1")
+	rec := httptest.NewRecorder()
+
+	c.handlePostWorkspaceAgentSessionPromptClear(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got proto.ClearQueueResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	require.Len(t, got.Messages, 2)
+	require.Equal(t, []string{"oldest", "newest"},
+		[]string{got.Messages[0].Prompt, got.Messages[1].Prompt})
+	require.Equal(t, want[1].Attachments, proto.AttachmentsToMessage(got.Messages[1].Attachments))
+}
+
+func TestPostWorkspaceAgentSessionPromptClearEmpty(t *testing.T) {
+	t.Parallel()
+	coord := &clearRunCoordinator{
+		runCoordinator: newRunCoordinator(func(context.Context) error { return nil }),
+	}
+	c, wsID := buildAgentWorkspace(t, coord)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", nil)
+	req.SetPathValue("id", wsID)
+	req.SetPathValue("sid", "S1")
+	rec := httptest.NewRecorder()
+
+	c.handlePostWorkspaceAgentSessionPromptClear(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got proto.ClearQueueResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	require.Empty(t, got.Messages)
 }
 
 // TestPostAgent_ReturnsOKOnContextCanceled verifies that when another

--- a/internal/server/agent_cancel_test.go
+++ b/internal/server/agent_cancel_test.go
@@ -153,7 +153,7 @@ func TestPostWorkspaceAgentSessionPromptPop(t *testing.T) {
 		found:          true,
 	}
 	c, wsID := buildAgentWorkspace(t, coord)
-	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", nil)
 	req.SetPathValue("id", wsID)
 	req.SetPathValue("sid", "S1")
 	rec := httptest.NewRecorder()
@@ -174,7 +174,7 @@ func TestPostWorkspaceAgentSessionPromptPopEmpty(t *testing.T) {
 		runCoordinator: newRunCoordinator(func(context.Context) error { return nil }),
 	}
 	c, wsID := buildAgentWorkspace(t, coord)
-	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/", nil)
 	req.SetPathValue("id", wsID)
 	req.SetPathValue("sid", "S1")
 	rec := httptest.NewRecorder()

--- a/internal/server/e2e_agent_test.go
+++ b/internal/server/e2e_agent_test.go
@@ -212,11 +212,14 @@ func (c *scriptedCoordinator) CancelAll() {
 	}
 }
 
-func (c *scriptedCoordinator) IsBusy() bool                                  { return false }
-func (c *scriptedCoordinator) IsSessionBusy(string) bool                     { return false }
-func (c *scriptedCoordinator) QueuedPrompts(string) int                      { return 0 }
-func (c *scriptedCoordinator) QueuedPromptsList(string) []string             { return nil }
-func (c *scriptedCoordinator) ClearQueue(string)                             {}
+func (c *scriptedCoordinator) IsBusy() bool                      { return false }
+func (c *scriptedCoordinator) IsSessionBusy(string) bool         { return false }
+func (c *scriptedCoordinator) QueuedPrompts(string) int          { return 0 }
+func (c *scriptedCoordinator) QueuedPromptsList(string) []string { return nil }
+func (c *scriptedCoordinator) ClearQueue(string)                 {}
+func (c *scriptedCoordinator) PopQueuedMessage(string) (agent.QueuedMessage, bool) {
+	return agent.QueuedMessage{}, false
+}
 func (c *scriptedCoordinator) Summarize(context.Context, string) error       { return nil }
 func (c *scriptedCoordinator) Model() agent.Model                            { return agent.Model{} }
 func (c *scriptedCoordinator) UpdateModels(context.Context) error            { return nil }

--- a/internal/server/e2e_agent_test.go
+++ b/internal/server/e2e_agent_test.go
@@ -212,11 +212,11 @@ func (c *scriptedCoordinator) CancelAll() {
 	}
 }
 
-func (c *scriptedCoordinator) IsBusy() bool                      { return false }
-func (c *scriptedCoordinator) IsSessionBusy(string) bool         { return false }
-func (c *scriptedCoordinator) QueuedPrompts(string) int          { return 0 }
-func (c *scriptedCoordinator) QueuedPromptsList(string) []string { return nil }
-func (c *scriptedCoordinator) ClearQueue(string)                 {}
+func (c *scriptedCoordinator) IsBusy() bool                            { return false }
+func (c *scriptedCoordinator) IsSessionBusy(string) bool               { return false }
+func (c *scriptedCoordinator) QueuedPrompts(string) int                { return 0 }
+func (c *scriptedCoordinator) QueuedPromptsList(string) []string       { return nil }
+func (c *scriptedCoordinator) ClearQueue(string) []agent.QueuedMessage { return nil }
 func (c *scriptedCoordinator) PopQueuedMessage(string) (agent.QueuedMessage, bool) {
 	return agent.QueuedMessage{}, false
 }

--- a/internal/server/proto.go
+++ b/internal/server/proto.go
@@ -929,6 +929,33 @@ func (c *controllerV1) handlePostWorkspaceAgentSessionPromptClear(w http.Respons
 	w.WriteHeader(http.StatusOK)
 }
 
+// handlePostWorkspaceAgentSessionPromptPop removes the newest queued message.
+//
+//	@Summary		Pop newest queued message
+//	@Tags			agent
+//	@Produce		json
+//	@Param			id	path	string	true	"Workspace ID"
+//	@Param			sid	path	string	true	"Session ID"
+//	@Success		200	{object}	proto.PopQueuedMessageResponse
+//	@Failure		404	{object}	proto.Error
+//	@Failure		500	{object}	proto.Error
+//	@Router			/workspaces/{id}/agent/sessions/{sid}/prompts/pop [post]
+func (c *controllerV1) handlePostWorkspaceAgentSessionPromptPop(w http.ResponseWriter, r *http.Request) {
+	queued, ok, err := c.backend.PopQueuedMessage(r.PathValue("id"), r.PathValue("sid"))
+	if err != nil {
+		c.handleError(w, r, err)
+		return
+	}
+
+	jsonEncode(w, proto.PopQueuedMessageResponse{
+		Found: ok,
+		Message: proto.QueuedMessage{
+			Prompt:      queued.Prompt,
+			Attachments: proto.AttachmentsFromMessage(queued.Attachments),
+		},
+	})
+}
+
 // handlePostWorkspaceAgentSessionSummarize summarizes a session.
 //
 //	@Summary		Summarize session

--- a/internal/server/proto.go
+++ b/internal/server/proto.go
@@ -940,7 +940,8 @@ func (c *controllerV1) handlePostWorkspaceAgentSessionPromptClear(w http.Respons
 	jsonEncode(w, proto.ClearQueueResponse{Messages: messages})
 }
 
-// handlePostWorkspaceAgentSessionPromptPop removes the newest queued message.
+// handlePostWorkspaceAgentSessionPromptPop removes the newest queued message
+// from the session's prompt queue, reporting whether one was found.
 //
 //	@Summary		Pop newest queued message
 //	@Tags			agent

--- a/internal/server/proto.go
+++ b/internal/server/proto.go
@@ -909,24 +909,35 @@ func (c *controllerV1) handleGetWorkspaceAgentSessionPromptQueued(w http.Respons
 	jsonEncode(w, queued)
 }
 
-// handlePostWorkspaceAgentSessionPromptClear clears the prompt queue for a session.
+// handlePostWorkspaceAgentSessionPromptClear clears the prompt queue for a
+// session and returns the messages it removed, oldest to newest.
 //
 //	@Summary		Clear prompt queue
 //	@Tags			agent
+//	@Produce		json
 //	@Param			id	path	string	true	"Workspace ID"
 //	@Param			sid	path	string	true	"Session ID"
-//	@Success		200
+//	@Success		200	{object}	proto.ClearQueueResponse
 //	@Failure		404	{object}	proto.Error
 //	@Failure		500	{object}	proto.Error
 //	@Router			/workspaces/{id}/agent/sessions/{sid}/prompts/clear [post]
 func (c *controllerV1) handlePostWorkspaceAgentSessionPromptClear(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	sid := r.PathValue("sid")
-	if err := c.backend.ClearQueue(id, sid); err != nil {
+	drained, err := c.backend.ClearQueue(id, sid)
+	if err != nil {
 		c.handleError(w, r, err)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
+
+	messages := make([]proto.QueuedMessage, len(drained))
+	for i, queued := range drained {
+		messages[i] = proto.QueuedMessage{
+			Prompt:      queued.Prompt,
+			Attachments: proto.AttachmentsFromMessage(queued.Attachments),
+		}
+	}
+	jsonEncode(w, proto.ClearQueueResponse{Messages: messages})
 }
 
 // handlePostWorkspaceAgentSessionPromptPop removes the newest queued message.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -198,6 +198,7 @@ func (s *Server) installHandler() {
 	mux.HandleFunc("GET /v1/workspaces/{id}/agent/sessions/{sid}/prompts/queued", c.handleGetWorkspaceAgentSessionPromptQueued)
 	mux.HandleFunc("GET /v1/workspaces/{id}/agent/sessions/{sid}/prompts/list", c.handleGetWorkspaceAgentSessionPromptList)
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent/sessions/{sid}/prompts/clear", c.handlePostWorkspaceAgentSessionPromptClear)
+	mux.HandleFunc("POST /v1/workspaces/{id}/agent/sessions/{sid}/prompts/pop", c.handlePostWorkspaceAgentSessionPromptPop)
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent/sessions/{sid}/summarize", c.handlePostWorkspaceAgentSessionSummarize)
 	mux.HandleFunc("POST /v1/workspaces/{id}/agent/sessions/{sid}/shell", c.handlePostWorkspaceAgentSessionShell)
 	mux.HandleFunc("GET /v1/workspaces/{id}/agent/default-small-model", c.handleGetWorkspaceAgentDefaultSmallModel)

--- a/internal/server/sessions_isbusy_test.go
+++ b/internal/server/sessions_isbusy_test.go
@@ -44,9 +44,9 @@ func (s *stubCoordinator) IsBusy() bool  { return false }
 func (s *stubCoordinator) IsSessionBusy(id string) bool {
 	return s.busy[id]
 }
-func (s *stubCoordinator) QueuedPrompts(string) int          { return 0 }
-func (s *stubCoordinator) QueuedPromptsList(string) []string { return nil }
-func (s *stubCoordinator) ClearQueue(string)                 {}
+func (s *stubCoordinator) QueuedPrompts(string) int                { return 0 }
+func (s *stubCoordinator) QueuedPromptsList(string) []string       { return nil }
+func (s *stubCoordinator) ClearQueue(string) []agent.QueuedMessage { return nil }
 func (s *stubCoordinator) PopQueuedMessage(string) (agent.QueuedMessage, bool) {
 	return agent.QueuedMessage{}, false
 }

--- a/internal/server/sessions_isbusy_test.go
+++ b/internal/server/sessions_isbusy_test.go
@@ -47,6 +47,10 @@ func (s *stubCoordinator) IsSessionBusy(id string) bool {
 func (s *stubCoordinator) QueuedPrompts(string) int          { return 0 }
 func (s *stubCoordinator) QueuedPromptsList(string) []string { return nil }
 func (s *stubCoordinator) ClearQueue(string)                 {}
+func (s *stubCoordinator) PopQueuedMessage(string) (agent.QueuedMessage, bool) {
+	return agent.QueuedMessage{}, false
+}
+
 func (s *stubCoordinator) Summarize(context.Context, string) error {
 	return nil
 }

--- a/internal/swagger/docs.go
+++ b/internal/swagger/docs.go
@@ -626,6 +626,53 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaces/{id}/agent/sessions/{sid}/prompts/pop": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agent"
+                ],
+                "summary": "Pop newest queued message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "sid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.PopQueuedMessageResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/agent/sessions/{sid}/prompts/queued": {
             "get": {
                 "produces": [
@@ -1579,6 +1626,105 @@ const docTemplate = `{
                 }
             }
         },
+        "/workspaces/{id}/mcp/auth": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Authenticate an MCP server",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MCP name request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPNameRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPAuthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/mcp/auth-url": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Get MCP OAuth authorization URL",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "MCP server name",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPAuthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/mcp/docker/disable": {
             "post": {
                 "tags": [
@@ -1688,6 +1834,49 @@ const docTemplate = `{
                         "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/mcp/pending-auth": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Get MCP servers pending OAuth",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/proto.MCPPendingAuthServer"
+                            }
                         }
                     },
                     "404": {
@@ -3562,6 +3751,9 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "is_summary_message": {
+                    "type": "boolean"
+                },
                 "model": {
                     "type": "string"
                 },
@@ -3924,6 +4116,15 @@ const docTemplate = `{
                 }
             }
         },
+        "proto.MCPAuthResponse": {
+            "type": "object",
+            "properties": {
+                "auth_url": {
+                    "description": "AuthURL is the OAuth authorization URL the user must visit, when\nthe flow is still in progress.",
+                    "type": "string"
+                }
+            }
+        },
         "proto.MCPClientInfo": {
             "type": "object",
             "properties": {
@@ -3977,6 +4178,17 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.MCPPendingAuthServer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
                     "type": "string"
                 }
             }
@@ -4134,6 +4346,17 @@ const docTemplate = `{
                 }
             }
         },
+        "proto.PopQueuedMessageResponse": {
+            "type": "object",
+            "properties": {
+                "found": {
+                    "type": "boolean"
+                },
+                "message": {
+                    "$ref": "#/definitions/proto.QueuedMessage"
+                }
+            }
+        },
         "proto.ProjectInitPromptResponse": {
             "type": "object",
             "properties": {
@@ -4195,6 +4418,20 @@ const docTemplate = `{
                 },
                 "yes": {
                     "type": "boolean"
+                }
+            }
+        },
+        "proto.QueuedMessage": {
+            "type": "object",
+            "properties": {
+                "attachments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.Attachment"
+                    }
+                },
+                "prompt": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/swagger/docs.go
+++ b/internal/swagger/docs.go
@@ -537,6 +537,9 @@ const docTemplate = `{
         },
         "/workspaces/{id}/agent/sessions/{sid}/prompts/clear": {
             "post": {
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "agent"
                 ],
@@ -559,7 +562,10 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.ClearQueueResponse"
+                        }
                     },
                     "404": {
                         "description": "Not Found",
@@ -3946,6 +3952,17 @@ const docTemplate = `{
                 },
                 "mime_type": {
                     "type": "string"
+                }
+            }
+        },
+        "proto.ClearQueueResponse": {
+            "type": "object",
+            "properties": {
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.QueuedMessage"
+                    }
                 }
             }
         },

--- a/internal/swagger/swagger.json
+++ b/internal/swagger/swagger.json
@@ -530,6 +530,9 @@
         },
         "/workspaces/{id}/agent/sessions/{sid}/prompts/clear": {
             "post": {
+                "produces": [
+                    "application/json"
+                ],
                 "tags": [
                     "agent"
                 ],
@@ -552,7 +555,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.ClearQueueResponse"
+                        }
                     },
                     "404": {
                         "description": "Not Found",
@@ -3939,6 +3945,17 @@
                 },
                 "mime_type": {
                     "type": "string"
+                }
+            }
+        },
+        "proto.ClearQueueResponse": {
+            "type": "object",
+            "properties": {
+                "messages": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.QueuedMessage"
+                    }
                 }
             }
         },

--- a/internal/swagger/swagger.json
+++ b/internal/swagger/swagger.json
@@ -619,6 +619,53 @@
                 }
             }
         },
+        "/workspaces/{id}/agent/sessions/{sid}/prompts/pop": {
+            "post": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agent"
+                ],
+                "summary": "Pop newest queued message",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Session ID",
+                        "name": "sid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.PopQueuedMessageResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/agent/sessions/{sid}/prompts/queued": {
             "get": {
                 "produces": [
@@ -1572,6 +1619,105 @@
                 }
             }
         },
+        "/workspaces/{id}/mcp/auth": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Authenticate an MCP server",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "MCP name request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPNameRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPAuthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/mcp/auth-url": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Get MCP OAuth authorization URL",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "MCP server name",
+                        "name": "name",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/proto.MCPAuthResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
         "/workspaces/{id}/mcp/docker/disable": {
             "post": {
                 "tags": [
@@ -1681,6 +1827,49 @@
                         "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/proto.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/workspaces/{id}/mcp/pending-auth": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "mcp"
+                ],
+                "summary": "Get MCP servers pending OAuth",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Workspace ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/proto.MCPPendingAuthServer"
+                            }
                         }
                     },
                     "404": {
@@ -3555,6 +3744,9 @@
                 "id": {
                     "type": "string"
                 },
+                "is_summary_message": {
+                    "type": "boolean"
+                },
                 "model": {
                     "type": "string"
                 },
@@ -3917,6 +4109,15 @@
                 }
             }
         },
+        "proto.MCPAuthResponse": {
+            "type": "object",
+            "properties": {
+                "auth_url": {
+                    "description": "AuthURL is the OAuth authorization URL the user must visit, when\nthe flow is still in progress.",
+                    "type": "string"
+                }
+            }
+        },
         "proto.MCPClientInfo": {
             "type": "object",
             "properties": {
@@ -3970,6 +4171,17 @@
             "type": "object",
             "properties": {
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "proto.MCPPendingAuthServer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "url": {
                     "type": "string"
                 }
             }
@@ -4127,6 +4339,17 @@
                 }
             }
         },
+        "proto.PopQueuedMessageResponse": {
+            "type": "object",
+            "properties": {
+                "found": {
+                    "type": "boolean"
+                },
+                "message": {
+                    "$ref": "#/definitions/proto.QueuedMessage"
+                }
+            }
+        },
         "proto.ProjectInitPromptResponse": {
             "type": "object",
             "properties": {
@@ -4188,6 +4411,20 @@
                 },
                 "yes": {
                     "type": "boolean"
+                }
+            }
+        },
+        "proto.QueuedMessage": {
+            "type": "object",
+            "properties": {
+                "attachments": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/proto.Attachment"
+                    }
+                },
+                "prompt": {
+                    "type": "string"
                 }
             }
         },

--- a/internal/swagger/swagger.yaml
+++ b/internal/swagger/swagger.yaml
@@ -417,6 +417,8 @@ definitions:
         type: integer
       id:
         type: string
+      is_summary_message:
+        type: boolean
       model:
         type: string
       parts:
@@ -657,6 +659,14 @@ definitions:
       path:
         type: string
     type: object
+  proto.MCPAuthResponse:
+    properties:
+      auth_url:
+        description: |-
+          AuthURL is the OAuth authorization URL the user must visit, when
+          the flow is still in progress.
+        type: string
+    type: object
   proto.MCPClientInfo:
     properties:
       connected_at:
@@ -692,6 +702,13 @@ definitions:
   proto.MCPNameRequest:
     properties:
       name:
+        type: string
+    type: object
+  proto.MCPPendingAuthServer:
+    properties:
+      name:
+        type: string
+      url:
         type: string
     type: object
   proto.MCPPrompt:
@@ -800,6 +817,13 @@ definitions:
       skip:
         type: boolean
     type: object
+  proto.PopQueuedMessageResponse:
+    properties:
+      found:
+        type: boolean
+      message:
+        $ref: '#/definitions/proto.QueuedMessage'
+    type: object
   proto.ProjectInitPromptResponse:
     properties:
       prompt:
@@ -840,6 +864,15 @@ definitions:
         type: array
       "yes":
         type: boolean
+    type: object
+  proto.QueuedMessage:
+    properties:
+      attachments:
+        items:
+          $ref: '#/definitions/proto.Attachment'
+        type: array
+      prompt:
+        type: string
     type: object
   proto.ReadSkillRequest:
     properties:
@@ -1437,6 +1470,37 @@ paths:
           schema:
             $ref: '#/definitions/proto.Error'
       summary: List queued prompts
+      tags:
+      - agent
+  /workspaces/{id}/agent/sessions/{sid}/prompts/pop:
+    post:
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Session ID
+        in: path
+        name: sid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/proto.PopQueuedMessageResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Pop newest queued message
       tags:
       - agent
   /workspaces/{id}/agent/sessions/{sid}/prompts/queued:
@@ -2063,6 +2127,71 @@ paths:
       summary: Stop all LSP servers
       tags:
       - lsp
+  /workspaces/{id}/mcp/auth:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: MCP name request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/proto.MCPNameRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/proto.MCPAuthResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Authenticate an MCP server
+      tags:
+      - mcp
+  /workspaces/{id}/mcp/auth-url:
+    get:
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: MCP server name
+        in: query
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/proto.MCPAuthResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Get MCP OAuth authorization URL
+      tags:
+      - mcp
   /workspaces/{id}/mcp/docker/disable:
     post:
       parameters:
@@ -2143,6 +2272,34 @@ paths:
           schema:
             $ref: '#/definitions/proto.Error'
       summary: Get MCP prompt
+      tags:
+      - mcp
+  /workspaces/{id}/mcp/pending-auth:
+    get:
+      parameters:
+      - description: Workspace ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/proto.MCPPendingAuthServer'
+            type: array
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/proto.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/proto.Error'
+      summary: Get MCP servers pending OAuth
       tags:
       - mcp
   /workspaces/{id}/mcp/prompts:

--- a/internal/swagger/swagger.yaml
+++ b/internal/swagger/swagger.yaml
@@ -551,6 +551,13 @@ definitions:
       mime_type:
         type: string
     type: object
+  proto.ClearQueueResponse:
+    properties:
+      messages:
+        items:
+          $ref: '#/definitions/proto.QueuedMessage'
+        type: array
+    type: object
   proto.ConfigCompactRequest:
     properties:
       enabled:
@@ -1425,9 +1432,13 @@ paths:
         name: sid
         required: true
         type: string
+      produces:
+      - application/json
       responses:
         "200":
           description: OK
+          schema:
+            $ref: '#/definitions/proto.ClearQueueResponse'
         "404":
           description: Not Found
           schema:

--- a/internal/ui/attachments/attachments.go
+++ b/internal/ui/attachments/attachments.go
@@ -39,6 +39,11 @@ type Attachments struct {
 func (m *Attachments) List() []message.Attachment { return m.list }
 func (m *Attachments) Reset()                     { m.list = nil }
 
+// Deleting reports whether delete mode is armed, i.e. the component is
+// waiting for the index of the attachment to remove. Callers need this to
+// avoid shadowing the Escape that backs out of that prompt.
+func (m *Attachments) Deleting() bool { return m.deleting }
+
 func (m *Attachments) Update(msg tea.Msg) bool {
 	switch msg := msg.(type) {
 	case message.Attachment:

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -46,14 +46,18 @@ type ActionSelectModel struct {
 
 // Messages for commands
 type (
-	ActionNewSession              struct{}
-	ActionToggleHelp              struct{}
-	ActionToggleCompactMode       struct{}
-	ActionToggleThinking          struct{}
-	ActionTogglePills             struct{}
-	ActionExternalEditor          struct{}
-	ActionToggleYoloMode          struct{}
-	ActionToggleNotifications     struct{}
+	ActionNewSession          struct{}
+	ActionToggleHelp          struct{}
+	ActionToggleCompactMode   struct{}
+	ActionToggleThinking      struct{}
+	ActionTogglePills         struct{}
+	ActionExternalEditor      struct{}
+	ActionToggleYoloMode      struct{}
+	ActionToggleNotifications struct{}
+	// ActionClearQueue discards every prompt queued for the current
+	// session. Popping (shift+up) restores one queued message at a time, so
+	// this is the only way to discard a queue built up by accident.
+	ActionClearQueue              struct{}
 	ActionSelectNotificationStyle struct {
 		Style string
 	}

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -55,8 +55,10 @@ type (
 	ActionToggleYoloMode      struct{}
 	ActionToggleNotifications struct{}
 	// ActionClearQueue discards every prompt queued for the current
-	// session. Popping (shift+up) restores one queued message at a time, so
-	// this is the only way to discard a queue built up by accident.
+	// session. It is the destructive discard: esc moves the whole queue
+	// into the input field and shift+up moves one message at a time, so
+	// this is the way to throw away a queue built up by accident instead
+	// of having it pasted back into the editor.
 	ActionClearQueue              struct{}
 	ActionSelectNotificationStyle struct {
 		Style string

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -527,6 +527,13 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		commands = append(commands, NewCommandItem(c.com.Styles, "toggle_pills", label, "ctrl+t", ActionTogglePills{}))
 	}
 
+	// Queued prompts are only removable one at a time (shift+up pops the
+	// newest back into the editor), so offer a bulk discard whenever the
+	// queue is non-empty.
+	if c.hasQueue {
+		commands = append(commands, NewCommandItem(c.com.Styles, "clear_queue", "Clear Queued Messages", "", ActionClearQueue{}))
+	}
+
 	// Add a command for selecting notification style via picker dialog.
 	notificationLabel := "Notification Style"
 	commands = append(commands, NewCommandItem(c.com.Styles, "select_notifications", notificationLabel, "", ActionOpenDialog{DialogID: NotificationsID}))

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -527,9 +527,6 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		commands = append(commands, NewCommandItem(c.com.Styles, "toggle_pills", label, "ctrl+t", ActionTogglePills{}))
 	}
 
-	// Queued prompts are only removable one at a time (shift+up pops the
-	// newest back into the editor), so offer a bulk discard whenever the
-	// queue is non-empty.
 	if c.hasQueue {
 		commands = append(commands, NewCommandItem(c.com.Styles, "clear_queue", "Clear Queued Messages", "", ActionClearQueue{}))
 	}

--- a/internal/ui/dialog/commands_test.go
+++ b/internal/ui/dialog/commands_test.go
@@ -31,11 +31,11 @@ func hasCommandAction(items []*CommandItem, action Action) bool {
 	return false
 }
 
-// TestDefaultCommandsClearQueueRequiresQueue pins the only bulk queue-discard
-// path the TUI has: escape is turn-scoped and preserves the queue, and
-// shift+up pops one message at a time into the editor, so the commands dialog
-// must offer a clear whenever prompts are queued — and must not offer it when
-// there is nothing to clear.
+// TestDefaultCommandsClearQueueRequiresQueue pins the only queue-discard path
+// the TUI has: esc moves the whole queue into the input field and shift+up
+// moves one message at a time, so this entry is how a queue is thrown away
+// instead of pasted back. It must be offered whenever prompts are queued —
+// and never when there is nothing to discard.
 func TestDefaultCommandsClearQueueRequiresQueue(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/dialog/commands_test.go
+++ b/internal/ui/dialog/commands_test.go
@@ -1,0 +1,52 @@
+package dialog
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+)
+
+// configWorkspace is the minimum the commands dialog needs: defaultCommands
+// reads configuration through common.Common. The embedded interface panics on
+// anything else, which is the point — building the command list must not
+// reach the workspace for anything but config.
+type configWorkspace struct {
+	workspace.Workspace
+}
+
+func (configWorkspace) Config() *config.Config { return &config.Config{} }
+
+// hasCommandAction reports whether any built command carries the action.
+func hasCommandAction(items []*CommandItem, action Action) bool {
+	for _, item := range items {
+		if item.Action() == action {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDefaultCommandsClearQueueRequiresQueue pins the only bulk queue-discard
+// path the TUI has: escape is turn-scoped and preserves the queue, and
+// shift+up pops one message at a time into the editor, so the commands dialog
+// must offer a clear whenever prompts are queued — and must not offer it when
+// there is nothing to clear.
+func TestDefaultCommandsClearQueueRequiresQueue(t *testing.T) {
+	t.Parallel()
+
+	s := styles.CharmtonePantera()
+	com := &common.Common{Workspace: configWorkspace{}, Styles: &s}
+
+	withQueue := &Commands{com: com, sessionID: "s1", hasSession: true, hasQueue: true}
+	require.True(t, hasCommandAction(withQueue.defaultCommands(), ActionClearQueue{}),
+		"a non-empty queue must offer a bulk clear")
+
+	withoutQueue := &Commands{com: com, sessionID: "s1", hasSession: true}
+	require.False(t, hasCommandAction(withoutQueue.defaultCommands(), ActionClearQueue{}),
+		"an empty queue must not offer a clear")
+}

--- a/internal/ui/dialog/commands_test.go
+++ b/internal/ui/dialog/commands_test.go
@@ -21,7 +21,6 @@ type configWorkspace struct {
 
 func (configWorkspace) Config() *config.Config { return &config.Config{} }
 
-// hasCommandAction reports whether any built command carries the action.
 func hasCommandAction(items []*CommandItem, action Action) bool {
 	for _, item := range items {
 		if item.Action() == action {

--- a/internal/ui/model/history.go
+++ b/internal/ui/model/history.go
@@ -89,11 +89,18 @@ func (m *UI) handleHistoryDown(msg tea.Msg) tea.Cmd {
 	return m.updateTextarea(msg)
 }
 
+// isBrowsingHistory reports whether the editor is currently showing a
+// message from prompt history rather than the user's own draft, which is
+// the state Escape leaves by restoring the draft.
+func (m *UI) isBrowsingHistory() bool {
+	return m.promptHistory.index >= 0
+}
+
 // handleHistoryEscape handles escape for exiting history navigation.
 func (m *UI) handleHistoryEscape(msg tea.Msg) tea.Cmd {
 	prevHeight := m.textarea.Height()
 	// Return to current draft when browsing history.
-	if m.promptHistory.index >= 0 {
+	if m.isBrowsingHistory() {
 		m.promptHistory.index = -1
 		m.textarea.Reset()
 		m.textarea.InsertString(m.promptHistory.draft)

--- a/internal/ui/model/history.go
+++ b/internal/ui/model/history.go
@@ -89,9 +89,6 @@ func (m *UI) handleHistoryDown(msg tea.Msg) tea.Cmd {
 	return m.updateTextarea(msg)
 }
 
-// isBrowsingHistory reports whether the editor is currently showing a
-// message from prompt history rather than the user's own draft, which is
-// the state Escape leaves by restoring the draft.
 func (m *UI) isBrowsingHistory() bool {
 	return m.promptHistory.index >= 0
 }

--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -4,13 +4,14 @@ import "charm.land/bubbles/v2/key"
 
 type KeyMap struct {
 	Editor struct {
-		SendMessage key.Binding
-		OpenEditor  key.Binding
-		Newline     key.Binding
-		AddImage    key.Binding
-		PasteImage  key.Binding
-		MentionFile key.Binding
-		Commands    key.Binding
+		SendMessage      key.Binding
+		OpenEditor       key.Binding
+		Newline          key.Binding
+		AddImage         key.Binding
+		PasteImage       key.Binding
+		MentionFile      key.Binding
+		Commands         key.Binding
+		PopQueuedMessage key.Binding
 
 		// Attachments key maps
 		AttachmentDeleteMode key.Binding
@@ -137,6 +138,9 @@ func DefaultKeyMap() KeyMap {
 	km.Editor.Commands = key.NewBinding(
 		key.WithKeys("/"),
 		key.WithHelp("/", "commands"),
+	)
+	km.Editor.PopQueuedMessage = key.NewBinding(
+		key.WithKeys("shift+up", "alt+up"),
 	)
 	km.Editor.AttachmentDeleteMode = key.NewBinding(
 		key.WithKeys("ctrl+r"),

--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -141,6 +141,7 @@ func DefaultKeyMap() KeyMap {
 	)
 	km.Editor.PopQueuedMessage = key.NewBinding(
 		key.WithKeys("shift+up", "alt+up"),
+		key.WithHelp("shift+↑", "edit last queued message"),
 	)
 	km.Editor.AttachmentDeleteMode = key.NewBinding(
 		key.WithKeys("ctrl+r"),

--- a/internal/ui/model/pill_border_test.go
+++ b/internal/ui/model/pill_border_test.go
@@ -1,10 +1,12 @@
 package model
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // roundedBorderRunes are chars that only appear when a pill has a visible
@@ -194,6 +196,63 @@ func TestPillsRowEscapeQueueHint(t *testing.T) {
 				if strings.Contains(u.pillsView, absent) {
 					t.Fatalf("expected %q to be absent from pills view:\n%s", absent, u.pillsView)
 				}
+			}
+		})
+	}
+}
+
+func TestExpandedQueueListEscapesControlsWithoutHidingItems(t *testing.T) {
+	u := newTestUI()
+	u.session = &session.Session{ID: "s1"}
+	u.promptQueueItems = []string{
+		"first line\r\nsecond line",
+		"tab\tvalue",
+		"message after controls",
+	}
+	u.promptQueue = len(u.promptQueueItems)
+	u.pillsExpanded = true
+	u.focusedPillSection = pillSectionQueue
+	u.updateLayoutAndSize()
+	u.renderPills()
+
+	view := ansi.Strip(u.pillsView)
+	var queueLines []string
+	for line := range strings.SplitSeq(view, "\n") {
+		if strings.Contains(line, "•") {
+			queueLines = append(queueLines, line)
+		}
+	}
+
+	if len(queueLines) != len(u.promptQueueItems) {
+		t.Fatalf("rendered %d queue rows, want %d:\n%s",
+			len(queueLines), len(u.promptQueueItems), view)
+	}
+	if !strings.Contains(queueLines[0], `first line\nsecond line`) {
+		t.Fatalf("expected escaped newline in first queue row: %q", queueLines[0])
+	}
+	if !strings.Contains(queueLines[1], `tab\tvalue`) {
+		t.Fatalf("expected escaped tab in second queue row: %q", queueLines[1])
+	}
+	if !strings.Contains(queueLines[2], "message after controls") {
+		t.Fatalf("expected final queued message to remain visible: %q", queueLines[2])
+	}
+}
+
+func TestQueueListFitsLiveContentWidth(t *testing.T) {
+	styles := newTestUI().com.Styles
+	item := "a queue message that must be truncated to fit the viewport"
+
+	for _, width := range []int{0, 1, 8, 40, 80, 100, 140} {
+		t.Run(fmt.Sprintf("width %d", width), func(t *testing.T) {
+			view := queueList([]string{item}, styles, width)
+			if got := ansi.StringWidth(view); got > width && width >= 4 {
+				t.Fatalf("queue row width = %d, want <= %d: %q", got, width, ansi.Strip(view))
+			}
+			if width < 4 && ansi.Strip(view) != "  • " {
+				t.Fatalf("narrow queue row = %q, want bullet only", ansi.Strip(view))
+			}
+			if width == 40 && !strings.HasSuffix(ansi.Strip(view), "…") {
+				t.Fatalf("truncated queue row lacks ellipsis: %q", ansi.Strip(view))
 			}
 		})
 	}

--- a/internal/ui/model/pill_border_test.go
+++ b/internal/ui/model/pill_border_test.go
@@ -142,3 +142,39 @@ func TestPillsRowPopHint(t *testing.T) {
 		})
 	}
 }
+
+// TestPillsRowClearQueueHint verifies the footer advertises the queue
+// clear only when esc actually clears: a queue must exist and the agent
+// must be idle. While the agent is busy, esc cancels the active turn and
+// deliberately preserves the queue, so advertising it there would point at
+// a binding that does something else.
+func TestPillsRowClearQueueHint(t *testing.T) {
+	cases := []struct {
+		name     string
+		queue    int
+		busy     bool
+		wantHint bool
+	}{
+		{"idle with queue", 2, false, true},
+		{"busy with queue", 2, true, false},
+		{"idle without queue", 0, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := newTestUI()
+			u.session = &session.Session{
+				ID:    "s1",
+				Todos: []session.Todo{{Content: "a", Status: session.TodoStatusPending}},
+			}
+			u.promptQueue = tc.queue
+			u.agentBusyCache.set(tc.busy)
+			u.updateLayoutAndSize()
+			u.renderPills()
+
+			hasHint := strings.Contains(u.pillsView, "clear the queue")
+			if hasHint != tc.wantHint {
+				t.Fatalf("clear hint presence = %v, want %v:\n%s", hasHint, tc.wantHint, u.pillsView)
+			}
+		})
+	}
+}

--- a/internal/ui/model/pill_border_test.go
+++ b/internal/ui/model/pill_border_test.go
@@ -143,21 +143,22 @@ func TestPillsRowPopHint(t *testing.T) {
 	}
 }
 
-// TestPillsRowClearQueueHint verifies the footer advertises the queue
-// clear only when esc actually clears: a queue must exist and the agent
-// must be idle. While the agent is busy, esc cancels the active turn and
-// deliberately preserves the queue, so advertising it there would point at
-// a binding that does something else.
-func TestPillsRowClearQueueHint(t *testing.T) {
+// TestPillsRowEscapeQueueHint verifies the footer advertises the Escape
+// queue move whenever a queue exists, with wording that matches the gesture:
+// a single press while the agent is idle, the confirming press of the
+// double-press cancel while it is busy. With no queue there is nothing to
+// advertise.
+func TestPillsRowEscapeQueueHint(t *testing.T) {
 	cases := []struct {
 		name     string
 		queue    int
 		busy     bool
-		wantHint bool
+		wantKey  string
+		wantDesc string
 	}{
-		{"idle with queue", 2, false, true},
-		{"busy with queue", 2, true, false},
-		{"idle without queue", 0, false, false},
+		{"idle with queue", 2, false, "esc", "pop all messages"},
+		{"busy with queue", 2, true, "esc esc", "cancel + pop all messages"},
+		{"idle without queue", 0, false, "", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -171,9 +172,17 @@ func TestPillsRowClearQueueHint(t *testing.T) {
 			u.updateLayoutAndSize()
 			u.renderPills()
 
-			hasHint := strings.Contains(u.pillsView, "clear the queue")
-			if hasHint != tc.wantHint {
-				t.Fatalf("clear hint presence = %v, want %v:\n%s", hasHint, tc.wantHint, u.pillsView)
+			if tc.wantDesc == "" {
+				if strings.Contains(u.pillsView, "pop all messages") {
+					t.Fatalf("expected no escape hint without a queue:\n%s", u.pillsView)
+				}
+				return
+			}
+			if !strings.Contains(u.pillsView, tc.wantKey) {
+				t.Fatalf("expected %q in pills view:\n%s", tc.wantKey, u.pillsView)
+			}
+			if !strings.Contains(u.pillsView, tc.wantDesc) {
+				t.Fatalf("expected %q in pills view:\n%s", tc.wantDesc, u.pillsView)
 			}
 		})
 	}

--- a/internal/ui/model/pill_border_test.go
+++ b/internal/ui/model/pill_border_test.go
@@ -201,13 +201,46 @@ func TestPillsRowEscapeQueueHint(t *testing.T) {
 	}
 }
 
-func TestPillsRowWrapsBusyEscapeHintBelowPills(t *testing.T) {
+func TestPillsRowWrapsBusyEscapeHintBesidePills(t *testing.T) {
+	u := newTestUI()
+	u.width = 80
+	u.session = &session.Session{ID: "s1"}
+	u.promptQueue = 1
+	u.agentBusyCache.set(true)
+	u.updateLayoutAndSize()
+	u.renderPills()
+
+	view := ansi.Strip(u.pillsView)
+	lines := strings.Split(view, "\n")
+	if got, want := len(lines), pillHeightWithBorder; got != want {
+		t.Fatalf("rendered line count = %d, want %d:\n%s", got, want, view)
+	}
+	ctrlLine := lineContaining(lines, "ctrl+t")
+	escapeLine := lineContaining(lines, "esc esc")
+	if ctrlLine < 0 || escapeLine < 0 {
+		t.Fatalf("expected wrapped queue hints in pills view:\n%s", view)
+	}
+	if !strings.Contains(lines[escapeLine], "╰") {
+		t.Fatalf("escape hint is not beside the pill bottom border: %q", lines[escapeLine])
+	}
+	ctrlColumn := ansi.StringWidth(lines[ctrlLine][:strings.Index(lines[ctrlLine], "ctrl+t")])
+	escapeColumn := ansi.StringWidth(lines[escapeLine][:strings.Index(lines[escapeLine], "esc esc")])
+	if escapeColumn != ctrlColumn {
+		t.Fatalf("escape hint column = %d, want ctrl+t column %d:\n%s",
+			escapeColumn, ctrlColumn, view)
+	}
+	if strings.HasPrefix(strings.TrimLeft(lines[escapeLine], " "), "esc esc") {
+		t.Fatalf("escape hint started at the panel's left edge: %q", lines[escapeLine])
+	}
+}
+
+func TestPillsRowWideHintFallsBackBelowPills(t *testing.T) {
 	u := newTestUI()
 	u.width = 120
 	u.session = &session.Session{
 		ID: "s1",
 		Todos: []session.Todo{{
-			Content: "Short task",
+			Content: "A task long enough to consume the available pill row",
 			Status:  session.TodoStatusInProgress,
 		}},
 	}
@@ -216,16 +249,19 @@ func TestPillsRowWrapsBusyEscapeHintBelowPills(t *testing.T) {
 	u.updateLayoutAndSize()
 	u.renderPills()
 
-	lines := strings.Split(ansi.Strip(u.pillsView), "\n")
-	ctrlLine := lineContaining(lines, "ctrl+t")
-	popLine := lineContaining(lines, "shift/alt+up")
-	escapeLine := lineContaining(lines, "esc esc")
-	if ctrlLine < 0 || popLine < 0 || escapeLine < 0 {
-		t.Fatalf("expected all queue hints in pills view:\n%s", ansi.Strip(u.pillsView))
+	view := ansi.Strip(u.pillsView)
+	lines := strings.Split(view, "\n")
+	escapeLine := lineContaining(lines, "esc esc cancel + pop all messages")
+	if escapeLine < pillHeightWithBorder {
+		t.Fatalf("escape hint line = %d, want below the pill block:\n%s", escapeLine, view)
 	}
-	if escapeLine <= ctrlLine || escapeLine <= popLine {
-		t.Fatalf("escape hint line = %d, want below ctrl+t line %d and pop line %d:\n%s",
-			escapeLine, ctrlLine, popLine, ansi.Strip(u.pillsView))
+	firstHint := strings.Index(lines[escapeLine], "ctrl+t")
+	if firstHint < 0 {
+		t.Fatalf("fallback line does not contain the first hint:\n%s", view)
+	}
+	if got, want := ansi.StringWidth(lines[escapeLine][:firstHint]), 3; got != want {
+		t.Fatalf("fallback hint column = %d, want panel content column %d:\n%s",
+			got, want, view)
 	}
 }
 

--- a/internal/ui/model/pill_border_test.go
+++ b/internal/ui/model/pill_border_test.go
@@ -99,3 +99,46 @@ func TestEffectiveFocusedSectionFallsThrough(t *testing.T) {
 		})
 	}
 }
+
+// TestPillsRowPopHint verifies that the pills-row footer advertises the
+// queued-message pop binding exactly while a queue exists — in both collapsed
+// and expanded states — and omits it when only todos drive the pills row.
+func TestPillsRowPopHint(t *testing.T) {
+	todos := []session.Todo{{Content: "a", Status: session.TodoStatusPending}}
+
+	cases := []struct {
+		name           string
+		expanded       bool
+		focusedSection pillSection
+		todos          []session.Todo
+		queue          int
+		wantHint       bool
+	}{
+		{"collapsed queue only", false, pillSectionQueue, nil, 2, true},
+		{"expanded queue only", true, pillSectionQueue, nil, 2, true},
+		{"collapsed queue+todos", false, pillSectionTodos, todos, 2, true},
+		{"expanded todos focused queue+todos", true, pillSectionTodos, todos, 2, true},
+		{"no queue collapsed", false, pillSectionTodos, todos, 0, false},
+		{"no queue expanded", true, pillSectionTodos, todos, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			u := newTestUI()
+			u.session = &session.Session{ID: "s1", Todos: tc.todos}
+			u.promptQueue = tc.queue
+			u.pillsExpanded = tc.expanded
+			u.focusedPillSection = tc.focusedSection
+			u.updateLayoutAndSize()
+			u.renderPills()
+
+			if !strings.Contains(u.pillsView, "ctrl+t") {
+				t.Fatalf("expected the ctrl+t toggle hint in pills view:\n%s", u.pillsView)
+			}
+			hasHint := strings.Contains(u.pillsView, "shift/alt+up") &&
+				strings.Contains(u.pillsView, "pop message")
+			if hasHint != tc.wantHint {
+				t.Fatalf("pop hint presence = %v, want %v:\n%s", hasHint, tc.wantHint, u.pillsView)
+			}
+		})
+	}
+}

--- a/internal/ui/model/pill_border_test.go
+++ b/internal/ui/model/pill_border_test.go
@@ -201,6 +201,99 @@ func TestPillsRowEscapeQueueHint(t *testing.T) {
 	}
 }
 
+func TestPillsRowWrapsBusyEscapeHintBelowPills(t *testing.T) {
+	u := newTestUI()
+	u.width = 120
+	u.session = &session.Session{
+		ID: "s1",
+		Todos: []session.Todo{{
+			Content: "Short task",
+			Status:  session.TodoStatusInProgress,
+		}},
+	}
+	u.promptQueue = 3
+	u.agentBusyCache.set(true)
+	u.updateLayoutAndSize()
+	u.renderPills()
+
+	lines := strings.Split(ansi.Strip(u.pillsView), "\n")
+	ctrlLine := lineContaining(lines, "ctrl+t")
+	popLine := lineContaining(lines, "shift/alt+up")
+	escapeLine := lineContaining(lines, "esc esc")
+	if ctrlLine < 0 || popLine < 0 || escapeLine < 0 {
+		t.Fatalf("expected all queue hints in pills view:\n%s", ansi.Strip(u.pillsView))
+	}
+	if escapeLine <= ctrlLine || escapeLine <= popLine {
+		t.Fatalf("escape hint line = %d, want below ctrl+t line %d and pop line %d:\n%s",
+			escapeLine, ctrlLine, popLine, ansi.Strip(u.pillsView))
+	}
+}
+
+func TestPillsRowWrappedHeightMatchesRenderedView(t *testing.T) {
+	for _, width := range []int{60, 80, 100, 120, 140} {
+		for _, withTodo := range []bool{false, true} {
+			for _, busy := range []bool{false, true} {
+				for _, expanded := range []bool{false, true} {
+					name := fmt.Sprintf("width=%d/todo=%t/busy=%t/expanded=%t",
+						width, withTodo, busy, expanded)
+					t.Run(name, func(t *testing.T) {
+						u := newTestUI()
+						u.width = width
+						u.session = &session.Session{ID: "s1"}
+						if withTodo {
+							u.session.Todos = []session.Todo{{
+								Content: "A task long enough to consume the available pill row",
+								Status:  session.TodoStatusInProgress,
+							}}
+						}
+						u.promptQueueItems = []string{"first", "second", "third"}
+						u.promptQueue = len(u.promptQueueItems)
+						u.agentBusyCache.set(busy)
+						u.pillsExpanded = expanded
+						u.focusedPillSection = pillSectionQueue
+						u.updateLayoutAndSize()
+						u.renderPills()
+
+						view := ansi.Strip(u.pillsView)
+						lines := strings.Split(view, "\n")
+						if got, want := len(lines), u.layout.pills.Dy(); got != want {
+							t.Fatalf("rendered line count = %d, pills height = %d:\n%s", got, want, view)
+						}
+						for i, line := range lines {
+							if got := ansi.StringWidth(line); got > u.layout.pills.Dx() {
+								t.Fatalf("line %d width = %d, pills width = %d: %q",
+									i, got, u.layout.pills.Dx(), line)
+							}
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestPillsRowWideIdleQueueDoesNotWrap(t *testing.T) {
+	u := newTestUI()
+	u.session = &session.Session{ID: "s1"}
+	u.promptQueue = 3
+	u.updateLayoutAndSize()
+	u.renderPills()
+
+	if got, want := len(strings.Split(ansi.Strip(u.pillsView), "\n")), pillHeightWithBorder; got != want {
+		t.Fatalf("rendered line count = %d, want %d without wrapping:\n%s",
+			got, want, ansi.Strip(u.pillsView))
+	}
+}
+
+func lineContaining(lines []string, text string) int {
+	for i, line := range lines {
+		if strings.Contains(line, text) {
+			return i
+		}
+	}
+	return -1
+}
+
 func TestExpandedQueueListEscapesControlsWithoutHidingItems(t *testing.T) {
 	u := newTestUI()
 	u.session = &session.Session{ID: "s1"}

--- a/internal/ui/model/pill_border_test.go
+++ b/internal/ui/model/pill_border_test.go
@@ -155,10 +155,16 @@ func TestPillsRowEscapeQueueHint(t *testing.T) {
 		busy     bool
 		wantKey  string
 		wantDesc string
+		// absent pins wording the case must *not* render. The idle wording
+		// is a substring of the busy wording ("esc esc" contains "esc",
+		// "cancel + pop all messages" contains "pop all messages"), so
+		// containment alone is satisfied by the busy rendering and the
+		// idle/busy distinction could be deleted undetected.
+		absent []string
 	}{
-		{"idle with queue", 2, false, "esc", "pop all messages"},
-		{"busy with queue", 2, true, "esc esc", "cancel + pop all messages"},
-		{"idle without queue", 0, false, "", ""},
+		{"idle with queue", 2, false, "esc", "pop all messages", []string{"esc esc", "cancel +"}},
+		{"busy with queue", 2, true, "esc esc", "cancel + pop all messages", nil},
+		{"idle without queue", 0, false, "", "", nil},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -183,6 +189,11 @@ func TestPillsRowEscapeQueueHint(t *testing.T) {
 			}
 			if !strings.Contains(u.pillsView, tc.wantDesc) {
 				t.Fatalf("expected %q in pills view:\n%s", tc.wantDesc, u.pillsView)
+			}
+			for _, absent := range tc.absent {
+				if strings.Contains(u.pillsView, absent) {
+					t.Fatalf("expected %q to be absent from pills view:\n%s", absent, u.pillsView)
+				}
 			}
 		})
 	}

--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -133,8 +133,6 @@ func escapeQueueItem(item string) string {
 	return strings.ReplaceAll(item, "\t", `\t`)
 }
 
-// pillHelpHint renders one compact keystroke/action hint with the shared pill
-// help styling.
 func pillHelpHint(t *styles.Styles, key, desc string) string {
 	keyView := t.Pills.HelpKey.Render(key)
 	descView := t.Pills.HelpText.Render(desc)

--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -17,8 +17,6 @@ const (
 	pillHeightWithBorder = 3
 	// maxTaskDisplayLength is the maximum length of a task name in the pill.
 	maxTaskDisplayLength = 40
-	// maxQueueDisplayLength is the maximum length of a queue item in the list.
-	maxQueueDisplayLength = 60
 )
 
 // pillSection represents which section of the pills panel is focused.
@@ -111,22 +109,28 @@ func todoList(sessionTodos []session.Todo, spinnerView string, t *styles.Styles,
 }
 
 // queueList renders the expanded queue items list.
-func queueList(queueItems []string, t *styles.Styles) string {
+func queueList(queueItems []string, t *styles.Styles, width int) string {
 	if len(queueItems) == 0 {
 		return ""
 	}
 
-	var lines []string
+	prefix := t.Pills.QueueItemPrefix.Render() + " "
+	textWidth := max(width-ansi.StringWidth(prefix), 0)
+	lines := make([]string, 0, len(queueItems))
 	for _, item := range queueItems {
-		text := item
-		if ansi.StringWidth(text) > maxQueueDisplayLength {
-			text = ansi.Truncate(text, maxQueueDisplayLength-1, "…")
-		}
-		prefix := t.Pills.QueueItemPrefix.Render() + " "
+		text := escapeQueueItem(item)
+		text = ansi.Truncate(text, textWidth, "…")
 		lines = append(lines, prefix+t.Pills.QueueItemText.Render(text))
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+func escapeQueueItem(item string) string {
+	item = strings.ReplaceAll(item, "\r\n", "\n")
+	item = strings.ReplaceAll(item, "\r", "\n")
+	item = strings.ReplaceAll(item, "\n", `\n`)
+	return strings.ReplaceAll(item, "\t", `\t`)
 }
 
 // pillHelpHint renders one compact keystroke/action hint with the shared pill
@@ -340,7 +344,7 @@ func (m *UI) renderPills() {
 			// workspace_cache.go): renderPills runs on the Update/View
 			// path and must never block on a workspace round-trip.
 			if len(m.promptQueueItems) > 0 {
-				expandedList = queueList(m.promptQueueItems, t)
+				expandedList = queueList(m.promptQueueItems, t, contentWidth)
 			}
 		}
 	}

--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -129,6 +129,14 @@ func queueList(queueItems []string, t *styles.Styles) string {
 	return strings.Join(lines, "\n")
 }
 
+// pillHelpHint renders one compact keystroke/action hint with the shared pill
+// help styling.
+func pillHelpHint(t *styles.Styles, key, desc string) string {
+	keyView := t.Pills.HelpKey.Render(key)
+	descView := t.Pills.HelpText.Render(desc)
+	return lipgloss.JoinHorizontal(lipgloss.Center, keyView, " ", descView)
+}
+
 // pillsHeightReasonableTerminalHeight is the minimum terminal height at which
 // we auto-expand pills when there are incomplete todos.
 const pillsHeightReasonableTerminalHeight = 40
@@ -347,9 +355,13 @@ func (m *UI) renderPills() {
 	if m.pillsExpanded {
 		helpDesc = "close"
 	}
-	helpKey := t.Pills.HelpKey.Render("ctrl+t")
-	helpText := t.Pills.HelpText.Render(helpDesc)
-	helpHint := lipgloss.JoinHorizontal(lipgloss.Center, helpKey, " ", helpText)
+	helpHint := pillHelpHint(t, "ctrl+t", helpDesc)
+	if hasQueue {
+		// Advertise the queued-message pop while the queue exists: the pills
+		// row is visible exactly when the binding is usable.
+		popHint := pillHelpHint(t, "shift/alt+up", "pop message")
+		helpHint = lipgloss.JoinHorizontal(lipgloss.Center, helpHint, " ", popHint)
+	}
 	pillsRow = lipgloss.JoinHorizontal(lipgloss.Center, pillsRow, " ", helpHint)
 
 	pillsArea := pillsRow

--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -141,6 +141,64 @@ func pillHelpHint(t *styles.Styles, key, desc string) string {
 	return lipgloss.JoinHorizontal(lipgloss.Center, keyView, " ", descView)
 }
 
+func packPillHints(hints []string, firstBudget, contentWidth int) []string {
+	lines := []string{""}
+	budget := max(firstBudget, 0)
+	for _, hint := range hints {
+		line := lines[len(lines)-1]
+		separatorWidth := 0
+		if line != "" {
+			separatorWidth = 1
+		}
+		if ansi.StringWidth(line)+separatorWidth+ansi.StringWidth(hint) <= budget {
+			if line == "" {
+				lines[len(lines)-1] = hint
+			} else {
+				lines[len(lines)-1] = line + " " + hint
+			}
+			continue
+		}
+
+		lines = append(lines, hint)
+		budget = max(contentWidth, 0)
+	}
+	return lines
+}
+
+func (m *UI) pillsRowParts(t *styles.Styles) (string, []string) {
+	hasIncomplete := hasIncompleteTodos(m.session.Todos)
+	hasQueue := m.promptQueue > 0
+
+	inProgressIcon := t.Tool.TodoInProgressIcon.Render(styles.SpinnerIcon)
+	if m.todoIsSpinning {
+		inProgressIcon = m.todoSpinner.View()
+	}
+
+	var pills []string
+	if hasIncomplete {
+		pills = append(pills, todoPill(m.session.Todos, inProgressIcon, m.pillsExpanded, t))
+	}
+	if hasQueue {
+		pills = append(pills, queuePill(m.promptQueue, t))
+	}
+
+	helpDesc := "open"
+	if m.pillsExpanded {
+		helpDesc = "close"
+	}
+	hints := []string{pillHelpHint(t, "ctrl+t", helpDesc)}
+	if hasQueue {
+		hints = append(hints, pillHelpHint(t, "shift/alt+up", "pop message"))
+		escKey, escDesc := "esc", "pop all messages"
+		if m.isAgentBusy() {
+			escKey, escDesc = "esc esc", "cancel + pop all messages"
+		}
+		hints = append(hints, pillHelpHint(t, escKey, escDesc))
+	}
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, pills...), hints
+}
+
 // pillsHeightReasonableTerminalHeight is the minimum terminal height at which
 // we auto-expand pills when there are incomplete todos.
 const pillsHeightReasonableTerminalHeight = 40
@@ -259,7 +317,7 @@ func (m *UI) effectiveFocusedSection() pillSection {
 }
 
 // pillsAreaHeight calculates the total height needed for the pills area.
-func (m *UI) pillsAreaHeight() int {
+func (m *UI) pillsAreaHeight(width int) int {
 	if !m.hasSession() {
 		return 0
 	}
@@ -275,7 +333,12 @@ func (m *UI) pillsAreaHeight() int {
 		return 0
 	}
 
-	pillsAreaHeight := pillHeightWithBorder
+	const paddingLeft = 3
+	contentWidth := max(width-paddingLeft, 0)
+	pillsRow, hints := m.pillsRowParts(m.com.Styles)
+	firstBudget := max(contentWidth-lipgloss.Width(pillsRow)-1, 0)
+	hintLines := packPillHints(hints, firstBudget, contentWidth)
+	pillsAreaHeight := pillHeightWithBorder + len(hintLines) - 1
 	if m.pillsExpanded {
 		switch m.effectiveFocusedSection() {
 		case pillSectionTodos:
@@ -326,14 +389,7 @@ func (m *UI) renderPills() {
 	if m.todoIsSpinning {
 		inProgressIcon = m.todoSpinner.View()
 	}
-
-	var pills []string
-	if hasIncomplete {
-		pills = append(pills, todoPill(m.session.Todos, inProgressIcon, m.pillsExpanded, t))
-	}
-	if hasQueue {
-		pills = append(pills, queuePill(m.promptQueue, t))
-	}
+	pillsRow, hints := m.pillsRowParts(t)
 
 	var expandedList string
 	if m.pillsExpanded {
@@ -349,34 +405,21 @@ func (m *UI) renderPills() {
 		}
 	}
 
-	if len(pills) == 0 {
+	if pillsRow == "" {
 		return
 	}
 
-	pillsRow := lipgloss.JoinHorizontal(lipgloss.Top, pills...)
-
-	helpDesc := "open"
-	if m.pillsExpanded {
-		helpDesc = "close"
+	firstBudget := max(contentWidth-lipgloss.Width(pillsRow)-1, 0)
+	hintLines := packPillHints(hints, firstBudget, contentWidth)
+	firstLine := pillsRow
+	if hintLines[0] != "" {
+		firstLine = lipgloss.JoinHorizontal(lipgloss.Center, pillsRow, " ", hintLines[0])
 	}
-	helpHint := pillHelpHint(t, "ctrl+t", helpDesc)
-	if hasQueue {
-		// Advertise the queued-message pop while the queue exists: the pills
-		// row is visible exactly when the binding is usable.
-		popHint := pillHelpHint(t, "shift/alt+up", "pop message")
-		helpHint = lipgloss.JoinHorizontal(lipgloss.Center, helpHint, " ", popHint)
-		// esc moves the whole queue into the input field. While the agent
-		// is busy that is the confirming press of the double-press cancel
-		// gesture, which stops the turn as well, so the hint spells out
-		// both halves rather than promising a single press will do it.
-		escKey, escDesc := "esc", "pop all messages"
-		if m.isAgentBusy() {
-			escKey, escDesc = "esc esc", "cancel + pop all messages"
-		}
-		helpHint = lipgloss.JoinHorizontal(lipgloss.Center, helpHint, " ",
-			pillHelpHint(t, escKey, escDesc))
+	pillsRow = firstLine
+	if len(hintLines) > 1 {
+		pillsRow = lipgloss.JoinVertical(lipgloss.Left,
+			append([]string{pillsRow}, hintLines[1:]...)...)
 	}
-	pillsRow = lipgloss.JoinHorizontal(lipgloss.Center, pillsRow, " ", helpHint)
 
 	pillsArea := pillsRow
 	if expandedList != "" {

--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -361,6 +361,13 @@ func (m *UI) renderPills() {
 		// row is visible exactly when the binding is usable.
 		popHint := pillHelpHint(t, "shift/alt+up", "pop message")
 		helpHint = lipgloss.JoinHorizontal(lipgloss.Center, helpHint, " ", popHint)
+		// esc clears the queue only once the agent has stopped; while it
+		// is busy esc arms and carries out cancellation instead, so the
+		// hint would be advertising a binding that does something else.
+		if !m.isAgentBusy() {
+			clearHint := pillHelpHint(t, "esc", "clear the queue")
+			helpHint = lipgloss.JoinHorizontal(lipgloss.Center, helpHint, " ", clearHint)
+		}
 	}
 	pillsRow = lipgloss.JoinHorizontal(lipgloss.Center, pillsRow, " ", helpHint)
 

--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -141,7 +141,7 @@ func pillHelpHint(t *styles.Styles, key, desc string) string {
 	return lipgloss.JoinHorizontal(lipgloss.Center, keyView, " ", descView)
 }
 
-func packPillHints(hints []string, firstBudget, contentWidth int) []string {
+func packPillHints(hints []string, firstBudget, continuationBudget int) []string {
 	lines := []string{""}
 	budget := max(firstBudget, 0)
 	for _, hint := range hints {
@@ -160,9 +160,30 @@ func packPillHints(hints []string, firstBudget, contentWidth int) []string {
 		}
 
 		lines = append(lines, hint)
-		budget = max(contentWidth, 0)
+		budget = max(continuationBudget, 0)
 	}
 	return lines
+}
+
+func layoutPillHints(hints []string, sideBudget, contentWidth int) ([]string, bool) {
+	column := true
+	for _, hint := range hints {
+		if ansi.StringWidth(hint) > sideBudget {
+			column = false
+			break
+		}
+	}
+	if column {
+		return packPillHints(hints, sideBudget, sideBudget), true
+	}
+	return packPillHints(hints, sideBudget, contentWidth), false
+}
+
+func pillHintRows(lines []string, column bool) int {
+	if column {
+		return max(pillHeightWithBorder, len(lines)+1)
+	}
+	return pillHeightWithBorder + len(lines) - 1
 }
 
 func (m *UI) pillsRowParts(t *styles.Styles) (string, []string) {
@@ -336,9 +357,9 @@ func (m *UI) pillsAreaHeight(width int) int {
 	const paddingLeft = 3
 	contentWidth := max(width-paddingLeft, 0)
 	pillsRow, hints := m.pillsRowParts(m.com.Styles)
-	firstBudget := max(contentWidth-lipgloss.Width(pillsRow)-1, 0)
-	hintLines := packPillHints(hints, firstBudget, contentWidth)
-	pillsAreaHeight := pillHeightWithBorder + len(hintLines) - 1
+	sideBudget := max(contentWidth-lipgloss.Width(pillsRow)-1, 0)
+	hintLines, column := layoutPillHints(hints, sideBudget, contentWidth)
+	pillsAreaHeight := pillHintRows(hintLines, column)
 	if m.pillsExpanded {
 		switch m.effectiveFocusedSection() {
 		case pillSectionTodos:
@@ -409,16 +430,24 @@ func (m *UI) renderPills() {
 		return
 	}
 
-	firstBudget := max(contentWidth-lipgloss.Width(pillsRow)-1, 0)
-	hintLines := packPillHints(hints, firstBudget, contentWidth)
-	firstLine := pillsRow
-	if hintLines[0] != "" {
-		firstLine = lipgloss.JoinHorizontal(lipgloss.Center, pillsRow, " ", hintLines[0])
-	}
-	pillsRow = firstLine
-	if len(hintLines) > 1 {
-		pillsRow = lipgloss.JoinVertical(lipgloss.Left,
-			append([]string{pillsRow}, hintLines[1:]...)...)
+	sideBudget := max(contentWidth-lipgloss.Width(pillsRow)-1, 0)
+	hintLines, column := layoutPillHints(hints, sideBudget, contentWidth)
+	if column {
+		hintColumn := lipgloss.JoinVertical(lipgloss.Left,
+			append([]string{""}, hintLines...)...)
+		pillsRow = lipgloss.JoinHorizontal(lipgloss.Top,
+			pillsRow, " ", hintColumn)
+	} else {
+		firstLine := pillsRow
+		if hintLines[0] != "" {
+			firstLine = lipgloss.JoinHorizontal(lipgloss.Center,
+				pillsRow, " ", hintLines[0])
+		}
+		pillsRow = firstLine
+		if len(hintLines) > 1 {
+			pillsRow = lipgloss.JoinVertical(lipgloss.Left,
+				append([]string{pillsRow}, hintLines[1:]...)...)
+		}
 	}
 
 	pillsArea := pillsRow

--- a/internal/ui/model/pills.go
+++ b/internal/ui/model/pills.go
@@ -361,13 +361,16 @@ func (m *UI) renderPills() {
 		// row is visible exactly when the binding is usable.
 		popHint := pillHelpHint(t, "shift/alt+up", "pop message")
 		helpHint = lipgloss.JoinHorizontal(lipgloss.Center, helpHint, " ", popHint)
-		// esc clears the queue only once the agent has stopped; while it
-		// is busy esc arms and carries out cancellation instead, so the
-		// hint would be advertising a binding that does something else.
-		if !m.isAgentBusy() {
-			clearHint := pillHelpHint(t, "esc", "clear the queue")
-			helpHint = lipgloss.JoinHorizontal(lipgloss.Center, helpHint, " ", clearHint)
+		// esc moves the whole queue into the input field. While the agent
+		// is busy that is the confirming press of the double-press cancel
+		// gesture, which stops the turn as well, so the hint spells out
+		// both halves rather than promising a single press will do it.
+		escKey, escDesc := "esc", "pop all messages"
+		if m.isAgentBusy() {
+			escKey, escDesc = "esc esc", "cancel + pop all messages"
 		}
+		helpHint = lipgloss.JoinHorizontal(lipgloss.Center, helpHint, " ",
+			pillHelpHint(t, escKey, escDesc))
 	}
 	pillsRow = lipgloss.JoinHorizontal(lipgloss.Center, pillsRow, " ", helpHint)
 

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -516,8 +516,6 @@ func TestCancelAgentDrainsQueueOnConfirmingPress(t *testing.T) {
 	require.Zero(t, m.promptQueue)
 }
 
-// cancelHelp returns the description the help panes show for the esc/cancel
-// binding, or "" when no cancel binding is offered.
 func cancelHelp(t *testing.T, binds []key.Binding) string {
 	t.Helper()
 	for _, b := range binds {
@@ -1209,8 +1207,6 @@ func TestPopQueuedMessageEmptyResultAfterSessionSwitchKeepsCurrentQueue(t *testi
 	require.Zero(t, ws.queueListCalls, "another session's empty pop must not re-fetch this queue")
 }
 
-// helpDesc returns the description the help panes show for the binding
-// rendered under helpKey, or "" when no such binding is offered.
 func helpDesc(groups [][]key.Binding, helpKey string) string {
 	for _, group := range groups {
 		for _, b := range group {
@@ -1854,9 +1850,8 @@ func TestIdleEscapeDrainWithStaleCountReportsEmptyQueue(t *testing.T) {
 	require.Empty(t, m.queuedRestoreOrphans, "an empty drain must not park anything")
 }
 
-// TestIdleEscapeWithoutQueueClearsNothing keeps esc inert on an idle
-// session with nothing queued: the binding acts only when the UI is
-// showing a queue to move.
+// TestIdleEscapeWithoutQueueClearsNothing: the esc binding acts only when
+// the UI is showing a queue to move.
 func TestIdleEscapeWithoutQueueClearsNothing(t *testing.T) {
 	pinTTLs(t)
 

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -924,6 +924,59 @@ func TestPopQueuedMessageRejectsNonEmptyInput(t *testing.T) {
 	require.Equal(t, "Can't pop queued message: input field is not empty.", m.status.msg.Msg)
 }
 
+// TestPopQueuedMessageKeepsTextTypedWhileInFlight pins the non-destructive
+// apply path. The "input field is not empty" guard runs at key-press time,
+// but the pop is an HTTP round-trip in client/server mode and the message is
+// already gone from the agent queue by the time the result lands — so
+// neither the draft nor the popped prompt may be dropped.
+func TestPopQueuedMessageKeepsTextTypedWhileInFlight(t *testing.T) {
+	pinTTLs(t)
+
+	for _, tc := range []struct {
+		name     string
+		bangMode bool
+		draft    string
+		want     string
+	}{
+		{name: "plain draft", draft: "typed while waiting", want: "typed while waiting\nqueued prompt"},
+		// In bang mode the leading "!" is stripped from the value, so
+		// re-syncing bang mode from the merged text would silently turn a
+		// shell command back into a prompt.
+		{name: "bang draft", bangMode: true, draft: "ls -la", want: "ls -la\nqueued prompt"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ws := &countingWorkspace{
+				ready:          true,
+				queued:         []string{"queued prompt"},
+				queuedMessages: []agent.QueuedMessage{{Prompt: "queued prompt"}},
+			}
+			m := newBusyUI(ws)
+			warmCaches(m, true)
+			m.promptQueue = 1
+			m.promptQueueItems = []string{"queued prompt"}
+			m.bangMode = tc.bangMode
+
+			_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+			// The user starts typing before the pop result arrives.
+			m.textarea.SetValue(tc.draft)
+			runCmds(m, cmd)
+
+			require.Equal(t, 1, ws.popQueueCalls)
+			require.Equal(t, tc.want, m.textarea.Value())
+			require.True(t, m.isAtEditorEnd())
+			require.Equal(t, tc.bangMode, m.bangMode)
+			require.Equal(t, -1, m.promptHistory.index)
+			require.Equal(t, tc.want, m.promptHistory.draft)
+			require.Equal(t, util.InfoTypeWarn, m.status.msg.Type)
+			require.Equal(t,
+				"Input field was not empty: appended the popped queued message below your text.",
+				m.status.msg.Msg)
+			require.Empty(t, m.promptQueueItems)
+			require.Empty(t, ws.queued)
+		})
+	}
+}
+
 func TestPopQueuedMessageAppendsAttachmentsAndSynchronizesBangMode(t *testing.T) {
 	pinTTLs(t)
 

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -10,6 +10,7 @@ import (
 	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 
+	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 
@@ -208,7 +209,8 @@ func runCmds(m *UI, cmd tea.Cmd) {
 		for _, c := range msg {
 			runCmds(m, c)
 		}
-	case busyStateMsg, promptQueueMsg, queuedMessagePoppedMsg, agentRunSubmittedMsg, lspStatesMsg, agentModelChangedMsg:
+	case busyStateMsg, promptQueueMsg, queuedMessagePoppedMsg, promptQueueClearedMsg,
+		agentRunSubmittedMsg, lspStatesMsg, agentModelChangedMsg:
 		_, next := m.Update(msg)
 		runCmds(m, next)
 	case util.InfoMsg:
@@ -1199,4 +1201,72 @@ func TestPopQueuedMessageSupersedesInFlightQueueRefresh(t *testing.T) {
 	})
 	require.Equal(t, []string{"older"}, m.promptQueueItems)
 	require.NotEmpty(t, cmds)
+}
+
+// actionDialog is a dialog stub that answers every message with a fixed
+// action, standing in for the commands dialog so a command action can be
+// driven through the real overlay routing (Overlay.Update -> handleDialogMsg)
+// without building the command list.
+type actionDialog struct {
+	id     string
+	action dialog.Action
+}
+
+func (d *actionDialog) ID() string                      { return d.id }
+func (d *actionDialog) HandleMsg(tea.Msg) dialog.Action { return d.action }
+
+func (d *actionDialog) Draw(uv.Screen, uv.Rectangle) *tea.Cursor { return nil }
+
+// TestClearQueueCommandDiscardsQueue pins the bulk escape hatch: escape is
+// turn-scoped now and preserves the queue, and shift+up pops one message at a
+// time, so the commands-dialog entry is the only way to discard a queue built
+// up by accident. The clear is a synchronous HTTP round-trip in client/server
+// mode, so Update must dispatch it rather than call it.
+func TestClearQueueCommandDiscardsQueue(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, queued: []string{"a", "b"}}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"a", "b"}
+	staleGen := m.promptQueueGen
+	m.dialog.OpenDialog(&actionDialog{id: dialog.CommandsID, action: dialog.ActionClearQueue{}})
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.Zero(t, ws.clearQueueCalls, "the clear must run off the Update goroutine")
+	require.False(t, m.dialog.ContainsDialog(dialog.CommandsID),
+		"selecting the command must close the dialog")
+
+	runCmds(m, cmd)
+
+	require.Equal(t, 1, ws.clearQueueCalls)
+	require.Empty(t, ws.queued, "the agent queue must be discarded")
+	require.Empty(t, m.promptQueueItems)
+	require.Zero(t, m.promptQueue)
+	require.Greater(t, m.promptQueueGen, staleGen,
+		"the clear must supersede queue reads started before it")
+	require.Equal(t, 1, ws.queueListCalls,
+		"the emptied queue must be confirmed by one authoritative re-fetch")
+	require.Equal(t, util.InfoTypeInfo, m.status.msg.Type)
+	require.Equal(t, "Queued messages cleared.", m.status.msg.Msg)
+}
+
+// TestClearQueueResultAfterSessionSwitchKeepsCurrentQueue: the clear is
+// dispatched for one session and its result lands one round-trip later, by
+// which time the user may have switched — it says nothing about the queue now
+// on screen, so it must not empty it.
+func TestClearQueueResultAfterSessionSwitchKeepsCurrentQueue(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, queued: []string{"a"}}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"a"}
+
+	require.Nil(t, m.applyPromptQueueCleared(promptQueueClearedMsg{forSession: "s0"}))
+	require.Equal(t, []string{"a"}, m.promptQueueItems,
+		"another session's clear must not empty this session's queue")
+	require.Equal(t, 1, m.promptQueue)
 }

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -464,16 +464,22 @@ func TestSendMessageSetsOptimisticBusy(t *testing.T) {
 	require.Equal(t, 1, ws.cancelCalls, "second esc press must cancel the agent")
 }
 
-// TestCancelAgentPreservesQueue verifies that queued prompts do not change
-// Escape's double-press active-task cancellation behavior, and that the UI
-// neither discards its cached queue nor asks the workspace to clear the
-// agent queue. The agent side of the contract — Cancel leaving the queue
+// TestCancelAgentDrainsQueueOnConfirmingPress pins the two halves of the esc
+// gesture at the cancelAgent level: the arming press is queue-neutral (it
+// must not touch the queue or probe it — the user may still let the window
+// expire), and the confirming press cancels the turn and dispatches the
+// drain, because cancellation is turn-scoped and would otherwise leave the
+// queue ownerless. The agent side of the contract — Cancel leaving the queue
 // intact — is pinned by agent.TestCancel_PreservesQueuedPrompts; the stub
 // here only models it.
-func TestCancelAgentPreservesQueue(t *testing.T) {
+func TestCancelAgentDrainsQueueOnConfirmingPress(t *testing.T) {
 	pinTTLs(t)
 
-	ws := &countingWorkspace{ready: true, queued: []string{"a"}}
+	ws := &countingWorkspace{
+		ready:          true,
+		queued:         []string{"a"},
+		queuedMessages: []agent.QueuedMessage{{Prompt: "a"}},
+	}
 	m := newBusyUI(ws)
 	warmCaches(m, true)
 	m.promptQueue = 1
@@ -486,15 +492,20 @@ func TestCancelAgentPreservesQueue(t *testing.T) {
 	require.Equal(t, []string{"a"}, ws.queued)
 	require.Equal(t, 1, m.promptQueue)
 	require.Equal(t, []string{"a"}, m.promptQueueItems)
-	require.Zero(t, ws.clearQueueCalls, "esc must not clear queued prompts")
+	require.Zero(t, ws.clearQueueCalls, "the arming press must not drain the queue")
 	require.Zero(t, ws.queuedCalls, "esc must not probe the queue")
 	require.Zero(t, ws.queueListCalls, "esc must not probe the queue")
 
-	m.cancelAgent()
+	cmd = m.cancelAgent()
 	require.False(t, m.isCanceling)
 	require.Equal(t, 1, ws.cancelCalls, "second esc press must cancel the agent")
-	require.Equal(t, []string{"a"}, ws.queued)
-	require.Zero(t, ws.clearQueueCalls, "canceling the agent must preserve queued prompts")
+	require.Zero(t, ws.clearQueueCalls, "the drain must run off the Update goroutine")
+
+	runCmds(m, cmd)
+	require.Equal(t, 1, ws.clearQueueCalls, "the confirming press must drain the queue")
+	require.Empty(t, ws.queued)
+	require.Equal(t, "a", m.textarea.Value(), "the drained prompt must reach the editor")
+	require.Zero(t, m.promptQueue)
 }
 
 // cancelHelp returns the description the help panes show for the esc/cancel
@@ -509,12 +520,12 @@ func cancelHelp(t *testing.T, binds []key.Binding) string {
 	return ""
 }
 
-// TestCancelHelpNeverAdvertisesClearQueue pins the help text against the
-// turn-scoped cancel semantics: esc cancels the active turn and leaves the
-// queue alone, so neither help pane may claim it clears the queue just
-// because prompts are queued. The armed state still shows the
-// double-press hint.
-func TestCancelHelpNeverAdvertisesClearQueue(t *testing.T) {
+// TestCancelHelpStaysOneWord pins the help text against the status line's
+// width budget: the confirming esc press also moves the queue into the input
+// field, but that is taught by the pills footer (which is on screen exactly
+// when a queue exists), so neither help pane may grow a queue clause. The
+// armed state still shows the double-press hint.
+func TestCancelHelpStaysOneWord(t *testing.T) {
 	pinTTLs(t)
 
 	ws := &countingWorkspace{ready: true, agentBusy: true, queued: []string{"a", "b"}}
@@ -524,11 +535,11 @@ func TestCancelHelpNeverAdvertisesClearQueue(t *testing.T) {
 	m.promptQueueItems = []string{"a", "b"}
 
 	require.Equal(t, "cancel", cancelHelp(t, m.ShortHelp()),
-		"short help must not advertise clearing the queue")
+		"short help must not grow a queue clause")
 	full := m.FullHelp()
 	require.NotEmpty(t, full)
 	require.Equal(t, "cancel", cancelHelp(t, full[0]),
-		"full help must not advertise clearing the queue")
+		"full help must not grow a queue clause")
 
 	// First esc press arms cancellation: both panes switch to the
 	// double-press hint, still never mentioning the queue.
@@ -651,7 +662,7 @@ func TestStalePromptQueueDiscardedAndReDispatched(t *testing.T) {
 	m.promptQueueItems = []string{"real"}
 
 	// A fetch is in flight; capture its generation, then a newer transition
-	// (esc clears the queue) supersedes it.
+	// (esc drains the queue) supersedes it.
 	m.promptQueueInFlight = true
 	staleGen := m.promptQueueGen
 	m.invalidatePromptQueue()
@@ -923,34 +934,56 @@ func TestPopQueuedMessageKeysRestoreNewestMessage(t *testing.T) {
 	}
 }
 
-func TestPopQueuedMessageRejectsNonEmptyInput(t *testing.T) {
+// TestPopQueuedMessagePrependsAboveDraft pins the unconditional pop: the
+// popped prompt goes in front of whatever the editor holds, separated by a
+// blank line, so a draft is never at risk and repeated presses walk the queue
+// back into the input field in the order the prompts would have run in. The
+// press after the queue is empty says so instead of doing nothing.
+func TestPopQueuedMessagePrependsAboveDraft(t *testing.T) {
 	pinTTLs(t)
 
 	ws := &countingWorkspace{
 		ready:          true,
-		queued:         []string{"queued"},
-		queuedMessages: []agent.QueuedMessage{{Prompt: "queued"}},
+		queued:         []string{"older", "newest"},
+		queuedMessages: []agent.QueuedMessage{{Prompt: "older"}, {Prompt: "newest"}},
 	}
 	m := newBusyUI(ws)
 	warmCaches(m, true)
-	m.promptQueue = 1
-	m.promptQueueItems = []string{"queued"}
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"older", "newest"}
 	m.textarea.SetValue("draft")
 
 	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
 	runCmds(m, cmd)
 
-	require.Zero(t, ws.popQueueCalls)
-	require.Equal(t, "draft", m.textarea.Value())
-	require.Equal(t, util.InfoTypeWarn, m.status.msg.Type)
-	require.Equal(t, "Can't pop queued message: input field is not empty.", m.status.msg.Msg)
+	require.Equal(t, 1, ws.popQueueCalls, "a draft must not refuse the pop")
+	require.Equal(t, "newest\n\ndraft", m.textarea.Value())
+	require.Empty(t, m.status.msg.Msg,
+		"a successful pop must not warn about the draft it prepended above")
+
+	// A second press brings the older prompt above both, so the buffer
+	// reads in queue order.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+	runCmds(m, cmd)
+
+	require.Equal(t, 2, ws.popQueueCalls)
+	require.Equal(t, "older\n\nnewest\n\ndraft", m.textarea.Value())
+	require.Empty(t, m.promptQueueItems)
+	require.Zero(t, m.promptQueue)
+
+	// The queue is empty now: the press reports that and leaves the buffer.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+	runCmds(m, cmd)
+
+	require.Equal(t, 2, ws.popQueueCalls, "an empty queue is answered from the cache")
+	require.Equal(t, "older\n\nnewest\n\ndraft", m.textarea.Value())
+	require.Equal(t, noQueuedMessages, m.status.msg.Msg)
 }
 
 // TestPopQueuedMessageKeepsTextTypedWhileInFlight pins the non-destructive
-// apply path. The "input field is not empty" guard runs at key-press time,
-// but the pop is an HTTP round-trip in client/server mode and the message is
-// already gone from the agent queue by the time the result lands — so
-// neither the draft nor the popped prompt may be dropped.
+// apply path: the pop is an HTTP round-trip in client/server mode and the
+// message is already gone from the agent queue by the time the result lands,
+// so neither text typed meanwhile nor the popped prompt may be dropped.
 func TestPopQueuedMessageKeepsTextTypedWhileInFlight(t *testing.T) {
 	pinTTLs(t)
 
@@ -960,11 +993,12 @@ func TestPopQueuedMessageKeepsTextTypedWhileInFlight(t *testing.T) {
 		draft    string
 		want     string
 	}{
-		{name: "plain draft", draft: "typed while waiting", want: "typed while waiting\nqueued prompt"},
-		// In bang mode the leading "!" is stripped from the value, so
-		// re-syncing bang mode from the merged text would silently turn a
-		// shell command back into a prompt.
-		{name: "bang draft", bangMode: true, draft: "ls -la", want: "ls -la\nqueued prompt"},
+		{name: "plain draft", draft: "typed while waiting", want: "queued prompt\n\ntyped while waiting"},
+		// Bang mode hides the leading "!" from the textarea value, so
+		// prepending in front of the draft would fold the restored prompt
+		// into the shell command. The "!" is materialized instead and bang
+		// mode ends, keeping the shell intent visible.
+		{name: "bang draft", bangMode: true, draft: "ls -la", want: "queued prompt\n\n!ls -la"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ws := &countingWorkspace{
@@ -986,13 +1020,10 @@ func TestPopQueuedMessageKeepsTextTypedWhileInFlight(t *testing.T) {
 			require.Equal(t, 1, ws.popQueueCalls)
 			require.Equal(t, tc.want, m.textarea.Value())
 			require.True(t, m.isAtEditorEnd())
-			require.Equal(t, tc.bangMode, m.bangMode)
+			require.False(t, m.bangMode,
+				"a restored prompt is prompt text, so bang mode must not survive it")
 			require.Equal(t, -1, m.promptHistory.index)
 			require.Equal(t, tc.want, m.promptHistory.draft)
-			require.Equal(t, util.InfoTypeWarn, m.status.msg.Type)
-			require.Equal(t,
-				"Input field was not empty: appended the popped queued message below your text.",
-				m.status.msg.Msg)
 			require.Empty(t, m.promptQueueItems)
 			require.Empty(t, ws.queued)
 		})
@@ -1229,7 +1260,8 @@ func TestPopQueuedMessageHelpListsBindingWhenQueued(t *testing.T) {
 // TestPopQueuedMessageIsSingleFlight pins the guard against key autorepeat:
 // the pop is destructive at the agent layer and nothing in the model changes
 // until its result lands, so a second dispatch would remove a second message
-// that the apply path then overwrites in the editor — losing it for good.
+// before the first is on screen, with only one round-trip's worth of queue
+// bookkeeping to account for both.
 func TestPopQueuedMessageIsSingleFlight(t *testing.T) {
 	pinTTLs(t)
 
@@ -1256,13 +1288,13 @@ func TestPopQueuedMessageIsSingleFlight(t *testing.T) {
 	require.Equal(t, 1, m.promptQueue)
 	require.Equal(t, []string{"older"}, ws.queued)
 
-	// A later press is allowed once the first pop settled.
-	m.textarea.SetValue("")
+	// A later press is allowed once the first pop settled, and it prepends
+	// above what the first one restored.
 	_, third := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
 	runCmds(m, third)
 
 	require.Equal(t, 2, ws.popQueueCalls)
-	require.Equal(t, "older", m.textarea.Value())
+	require.Equal(t, "older\n\nnewest", m.textarea.Value())
 	require.Empty(t, ws.queued)
 }
 
@@ -1331,11 +1363,11 @@ func TestPopQueuedMessageParksResultAfterSessionSwitch(t *testing.T) {
 	require.Empty(t, m.attachments.List())
 	require.Equal(t, util.InfoTypeWarn, m.status.msg.Type)
 	require.Equal(t,
-		"Session changed: the popped message will be restored when you return to that session.",
+		"Session changed: the queued message will be restored when you return to that session.",
 		m.status.msg.Msg)
 	require.Equal(t,
-		agent.QueuedMessage{Prompt: "newest", Attachments: []message.Attachment{restored}},
-		m.queuedPopOrphans["s1"],
+		[]agent.QueuedMessage{{Prompt: "newest", Attachments: []message.Attachment{restored}}},
+		m.queuedRestoreOrphans["s1"],
 		"the popped message must be parked for the session it came from")
 
 	_, cmd = m.Update(loadSessionMsg{session: &session.Session{ID: "s1"}})
@@ -1346,34 +1378,37 @@ func TestPopQueuedMessageParksResultAfterSessionSwitch(t *testing.T) {
 	require.Equal(t, []message.Attachment{restored}, m.attachments.List())
 	require.Equal(t, util.InfoTypeWarn, m.status.msg.Type)
 	require.Equal(t,
-		"Restored the queued message you popped before switching sessions.",
+		"Restored the queued message you removed before switching sessions.",
 		m.status.msg.Msg)
-	require.Empty(t, m.queuedPopOrphans, "a restored message must not be parked twice")
+	require.Empty(t, m.queuedRestoreOrphans, "a restored message must not be parked twice")
 }
 
-// TestParkedPopRestoreKeepsEditorDraft pins that the parked restore is
+// TestParkedRestoreKeepsEditorDraft pins that the parked restore is
 // non-destructive: the editor is shared across sessions, so text typed while
-// the message was parked must survive it coming back.
-func TestParkedPopRestoreKeepsEditorDraft(t *testing.T) {
+// the messages were parked must survive them coming back, and the whole
+// parked batch comes back in queue order.
+func TestParkedRestoreKeepsEditorDraft(t *testing.T) {
 	pinTTLs(t)
 
 	ws := &countingWorkspace{ready: true}
 	m := newBusyUI(ws)
 	warmCaches(m, true)
 	m.session = &session.Session{ID: "s2"}
-	m.queuedPopOrphans = map[string]agent.QueuedMessage{"s1": {Prompt: "newest"}}
+	m.queuedRestoreOrphans = map[string][]agent.QueuedMessage{
+		"s1": {{Prompt: "older"}, {Prompt: "newest"}},
+	}
 	m.textarea.SetValue("draft")
 
 	_, cmd := m.Update(loadSessionMsg{session: &session.Session{ID: "s1"}})
 	runCmds(m, cmd)
 
-	require.Equal(t, "draft\nnewest", m.textarea.Value())
+	require.Equal(t, "older\n\nnewest\n\ndraft", m.textarea.Value())
 	require.True(t, m.isAtEditorEnd())
 	require.Equal(t, util.InfoTypeWarn, m.status.msg.Type)
 	require.Equal(t,
-		"Appended the queued message you popped before switching sessions below your text.",
+		"Restored 2 queued messages you removed before switching sessions.",
 		m.status.msg.Msg)
-	require.Empty(t, m.queuedPopOrphans)
+	require.Empty(t, m.queuedRestoreOrphans)
 }
 
 func TestPopQueuedMessageSupersedesInFlightQueueRefresh(t *testing.T) {
@@ -1419,19 +1454,24 @@ func (d *actionDialog) HandleMsg(tea.Msg) dialog.Action { return d.action }
 
 func (d *actionDialog) Draw(uv.Screen, uv.Rectangle) *tea.Cursor { return nil }
 
-// TestClearQueueCommandDiscardsQueue pins the commands-dialog escape
-// hatch, which discards the queue regardless of whether the agent is busy
-// (idle esc only covers the stopped case, and shift+up pops one message at
-// a time). The clear is a synchronous HTTP round-trip in client/server
-// mode, so Update must dispatch it rather than call it.
+// TestClearQueueCommandDiscardsQueue pins the commands-dialog entry as the
+// one genuinely destructive path: both esc gestures now move the queue into
+// the input field, so this is how a queue built up by accident is thrown
+// away instead of pasted back. The drain is a synchronous HTTP round-trip in
+// client/server mode, so Update must dispatch it rather than call it.
 func TestClearQueueCommandDiscardsQueue(t *testing.T) {
 	pinTTLs(t)
 
-	ws := &countingWorkspace{ready: true, queued: []string{"a", "b"}}
+	ws := &countingWorkspace{
+		ready:          true,
+		queued:         []string{"a", "b"},
+		queuedMessages: []agent.QueuedMessage{{Prompt: "a"}, {Prompt: "b"}},
+	}
 	m := newBusyUI(ws)
 	warmCaches(m, true)
 	m.promptQueue = 2
 	m.promptQueueItems = []string{"a", "b"}
+	m.textarea.SetValue("draft")
 	staleGen := m.promptQueueGen
 	m.dialog.OpenDialog(&actionDialog{id: dialog.CommandsID, action: dialog.ActionClearQueue{}})
 
@@ -1450,14 +1490,20 @@ func TestClearQueueCommandDiscardsQueue(t *testing.T) {
 		"the clear must supersede queue reads started before it")
 	require.Equal(t, 1, ws.queueListCalls,
 		"the emptied queue must be confirmed by one authoritative re-fetch")
+	require.Equal(t, "draft", m.textarea.Value(),
+		"a discard must not paste the queue into the editor")
+	require.Empty(t, m.queuedRestoreOrphans, "a discard must not park anything")
 	require.Equal(t, util.InfoTypeInfo, m.status.msg.Type)
 	require.Equal(t, "Queued messages cleared.", m.status.msg.Msg)
 }
 
-// TestClearQueueResultAfterSessionSwitchKeepsCurrentQueue: the clear is
+// TestClearQueueResultAfterSessionSwitchKeepsCurrentQueue: the drain is
 // dispatched for one session and its result lands one round-trip later, by
 // which time the user may have switched — it says nothing about the queue now
-// on screen, so it must not empty it.
+// on screen, so it must not empty it. A discard drops its payload there
+// (discarding was the point); a restore parks it instead, because the
+// prompts are already out of the other session's queue and were written for
+// it.
 func TestClearQueueResultAfterSessionSwitchKeepsCurrentQueue(t *testing.T) {
 	pinTTLs(t)
 
@@ -1467,47 +1513,118 @@ func TestClearQueueResultAfterSessionSwitchKeepsCurrentQueue(t *testing.T) {
 	m.promptQueue = 1
 	m.promptQueueItems = []string{"a"}
 
-	require.Nil(t, m.applyPromptQueueCleared(promptQueueClearedMsg{forSession: "s0"}))
+	require.Nil(t, m.applyPromptQueueCleared(promptQueueClearedMsg{
+		forSession: "s0",
+		messages:   []agent.QueuedMessage{{Prompt: "discarded"}},
+	}))
 	require.Equal(t, []string{"a"}, m.promptQueueItems,
 		"another session's clear must not empty this session's queue")
 	require.Equal(t, 1, m.promptQueue)
+	require.Empty(t, m.queuedRestoreOrphans, "a discard must not park anything")
+	require.Empty(t, m.textarea.Value())
 }
 
-// TestIdleEscapeClearsQueue covers the state a cancel leaves behind:
-// cancellation is turn-scoped, so stopping the agent keeps the queue, and
-// the queue then has no owner — the next submission would drag it along.
-// Once the agent is idle, esc is therefore the bulk discard for it. The
-// clear is an HTTP round-trip in client/server mode, so Update must
-// dispatch it, and nothing may arm the double-press cancel: there is no
-// turn to stop.
-func TestIdleEscapeClearsQueue(t *testing.T) {
+// TestEscapeDrainResultAfterSessionSwitchParksBatch: an Escape drain is as
+// destructive at the agent layer as a pop, so a result landing after a
+// session switch may neither be dropped nor pasted into the session now on
+// screen. The whole batch is parked and restored, in order, on the next load
+// of the session it came from.
+func TestEscapeDrainResultAfterSessionSwitchParksBatch(t *testing.T) {
 	pinTTLs(t)
 
-	ws := &countingWorkspace{ready: true, queued: []string{"a", "b"}}
+	attachment := message.Attachment{FileName: "notes.txt", MimeType: "text/plain"}
+	ws := &countingWorkspace{
+		ready:  true,
+		queued: []string{"older", "newest"},
+		queuedMessages: []agent.QueuedMessage{
+			{Prompt: "older"},
+			{Prompt: "newest", Attachments: []message.Attachment{attachment}},
+		},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"older", "newest"}
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	// The user switches sessions while the drain is in flight.
+	m.session = &session.Session{ID: "s2"}
+	runCmds(m, cmd)
+
+	require.Equal(t, 1, ws.clearQueueCalls)
+	require.Empty(t, m.textarea.Value(),
+		"another session's prompts must not land in the current editor")
+	require.Empty(t, m.attachments.List())
+	require.Equal(t, util.InfoTypeWarn, m.status.msg.Type)
+	require.Equal(t,
+		"Session changed: 2 queued messages will be restored when you return to that session.",
+		m.status.msg.Msg)
+
+	_, cmd = m.Update(loadSessionMsg{session: &session.Session{ID: "s1"}})
+	runCmds(m, cmd)
+
+	require.Equal(t, "older\n\nnewest", m.textarea.Value(),
+		"returning must hand the whole batch back in queue order")
+	require.Equal(t, []message.Attachment{attachment}, m.attachments.List())
+	require.Empty(t, m.queuedRestoreOrphans)
+}
+
+// TestIdleEscapeDrainsQueueIntoEditor covers the state a cancel leaves
+// behind: cancellation is turn-scoped, so stopping the agent keeps the queue,
+// and the queue then has no owner. Once the agent is idle a single esc takes
+// the queue off it and moves the prompts — text and attachments — into the
+// input field, above whatever is already there. The drain is an HTTP
+// round-trip in client/server mode, so Update must dispatch it, and nothing
+// may arm the double-press cancel: there is no turn to stop, and nothing is
+// destroyed.
+func TestIdleEscapeDrainsQueueIntoEditor(t *testing.T) {
+	pinTTLs(t)
+
+	attachment := message.Attachment{FileName: "notes.txt", MimeType: "text/plain"}
+	ws := &countingWorkspace{
+		ready:  true,
+		queued: []string{"a", "b"},
+		queuedMessages: []agent.QueuedMessage{
+			{Prompt: "a"},
+			{Prompt: "b", Attachments: []message.Attachment{attachment}},
+		},
+	}
 	m := newBusyUI(ws)
 	warmCaches(m, false)
 	m.promptQueue = 2
 	m.promptQueueItems = []string{"a", "b"}
+	m.textarea.SetValue("draft")
 	ws.resetCounters()
 
 	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
-	require.Zero(t, ws.clearQueueCalls, "the clear must run off the Update goroutine")
+	require.Zero(t, ws.clearQueueCalls, "the drain must run off the Update goroutine")
 	require.False(t, m.isCanceling, "esc must not arm cancellation when the agent is idle")
 	require.Zero(t, ws.cancelCalls, "there is no turn to cancel")
 
 	runCmds(m, cmd)
 
 	require.Equal(t, 1, ws.clearQueueCalls)
-	require.Empty(t, ws.queued, "the agent queue must be discarded")
+	require.Empty(t, ws.queued, "the queue must leave the agent")
 	require.Empty(t, m.promptQueueItems)
 	require.Zero(t, m.promptQueue)
+	require.Equal(t, "a\n\nb\n\ndraft", m.textarea.Value(),
+		"the drained prompts must land above the draft, oldest first")
+	require.True(t, m.isAtEditorEnd())
+	require.Equal(t, []message.Attachment{attachment}, m.attachments.List())
 	require.Equal(t, util.InfoTypeInfo, m.status.msg.Type)
-	require.Equal(t, "Queued messages cleared.", m.status.msg.Msg)
+	require.Equal(t, "Queued messages moved to the input field.", m.status.msg.Msg)
+
+	// A burst of further presses is harmless: the memoized queue is empty,
+	// so they are answered from the cache and the buffer is untouched.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+	require.Equal(t, 1, ws.clearQueueCalls, "an empty queue must not cost a round-trip")
+	require.Equal(t, "a\n\nb\n\ndraft", m.textarea.Value())
 }
 
 // TestIdleEscapeWithoutQueueClearsNothing keeps esc inert on an idle
 // session with nothing queued: the binding acts only when the UI is
-// showing a queue to discard.
+// showing a queue to move.
 func TestIdleEscapeWithoutQueueClearsNothing(t *testing.T) {
 	pinTTLs(t)
 
@@ -1524,17 +1641,28 @@ func TestIdleEscapeWithoutQueueClearsNothing(t *testing.T) {
 	require.False(t, m.isCanceling)
 }
 
-// TestBusyEscapeCancelsAndKeepsQueue pins the precedence: while the agent
-// is busy, esc still means cancel-the-turn (double press) and must not
-// discard the queue — that is the whole point of the turn-scoped cancel.
-func TestBusyEscapeCancelsAndKeepsQueue(t *testing.T) {
+// TestBusyEscapeCancelsAndDrainsQueue pins the busy gesture: the arming press
+// is queue-neutral, and the confirming press both cancels the turn and moves
+// the queue into the input field, so one esc gesture does both halves of what
+// the user asks of it without destroying text.
+func TestBusyEscapeCancelsAndDrainsQueue(t *testing.T) {
 	pinTTLs(t)
 
-	ws := &countingWorkspace{ready: true, agentBusy: true, queued: []string{"a"}}
+	attachment := message.Attachment{FileName: "notes.txt", MimeType: "text/plain"}
+	ws := &countingWorkspace{
+		ready:     true,
+		agentBusy: true,
+		queued:    []string{"a", "b"},
+		queuedMessages: []agent.QueuedMessage{
+			{Prompt: "a"},
+			{Prompt: "b", Attachments: []message.Attachment{attachment}},
+		},
+	}
 	m := newBusyUI(ws)
 	warmCaches(m, true)
-	m.promptQueue = 1
-	m.promptQueueItems = []string{"a"}
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"a", "b"}
+	m.textarea.SetValue("draft")
 	ws.resetCounters()
 
 	// The first press only arms the double-press window; the command it
@@ -1543,23 +1671,34 @@ func TestBusyEscapeCancelsAndKeepsQueue(t *testing.T) {
 	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	require.NotNil(t, cmd, "the first esc press must return the arming timer")
 	require.True(t, m.isCanceling, "the first esc press must arm cancellation")
-	require.Zero(t, ws.clearQueueCalls, "canceling must preserve the queue")
-	require.Equal(t, []string{"a"}, m.promptQueueItems)
+	require.Zero(t, ws.clearQueueCalls, "the arming press must be queue-neutral")
+	require.Equal(t, []string{"a", "b"}, m.promptQueueItems)
+	require.Equal(t, "draft", m.textarea.Value())
 
 	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
-	runCmds(m, cmd)
 	require.Equal(t, 1, ws.cancelCalls, "the second esc press must cancel the agent")
-	require.Zero(t, ws.clearQueueCalls, "canceling must preserve the queue")
-	require.Equal(t, []string{"a"}, m.promptQueueItems)
+	require.Zero(t, ws.clearQueueCalls, "the drain must run off the Update goroutine")
+
+	runCmds(m, cmd)
+
+	require.Equal(t, 1, ws.clearQueueCalls, "the confirming press must drain the queue")
+	require.Equal(t, "a\n\nb\n\ndraft", m.textarea.Value())
+	require.Equal(t, []message.Attachment{attachment}, m.attachments.List())
+	require.Empty(t, m.promptQueueItems)
+	require.Zero(t, m.promptQueue)
 }
 
 // TestIdleEscapeDuringHistoryNavigationKeepsQueue: esc keeps its more
 // local meaning while the user is browsing prompt history — it restores
-// the draft — so a queue must not be discarded by the same press.
+// the draft — so the queue must not move on the same press.
 func TestIdleEscapeDuringHistoryNavigationKeepsQueue(t *testing.T) {
 	pinTTLs(t)
 
-	ws := &countingWorkspace{ready: true, queued: []string{"a"}}
+	ws := &countingWorkspace{
+		ready:          true,
+		queued:         []string{"a"},
+		queuedMessages: []agent.QueuedMessage{{Prompt: "a"}},
+	}
 	m := newBusyUI(ws)
 	warmCaches(m, false)
 	m.promptQueue = 1
@@ -1578,9 +1717,10 @@ func TestIdleEscapeDuringHistoryNavigationKeepsQueue(t *testing.T) {
 	require.Equal(t, "draft", m.textarea.Value(), "esc must restore the draft")
 	require.Equal(t, -1, m.promptHistory.index)
 
-	// A second press, now that history navigation is over, clears.
+	// A second press, now that history navigation is over, drains.
 	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
 	runCmds(m, cmd)
 	require.Equal(t, 1, ws.clearQueueCalls)
 	require.Empty(t, m.promptQueueItems)
+	require.Equal(t, "a\n\ndraft", m.textarea.Value())
 }

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -159,7 +159,7 @@ func (w *countingWorkspace) resetCounters() {
 // "s1", enough state for Update to run end to end.
 func newBusyUI(ws *countingWorkspace) *UI {
 	com := common.DefaultCommon(ws)
-	return &UI{
+	m := &UI{
 		com:         com,
 		status:      NewStatus(com, nil),
 		chat:        NewChat(com, config.ScrollbarDefault),
@@ -173,6 +173,11 @@ func newBusyUI(ws *countingWorkspace) *UI {
 		dialog:      dialog.NewOverlay(),
 		attachments: attachments.New(nil, attachments.Keymap{}),
 	}
+	// -1 is "not browsing history", the state production is in once
+	// history has loaded or a prompt has been submitted. The struct's zero
+	// value (0) would instead mean the editor is showing history entry 0.
+	m.promptHistory.index = -1
+	return m
 }
 
 // pinTTLs makes the TTL backstop inert for the duration of the test so
@@ -1335,10 +1340,10 @@ func (d *actionDialog) HandleMsg(tea.Msg) dialog.Action { return d.action }
 
 func (d *actionDialog) Draw(uv.Screen, uv.Rectangle) *tea.Cursor { return nil }
 
-// TestClearQueueCommandDiscardsQueue pins the bulk escape hatch: escape is
-// turn-scoped now and preserves the queue, and shift+up pops one message at a
-// time, so the commands-dialog entry is the only way to discard a queue built
-// up by accident. The clear is a synchronous HTTP round-trip in client/server
+// TestClearQueueCommandDiscardsQueue pins the commands-dialog escape
+// hatch, which discards the queue regardless of whether the agent is busy
+// (idle esc only covers the stopped case, and shift+up pops one message at
+// a time). The clear is a synchronous HTTP round-trip in client/server
 // mode, so Update must dispatch it rather than call it.
 func TestClearQueueCommandDiscardsQueue(t *testing.T) {
 	pinTTLs(t)
@@ -1387,4 +1392,116 @@ func TestClearQueueResultAfterSessionSwitchKeepsCurrentQueue(t *testing.T) {
 	require.Equal(t, []string{"a"}, m.promptQueueItems,
 		"another session's clear must not empty this session's queue")
 	require.Equal(t, 1, m.promptQueue)
+}
+
+// TestIdleEscapeClearsQueue covers the state a cancel leaves behind:
+// cancellation is turn-scoped, so stopping the agent keeps the queue, and
+// the queue then has no owner — the next submission would drag it along.
+// Once the agent is idle, esc is therefore the bulk discard for it. The
+// clear is an HTTP round-trip in client/server mode, so Update must
+// dispatch it, and nothing may arm the double-press cancel: there is no
+// turn to stop.
+func TestIdleEscapeClearsQueue(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, queued: []string{"a", "b"}}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"a", "b"}
+	ws.resetCounters()
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	require.Zero(t, ws.clearQueueCalls, "the clear must run off the Update goroutine")
+	require.False(t, m.isCanceling, "esc must not arm cancellation when the agent is idle")
+	require.Zero(t, ws.cancelCalls, "there is no turn to cancel")
+
+	runCmds(m, cmd)
+
+	require.Equal(t, 1, ws.clearQueueCalls)
+	require.Empty(t, ws.queued, "the agent queue must be discarded")
+	require.Empty(t, m.promptQueueItems)
+	require.Zero(t, m.promptQueue)
+	require.Equal(t, util.InfoTypeInfo, m.status.msg.Type)
+	require.Equal(t, "Queued messages cleared.", m.status.msg.Msg)
+}
+
+// TestIdleEscapeWithoutQueueClearsNothing keeps esc inert on an idle
+// session with nothing queued: the binding acts only when the UI is
+// showing a queue to discard.
+func TestIdleEscapeWithoutQueueClearsNothing(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	ws.resetCounters()
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+
+	require.Zero(t, ws.clearQueueCalls)
+	require.Zero(t, ws.cancelCalls)
+	require.False(t, m.isCanceling)
+}
+
+// TestBusyEscapeCancelsAndKeepsQueue pins the precedence: while the agent
+// is busy, esc still means cancel-the-turn (double press) and must not
+// discard the queue — that is the whole point of the turn-scoped cancel.
+func TestBusyEscapeCancelsAndKeepsQueue(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, agentBusy: true, queued: []string{"a"}}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"a"}
+	ws.resetCounters()
+
+	// The first press only arms the double-press window; the command it
+	// returns is the arming timer, deliberately not run here (it blocks for
+	// the whole window before emitting its expiry).
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	require.NotNil(t, cmd, "the first esc press must return the arming timer")
+	require.True(t, m.isCanceling, "the first esc press must arm cancellation")
+	require.Zero(t, ws.clearQueueCalls, "canceling must preserve the queue")
+	require.Equal(t, []string{"a"}, m.promptQueueItems)
+
+	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+	require.Equal(t, 1, ws.cancelCalls, "the second esc press must cancel the agent")
+	require.Zero(t, ws.clearQueueCalls, "canceling must preserve the queue")
+	require.Equal(t, []string{"a"}, m.promptQueueItems)
+}
+
+// TestIdleEscapeDuringHistoryNavigationKeepsQueue: esc keeps its more
+// local meaning while the user is browsing prompt history — it restores
+// the draft — so a queue must not be discarded by the same press.
+func TestIdleEscapeDuringHistoryNavigationKeepsQueue(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, queued: []string{"a"}}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"a"}
+	m.promptHistory.messages = []string{"older prompt"}
+	m.promptHistory.index = 0
+	m.promptHistory.draft = "draft"
+	m.textarea.SetValue("older prompt")
+	ws.resetCounters()
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+
+	require.Zero(t, ws.clearQueueCalls, "esc must leave history navigation first")
+	require.Equal(t, []string{"a"}, m.promptQueueItems)
+	require.Equal(t, "draft", m.textarea.Value(), "esc must restore the draft")
+	require.Equal(t, -1, m.promptHistory.index)
+
+	// A second press, now that history navigation is over, clears.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+	require.Equal(t, 1, ws.clearQueueCalls)
+	require.Empty(t, m.promptQueueItems)
 }

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -439,10 +439,9 @@ func TestSendMessageSetsOptimisticBusy(t *testing.T) {
 	require.Equal(t, 1, ws.cancelCalls, "second esc press must cancel the agent")
 }
 
-// TestCancelAgentClearsQueueFromCachedCount: the queue-clear decision must
-// come from the memoized count — no synchronous AgentQueuedPrompts probe —
-// and clearing must zero the cached count immediately.
-func TestCancelAgentClearsQueueFromCachedCount(t *testing.T) {
+// TestCancelAgentPreservesQueue verifies that queued prompts do not change
+// Escape's double-press active-task cancellation behavior.
+func TestCancelAgentPreservesQueue(t *testing.T) {
 	pinTTLs(t)
 
 	ws := &countingWorkspace{ready: true, queued: []string{"a"}}
@@ -453,13 +452,20 @@ func TestCancelAgentClearsQueueFromCachedCount(t *testing.T) {
 	ws.resetCounters()
 
 	cmd := m.cancelAgent()
-	require.Nil(t, cmd)
-	require.Equal(t, 1, ws.clearQueueCalls, "esc with a queue must clear it")
-	require.Zero(t, ws.queuedCalls, "the decision must use the cached count, not a probe")
-	require.Zero(t, ws.queueListCalls, "the decision must use the cached count, not a probe")
-	require.Zero(t, m.promptQueue, "the cached count must be zeroed immediately")
-	require.Empty(t, m.promptQueueItems)
-	require.False(t, m.isCanceling, "clearing the queue must not arm cancellation")
+	require.NotNil(t, cmd, "first esc press must arm the cancellation timer")
+	require.True(t, m.isCanceling)
+	require.Equal(t, []string{"a"}, ws.queued)
+	require.Equal(t, 1, m.promptQueue)
+	require.Equal(t, []string{"a"}, m.promptQueueItems)
+	require.Zero(t, ws.clearQueueCalls, "esc must not clear queued prompts")
+	require.Zero(t, ws.queuedCalls, "esc must not probe the queue")
+	require.Zero(t, ws.queueListCalls, "esc must not probe the queue")
+
+	m.cancelAgent()
+	require.False(t, m.isCanceling)
+	require.Equal(t, 1, ws.cancelCalls, "second esc press must cancel the agent")
+	require.Equal(t, []string{"a"}, ws.queued)
+	require.Zero(t, ws.clearQueueCalls, "canceling the agent must preserve queued prompts")
 }
 
 // TestBackstopRefreshesStaleCaches: when the memoized state outlives its TTL

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/lsp"
@@ -79,7 +80,10 @@ func (w *countingWorkspace) PermissionSetSkipRequests(skip bool) {
 }
 
 func (w *countingWorkspace) AgentClearQueue(string) { w.clearQueueCalls++; w.queued = nil }
-func (w *countingWorkspace) AgentCancel(string)     { w.cancelCalls++ }
+func (w *countingWorkspace) AgentPopQueuedMessage(string) (agent.QueuedMessage, bool, error) {
+	return agent.QueuedMessage{}, false, nil
+}
+func (w *countingWorkspace) AgentCancel(string) { w.cancelCalls++ }
 
 func (w *countingWorkspace) AgentModel() workspace.AgentModel {
 	w.modelCalls++

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -2,11 +2,13 @@ package model
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
+
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/require"
 
@@ -20,6 +22,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/dialog"
+	"github.com/charmbracelet/crush/internal/ui/util"
 	"github.com/charmbracelet/crush/internal/workspace"
 )
 
@@ -30,13 +33,15 @@ import (
 type countingWorkspace struct {
 	workspace.Workspace
 
-	ready     bool
-	agentBusy bool
-	yolo      bool
-	queued    []string
-	model     workspace.AgentModel
-	lspStates map[string]workspace.LSPClientInfo
-	lspDiags  map[string]lsp.DiagnosticCounts
+	ready          bool
+	agentBusy      bool
+	yolo           bool
+	queued         []string
+	queuedMessages []agent.QueuedMessage
+	popErr         error
+	model          workspace.AgentModel
+	lspStates      map[string]workspace.LSPClientInfo
+	lspDiags       map[string]lsp.DiagnosticCounts
 
 	readyCalls      int
 	agentBusyCalls  int
@@ -45,6 +50,7 @@ type countingWorkspace struct {
 	permCalls       int
 	permSetCalls    int
 	clearQueueCalls int
+	popQueueCalls   int
 	cancelCalls     int
 	modelCalls      int
 	lspStateCalls   int
@@ -81,7 +87,20 @@ func (w *countingWorkspace) PermissionSetSkipRequests(skip bool) {
 
 func (w *countingWorkspace) AgentClearQueue(string) { w.clearQueueCalls++; w.queued = nil }
 func (w *countingWorkspace) AgentPopQueuedMessage(string) (agent.QueuedMessage, bool, error) {
-	return agent.QueuedMessage{}, false, nil
+	w.popQueueCalls++
+	if w.popErr != nil {
+		return agent.QueuedMessage{}, false, w.popErr
+	}
+	if len(w.queuedMessages) == 0 {
+		return agent.QueuedMessage{}, false, nil
+	}
+	last := len(w.queuedMessages) - 1
+	queued := w.queuedMessages[last]
+	w.queuedMessages = w.queuedMessages[:last]
+	if len(w.queued) > 0 {
+		w.queued = w.queued[:len(w.queued)-1]
+	}
+	return queued, true, nil
 }
 func (w *countingWorkspace) AgentCancel(string) { w.cancelCalls++ }
 
@@ -126,7 +145,7 @@ func (w *countingWorkspace) syncProbes() int {
 func (w *countingWorkspace) resetCounters() {
 	w.readyCalls, w.agentBusyCalls = 0, 0
 	w.queuedCalls, w.queueListCalls, w.permCalls = 0, 0, 0
-	w.permSetCalls, w.clearQueueCalls, w.cancelCalls = 0, 0, 0
+	w.permSetCalls, w.clearQueueCalls, w.popQueueCalls, w.cancelCalls = 0, 0, 0, 0
 	w.modelCalls, w.lspStateCalls, w.lspDiagCalls = 0, 0, 0
 }
 
@@ -184,9 +203,11 @@ func runCmds(m *UI, cmd tea.Cmd) {
 		for _, c := range msg {
 			runCmds(m, c)
 		}
-	case busyStateMsg, promptQueueMsg, agentRunSubmittedMsg, lspStatesMsg, agentModelChangedMsg:
+	case busyStateMsg, promptQueueMsg, queuedMessagePoppedMsg, agentRunSubmittedMsg, lspStatesMsg, agentModelChangedMsg:
 		_, next := m.Update(msg)
 		runCmds(m, next)
+	case util.InfoMsg:
+		m.status.SetInfoMsg(msg)
 	}
 }
 
@@ -781,4 +802,155 @@ func TestRemoteYoloToggleUpdatesEditorPrompt(t *testing.T) {
 	require.False(t, m.yoloModeCached())
 	require.Equal(t, normalPrompt, ansi.Strip(m.textarea.View()),
 		"toggling yolo off must restore the normal editor prompt")
+}
+
+func TestPopQueuedMessageKeysRestoreNewestMessage(t *testing.T) {
+	pinTTLs(t)
+
+	for _, tc := range []struct {
+		name string
+		mod  tea.KeyMod
+	}{
+		{name: "shift up", mod: tea.ModShift},
+		{name: "alt up", mod: tea.ModAlt},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			attachment := message.Attachment{FileName: "notes.txt", MimeType: "text/plain"}
+			ws := &countingWorkspace{
+				ready:  true,
+				queued: []string{"older", "newest"},
+				queuedMessages: []agent.QueuedMessage{
+					{Prompt: "older"},
+					{Prompt: "newest", Attachments: []message.Attachment{attachment}},
+				},
+			}
+			m := newBusyUI(ws)
+			warmCaches(m, true)
+			m.promptQueue = 2
+			m.promptQueueItems = []string{"older", "newest"}
+
+			_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tc.mod})
+			require.Zero(t, ws.popQueueCalls, "pop must run asynchronously")
+			runCmds(m, cmd)
+
+			require.Equal(t, 1, ws.popQueueCalls)
+			require.Equal(t, "newest", m.textarea.Value())
+			require.True(t, m.isAtEditorEnd())
+			require.Equal(t, []message.Attachment{attachment}, m.attachments.List())
+			require.Equal(t, -1, m.promptHistory.index)
+			require.Equal(t, "newest", m.promptHistory.draft)
+			require.Equal(t, []string{"older"}, m.promptQueueItems)
+			require.Equal(t, 1, m.promptQueue)
+			require.Equal(t, []string{"older"}, ws.queued)
+		})
+	}
+}
+
+func TestPopQueuedMessageRejectsNonEmptyInput(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{
+		ready:          true,
+		queued:         []string{"queued"},
+		queuedMessages: []agent.QueuedMessage{{Prompt: "queued"}},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.textarea.SetValue("draft")
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+	runCmds(m, cmd)
+
+	require.Zero(t, ws.popQueueCalls)
+	require.Equal(t, "draft", m.textarea.Value())
+	require.Equal(t, util.InfoTypeWarn, m.status.msg.Type)
+	require.Equal(t, "Can't pop queued message: input field is not empty.", m.status.msg.Msg)
+}
+
+func TestPopQueuedMessageAppendsAttachmentsAndSynchronizesBangMode(t *testing.T) {
+	pinTTLs(t)
+
+	existing := message.Attachment{FileName: "existing.txt", MimeType: "text/plain"}
+	restored := message.Attachment{FileName: "restored.png", MimeType: "image/png"}
+	ws := &countingWorkspace{
+		ready:          true,
+		queued:         []string{"!echo queued"},
+		queuedMessages: []agent.QueuedMessage{{Prompt: "!echo queued", Attachments: []message.Attachment{restored}}},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"!echo queued"}
+	m.attachments.Update(existing)
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModAlt})
+	runCmds(m, cmd)
+
+	require.True(t, m.bangMode)
+	require.Equal(t, "echo queued", m.textarea.Value())
+	require.True(t, m.isAtEditorEnd())
+	require.Equal(t, []message.Attachment{existing, restored}, m.attachments.List())
+}
+
+func TestPopQueuedMessageEmptyQueueIsNoOp(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 0
+	m.promptQueueItems = nil
+	gen := m.promptQueueGen
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+	runCmds(m, cmd)
+
+	require.Equal(t, 1, ws.popQueueCalls)
+	require.Empty(t, m.textarea.Value())
+	require.Empty(t, m.attachments.List())
+	require.Equal(t, gen, m.promptQueueGen)
+}
+
+func TestPopQueuedMessageReportsWorkspaceError(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, popErr: errors.New("pop failed")}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModAlt})
+	runCmds(m, cmd)
+
+	require.Equal(t, 1, ws.popQueueCalls)
+	require.Equal(t, util.InfoTypeError, m.status.msg.Type)
+	require.Equal(t, "pop failed", m.status.msg.Msg)
+}
+
+func TestPopQueuedMessageSupersedesInFlightQueueRefresh(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{
+		ready:          true,
+		queued:         []string{"older", "newest"},
+		queuedMessages: []agent.QueuedMessage{{Prompt: "older"}, {Prompt: "newest"}},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"older", "newest"}
+	m.promptQueueInFlight = true
+	staleGen := m.promptQueueGen
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+	runCmds(m, cmd)
+
+	require.Equal(t, []string{"older"}, m.promptQueueItems)
+	require.Greater(t, m.promptQueueGen, staleGen)
+	cmds := m.applyPromptQueue(promptQueueMsg{
+		forSession: "s1",
+		gen:        staleGen,
+		prompts:    []string{"older", "newest"},
+	})
+	require.Equal(t, []string{"older"}, m.promptQueueItems)
+	require.NotEmpty(t, cmds)
 }

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -41,6 +41,7 @@ type countingWorkspace struct {
 	queued         []string
 	queuedMessages []agent.QueuedMessage
 	popErr         error
+	clearErr       error
 	model          workspace.AgentModel
 	lspStates      map[string]workspace.LSPClientInfo
 	lspDiags       map[string]lsp.DiagnosticCounts
@@ -89,8 +90,14 @@ func (w *countingWorkspace) PermissionSetSkipRequests(skip bool) {
 
 // AgentClearQueue mirrors the production drain: it returns the messages it
 // removed, oldest to newest, so tests can assert what reaches the editor.
+// With clearErr set it fails the way the client does — nil messages plus the
+// error — and leaves the stub's queue alone, so a test can decide whether
+// the drain reached the agent before the failure.
 func (w *countingWorkspace) AgentClearQueue(string) ([]agent.QueuedMessage, error) {
 	w.clearQueueCalls++
+	if w.clearErr != nil {
+		return nil, w.clearErr
+	}
 	drained := w.queuedMessages
 	w.queuedMessages = nil
 	w.queued = nil
@@ -1567,6 +1574,54 @@ func TestEscapeDrainResultAfterSessionSwitchParksBatch(t *testing.T) {
 		"returning must hand the whole batch back in queue order")
 	require.Equal(t, []message.Attachment{attachment}, m.attachments.List())
 	require.Empty(t, m.queuedRestoreOrphans)
+}
+
+// TestEscapeDrainReportsWorkspaceError pins the transport-failure path of
+// the drain, mirroring TestPopQueuedMessageReportsWorkspaceError: the clear
+// is destructive server-side, so an error may be raised after the messages
+// were already removed. From here the queue state is unknown, so the
+// memoized count must be superseded by an authoritative re-fetch rather
+// than either kept (a pill that may now be too high) or zeroed (a queue the
+// drain may never have reached), and the banner must not promise the
+// prompts are still queued.
+func TestEscapeDrainReportsWorkspaceError(t *testing.T) {
+	pinTTLs(t)
+
+	// The drain never reached the agent, and while it was in flight the
+	// agent dequeued "older" to run it: neither the memoized ["older",
+	// "newest"] nor an empty queue is the truth.
+	ws := &countingWorkspace{
+		ready:    true,
+		clearErr: errors.New("clear failed"),
+		queued:   []string{"newest"},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"older", "newest"}
+	m.textarea.SetValue("draft")
+	staleGen := m.promptQueueGen
+	ws.resetCounters()
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+
+	require.Equal(t, 1, ws.clearQueueCalls)
+	require.Equal(t, util.InfoTypeError, m.status.msg.Type)
+	require.Equal(t, "clear failed (the queue may have been emptied anyway)", m.status.msg.Msg)
+	require.False(t, m.queueClearInFlight,
+		"a failed drain must clear the in-flight mark so the key is not wedged")
+	require.Greater(t, m.promptQueueGen, staleGen,
+		"an unknown queue state must supersede the memoized one")
+	require.Equal(t, 1, ws.queueListCalls,
+		"the unknown queue state must be replaced by one authoritative re-fetch")
+	require.Equal(t, []string{"newest"}, m.promptQueueItems,
+		"the re-fetch must replace the queue the drain may have emptied")
+	require.Equal(t, 1, m.promptQueue)
+	require.Equal(t, "draft", m.textarea.Value(),
+		"a failed drain restores nothing: the editor must be left alone")
+	require.Empty(t, m.attachments.List())
+	require.Empty(t, m.queuedRestoreOrphans, "a failed drain must not park anything")
 }
 
 // TestIdleEscapeDrainsQueueIntoEditor covers the state a cancel leaves

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -1724,3 +1724,54 @@ func TestIdleEscapeDuringHistoryNavigationKeepsQueue(t *testing.T) {
 	require.Empty(t, m.promptQueueItems)
 	require.Equal(t, "a\n\ndraft", m.textarea.Value())
 }
+
+// TestIdleEscapeDuringAttachmentDeleteModeKeepsQueue: esc keeps its more
+// local meaning while the ctrl+r attachment delete prompt is armed — it
+// only backs out of that prompt — so the queue must not be drained on the
+// same press. Draining it would cancel queued client submissions and
+// prepend their text to a draft the user was not editing.
+func TestIdleEscapeDuringAttachmentDeleteModeKeepsQueue(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{
+		ready:          true,
+		queued:         []string{"a"},
+		queuedMessages: []agent.QueuedMessage{{Prompt: "a"}},
+	}
+	m := newBusyUI(ws)
+	// The shared harness wires an empty keymap; delete mode needs the real
+	// bindings so ctrl+r and esc route exactly as they do in production.
+	m.attachments = attachments.New(nil, attachments.Keymap{
+		DeleteMode: m.keyMap.Editor.AttachmentDeleteMode,
+		DeleteAll:  m.keyMap.Editor.DeleteAllAttachments,
+		Escape:     m.keyMap.Editor.Escape,
+	})
+	warmCaches(m, false)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"a"}
+	m.textarea.SetValue("draft")
+	m.attachments.Update(message.Attachment{FileName: "notes.txt"})
+	ws.resetCounters()
+
+	// ctrl+r arms delete mode: from here a digit key removes that
+	// attachment, so esc has to be the way back out.
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
+	runCmds(m, cmd)
+	require.True(t, m.attachments.Deleting(), "ctrl+r must arm delete mode")
+
+	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+
+	require.False(t, m.attachments.Deleting(), "esc must back out of delete mode")
+	require.Zero(t, ws.clearQueueCalls, "esc must leave delete mode first")
+	require.Equal(t, []string{"a"}, m.promptQueueItems)
+	require.Equal(t, "draft", m.textarea.Value(), "the queue must stay off the editor")
+	require.Len(t, m.attachments.List(), 1, "backing out must keep the attachment")
+
+	// A second press, now that delete mode is disarmed, drains.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+	require.Equal(t, 1, ws.clearQueueCalls)
+	require.Empty(t, m.promptQueueItems)
+	require.Equal(t, "a\n\ndraft", m.textarea.Value())
+}

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -915,6 +915,8 @@ func TestPopQueuedMessageRejectsNonEmptyInput(t *testing.T) {
 	}
 	m := newBusyUI(ws)
 	warmCaches(m, true)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"queued"}
 	m.textarea.SetValue("draft")
 
 	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
@@ -1004,7 +1006,12 @@ func TestPopQueuedMessageAppendsAttachmentsAndSynchronizesBangMode(t *testing.T)
 	require.Equal(t, []message.Attachment{existing, restored}, m.attachments.List())
 }
 
-func TestPopQueuedMessageEmptyQueueIsNoOp(t *testing.T) {
+// TestPopQueuedMessageEmptyQueueIsAnsweredFromCache pins that a pop with
+// nothing queued costs no workspace round-trip (it is an HTTP POST in
+// client/server mode, and the memoized count already answers it) and still
+// tells the user why the editor stayed empty, so the chord does not read as
+// a broken binding.
+func TestPopQueuedMessageEmptyQueueIsAnsweredFromCache(t *testing.T) {
 	pinTTLs(t)
 
 	ws := &countingWorkspace{ready: true}
@@ -1017,11 +1024,62 @@ func TestPopQueuedMessageEmptyQueueIsNoOp(t *testing.T) {
 	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
 	runCmds(m, cmd)
 
-	require.Equal(t, 1, ws.popQueueCalls)
+	require.Zero(t, ws.popQueueCalls, "the memoized count must answer this without a round-trip")
+	require.Equal(t, util.InfoTypeInfo, m.status.msg.Type)
+	require.Equal(t, "No queued messages.", m.status.msg.Msg)
 	require.Empty(t, m.textarea.Value())
 	require.Empty(t, m.attachments.List())
 	require.Equal(t, gen, m.promptQueueGen)
+	require.False(t, m.queuedPopInFlight, "a short-circuited pop must not mark itself in flight")
+}
+
+// TestPopQueuedMessageStaleCountReportsEmptyQueue pins the other half: the
+// memoized count is the gate, so it can be one round-trip stale (the agent
+// dequeued the last prompt meanwhile). The server's "not found" stays the
+// authority — it must report the empty queue and supersede the wrong count
+// rather than leave the pill promising a message that is gone.
+func TestPopQueuedMessageStaleCountReportsEmptyQueue(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"already dequeued"}
+	staleGen := m.promptQueueGen
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+	runCmds(m, cmd)
+
+	require.Equal(t, 1, ws.popQueueCalls)
+	require.Equal(t, util.InfoTypeInfo, m.status.msg.Type)
+	require.Equal(t, "No queued messages.", m.status.msg.Msg)
+	require.Empty(t, m.textarea.Value())
+	require.Greater(t, m.promptQueueGen, staleGen,
+		"a queue the server says is empty must supersede the memoized one")
+	require.Zero(t, m.promptQueue, "the re-fetch must drop the phantom queue pill")
+	require.Empty(t, m.promptQueueItems)
 	require.False(t, m.queuedPopInFlight, "an empty-queue result must clear the in-flight mark")
+}
+
+// TestPopQueuedMessageEmptyResultAfterSessionSwitchKeepsCurrentQueue: a pop
+// that found nothing says nothing about the session the user switched to, so
+// it must not invalidate or empty that session's queue.
+func TestPopQueuedMessageEmptyResultAfterSessionSwitchKeepsCurrentQueue(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, queued: []string{"a"}}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"a"}
+	gen := m.promptQueueGen
+
+	require.Nil(t, m.applyQueuedMessagePop(queuedMessagePoppedMsg{forSession: "s0"}))
+	require.Equal(t, []string{"a"}, m.promptQueueItems)
+	require.Equal(t, 1, m.promptQueue)
+	require.Equal(t, gen, m.promptQueueGen)
+	require.Zero(t, ws.queueListCalls, "another session's empty pop must not re-fetch this queue")
 }
 
 // helpDesc returns the description the help panes show for the binding

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/completions"
 	"github.com/charmbracelet/crush/internal/ui/dialog"
 	"github.com/charmbracelet/crush/internal/ui/util"
 	"github.com/charmbracelet/crush/internal/workspace"
@@ -1741,6 +1742,118 @@ func TestIdleEscapeDrainsQueueIntoEditor(t *testing.T) {
 	require.Equal(t, "a\n\nb\n\ndraft", m.textarea.Value())
 }
 
+// TestIdleEscapeDrainRestoresAttachmentOnlyMessage pins the empty-parts
+// guard in restoreQueuedMessages: a submission can carry attachments and no
+// text at all (a large paste becomes paste_1.txt with nothing typed), and
+// rewriting the buffer for such a restore would disengage bang mode with no
+// "!" to materialize in its place — the shell intent the prompt is still
+// advertising would silently become an ordinary prompt.
+func TestIdleEscapeDrainRestoresAttachmentOnlyMessage(t *testing.T) {
+	pinTTLs(t)
+
+	paste := message.Attachment{
+		FilePath: "paste_1.txt",
+		FileName: "paste_1.txt",
+		MimeType: "text/plain",
+		Content:  []byte("pasted blob"),
+	}
+	ws := &countingWorkspace{
+		ready:          true,
+		queued:         []string{""},
+		queuedMessages: []agent.QueuedMessage{{Attachments: []message.Attachment{paste}}},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{""}
+	// The user has just typed "!": bang mode is armed and the textarea is
+	// empty, because the leading "!" is not part of its value.
+	m.bangMode = true
+	ws.resetCounters()
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+
+	require.Equal(t, 1, ws.clearQueueCalls)
+	require.Empty(t, m.textarea.Value(), "an attachment-only restore has no text to prepend")
+	require.True(t, m.bangMode,
+		"an attachment-only restore must not disengage bang mode: there is no \"!\" to materialize")
+	require.Equal(t, []message.Attachment{paste}, m.attachments.List())
+	require.Equal(t, util.InfoTypeInfo, m.status.msg.Type)
+	require.Equal(t, "Queued messages moved to the input field.", m.status.msg.Msg)
+}
+
+// TestIdleEscapeDrainRestoresTheSameAttachmentTwiceInOneBatch pins the held
+// snapshot taken before the restore loop: two queued submissions can carry
+// the same file, and a drain restores the whole queue at once, so the batch
+// must reach the editor as it was queued. Snapshotting inside the loop would
+// let the first copy hide the second — a case only the drain can produce,
+// since a pop restores one message at a time. The dedupe is against chips
+// the editor already held, not against the batch itself.
+func TestIdleEscapeDrainRestoresTheSameAttachmentTwiceInOneBatch(t *testing.T) {
+	pinTTLs(t)
+
+	shared := message.Attachment{
+		FilePath: "/tmp/notes.txt",
+		FileName: "notes.txt",
+		MimeType: "text/plain",
+		Content:  []byte("hello"),
+	}
+	ws := &countingWorkspace{
+		ready:  true,
+		queued: []string{"first", "second"},
+		queuedMessages: []agent.QueuedMessage{
+			{Prompt: "first", Attachments: []message.Attachment{shared}},
+			{Prompt: "second", Attachments: []message.Attachment{shared}},
+		},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"first", "second"}
+	ws.resetCounters()
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+
+	require.Equal(t, 1, ws.clearQueueCalls)
+	require.Equal(t, "first\n\nsecond", m.textarea.Value())
+	require.Equal(t, []message.Attachment{shared, shared}, m.attachments.List(),
+		"a batch carrying the same file twice must be restored as it was queued")
+}
+
+// TestIdleEscapeDrainWithStaleCountReportsEmptyQueue pins the restore arm
+// for a drain that comes back empty. The memoized count is the gate, so it
+// can be one round-trip stale (the agent dequeued the last prompt, or
+// another client drained it, while the press was in flight). Nothing reaches
+// the editor, so the banner must say the queue was empty instead of claiming
+// prompts were moved into the input field.
+func TestIdleEscapeDrainWithStaleCountReportsEmptyQueue(t *testing.T) {
+	pinTTLs(t)
+
+	// The stub has nothing queued while the UI is still showing a queue.
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"a"}
+	m.textarea.SetValue("draft")
+	ws.resetCounters()
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+
+	require.Equal(t, 1, ws.clearQueueCalls, "the memoized count must let the press through")
+	require.Equal(t, util.InfoTypeInfo, m.status.msg.Type)
+	require.Equal(t, noQueuedMessages, m.status.msg.Msg,
+		"an empty drain must not claim prompts were moved into the input field")
+	require.Equal(t, "draft", m.textarea.Value(), "an empty drain restores nothing")
+	require.Empty(t, m.promptQueueItems)
+	require.Zero(t, m.promptQueue)
+	require.False(t, m.queueClearInFlight)
+	require.Empty(t, m.queuedRestoreOrphans, "an empty drain must not park anything")
+}
+
 // TestIdleEscapeWithoutQueueClearsNothing keeps esc inert on an idle
 // session with nothing queued: the binding acts only when the UI is
 // showing a queue to move.
@@ -1893,6 +2006,59 @@ func TestIdleEscapeDuringAttachmentDeleteModeKeepsQueue(t *testing.T) {
 	require.Equal(t, 1, ws.clearQueueCalls)
 	require.Empty(t, m.promptQueueItems)
 	require.Equal(t, "a\n\ndraft", m.textarea.Value())
+}
+
+// TestIdleEscapeWithCompletionsOpenKeepsQueue: esc keeps its more local
+// meaning while the @-completions popup is open — it closes the popup — so
+// the queue must not be drained on the same press. Draining it would cancel
+// queued client submissions and prepend their text above the draft the user
+// is completing a path into.
+func TestIdleEscapeWithCompletionsOpenKeepsQueue(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{
+		ready:          true,
+		queued:         []string{"a"},
+		queuedMessages: []agent.QueuedMessage{{Prompt: "a"}},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"a"}
+	m.textarea.SetValue("look at @")
+	// The shared harness leaves the completions component nil, and the "@"
+	// keystroke that opens it in production needs both a config (for the
+	// walk limits) and a filesystem walk. Open it the way that keystroke
+	// does — raise the flag, then let the production
+	// CompletionItemsLoadedMsg handler hand the loaded items to the
+	// component — so the escape press itself routes exactly as it does in
+	// production.
+	m.completions = completions.New(
+		m.com.Styles.Completions.Normal,
+		m.com.Styles.Completions.Focused,
+		m.com.Styles.Completions.Match,
+	)
+	m.completionsOpen = true
+	m.Update(completions.CompletionItemsLoadedMsg{
+		Files: []completions.FileCompletionValue{{Path: "internal/ui/model/ui.go"}},
+	})
+	require.True(t, m.completions.IsOpen(), "the popup must be open before the press")
+	ws.resetCounters()
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+
+	require.False(t, m.completionsOpen, "esc must close the completions popup")
+	require.Zero(t, ws.clearQueueCalls, "esc must close the popup first")
+	require.Equal(t, []string{"a"}, m.promptQueueItems)
+	require.Equal(t, "look at @", m.textarea.Value(), "the queue must stay off the editor")
+
+	// A second press, now that the popup is closed, drains.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+	require.Equal(t, 1, ws.clearQueueCalls)
+	require.Empty(t, m.promptQueueItems)
+	require.Equal(t, "a\n\nlook at @", m.textarea.Value())
 }
 
 // TestIdleEscapeDrainIsSingleFlight pins the guard against a repeated press:

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -102,6 +102,10 @@ func (w *countingWorkspace) AgentPopQueuedMessage(string) (agent.QueuedMessage, 
 	}
 	return queued, true, nil
 }
+
+// AgentCancel mirrors production: agent.sessionAgent.Cancel ends the turn
+// in progress and deliberately leaves the message queue alone, so w.queued
+// must stay untouched here. Only AgentClearQueue discards queued prompts.
 func (w *countingWorkspace) AgentCancel(string) { w.cancelCalls++ }
 
 func (w *countingWorkspace) AgentModel() workspace.AgentModel {
@@ -440,7 +444,11 @@ func TestSendMessageSetsOptimisticBusy(t *testing.T) {
 }
 
 // TestCancelAgentPreservesQueue verifies that queued prompts do not change
-// Escape's double-press active-task cancellation behavior.
+// Escape's double-press active-task cancellation behavior, and that the UI
+// neither discards its cached queue nor asks the workspace to clear the
+// agent queue. The agent side of the contract — Cancel leaving the queue
+// intact — is pinned by agent.TestCancel_PreservesQueuedPrompts; the stub
+// here only models it.
 func TestCancelAgentPreservesQueue(t *testing.T) {
 	pinTTLs(t)
 

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -1775,3 +1775,103 @@ func TestIdleEscapeDuringAttachmentDeleteModeKeepsQueue(t *testing.T) {
 	require.Empty(t, m.promptQueueItems)
 	require.Equal(t, "a\n\ndraft", m.textarea.Value())
 }
+
+// TestIdleEscapeDrainIsSingleFlight pins the guard against a repeated press:
+// the drain empties the agent queue while the memoized count deliberately
+// stays put until the result lands, and the idle branch gates on nothing
+// else, so a second press would dispatch a second drain. That drain finds
+// the queue already empty and its apply path reports "No queued messages."
+// over the restore banner the first drain just published — telling the user
+// nothing was restored right after restoring it.
+func TestIdleEscapeDrainIsSingleFlight(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{
+		ready:          true,
+		queued:         []string{"a", "b"},
+		queuedMessages: []agent.QueuedMessage{{Prompt: "a"}, {Prompt: "b"}},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"a", "b"}
+	m.textarea.SetValue("draft")
+	ws.resetCounters()
+
+	_, first := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	require.True(t, m.queueClearInFlight, "the dispatched drain must be marked in flight")
+	_, second := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	require.Nil(t, second, "a press during the round-trip must dispatch nothing")
+
+	runCmds(m, first)
+	runCmds(m, second)
+
+	require.Equal(t, 1, ws.clearQueueCalls, "an esc mash must not drain twice")
+	require.False(t, m.queueClearInFlight, "the result must clear the in-flight mark")
+	require.Equal(t, "a\n\nb\n\ndraft", m.textarea.Value())
+	require.Equal(t, util.InfoTypeInfo, m.status.msg.Type)
+	require.Equal(t, "Queued messages moved to the input field.", m.status.msg.Msg,
+		"the restore banner must survive the suppressed press")
+
+	// The mark is released, not latched: a later press with something queued
+	// again drains as usual.
+	ws.queued = []string{"c"}
+	ws.queuedMessages = []agent.QueuedMessage{{Prompt: "c"}}
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"c"}
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	runCmds(m, cmd)
+
+	require.Equal(t, 2, ws.clearQueueCalls)
+	require.Equal(t, "c\n\na\n\nb\n\ndraft", m.textarea.Value())
+}
+
+// TestBusyEscapeDrainIsSingleFlightAcrossTheBusyEdge covers the other way
+// the same drain re-fires: the busy double-press drains on its confirming
+// press, the cancel makes the session read idle before the round-trip
+// returns, and the next press of the "esc esc esc" mash the double-press
+// machine trains takes the *idle* branch on the still-non-zero memoized
+// count.
+func TestBusyEscapeDrainIsSingleFlightAcrossTheBusyEdge(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{
+		ready:          true,
+		agentBusy:      true,
+		queued:         []string{"a"},
+		queuedMessages: []agent.QueuedMessage{{Prompt: "a"}},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 1
+	m.promptQueueItems = []string{"a"}
+	m.textarea.SetValue("draft")
+	ws.resetCounters()
+
+	// Arming press: its command is the double-press timer, deliberately not
+	// run here (it blocks for the whole window before emitting its expiry).
+	m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	require.True(t, m.isCanceling)
+
+	// Confirming press: cancels and dispatches the drain.
+	_, confirm := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	require.Equal(t, 1, ws.cancelCalls)
+	require.True(t, m.queueClearInFlight)
+
+	// The cancel lands: the session now reads idle while the drain is still
+	// out, which is what routes the next press to the idle branch.
+	ws.agentBusy = false
+	m.agentBusyCache.set(false)
+
+	_, third := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	require.Nil(t, third, "the idle branch must not re-fire the in-flight drain")
+
+	runCmds(m, confirm)
+	runCmds(m, third)
+
+	require.Equal(t, 1, ws.clearQueueCalls, "the gesture must drain exactly once")
+	require.False(t, m.queueClearInFlight)
+	require.Equal(t, "a\n\ndraft", m.textarea.Value())
+	require.Equal(t, "Queued messages moved to the input field.", m.status.msg.Msg)
+}

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -87,7 +87,16 @@ func (w *countingWorkspace) PermissionSetSkipRequests(skip bool) {
 	w.yolo = skip
 }
 
-func (w *countingWorkspace) AgentClearQueue(string) { w.clearQueueCalls++; w.queued = nil }
+// AgentClearQueue mirrors the production drain: it returns the messages it
+// removed, oldest to newest, so tests can assert what reaches the editor.
+func (w *countingWorkspace) AgentClearQueue(string) ([]agent.QueuedMessage, error) {
+	w.clearQueueCalls++
+	drained := w.queuedMessages
+	w.queuedMessages = nil
+	w.queued = nil
+	return drained, nil
+}
+
 func (w *countingWorkspace) AgentPopQueuedMessage(string) (agent.QueuedMessage, bool, error) {
 	w.popQueueCalls++
 	if w.popErr != nil {

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -1024,6 +1024,62 @@ func TestPopQueuedMessageEmptyQueueIsNoOp(t *testing.T) {
 	require.False(t, m.queuedPopInFlight, "an empty-queue result must clear the in-flight mark")
 }
 
+// helpDesc returns the description the help panes show for the binding
+// rendered under helpKey, or "" when no such binding is offered.
+func helpDesc(groups [][]key.Binding, helpKey string) string {
+	for _, group := range groups {
+		for _, b := range group {
+			if b.Help().Key == helpKey {
+				return b.Help().Desc
+			}
+		}
+	}
+	return ""
+}
+
+// TestPopQueuedMessageHelpListsBindingWhenQueued pins the discoverability of
+// the pop binding: an unlisted chord is the feature's only entry point, so
+// the full help pane must name it whenever prompts are queued in editor
+// focus — including while a draft is in the editor, which is exactly when a
+// user wonders how to get back to a queued prompt. It must stay out of chat
+// focus, where the same chord scrolls the conversation, and out of the
+// status line, which is already 113 columns wide: another entry there would
+// push "ctrl+g more" (the way to reach the full pane) off a 120- or
+// 140-column terminal.
+func TestPopQueuedMessageHelpListsBindingWhenQueued(t *testing.T) {
+	pinTTLs(t)
+
+	const desc = "edit last queued message"
+
+	ws := &countingWorkspace{ready: true, queued: []string{"older", "newest"}}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"older", "newest"}
+
+	require.Equal(t, desc, helpDesc(m.FullHelp(), "shift+↑"),
+		"full help must list the pop binding while prompts are queued")
+	require.Empty(t, helpDesc([][]key.Binding{m.ShortHelp()}, "shift+↑"),
+		"the status line must stay short enough to keep its own tail")
+
+	m.textarea.SetValue("draft")
+	require.Equal(t, desc, helpDesc(m.FullHelp(), "shift+↑"),
+		"a draft must not hide the binding: it is how the user recovers one")
+	m.textarea.SetValue("")
+
+	// Chat focus: the editor never sees the key press there.
+	m.focus = uiFocusMain
+	require.NotEqual(t, desc, helpDesc(m.FullHelp(), "shift+↑"),
+		"full help must not list the editor pop in chat focus")
+	m.focus = uiFocusEditor
+
+	// Nothing queued: nothing to pop.
+	m.promptQueue = 0
+	m.promptQueueItems = nil
+	require.Empty(t, helpDesc(m.FullHelp(), "shift+↑"),
+		"full help must not list the pop with an empty queue")
+}
+
 // TestPopQueuedMessageIsSingleFlight pins the guard against key autorepeat:
 // the pop is destructive at the agent layer and nothing in the model changes
 // until its result lands, so a second dispatch would remove a second message

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -1062,21 +1062,114 @@ func TestPopQueuedMessageIsSingleFlight(t *testing.T) {
 	require.Empty(t, ws.queued)
 }
 
+// TestPopQueuedMessageReportsWorkspaceError pins the transport-failure path:
+// the error may be raised after the server already removed the message
+// (response read/decode failure, dropped connection), so the queue state is
+// unknown from here — it must be re-fetched, and the banner must not imply
+// the message is still queued.
 func TestPopQueuedMessageReportsWorkspaceError(t *testing.T) {
 	pinTTLs(t)
 
-	ws := &countingWorkspace{ready: true, popErr: errors.New("pop failed")}
+	// The server popped "newest" and then the response was lost.
+	ws := &countingWorkspace{ready: true, popErr: errors.New("pop failed"), queued: []string{"older"}}
 	m := newBusyUI(ws)
 	warmCaches(m, true)
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"older", "newest"}
+	staleGen := m.promptQueueGen
 
 	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModAlt})
 	runCmds(m, cmd)
 
 	require.Equal(t, 1, ws.popQueueCalls)
 	require.Equal(t, util.InfoTypeError, m.status.msg.Type)
-	require.Equal(t, "pop failed", m.status.msg.Msg)
+	require.Equal(t, "pop failed (it may have left the queue anyway)", m.status.msg.Msg)
 	require.False(t, m.queuedPopInFlight,
 		"a failed pop must clear the in-flight mark so the key is not wedged")
+	require.Greater(t, m.promptQueueGen, staleGen,
+		"an unknown queue state must supersede the memoized one")
+	require.Equal(t, []string{"older"}, m.promptQueueItems,
+		"the re-fetch must replace the queue the pop may have shortened")
+	require.Equal(t, 1, m.promptQueue)
+}
+
+// TestPopQueuedMessageParksResultAfterSessionSwitch pins the session-switch
+// race: the pop is destructive at the agent layer and queued prompts live
+// nowhere else (they are not persisted until they run), so a result that
+// lands after a session switch may not be dropped. It also may not be
+// restored into the current session's editor — the prompt was written for
+// another session. It is parked and handed back on return.
+func TestPopQueuedMessageParksResultAfterSessionSwitch(t *testing.T) {
+	pinTTLs(t)
+
+	restored := message.Attachment{FileName: "restored.png", MimeType: "image/png"}
+	ws := &countingWorkspace{
+		ready:  true,
+		queued: []string{"older", "newest"},
+		queuedMessages: []agent.QueuedMessage{
+			{Prompt: "older"},
+			{Prompt: "newest", Attachments: []message.Attachment{restored}},
+		},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"older", "newest"}
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+	// The user switches sessions while the pop is in flight.
+	m.session = &session.Session{ID: "s2"}
+	runCmds(m, cmd)
+
+	require.Equal(t, 1, ws.popQueueCalls)
+	require.Empty(t, m.textarea.Value(),
+		"another session's prompt must not land in the current editor")
+	require.Empty(t, m.attachments.List())
+	require.Equal(t, util.InfoTypeWarn, m.status.msg.Type)
+	require.Equal(t,
+		"Session changed: the popped message will be restored when you return to that session.",
+		m.status.msg.Msg)
+	require.Equal(t,
+		agent.QueuedMessage{Prompt: "newest", Attachments: []message.Attachment{restored}},
+		m.queuedPopOrphans["s1"],
+		"the popped message must be parked for the session it came from")
+
+	_, cmd = m.Update(loadSessionMsg{session: &session.Session{ID: "s1"}})
+	runCmds(m, cmd)
+
+	require.Equal(t, "newest", m.textarea.Value(), "returning must hand the message back")
+	require.True(t, m.isAtEditorEnd())
+	require.Equal(t, []message.Attachment{restored}, m.attachments.List())
+	require.Equal(t, util.InfoTypeWarn, m.status.msg.Type)
+	require.Equal(t,
+		"Restored the queued message you popped before switching sessions.",
+		m.status.msg.Msg)
+	require.Empty(t, m.queuedPopOrphans, "a restored message must not be parked twice")
+}
+
+// TestParkedPopRestoreKeepsEditorDraft pins that the parked restore is
+// non-destructive: the editor is shared across sessions, so text typed while
+// the message was parked must survive it coming back.
+func TestParkedPopRestoreKeepsEditorDraft(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.session = &session.Session{ID: "s2"}
+	m.queuedPopOrphans = map[string]agent.QueuedMessage{"s1": {Prompt: "newest"}}
+	m.textarea.SetValue("draft")
+
+	_, cmd := m.Update(loadSessionMsg{session: &session.Session{ID: "s1"}})
+	runCmds(m, cmd)
+
+	require.Equal(t, "draft\nnewest", m.textarea.Value())
+	require.True(t, m.isAtEditorEnd())
+	require.Equal(t, util.InfoTypeWarn, m.status.msg.Type)
+	require.Equal(t,
+		"Appended the queued message you popped before switching sessions below your text.",
+		m.status.msg.Msg)
+	require.Empty(t, m.queuedPopOrphans)
 }
 
 func TestPopQueuedMessageSupersedesInFlightQueueRefresh(t *testing.T) {

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -923,6 +923,47 @@ func TestPopQueuedMessageEmptyQueueIsNoOp(t *testing.T) {
 	require.Empty(t, m.textarea.Value())
 	require.Empty(t, m.attachments.List())
 	require.Equal(t, gen, m.promptQueueGen)
+	require.False(t, m.queuedPopInFlight, "an empty-queue result must clear the in-flight mark")
+}
+
+// TestPopQueuedMessageIsSingleFlight pins the guard against key autorepeat:
+// the pop is destructive at the agent layer and nothing in the model changes
+// until its result lands, so a second dispatch would remove a second message
+// that the apply path then overwrites in the editor — losing it for good.
+func TestPopQueuedMessageIsSingleFlight(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{
+		ready:          true,
+		queued:         []string{"older", "newest"},
+		queuedMessages: []agent.QueuedMessage{{Prompt: "older"}, {Prompt: "newest"}},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"older", "newest"}
+
+	_, first := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+	require.True(t, m.queuedPopInFlight, "the dispatched pop must be marked in flight")
+	_, second := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+	runCmds(m, first)
+	runCmds(m, second)
+
+	require.Equal(t, 1, ws.popQueueCalls, "autorepeat must not pop twice")
+	require.False(t, m.queuedPopInFlight, "the result must clear the in-flight mark")
+	require.Equal(t, "newest", m.textarea.Value())
+	require.Equal(t, []string{"older"}, m.promptQueueItems)
+	require.Equal(t, 1, m.promptQueue)
+	require.Equal(t, []string{"older"}, ws.queued)
+
+	// A later press is allowed once the first pop settled.
+	m.textarea.SetValue("")
+	_, third := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+	runCmds(m, third)
+
+	require.Equal(t, 2, ws.popQueueCalls)
+	require.Equal(t, "older", m.textarea.Value())
+	require.Empty(t, ws.queued)
 }
 
 func TestPopQueuedMessageReportsWorkspaceError(t *testing.T) {
@@ -938,6 +979,8 @@ func TestPopQueuedMessageReportsWorkspaceError(t *testing.T) {
 	require.Equal(t, 1, ws.popQueueCalls)
 	require.Equal(t, util.InfoTypeError, m.status.msg.Type)
 	require.Equal(t, "pop failed", m.status.msg.Msg)
+	require.False(t, m.queuedPopInFlight,
+		"a failed pop must clear the in-flight mark so the key is not wedged")
 }
 
 func TestPopQueuedMessageSupersedesInFlightQueueRefresh(t *testing.T) {

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -1015,6 +1015,76 @@ func TestPopQueuedMessageAppendsAttachmentsAndSynchronizesBangMode(t *testing.T)
 	require.Equal(t, []message.Attachment{existing, restored}, m.attachments.List())
 }
 
+// TestPopQueuedMessageSkipsAttachmentsAlreadyOnEditor pins the identity used
+// when a restore collides with chips the editor already holds: an attachment
+// that is already there byte for byte is not added again (two identical
+// chips would send the same file twice), while a same-named attachment
+// carrying different bytes is kept, since paste_<n>.txt names are only
+// unique within one editor's list and the restore may never drop content.
+func TestPopQueuedMessageSkipsAttachmentsAlreadyOnEditor(t *testing.T) {
+	pinTTLs(t)
+
+	notes := message.Attachment{
+		FilePath: "/tmp/notes.txt",
+		FileName: "notes.txt",
+		MimeType: "text/plain",
+		Content:  []byte("hello"),
+	}
+	diagram := message.Attachment{
+		FilePath: "/tmp/diagram.png",
+		FileName: "diagram.png",
+		MimeType: "image/png",
+		Content:  []byte("png bytes"),
+	}
+	typedPaste := message.Attachment{
+		FilePath: "paste_1.txt",
+		FileName: "paste_1.txt",
+		MimeType: "text/plain",
+		Content:  []byte("typed later"),
+	}
+	queuedPaste := typedPaste
+	queuedPaste.Content = []byte("queued earlier")
+
+	for _, tc := range []struct {
+		name     string
+		held     message.Attachment
+		restored []message.Attachment
+		want     []message.Attachment
+	}{
+		{
+			name:     "identical attachment is not duplicated",
+			held:     notes,
+			restored: []message.Attachment{notes, diagram},
+			want:     []message.Attachment{notes, diagram},
+		},
+		{
+			name:     "same name with different bytes is kept",
+			held:     typedPaste,
+			restored: []message.Attachment{queuedPaste},
+			want:     []message.Attachment{typedPaste, queuedPaste},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ws := &countingWorkspace{
+				ready:          true,
+				queued:         []string{"queued prompt"},
+				queuedMessages: []agent.QueuedMessage{{Prompt: "queued prompt", Attachments: tc.restored}},
+			}
+			m := newBusyUI(ws)
+			warmCaches(m, true)
+			m.promptQueue = 1
+			m.promptQueueItems = []string{"queued prompt"}
+			m.attachments.Update(tc.held)
+
+			_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+			runCmds(m, cmd)
+
+			require.Equal(t, "queued prompt", m.textarea.Value())
+			require.Equal(t, tc.want, m.attachments.List())
+		})
+	}
+}
+
 // TestPopQueuedMessageEmptyQueueIsAnsweredFromCache pins that a pop with
 // nothing queued costs no workspace round-trip (it is an HTTP POST in
 // client/server mode, and the memoized count already answers it) and still

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -214,7 +214,11 @@ func runCmds(m *UI, cmd tea.Cmd) {
 		_, next := m.Update(msg)
 		runCmds(m, next)
 	case util.InfoMsg:
-		m.status.SetInfoMsg(msg)
+		// Status banners go through Update exactly as they do in production
+		// (ui.go's util.InfoMsg case). The one command it returns is the
+		// status-clear tick, which blocks for the whole status TTL before
+		// emitting util.ClearStatusMsg, so it is deliberately not run here.
+		m.Update(msg)
 	}
 }
 

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 
@@ -474,6 +475,48 @@ func TestCancelAgentPreservesQueue(t *testing.T) {
 	require.Equal(t, 1, ws.cancelCalls, "second esc press must cancel the agent")
 	require.Equal(t, []string{"a"}, ws.queued)
 	require.Zero(t, ws.clearQueueCalls, "canceling the agent must preserve queued prompts")
+}
+
+// cancelHelp returns the description the help panes show for the esc/cancel
+// binding, or "" when no cancel binding is offered.
+func cancelHelp(t *testing.T, binds []key.Binding) string {
+	t.Helper()
+	for _, b := range binds {
+		if b.Help().Key == "esc" {
+			return b.Help().Desc
+		}
+	}
+	return ""
+}
+
+// TestCancelHelpNeverAdvertisesClearQueue pins the help text against the
+// turn-scoped cancel semantics: esc cancels the active turn and leaves the
+// queue alone, so neither help pane may claim it clears the queue just
+// because prompts are queued. The armed state still shows the
+// double-press hint.
+func TestCancelHelpNeverAdvertisesClearQueue(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, agentBusy: true, queued: []string{"a", "b"}}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	m.promptQueue = 2
+	m.promptQueueItems = []string{"a", "b"}
+
+	require.Equal(t, "cancel", cancelHelp(t, m.ShortHelp()),
+		"short help must not advertise clearing the queue")
+	full := m.FullHelp()
+	require.NotEmpty(t, full)
+	require.Equal(t, "cancel", cancelHelp(t, full[0]),
+		"full help must not advertise clearing the queue")
+
+	// First esc press arms cancellation: both panes switch to the
+	// double-press hint, still never mentioning the queue.
+	m.isCanceling = true
+	require.Equal(t, "press again to cancel", cancelHelp(t, m.ShortHelp()))
+	full = m.FullHelp()
+	require.NotEmpty(t, full)
+	require.Equal(t, "press again to cancel", cancelHelp(t, full[0]))
 }
 
 // TestBackstopRefreshesStaleCaches: when the memoized state outlives its TTL

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -1390,6 +1390,70 @@ func TestPopQueuedMessageParksResultAfterSessionSwitch(t *testing.T) {
 	require.Empty(t, m.queuedRestoreOrphans, "a restored message must not be parked twice")
 }
 
+// TestParksAccumulateAcrossPopAndDrain pins that parking appends. Both
+// destructive queue ops can land after the same session switch — the user
+// pops, then Escapes, then leaves before either round-trip returns — and
+// parked prompts live nowhere else, so a second park that overwrote the
+// first would destroy text outright. Both batches come back on the single
+// return, in the order they were removed.
+func TestParksAccumulateAcrossPopAndDrain(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{
+		ready:  true,
+		queued: []string{"drained-older", "drained-newer", "popped"},
+		queuedMessages: []agent.QueuedMessage{
+			{Prompt: "drained-older"},
+			{Prompt: "drained-newer"},
+			{Prompt: "popped"},
+		},
+	}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+	m.promptQueue = 3
+	m.promptQueueItems = []string{"drained-older", "drained-newer", "popped"}
+
+	// Both ops are dispatched against s1 and are still in flight when the
+	// user switches away: the pop takes the newest prompt, the Escape drain
+	// takes what is left. Neither memoized-count gate has been zeroed yet,
+	// so the second press goes out too (they hold separate single-flight
+	// marks).
+	_, popCmd := m.Update(tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift})
+	_, drainCmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	m.session = &session.Session{ID: "s2"}
+	runCmds(m, popCmd)
+	runCmds(m, drainCmd)
+
+	require.Equal(t, 1, ws.popQueueCalls)
+	require.Equal(t, 1, ws.clearQueueCalls)
+	require.Empty(t, m.textarea.Value(),
+		"another session's prompts must not land in the current editor")
+	require.Equal(t, util.InfoTypeWarn, m.status.msg.Type)
+	require.Equal(t,
+		"Session changed: 2 queued messages will be restored when you return to that session.",
+		m.status.msg.Msg)
+	require.Equal(t,
+		[]agent.QueuedMessage{
+			{Prompt: "popped"},
+			{Prompt: "drained-older"},
+			{Prompt: "drained-newer"},
+		},
+		m.queuedRestoreOrphans["s1"],
+		"the drain must park behind the pop, not replace it")
+
+	_, cmd := m.Update(loadSessionMsg{session: &session.Session{ID: "s1"}})
+	runCmds(m, cmd)
+
+	require.Equal(t, "popped\n\ndrained-older\n\ndrained-newer", m.textarea.Value(),
+		"returning must hand back every parked batch, in the order they were parked")
+	require.True(t, m.isAtEditorEnd())
+	require.Equal(t, util.InfoTypeWarn, m.status.msg.Type)
+	require.Equal(t,
+		"Restored 3 queued messages you removed before switching sessions.",
+		m.status.msg.Msg)
+	require.Empty(t, m.queuedRestoreOrphans, "a restored batch must not be parked twice")
+}
+
 // TestParkedRestoreKeepsEditorDraft pins that the parked restore is
 // non-destructive: the editor is shared across sessions, so text typed while
 // the messages were parked must survive them coming back, and the whole

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -731,6 +731,8 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, m.applyPromptQueue(msg)...)
 	case queuedMessagePoppedMsg:
 		cmds = append(cmds, m.applyQueuedMessagePop(msg)...)
+	case promptQueueClearedMsg:
+		cmds = append(cmds, m.applyPromptQueueCleared(msg)...)
 	case lspStatesMsg:
 		if cmd := m.applyLSPStates(msg); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -1956,6 +1958,13 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionTogglePills:
 		if cmd := m.togglePillsExpanded(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionClearQueue:
+		// The clear is off-thread; the memoized queue is emptied when its
+		// promptQueueClearedMsg lands.
+		if cmd := m.clearQueuedMessages(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 		m.dialog.CloseDialog(dialog.CommandsID)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -343,28 +343,14 @@ type UI struct {
 	// in-flight fetch captures it at dispatch and its result is discarded
 	// if the generation has moved on (see workspace_cache.go).
 	promptQueueGen uint64
-	// queuedPopInFlight is set while a queued-message pop is in flight. The
-	// pop is destructive at the agent layer and nothing in the model
-	// changes until its result lands, so without this guard key autorepeat
-	// (or impatience over an HTTP round-trip) would pop several messages
-	// and only the last result would survive in the editor.
+	// queuedPopInFlight guards the destructive pop: without it key
+	// autorepeat would pop several messages and keep only the last.
 	queuedPopInFlight bool
-	// queueClearInFlight is the same guard for the queue drain, which has
-	// the same shape: it empties the agent queue while the memoized count
-	// deliberately stays put until the result lands, and both Escape paths
-	// gate on that count. Without it an "esc esc esc" mash — or a busy
-	// double-press whose busy->idle edge arrives before the round-trip
-	// returns — fires a second drain whose empty result reports "No queued
-	// messages." over the restore banner the first one just published.
+	// queueClearInFlight is the same guard for the drain: a second press
+	// during the round-trip would drain an already-emptied queue.
 	queueClearInFlight bool
-	// queuedRestoreOrphans holds queued messages a pop or an Escape drain
-	// removed, whose result landed after the user had switched away from
-	// the session they came from, keyed by that session. They are already
-	// out of the agent queue and queued prompts are not persisted
-	// anywhere, so dropping the result would destroy the text: it is
-	// parked here and restored by restoreParkedQueuedMessages the next
-	// time that session is loaded. A drain parks a whole batch, and a
-	// session can accumulate several before the user returns.
+	// queuedRestoreOrphans holds queue removals that landed after a
+	// session switch, keyed by session, for restoreParkedQueuedMessages.
 	queuedRestoreOrphans map[string][]agent.QueuedMessage
 	// agentBusyCache / yoloCache memoize the workspace busy and permission
 	// probes (synchronous HTTP round-trips in client/server mode). Reads
@@ -821,9 +807,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Reload prompt history for the new session.
 		m.historyReset()
 		cmds = append(cmds, m.loadPromptHistory())
-		// Queued messages a pop or an Escape drain removed just before the
-		// user switched away from this session were parked rather than
-		// dropped; hand them back now.
+		// Messages parked across the session switch come back now.
 		if cmd := m.restoreParkedQueuedMessages(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
@@ -1973,10 +1957,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		}
 		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionClearQueue:
-		// This entry is the destructive discard: the drained prompts are
-		// thrown away rather than handed back to the editor, which is what
-		// both Escape paths do. It runs off-thread; the memoized queue is
-		// emptied when its promptQueueClearedMsg lands.
+		// The destructive discard: both Escape paths restore instead.
 		if cmd := m.clearQueuedMessages(false); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
@@ -2539,31 +2520,15 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 
 	if key.Matches(msg, m.keyMap.Chat.Cancel) {
 		if m.isAgentBusy() {
-			// The double-press machine lives in cancelAgent, which drains
-			// on the confirming press: the arming press must stay
-			// queue-neutral.
+			// cancelAgent's double-press machine drains on the confirming
+			// press; the arming press must stay queue-neutral.
 			if cmd := m.cancelAgent(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
 			return tea.Batch(cmds...)
 		}
-		// Idle with queued prompts: there is no turn to stop, so a single
-		// press drains. The memoized count gates it — the same value that
-		// gates the queue pill and the pop — so the key only acts when the
-		// UI is showing a queue. The drain is an HTTP round-trip in
-		// client/server mode, so it runs as a cmd: the pill empties and
-		// the prompts reach the editor when promptQueueClearedMsg lands.
-		// Nothing here arms isCanceling or starts the cancel timer, and
-		// nothing needs confirming, because no text is destroyed.
-		//
-		// Escape keeps its more local meanings: it still closes the
-		// completions popup, still leaves prompt-history navigation (which
-		// restores the draft), and it still *only* backs out of the ctrl+r
-		// attachment delete prompt. The first two are handled further down;
-		// the delete prompt disarms from Update's tail whichever branch runs
-		// here, so without the guard the drain would ride along with the
-		// press that was meant to cancel a deletion — cancelling any queued
-		// client submissions on the way out.
+		// Idle with queued prompts there is no turn to stop, so a single
+		// press drains the queue; the gates keep Escape's local meanings.
 		if m.promptQueue > 0 && !m.completionsOpen && !m.isBrowsingHistory() &&
 			!m.attachments.Deleting() {
 			if cmd := m.clearQueuedMessages(true); cmd != nil {
@@ -2697,11 +2662,8 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				m.closeCompletions()
 				cmds = append(cmds, m.updateTextareaWithPrevHeight(msg, prevHeight))
 			case key.Matches(msg, m.keyMap.Editor.PopQueuedMessage):
-				// Unconditional: the popped prompt is prepended above
-				// whatever the editor holds, so a draft is never at risk
-				// and the binding can be pressed repeatedly to walk the
-				// queue back into the input field. popQueuedMessage keeps
-				// the single-flight and empty-queue gates.
+				// Unconditional: the popped prompt is prepended above the
+				// draft, so repeated presses walk the queue back.
 				if cmd := m.popQueuedMessage(); cmd != nil {
 					cmds = append(cmds, cmd)
 				}
@@ -3329,14 +3291,8 @@ func (m *UI) FullHelp() [][]key.Binding {
 			if m.currentModelSupportsImages() {
 				editorBinds = append(editorBinds, k.Editor.AddImage, k.Editor.PasteImage)
 			}
-			// Shift+Up/Alt+Up pops the newest queued prompt back into
-			// the editor. It is only handled in editor focus (in chat
-			// focus the same chord is Chat.UpOneItem) and only does
-			// something when prompts are queued, so it is listed here
-			// exactly then. It is deliberately kept out of ShortHelp:
-			// that line is already 113 columns wide, and another entry
-			// would push "ctrl+g more" — the way to reach this pane —
-			// off the end of a 120- or 140-column terminal.
+			// Editor focus only (chat focus binds the chord to
+			// UpOneItem) and only with a queue; ShortHelp has no room.
 			if m.promptQueue > 0 {
 				editorBinds = append(editorBinds, k.Editor.PopQueuedMessage)
 			}
@@ -4330,12 +4286,8 @@ func cancelTimerCmd() tea.Cmd {
 	})
 }
 
-// cancelAgent handles the cancel key press. The first press sets isCanceling
-// to true and starts a timer; it is queue-neutral. The second press (before
-// the timer expires) cancels the agent and also takes the queue off it,
-// moving the queued prompts into the input field: one esc gesture both stops
-// the work and hands the queue back, and cancellation itself is turn-scoped,
-// so the queue would otherwise be left ownerless.
+// cancelAgent handles the cancel key press. The first press arms the timer;
+// the second cancels the turn and drains the queue into the input field.
 func (m *UI) cancelAgent() tea.Cmd {
 	if !m.hasSession() {
 		return nil
@@ -4365,10 +4317,7 @@ func (m *UI) cancelAgent() tea.Cmd {
 		m.todoIsSpinning = false
 		m.invalidateBusyCaches()
 		m.renderPills()
-		// The drain is an HTTP round-trip in client/server mode, so it
-		// runs as a cmd: the prompts reach the editor and the pill empties
-		// when promptQueueClearedMsg lands. The memoized count gates it,
-		// the same value that gates the pill and the pop.
+		// The drain runs as a cmd; the prompts land when promptQueueClearedMsg arrives.
 		if m.promptQueue > 0 {
 			return tea.Batch(m.dispatchBusyRefresh(), m.clearQueuedMessages(true))
 		}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -342,6 +342,12 @@ type UI struct {
 	// in-flight fetch captures it at dispatch and its result is discarded
 	// if the generation has moved on (see workspace_cache.go).
 	promptQueueGen uint64
+	// queuedPopInFlight is set while a queued-message pop is in flight. The
+	// pop is destructive at the agent layer and nothing in the model
+	// changes until its result lands, so without this guard key autorepeat
+	// (or impatience over an HTTP round-trip) would pop several messages
+	// and only the last result would survive in the editor.
+	queuedPopInFlight bool
 	// agentBusyCache / yoloCache memoize the workspace busy and permission
 	// probes (synchronous HTTP round-trips in client/server mode). Reads
 	// never probe; refreshes happen off-thread (see workspace_cache.go).

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -715,6 +715,8 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, m.applyBusyState(msg)...)
 	case promptQueueMsg:
 		cmds = append(cmds, m.applyPromptQueue(msg)...)
+	case queuedMessagePoppedMsg:
+		cmds = append(cmds, m.applyQueuedMessagePop(msg)...)
 	case lspStatesMsg:
 		if cmd := m.applyLSPStates(msg); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -2624,6 +2626,14 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				m.textarea.InsertRune('\n')
 				m.closeCompletions()
 				cmds = append(cmds, m.updateTextareaWithPrevHeight(msg, prevHeight))
+			case key.Matches(msg, m.keyMap.Editor.PopQueuedMessage):
+				if m.textarea.Value() != "" {
+					cmds = append(cmds, util.ReportWarn("Can't pop queued message: input field is not empty."))
+					break
+				}
+				if cmd := m.popQueuedMessage(); cmd != nil {
+					cmds = append(cmds, cmd)
+				}
 			case key.Matches(msg, m.keyMap.Editor.HistoryPrev):
 				cmd := m.handleHistoryUp(msg)
 				if cmd != nil {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2552,9 +2552,15 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		// nothing needs confirming, because no text is destroyed.
 		//
 		// Escape keeps its more local meanings: it still closes the
-		// completions popup and still leaves prompt-history navigation
-		// (which restores the draft), both handled further down.
-		if m.promptQueue > 0 && !m.completionsOpen && !m.isBrowsingHistory() {
+		// completions popup, still leaves prompt-history navigation (which
+		// restores the draft), and it still *only* backs out of the ctrl+r
+		// attachment delete prompt. The first two are handled further down;
+		// the delete prompt disarms from Update's tail whichever branch runs
+		// here, so without the guard the drain would ride along with the
+		// press that was meant to cancel a deletion — cancelling any queued
+		// client submissions on the way out.
+		if m.promptQueue > 0 && !m.completionsOpen && !m.isBrowsingHistory() &&
+			!m.attachments.Deleting() {
 			if cmd := m.clearQueuedMessages(true); cmd != nil {
 				cmds = append(cmds, cmd)
 			}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3126,13 +3126,13 @@ func (m *UI) ShortHelp() []key.Binding {
 	case uiInitialize:
 		binds = append(binds, k.Quit)
 	case uiChat:
-		// Show cancel binding if agent is busy.
+		// Show cancel binding if agent is busy. Cancel is turn-scoped and
+		// leaves queued prompts intact, so the help text must never
+		// advertise clearing the queue.
 		if m.isAgentBusy() {
 			cancelBinding := k.Chat.Cancel
 			if m.isCanceling {
 				cancelBinding.SetHelp("esc", "press again to cancel")
-			} else if m.promptQueue > 0 {
-				cancelBinding.SetHelp("esc", "clear queue")
 			}
 			binds = append(binds, cancelBinding)
 		}
@@ -3222,13 +3222,13 @@ func (m *UI) FullHelp() [][]key.Binding {
 				k.Quit,
 			})
 	case uiChat:
-		// Show cancel binding if agent is busy.
+		// Show cancel binding if agent is busy. Cancel is turn-scoped and
+		// leaves queued prompts intact, so the help text must never
+		// advertise clearing the queue.
 		if m.isAgentBusy() {
 			cancelBinding := k.Chat.Cancel
 			if m.isCanceling {
 				cancelBinding.SetHelp("esc", "press again to cancel")
-			} else if m.promptQueue > 0 {
-				cancelBinding.SetHelp("esc", "clear queue")
 			}
 			binds = append(binds, []key.Binding{cancelBinding})
 		}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4285,19 +4285,6 @@ func (m *UI) cancelAgent() tea.Cmd {
 		return m.dispatchBusyRefresh()
 	}
 
-	// Queued prompts pending: esc clears the queue. Decide from the cached
-	// count (event-driven) instead of a synchronous workspace probe.
-	if m.promptQueue > 0 {
-		m.com.Workspace.AgentClearQueue(m.session.ID)
-		m.promptQueue = 0
-		m.promptQueueItems = nil
-		m.promptQueueCheckedAt = time.Now()
-		// Bump the queue generation so a fetch started before this clear
-		// cannot land and repopulate the pill we just emptied.
-		m.invalidatePromptQueue()
-		m.updateLayoutAndSize()
-		return nil
-	}
 
 	// First escape press - set canceling state and start timer.
 	m.isCanceling = true

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2524,10 +2524,30 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		return tea.Batch(cmds...)
 	}
 
-	// Handle cancel key when agent is busy.
+	// Handle the cancel key: it stops the agent while it is busy, and once
+	// the agent has stopped it discards what is still queued.
 	if key.Matches(msg, m.keyMap.Chat.Cancel) {
 		if m.isAgentBusy() {
 			if cmd := m.cancelAgent(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			return tea.Batch(cmds...)
+		}
+		// Idle with queued prompts: cancellation is turn-scoped, so
+		// stopping the agent leaves the queue intact and esc becomes the
+		// bulk discard for it. The memoized count gates this — the same
+		// value that gates the queue pill and the pop — so the key only
+		// acts when the UI is showing something to discard. The clear is
+		// an HTTP round-trip in client/server mode, so it runs as a cmd
+		// and the pill empties when promptQueueClearedMsg lands. Nothing
+		// here arms isCanceling or starts the cancel timer: there is no
+		// turn to stop.
+		//
+		// Escape keeps its more local meanings: it still closes the
+		// completions popup and still leaves prompt-history navigation
+		// (which restores the draft), both handled further down.
+		if m.promptQueue > 0 && !m.completionsOpen && !m.isBrowsingHistory() {
+			if cmd := m.clearQueuedMessages(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
 			return tea.Batch(cmds...)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -892,7 +892,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.session != nil && msg.Payload.ID == m.session.ID {
 			prevHasInProgress := hasInProgressTodo(m.session.Todos)
-			prevPillsHeight := m.pillsAreaHeight()
+			prevPillsHeight := m.pillsAreaHeight(m.layout.main.Dx())
 			m.session = &msg.Payload
 			if !prevHasInProgress && hasInProgressTodo(m.session.Todos) {
 				m.todoIsSpinning = true
@@ -905,7 +905,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// When the footprint is unchanged we still re-render the pill
 			// content so status changes (e.g. the in-progress spinner)
 			// show up.
-			if m.pillsAreaHeight() != prevPillsHeight {
+			if m.pillsAreaHeight(m.layout.main.Dx()) != prevPillsHeight {
 				m.updateLayoutAndSize()
 			} else {
 				m.renderPills()
@@ -3688,7 +3688,7 @@ func (m *UI) generateLayout(w, h int) uiLayout {
 			).Split(mainRect).Assign(&mainRect, &editorRect)
 			mainRect.Max.X -= 1 // Add padding right
 			uiLayout.header = headerRect
-			pillsHeight := m.pillsAreaHeight()
+			pillsHeight := m.pillsAreaHeight(mainRect.Dx())
 			if pillsHeight > 0 {
 				pillsHeight = min(pillsHeight, mainRect.Dy())
 				var chatRect, pillsRect image.Rectangle
@@ -3728,7 +3728,7 @@ func (m *UI) generateLayout(w, h int) uiLayout {
 			).Split(mainRect).Assign(&mainRect, &editorRect)
 			mainRect.Max.X -= 1 // Add padding right
 			uiLayout.sidebar = sideRect
-			pillsHeight := m.pillsAreaHeight()
+			pillsHeight := m.pillsAreaHeight(mainRect.Dx())
 			if pillsHeight > 0 {
 				pillsHeight = min(pillsHeight, mainRect.Dy())
 				var chatRect, pillsRect image.Rectangle

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3291,6 +3291,17 @@ func (m *UI) FullHelp() [][]key.Binding {
 			if m.currentModelSupportsImages() {
 				editorBinds = append(editorBinds, k.Editor.AddImage, k.Editor.PasteImage)
 			}
+			// Shift+Up/Alt+Up pops the newest queued prompt back into
+			// the editor. It is only handled in editor focus (in chat
+			// focus the same chord is Chat.UpOneItem) and only does
+			// something when prompts are queued, so it is listed here
+			// exactly then. It is deliberately kept out of ShortHelp:
+			// that line is already 113 columns wide, and another entry
+			// would push "ctrl+g more" — the way to reach this pane —
+			// off the end of a 120- or 140-column terminal.
+			if m.promptQueue > 0 {
+				editorBinds = append(editorBinds, k.Editor.PopQueuedMessage)
+			}
 			binds = append(binds, editorBinds)
 			if hasAttachments {
 				binds = append(

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -349,13 +349,15 @@ type UI struct {
 	// (or impatience over an HTTP round-trip) would pop several messages
 	// and only the last result would survive in the editor.
 	queuedPopInFlight bool
-	// queuedPopOrphans holds popped queued messages whose result landed
-	// after the user had switched away from the session they came from,
-	// keyed by that session. The pop already removed the message at the
-	// agent layer and queued prompts are not persisted anywhere, so
-	// dropping the result would destroy the text: it is parked here and
-	// restored by restoreParkedPop the next time that session is loaded.
-	queuedPopOrphans map[string]agent.QueuedMessage
+	// queuedRestoreOrphans holds queued messages a pop or an Escape drain
+	// removed, whose result landed after the user had switched away from
+	// the session they came from, keyed by that session. They are already
+	// out of the agent queue and queued prompts are not persisted
+	// anywhere, so dropping the result would destroy the text: it is
+	// parked here and restored by restoreParkedQueuedMessages the next
+	// time that session is loaded. A drain parks a whole batch, and a
+	// session can accumulate several before the user returns.
+	queuedRestoreOrphans map[string][]agent.QueuedMessage
 	// agentBusyCache / yoloCache memoize the workspace busy and permission
 	// probes (synchronous HTTP round-trips in client/server mode). Reads
 	// never probe; refreshes happen off-thread (see workspace_cache.go).
@@ -811,9 +813,10 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Reload prompt history for the new session.
 		m.historyReset()
 		cmds = append(cmds, m.loadPromptHistory())
-		// A queued message popped just before the user switched away from
-		// this session was parked rather than dropped; hand it back now.
-		if cmd := m.restoreParkedPop(); cmd != nil {
+		// Queued messages a pop or an Escape drain removed just before the
+		// user switched away from this session were parked rather than
+		// dropped; hand them back now.
+		if cmd := m.restoreParkedQueuedMessages(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 		m.updateLayoutAndSize()
@@ -869,9 +872,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case pubsub.Event[session.Session]:
 		if msg.Type == pubsub.DeletedEvent {
-			// The session can never be loaded again, so a message parked
+			// The session can never be loaded again, so messages parked
 			// for it can never be restored.
-			delete(m.queuedPopOrphans, msg.Payload.ID)
+			delete(m.queuedRestoreOrphans, msg.Payload.ID)
 			if m.session != nil && m.session.ID == msg.Payload.ID {
 				if cmd := m.newSession(); cmd != nil {
 					cmds = append(cmds, cmd)
@@ -1962,9 +1965,11 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		}
 		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionClearQueue:
-		// The clear is off-thread; the memoized queue is emptied when its
-		// promptQueueClearedMsg lands.
-		if cmd := m.clearQueuedMessages(); cmd != nil {
+		// This entry is the destructive discard: the drained prompts are
+		// thrown away rather than handed back to the editor, which is what
+		// both Escape paths do. It runs off-thread; the memoized queue is
+		// emptied when its promptQueueClearedMsg lands.
+		if cmd := m.clearQueuedMessages(false); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 		m.dialog.CloseDialog(dialog.CommandsID)
@@ -2524,30 +2529,33 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		return tea.Batch(cmds...)
 	}
 
-	// Handle the cancel key: it stops the agent while it is busy, and once
-	// the agent has stopped it discards what is still queued.
+	// Handle the cancel key: it stops the agent while it is busy, and it
+	// takes the queue off the agent, moving the queued prompts into the
+	// input field rather than destroying them.
 	if key.Matches(msg, m.keyMap.Chat.Cancel) {
 		if m.isAgentBusy() {
+			// The double-press machine lives in cancelAgent, which drains
+			// on the confirming press: the arming press must stay
+			// queue-neutral.
 			if cmd := m.cancelAgent(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
 			return tea.Batch(cmds...)
 		}
-		// Idle with queued prompts: cancellation is turn-scoped, so
-		// stopping the agent leaves the queue intact and esc becomes the
-		// bulk discard for it. The memoized count gates this — the same
-		// value that gates the queue pill and the pop — so the key only
-		// acts when the UI is showing something to discard. The clear is
-		// an HTTP round-trip in client/server mode, so it runs as a cmd
-		// and the pill empties when promptQueueClearedMsg lands. Nothing
-		// here arms isCanceling or starts the cancel timer: there is no
-		// turn to stop.
+		// Idle with queued prompts: there is no turn to stop, so a single
+		// press drains. The memoized count gates it — the same value that
+		// gates the queue pill and the pop — so the key only acts when the
+		// UI is showing a queue. The drain is an HTTP round-trip in
+		// client/server mode, so it runs as a cmd: the pill empties and
+		// the prompts reach the editor when promptQueueClearedMsg lands.
+		// Nothing here arms isCanceling or starts the cancel timer, and
+		// nothing needs confirming, because no text is destroyed.
 		//
 		// Escape keeps its more local meanings: it still closes the
 		// completions popup and still leaves prompt-history navigation
 		// (which restores the draft), both handled further down.
 		if m.promptQueue > 0 && !m.completionsOpen && !m.isBrowsingHistory() {
-			if cmd := m.clearQueuedMessages(); cmd != nil {
+			if cmd := m.clearQueuedMessages(true); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
 			return tea.Batch(cmds...)
@@ -2678,10 +2686,11 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				m.closeCompletions()
 				cmds = append(cmds, m.updateTextareaWithPrevHeight(msg, prevHeight))
 			case key.Matches(msg, m.keyMap.Editor.PopQueuedMessage):
-				if m.textarea.Value() != "" {
-					cmds = append(cmds, util.ReportWarn("Can't pop queued message: input field is not empty."))
-					break
-				}
+				// Unconditional: the popped prompt is prepended above
+				// whatever the editor holds, so a draft is never at risk
+				// and the binding can be pressed repeatedly to walk the
+				// queue back into the input field. popQueuedMessage keeps
+				// the single-flight and empty-queue gates.
 				if cmd := m.popQueuedMessage(); cmd != nil {
 					cmds = append(cmds, cmd)
 				}
@@ -4312,9 +4321,12 @@ func cancelTimerCmd() tea.Cmd {
 	})
 }
 
-// cancelAgent handles the cancel key press. The first press sets isCanceling to true
-// and starts a timer. The second press (before the timer expires) actually
-// cancels the agent.
+// cancelAgent handles the cancel key press. The first press sets isCanceling
+// to true and starts a timer; it is queue-neutral. The second press (before
+// the timer expires) cancels the agent and also takes the queue off it,
+// moving the queued prompts into the input field: one esc gesture both stops
+// the work and hands the queue back, and cancellation itself is turn-scoped,
+// so the queue would otherwise be left ownerless.
 func (m *UI) cancelAgent() tea.Cmd {
 	if !m.hasSession() {
 		return nil
@@ -4344,6 +4356,13 @@ func (m *UI) cancelAgent() tea.Cmd {
 		m.todoIsSpinning = false
 		m.invalidateBusyCaches()
 		m.renderPills()
+		// The drain is an HTTP round-trip in client/server mode, so it
+		// runs as a cmd: the prompts reach the editor and the pill empties
+		// when promptQueueClearedMsg lands. The memoized count gates it,
+		// the same value that gates the pill and the pop.
+		if m.promptQueue > 0 {
+			return tea.Batch(m.dispatchBusyRefresh(), m.clearQueuedMessages(true))
+		}
 		return m.dispatchBusyRefresh()
 	}
 

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -27,6 +27,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/hyper"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	agenttools "github.com/charmbracelet/crush/internal/agent/tools"
@@ -348,6 +349,13 @@ type UI struct {
 	// (or impatience over an HTTP round-trip) would pop several messages
 	// and only the last result would survive in the editor.
 	queuedPopInFlight bool
+	// queuedPopOrphans holds popped queued messages whose result landed
+	// after the user had switched away from the session they came from,
+	// keyed by that session. The pop already removed the message at the
+	// agent layer and queued prompts are not persisted anywhere, so
+	// dropping the result would destroy the text: it is parked here and
+	// restored by restoreParkedPop the next time that session is loaded.
+	queuedPopOrphans map[string]agent.QueuedMessage
 	// agentBusyCache / yoloCache memoize the workspace busy and permission
 	// probes (synchronous HTTP round-trips in client/server mode). Reads
 	// never probe; refreshes happen off-thread (see workspace_cache.go).
@@ -801,6 +809,11 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Reload prompt history for the new session.
 		m.historyReset()
 		cmds = append(cmds, m.loadPromptHistory())
+		// A queued message popped just before the user switched away from
+		// this session was parked rather than dropped; hand it back now.
+		if cmd := m.restoreParkedPop(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 		m.updateLayoutAndSize()
 
 	case sessionFilesUpdatesMsg:
@@ -854,6 +867,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case pubsub.Event[session.Session]:
 		if msg.Type == pubsub.DeletedEvent {
+			// The session can never be loaded again, so a message parked
+			// for it can never be restored.
+			delete(m.queuedPopOrphans, msg.Payload.ID)
 			if m.session != nil && m.session.ID == msg.Payload.ID {
 				if cmd := m.newSession(); cmd != nil {
 					cmds = append(cmds, cmd)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2537,9 +2537,6 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 		return tea.Batch(cmds...)
 	}
 
-	// Handle the cancel key: it stops the agent while it is busy, and it
-	// takes the queue off the agent, moving the queued prompts into the
-	// input field rather than destroying them.
 	if key.Matches(msg, m.keyMap.Chat.Cancel) {
 		if m.isAgentBusy() {
 			// The double-press machine lives in cancelAgent, which drains
@@ -3194,9 +3191,8 @@ func (m *UI) ShortHelp() []key.Binding {
 	case uiInitialize:
 		binds = append(binds, k.Quit)
 	case uiChat:
-		// Show cancel binding if agent is busy. Cancel is turn-scoped and
-		// leaves queued prompts intact, so the help text must never
-		// advertise clearing the queue.
+		// Cancel help must not advertise queue clearing: cancel is
+		// turn-scoped and leaves queued prompts intact.
 		if m.isAgentBusy() {
 			cancelBinding := k.Chat.Cancel
 			if m.isCanceling {
@@ -3290,9 +3286,8 @@ func (m *UI) FullHelp() [][]key.Binding {
 				k.Quit,
 			})
 	case uiChat:
-		// Show cancel binding if agent is busy. Cancel is turn-scoped and
-		// leaves queued prompts intact, so the help text must never
-		// advertise clearing the queue.
+		// Cancel help must not advertise queue clearing: cancel is
+		// turn-scoped and leaves queued prompts intact.
 		if m.isAgentBusy() {
 			cancelBinding := k.Chat.Cancel
 			if m.isCanceling {

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4285,7 +4285,6 @@ func (m *UI) cancelAgent() tea.Cmd {
 		return m.dispatchBusyRefresh()
 	}
 
-
 	// First escape press - set canceling state and start timer.
 	m.isCanceling = true
 	return cancelTimerCmd()

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -349,6 +349,14 @@ type UI struct {
 	// (or impatience over an HTTP round-trip) would pop several messages
 	// and only the last result would survive in the editor.
 	queuedPopInFlight bool
+	// queueClearInFlight is the same guard for the queue drain, which has
+	// the same shape: it empties the agent queue while the memoized count
+	// deliberately stays put until the result lands, and both Escape paths
+	// gate on that count. Without it an "esc esc esc" mash — or a busy
+	// double-press whose busy->idle edge arrives before the round-trip
+	// returns — fires a second drain whose empty result reports "No queued
+	// messages." over the restore banner the first one just published.
+	queueClearInFlight bool
 	// queuedRestoreOrphans holds queued messages a pop or an Escape drain
 	// removed, whose result landed after the user had switched away from
 	// the session they came from, keyed by that session. They are already

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -25,6 +25,7 @@ package model
 // Update, no model mutation inside commands).
 
 import (
+	"bytes"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -34,6 +35,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/charmbracelet/crush/internal/agent"
+	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/ui/util"
 	"github.com/charmbracelet/crush/internal/workspace"
 )
@@ -476,10 +478,35 @@ func (m *UI) restorePoppedMessage(queued agent.QueuedMessage) (cmds []tea.Cmd, a
 	}
 	m.promptHistory.index = -1
 	m.promptHistory.draft = m.textarea.Value()
+	// Attachments are additive, so the restore can collide with chips the
+	// editor already holds (the text guard says nothing about
+	// attachments). Skip an attachment that is already there byte for
+	// byte: re-adding it would show two identical chips and send the same
+	// file twice. Same-named attachments whose bytes differ are both kept
+	// — paste_<n>.txt names are only unique within one editor's list, so
+	// a name-keyed dedupe would drop content this path may not drop. The
+	// held set is snapshotted before the loop, so a queued message that
+	// itself carries the same file twice is restored as it was queued.
+	held := m.attachments.List()
 	for _, attachment := range queued.Attachments {
+		if slices.ContainsFunc(held, func(have message.Attachment) bool {
+			return sameAttachment(have, attachment)
+		}) {
+			continue
+		}
 		m.attachments.Update(attachment)
 	}
 	return []tea.Cmd{m.updateTextareaWithPrevHeight(nil, prevHeight)}, appended
+}
+
+// sameAttachment reports whether two attachments are the same file carrying
+// the same bytes, i.e. adding b to a list that already holds a would send
+// the identical payload twice.
+func sameAttachment(a, b message.Attachment) bool {
+	return a.FilePath == b.FilePath &&
+		a.FileName == b.FileName &&
+		a.MimeType == b.MimeType &&
+		bytes.Equal(a.Content, b.Content)
 }
 
 // restoreParkedPop restores the queued message parked when a pop result

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -282,11 +282,15 @@ func (m *UI) applyPromptQueue(msg promptQueueMsg) []tea.Cmd {
 	return nil
 }
 
-// popQueuedMessage removes the newest queued message off the Update goroutine.
+// popQueuedMessage removes the newest queued message off the Update
+// goroutine. It is single-flight: the pop mutates the agent queue, so a
+// second dispatch before the first result lands would remove a second
+// message that no apply path can restore.
 func (m *UI) popQueuedMessage() tea.Cmd {
-	if !m.hasSession() || m.com == nil || m.com.Workspace == nil {
+	if m.queuedPopInFlight || !m.hasSession() || m.com == nil || m.com.Workspace == nil {
 		return nil
 	}
+	m.queuedPopInFlight = true
 	ws := m.com.Workspace
 	sessionID := m.session.ID
 	return func() tea.Msg {
@@ -303,6 +307,7 @@ func (m *UI) popQueuedMessage() tea.Cmd {
 // applyQueuedMessagePop restores a popped message and supersedes stale queue
 // reads. It runs on the Update goroutine.
 func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
+	m.queuedPopInFlight = false
 	if msg.err != nil {
 		return []tea.Cmd{util.ReportError(msg.err)}
 	}

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -113,10 +113,19 @@ type queuedMessagePoppedMsg struct {
 	err        error
 }
 
-// promptQueueClearedMsg reports that an off-thread queue clear finished for
+// promptQueueClearedMsg reports that an off-thread queue drain finished for
 // the session, so the memoized queue can be emptied and re-fetched.
 type promptQueueClearedMsg struct {
 	forSession string
+	// messages is what the drain removed, oldest to newest. The drain is
+	// destructive at the agent layer and queued prompts live nowhere else,
+	// so nothing on the apply path may drop this unless restore is false.
+	messages []agent.QueuedMessage
+	// restore reports whether the drained prompts belong back in the input
+	// field (both Escape paths) or are a deliberate discard (the
+	// commands-dialog entry).
+	restore bool
+	err     error
 }
 
 // agentModelChangedMsg reports that the coordinator's model was updated
@@ -376,17 +385,11 @@ func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
 		// session to the current one.
 		slog.Warn("Parking popped queued message after session switch",
 			"for_session", msg.forSession, "current_session", m.currentSessionID())
-		if m.queuedPopOrphans == nil {
-			m.queuedPopOrphans = make(map[string]agent.QueuedMessage, 1)
-		}
-		m.queuedPopOrphans[msg.forSession] = msg.message
-		return []tea.Cmd{util.ReportWarn("Session changed: the popped message will be restored when you return to that session.")}
+		m.parkQueuedMessages(msg.forSession, []agent.QueuedMessage{msg.message})
+		return []tea.Cmd{util.ReportWarn(parkedQueuedMessagesBanner(1))}
 	}
 
-	cmds, appended := m.restorePoppedMessage(msg.message)
-	if appended {
-		cmds = append(cmds, util.ReportWarn("Input field was not empty: appended the popped queued message below your text."))
-	}
+	cmds := m.restoreQueuedMessages([]agent.QueuedMessage{msg.message})
 
 	m.invalidatePromptQueue()
 	if len(m.promptQueueItems) > 0 {
@@ -402,41 +405,70 @@ func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
 	return cmds
 }
 
-// clearQueuedMessages discards every prompt queued for the session off the
+// clearQueuedMessages drains every prompt queued for the session off the
 // Update goroutine (the workspace call is a synchronous HTTP round-trip in
-// client/server mode), delivering a promptQueueClearedMsg. The memoized
-// queue is deliberately not zeroed here: no caller needs an optimistic
-// value, and emptying the cache before the clear lands would let a queue
-// fetch dispatched during the round-trip repopulate the pill.
-func (m *UI) clearQueuedMessages() tea.Cmd {
+// client/server mode), delivering a promptQueueClearedMsg that carries what
+// the drain removed. restore says whether those prompts belong back in the
+// input field (both Escape paths) or are a deliberate discard (the
+// commands-dialog entry). The memoized queue is deliberately not zeroed
+// here: no caller needs an optimistic value, and emptying the cache before
+// the drain lands would let a queue fetch dispatched during the round-trip
+// repopulate the pill.
+func (m *UI) clearQueuedMessages(restore bool) tea.Cmd {
 	if !m.hasSession() || m.com == nil || m.com.Workspace == nil {
 		return nil
 	}
 	ws := m.com.Workspace
 	sessionID := m.session.ID
 	return func() tea.Msg {
-		// The drained prompts have no consumer on this path: the
-		// commands-dialog clear is the deliberate discard. A failure is
-		// logged rather than dropped, since the clear may have removed
-		// them before the error was raised.
-		if _, err := ws.AgentClearQueue(sessionID); err != nil {
-			slog.Error("Failed to clear queued messages",
-				"session_id", sessionID, "error", err)
+		messages, err := ws.AgentClearQueue(sessionID)
+		return promptQueueClearedMsg{
+			forSession: sessionID,
+			messages:   messages,
+			restore:    restore,
+			err:        err,
 		}
-		return promptQueueClearedMsg{forSession: sessionID}
 	}
 }
 
-// applyPromptQueueCleared empties the memoized queue once a clear has landed
-// and supersedes queue reads started before it. Runs on the Update
+// applyPromptQueueCleared empties the memoized queue once a drain has
+// landed, hands the drained prompts to the editor when the drain was a
+// restore, and supersedes queue reads started before it. Runs on the Update
 // goroutine.
 func (m *UI) applyPromptQueueCleared(msg promptQueueClearedMsg) []tea.Cmd {
+	if msg.err != nil {
+		// The failure may have been raised after the agent already removed
+		// the messages (response read/decode failure, dropped connection),
+		// so from here the queue state is unknown: re-fetch it instead of
+		// serving a count that may be too high, and do not promise the
+		// user their prompts are still queued.
+		slog.Error("Failed to clear queued messages",
+			"session_id", msg.forSession, "error", msg.err)
+		m.invalidatePromptQueue()
+		cmds := []tea.Cmd{util.ReportError(fmt.Errorf("%w (the queue may have been emptied anyway)", msg.err))}
+		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		return cmds
+	}
 	if msg.forSession != m.currentSessionID() {
-		// The clear raced a session switch, so it says nothing about the
+		// The drain raced a session switch, so it says nothing about the
 		// queue now on screen; that session's own reads stay authoritative.
+		if msg.restore && len(msg.messages) > 0 {
+			// The prompts are already out of that session's queue and
+			// cannot be put back, and they were written for it rather
+			// than for the session now loaded: park the batch and hand it
+			// back on the next load of that session. A discard has
+			// nothing to park — dropping the prompts was the point.
+			slog.Warn("Parking drained queued messages after session switch",
+				"for_session", msg.forSession, "current_session", m.currentSessionID(),
+				"messages", len(msg.messages))
+			m.parkQueuedMessages(msg.forSession, msg.messages)
+			return []tea.Cmd{util.ReportWarn(parkedQueuedMessagesBanner(len(msg.messages)))}
+		}
 		return nil
 	}
-	// Bump the generation so a fetch started before the clear cannot land
+	// Bump the generation so a fetch started before the drain cannot land
 	// and repopulate the pill it just emptied.
 	m.invalidatePromptQueue()
 	hadQueue := m.promptQueue > 0 || len(m.promptQueueItems) > 0
@@ -447,63 +479,87 @@ func (m *UI) applyPromptQueueCleared(msg promptQueueClearedMsg) []tea.Cmd {
 		m.updateLayoutAndSize()
 	}
 
-	cmds := []tea.Cmd{util.ReportInfo("Queued messages cleared.")}
+	var cmds []tea.Cmd
+	switch {
+	case !msg.restore:
+		cmds = append(cmds, util.ReportInfo("Queued messages cleared."))
+	case len(msg.messages) == 0:
+		// The memoized count that let the press through was wrong: the
+		// agent dequeued the last prompt, or another client emptied the
+		// queue, while the drain was in flight.
+		cmds = append(cmds, util.ReportInfo(noQueuedMessages))
+	default:
+		cmds = append(m.restoreQueuedMessages(msg.messages),
+			util.ReportInfo("Queued messages moved to the input field."))
+	}
 	if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
 	return cmds
 }
 
-// restorePoppedMessage puts a popped queued message back into the editor and
-// reports whether it had to be appended below existing text. Shared by the
-// pop apply path and the parked-restore path, both of which run after the
-// message has already left the agent queue: it can be neither refused nor
-// re-queued, so nothing here may drop it.
+// restoreQueuedMessages puts queued prompts that have left the agent queue
+// back into the editor, in front of whatever it already holds. Shared by the
+// pop apply path, the Escape drain and the parked restore, all of which run
+// after the messages were removed: they can be neither refused nor
+// re-queued, so nothing here may drop text.
 //
-// The key handler refuses to pop while the editor holds text, but that check
-// ran before the round-trip (an HTTP POST in client/server mode), and a
-// parked message is restored into whatever the editor holds on session load.
-// Either way an existing draft must survive, so the prompt is appended below
-// it rather than overwriting it.
-func (m *UI) restorePoppedMessage(queued agent.QueuedMessage) (cmds []tea.Cmd, appended bool) {
+// The prompts go ahead of the draft, oldest first, separated by blank lines.
+// Repeated pops then read in the order the prompts would have run in, a
+// blank line keeps separately queued prompts readable as distinct paragraphs
+// instead of welding two lines into one, and the user's own draft stays last,
+// where the cursor is left.
+func (m *UI) restoreQueuedMessages(queued []agent.QueuedMessage) []tea.Cmd {
 	prevHeight := m.textarea.Height()
-	if draft := m.textarea.Value(); draft != "" {
-		appended = true
-		m.textarea.MoveToEnd()
-		if !strings.HasSuffix(draft, "\n") {
-			m.textarea.InsertRune('\n')
+	parts := make([]string, 0, len(queued)+1)
+	for _, restored := range queued {
+		if restored.Prompt != "" {
+			parts = append(parts, restored.Prompt)
 		}
-		m.textarea.InsertString(queued.Prompt)
-		m.textarea.MoveToEnd()
-		// Bang mode is not re-synced: the "!" prefix that drives it belongs
-		// to the draft, which is unchanged, and the restored prompt is no
-		// longer at the start of the value.
-	} else {
-		m.textarea.SetValue(queued.Prompt)
+	}
+	// With no prompt text to prepend (a submission that carried only
+	// attachments) the buffer is left exactly as it is: rewriting it would
+	// disengage bang mode with no "!" to materialize in its place.
+	if len(parts) > 0 {
+		draft := m.textarea.Value()
+		// Bang mode hides the leading "!" from the textarea value, so a
+		// prompt prepended in front of a bang draft would silently be
+		// folded into the shell command. Materialize the "!" so the shell
+		// intent stays visible; syncBangModeFromTextarea then leaves bang
+		// mode, since the value no longer starts with it. A bare "!"
+		// carries no content and is dropped along with the mode.
+		if m.bangMode && draft != "" {
+			draft = "!" + draft
+		}
+		if draft != "" {
+			parts = append(parts, draft)
+		}
+		m.textarea.SetValue(strings.Join(parts, "\n\n"))
 		m.syncBangModeFromTextarea()
 		m.textarea.MoveToEnd()
+		m.promptHistory.index = -1
+		m.promptHistory.draft = m.textarea.Value()
 	}
-	m.promptHistory.index = -1
-	m.promptHistory.draft = m.textarea.Value()
-	// Attachments are additive, so the restore can collide with chips the
-	// editor already holds (the text guard says nothing about
-	// attachments). Skip an attachment that is already there byte for
-	// byte: re-adding it would show two identical chips and send the same
-	// file twice. Same-named attachments whose bytes differ are both kept
-	// — paste_<n>.txt names are only unique within one editor's list, so
-	// a name-keyed dedupe would drop content this path may not drop. The
-	// held set is snapshotted before the loop, so a queued message that
-	// itself carries the same file twice is restored as it was queued.
+	// Attachments are additive, so a restore can collide with chips the
+	// editor already holds. Skip an attachment that is already there byte
+	// for byte: re-adding it would show two identical chips and send the
+	// same file twice. Same-named attachments whose bytes differ are both
+	// kept — paste_<n>.txt names are only unique within one editor's list,
+	// so a name-keyed dedupe would drop content this path may not drop.
+	// The held set is snapshotted before the loop, so a batch that carries
+	// the same file twice is restored as it was queued.
 	held := m.attachments.List()
-	for _, attachment := range queued.Attachments {
-		if slices.ContainsFunc(held, func(have message.Attachment) bool {
-			return sameAttachment(have, attachment)
-		}) {
-			continue
+	for _, restored := range queued {
+		for _, attachment := range restored.Attachments {
+			if slices.ContainsFunc(held, func(have message.Attachment) bool {
+				return sameAttachment(have, attachment)
+			}) {
+				continue
+			}
+			m.attachments.Update(attachment)
 		}
-		m.attachments.Update(attachment)
 	}
-	return []tea.Cmd{m.updateTextareaWithPrevHeight(nil, prevHeight)}, appended
+	return []tea.Cmd{m.updateTextareaWithPrevHeight(nil, prevHeight)}
 }
 
 // sameAttachment reports whether two attachments are the same file carrying
@@ -516,24 +572,48 @@ func sameAttachment(a, b message.Attachment) bool {
 		bytes.Equal(a.Content, b.Content)
 }
 
-// restoreParkedPop restores the queued message parked when a pop result
-// landed after a session switch (see applyQueuedMessagePop). Called on
-// session load, so the message comes back the first time the user returns to
-// the session it was popped from. At most one message can be parked per
-// session: the pop is single-flight, and this clears the entry on the load
-// that must precede any further pop for that session.
-func (m *UI) restoreParkedPop() tea.Cmd {
+// parkQueuedMessages parks messages removed from a session the user is no
+// longer looking at, keyed by that session, so the next load of it hands
+// them back (see restoreParkedQueuedMessages). Parks append: a session can
+// accumulate a pop and a drain, or several drains, before the user returns.
+func (m *UI) parkQueuedMessages(sessionID string, queued []agent.QueuedMessage) {
+	if m.queuedRestoreOrphans == nil {
+		m.queuedRestoreOrphans = make(map[string][]agent.QueuedMessage, 1)
+	}
+	m.queuedRestoreOrphans[sessionID] = append(m.queuedRestoreOrphans[sessionID], queued...)
+}
+
+// queuedMessagesLabel renders a queued-message count for banner text: "the
+// queued message" for one, "3 queued messages" beyond that.
+func queuedMessagesLabel(n int) string {
+	if n == 1 {
+		return "the queued message"
+	}
+	return fmt.Sprintf("%d queued messages", n)
+}
+
+// parkedQueuedMessagesBanner is the warning shown when messages are parked
+// for a session the user has left.
+func parkedQueuedMessagesBanner(n int) string {
+	return fmt.Sprintf("Session changed: %s will be restored when you return to that session.",
+		queuedMessagesLabel(n))
+}
+
+// restoreParkedQueuedMessages restores the messages parked when a pop or
+// drain result landed after a session switch (see applyQueuedMessagePop and
+// applyPromptQueueCleared). Called on session load, so they come back the
+// first time the user returns to the session they were removed from, in the
+// order they were queued.
+func (m *UI) restoreParkedQueuedMessages() tea.Cmd {
 	sessionID := m.currentSessionID()
-	queued, ok := m.queuedPopOrphans[sessionID]
+	queued, ok := m.queuedRestoreOrphans[sessionID]
 	if !ok {
 		return nil
 	}
-	delete(m.queuedPopOrphans, sessionID)
-	cmds, appended := m.restorePoppedMessage(queued)
-	warn := "Restored the queued message you popped before switching sessions."
-	if appended {
-		warn = "Appended the queued message you popped before switching sessions below your text."
-	}
+	delete(m.queuedRestoreOrphans, sessionID)
+	cmds := m.restoreQueuedMessages(queued)
+	warn := fmt.Sprintf("Restored %s you removed before switching sessions.",
+		queuedMessagesLabel(len(queued)))
 	return tea.Batch(append(cmds, util.ReportWarn(warn))...)
 }
 

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -302,8 +302,8 @@ func (m *UI) applyPromptQueue(msg promptQueueMsg) []tea.Cmd {
 	return nil
 }
 
-// noQueuedMessages is the banner shown when a pop finds nothing to restore,
-// either from the memoized count or from the workspace itself.
+// noQueuedMessages is the banner shown when a pop or a restore drain finds
+// nothing to bring back.
 const noQueuedMessages = "No queued messages."
 
 // popQueuedMessage removes the newest queued message off the Update
@@ -597,8 +597,6 @@ func (m *UI) parkQueuedMessages(sessionID string, queued []agent.QueuedMessage) 
 	m.queuedRestoreOrphans[sessionID] = append(m.queuedRestoreOrphans[sessionID], queued...)
 }
 
-// queuedMessagesLabel renders a queued-message count for banner text: "the
-// queued message" for one, "3 queued messages" beyond that.
 func queuedMessagesLabel(n int) string {
 	if n == 1 {
 		return "the queued message"
@@ -606,8 +604,6 @@ func queuedMessagesLabel(n int) string {
 	return fmt.Sprintf("%d queued messages", n)
 }
 
-// parkedQueuedMessagesBanner is the warning shown when messages are parked
-// for a session the user has left.
 func parkedQueuedMessagesBanner(n int) string {
 	return fmt.Sprintf("Session changed: %s will be restored when you return to that session.",
 		queuedMessagesLabel(n))

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -414,10 +414,21 @@ func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
 // here: no caller needs an optimistic value, and emptying the cache before
 // the drain lands would let a queue fetch dispatched during the round-trip
 // repopulate the pill.
+//
+// It is single-flight for the same reason the pop is: because the memoized
+// count stays non-zero for the whole round-trip, and both Escape paths gate
+// on nothing else, a further press would dispatch a second drain that finds
+// the queue already empty and reports noQueuedMessages over the first
+// drain's restore banner. The in-flight drain's own result is the feedback
+// for the suppressed press, so there is nothing to report here.
 func (m *UI) clearQueuedMessages(restore bool) tea.Cmd {
+	if m.queueClearInFlight {
+		return nil
+	}
 	if !m.hasSession() || m.com == nil || m.com.Workspace == nil {
 		return nil
 	}
+	m.queueClearInFlight = true
 	ws := m.com.Workspace
 	sessionID := m.session.ID
 	return func() tea.Msg {
@@ -433,9 +444,12 @@ func (m *UI) clearQueuedMessages(restore bool) tea.Cmd {
 
 // applyPromptQueueCleared empties the memoized queue once a drain has
 // landed, hands the drained prompts to the editor when the drain was a
-// restore, and supersedes queue reads started before it. Runs on the Update
-// goroutine.
+// restore, and supersedes queue reads started before it. It releases the
+// single-flight mark on every path, including the ones that leave the
+// memoized queue alone, so a failed or session-crossing drain cannot wedge
+// the key. Runs on the Update goroutine.
 func (m *UI) applyPromptQueueCleared(msg promptQueueClearedMsg) []tea.Cmd {
+	m.queueClearInFlight = false
 	if msg.err != nil {
 		// The failure may have been raised after the agent already removed
 		// the messages (response read/decode failure, dropped connection),

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -415,7 +415,14 @@ func (m *UI) clearQueuedMessages() tea.Cmd {
 	ws := m.com.Workspace
 	sessionID := m.session.ID
 	return func() tea.Msg {
-		ws.AgentClearQueue(sessionID)
+		// The drained prompts have no consumer on this path: the
+		// commands-dialog clear is the deliberate discard. A failure is
+		// logged rather than dropped, since the clear may have removed
+		// them before the error was raised.
+		if _, err := ws.AgentClearQueue(sessionID); err != nil {
+			slog.Error("Failed to clear queued messages",
+				"session_id", sessionID, "error", err)
+		}
 		return promptQueueClearedMsg{forSession: sessionID}
 	}
 }

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -26,6 +26,7 @@ package model
 
 import (
 	"slices"
+	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -316,9 +317,28 @@ func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
 	}
 
 	prevHeight := m.textarea.Height()
-	m.textarea.SetValue(msg.message.Prompt)
-	m.syncBangModeFromTextarea()
-	m.textarea.MoveToEnd()
+	var cmds []tea.Cmd
+	// The key handler refuses to pop while the editor holds text, but that
+	// check ran before the round-trip (an HTTP POST in client/server mode).
+	// Anything typed since then must survive: the pop already removed the
+	// message at the agent layer, so it can neither be refused nor put back
+	// here. Append below the draft instead of overwriting it, and say so.
+	if draft := m.textarea.Value(); draft != "" {
+		m.textarea.MoveToEnd()
+		if !strings.HasSuffix(draft, "\n") {
+			m.textarea.InsertRune('\n')
+		}
+		m.textarea.InsertString(msg.message.Prompt)
+		m.textarea.MoveToEnd()
+		// Bang mode is not re-synced: the "!" prefix that drives it belongs
+		// to the draft, which is unchanged, and the restored prompt is no
+		// longer at the start of the value.
+		cmds = append(cmds, util.ReportWarn("Input field was not empty: appended the popped queued message below your text."))
+	} else {
+		m.textarea.SetValue(msg.message.Prompt)
+		m.syncBangModeFromTextarea()
+		m.textarea.MoveToEnd()
+	}
 	m.promptHistory.index = -1
 	m.promptHistory.draft = m.textarea.Value()
 	for _, attachment := range msg.message.Attachments {
@@ -333,7 +353,7 @@ func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
 	m.promptQueueCheckedAt = time.Now()
 	m.updateLayoutAndSize()
 
-	cmds := []tea.Cmd{m.updateTextareaWithPrevHeight(nil, prevHeight)}
+	cmds = append(cmds, m.updateTextareaWithPrevHeight(nil, prevHeight))
 	if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -117,13 +117,11 @@ type queuedMessagePoppedMsg struct {
 // the session, so the memoized queue can be emptied and re-fetched.
 type promptQueueClearedMsg struct {
 	forSession string
-	// messages is what the drain removed, oldest to newest. The drain is
-	// destructive at the agent layer and queued prompts live nowhere else,
-	// so nothing on the apply path may drop this unless restore is false.
+	// messages is what the drain removed, oldest to newest. They live
+	// nowhere else anymore, so only a discard may drop them.
 	messages []agent.QueuedMessage
-	// restore reports whether the drained prompts belong back in the input
-	// field (both Escape paths) or are a deliberate discard (the
-	// commands-dialog entry).
+	// restore reports whether the drained prompts belong back in the
+	// input field or are a deliberate discard (commands dialog).
 	restore bool
 	err     error
 }
@@ -307,13 +305,7 @@ func (m *UI) applyPromptQueue(msg promptQueueMsg) []tea.Cmd {
 const noQueuedMessages = "No queued messages."
 
 // popQueuedMessage removes the newest queued message off the Update
-// goroutine. It is single-flight: the pop mutates the agent queue, so a
-// second dispatch before the first result lands would remove a second
-// message that no apply path can restore. An empty memoized queue is
-// answered from the cache — the pop is an HTTP round-trip in client/server
-// mode, and this file exists to keep those off key presses the cache can
-// answer — with a banner, because a key that silently does nothing reads as
-// a broken binding.
+// goroutine. Single-flight: the pop is destructive at the agent layer.
 func (m *UI) popQueuedMessage() tea.Cmd {
 	if m.queuedPopInFlight {
 		return nil
@@ -343,11 +335,8 @@ func (m *UI) popQueuedMessage() tea.Cmd {
 func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
 	m.queuedPopInFlight = false
 	if msg.err != nil {
-		// The failure may have been raised after the server already
-		// removed the message (response read/decode failure, dropped
-		// connection), so from here the queue state is unknown: re-fetch
-		// it instead of serving a count that may be one too high, and do
-		// not promise the user their message is still queued.
+		// The pop may have succeeded before the error (decode failure,
+		// dropped connection): the queue state is unknown, so re-fetch.
 		slog.Error("Failed to pop queued message",
 			"session_id", msg.forSession, "error", msg.err)
 		m.invalidatePromptQueue()
@@ -359,16 +348,12 @@ func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
 	}
 	if !msg.found {
 		if msg.forSession != m.currentSessionID() {
-			// Nothing was popped and the result belongs to a session
-			// the user has left: it says nothing about the queue now on
-			// screen, so leave that queue and the editor alone.
+			// Nothing was popped, for a session the user has left: the
+			// result says nothing about the queue now on screen.
 			return nil
 		}
-		// The pop only runs with a non-empty memoized queue, so the
-		// queue drained while the request was in flight (the agent
-		// dequeued it, or another client cleared it). The memoized
-		// count is known wrong: supersede it and re-fetch, and say why
-		// the editor stayed empty.
+		// The queue drained while the pop was in flight: supersede the
+		// wrong count, re-fetch, and explain the empty editor.
 		m.invalidatePromptQueue()
 		cmds := []tea.Cmd{util.ReportInfo(noQueuedMessages)}
 		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
@@ -377,12 +362,8 @@ func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
 		return cmds
 	}
 	if msg.forSession != m.currentSessionID() {
-		// The pop raced a session switch. It is destructive at the agent
-		// layer — the message is already out of that session's queue and
-		// cannot be put back — so park it instead of dropping it, and
-		// restore it the next time that session is loaded. Restoring it
-		// into the editor here would offer a prompt written for another
-		// session to the current one.
+		// The pop raced a session switch: the message is already out of
+		// its queue and cannot go back, so park it for that session.
 		slog.Warn("Parking popped queued message after session switch",
 			"for_session", msg.forSession, "current_session", m.currentSessionID())
 		m.parkQueuedMessages(msg.forSession, []agent.QueuedMessage{msg.message})
@@ -405,22 +386,8 @@ func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
 	return cmds
 }
 
-// clearQueuedMessages drains every prompt queued for the session off the
-// Update goroutine (the workspace call is a synchronous HTTP round-trip in
-// client/server mode), delivering a promptQueueClearedMsg that carries what
-// the drain removed. restore says whether those prompts belong back in the
-// input field (both Escape paths) or are a deliberate discard (the
-// commands-dialog entry). The memoized queue is deliberately not zeroed
-// here: no caller needs an optimistic value, and emptying the cache before
-// the drain lands would let a queue fetch dispatched during the round-trip
-// repopulate the pill.
-//
-// It is single-flight for the same reason the pop is: because the memoized
-// count stays non-zero for the whole round-trip, and both Escape paths gate
-// on nothing else, a further press would dispatch a second drain that finds
-// the queue already empty and reports noQueuedMessages over the first
-// drain's restore banner. The in-flight drain's own result is the feedback
-// for the suppressed press, so there is nothing to report here.
+// clearQueuedMessages drains the session's queued prompts off the Update
+// goroutine; restore says whether they return to the editor or are dropped.
 func (m *UI) clearQueuedMessages(restore bool) tea.Cmd {
 	if m.queueClearInFlight {
 		return nil
@@ -442,20 +409,13 @@ func (m *UI) clearQueuedMessages(restore bool) tea.Cmd {
 	}
 }
 
-// applyPromptQueueCleared empties the memoized queue once a drain has
-// landed, hands the drained prompts to the editor when the drain was a
-// restore, and supersedes queue reads started before it. It releases the
-// single-flight mark on every path, including the ones that leave the
-// memoized queue alone, so a failed or session-crossing drain cannot wedge
-// the key. Runs on the Update goroutine.
+// applyPromptQueueCleared empties the memoized queue once a drain lands,
+// restoring the drained prompts to the editor when the drain was a restore.
 func (m *UI) applyPromptQueueCleared(msg promptQueueClearedMsg) []tea.Cmd {
 	m.queueClearInFlight = false
 	if msg.err != nil {
-		// The failure may have been raised after the agent already removed
-		// the messages (response read/decode failure, dropped connection),
-		// so from here the queue state is unknown: re-fetch it instead of
-		// serving a count that may be too high, and do not promise the
-		// user their prompts are still queued.
+		// The drain may have succeeded before the error, so the queue
+		// state is unknown: re-fetch rather than serve a stale count.
 		slog.Error("Failed to clear queued messages",
 			"session_id", msg.forSession, "error", msg.err)
 		m.invalidatePromptQueue()
@@ -469,11 +429,8 @@ func (m *UI) applyPromptQueueCleared(msg promptQueueClearedMsg) []tea.Cmd {
 		// The drain raced a session switch, so it says nothing about the
 		// queue now on screen; that session's own reads stay authoritative.
 		if msg.restore && len(msg.messages) > 0 {
-			// The prompts are already out of that session's queue and
-			// cannot be put back, and they were written for it rather
-			// than for the session now loaded: park the batch and hand it
-			// back on the next load of that session. A discard has
-			// nothing to park — dropping the prompts was the point.
+			// Already out of their session's queue and written for it, so
+			// park them for its next load; a discard has nothing to park.
 			slog.Warn("Parking drained queued messages after session switch",
 				"for_session", msg.forSession, "current_session", m.currentSessionID(),
 				"messages", len(msg.messages))
@@ -498,9 +455,8 @@ func (m *UI) applyPromptQueueCleared(msg promptQueueClearedMsg) []tea.Cmd {
 	case !msg.restore:
 		cmds = append(cmds, util.ReportInfo("Queued messages cleared."))
 	case len(msg.messages) == 0:
-		// The memoized count that let the press through was wrong: the
-		// agent dequeued the last prompt, or another client emptied the
-		// queue, while the drain was in flight.
+		// The count that let the press through was stale: the queue
+		// emptied while the drain was in flight.
 		cmds = append(cmds, util.ReportInfo(noQueuedMessages))
 	default:
 		cmds = append(m.restoreQueuedMessages(msg.messages),
@@ -512,17 +468,8 @@ func (m *UI) applyPromptQueueCleared(msg promptQueueClearedMsg) []tea.Cmd {
 	return cmds
 }
 
-// restoreQueuedMessages puts queued prompts that have left the agent queue
-// back into the editor, in front of whatever it already holds. Shared by the
-// pop apply path, the Escape drain and the parked restore, all of which run
-// after the messages were removed: they can be neither refused nor
-// re-queued, so nothing here may drop text.
-//
-// The prompts go ahead of the draft, oldest first, separated by blank lines.
-// Repeated pops then read in the order the prompts would have run in, a
-// blank line keeps separately queued prompts readable as distinct paragraphs
-// instead of welding two lines into one, and the user's own draft stays last,
-// where the cursor is left.
+// restoreQueuedMessages puts queue-removed prompts back into the editor,
+// ahead of the draft. They cannot be re-queued, so nothing here drops text.
 func (m *UI) restoreQueuedMessages(queued []agent.QueuedMessage) []tea.Cmd {
 	prevHeight := m.textarea.Height()
 	parts := make([]string, 0, len(queued)+1)
@@ -531,17 +478,12 @@ func (m *UI) restoreQueuedMessages(queued []agent.QueuedMessage) []tea.Cmd {
 			parts = append(parts, restored.Prompt)
 		}
 	}
-	// With no prompt text to prepend (a submission that carried only
-	// attachments) the buffer is left exactly as it is: rewriting it would
-	// disengage bang mode with no "!" to materialize in its place.
+	// No prompt text (attachments-only): leave the buffer alone, since
+	// rewriting it would disengage bang mode with no "!" to materialize.
 	if len(parts) > 0 {
 		draft := m.textarea.Value()
-		// Bang mode hides the leading "!" from the textarea value, so a
-		// prompt prepended in front of a bang draft would silently be
-		// folded into the shell command. Materialize the "!" so the shell
-		// intent stays visible; syncBangModeFromTextarea then leaves bang
-		// mode, since the value no longer starts with it. A bare "!"
-		// carries no content and is dropped along with the mode.
+		// Bang mode hides the leading "!" from the value: materialize it so
+		// the prepended prompt is not folded into the shell command.
 		if m.bangMode && draft != "" {
 			draft = "!" + draft
 		}
@@ -554,14 +496,8 @@ func (m *UI) restoreQueuedMessages(queued []agent.QueuedMessage) []tea.Cmd {
 		m.promptHistory.index = -1
 		m.promptHistory.draft = m.textarea.Value()
 	}
-	// Attachments are additive, so a restore can collide with chips the
-	// editor already holds. Skip an attachment that is already there byte
-	// for byte: re-adding it would show two identical chips and send the
-	// same file twice. Same-named attachments whose bytes differ are both
-	// kept — paste_<n>.txt names are only unique within one editor's list,
-	// so a name-keyed dedupe would drop content this path may not drop.
-	// The held set is snapshotted before the loop, so a batch that carries
-	// the same file twice is restored as it was queued.
+	// Skip attachments already held byte for byte; dedupe by bytes, not
+	// name — paste_<n>.txt names are only unique within one editor.
 	held := m.attachments.List()
 	for _, restored := range queued {
 		for _, attachment := range restored.Attachments {
@@ -576,9 +512,7 @@ func (m *UI) restoreQueuedMessages(queued []agent.QueuedMessage) []tea.Cmd {
 	return []tea.Cmd{m.updateTextareaWithPrevHeight(nil, prevHeight)}
 }
 
-// sameAttachment reports whether two attachments are the same file carrying
-// the same bytes, i.e. adding b to a list that already holds a would send
-// the identical payload twice.
+// sameAttachment reports whether a and b are the same file with the same bytes.
 func sameAttachment(a, b message.Attachment) bool {
 	return a.FilePath == b.FilePath &&
 		a.FileName == b.FileName &&
@@ -586,10 +520,8 @@ func sameAttachment(a, b message.Attachment) bool {
 		bytes.Equal(a.Content, b.Content)
 }
 
-// parkQueuedMessages parks messages removed from a session the user is no
-// longer looking at, keyed by that session, so the next load of it hands
-// them back (see restoreParkedQueuedMessages). Parks append: a session can
-// accumulate a pop and a drain, or several drains, before the user returns.
+// parkQueuedMessages parks messages removed from a session the user has
+// left, keyed by that session, for restoreParkedQueuedMessages. Parks append.
 func (m *UI) parkQueuedMessages(sessionID string, queued []agent.QueuedMessage) {
 	if m.queuedRestoreOrphans == nil {
 		m.queuedRestoreOrphans = make(map[string][]agent.QueuedMessage, 1)
@@ -609,11 +541,8 @@ func parkedQueuedMessagesBanner(n int) string {
 		queuedMessagesLabel(n))
 }
 
-// restoreParkedQueuedMessages restores the messages parked when a pop or
-// drain result landed after a session switch (see applyQueuedMessagePop and
-// applyPromptQueueCleared). Called on session load, so they come back the
-// first time the user returns to the session they were removed from, in the
-// order they were queued.
+// restoreParkedQueuedMessages restores the messages parked for the session
+// now loading, in the order they were parked.
 func (m *UI) restoreParkedQueuedMessages() tea.Cmd {
 	sessionID := m.currentSessionID()
 	queued, ok := m.queuedRestoreOrphans[sessionID]

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -291,12 +291,26 @@ func (m *UI) applyPromptQueue(msg promptQueueMsg) []tea.Cmd {
 	return nil
 }
 
+// noQueuedMessages is the banner shown when a pop finds nothing to restore,
+// either from the memoized count or from the workspace itself.
+const noQueuedMessages = "No queued messages."
+
 // popQueuedMessage removes the newest queued message off the Update
 // goroutine. It is single-flight: the pop mutates the agent queue, so a
 // second dispatch before the first result lands would remove a second
-// message that no apply path can restore.
+// message that no apply path can restore. An empty memoized queue is
+// answered from the cache — the pop is an HTTP round-trip in client/server
+// mode, and this file exists to keep those off key presses the cache can
+// answer — with a banner, because a key that silently does nothing reads as
+// a broken binding.
 func (m *UI) popQueuedMessage() tea.Cmd {
-	if m.queuedPopInFlight || !m.hasSession() || m.com == nil || m.com.Workspace == nil {
+	if m.queuedPopInFlight {
+		return nil
+	}
+	if m.promptQueue == 0 {
+		return util.ReportInfo(noQueuedMessages)
+	}
+	if !m.hasSession() || m.com == nil || m.com.Workspace == nil {
 		return nil
 	}
 	m.queuedPopInFlight = true
@@ -333,7 +347,23 @@ func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
 		return cmds
 	}
 	if !msg.found {
-		return nil
+		if msg.forSession != m.currentSessionID() {
+			// Nothing was popped and the result belongs to a session
+			// the user has left: it says nothing about the queue now on
+			// screen, so leave that queue and the editor alone.
+			return nil
+		}
+		// The pop only runs with a non-empty memoized queue, so the
+		// queue drained while the request was in flight (the agent
+		// dequeued it, or another client cleared it). The memoized
+		// count is known wrong: supersede it and re-fetch, and say why
+		// the editor stayed empty.
+		m.invalidatePromptQueue()
+		cmds := []tea.Cmd{util.ReportInfo(noQueuedMessages)}
+		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		return cmds
 	}
 	if msg.forSession != m.currentSessionID() {
 		// The pop raced a session switch. It is destructive at the agent

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -30,6 +30,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/charmbracelet/crush/internal/agent"
+	"github.com/charmbracelet/crush/internal/ui/util"
 	"github.com/charmbracelet/crush/internal/workspace"
 )
 
@@ -97,6 +99,14 @@ type promptQueueMsg struct {
 // started a run or was enqueued behind one), so busy and queue state should
 // be re-fetched.
 type agentRunSubmittedMsg struct{}
+
+// queuedMessagePoppedMsg delivers an off-thread queued-message pop result.
+type queuedMessagePoppedMsg struct {
+	forSession string
+	message    agent.QueuedMessage
+	found      bool
+	err        error
+}
 
 // agentModelChangedMsg reports that the coordinator's model was updated
 // (model selection, thinking toggle, reasoning effort), so the memoized
@@ -270,6 +280,59 @@ func (m *UI) applyPromptQueue(msg promptQueueMsg) []tea.Cmd {
 		m.renderPills()
 	}
 	return nil
+}
+
+// popQueuedMessage removes the newest queued message off the Update goroutine.
+func (m *UI) popQueuedMessage() tea.Cmd {
+	if !m.hasSession() || m.com == nil || m.com.Workspace == nil {
+		return nil
+	}
+	ws := m.com.Workspace
+	sessionID := m.session.ID
+	return func() tea.Msg {
+		queued, found, err := ws.AgentPopQueuedMessage(sessionID)
+		return queuedMessagePoppedMsg{
+			forSession: sessionID,
+			message:    queued,
+			found:      found,
+			err:        err,
+		}
+	}
+}
+
+// applyQueuedMessagePop restores a popped message and supersedes stale queue
+// reads. It runs on the Update goroutine.
+func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
+	if msg.err != nil {
+		return []tea.Cmd{util.ReportError(msg.err)}
+	}
+	if !msg.found || msg.forSession != m.currentSessionID() {
+		return nil
+	}
+
+	prevHeight := m.textarea.Height()
+	m.textarea.SetValue(msg.message.Prompt)
+	m.syncBangModeFromTextarea()
+	m.textarea.MoveToEnd()
+	m.promptHistory.index = -1
+	m.promptHistory.draft = m.textarea.Value()
+	for _, attachment := range msg.message.Attachments {
+		m.attachments.Update(attachment)
+	}
+
+	m.invalidatePromptQueue()
+	if len(m.promptQueueItems) > 0 {
+		m.promptQueueItems = m.promptQueueItems[:len(m.promptQueueItems)-1]
+	}
+	m.promptQueue = len(m.promptQueueItems)
+	m.promptQueueCheckedAt = time.Now()
+	m.updateLayoutAndSize()
+
+	cmds := []tea.Cmd{m.updateTextareaWithPrevHeight(nil, prevHeight)}
+	if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	return cmds
 }
 
 // staleWorkspaceRefreshCmds is the TTL backstop, called at the tail of

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -111,6 +111,12 @@ type queuedMessagePoppedMsg struct {
 	err        error
 }
 
+// promptQueueClearedMsg reports that an off-thread queue clear finished for
+// the session, so the memoized queue can be emptied and re-fetched.
+type promptQueueClearedMsg struct {
+	forSession string
+}
+
 // agentModelChangedMsg reports that the coordinator's model was updated
 // (model selection, thinking toggle, reasoning effort), so the memoized
 // ready/model state should be re-fetched without waiting for the TTL.
@@ -358,6 +364,51 @@ func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
 	m.promptQueueCheckedAt = time.Now()
 	m.updateLayoutAndSize()
 
+	if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	return cmds
+}
+
+// clearQueuedMessages discards every prompt queued for the session off the
+// Update goroutine (the workspace call is a synchronous HTTP round-trip in
+// client/server mode), delivering a promptQueueClearedMsg. The memoized
+// queue is deliberately not zeroed here: no caller needs an optimistic
+// value, and emptying the cache before the clear lands would let a queue
+// fetch dispatched during the round-trip repopulate the pill.
+func (m *UI) clearQueuedMessages() tea.Cmd {
+	if !m.hasSession() || m.com == nil || m.com.Workspace == nil {
+		return nil
+	}
+	ws := m.com.Workspace
+	sessionID := m.session.ID
+	return func() tea.Msg {
+		ws.AgentClearQueue(sessionID)
+		return promptQueueClearedMsg{forSession: sessionID}
+	}
+}
+
+// applyPromptQueueCleared empties the memoized queue once a clear has landed
+// and supersedes queue reads started before it. Runs on the Update
+// goroutine.
+func (m *UI) applyPromptQueueCleared(msg promptQueueClearedMsg) []tea.Cmd {
+	if msg.forSession != m.currentSessionID() {
+		// The clear raced a session switch, so it says nothing about the
+		// queue now on screen; that session's own reads stay authoritative.
+		return nil
+	}
+	// Bump the generation so a fetch started before the clear cannot land
+	// and repopulate the pill it just emptied.
+	m.invalidatePromptQueue()
+	hadQueue := m.promptQueue > 0 || len(m.promptQueueItems) > 0
+	m.promptQueueItems = nil
+	m.promptQueue = 0
+	m.promptQueueCheckedAt = time.Now()
+	if hadQueue {
+		m.updateLayoutAndSize()
+	}
+
+	cmds := []tea.Cmd{util.ReportInfo("Queued messages cleared.")}
 	if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}

--- a/internal/ui/model/workspace_cache.go
+++ b/internal/ui/model/workspace_cache.go
@@ -25,6 +25,8 @@ package model
 // Update, no model mutation inside commands).
 
 import (
+	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 	"time"
@@ -310,39 +312,42 @@ func (m *UI) popQueuedMessage() tea.Cmd {
 func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
 	m.queuedPopInFlight = false
 	if msg.err != nil {
-		return []tea.Cmd{util.ReportError(msg.err)}
+		// The failure may have been raised after the server already
+		// removed the message (response read/decode failure, dropped
+		// connection), so from here the queue state is unknown: re-fetch
+		// it instead of serving a count that may be one too high, and do
+		// not promise the user their message is still queued.
+		slog.Error("Failed to pop queued message",
+			"session_id", msg.forSession, "error", msg.err)
+		m.invalidatePromptQueue()
+		cmds := []tea.Cmd{util.ReportError(fmt.Errorf("%w (it may have left the queue anyway)", msg.err))}
+		if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+		return cmds
 	}
-	if !msg.found || msg.forSession != m.currentSessionID() {
+	if !msg.found {
 		return nil
 	}
-
-	prevHeight := m.textarea.Height()
-	var cmds []tea.Cmd
-	// The key handler refuses to pop while the editor holds text, but that
-	// check ran before the round-trip (an HTTP POST in client/server mode).
-	// Anything typed since then must survive: the pop already removed the
-	// message at the agent layer, so it can neither be refused nor put back
-	// here. Append below the draft instead of overwriting it, and say so.
-	if draft := m.textarea.Value(); draft != "" {
-		m.textarea.MoveToEnd()
-		if !strings.HasSuffix(draft, "\n") {
-			m.textarea.InsertRune('\n')
+	if msg.forSession != m.currentSessionID() {
+		// The pop raced a session switch. It is destructive at the agent
+		// layer — the message is already out of that session's queue and
+		// cannot be put back — so park it instead of dropping it, and
+		// restore it the next time that session is loaded. Restoring it
+		// into the editor here would offer a prompt written for another
+		// session to the current one.
+		slog.Warn("Parking popped queued message after session switch",
+			"for_session", msg.forSession, "current_session", m.currentSessionID())
+		if m.queuedPopOrphans == nil {
+			m.queuedPopOrphans = make(map[string]agent.QueuedMessage, 1)
 		}
-		m.textarea.InsertString(msg.message.Prompt)
-		m.textarea.MoveToEnd()
-		// Bang mode is not re-synced: the "!" prefix that drives it belongs
-		// to the draft, which is unchanged, and the restored prompt is no
-		// longer at the start of the value.
-		cmds = append(cmds, util.ReportWarn("Input field was not empty: appended the popped queued message below your text."))
-	} else {
-		m.textarea.SetValue(msg.message.Prompt)
-		m.syncBangModeFromTextarea()
-		m.textarea.MoveToEnd()
+		m.queuedPopOrphans[msg.forSession] = msg.message
+		return []tea.Cmd{util.ReportWarn("Session changed: the popped message will be restored when you return to that session.")}
 	}
-	m.promptHistory.index = -1
-	m.promptHistory.draft = m.textarea.Value()
-	for _, attachment := range msg.message.Attachments {
-		m.attachments.Update(attachment)
+
+	cmds, appended := m.restorePoppedMessage(msg.message)
+	if appended {
+		cmds = append(cmds, util.ReportWarn("Input field was not empty: appended the popped queued message below your text."))
 	}
 
 	m.invalidatePromptQueue()
@@ -353,11 +358,68 @@ func (m *UI) applyQueuedMessagePop(msg queuedMessagePoppedMsg) []tea.Cmd {
 	m.promptQueueCheckedAt = time.Now()
 	m.updateLayoutAndSize()
 
-	cmds = append(cmds, m.updateTextareaWithPrevHeight(nil, prevHeight))
 	if cmd := m.dispatchPromptQueueRefresh(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
 	return cmds
+}
+
+// restorePoppedMessage puts a popped queued message back into the editor and
+// reports whether it had to be appended below existing text. Shared by the
+// pop apply path and the parked-restore path, both of which run after the
+// message has already left the agent queue: it can be neither refused nor
+// re-queued, so nothing here may drop it.
+//
+// The key handler refuses to pop while the editor holds text, but that check
+// ran before the round-trip (an HTTP POST in client/server mode), and a
+// parked message is restored into whatever the editor holds on session load.
+// Either way an existing draft must survive, so the prompt is appended below
+// it rather than overwriting it.
+func (m *UI) restorePoppedMessage(queued agent.QueuedMessage) (cmds []tea.Cmd, appended bool) {
+	prevHeight := m.textarea.Height()
+	if draft := m.textarea.Value(); draft != "" {
+		appended = true
+		m.textarea.MoveToEnd()
+		if !strings.HasSuffix(draft, "\n") {
+			m.textarea.InsertRune('\n')
+		}
+		m.textarea.InsertString(queued.Prompt)
+		m.textarea.MoveToEnd()
+		// Bang mode is not re-synced: the "!" prefix that drives it belongs
+		// to the draft, which is unchanged, and the restored prompt is no
+		// longer at the start of the value.
+	} else {
+		m.textarea.SetValue(queued.Prompt)
+		m.syncBangModeFromTextarea()
+		m.textarea.MoveToEnd()
+	}
+	m.promptHistory.index = -1
+	m.promptHistory.draft = m.textarea.Value()
+	for _, attachment := range queued.Attachments {
+		m.attachments.Update(attachment)
+	}
+	return []tea.Cmd{m.updateTextareaWithPrevHeight(nil, prevHeight)}, appended
+}
+
+// restoreParkedPop restores the queued message parked when a pop result
+// landed after a session switch (see applyQueuedMessagePop). Called on
+// session load, so the message comes back the first time the user returns to
+// the session it was popped from. At most one message can be parked per
+// session: the pop is single-flight, and this clears the entry on the load
+// that must precede any further pop for that session.
+func (m *UI) restoreParkedPop() tea.Cmd {
+	sessionID := m.currentSessionID()
+	queued, ok := m.queuedPopOrphans[sessionID]
+	if !ok {
+		return nil
+	}
+	delete(m.queuedPopOrphans, sessionID)
+	cmds, appended := m.restorePoppedMessage(queued)
+	warn := "Restored the queued message you popped before switching sessions."
+	if appended {
+		warn = "Appended the queued message you popped before switching sessions below your text."
+	}
+	return tea.Batch(append(cmds, util.ReportWarn(warn))...)
 }
 
 // staleWorkspaceRefreshCmds is the TTL backstop, called at the tail of

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -219,6 +219,14 @@ func (w *AppWorkspace) AgentClearQueue(sessionID string) {
 	}
 }
 
+func (w *AppWorkspace) AgentPopQueuedMessage(sessionID string) (agent.QueuedMessage, bool, error) {
+	if w.app.AgentCoordinator == nil {
+		return agent.QueuedMessage{}, false, ErrAgentNotInitialized
+	}
+	queued, ok := w.app.AgentCoordinator.PopQueuedMessage(sessionID)
+	return queued, ok, nil
+}
+
 func (w *AppWorkspace) AgentSummarize(ctx context.Context, sessionID string) error {
 	if w.app.AgentCoordinator == nil {
 		return errors.New("agent coordinator not initialized")

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -213,10 +213,11 @@ func (w *AppWorkspace) AgentQueuedPromptsList(sessionID string) []string {
 	return w.app.AgentCoordinator.QueuedPromptsList(sessionID)
 }
 
-func (w *AppWorkspace) AgentClearQueue(sessionID string) {
-	if w.app.AgentCoordinator != nil {
-		w.app.AgentCoordinator.ClearQueue(sessionID)
+func (w *AppWorkspace) AgentClearQueue(sessionID string) ([]agent.QueuedMessage, error) {
+	if w.app.AgentCoordinator == nil {
+		return nil, nil
 	}
+	return w.app.AgentCoordinator.ClearQueue(sessionID), nil
 }
 
 // AgentPopQueuedMessage removes and returns the newest queued message for

--- a/internal/workspace/app_workspace.go
+++ b/internal/workspace/app_workspace.go
@@ -219,9 +219,15 @@ func (w *AppWorkspace) AgentClearQueue(sessionID string) {
 	}
 }
 
+// AgentPopQueuedMessage removes and returns the newest queued message for
+// the session. A nil coordinator is reported as an empty queue, not an
+// error: no coordinator means no queue exists, so nothing can be popped
+// and nothing can be lost. This matches the other queue operations and,
+// crucially, Backend.PopQueuedMessage, so the same user action behaves
+// identically in client/server mode.
 func (w *AppWorkspace) AgentPopQueuedMessage(sessionID string) (agent.QueuedMessage, bool, error) {
 	if w.app.AgentCoordinator == nil {
-		return agent.QueuedMessage{}, false, ErrAgentNotInitialized
+		return agent.QueuedMessage{}, false, nil
 	}
 	queued, ok := w.app.AgentCoordinator.PopQueuedMessage(sessionID)
 	return queued, ok, nil

--- a/internal/workspace/app_workspace_test.go
+++ b/internal/workspace/app_workspace_test.go
@@ -10,11 +10,10 @@ import (
 
 // TestAppWorkspace_QueueOpsWithUninitializedAgent pins the local half of the
 // queue contract for a workspace whose coder agent was never initialized.
-// Popping used to return ErrAgentNotInitialized here while the remote path
-// answered "empty queue" (Backend.PopQueuedMessage, covered by
-// TestPopQueuedMessageEmptyAndErrors), so the same key press showed an error
-// banner locally and did nothing in client/server mode. No coordinator means
-// no queue, so every queue operation collapses to zero values.
+// Local must answer like client/server does (the remote path is
+// Backend.PopQueuedMessage, covered by TestPopQueuedMessageEmptyAndErrors):
+// no coordinator means no queue, so every queue operation collapses to zero
+// values rather than an error.
 func TestAppWorkspace_QueueOpsWithUninitializedAgent(t *testing.T) {
 	t.Parallel()
 
@@ -33,7 +32,6 @@ func TestAppWorkspace_QueueOpsWithUninitializedAgent(t *testing.T) {
 	require.Zero(t, ws.AgentQueuedPrompts("session"))
 	require.Empty(t, ws.AgentQueuedPromptsList("session"))
 
-	// The uninitialized agent is still reported where the UI acts on it.
 	require.ErrorIs(t, ws.AgentReadyErr(), ErrAgentNotInitialized)
 	require.False(t, ws.AgentIsReady())
 }

--- a/internal/workspace/app_workspace_test.go
+++ b/internal/workspace/app_workspace_test.go
@@ -26,9 +26,12 @@ func TestAppWorkspace_QueueOpsWithUninitializedAgent(t *testing.T) {
 	require.False(t, found)
 	require.Equal(t, agent.QueuedMessage{}, popped)
 
+	drained, err := ws.AgentClearQueue("session")
+	require.NoError(t, err)
+	require.Nil(t, drained)
+
 	require.Zero(t, ws.AgentQueuedPrompts("session"))
 	require.Empty(t, ws.AgentQueuedPromptsList("session"))
-	require.NotPanics(t, func() { ws.AgentClearQueue("session") })
 
 	// The uninitialized agent is still reported where the UI acts on it.
 	require.ErrorIs(t, ws.AgentReadyErr(), ErrAgentNotInitialized)

--- a/internal/workspace/app_workspace_test.go
+++ b/internal/workspace/app_workspace_test.go
@@ -1,0 +1,36 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent"
+	"github.com/charmbracelet/crush/internal/app"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAppWorkspace_QueueOpsWithUninitializedAgent pins the local half of the
+// queue contract for a workspace whose coder agent was never initialized.
+// Popping used to return ErrAgentNotInitialized here while the remote path
+// answered "empty queue" (Backend.PopQueuedMessage, covered by
+// TestPopQueuedMessageEmptyAndErrors), so the same key press showed an error
+// banner locally and did nothing in client/server mode. No coordinator means
+// no queue, so every queue operation collapses to zero values.
+func TestAppWorkspace_QueueOpsWithUninitializedAgent(t *testing.T) {
+	t.Parallel()
+
+	ws := NewAppWorkspace(&app.App{}, nil)
+	require.Nil(t, ws.app.AgentCoordinator, "test premise: agent not initialized")
+
+	popped, found, err := ws.AgentPopQueuedMessage("session")
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Equal(t, agent.QueuedMessage{}, popped)
+
+	require.Zero(t, ws.AgentQueuedPrompts("session"))
+	require.Empty(t, ws.AgentQueuedPromptsList("session"))
+	require.NotPanics(t, func() { ws.AgentClearQueue("session") })
+
+	// The uninitialized agent is still reported where the UI acts on it.
+	require.ErrorIs(t, ws.AgentReadyErr(), ErrAgentNotInitialized)
+	require.False(t, ws.AgentIsReady())
+}

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/agent/notify"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/app"
@@ -308,6 +309,10 @@ func (w *ClientWorkspace) AgentQueuedPromptsList(sessionID string) []string {
 
 func (w *ClientWorkspace) AgentClearQueue(sessionID string) {
 	_ = w.client.ClearAgentSessionQueuedPrompts(context.Background(), w.workspaceID(), sessionID)
+}
+
+func (w *ClientWorkspace) AgentPopQueuedMessage(sessionID string) (agent.QueuedMessage, bool, error) {
+	return w.client.PopAgentSessionQueuedMessage(context.Background(), w.workspaceID(), sessionID)
 }
 
 func (w *ClientWorkspace) AgentSummarize(ctx context.Context, sessionID string) error {

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -307,8 +307,8 @@ func (w *ClientWorkspace) AgentQueuedPromptsList(sessionID string) []string {
 	return prompts
 }
 
-func (w *ClientWorkspace) AgentClearQueue(sessionID string) {
-	_ = w.client.ClearAgentSessionQueuedPrompts(context.Background(), w.workspaceID(), sessionID)
+func (w *ClientWorkspace) AgentClearQueue(sessionID string) ([]agent.QueuedMessage, error) {
+	return w.client.ClearAgentSessionQueuedPrompts(context.Background(), w.workspaceID(), sessionID)
 }
 
 func (w *ClientWorkspace) AgentPopQueuedMessage(sessionID string) (agent.QueuedMessage, bool, error) {

--- a/internal/workspace/client_workspace_test.go
+++ b/internal/workspace/client_workspace_test.go
@@ -24,6 +24,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestClientWorkspaceAgentPopQueuedMessage(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/workspaces/ws-1/agent/sessions/sess-1/prompts/pop", r.URL.Path)
+		require.NoError(t, json.NewEncoder(w).Encode(proto.PopQueuedMessageResponse{
+			Found: true,
+			Message: proto.QueuedMessage{
+				Prompt: "queued",
+				Attachments: []proto.Attachment{{
+					FileName: "notes.txt",
+					MimeType: "text/plain",
+				}},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	c, err := client.NewClient(t.TempDir(), "tcp", u.Host)
+	require.NoError(t, err)
+	ws := NewClientWorkspace(c, proto.Workspace{ID: "ws-1"})
+
+	got, found, err := ws.AgentPopQueuedMessage("sess-1")
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, "queued", got.Prompt)
+	require.Equal(t, "notes.txt", got.Attachments[0].FileName)
+}
+
 // TestProtoToMessageToolResult ensures that ToolResult metadata,
 // data, and MIME type survive the conversion from proto on the
 // client. Without these fields the TUI cannot render rich tool

--- a/internal/workspace/client_workspace_test.go
+++ b/internal/workspace/client_workspace_test.go
@@ -54,6 +54,39 @@ func TestClientWorkspaceAgentPopQueuedMessage(t *testing.T) {
 	require.Equal(t, "notes.txt", got.Attachments[0].FileName)
 }
 
+func TestClientWorkspaceAgentClearQueue(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/workspaces/ws-1/agent/sessions/sess-1/prompts/clear", r.URL.Path)
+		require.NoError(t, json.NewEncoder(w).Encode(proto.ClearQueueResponse{
+			Messages: []proto.QueuedMessage{
+				{Prompt: "oldest"},
+				{
+					Prompt: "newest",
+					Attachments: []proto.Attachment{{
+						FileName: "notes.txt",
+						MimeType: "text/plain",
+					}},
+				},
+			},
+		}))
+	}))
+	defer srv.Close()
+
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	c, err := client.NewClient(t.TempDir(), "tcp", u.Host)
+	require.NoError(t, err)
+	ws := NewClientWorkspace(c, proto.Workspace{ID: "ws-1"})
+
+	drained, err := ws.AgentClearQueue("sess-1")
+	require.NoError(t, err)
+	require.Len(t, drained, 2)
+	require.Equal(t, []string{"oldest", "newest"},
+		[]string{drained[0].Prompt, drained[1].Prompt})
+	require.Equal(t, "notes.txt", drained[1].Attachments[0].FileName)
+}
+
 // TestProtoToMessageToolResult ensures that ToolResult metadata,
 // data, and MIME type survive the conversion from proto on the
 // client. Without these fields the TUI cannot render rich tool

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -11,6 +11,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/agent"
 	mcptools "github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/commands"
 	"github.com/charmbracelet/crush/internal/config"
@@ -153,6 +154,7 @@ type Workspace interface {
 	AgentQueuedPrompts(sessionID string) int
 	AgentQueuedPromptsList(sessionID string) []string
 	AgentClearQueue(sessionID string)
+	AgentPopQueuedMessage(sessionID string) (agent.QueuedMessage, bool, error)
 	AgentSummarize(ctx context.Context, sessionID string) error
 	UpdateAgentModel(ctx context.Context) error
 	InitCoderAgent(ctx context.Context) error

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -154,6 +154,13 @@ type Workspace interface {
 	AgentQueuedPrompts(sessionID string) int
 	AgentQueuedPromptsList(sessionID string) []string
 	AgentClearQueue(sessionID string)
+	// AgentPopQueuedMessage removes the newest queued message for the
+	// session and returns it. The bool reports whether anything was
+	// queued; an uninitialized agent is reported as an empty queue, not
+	// an error, so the operation behaves the same in both modes. The
+	// error is reserved for a transport or backend failure, and because
+	// the pop is destructive it may be raised after the message was
+	// already removed.
 	AgentPopQueuedMessage(sessionID string) (agent.QueuedMessage, bool, error)
 	AgentSummarize(ctx context.Context, sessionID string) error
 	UpdateAgentModel(ctx context.Context) error

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -153,7 +153,14 @@ type Workspace interface {
 	AgentReadyErr() error
 	AgentQueuedPrompts(sessionID string) int
 	AgentQueuedPromptsList(sessionID string) []string
-	AgentClearQueue(sessionID string)
+	// AgentClearQueue removes every prompt queued for the session and
+	// returns them, oldest to newest, so a caller can hand them back to
+	// the user instead of destroying them. An uninitialized agent is
+	// reported as an empty queue, not an error, matching
+	// AgentPopQueuedMessage. The error is reserved for a transport or
+	// backend failure, and because the clear is destructive it may be
+	// raised after the messages were already removed.
+	AgentClearQueue(sessionID string) ([]agent.QueuedMessage, error)
 	// AgentPopQueuedMessage removes the newest queued message for the
 	// session and returns it. The bool reports whether anything was
 	// queued; an uninitialized agent is reported as an empty queue, not

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -153,21 +153,11 @@ type Workspace interface {
 	AgentReadyErr() error
 	AgentQueuedPrompts(sessionID string) int
 	AgentQueuedPromptsList(sessionID string) []string
-	// AgentClearQueue removes every prompt queued for the session and
-	// returns them, oldest to newest, so a caller can hand them back to
-	// the user instead of destroying them. An uninitialized agent is
-	// reported as an empty queue, not an error, matching
-	// AgentPopQueuedMessage. The error is reserved for a transport or
-	// backend failure, and because the clear is destructive it may be
-	// raised after the messages were already removed.
+	// AgentClearQueue removes and returns every prompt queued for the
+	// session, oldest to newest; an error may follow a successful removal.
 	AgentClearQueue(sessionID string) ([]agent.QueuedMessage, error)
-	// AgentPopQueuedMessage removes the newest queued message for the
-	// session and returns it. The bool reports whether anything was
-	// queued; an uninitialized agent is reported as an empty queue, not
-	// an error, so the operation behaves the same in both modes. The
-	// error is reserved for a transport or backend failure, and because
-	// the pop is destructive it may be raised after the message was
-	// already removed.
+	// AgentPopQueuedMessage removes and returns the newest queued
+	// message; the bool reports whether anything was queued.
 	AgentPopQueuedMessage(sessionID string) (agent.QueuedMessage, bool, error)
 	AgentSummarize(ctx context.Context, sessionID string) error
 	UpdateAgentModel(ctx context.Context) error


### PR DESCRIPTION
Closes #3558.

Adds `SHIFT+UP` and `ALT+UP` to add the ability to pop messages off the queue.

ESC now works much better too, it pops the entire queued message stack without losing any of them.

The queued messages UI has also been updated to show the new shortcuts so that users know how to use this feature:

[crush-queued-messages.webm](https://github.com/user-attachments/assets/2db295b0-fbe1-4c4f-b3e2-70f05a3ecd6a)


- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

## AI Disclosure

- Planning and implementation: GPT-5.6-Sol (xhigh), Opus 5 (xhigh), Kimi K3 (max), GLM-5.3 (max)
- Verification and review: Opus 5 (xhigh), Kimi K3 (max)