### PR TITLE
fix(ui): use dialog background for bash syntax highlighting in permissions

### DIFF
--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -571,7 +571,7 @@ func (p *Permissions) renderBashContent(width int) string {
 	}
 
 	cmd := common.StripBashDisplayPrefix(params.Command, p.com.Workspace.WorkingDir())
-	command, err := common.SyntaxHighlightLexerName(p.com.Styles, cmd, "bash", nil)
+	command, err := common.SyntaxHighlightLexerName(p.com.Styles, cmd, "bash", p.com.Styles.Dialog.ContentPanelBg)
 	if err != nil {
 		command = cmd
 	}

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -960,6 +960,7 @@ func quickStyle(o quickStyleOpts) Styles {
 
 	s.Dialog.List = base.Margin(0, 0, 1, 0)
 	s.Dialog.ContentPanel = base.Background(o.bgLessVisible).Foreground(o.fgBase).Padding(1, 2)
+	s.Dialog.ContentPanelBg = o.bgLessVisible
 	s.Dialog.Spinner = base.Foreground(o.secondary)
 	s.Dialog.ScrollbarThumb = base.Foreground(o.secondary)
 	s.Dialog.ScrollbarTrack = base.Foreground(o.separator)

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -456,7 +456,8 @@ type Styles struct {
 		Spinner lipgloss.Style
 
 		// ContentPanel is used for content blocks with subtle background.
-		ContentPanel lipgloss.Style
+		ContentPanel   lipgloss.Style
+		ContentPanelBg color.Color // Background color for ContentPanel syntax highlighting.
 
 		// Scrollbar styles for scrollable content.
 		ScrollbarThumb lipgloss.Style


### PR DESCRIPTION
Reported by @hongquan here: https://github.com/charmbracelet/crush/pull/3538#issuecomment-5289656479