### PR TITLE
feat(mcp): cap tool result size before it enters model context

### DIFF
--- a/internal/agent/tools/mcp/lifecycle.go
+++ b/internal/agent/tools/mcp/lifecycle.go
@@ -179,6 +179,7 @@ func mcpConfigEqual(a, b config.MCPConfig) bool {
 		slices.Equal(a.DisabledTools, b.DisabledTools) &&
 		slices.Equal(a.EnabledTools, b.EnabledTools) &&
 		a.Timeout == b.Timeout &&
+		a.MaxToolResultBytes == b.MaxToolResultBytes &&
 		maps.Equal(a.Headers, b.Headers) &&
 		a.OAuth == b.OAuth &&
 		a.OAuthClientID == b.OAuthClientID &&

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/csync"
@@ -81,6 +82,7 @@ func RunTool(ctx context.Context, cfg *config.ConfigStore, name, toolName string
 	}
 
 	textContent := strings.Join(textParts, "\n")
+	textContent = capToolResult(textContent, maxToolResultBytes(cfg, name))
 
 	// We need to make sure the data is base64
 	// when using something like docker + playwright the data was not returned correctly.
@@ -192,6 +194,80 @@ func filterTools(mcpCfg config.MCPConfig, tools []*Tool) []*Tool {
 	}
 
 	return tools
+}
+
+// defaultMaxToolResultBytes is the default cap applied to MCP tool result
+// text before it is added to the model context, matching the size suggested
+// in the config schema default. Oversized results from third-party MCP
+// servers are the most common way a single tool call blows past a model's
+// context window (see #2835 for the built-in tool precedent).
+const defaultMaxToolResultBytes = 131072
+
+// maxToolResultBytes returns the configured cap for the MCP server, falling
+// back to the default when the server doesn't set one.
+func maxToolResultBytes(cfg *config.ConfigStore, name string) int {
+	m := cfg.Config().MCP[name]
+	if m.MaxToolResultBytes > 0 {
+		return m.MaxToolResultBytes
+	}
+	return defaultMaxToolResultBytes
+}
+
+// capToolResult caps text content to maxBytes, keeping the head (~75%) and
+// tail (~25%) of the cap and inserting a marker that states how much was
+// dropped. Keeping the tail preserves the final error/exit summary, and the
+// marker teaches the model to narrow its next call instead of retrying the
+// same oversized one. Content within the cap is returned unchanged. The
+// split points are adjusted so the result never splits a multi-byte UTF-8
+// rune.
+func capToolResult(content string, maxBytes int) string {
+	if maxBytes <= 0 || len(content) <= maxBytes {
+		return content
+	}
+
+	headBytes := maxBytes * 3 / 4
+	tailBytes := maxBytes - headBytes
+
+	head := content[:trimRune(content, headBytes)]
+	tail := content[trimRuneBack(content, len(content)-tailBytes):]
+
+	dropped := len(content) - len(head) - len(tail)
+	return fmt.Sprintf("%s\n\n[... %s truncated (returned first %s + last %s). Narrow the command with head/tail/grep, or write to a file and sample it. ...]\n\n%s",
+		head, formatBytes(dropped), formatBytes(len(head)), formatBytes(len(tail)), tail)
+}
+
+// trimRune returns the largest index <= n that is a UTF-8 rune boundary in s,
+// so a byte slice ending there never splits a rune.
+func trimRune(s string, n int) int {
+	for n > 0 && n < len(s) && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return n
+}
+
+// trimRuneBack returns the smallest index >= n that is a UTF-8 rune boundary
+// in s, so a byte slice starting there never splits a rune.
+func trimRuneBack(s string, n int) int {
+	for n < len(s) && !utf8.RuneStart(s[n]) {
+		n++
+	}
+	return n
+}
+
+// formatBytes renders a byte count in a human-readable form, e.g. 41.2 MB.
+func formatBytes(bytes int) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+	)
+	switch {
+	case bytes >= mb:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(mb))
+	case bytes >= kb:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
 }
 
 // ensureRawBytes normalizes MCP media data into raw binary bytes.

--- a/internal/agent/tools/mcp/tools_test.go
+++ b/internal/agent/tools/mcp/tools_test.go
@@ -3,7 +3,9 @@ package mcp
 import (
 	"bytes"
 	"encoding/base64"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/stretchr/testify/require"
@@ -113,5 +115,86 @@ func TestFilterTools(t *testing.T) {
 		t.Parallel()
 		result := filterTools(config.MCPConfig{EnabledTools: []string{"non_existent"}}, tools)
 		require.Len(t, result, 0)
+	})
+}
+
+func TestCapToolResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("short content is unchanged", func(t *testing.T) {
+		t.Parallel()
+		content := "small output"
+		require.Equal(t, content, capToolResult(content, 131072))
+	})
+
+	t.Run("content at the cap is unchanged", func(t *testing.T) {
+		t.Parallel()
+		content := strings.Repeat("a", 131072)
+		require.Equal(t, content, capToolResult(content, 131072))
+	})
+
+	t.Run("oversized content is capped with head, marker, and tail", func(t *testing.T) {
+		t.Parallel()
+		content := strings.Repeat("a", 131072) + strings.Repeat("b", 131072)
+		out := capToolResult(content, 131072)
+		require.Contains(t, out, "truncated")
+		require.Contains(t, out, "128.0 KB")
+		require.True(t, strings.HasPrefix(out, strings.Repeat("a", 131072*3/4)))
+		require.True(t, strings.HasSuffix(out, strings.Repeat("b", 131072/4)))
+	})
+
+	t.Run("zero cap returns content unchanged", func(t *testing.T) {
+		t.Parallel()
+		content := "some output"
+		require.Equal(t, content, capToolResult(content, 0))
+	})
+
+	t.Run("output stays valid UTF-8", func(t *testing.T) {
+		t.Parallel()
+		content := strings.Repeat("你好世界", 65536)
+		out := capToolResult(content, 131072)
+		require.True(t, utf8.ValidString(out))
+	})
+}
+
+func TestFormatBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		bytes int
+		want  string
+	}{
+		{name: "bytes", bytes: 512, want: "512 B"},
+		{name: "kilobytes", bytes: 96 * 1024, want: "96.0 KB"},
+		{name: "megabytes", bytes: 41*1024*1024 + 209715, want: "41.2 MB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, formatBytes(tt.bytes))
+		})
+	}
+}
+
+func TestMaxToolResultBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("configured server uses its own cap", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{"myserver": {MaxToolResultBytes: 65536}}})
+		require.Equal(t, 65536, maxToolResultBytes(cfg, "myserver"))
+	})
+
+	t.Run("unconfigured server uses default", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.NewTestStore(&config.Config{})
+		require.Equal(t, defaultMaxToolResultBytes, maxToolResultBytes(cfg, "myserver"))
+	})
+
+	t.Run("server without cap uses default", func(t *testing.T) {
+		t.Parallel()
+		cfg := config.NewTestStore(&config.Config{MCP: config.MCPs{"myserver": {}}})
+		require.Equal(t, defaultMaxToolResultBytes, maxToolResultBytes(cfg, "myserver"))
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,6 +201,12 @@ type MCPConfig struct {
 	EnabledTools  []string          `json:"enabled_tools,omitempty" jsonschema:"description=Allow list of tools from this MCP server,example=get-library-doc"`
 	Timeout       int               `json:"timeout,omitempty" jsonschema:"description=Timeout in seconds for MCP server connections,default=10,example=30,example=60,example=120"`
 
+	// MaxToolResultBytes caps the text content of a tool result before it is
+	// added to the model context. Zero uses the package default so oversized
+	// results from third-party MCP servers cannot blow past the context
+	// window.
+	MaxToolResultBytes int `json:"max_tool_result_bytes,omitempty" jsonschema:"description=Maximum number of bytes of a tool result to include in the model context,default=131072,example=131072,example=1048576"`
+
 	// Headers are HTTP headers for HTTP/SSE MCP servers. Values run
 	// through shell expansion at MCP startup, so $VAR and $(cmd)
 	// work. A header whose value resolves to the empty string (unset

--- a/internal/shellconfig/mcp.go
+++ b/internal/shellconfig/mcp.go
@@ -13,7 +13,7 @@ import (
 //
 //	mcp add <name> --type stdio|sse|http [--command CMD] [--args ARG ...]
 //	    [--env KEY VALUE ...] [--url URL] [--header KEY VALUE ...]
-//	    [--timeout N] [--disabled true|false]
+//	    [--timeout N] [--max-tool-result-bytes N] [--disabled true|false]
 //	    [--disabled-tools TOOL ...] [--enabled-tools TOOL ...]
 //	    [--oauth true|false] [--oauth-client-id ID]
 //	    [--oauth-client-secret SECRET] [--oauth-callback-port PORT]
@@ -49,6 +49,7 @@ var mcpAddFlags = []flagSpec{
 	{name: "--url", jsonKey: "url", kind: flagString, op: opSet},
 	{name: "--header", child: "headers", kind: flagKeyValue, op: opSetChild},
 	{name: "--timeout", jsonKey: "timeout", kind: flagInt, op: opSet},
+	{name: "--max-tool-result-bytes", jsonKey: "max_tool_result_bytes", kind: flagInt, op: opSet},
 	{name: "--disabled", jsonKey: "disabled", kind: flagBool, op: opSet},
 	{name: "--disabled-tools", jsonKey: "disabled_tools", kind: flagString, op: opAppend},
 	{name: "--enabled-tools", jsonKey: "enabled_tools", kind: flagString, op: opAppend},
@@ -60,7 +61,7 @@ var mcpAddFlags = []flagSpec{
 
 func mcpAdd(b *ConfigBuilder, args []string, stderr io.Writer) error {
 	if len(args) < 3 {
-		return usage(stderr, "usage: mcp add <name> --type stdio|sse|http [--command CMD] [--args ARG ...] [--env KEY VALUE ...] [--url URL] [--header KEY VALUE ...] [--timeout N] [--disabled true|false] [--disabled-tools TOOL ...] [--enabled-tools TOOL ...] [--oauth true|false] [--oauth-client-id ID] [--oauth-client-secret SECRET] [--oauth-callback-port PORT]")
+		return usage(stderr, "usage: mcp add <name> --type stdio|sse|http [--command CMD] [--args ARG ...] [--env KEY VALUE ...] [--url URL] [--header KEY VALUE ...] [--timeout N] [--max-tool-result-bytes N] [--disabled true|false] [--disabled-tools TOOL ...] [--enabled-tools TOOL ...] [--oauth true|false] [--oauth-client-id ID] [--oauth-client-secret SECRET] [--oauth-callback-port PORT]")
 	}
 	name := args[2]
 	slog.Info("MCP server defined in shell config", "name", name)


### PR DESCRIPTION
## What

Closes #3480. MCP tool results are now capped before they enter the model context, so a single oversized result (e.g. an agent running `cat` on a multi-MB build or job log through an SSH/exec MCP server) can no longer blow past the model's entire context window and lose the turn.

## How it works

- New per-server config knob `max_tool_result_bytes` (default **131072**) on `MCPConfig`, e.g.:
  ```json
  {
    "mcp": {
      "myserver": {
        "type": "stdio",
        "command": "...",
        "max_tool_result_bytes": 131072
      }
    }
  }
  ```
  Also exposed as `--max-tool-result-bytes` on the `mcp add` crushrc builtin.
- Applied in `mcp.RunTool` (the single seam every MCP tool result flows through) before the text is joined into context.
- On overflow, keeps ~75% head + ~25% tail and inserts a marker stating how much was dropped, e.g.:
  ```
  [... 41.2 MB truncated (returned first 96 KB + last 32 KB). Narrow the command with head/tail/grep, or write to a file and sample it. ...]
  ```
  Head keeps the command banner/first errors, tail keeps the final error/exit summary, and the marker teaches the model to self-correct with a narrower command instead of retrying the same one (the same head+tail+marker shape that's proven to work in the SSH MCP server prior art linked in the issue).
- Split points are UTF-8-safe — the result never cuts a multi-byte rune in half.

Built-in tools already truncated via `truncateOutput` (#2835); this brings MCP results in line with that client-side last-line-of-defense behavior.

## Files

- `internal/config/config.go` — `MaxToolResultBytes` field on `MCPConfig`.
- `internal/agent/tools/mcp/tools.go` — `capToolResult`, `maxToolResultBytes`, `formatBytes` helpers, wired into `RunTool`.
- `internal/agent/tools/mcp/tools_test.go` — tests for capping (short/at-cap/oversized/zero cap/UTF-8), byte formatting, default resolution.
- `internal/agent/tools/mcp/lifecycle.go` — `MaxToolResultBytes` included in `mcpConfigEqual` so a cap change forces a session renewal (guarded by `TestMCPConfigEqualExhaustive`).
- `internal/shellconfig/mcp.go` — `--max-tool-result-bytes` flag on `mcp add`.

## Notes / open questions

- I made the cap **default-on at 131072** (no opt-in needed), mirroring how built-in tools truncate by default. If you'd prefer it off until configured, that's a one-line change to `maxToolResultBytes`.
- `schema.json` is regenerated by the `schema-update` workflow on push to main, so I didn't hand-edit it.
- Couldn't run golangci-lint locally (pathologically slow on this machine) but `gofmt`/`gofumpt`, `go vet`, `go build`, and tests for config/mcp/shellconfig all pass; CI runs the full lint.