### PR TITLE
fix(bash): auto-approve read-only gh and brew commands

### DIFF
--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -168,6 +168,63 @@ func TestBashTool_ChainedCommandsDenied(t *testing.T) {
 	require.Contains(t, resp.Content, "User denied permission")
 }
 
+// TestBashTool_GhReadOnlySafeCommands — the GitHub CLI's read-only queries
+// are auto-approved like the git read-only list, so non-interactive sessions
+// no longer stall on a permission prompt for `gh pr view`. Mutating gh
+// commands stay gated.
+func TestBashTool_GhReadOnlySafeCommands(t *testing.T) {
+	workingDir := t.TempDir()
+
+	for _, tc := range []struct {
+		name    string
+		command string
+		want    int // permission requests
+	}{
+		{"gh pr view", "gh pr view 123", 0},
+		{"gh pr list", "gh pr list --json number,title", 0},
+		{"gh issue list", "gh issue list --state open", 0},
+		{"gh repo view", "gh repo view charmbracelet/crush", 0},
+		{"gh auth status", "gh auth status", 0},
+		{"gh search", "gh search repos crush", 0},
+		{"gh mutating create stays gated", "gh pr create --title x", 1},
+		{"gh mutating release stays gated", "gh release create v1.0", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tool, perms := newBashToolWithRecordingPerms(workingDir, true)
+			ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+			resp := runBashTool(t, tool, ctx, BashParams{Description: "gh", Command: tc.command})
+			require.False(t, resp.IsError)
+			require.Equal(t, tc.want, perms.requestCount, "permission requests for %q", tc.command)
+		})
+	}
+}
+
+// TestBashTool_BrewReadOnlySafeCommands — read-only Homebrew inspections are
+// auto-approved, but `brew install` stays blocked by its ArgumentsBlocker.
+func TestBashTool_BrewReadOnlySafeCommands(t *testing.T) {
+	workingDir := t.TempDir()
+
+	for _, tc := range []struct {
+		name    string
+		command string
+		want    int // permission requests
+	}{
+		{"brew info", "brew info crush", 0},
+		{"brew list", "brew list", 0},
+		{"brew outdated", "brew outdated", 0},
+		{"brew search", "brew search crush", 0},
+		{"brew install stays gated", "brew install charmbracelet/crush/crush", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tool, perms := newBashToolWithRecordingPerms(workingDir, true)
+			ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+			resp := runBashTool(t, tool, ctx, BashParams{Description: "brew", Command: tc.command})
+			require.False(t, resp.IsError)
+			require.Equal(t, tc.want, perms.requestCount, "permission requests for %q", tc.command)
+		})
+	}
+}
+
 func runBashTool(t *testing.T, tool fantasy.AgentTool, ctx context.Context, params BashParams) fantasy.ToolResponse {
 	t.Helper()
 

--- a/internal/agent/tools/safe.go
+++ b/internal/agent/tools/safe.go
@@ -56,6 +56,48 @@ var safeCommands = []string{
 	"git show",
 	"git status",
 	"git tag",
+
+	// GitHub CLI — read-only queries only. `gh` is otherwise entirely absent
+	// from the safe list, so even `gh pr view` hits the permission gate and
+	// stalls non-interactive sessions waiting for an answer that never comes.
+	// Mutating subcommands (pr create, release create, api POST, …) are NOT
+	// listed, so they still require explicit approval.
+	"gh auth status",
+	"gh alias list",
+	"gh cache list",
+	"gh codespace list",
+	"gh extension list",
+	"gh gist list",
+	"gh issue list",
+	"gh issue view",
+	"gh label list",
+	"gh pr diff",
+	"gh pr list",
+	"gh pr view",
+	"gh repo list",
+	"gh repo view",
+	"gh run list",
+	"gh run view",
+	"gh search",
+	"gh secret list",
+	"gh ssh-key list",
+	"gh variable list",
+	"gh workflow list",
+
+	// Homebrew — read-only inspections only. `brew install` stays blocked by
+	// its ArgumentsBlocker; these merely let an agent look before it asks.
+	"brew --version",
+	"brew config",
+	"brew deps",
+	"brew doctor",
+	"brew info",
+	"brew leaves",
+	"brew list",
+	"brew outdated",
+	"brew search",
+	"brew services list",
+	"brew tap",
+	"brew uses",
 }
 
 var chainingMetacharacters = []string{


### PR DESCRIPTION
## What

The read-only safe-command list (`internal/agent/tools/safe.go`) covers `git` deeply but had **no** `gh` entries and no `brew` inspections. Every `gh` command — even `gh pr view` / `gh auth status` — went through the permission gate.

## Why it matters

In an interactive session a prompt can be answered. In a `crush run` / headless session there is nobody to answer it, so the model stalls waiting on the permission gate: the session appears to **hang on github**. The same gate tripped read-only Homebrew inspections like `brew outdated`.

## Change

- add read-only `gh` subcommands to `safeCommands`: `gh pr view`/list, `gh issue view`/list, `gh repo view`/list, `gh search`, `gh auth status`, `gh run view`/list, `gh workflow list`, `gh gist list`, `gh label list`, `gh secret list`, `gh variable list`, `gh codespace list`, `gh cache list`, `gh ssh-key list`, `gh extension list`, `gh alias list`
- add read-only `brew` inspections: `brew info`, `brew list`, `brew outdated`, `brew search`, `brew doctor`, `brew deps`, `brew leaves`, `brew tap`, `brew uses`, `brew services list`, `brew config`, `brew --version`
- mutating commands stay gated: `gh pr create`, `gh release create`, `gh api` (not listed), `brew install` (still `ArgumentsBlocker`)

## Tests

`TestBashTool_GhReadOnlySafeCommands` + `TestBashTool_BrewReadOnlySafeCommands`: read-only commands run with 0 permission requests; mutating ones still request permission.