### PR TITLE
fix(windows): scrolling up on modifier keys alone

### DIFF
--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -231,15 +231,11 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 			prevValue := c.input.Value()
 			c.input, cmd = c.input.Update(msg)
 			value := c.input.Value()
-			// Only reset the filter and selection when the query actually
-			// changed. Modifier-only keys (Ctrl, Shift, Alt) and other
-			// keys that don't change the input must not move the selection.
-			if value == prevValue {
-				return ActionCmd{cmd}
+			if value != prevValue {
+				c.list.SetFilter(value)
+				c.list.ScrollToTop()
+				c.list.SetSelected(0)
 			}
-			c.list.SetFilter(value)
-			c.list.ScrollToTop()
-			c.list.SetSelected(0)
 			return ActionCmd{cmd}
 		}
 	}

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -228,8 +228,15 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 					}
 				}
 			}
+			prevValue := c.input.Value()
 			c.input, cmd = c.input.Update(msg)
 			value := c.input.Value()
+			// Only reset the filter and selection when the query actually
+			// changed. Modifier-only keys (Ctrl, Shift, Alt) and other
+			// keys that don't change the input must not move the selection.
+			if value == prevValue {
+				return ActionCmd{cmd}
+			}
 			c.list.SetFilter(value)
 			c.list.ScrollToTop()
 			c.list.SetSelected(0)

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -221,9 +221,16 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 				return util.ReportError(err)
 			}
 		default:
+			prevValue := m.input.Value()
 			var cmd tea.Cmd
 			m.input, cmd = m.input.Update(msg)
 			value := m.input.Value()
+			// Only reset the filter and selection when the query actually
+			// changed. Modifier-only keys (Ctrl, Shift, Alt) and other
+			// keys that don't change the input must not move the selection.
+			if value == prevValue {
+				return ActionCmd{cmd}
+			}
 			m.list.Focus()
 			m.list.SetFilter(value)
 			m.list.SelectFirst()

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -225,16 +225,12 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 			var cmd tea.Cmd
 			m.input, cmd = m.input.Update(msg)
 			value := m.input.Value()
-			// Only reset the filter and selection when the query actually
-			// changed. Modifier-only keys (Ctrl, Shift, Alt) and other
-			// keys that don't change the input must not move the selection.
-			if value == prevValue {
-				return ActionCmd{cmd}
+			if value != prevValue {
+				m.list.Focus()
+				m.list.SetFilter(value)
+				m.list.SelectFirst()
+				m.list.ScrollToTop()
 			}
-			m.list.Focus()
-			m.list.SetFilter(value)
-			m.list.SelectFirst()
-			m.list.ScrollToTop()
 			return ActionCmd{cmd}
 		}
 	}

--- a/internal/ui/dialog/notifications.go
+++ b/internal/ui/dialog/notifications.go
@@ -154,9 +154,16 @@ func (n *Notifications) HandleMsg(msg tea.Msg) Action {
 			}
 			return ActionSelectNotificationStyle{Style: notifItem.style.ID}
 		default:
+			prevValue := n.input.Value()
 			var cmd tea.Cmd
 			n.input, cmd = n.input.Update(msg)
 			value := n.input.Value()
+			// Only reset the filter and selection when the query actually
+			// changed. Modifier-only keys (Ctrl, Shift, Alt) and other
+			// keys that don't change the input must not move the selection.
+			if value == prevValue {
+				return ActionCmd{cmd}
+			}
 			n.list.SetFilter(value)
 			n.list.ScrollToTop()
 			n.list.SetSelected(0)

--- a/internal/ui/dialog/notifications.go
+++ b/internal/ui/dialog/notifications.go
@@ -158,15 +158,12 @@ func (n *Notifications) HandleMsg(msg tea.Msg) Action {
 			var cmd tea.Cmd
 			n.input, cmd = n.input.Update(msg)
 			value := n.input.Value()
-			// Only reset the filter and selection when the query actually
-			// changed. Modifier-only keys (Ctrl, Shift, Alt) and other
-			// keys that don't change the input must not move the selection.
-			if value == prevValue {
-				return ActionCmd{cmd}
+			if value != prevValue {
+				n.list.SetFilter(value)
+				n.list.ScrollToTop()
+				n.list.SetSelected(0)
 			}
-			n.list.SetFilter(value)
-			n.list.ScrollToTop()
-			n.list.SetSelected(0)
+
 			return ActionCmd{cmd}
 		}
 	}

--- a/internal/ui/dialog/reasoning.go
+++ b/internal/ui/dialog/reasoning.go
@@ -149,15 +149,11 @@ func (r *Reasoning) HandleMsg(msg tea.Msg) Action {
 			var cmd tea.Cmd
 			r.input, cmd = r.input.Update(msg)
 			value := r.input.Value()
-			// Only reset the filter and selection when the query actually
-			// changed. Modifier-only keys (Ctrl, Shift, Alt) and other
-			// keys that don't change the input must not move the selection.
-			if value == prevValue {
-				return ActionCmd{cmd}
+			if value != prevValue {
+				r.list.SetFilter(value)
+				r.list.ScrollToTop()
+				r.list.SetSelected(0)
 			}
-			r.list.SetFilter(value)
-			r.list.ScrollToTop()
-			r.list.SetSelected(0)
 			return ActionCmd{cmd}
 		}
 	}

--- a/internal/ui/dialog/reasoning.go
+++ b/internal/ui/dialog/reasoning.go
@@ -145,9 +145,16 @@ func (r *Reasoning) HandleMsg(msg tea.Msg) Action {
 			}
 			return ActionSelectReasoningEffort{Effort: reasoningItem.effort}
 		default:
+			prevValue := r.input.Value()
 			var cmd tea.Cmd
 			r.input, cmd = r.input.Update(msg)
 			value := r.input.Value()
+			// Only reset the filter and selection when the query actually
+			// changed. Modifier-only keys (Ctrl, Shift, Alt) and other
+			// keys that don't change the input must not move the selection.
+			if value == prevValue {
+				return ActionCmd{cmd}
+			}
 			r.list.SetFilter(value)
 			r.list.ScrollToTop()
 			r.list.SetSelected(0)

--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -212,16 +212,11 @@ func (s *Session) HandleMsg(msg tea.Msg) Action {
 				var cmd tea.Cmd
 				s.input, cmd = s.input.Update(msg)
 				value := s.input.Value()
-				// Only reset the filter and selection when the query
-				// actually changed. Modifier-only keys (Ctrl, Shift, Alt)
-				// and other keys that don't change the input must not
-				// move the selection.
-				if value == prevValue {
-					return ActionCmd{cmd}
+				if value != prevValue {
+					s.list.SetFilter(value)
+					s.list.ScrollToTop()
+					s.list.SetSelected(0)
 				}
-				s.list.SetFilter(value)
-				s.list.ScrollToTop()
-				s.list.SetSelected(0)
 				return ActionCmd{cmd}
 			}
 		}

--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -208,9 +208,17 @@ func (s *Session) HandleMsg(msg tea.Msg) Action {
 					return ActionSelectSession{sessionItem.Session}
 				}
 			default:
+				prevValue := s.input.Value()
 				var cmd tea.Cmd
 				s.input, cmd = s.input.Update(msg)
 				value := s.input.Value()
+				// Only reset the filter and selection when the query
+				// actually changed. Modifier-only keys (Ctrl, Shift, Alt)
+				// and other keys that don't change the input must not
+				// move the selection.
+				if value == prevValue {
+					return ActionCmd{cmd}
+				}
 				s.list.SetFilter(value)
 				s.list.ScrollToTop()
 				s.list.SetSelected(0)


### PR DESCRIPTION
## What?

Ignores input from modifier keys alone (e.g. just `shift`) in selections

## Why?

Closes charmbracelet/crush#3534

This was an issue of `default` case going to the top. *Why was this reported only on Windows?* *Most* Unix terminals do not send just modifier keys, whilst Windows can.