### PR TITLE
fix(tools): make network failures recoverable tool errors

### DIFF
--- a/internal/agent/tools/download.go
+++ b/internal/agent/tools/download.go
@@ -126,7 +126,13 @@ func NewDownloadTool(permissions permission.Service, workingDir string, client *
 
 			resp, err := client.Do(req)
 			if err != nil {
-				return fantasy.ToolResponse{}, fmt.Errorf("failed to download from URL: %w", err)
+				// Preserve abort semantics when the caller cancelled the run.
+				if requestCtx.Err() == context.Canceled {
+					return fantasy.ToolResponse{}, err
+				}
+				// Network failures (timeouts, DNS errors) should degrade to a
+				// recoverable tool error so the agent can retry or move on.
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("Failed to download from URL: %s", err)), nil
 			}
 			defer resp.Body.Close()
 

--- a/internal/agent/tools/fetch.go
+++ b/internal/agent/tools/fetch.go
@@ -119,7 +119,13 @@ func NewFetchTool(permissions permission.Service, workingDir string, client *htt
 
 			resp, err := client.Do(req)
 			if err != nil {
-				return fantasy.ToolResponse{}, fmt.Errorf("failed to fetch URL: %w", err)
+				// Preserve abort semantics when the caller cancelled the run.
+				if requestCtx.Err() == context.Canceled {
+					return fantasy.ToolResponse{}, err
+				}
+				// Network failures (timeouts, DNS errors) should degrade to a
+				// recoverable tool error so the agent can retry or move on.
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("Failed to fetch URL: %s", err)), nil
 			}
 			defer resp.Body.Close()
 

--- a/internal/agent/tools/sourcegraph.go
+++ b/internal/agent/tools/sourcegraph.go
@@ -122,7 +122,13 @@ func NewSourcegraphTool(client *http.Client) fantasy.AgentTool {
 
 			resp, err := client.Do(req)
 			if err != nil {
-				return fantasy.ToolResponse{}, fmt.Errorf("failed to fetch URL: %w", err)
+				// Preserve abort semantics when the caller cancelled the run.
+				if requestCtx.Err() == context.Canceled {
+					return fantasy.ToolResponse{}, err
+				}
+				// Network failures (timeouts, DNS errors) should degrade to a
+				// recoverable tool error so the agent can retry or move on.
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("Failed to fetch URL: %s", err)), nil
 			}
 			defer resp.Body.Close()
 
@@ -136,12 +142,12 @@ func NewSourcegraphTool(client *http.Client) fantasy.AgentTool {
 			}
 			body, err := io.ReadAll(resp.Body)
 			if err != nil {
-				return fantasy.ToolResponse{}, fmt.Errorf("failed to read response body: %w", err)
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("Failed to read response body: %s", err)), nil
 			}
 
 			var result map[string]any
 			if err = json.Unmarshal(body, &result); err != nil {
-				return fantasy.ToolResponse{}, fmt.Errorf("failed to unmarshal response: %w", err)
+				return fantasy.NewTextErrorResponse(fmt.Sprintf("Failed to parse response: %s", err)), nil
 			}
 
 			formattedResults, err := formatSourcegraphResults(result, params.ContextWindow, params.Count)

--- a/internal/agent/tools/sourcegraph_test.go
+++ b/internal/agent/tools/sourcegraph_test.go
@@ -1,9 +1,14 @@
 package tools
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
+	"charm.land/fantasy"
 	"github.com/stretchr/testify/require"
 )
 
@@ -108,4 +113,58 @@ func TestFormatSourcegraphResultsErrorsAndNoResults(t *testing.T) {
 	got, err = formatSourcegraphResults(noResult, 1, 10)
 	require.NoError(t, err)
 	require.True(t, strings.HasSuffix(got, "No results found. Try a different query.\n"))
+}
+
+type erroringRoundTripper struct {
+	err error
+}
+
+func (rt erroringRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, rt.err
+}
+
+func runSourcegraphTool(t *testing.T, tool fantasy.AgentTool, ctx context.Context, params SourcegraphParams) (fantasy.ToolResponse, error) {
+	t.Helper()
+
+	input, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	call := fantasy.ToolCall{
+		ID:    "test-call",
+		Name:  SourcegraphToolName,
+		Input: string(input),
+	}
+
+	return tool.Run(ctx, call)
+}
+
+func TestSourcegraphToolNetworkError(t *testing.T) {
+	t.Parallel()
+
+	client := &http.Client{
+		Transport: erroringRoundTripper{err: errors.New("dial tcp: i/o timeout")},
+	}
+	tool := NewSourcegraphTool(client)
+
+	resp, err := runSourcegraphTool(t, tool, context.Background(), SourcegraphParams{
+		Query: "context cancellation",
+	})
+	require.NoError(t, err)
+	require.True(t, resp.IsError)
+	require.Contains(t, resp.Content, "Failed to fetch URL")
+}
+
+func TestSourcegraphToolContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tool := NewSourcegraphTool(nil)
+
+	resp, err := runSourcegraphTool(t, tool, ctx, SourcegraphParams{
+		Query: "context cancellation",
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, resp.IsError)
 }


### PR DESCRIPTION
## Summary

Fixes #3582. When a network tool like `sourcegraph`, `fetch`, or `download` hit a network failure (DNS error, connection refused, timeout), the tool returned a **raw Go error**. In the `charm.land/fantasy` executor, any Go error from a tool is treated as critical and aborts the **entire step**, discarding all sibling tool results — which is why an `agentic_fetch` run was cancelled with no output when Sourcegraph timed out.

The sibling search tools (`web_fetch`, `web_search`) already return a recoverable `fantasy.NewTextErrorResponse(...)` for network failures, which is exactly the behavior requested in the issue: "the tool should simply error out ... to allow the subagent to make more tool calls."

## Changes

- **`internal/agent/tools/sourcegraph.go`**: `client.Do` failures now return a `NewTextErrorResponse` (recoverable) instead of a hard Go error. Also made response-body read and JSON unmarshal failures recoverable.
- **`internal/agent/tools/fetch.go`** and **`internal/agent/tools/download.go`**: same fix for the identical `client.Do` failure pattern, so the bug doesn't resurface through the other network tools.
- **Cancellation semantics preserved**: if the run itself was cancelled by the caller (`requestCtx.Err() == context.Canceled`), the hard error is still returned so user-initiated aborts keep their existing behavior. Only network/timeout failures degrade to recoverable tool errors.

## Tests

- `TestSourcegraphToolNetworkError`: a round-tripper that fails (simulating a timeout) → asserts the tool returns `resp.IsError == true` with `nil` Go error, so the subagent can continue.
- `TestSourcegraphToolContextCancelled`: a cancelled context → asserts the hard error is still surfaced (`errors.Is(err, context.Canceled)`).

## Verification

- `go build .` passes
- `go test ./... -count=1` — all 52 packages pass
- `gofumpt -l internal/agent/tools/` — clean