### PR TITLE
feat(run): support OMP-style reasoning-effort suffixes on model flags

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -501,6 +501,9 @@ func (app *App) restoreModelFromSession(ctx context.Context, sessionID string) e
 func (app *App) overrideModelsForNonInteractive(ctx context.Context, largeModel, smallModel string) error {
 	providers := app.config.Config().Providers.Copy()
 
+	largeModel, largeEffort := config.SplitModelEffort(largeModel)
+	smallModel, smallEffort := config.SplitModelEffort(smallModel)
+
 	largeMatches, smallMatches, err := findModels(providers, largeModel, smallModel)
 	if err != nil {
 		return err
@@ -515,10 +518,11 @@ func (app *App) overrideModelsForNonInteractive(ctx context.Context, largeModel,
 			return err
 		}
 		largeProviderID = found.provider
-		slog.Info("Overriding large model for non-interactive run", "provider", found.provider, "model", found.modelID)
+		slog.Info("Overriding large model for non-interactive run", "provider", found.provider, "model", found.modelID, "reasoning_effort", largeEffort)
 		app.config.OverridePreferredModel(config.SelectedModelTypeLarge, config.SelectedModel{
-			Provider: found.provider,
-			Model:    found.modelID,
+			Provider:        found.provider,
+			Model:           found.modelID,
+			ReasoningEffort: config.ResolveModelReasoningEffort(providers[found.provider], found.modelID, largeEffort),
 		})
 	}
 
@@ -529,10 +533,11 @@ func (app *App) overrideModelsForNonInteractive(ctx context.Context, largeModel,
 		if err != nil {
 			return err
 		}
-		slog.Info("Overriding small model for non-interactive run", "provider", found.provider, "model", found.modelID)
+		slog.Info("Overriding small model for non-interactive run", "provider", found.provider, "model", found.modelID, "reasoning_effort", smallEffort)
 		app.config.OverridePreferredModel(config.SelectedModelTypeSmall, config.SelectedModel{
-			Provider: found.provider,
-			Model:    found.modelID,
+			Provider:        found.provider,
+			Model:           found.modelID,
+			ReasoningEffort: config.ResolveModelReasoningEffort(providers[found.provider], found.modelID, smallEffort),
 		})
 
 	case largeModel != "":

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -161,8 +161,8 @@ crush run --continue "Follow up on your last response"
 func init() {
 	runCmd.Flags().BoolP("quiet", "q", false, "Hide spinner")
 	runCmd.Flags().BoolP("verbose", "v", false, "Show logs")
-	runCmd.Flags().StringP("model", "m", "", "Model to use. Accepts 'model' or 'provider/model' to disambiguate models with the same name across providers")
-	runCmd.Flags().String("small-model", "", "Small model to use. If not provided, uses the default small model for the provider")
+	runCmd.Flags().StringP("model", "m", "", "Model to use. Accepts 'model' or 'provider/model' to disambiguate models with the same name across providers. Optionally append an OMP-style reasoning-effort suffix such as ':high' or ':xhigh' (off, minimal, low, medium, high, xhigh, max)")
+	runCmd.Flags().String("small-model", "", "Small model to use. If not provided, uses the default small model for the provider. Accepts the same model syntax as --model, including a reasoning-effort suffix")
 	runCmd.Flags().StringP("session", "s", "", "Continue a previous session by ID")
 	runCmd.Flags().BoolP("continue", "C", false, "Continue the most recent session")
 	runCmd.MarkFlagsMutuallyExclusive("session", "continue")
@@ -491,6 +491,9 @@ func overrideModels(
 
 	providers := cfg.Providers.Copy()
 
+	largeModel, largeEffort := config.SplitModelEffort(largeModel)
+	smallModel, smallEffort := config.SplitModelEffort(smallModel)
+
 	largeMatches, smallMatches := findModelMatches(providers, largeModel, smallModel)
 
 	var largeProviderID string
@@ -501,10 +504,11 @@ func overrideModels(
 			return err
 		}
 		largeProviderID = found.provider
-		slog.Info("Overriding large model", "provider", found.provider, "model", found.modelID)
+		slog.Info("Overriding large model", "provider", found.provider, "model", found.modelID, "reasoning_effort", largeEffort)
 		if err := c.UpdatePreferredModel(ctx, ws.ID, config.ScopeWorkspace, config.SelectedModelTypeLarge, config.SelectedModel{
-			Provider: found.provider,
-			Model:    found.modelID,
+			Provider:        found.provider,
+			Model:           found.modelID,
+			ReasoningEffort: config.ResolveModelReasoningEffort(providers[found.provider], found.modelID, largeEffort),
 		}); err != nil {
 			return fmt.Errorf("failed to set large model: %w", err)
 		}
@@ -516,10 +520,11 @@ func overrideModels(
 		if err != nil {
 			return err
 		}
-		slog.Info("Overriding small model", "provider", found.provider, "model", found.modelID)
+		slog.Info("Overriding small model", "provider", found.provider, "model", found.modelID, "reasoning_effort", smallEffort)
 		if err := c.UpdatePreferredModel(ctx, ws.ID, config.ScopeWorkspace, config.SelectedModelTypeSmall, config.SelectedModel{
-			Provider: found.provider,
-			Model:    found.modelID,
+			Provider:        found.provider,
+			Model:           found.modelID,
+			ReasoningEffort: config.ResolveModelReasoningEffort(providers[found.provider], found.modelID, smallEffort),
 		}); err != nil {
 			return fmt.Errorf("failed to set small model: %w", err)
 		}

--- a/internal/config/reasoning.go
+++ b/internal/config/reasoning.go
@@ -1,0 +1,114 @@
+package config
+
+import (
+	"log/slog"
+	"slices"
+	"strings"
+)
+
+// ompEffortOrder ranks the OMP-style reasoning suffixes accepted on
+// `crush run` model flags from least to most reasoning effort.
+var ompEffortOrder = []string{"off", "minimal", "low", "medium", "high", "xhigh", "max"}
+
+// SplitModelEffort separates an OMP-style reasoning-effort suffix from a
+// model string such as "anthropic/claude-opus-5:xhigh". It returns the model
+// string without the suffix and the requested effort. When the trailing
+// segment after the last colon is not a known effort level (e.g. openrouter
+// ":free" or ":exacto" model IDs), the model string is returned unchanged
+// with an empty effort.
+func SplitModelEffort(model string) (clean string, effort string) {
+	if model == "" {
+		return model, ""
+	}
+	idx := strings.LastIndex(model, ":")
+	if idx < 0 {
+		return model, ""
+	}
+	suffix := model[idx+1:]
+	if !slices.Contains(ompEffortOrder, suffix) {
+		return model, ""
+	}
+	return model[:idx], suffix
+}
+
+// ResolveReasoningEffort maps an OMP reasoning-effort suffix to the closest
+// reasoning level the model supports. "off" maps to "none" when the model
+// supports it (the standard way to disable reasoning); otherwise, when the
+// model has no disable level, it returns "" so the caller leaves the effort
+// unset. Unknown or empty efforts also return "".
+func ResolveReasoningEffort(effort string, levels []string) string {
+	if effort == "" || len(levels) == 0 {
+		return ""
+	}
+
+	// Direct hit, including "off" aliasing "none".
+	for _, lv := range levels {
+		if lv == effort || (effort == "off" && lv == "none") {
+			return lv
+		}
+	}
+
+	// "off" with no disable level cannot be honored.
+	if effort == "off" {
+		return ""
+	}
+
+	want := -1
+	for i, lv := range ompEffortOrder {
+		if lv == effort {
+			want = i
+			break
+		}
+	}
+	if want < 0 {
+		return ""
+	}
+
+	// Pick the supported level closest to the requested effort on the
+	// OMP ordering. Unknown levels (e.g. "none") are skipped.
+	best := ""
+	bestDist := int(^uint(0) >> 1)
+	for _, lv := range levels {
+		idx := -1
+		for i, o := range ompEffortOrder {
+			if o == lv {
+				idx = i
+				break
+			}
+		}
+		if idx < 0 {
+			continue
+		}
+		d := idx - want
+		if d < 0 {
+			d = -d
+		}
+		if d < bestDist {
+			bestDist = d
+			best = lv
+		}
+	}
+	return best
+}
+
+// ResolveModelReasoningEffort maps an OMP reasoning-effort suffix to the
+// closest supported level for a specific model within a provider config. It
+// logs a warning when the requested effort cannot be honored so silent
+// fallback to the model default is visible to the user.
+func ResolveModelReasoningEffort(p ProviderConfig, modelID, effort string) string {
+	if effort == "" {
+		return ""
+	}
+	for _, m := range p.Models {
+		if m.ID != modelID {
+			continue
+		}
+		resolved := ResolveReasoningEffort(effort, m.ReasoningLevels)
+		if resolved == "" {
+			slog.Warn("Reasoning effort not supported by model, using default",
+				"model", modelID, "effort", effort, "levels", m.ReasoningLevels)
+		}
+		return resolved
+	}
+	return ""
+}

--- a/internal/config/reasoning_test.go
+++ b/internal/config/reasoning_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitModelEffort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		model      string
+		wantModel  string
+		wantEffort string
+	}{
+		{name: "empty", model: "", wantModel: "", wantEffort: ""},
+		{name: "no suffix", model: "gpt-4o", wantModel: "gpt-4o", wantEffort: ""},
+		{name: "provider and model with suffix", model: "anthropic/claude-opus-5:xhigh", wantModel: "anthropic/claude-opus-5", wantEffort: "xhigh"},
+		{name: "model with suffix", model: "claude-opus-5:high", wantModel: "claude-opus-5", wantEffort: "high"},
+		{name: "off suffix", model: "openai/gpt-4o:off", wantModel: "openai/gpt-4o", wantEffort: "off"},
+		{name: "unknown suffix preserved", model: "openrouter/model:free", wantModel: "openrouter/model:free", wantEffort: ""},
+		{name: "exacto suffix preserved", model: "openrouter/deepseek/deepseek-v3.1-terminus:exacto", wantModel: "openrouter/deepseek/deepseek-v3.1-terminus:exacto", wantEffort: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clean, effort := SplitModelEffort(tt.model)
+			require.Equal(t, tt.wantModel, clean)
+			require.Equal(t, tt.wantEffort, effort)
+		})
+	}
+}
+
+func TestResolveReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		effort string
+		levels []string
+		want   string
+	}{
+		{name: "empty effort", effort: "", levels: []string{"low", "medium", "high"}, want: ""},
+		{name: "direct match", effort: "medium", levels: []string{"low", "medium", "high"}, want: "medium"},
+		{name: "xhigh falls back to high", effort: "xhigh", levels: []string{"low", "medium", "high"}, want: "high"},
+		{name: "max falls back to high", effort: "max", levels: []string{"low", "medium", "high"}, want: "high"},
+		{name: "minimal falls back to low", effort: "minimal", levels: []string{"low", "medium", "high"}, want: "low"},
+		{name: "xhigh supported", effort: "xhigh", levels: []string{"low", "medium", "high", "xhigh"}, want: "xhigh"},
+		{name: "off maps to none", effort: "off", levels: []string{"none", "low", "medium", "high"}, want: "none"},
+		{name: "off unsupported returns empty", effort: "off", levels: []string{"low", "medium", "high"}, want: ""},
+		{name: "no levels", effort: "high", levels: nil, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ResolveReasoningEffort(tt.effort, tt.levels))
+		})
+	}
+}
+
+func TestResolveModelReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	p := ProviderConfig{
+		ID:   "openai",
+		Name: "OpenAI",
+		Models: []catwalk.Model{
+			{ID: "gpt-4o", ReasoningLevels: []string{"low", "medium", "high"}},
+		},
+	}
+
+	require.Equal(t, "high", ResolveModelReasoningEffort(p, "gpt-4o", "xhigh"))
+	require.Equal(t, "medium", ResolveModelReasoningEffort(p, "gpt-4o", "medium"))
+	require.Equal(t, "", ResolveModelReasoningEffort(p, "gpt-4o", "off"))
+	require.Equal(t, "", ResolveModelReasoningEffort(p, "gpt-4o", ""))
+	require.Equal(t, "", ResolveModelReasoningEffort(p, "nonexistent", "high"))
+}


### PR DESCRIPTION
## What

Closes #3540. `crush run` now accepts an OMP-style reasoning-effort suffix on the `-m`/`--model` and `--small-model` flags, e.g.:

```
crush run -m "anthropic/claude-opus-5:xhigh" "explain this bug"
crush run -m "openai/gpt-4o:off" "why is this failing"
```

Supported suffixes: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`.

## How it works

The suffix is stripped from the model string **before** model matching, so `anthropic/claude-opus-5:xhigh` resolves to `anthropic/claude-opus-5` with effort `xhigh`. The requested effort is then resolved against the selected model's catwalk reasoning levels and applied to the workspace's preferred model — no new `--effort` flag, per the issue.

Resolution rules:
- **Direct match** — the suffix maps straight to the model's supported level (e.g. `:high` → `high`).
- **Closest supported level** — if a model doesn't expose a given level, the nearest one is used. `gpt-4o:max` on a model capped at `high` falls back to `high`, `:minimal` on `[low, medium, high]` falls back to `low`.
- **`:off`** — maps to the `none` level where the model supports disabling reasoning (OpenAI). For thinking-mode-only models (Anthropic) that have no `none` level, the effort is left at the model default and a warning is logged so the fallback is visible rather than silent.

This also respects the existing behavior where non-effort suffixes are untouched — openrouter model IDs like `:free` and the runtime-appended `:exacto` still pass through unchanged (verified no catalog model IDs end in an OMP suffix, so stripping is unambiguous).

## Files

- `internal/config/reasoning.go` — new shared helpers: `SplitModelEffort`, `ResolveReasoningEffort`, `ResolveModelReasoningEffort` (+ `reasoning_test.go` with table tests).
- `internal/cmd/run.go` — parse the suffix in the client/server path `overrideModels`, set `ReasoningEffort` on the `SelectedModel`, document the syntax in the flag help.
- `internal/app/app.go` — same wiring for the local non-interactive path `overrideModelsForNonInteractive`.

## Notes / open questions

Re: the issue's edit note about "Enable thinking mode" models — those models simply have no disable level, so `:off` degrades gracefully (default effort + warning) instead of erroring. I think that's the right call but happy to make `:off` hard-error on such models if you'd prefer.

I could not run golangci-lint locally (pathologically slow on this machine), but `gofmt`/`gofumpt`, `go vet`, `go build`, and `go test ./internal/config/... ./internal/cmd/ ./internal/app/` all pass. CI runs the full lint.