### PR TITLE
feat(ui): show pasted text content in transcript

### DIFF
--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -2,6 +2,7 @@ package chat
 
 import (
 	"encoding/xml"
+	"path/filepath"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -11,6 +12,7 @@ import (
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/list"
 	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // skillInvocation represents the XML structure for a loaded skill.
@@ -28,9 +30,10 @@ type UserMessageItem struct {
 	*cachedMessageItem
 	*focusableMessageItem
 
-	attachments *attachments.Renderer
-	message     *message.Message
-	sty         *styles.Styles
+	attachments     *attachments.Renderer
+	message         *message.Message
+	sty             *styles.Styles
+	expandedContent bool
 }
 
 // NewUserMessageItem creates a new UserMessageItem.
@@ -45,6 +48,41 @@ func NewUserMessageItem(sty *styles.Styles, message *message.Message, attachment
 		message:                  message,
 		sty:                      sty,
 	}
+}
+
+var (
+	_ Expandable          = (*UserMessageItem)(nil)
+	_ list.MouseClickable = (*UserMessageItem)(nil)
+)
+
+// hasTextAttachments reports whether the message carries any text
+// attachments whose content can be shown when expanded.
+func (m *UserMessageItem) hasTextAttachments() bool {
+	for _, bc := range m.message.BinaryContent() {
+		if strings.HasPrefix(bc.MIMEType, "text/") {
+			return true
+		}
+	}
+	return false
+}
+
+// ToggleExpanded implements [Expandable]. Pasted text attachments are
+// collapsed to a truncated preview by default; toggling reveals their
+// full content.
+func (m *UserMessageItem) ToggleExpanded() bool {
+	if !m.hasTextAttachments() {
+		return false
+	}
+	m.expandedContent = !m.expandedContent
+	m.clearCache()
+	m.Bump()
+	return m.expandedContent
+}
+
+// HandleMouseClick implements [list.MouseClickable]. The whole message
+// is clickable so a single click toggles the pasted content.
+func (m *UserMessageItem) HandleMouseClick(btn ansi.MouseButton, x, y int) bool {
+	return btn == ansi.MouseLeft && m.hasTextAttachments()
 }
 
 // Finished implements list.Item. User messages are immutable once
@@ -92,6 +130,14 @@ func (m *UserMessageItem) RawRender(width int) string {
 			content = attachmentsStr
 		} else {
 			content = strings.Join([]string{content, "", attachmentsStr}, "\n")
+		}
+	}
+
+	if textBlocks := m.renderTextAttachmentContent(cappedWidth); textBlocks != "" {
+		if content == "" {
+			content = textBlocks
+		} else {
+			content = strings.Join([]string{content, "", textBlocks}, "\n")
 		}
 	}
 
@@ -171,6 +217,28 @@ func (m *UserMessageItem) renderAttachments(width int) string {
 	// This message is already posted, so the attachment can't be removed;
 	// don't render the remove button.
 	return m.attachments.Render(attachments, false, false, width)
+}
+
+// renderTextAttachmentContent renders the content of pasted text
+// attachments below the attachment chips. Collapsed attachments show a
+// truncated preview with an expand hint; expanded attachments show the
+// full content.
+func (m *UserMessageItem) renderTextAttachmentContent(width int) string {
+	var blocks []string
+	for _, bc := range m.message.BinaryContent() {
+		if !strings.HasPrefix(bc.MIMEType, "text/") {
+			continue
+		}
+		filename := filepath.Base(bc.Path)
+		header := lipgloss.JoinHorizontal(lipgloss.Left,
+			m.sty.Attachments.Text.String(),
+			m.sty.Attachments.Normal.Render(filename),
+		)
+		bodyWidth := max(0, width-toolBodyLeftPaddingTotal)
+		body := m.sty.Tool.Body.Render(toolOutputPlainContent(m.sty, string(bc.Data), bodyWidth, m.expandedContent))
+		blocks = append(blocks, strings.Join([]string{header, "", body}, "\n"))
+	}
+	return strings.Join(blocks, "\n\n")
 }
 
 // HandleKeyEvent implements KeyEventHandler.

--- a/internal/ui/chat/user_test.go
+++ b/internal/ui/chat/user_test.go
@@ -1,0 +1,182 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestUserItem(t *testing.T, msg *message.Message) *UserMessageItem {
+	t.Helper()
+
+	sty := styles.CharmtonePantera()
+	r := attachments.NewRenderer(
+		sty.Attachments.Normal,
+		sty.Attachments.Deleting,
+		sty.Attachments.Image,
+		sty.Attachments.Text,
+		sty.Attachments.Skill,
+		sty.Attachments.Remove,
+	)
+	return NewUserMessageItem(&sty, msg, r).(*UserMessageItem)
+}
+
+func userMessageWithTextAttachment(t *testing.T, path, content string) *message.Message {
+	t.Helper()
+
+	return &message.Message{
+		ID:   "u1",
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "See the paste below."},
+			message.BinaryContent{
+				Path:     path,
+				MIMEType: "text/plain; charset=utf-8",
+				Data:     []byte(content),
+			},
+		},
+	}
+}
+
+// TestUserMessageItem_ToggleExpandedWithTextAttachment ensures pasted
+// text attachments expand and collapse, clearing the render cache so
+// the transcript updates.
+func TestUserMessageItem_ToggleExpandedWithTextAttachment(t *testing.T) {
+	t.Parallel()
+
+	item := newTestUserItem(t, userMessageWithTextAttachment(t, "paste_1.txt", "hello world"))
+	require.False(t, item.expandedContent, "should start collapsed")
+
+	// Populate the cache so the clearCache assertion below is meaningful.
+	item.RawRender(80)
+	require.NotEqual(t, "", item.rendered, "precondition: cache should be populated")
+
+	require.True(t, item.ToggleExpanded(), "first toggle should expand")
+	require.True(t, item.expandedContent)
+	require.Equal(t, "", item.rendered, "expansion must clear the render cache")
+	require.NotEqual(t, "", item.RawRender(80), "expanded render should repopulate the cache")
+
+	require.False(t, item.ToggleExpanded(), "second toggle should collapse")
+	require.False(t, item.expandedContent)
+	require.Equal(t, "", item.rendered, "collapse must clear the render cache")
+}
+
+// TestUserMessageItem_ToggleExpandedNoTextAttachment ensures messages
+// without text attachments are not expandable.
+func TestUserMessageItem_ToggleExpandedNoTextAttachment(t *testing.T) {
+	t.Parallel()
+
+	msg := &message.Message{
+		ID:   "u1",
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "plain"},
+			message.BinaryContent{Path: "image.png", MIMEType: "image/png", Data: []byte{1, 2, 3}},
+		},
+	}
+	item := newTestUserItem(t, msg)
+
+	require.False(t, item.ToggleExpanded(), "image-only messages must not expand")
+	require.False(t, item.expandedContent)
+}
+
+// TestUserMessageItem_HandleMouseClick ensures only left clicks on
+// messages with text attachments signal a handled click.
+func TestUserMessageItem_HandleMouseClick(t *testing.T) {
+	t.Parallel()
+
+	textItem := newTestUserItem(t, userMessageWithTextAttachment(t, "paste_1.txt", "hello"))
+	require.True(t, textItem.HandleMouseClick(ansi.MouseLeft, 0, 0))
+	require.False(t, textItem.HandleMouseClick(ansi.MouseRight, 0, 0))
+
+	imageItem := newTestUserItem(t, &message.Message{
+		ID:   "u2",
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.BinaryContent{Path: "image.png", MIMEType: "image/png", Data: []byte{1}},
+		},
+	})
+	require.False(t, imageItem.HandleMouseClick(ansi.MouseLeft, 0, 0))
+}
+
+// TestUserMessageItem_RenderTextAttachmentContent ensures collapsed
+// renders a truncated preview with an expand hint and expanded renders
+// the full pasted content.
+func TestUserMessageItem_RenderTextAttachmentContent(t *testing.T) {
+	t.Parallel()
+
+	lines := make([]string, 30)
+	for i := range lines {
+		lines[i] = "line " + string(rune('a'+i%26))
+	}
+	content := strings.Join(lines, "\n")
+
+	item := newTestUserItem(t, userMessageWithTextAttachment(t, "paste_1.txt", content))
+
+	collapsed := item.renderTextAttachmentContent(80)
+	require.Contains(t, collapsed, "paste_1.txt", "collapsed render should keep the filename")
+	require.Contains(t, collapsed, "lines hidden", "collapsed render should advertise hidden lines")
+
+	item.expandedContent = true
+	expanded := item.renderTextAttachmentContent(80)
+	require.Contains(t, expanded, "line a", "expanded render should include the start of the paste")
+	require.Contains(t, expanded, "line y", "expanded render should include the end of the paste")
+	require.NotContains(t, expanded, "lines hidden", "expanded render should not advertise hidden lines")
+}
+
+// TestUserMessageItem_RenderMultipleTextAttachments ensures multiple
+// pasted attachments render as separate blocks, each with its filename.
+func TestUserMessageItem_RenderMultipleTextAttachments(t *testing.T) {
+	t.Parallel()
+
+	msg := &message.Message{
+		ID:   "u1",
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "two pastes"},
+			message.BinaryContent{Path: "paste_1.txt", MIMEType: "text/plain", Data: []byte("first")},
+			message.BinaryContent{Path: "paste_2.txt", MIMEType: "text/plain", Data: []byte("second")},
+			message.BinaryContent{Path: "image.png", MIMEType: "image/png", Data: []byte{1}},
+		},
+	}
+	item := newTestUserItem(t, msg)
+	item.expandedContent = true
+
+	out := item.renderTextAttachmentContent(80)
+	require.Contains(t, out, "paste_1.txt")
+	require.Contains(t, out, "first")
+	require.Contains(t, out, "paste_2.txt")
+	require.Contains(t, out, "second")
+	require.NotContains(t, out, "image.png", "image attachments should stay pills only")
+}
+
+// TestUserMessageItem_RenderPastedContentNoText checks that the full
+// RawRender includes the pasted content when expanded and omits it (only
+// the pills) when collapsed for short content under the truncation cap.
+func TestUserMessageItem_RenderPastedContentNoText(t *testing.T) {
+	t.Parallel()
+
+	msg := &message.Message{
+		ID:   "u1",
+		Role: message.User,
+		Parts: []message.ContentPart{
+			message.TextContent{Text: "See below."},
+			message.BinaryContent{Path: "paste_1.txt", MIMEType: "text/plain", Data: []byte("tiny paste")},
+		},
+	}
+	item := newTestUserItem(t, msg)
+
+	collapsed := item.RawRender(80)
+	require.Contains(t, collapsed, "paste_1.txt")
+
+	item.expandedContent = true
+	expanded := item.RawRender(80)
+	require.Contains(t, expanded, "tiny paste", "expanded render should surface the pasted text")
+	_ = lipgloss.Width(expanded)
+}

--- a/internal/ui/chat/version_bump_test.go
+++ b/internal/ui/chat/version_bump_test.go
@@ -91,6 +91,7 @@ func TestUserMessageItem_MutatorsBumpVersion(t *testing.T) {
 		Role: message.User,
 		Parts: []message.ContentPart{
 			message.TextContent{Text: "Hello"},
+			message.BinaryContent{Path: "paste_1.txt", MIMEType: "text/plain", Data: []byte("hi")},
 		},
 	}
 	item := NewUserMessageItem(&sty, msg, r).(*UserMessageItem)
@@ -100,6 +101,9 @@ func TestUserMessageItem_MutatorsBumpVersion(t *testing.T) {
 	})
 	requireBump(t, "SetHighlight", item, func() {
 		item.SetHighlight(0, 0, 0, 3)
+	})
+	requireBump(t, "ToggleExpanded", item, func() {
+		item.ToggleExpanded()
 	})
 }
 


### PR DESCRIPTION
## What

When you paste a large block of text into the prompt, crush stores it as an attachment (`paste_1.txt`) but only shows a small pill in the transcript. You can never actually read what you pasted. This makes user messages with text attachments expandable so the content is shown below the pills.

## How

- `UserMessageItem` now implements `Expandable` and `MouseClickable`, so the existing space-key / click handling toggles it for free (no new keys or plumbing).
- Collapsed: the pills stay, and each pasted text attachment shows a truncated preview (first 10 lines) with the standard "… (N lines hidden) [click or space to expand]" hint.
- Expanded: full content, styled like other tool output.
- Works with multiple pasted attachments — each renders its own block with a filename header. Images stay pills only.
- Non-text MIME types are skipped, so this never touches image or binary attachments.

## Why this shape

It reuses the machinery that already exists for collapsible tool output and thinking blocks — the `Expandable` interface, the truncation hint format, and `toolOutputPlainContent` — so it fits the codebase rather than inventing a new pattern. Defaulting to a readable 10-line preview means pasted content is actually visible without the user knowing to press space.

## Test

- New tests in `internal/ui/chat/user_test.go` cover: expand/collapse toggle with cache invalidation, no-op for image-only messages, mouse click behavior, collapsed preview + hint, full content when expanded, and multiple attachments rendering separately.
- Added `ToggleExpanded` to the existing mutator/version-bump enumeration.
- `go test ./internal/ui/chat/ ./internal/ui/model/` passes.

Closes #3561