### PR TITLE
perf(db): make secure_delete opt-in via CRUSH_SECURE_DELETE

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,6 +934,20 @@ export CRUSH_DISABLE_METRICS=1
 Crush also respects the [`DO_NOT_TRACK`](https://donottrack.sh/) convention
 which can be enabled via `export DO_NOT_TRACK=1`.
 
+## Local Data
+
+Your sessions and chat history are stored locally in a SQLite database. By
+default, deleted content is left in place on disk (SQLite's default), which
+keeps updates fast. If you want deleted content scrubbed with zeros, opt in:
+
+```bash
+export CRUSH_SECURE_DELETE=1
+```
+
+Note that scrubbing is best-effort: it does not protect data on
+copy-on-write filesystems or wear-leveled SSDs, and deleted rows remain in
+the write-ahead log until it is checkpointed.
+
 ## Q&A
 
 ### Why is clipboard copy and paste not working?

--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -16,18 +17,27 @@ import (
 
 var (
 	pragmas = map[string]string{
-		"foreign_keys":  "ON",
-		"journal_mode":  "WAL",
-		"page_size":     "4096",
-		"temp_store":    "MEMORY",
-		"cache_size":    "-8000",
-		"synchronous":   "NORMAL",
-		"secure_delete": "ON",
-		"busy_timeout":  "30000",
+		"foreign_keys": "ON",
+		"journal_mode": "WAL",
+		"page_size":    "4096",
+		"temp_store":   "MEMORY",
+		"cache_size":   "-8000",
+		"synchronous":  "NORMAL",
+		"busy_timeout": "30000",
 	}
 	gooseInitOnce sync.Once
 	gooseInitErr  error
 )
+
+// secureDeleteEnabled reports whether deleted SQLite content should be
+// overwritten with zeros. It is off by default (SQLite's default) and
+// can be enabled with CRUSH_SECURE_DELETE=1. The zeroing adds write
+// amplification to every UPDATE and DELETE without protecting data on
+// copy-on-write filesystems or wear-leveled SSDs.
+func secureDeleteEnabled() bool {
+	v, _ := strconv.ParseBool(os.Getenv("CRUSH_SECURE_DELETE"))
+	return v
+}
 
 //go:embed migrations/*.sql
 var FS embed.FS

--- a/internal/db/connect_modernc.go
+++ b/internal/db/connect_modernc.go
@@ -32,6 +32,9 @@ func openDB(dbPath string) (*sql.DB, error) {
 	for name, value := range pragmas {
 		params.Add("_pragma", fmt.Sprintf("%s(%s)", name, value))
 	}
+	if secureDeleteEnabled() {
+		params.Add("_pragma", "secure_delete(ON)")
+	}
 	// Use BEGIN IMMEDIATE so writers acquire the reserved lock up front,
 	// preventing deferred-to-writer upgrade deadlocks.
 	params.Set("_txlock", "immediate")

--- a/internal/db/connect_ncruces.go
+++ b/internal/db/connect_ncruces.go
@@ -33,6 +33,11 @@ func openDB(dbPath string) (*sql.DB, error) {
 				return fmt.Errorf("failed to set pragma %q: %w", name, err)
 			}
 		}
+		if secureDeleteEnabled() {
+			if err := c.Exec("PRAGMA secure_delete = ON;"); err != nil {
+				return fmt.Errorf("failed to set pragma %q: %w", "secure_delete", err)
+			}
+		}
 		return nil
 	})
 	if err != nil {

--- a/internal/db/connect_test.go
+++ b/internal/db/connect_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -207,4 +208,70 @@ func TestConnect_ServerPathFailsWhenDataDirLocked(t *testing.T) {
 	_, err = Connect(context.Background(), dataDir, WithDataDirLock(true))
 	require.Error(t, err, "server-path Connect must refuse to open a locked data dir")
 	require.ErrorIs(t, err, ErrDataDirLocked)
+}
+
+// secureDeleteMode reports the connection's secure_delete pragma value.
+func secureDeleteMode(t *testing.T, conn interface {
+	QueryRow(string, ...any) *sql.Row
+},
+) int {
+	t.Helper()
+
+	var mode int
+	require.NoError(t, conn.QueryRow("PRAGMA secure_delete;").Scan(&mode))
+	return mode
+}
+
+// TestConnect_SecureDeleteOffByDefault confirms the SQLite default
+// (off) is used unless the user opts in, so deleted content is not
+// zeroed on every UPDATE/DELETE.
+func TestConnect_SecureDeleteOffByDefault(t *testing.T) {
+	t.Cleanup(ResetPool)
+
+	dataDir := t.TempDir()
+	conn, err := Connect(context.Background(), dataDir)
+	require.NoError(t, err)
+
+	require.Zero(t, secureDeleteMode(t, conn), "secure_delete should default to off")
+
+	require.NoError(t, Release(dataDir))
+}
+
+// TestConnect_SecureDeleteOptIn confirms CRUSH_SECURE_DELETE enables
+// the pragma for users who want deleted content scrubbed.
+func TestConnect_SecureDeleteOptIn(t *testing.T) {
+	t.Cleanup(ResetPool)
+	t.Setenv("CRUSH_SECURE_DELETE", "1")
+
+	dataDir := t.TempDir()
+	conn, err := Connect(context.Background(), dataDir)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, secureDeleteMode(t, conn), "secure_delete should be on when opted in")
+
+	require.NoError(t, Release(dataDir))
+}
+
+// TestSecureDeleteEnabled covers how the CRUSH_SECURE_DELETE env var is
+// parsed: only truthy values opt in, anything else falls back to the
+// SQLite default.
+func TestSecureDeleteEnabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "unset", value: "", want: false},
+		{name: "zero", value: "0", want: false},
+		{name: "garbage", value: "banana", want: false},
+		{name: "one", value: "1", want: true},
+		{name: "true", value: "true", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CRUSH_SECURE_DELETE", tt.value)
+			require.Equal(t, tt.want, secureDeleteEnabled())
+		})
+	}
 }


### PR DESCRIPTION
## What

`secure_delete=ON` is removed from the default SQLite pragmas. It is now opt-in via `CRUSH_SECURE_DELETE=1`, applied on both sqlite drivers (modernc and ncruces).

## Why

To answer the question in the issue: no, there wasnt really a specific threat model behind it. It was added in #966 based on a blog post about not leaving sensitive data in the database. But in WAL mode (which crush uses), deleted rows survive in the write-ahead log until its checkpointed, and on copy-on-write filesystems and wear-leveled SSDs the zeroing doesnt actually erase the old data anyway. So we were paying the write amplification tax on every `UPDATE`/`DELETE` (including the ~33ms message-part flush) for a property that mostly isnt delivered.

## Tradeoff

This is a deliberate, conscious tradeoff, not a silent removal. The default is now SQLites default (off), which is faster. Users who want deleted content scrubbed can still opt in:

```bash
export CRUSH_SECURE_DELETE=1
```

The README documents this, including the caveats (WAL retention, CoW/SSDs), so the hardening loss is visible rather than incidental.

## Test

- `go test ./internal/db/` passes.
- Added tests asserting the pragma defaults to off, is on when opted in, and that the env var parsing is strict (only truthy values enable it).
- Verified the ncruces driver path still compiles (cross-build) and that lint is clean.

Closes #3578