### PR TITLE
chore: standardize Go toolchain on 1.26.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   goreleaser:
     uses: charmbracelet/meta/.github/workflows/goreleaser.yml@main
     with:
-      go_version: "1.26"
+      go_version: "1.26.6"
       macos_sign_entitlements: "./.github/entitlements.plist"
     secrets:
       docker_username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -18,7 +18,7 @@ tasks:
     cmds:
       - go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
     env:
-      GOTOOLCHAIN: go1.25.0
+      GOTOOLCHAIN: go1.26.6
 
   lint:
     desc: Run base linters

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/charmbracelet/crush
 
-go 1.26.5
+go 1.26.6
 
 require (
 	charm.land/bubbles/v2 v2.1.1


### PR DESCRIPTION
## Summary

- Set the module language version to Go 1.26.6.
- Align the lint installer and release workflow with Go 1.26.6.

## Verification

- `go mod tidy`
- `CGO_ENABLED=0 GOEXPERIMENT=greenteagc go test ./internal/config ./internal/version`
- `CGO_ENABLED=0 GOEXPERIMENT=greenteagc go build .`