### PR TITLE
feat(ui): show user@host:cwd in the header by default

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -534,7 +534,8 @@ Available Keys:
   completions-max-items int     maximum items returned to completions
   working-dir-format string     how the header shows the working directory,
                                 with {cwd}, {user} and {host} placeholders;
-                                defaults to {user}@{host}:{cwd}
+                                defaults to {user}@{host}:{cwd}; falls back
+                                to {cwd} when the header is too narrow
 ```
 
 ```bash

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -532,6 +532,9 @@ Available Keys:
                                 always, or never
   completions-max-depth int     maximum directory depth shown by completions
   completions-max-items int     maximum items returned to completions
+  working-dir-format string     how the header shows the working directory,
+                                with {cwd}, {user} and {host} placeholders;
+                                defaults to {user}@{host}:{cwd}
 ```
 
 ```bash
@@ -541,6 +544,7 @@ option ui transparent true
 option ui scrollbar always
 option ui completions-max-depth 4
 option ui completions-max-items 200
+option ui working-dir-format "{host}:{cwd}"
 ```
 
 > [!IMPORTANT]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -265,6 +265,9 @@ type TUIOptions struct {
 	Completions Completions `json:"completions,omitzero" jsonschema:"description=Completions UI options"`
 	Transparent *bool       `json:"transparent,omitempty" jsonschema:"description=Enable transparent background for the TUI interface,default=false"`
 	Scrollbar   string      `json:"scrollbar,omitempty" jsonschema:"description=Chat scrollbar visibility,enum=default,enum=always,enum=never,default=default"`
+	// WorkingDirFormat controls how the working directory is rendered in
+	// the header. Supported placeholders: {cwd}, {user}, {host}.
+	WorkingDirFormat string `json:"working_dir_format,omitempty" jsonschema:"description=Format for the working directory shown in the header. Supported placeholders: {cwd} for the path, {user} for the current user, {host} for the hostname.,default={user}@{host}:{cwd},example={cwd},example={host}:{cwd}"`
 }
 
 // Completions defines options for the completions UI.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -267,7 +267,7 @@ type TUIOptions struct {
 	Scrollbar   string      `json:"scrollbar,omitempty" jsonschema:"description=Chat scrollbar visibility,enum=default,enum=always,enum=never,default=default"`
 	// WorkingDirFormat controls how the working directory is rendered in
 	// the header. Supported placeholders: {cwd}, {user}, {host}.
-	WorkingDirFormat string `json:"working_dir_format,omitempty" jsonschema:"description=Format for the working directory shown in the header. Supported placeholders: {cwd} for the path, {user} for the current user, {host} for the hostname.,default={user}@{host}:{cwd},example={cwd},example={host}:{cwd}"`
+	WorkingDirFormat string `json:"working_dir_format,omitempty" jsonschema:"description=Format for the working directory shown in the header. Supported placeholders: {cwd} for the path\\, {user} for the current user\\, {host} for the hostname.,default={user}@{host}:{cwd},example={cwd},example={host}:{cwd}"`
 }
 
 // Completions defines options for the completions UI.

--- a/internal/shellconfig/options.go
+++ b/internal/shellconfig/options.go
@@ -206,7 +206,7 @@ var optionSpecs = map[string]optionSpec{
 // that live under options.tui rather than as top-level options.
 func optionUI(options map[string]any, args []string, stderr io.Writer) error {
 	if len(args) != 4 {
-		return usage(stderr, "usage: option ui <compact|diff|transparent|scrollbar|completions-max-depth|completions-max-items> <value>")
+		return usage(stderr, "usage: option ui <compact|diff|transparent|scrollbar|working-dir-format|completions-max-depth|completions-max-items> <value>")
 	}
 
 	key := args[2]
@@ -234,6 +234,11 @@ func optionUI(options map[string]any, args []string, stderr io.Writer) error {
 			return usage(stderr, fmt.Sprintf("option ui scrollbar expects default, always, or never, got %q", value))
 		}
 		ui["scrollbar"] = value
+	case "working-dir-format":
+		if strings.TrimSpace(value) == "" {
+			return usage(stderr, "option ui working-dir-format requires a value, e.g. {user}@{host}:{cwd} ({cwd}, {user}, {host} placeholders)")
+		}
+		ui["working_dir_format"] = value
 	case "completions-max-depth", "completions-max-items":
 		parsed, err := strconv.Atoi(value)
 		if err != nil || parsed < 0 {

--- a/internal/shellconfig/options.go
+++ b/internal/shellconfig/options.go
@@ -235,8 +235,12 @@ func optionUI(options map[string]any, args []string, stderr io.Writer) error {
 		}
 		ui["scrollbar"] = value
 	case "working-dir-format":
-		if strings.TrimSpace(value) == "" {
+		value = strings.TrimSpace(value)
+		if value == "" {
 			return usage(stderr, "option ui working-dir-format requires a value, e.g. {user}@{host}:{cwd} ({cwd}, {user}, {host} placeholders)")
+		}
+		if !strings.Contains(value, "{cwd}") && !strings.Contains(value, "{user}") && !strings.Contains(value, "{host}") {
+			return usage(stderr, fmt.Sprintf("option ui working-dir-format expects at least one of {cwd}, {user}, {host}, got %q", value))
 		}
 		ui["working_dir_format"] = value
 	case "completions-max-depth", "completions-max-items":

--- a/internal/shellconfig/options_test.go
+++ b/internal/shellconfig/options_test.go
@@ -185,6 +185,15 @@ func TestOption_UIWorkingDirFormatRequiresValue(t *testing.T) {
 	require.Contains(t, err.Error(), "requires a value")
 }
 
+func TestOption_UIWorkingDirFormatRequiresPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "crushrc")
+	_, err := LoadShellConfig(t.Context(), path, []byte(`option ui working-dir-format "{pwd}"`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expects at least one of")
+}
+
 func TestOption_BoolShorthand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/shellconfig/options_test.go
+++ b/internal/shellconfig/options_test.go
@@ -162,6 +162,29 @@ func TestOption_UIUnknownKey(t *testing.T) {
 	require.Contains(t, err.Error(), "unknown key")
 }
 
+func TestOption_UIWorkingDirFormat(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "crushrc")
+	jsonBytes, err := LoadShellConfig(t.Context(), path, []byte(`option ui working-dir-format {host}:{cwd}`))
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(jsonBytes, &result))
+
+	ui := result["options"].(map[string]any)["tui"].(map[string]any)
+	require.Equal(t, "{host}:{cwd}", ui["working_dir_format"])
+}
+
+func TestOption_UIWorkingDirFormatRequiresValue(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "crushrc")
+	_, err := LoadShellConfig(t.Context(), path, []byte(`option ui working-dir-format ""`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires a value")
+}
+
 func TestOption_BoolShorthand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -187,7 +187,9 @@ option reset <list-key>    # clear a list option back to empty
   `assisted-by`) and `attribution-generated-with` (boolean).
 - **UI settings**: `option ui compact BOOL`, `option ui diff unified|split`,
   `option ui transparent BOOL`, `option ui scrollbar default|always|never`,
-  `option ui completions-max-depth N`, `option ui completions-max-items N`.
+  `option ui completions-max-depth N`, `option ui completions-max-items N`,
+  `option ui working-dir-format FMT` (header working-dir format with
+  `{cwd}`, `{user}`, `{host}` placeholders; default `{user}@{host}:{cwd}`).
 - **List keys** (singular, one value per call, repeatable): `context-path`,
   `global-context-path`, `skill-path`, `disable-skill`. Use `option reset <key>`
   to wipe inherited values (e.g. after `source`).

--- a/internal/ui/model/header.go
+++ b/internal/ui/model/header.go
@@ -2,7 +2,10 @@ package model
 
 import (
 	"fmt"
+	"os"
+	"os/user"
 	"strings"
+	"sync"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/config"
@@ -21,6 +24,47 @@ const (
 	rightPadding         = 1
 	diagToDetailsSpacing = 1 // space between diagonal pattern and details section
 )
+
+// defaultWorkingDirFormat is used when options.tui.working_dir_format is
+// unset. It mirrors the familiar user@host:cwd shell prompt so the header
+// stays unambiguous when hopping between hosts.
+const defaultWorkingDirFormat = "{user}@{host}:{cwd}"
+
+// currentUserHost resolves the current username and hostname once per
+// process. The hostname is shortened to its first label so long FQDNs do
+// not crowd the header.
+var currentUserHost = sync.OnceValue(func() userHost {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "localhost"
+	}
+	if label, _, ok := strings.Cut(host, "."); ok && label != "" {
+		host = label
+	}
+	username, err := user.Current()
+	if err != nil || username.Username == "" {
+		return userHost{name: os.Getenv("USER"), host: host}
+	}
+	return userHost{name: username.Username, host: host}
+})
+
+type userHost struct {
+	name string
+	host string
+}
+
+// formatWorkingDir expands {cwd}, {user} and {host} placeholders in a
+// working directory format string. Unknown placeholders are left verbatim.
+func formatWorkingDir(format, cwd, user, host string) string {
+	if strings.TrimSpace(format) == "" {
+		format = defaultWorkingDirFormat
+	}
+	return strings.NewReplacer(
+		"{cwd}", cwd,
+		"{user}", user,
+		"{host}", host,
+	).Replace(format)
+}
 
 type header struct {
 	// cached logo and compact logo
@@ -173,7 +217,13 @@ func renderHeaderDetails(
 
 	const dirTrimLimit = 4
 	cwd := fsext.DirTrim(fsext.PrettyPath(com.Workspace.WorkingDir()), dirTrimLimit)
-	cwd = t.Header.WorkingDir.Render(cwd)
+
+	format := defaultWorkingDirFormat
+	if cfg := com.Config().Options.TUI; cfg != nil && strings.TrimSpace(cfg.WorkingDirFormat) != "" {
+		format = cfg.WorkingDirFormat
+	}
+	uh := currentUserHost()
+	cwd = t.Header.WorkingDir.Render(formatWorkingDir(format, cwd, uh.name, uh.host))
 
 	result := cwd + metadata
 	return ansi.Truncate(result, max(0, availWidth), "…")

--- a/internal/ui/model/header.go
+++ b/internal/ui/model/header.go
@@ -38,9 +38,7 @@ var currentUserHost = sync.OnceValue(func() userHost {
 	if err != nil || host == "" {
 		host = "localhost"
 	}
-	if label, _, ok := strings.Cut(host, "."); ok && label != "" {
-		host = label
-	}
+	host = shortHost(host)
 	username, err := user.Current()
 	if err != nil || username.Username == "" {
 		return userHost{name: os.Getenv("USER"), host: host}
@@ -51,6 +49,15 @@ var currentUserHost = sync.OnceValue(func() userHost {
 type userHost struct {
 	name string
 	host string
+}
+
+// shortHost shortens a hostname to its first label so long FQDNs do not
+// crowd the header.
+func shortHost(host string) string {
+	if label, _, ok := strings.Cut(host, "."); ok && label != "" {
+		return label
+	}
+	return host
 }
 
 // formatWorkingDir expands {cwd}, {user} and {host} placeholders in a

--- a/internal/ui/model/header.go
+++ b/internal/ui/model/header.go
@@ -1,7 +1,9 @@
 package model
 
 import (
+	"cmp"
 	"fmt"
+	"net"
 	"os"
 	"os/user"
 	"strings"
@@ -35,15 +37,17 @@ const defaultWorkingDirFormat = "{user}@{host}:{cwd}"
 // not crowd the header.
 var currentUserHost = sync.OnceValue(func() userHost {
 	host, err := os.Hostname()
-	if err != nil || host == "" {
-		host = "localhost"
+	if err != nil {
+		host = ""
 	}
-	host = shortHost(host)
-	username, err := user.Current()
-	if err != nil || username.Username == "" {
-		return userHost{name: os.Getenv("USER"), host: host}
+	name := ""
+	if u, err := user.Current(); err == nil {
+		name = u.Username
 	}
-	return userHost{name: username.Username, host: host}
+	if name == "" {
+		name = cmp.Or(os.Getenv("USER"), os.Getenv("USERNAME"), os.Getenv("LOGNAME"))
+	}
+	return userHost{name: shortUsername(name), host: shortHostname(host)}
 })
 
 type userHost struct {
@@ -51,26 +55,41 @@ type userHost struct {
 	host string
 }
 
-// shortHost shortens a hostname to its first label so long FQDNs do not
-// crowd the header.
-func shortHost(host string) string {
+// shortHostname reduces a hostname to its first DNS label so long FQDNs do
+// not crowd the header. IP literals are left intact and an empty hostname
+// falls back to "localhost".
+func shortHostname(host string) string {
+	if host == "" {
+		return "localhost"
+	}
+	if net.ParseIP(host) != nil {
+		return host
+	}
 	if label, _, ok := strings.Cut(host, "."); ok && label != "" {
 		return label
 	}
 	return host
 }
 
+// shortUsername strips a Windows-style DOMAIN\ prefix from a username.
+func shortUsername(name string) string {
+	if _, short, ok := strings.Cut(name, `\`); ok && short != "" {
+		return short
+	}
+	return name
+}
+
 // formatWorkingDir expands {cwd}, {user} and {host} placeholders in a
 // working directory format string. Unknown placeholders are left verbatim.
+// A blank format falls back to defaultWorkingDirFormat.
 func formatWorkingDir(format, cwd, user, host string) string {
 	if strings.TrimSpace(format) == "" {
 		format = defaultWorkingDirFormat
 	}
-	return strings.NewReplacer(
-		"{cwd}", cwd,
-		"{user}", user,
-		"{host}", host,
-	).Replace(format)
+	// Sequential ReplaceAll avoids building a Replacer trie on every frame.
+	out := strings.ReplaceAll(format, "{host}", host)
+	out = strings.ReplaceAll(out, "{user}", user)
+	return strings.ReplaceAll(out, "{cwd}", cwd)
 }
 
 type header struct {
@@ -225,13 +244,18 @@ func renderHeaderDetails(
 	const dirTrimLimit = 4
 	cwd := fsext.DirTrim(fsext.PrettyPath(com.Workspace.WorkingDir()), dirTrimLimit)
 
-	format := defaultWorkingDirFormat
-	if cfg := com.Config().Options.TUI; cfg != nil && strings.TrimSpace(cfg.WorkingDirFormat) != "" {
+	format := ""
+	if cfg := com.Config().Options.TUI; cfg != nil {
 		format = cfg.WorkingDirFormat
 	}
 	uh := currentUserHost()
-	cwd = t.Header.WorkingDir.Render(formatWorkingDir(format, cwd, uh.name, uh.host))
-
-	result := cwd + metadata
+	dir := formatWorkingDir(format, cwd, uh.name, uh.host)
+	// Truncation drops from the right, which is where the metadata lives.
+	// When the formatted directory would crowd out the metadata, fall back
+	// to the bare path rather than losing the token usage and keystroke hint.
+	if lipgloss.Width(dir+metadata) > availWidth && lipgloss.Width(cwd+metadata) <= availWidth {
+		dir = cwd
+	}
+	result := t.Header.WorkingDir.Render(dir) + metadata
 	return ansi.Truncate(result, max(0, availWidth), "…")
 }

--- a/internal/ui/model/header_test.go
+++ b/internal/ui/model/header_test.go
@@ -1,8 +1,14 @@
 package model
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestFormatWorkingDir(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		format string
@@ -63,39 +69,51 @@ func TestFormatWorkingDir(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := formatWorkingDir(tt.format, tt.cwd, tt.user, tt.host)
-			if got != tt.want {
-				t.Errorf("formatWorkingDir(%q, %q, %q, %q) = %q, want %q",
-					tt.format, tt.cwd, tt.user, tt.host, got, tt.want)
-			}
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
 
-func TestShortHost(t *testing.T) {
-	tests := []struct {
-		host string
-		want string
-	}{
-		{"lir", "lir"},
-		{"lir.stump.rocks", "lir"},
-		{"lir.stump.rocks.", "lir"},
-		{".leading", ".leading"},
-		{"", ""},
+func TestShortHostname(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"":                  "localhost",
+		"lir":               "lir",
+		"lir.stump.rocks":   "lir",
+		"192.168.1.5":       "192.168.1.5",
+		"::1":               "::1",
+		".weird":            ".weird",
+		"DESKTOP-8F2A1C":    "DESKTOP-8F2A1C",
+		"host.example.com.": "host",
 	}
-	for _, tt := range tests {
-		if got := shortHost(tt.host); got != tt.want {
-			t.Errorf("shortHost(%q) = %q, want %q", tt.host, got, tt.want)
-		}
+	for in, want := range tests {
+		require.Equal(t, want, shortHostname(in), "input %q", in)
+	}
+}
+
+func TestShortUsername(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"":              "",
+		"joestump":      "joestump",
+		`MYCORP\jstump`: "jstump",
+		`\`:             `\`,
+	}
+	for in, want := range tests {
+		require.Equal(t, want, shortUsername(in), "input %q", in)
 	}
 }
 
 func TestCurrentUserHost(t *testing.T) {
+	t.Parallel()
+
+	// The username depends on the ambient environment and may legitimately
+	// be empty (e.g. containers with no passwd entry), but the hostname
+	// always falls back to "localhost".
 	uh := currentUserHost()
-	if uh.name == "" {
-		t.Error("currentUserHost returned an empty username")
-	}
-	if uh.host == "" {
-		t.Error("currentUserHost returned an empty hostname")
-	}
+	require.NotEmpty(t, uh.host)
 }

--- a/internal/ui/model/header_test.go
+++ b/internal/ui/model/header_test.go
@@ -1,0 +1,83 @@
+package model
+
+import "testing"
+
+func TestFormatWorkingDir(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		cwd    string
+		user   string
+		host   string
+		want   string
+	}{
+		{
+			name:   "default format when empty",
+			format: "",
+			cwd:    "~/src/crush",
+			user:   "joestump",
+			host:   "lir",
+			want:   "joestump@lir:~/src/crush",
+		},
+		{
+			name:   "default format when blank",
+			format: "   ",
+			cwd:    "~/src",
+			user:   "u",
+			host:   "h",
+			want:   "u@h:~/src",
+		},
+		{
+			name:   "path only restores previous behavior",
+			format: "{cwd}",
+			cwd:    "~/src/crush",
+			user:   "joestump",
+			host:   "lir",
+			want:   "~/src/crush",
+		},
+		{
+			name:   "host and cwd only",
+			format: "{host}:{cwd}",
+			cwd:    "/tmp",
+			user:   "joestump",
+			host:   "nyma",
+			want:   "nyma:/tmp",
+		},
+		{
+			name:   "unknown placeholders left verbatim",
+			format: "{cwd} {unknown}",
+			cwd:    "/tmp",
+			user:   "u",
+			host:   "h",
+			want:   "/tmp {unknown}",
+		},
+		{
+			name:   "placeholder-like literals around values",
+			format: "{user}@{host}:{cwd}$",
+			cwd:    "~/x",
+			user:   "agent",
+			host:   "pidge",
+			want:   "agent@pidge:~/x$",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatWorkingDir(tt.format, tt.cwd, tt.user, tt.host)
+			if got != tt.want {
+				t.Errorf("formatWorkingDir(%q, %q, %q, %q) = %q, want %q",
+					tt.format, tt.cwd, tt.user, tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCurrentUserHost(t *testing.T) {
+	uh := currentUserHost()
+	if uh.name == "" {
+		t.Error("currentUserHost returned an empty username")
+	}
+	if uh.host == "" {
+		t.Error("currentUserHost returned an empty hostname")
+	}
+}

--- a/internal/ui/model/header_test.go
+++ b/internal/ui/model/header_test.go
@@ -72,6 +72,24 @@ func TestFormatWorkingDir(t *testing.T) {
 	}
 }
 
+func TestShortHost(t *testing.T) {
+	tests := []struct {
+		host string
+		want string
+	}{
+		{"lir", "lir"},
+		{"lir.stump.rocks", "lir"},
+		{"lir.stump.rocks.", "lir"},
+		{".leading", ".leading"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := shortHost(tt.host); got != tt.want {
+			t.Errorf("shortHost(%q) = %q, want %q", tt.host, got, tt.want)
+		}
+	}
+}
+
 func TestCurrentUserHost(t *testing.T) {
 	uh := currentUserHost()
 	if uh.name == "" {


### PR DESCRIPTION
## What

The compact header previously showed only the working directory, which is ambiguous when working across multiple hosts (especially over SSH). This PR renders it as `user@host:cwd` by default, mirroring the familiar shell prompt.

## How

- New `options.tui.working_dir_format` config option (crush.json) with `{cwd}`, `{user}`, and `{host}` placeholders. Default: `{user}@{host}:{cwd}`. Setting it to `{cwd}` restores the previous path-only display.
- Exposed through the new bash config (crushrc) as `option ui working-dir-format "{host}:{cwd}"`, so a PS1-style header can be set from the rc file like any other option.
- Username/hostname are resolved once per process; the hostname is shortened to its first label so long FQDNs don't crowd the header.

## Verification

- `go build ./...`
- `go vet` on the touched packages, `golangci-lint` clean
- New tests: `TestFormatWorkingDir` (format expansion incl. default and path-only), `TestCurrentUserHost`, `TestOption_UIWorkingDirFormat`, `TestOption_UIWorkingDirFormatRequiresValue`
- Full `go test` for `internal/ui/model`, `internal/shellconfig`, `internal/config` passes

🤖 This was posted autonomously by [`glm-5.3`](https://openrouter.ai/z-ai/glm-5.3) using [Crush](https://github.com/charmbracelet/crush).