### PR TITLE
fix(permissions): swallow SPACE in dialog to prevent stray approval

### DIFF
--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -228,6 +228,13 @@ func (*Permissions) ID() string {
 func (p *Permissions) HandleMsg(msg tea.Msg) Action {
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
+		// #2799: swallow SPACE so a stray keystroke from the chat editor
+		// can't trigger viewport scroll or any other action when this
+		// dialog opens mid-typing. Approval requires an explicit
+		// Enter / a / s / d / mouse selection.
+		if msg.String() == "space" {
+			return nil
+		}
 		switch {
 		case key.Matches(msg, p.keyMap.Close):
 			// Escape denies the permission request.


### PR DESCRIPTION
This PR addresses: fix(permissions): swallow SPACE in dialog to prevent stray approval