### PR TITLE
chore(deps): bump ultraviolet for input event pacing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/charlievieth/fastwalk v1.0.14
 	github.com/charmbracelet/colorprofile v0.4.3
 	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7
-	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/charmbracelet/x/editor v0.2.0
 	github.com/charmbracelet/x/etag v0.2.0
 	github.com/charmbracelet/x/exp/charmtone v0.0.0-20260527151214-009e6338d40d
@@ -220,3 +220,5 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 )
+
+replace github.com/charmbracelet/ultraviolet => github.com/marwan562/ultraviolet v0.0.0-20260818224207-528ad79de4ba

--- a/go.sum
+++ b/go.sum
@@ -106,10 +106,8 @@ github.com/charlievieth/fastwalk v1.0.14 h1:3Eh5uaFGwHZd8EGwTjJnSpBkfwfsak9h6ICg
 github.com/charlievieth/fastwalk v1.0.14/go.mod h1:diVcUreiU1aQ4/Wu3NbxxH4/KYdKpLDojrQ1Bb2KgNY=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
-github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 h1:3FmWoGNWK4STvqg0O0Aeav2T7rodWJAPeF0QpH+8gFw=
-github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7/go.mod h1:f/jRa757WUmaOZrbPspXymbg/GnbF+rwe4OLsG7aXYo=
-github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
-github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
+github.com/charmbracelet/x/ansi v0.11.8 h1:JMFwp0CgDC2+jcOB162HH5k7I3FVbgFSMMYg7dSPBQQ=
+github.com/charmbracelet/x/ansi v0.11.8/go.mod h1:ZNN+3mXny/516oTQPLMPIBeSINvNJJQ8uQXDgbeJxY0=
 github.com/charmbracelet/x/editor v0.2.0 h1:7XLUKtaRaB8jN7bWU2p2UChiySyaAuIfYiIRg8gGWwk=
 github.com/charmbracelet/x/editor v0.2.0/go.mod h1:p3oQ28TSL3YPd+GKJ1fHWcp+7bVGpedHpXmo0D6t1dY=
 github.com/charmbracelet/x/etag v0.2.0 h1:Euj1VkheoHfTYA9y+TCwkeXF/hN8Fb9l4LqZl79pt04=
@@ -286,6 +284,8 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/marwan562/ultraviolet v0.0.0-20260818224207-528ad79de4ba h1:B7B/x9Xjiy5EewiZjbk2/LQEvaqprdQgWJNiBmtiQ3o=
+github.com/marwan562/ultraviolet v0.0.0-20260818224207-528ad79de4ba/go.mod h1:nAw0d9PhFp1qdzi2xhQU5YOu5sVpDIHWlaW2Uz/bCro=
 github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
 github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=


### PR DESCRIPTION
## What

Bumps `github.com/charmbracelet/ultraviolet` to a commit containing the input-event pacing fix from [charmbracelet/ultraviolet#158](<https://github.com/charmbracelet/ultraviolet/pull/158>).

## Why

Fixes charmbracelet/crush#3392 — holding `alt+left`/`alt+right` to move by word appears to jump straight to the final position.

**Root cause:** when a terminal delivers a burst of key events in a single read (as happens with auto-repeat on macOS/Ghostty), ultraviolet decodes and dispatches them all back-to-back. Bubble Tea's renderer flushes at 60 fps, so the whole burst is processed within a single frame and only the first and last cursor positions are ever rendered. The fix paces the dispatch of non-printable key events decoded from the same buffer (20ms, just over one 60fps frame), letting each intermediate word-move render.

Verified with a real Bubble Tea + `ScreenBuffer` harness replicating crush's editor: before the fix a burst of 7 `alt+left` sequences produced only the initial and final cursor positions; after the fix all 7 intermediate positions render, matching spread-out delivery.

## Notes for maintainers

This uses a temporary `replace` pointing at my fork's commit. Once ultraviolet#158 merges and a version is tagged, swap it for the released version:

```
go mod edit -dropreplace github.com/charmbracelet/ultraviolet
go get github.com/charmbracelet/ultraviolet@latest
```

Transitively bumps `github.com/charmbracelet/x/ansi` v0.11.7 → v0.11.8 (required by the newer ultraviolet). `go build .` and all 51 test packages pass.