### PR TITLE
feat: Add configured-only filter to model selection dialog

### DIFF
--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -82,14 +82,14 @@ type Models struct {
 	showConfiguredOnly bool
 
 	keyMap struct {
-		Tab            key.Binding
-		UpDown         key.Binding
-		Select         key.Binding
-		Edit           key.Binding
-		Next           key.Binding
-		Previous       key.Binding
-		ToggleFilter   key.Binding
-		Close          key.Binding
+		Tab          key.Binding
+		UpDown       key.Binding
+		Select       key.Binding
+		Edit         key.Binding
+		Next         key.Binding
+		Previous     key.Binding
+		ToggleFilter key.Binding
+		Close        key.Binding
 	}
 	list  *ModelsList
 	input textinput.Model
@@ -215,25 +215,25 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 				ReAuthenticate: isEdit,
 			}
 		case key.Matches(msg, m.keyMap.ToggleFilter):
-				if m.isOnboarding {
-					break
-				}
-				m.showConfiguredOnly = !m.showConfiguredOnly
-				if err := m.setProviderItems(); err != nil {
-					return util.ReportError(err)
-				}
-			case key.Matches(msg, m.keyMap.Tab):
-				if m.isOnboarding {
-					break
-				}
-				if m.modelType == ModelTypeLarge {
-					m.modelType = ModelTypeSmall
-				} else {
-					m.modelType = ModelTypeLarge
-				}
-				if err := m.setProviderItems(); err != nil {
-					return util.ReportError(err)
-				}
+			if m.isOnboarding {
+				break
+			}
+			m.showConfiguredOnly = !m.showConfiguredOnly
+			if err := m.setProviderItems(); err != nil {
+				return util.ReportError(err)
+			}
+		case key.Matches(msg, m.keyMap.Tab):
+			if m.isOnboarding {
+				break
+			}
+			if m.modelType == ModelTypeLarge {
+				m.modelType = ModelTypeSmall
+			} else {
+				m.modelType = ModelTypeLarge
+			}
+			if err := m.setProviderItems(); err != nil {
+				return util.ReportError(err)
+			}
 		default:
 			var cmd tea.Cmd
 			m.input, cmd = m.input.Update(msg)

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -77,17 +77,19 @@ type Models struct {
 	com          *common.Common
 	isOnboarding bool
 
-	modelType ModelType
-	providers []catwalk.Provider
+	modelType          ModelType
+	providers          []catwalk.Provider
+	showConfiguredOnly bool
 
 	keyMap struct {
-		Tab      key.Binding
-		UpDown   key.Binding
-		Select   key.Binding
-		Edit     key.Binding
-		Next     key.Binding
-		Previous key.Binding
-		Close    key.Binding
+		Tab            key.Binding
+		UpDown         key.Binding
+		Select         key.Binding
+		Edit           key.Binding
+		Next           key.Binding
+		Previous       key.Binding
+		ToggleFilter   key.Binding
+		Close          key.Binding
 	}
 	list  *ModelsList
 	input textinput.Model
@@ -140,6 +142,10 @@ func NewModels(com *common.Common, isOnboarding bool) (*Models, error) {
 	m.keyMap.Previous = key.NewBinding(
 		key.WithKeys("up", "ctrl+p"),
 		key.WithHelp("↑", "previous item"),
+	)
+	m.keyMap.ToggleFilter = key.NewBinding(
+		key.WithKeys("ctrl+f"),
+		key.WithHelp("ctrl+f", "toggle configured"),
 	)
 	m.keyMap.Close = CloseKey
 
@@ -208,18 +214,26 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 				ModelType:      modelItem.SelectedModelType(),
 				ReAuthenticate: isEdit,
 			}
-		case key.Matches(msg, m.keyMap.Tab):
-			if m.isOnboarding {
-				break
-			}
-			if m.modelType == ModelTypeLarge {
-				m.modelType = ModelTypeSmall
-			} else {
-				m.modelType = ModelTypeLarge
-			}
-			if err := m.setProviderItems(); err != nil {
-				return util.ReportError(err)
-			}
+		case key.Matches(msg, m.keyMap.ToggleFilter):
+				if m.isOnboarding {
+					break
+				}
+				m.showConfiguredOnly = !m.showConfiguredOnly
+				if err := m.setProviderItems(); err != nil {
+					return util.ReportError(err)
+				}
+			case key.Matches(msg, m.keyMap.Tab):
+				if m.isOnboarding {
+					break
+				}
+				if m.modelType == ModelTypeLarge {
+					m.modelType = ModelTypeSmall
+				} else {
+					m.modelType = ModelTypeLarge
+				}
+				if err := m.setProviderItems(); err != nil {
+					return util.ReportError(err)
+				}
 		default:
 			var cmd tea.Cmd
 			m.input, cmd = m.input.Update(msg)
@@ -271,7 +285,12 @@ func (m *Models) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	rc := NewRenderContext(t, width)
 	rc.Title = "Switch Model"
-	rc.TitleInfo = m.modelTypeRadioView()
+	var titleInfo string
+	if m.showConfiguredOnly {
+		titleInfo = "  " + t.Dialog.Models.ConfiguredText.Render("Configured only") + "  "
+	}
+	titleInfo += m.modelTypeRadioView()
+	rc.TitleInfo = titleInfo
 
 	if m.isOnboarding {
 		titleText := t.Dialog.PrimaryText.Render("To start, let's choose a provider and model.")
@@ -314,12 +333,11 @@ func (m *Models) ShortHelp() []key.Binding {
 	h := []key.Binding{
 		m.keyMap.UpDown,
 		m.keyMap.Tab,
-		m.keyMap.Select,
+		m.keyMap.ToggleFilter,
 	}
 	if m.isSelectedConfigured() {
 		h = append(h, m.keyMap.Edit)
 	}
-	h = append(h, m.keyMap.Close)
 	return h
 }
 
@@ -410,6 +428,11 @@ func (m *Models) setProviderItems() error {
 
 		providerConfig, providerConfigured := cfg.Providers.Get(providerID)
 		if providerConfigured && providerConfig.Disable {
+			continue
+		}
+
+		// When configured-only filter is active, skip unconfigured providers.
+		if m.showConfiguredOnly && !providerConfigured {
 			continue
 		}
 


### PR DESCRIPTION
Adds a `ctrl+f` toggle in the model selection dialog (`ctrl+l`) that filters the provider list to only show providers the user has actually configured with credentials. This makes it easier to find relevant models when the catalog has many providers.

### Motivation

The model selection dialog shows every provider from the catalog — including ones the user hasn't configured. With 20+ providers, finding the one you actually use requires scrolling or searching. 
This toggle hides unconfigured providers so only relevant ones remain.

> There is an option for disabling the default providers but I find it a bit of a hassle, because users must fully specify the provider fields.

### Changes

- Added `showConfiguredOnly` field and `ctrl+f` keybinding to the `Models` dialog
- "Configured only" badge appears in the title bar (left side) when the filter is active
- Removed `enter` and `esc` from the short help bar to reduce clutter

## Screenshot
<img width="662" height="463" alt="output5" src="https://github.com/user-attachments/assets/9870bfe0-ac30-447f-aee1-4694ac974ae2" />



- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] ~I have created a discussion that was approved by a maintainer (for new features).~ There is a releated issue #1425 
