### PR TITLE
feat(ui): a Skills menu — browse every skill, not just the incantable ones

### DIFF
--- a/internal/agent/tools/bash_test.go
+++ b/internal/agent/tools/bash_test.go
@@ -168,6 +168,63 @@ func TestBashTool_ChainedCommandsDenied(t *testing.T) {
 	require.Contains(t, resp.Content, "User denied permission")
 }
 
+// TestBashTool_GhReadOnlySafeCommands — the GitHub CLI's read-only queries
+// are auto-approved like the git read-only list, so non-interactive sessions
+// no longer stall on a permission prompt for `gh pr view`. Mutating gh
+// commands stay gated.
+func TestBashTool_GhReadOnlySafeCommands(t *testing.T) {
+	workingDir := t.TempDir()
+
+	for _, tc := range []struct {
+		name    string
+		command string
+		want    int // permission requests
+	}{
+		{"gh pr view", "gh pr view 123", 0},
+		{"gh pr list", "gh pr list --json number,title", 0},
+		{"gh issue list", "gh issue list --state open", 0},
+		{"gh repo view", "gh repo view charmbracelet/crush", 0},
+		{"gh auth status", "gh auth status", 0},
+		{"gh search", "gh search repos crush", 0},
+		{"gh mutating create stays gated", "gh pr create --title x", 1},
+		{"gh mutating release stays gated", "gh release create v1.0", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tool, perms := newBashToolWithRecordingPerms(workingDir, true)
+			ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+			resp := runBashTool(t, tool, ctx, BashParams{Description: "gh", Command: tc.command})
+			require.False(t, resp.IsError)
+			require.Equal(t, tc.want, perms.requestCount, "permission requests for %q", tc.command)
+		})
+	}
+}
+
+// TestBashTool_BrewReadOnlySafeCommands — read-only Homebrew inspections are
+// auto-approved, but `brew install` stays blocked by its ArgumentsBlocker.
+func TestBashTool_BrewReadOnlySafeCommands(t *testing.T) {
+	workingDir := t.TempDir()
+
+	for _, tc := range []struct {
+		name    string
+		command string
+		want    int // permission requests
+	}{
+		{"brew info", "brew info crush", 0},
+		{"brew list", "brew list", 0},
+		{"brew outdated", "brew outdated", 0},
+		{"brew search", "brew search crush", 0},
+		{"brew install stays gated", "brew install charmbracelet/crush/crush", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tool, perms := newBashToolWithRecordingPerms(workingDir, true)
+			ctx := context.WithValue(context.Background(), SessionIDContextKey, "test-session")
+			resp := runBashTool(t, tool, ctx, BashParams{Description: "brew", Command: tc.command})
+			require.False(t, resp.IsError)
+			require.Equal(t, tc.want, perms.requestCount, "permission requests for %q", tc.command)
+		})
+	}
+}
+
 func runBashTool(t *testing.T, tool fantasy.AgentTool, ctx context.Context, params BashParams) fantasy.ToolResponse {
 	t.Helper()
 

--- a/internal/agent/tools/safe.go
+++ b/internal/agent/tools/safe.go
@@ -56,6 +56,48 @@ var safeCommands = []string{
 	"git show",
 	"git status",
 	"git tag",
+
+	// GitHub CLI — read-only queries only. `gh` is otherwise entirely absent
+	// from the safe list, so even `gh pr view` hits the permission gate and
+	// stalls non-interactive sessions waiting for an answer that never comes.
+	// Mutating subcommands (pr create, release create, api POST, …) are NOT
+	// listed, so they still require explicit approval.
+	"gh auth status",
+	"gh alias list",
+	"gh cache list",
+	"gh codespace list",
+	"gh extension list",
+	"gh gist list",
+	"gh issue list",
+	"gh issue view",
+	"gh label list",
+	"gh pr diff",
+	"gh pr list",
+	"gh pr view",
+	"gh repo list",
+	"gh repo view",
+	"gh run list",
+	"gh run view",
+	"gh search",
+	"gh secret list",
+	"gh ssh-key list",
+	"gh variable list",
+	"gh workflow list",
+
+	// Homebrew — read-only inspections only. `brew install` stays blocked by
+	// its ArgumentsBlocker; these merely let an agent look before it asks.
+	"brew --version",
+	"brew config",
+	"brew deps",
+	"brew doctor",
+	"brew info",
+	"brew leaves",
+	"brew list",
+	"brew outdated",
+	"brew search",
+	"brew services list",
+	"brew tap",
+	"brew uses",
 }
 
 var chainingMetacharacters = []string{

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/commands"
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/skills"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/list"
 	"github.com/charmbracelet/crush/internal/ui/styles"
@@ -24,7 +25,9 @@ const CommandsID = "commands"
 type CommandType uint
 
 // String returns the string representation of the CommandType.
-func (c CommandType) String() string { return []string{"System", "User", "MCP"}[c] }
+func (c CommandType) String() string {
+	return []string{"System", "User", "MCP", "Skills"}[c]
+}
 
 const (
 	sidebarCompactModeBreakpoint = 120
@@ -34,6 +37,7 @@ const (
 	SystemCommands CommandType = iota
 	UserCommands
 	MCPPrompts
+	SkillsCommands
 )
 
 // Commands represents a dialog that shows available commands.
@@ -71,6 +75,10 @@ type Commands struct {
 	customCommands []commands.CustomCommand
 	mcpPrompts     []commands.MCPPrompt
 
+	// skills is the full skill catalog — every discovered skill, not only
+	// the user-invocable subset that appears under the User tab.
+	skills []skills.CatalogEntry
+
 	dockerMCPAvailable     *bool
 	dockerMCPCheckInFlight bool
 }
@@ -78,7 +86,7 @@ type Commands struct {
 var _ Dialog = (*Commands)(nil)
 
 // NewCommands creates a new commands dialog.
-func NewCommands(com *common.Common, sessionID string, hasSession, hasTodos, hasQueue bool, customCommands []commands.CustomCommand, mcpPrompts []commands.MCPPrompt) (*Commands, error) {
+func NewCommands(com *common.Common, sessionID string, hasSession, hasTodos, hasQueue bool, customCommands []commands.CustomCommand, mcpPrompts []commands.MCPPrompt, skillCatalog []skills.CatalogEntry) (*Commands, error) {
 	c := &Commands{
 		com:            com,
 		selected:       SystemCommands,
@@ -88,6 +96,7 @@ func NewCommands(com *common.Common, sessionID string, hasSession, hasTodos, has
 		hasQueue:       hasQueue,
 		customCommands: customCommands,
 		mcpPrompts:     mcpPrompts,
+		skills:         skillCatalog,
 	}
 
 	help := help.New()
@@ -210,12 +219,12 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 				}
 			}
 		case key.Matches(msg, c.keyMap.Tab):
-			if len(c.customCommands) > 0 || len(c.mcpPrompts) > 0 {
+			if len(c.customCommands) > 0 || len(c.mcpPrompts) > 0 || len(c.skills) > 0 {
 				c.selected = c.nextCommandType()
 				c.setCommandItems(c.selected)
 			}
 		case key.Matches(msg, c.keyMap.ShiftTab):
-			if len(c.customCommands) > 0 || len(c.mcpPrompts) > 0 {
+			if len(c.customCommands) > 0 || len(c.mcpPrompts) > 0 || len(c.skills) > 0 {
 				c.selected = c.previousCommandType()
 				c.setCommandItems(c.selected)
 			}
@@ -259,8 +268,8 @@ func (c *Commands) Cursor() *tea.Cursor {
 }
 
 // commandsRadioView generates the command type selector radio buttons.
-func commandsRadioView(sty *styles.Styles, selected CommandType, hasUserCmds bool, hasMCPPrompts bool) string {
-	if !hasUserCmds && !hasMCPPrompts {
+func commandsRadioView(sty *styles.Styles, selected CommandType, hasUserCmds bool, hasMCPPrompts bool, hasSkills bool) string {
+	if !hasUserCmds && !hasMCPPrompts && !hasSkills {
 		return ""
 	}
 
@@ -280,6 +289,9 @@ func commandsRadioView(sty *styles.Styles, selected CommandType, hasUserCmds boo
 	}
 	if hasMCPPrompts {
 		parts = append(parts, selectedFn(MCPPrompts))
+	}
+	if hasSkills {
+		parts = append(parts, selectedFn(SkillsCommands))
 	}
 
 	return strings.Join(parts, " ")
@@ -312,7 +324,7 @@ func (c *Commands) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 
 	rc := NewRenderContext(t, width)
 	rc.Title = "Commands"
-	rc.TitleInfo = commandsRadioView(t, c.selected, len(c.customCommands) > 0, len(c.mcpPrompts) > 0)
+	rc.TitleInfo = commandsRadioView(t, c.selected, len(c.customCommands) > 0, len(c.mcpPrompts) > 0, len(c.skills) > 0)
 	inputView := t.Dialog.InputPrompt.Render(c.input.View())
 	rc.AddPart(inputView)
 	listView := t.Dialog.List.Height(c.list.Height()).Render(c.list.Render())
@@ -358,13 +370,24 @@ func (c *Commands) nextCommandType() CommandType {
 		if len(c.mcpPrompts) > 0 {
 			return MCPPrompts
 		}
+		if len(c.skills) > 0 {
+			return SkillsCommands
+		}
 		fallthrough
 	case UserCommands:
 		if len(c.mcpPrompts) > 0 {
 			return MCPPrompts
 		}
+		if len(c.skills) > 0 {
+			return SkillsCommands
+		}
 		fallthrough
 	case MCPPrompts:
+		if len(c.skills) > 0 {
+			return SkillsCommands
+		}
+		fallthrough
+	case SkillsCommands:
 		return SystemCommands
 	default:
 		return SystemCommands
@@ -375,6 +398,9 @@ func (c *Commands) nextCommandType() CommandType {
 func (c *Commands) previousCommandType() CommandType {
 	switch c.selected {
 	case SystemCommands:
+		if len(c.skills) > 0 {
+			return SkillsCommands
+		}
 		if len(c.mcpPrompts) > 0 {
 			return MCPPrompts
 		}
@@ -389,8 +415,24 @@ func (c *Commands) previousCommandType() CommandType {
 			return UserCommands
 		}
 		return SystemCommands
+	case SkillsCommands:
+		if len(c.mcpPrompts) > 0 {
+			return MCPPrompts
+		}
+		if len(c.customCommands) > 0 {
+			return UserCommands
+		}
+		return SystemCommands
 	default:
 		return SystemCommands
+	}
+}
+
+// SelectSkillsTab jumps the dialog to the Skills tab, which lists the full
+// skill catalog. Used by the /skills entry point.
+func (c *Commands) SelectSkillsTab() {
+	if len(c.skills) > 0 {
+		c.setCommandItems(SkillsCommands)
 	}
 }
 
@@ -432,6 +474,18 @@ func (c *Commands) setCommandItems(commandType CommandType) {
 				Arguments:   cmd.Arguments,
 			}
 			commandItems = append(commandItems, NewCommandItem(c.com.Styles, "mcp_"+cmd.ID, cmd.PromptID, "", action))
+		}
+	case SkillsCommands:
+		// the full catalog — every skill, user-invocable or not. Selecting
+		// one attaches it to the conversation, the same way the User tab's
+		// user-invocable skills do.
+		for _, entry := range c.skills {
+			action := ActionAttachSkill{ID: entry.ID, Name: entry.Name}
+			item := NewCommandItem(c.com.Styles, "skill_"+entry.ID, entry.Name, "", action)
+			if entry.Description != "" {
+				item = item.WithDescription(entry.Description)
+			}
+			commandItems = append(commandItems, item)
 		}
 	}
 

--- a/internal/ui/dialog/skills_test.go
+++ b/internal/ui/dialog/skills_test.go
@@ -1,0 +1,76 @@
+package dialog
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/commands"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/skills"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+// testWorkspace is a minimal [workspace.Workspace] stub: the dialogs only
+// reach Config().
+type testWorkspace struct {
+	workspace.Workspace
+	cfg *config.Config
+}
+
+func (w *testWorkspace) Config() *config.Config { return w.cfg }
+
+func newTestCommandsDialog(t *testing.T, catalog []skills.CatalogEntry) *Commands {
+	t.Helper()
+	s := styles.CharmtonePantera()
+	com := &common.Common{
+		Styles:    &s,
+		Workspace: &testWorkspace{cfg: &config.Config{}},
+	}
+	d, err := NewCommands(com, "test-session", true, false, false, []commands.CustomCommand{}, []commands.MCPPrompt{}, catalog)
+	require.NoError(t, err)
+	return d
+}
+
+// TestCommandsSkillsTabListsTheFullCatalog — the Skills tab shows every
+// discovered skill (not just the user-invocable subset), name + description,
+// and selecting one attaches it to the conversation.
+func TestCommandsSkillsTabListsTheFullCatalog(t *testing.T) {
+	catalog := []skills.CatalogEntry{
+		{ID: "al-biruni", Name: "al-biruni", Description: "two minds, one brain"},
+		{ID: "superpowers", Name: "superpowers", Description: "the whole toolbox"},
+		{ID: "ctx-out", Name: "ctx-out", Description: "context management"},
+	}
+	d := newTestCommandsDialog(t, catalog)
+
+	require.Equal(t, SystemCommands, d.selected, "opens on System by default")
+	d.SelectSkillsTab()
+	require.Equal(t, SkillsCommands, d.selected, "SelectSkillsTab jumps to the Skills tab")
+
+	items := d.list.FilteredItems()
+	require.Len(t, items, len(catalog), "all skills are listed, user-invocable or not")
+
+	names := map[string]string{}
+	for _, it := range items {
+		ci, ok := it.(*CommandItem)
+		require.True(t, ok, "skill items are CommandItems")
+		names[ci.title] = ci.description
+	}
+	require.Equal(t, "two minds, one brain", names["al-biruni"])
+	require.Equal(t, "the whole toolbox", names["superpowers"])
+
+	// selecting the first skill returns an attach action, not a raw command
+	action := items[0].(*CommandItem).Action()
+	attach, ok := action.(ActionAttachSkill)
+	require.True(t, ok, "selecting a skill attaches it: %T", action)
+	require.Equal(t, "al-biruni", attach.Name)
+}
+
+// TestCommandsSkillsTabEmptyCatalog — with no skills the tab is a no-op, so
+// the dialog stays on System.
+func TestCommandsSkillsTabEmptyCatalog(t *testing.T) {
+	d := newTestCommandsDialog(t, nil)
+	d.SelectSkillsTab()
+	require.Equal(t, SystemCommands, d.selected)
+}

--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -69,6 +69,7 @@ type KeyMap struct {
 	Sessions   key.Binding
 	Tab        key.Binding
 	ToggleYolo key.Binding
+	Skills     key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
@@ -88,6 +89,10 @@ func DefaultKeyMap() KeyMap {
 		Models: key.NewBinding(
 			key.WithKeys("ctrl+m", "ctrl+l"),
 			key.WithHelp("ctrl+l", "models"),
+		),
+		Skills: key.NewBinding(
+			key.WithKeys("ctrl+k"),
+			key.WithHelp("ctrl+k", "skills"),
 		),
 		Suspend: key.NewBinding(
 			key.WithKeys("ctrl+z"),

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -2381,6 +2381,11 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				cmds = append(cmds, cmd)
 			}
 			return true
+		case key.Matches(msg, m.keyMap.Skills):
+			if cmd := m.openSkillsDialog(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			return true
 		case key.Matches(msg, m.keyMap.Models):
 			if cmd := m.openModelsDialog(); cmd != nil {
 				cmds = append(cmds, cmd)
@@ -4367,6 +4372,17 @@ func (m *UI) openModelsDialog() tea.Cmd {
 
 // openCommandsDialog opens the commands dialog.
 func (m *UI) openCommandsDialog() tea.Cmd {
+	return m.openCommandsDialogOn(dialog.SystemCommands)
+}
+
+// openSkillsDialog opens the commands dialog on the Skills tab — the menu
+// of every discovered skill, so invoking one needs no natural-language
+// incantation ("use Al-Biruni", "use superpowers").
+func (m *UI) openSkillsDialog() tea.Cmd {
+	return m.openCommandsDialogOn(dialog.SkillsCommands)
+}
+
+func (m *UI) openCommandsDialogOn(tab dialog.CommandType) tea.Cmd {
 	if m.dialog.ContainsDialog(dialog.CommandsID) {
 		// Bring to front
 		m.dialog.BringToFront(dialog.CommandsID)
@@ -4381,9 +4397,17 @@ func (m *UI) openCommandsDialog() tea.Cmd {
 	hasTodos := hasSession && hasIncompleteTodos(m.session.Todos)
 	hasQueue := m.promptQueue > 0
 
-	commands, err := dialog.NewCommands(m.com, sessionID, hasSession, hasTodos, hasQueue, m.customCommands, m.mcpPrompts)
+	skillCatalog := []skills.CatalogEntry{}
+	if entries, err := m.com.Workspace.ListSkills(context.Background()); err == nil {
+		skillCatalog = entries
+	}
+
+	commands, err := dialog.NewCommands(m.com, sessionID, hasSession, hasTodos, hasQueue, m.customCommands, m.mcpPrompts, skillCatalog)
 	if err != nil {
 		return util.ReportError(err)
+	}
+	if tab == dialog.SkillsCommands {
+		commands.SelectSkillsTab()
 	}
 
 	m.dialog.OpenDialog(commands)


### PR DESCRIPTION
## What

Invoking a skill today means *knowing its name and saying it* — `use Al-Biruni`, `use superpowers`. Only skills marked `user-invocable: true` appear in the commands dialog (`ctrl+p`), so every other skill has to be summoned by natural-language incantation, which models miss or mangle.

This adds a **Skills menu**: a dedicated tab in the commands dialog that lists the **full** skill catalog — every discovered skill, name + description — filterable exactly like the other tabs.

## Change

- `internal/ui/dialog/commands.go`: a fourth `SkillsCommands` tab fed the full `skills.CatalogEntry` list; `tab`/`shift+tab` cycle System / User / MCP / Skills; selecting a skill emits `ActionAttachSkill` (the same attach path the user-invocable subset already used)
- `internal/ui/model/ui.go`: `openSkillsDialog()` (`ctrl+k`) opens the dialog straight onto the Skills tab; the dialog now receives the full catalog from `Workspace.ListSkills`
- `internal/ui/model/keys.go`: `ctrl+k` = skills
- tests: the Skills tab lists the full catalog with descriptions, selecting emits an attach action, empty catalog is a no-op

## Why

A menu is discoverable; an incantation is not. The model stops guessing the magic phrase and the user stops teaching it — the skills are right there, one keystroke away, like in other coding agents.