### PR TITLE
feat(theme): the dyad-mapper theme + a theme menu

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -259,8 +259,8 @@ type LSPConfig struct {
 type TUIOptions struct {
 	CompactMode bool   `json:"compact_mode,omitempty" jsonschema:"description=Enable compact mode for the TUI interface,default=false"`
 	DiffMode    string `json:"diff_mode,omitempty" jsonschema:"description=Diff mode for the TUI interface,enum=unified,enum=split"`
-	// Here we can add themes later or any TUI related options
-	//
+	// Theme is the UI theme id. Empty uses the provider-derived default.
+	Theme string `json:"theme,omitempty" jsonschema:"description=UI theme id,enum=charmtone,enum=hyper,enum=dyad-mapper"`
 
 	Completions Completions `json:"completions,omitzero" jsonschema:"description=Completions UI options"`
 	Transparent *bool       `json:"transparent,omitempty" jsonschema:"description=Enable transparent background for the TUI interface,default=false"`

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -84,6 +84,10 @@ type (
 		ID   string
 		Name string
 	}
+	// ActionApplyTheme is sent when a theme is selected from the theme dialog.
+	ActionApplyTheme struct {
+		Name string
+	}
 	// ActionRunMCPPrompt is a message to run a custom command.
 	ActionRunMCPPrompt struct {
 		Title       string

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -448,6 +448,7 @@ func (c *Commands) defaultCommands() []*CommandItem {
 		NewCommandItem(c.com.Styles, "new_session", "New Session", "ctrl+n", ActionNewSession{}).WithAliases("clear"),
 		NewCommandItem(c.com.Styles, "switch_session", "Sessions", "ctrl+s", ActionOpenDialog{SessionsID}),
 		NewCommandItem(c.com.Styles, "switch_model", "Switch Model", "ctrl+l", ActionOpenDialog{ModelsID}),
+		NewCommandItem(c.com.Styles, "theme", "Theme", "ctrl+t", ActionOpenDialog{ThemeID}).WithAliases("dyad-mapper", "colors"),
 	}
 
 	// Only show compact command if there's an active session

--- a/internal/ui/dialog/theme.go
+++ b/internal/ui/dialog/theme.go
@@ -1,0 +1,266 @@
+package dialog
+
+import (
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/list"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/sahilm/fuzzy"
+)
+
+const (
+	// ThemeID is the identifier for the theme dialog.
+	ThemeID              = "theme"
+	themeDialogMaxWidth  = 50
+	themeDialogMinHeight = 8
+	themeDialogMaxHeight = 16
+)
+
+// Theme represents a dialog for selecting the UI theme.
+type Theme struct {
+	com   *common.Common
+	help  help.Model
+	list  *list.FilterableList
+	input textinput.Model
+
+	keyMap struct {
+		Select   key.Binding
+		Next     key.Binding
+		Previous key.Binding
+		UpDown   key.Binding
+		Close    key.Binding
+	}
+}
+
+// ThemeItem represents a theme list item.
+type ThemeItem struct {
+	*list.Versioned
+	name      string
+	title     string
+	isCurrent bool
+	t         *styles.Styles
+	m         fuzzy.Match
+	cache     map[int]string
+	focused   bool
+}
+
+// Finished implements list.Item. Theme items are render-stable outside of
+// explicit SetFocused / SetMatch.
+func (t *ThemeItem) Finished() bool { return true }
+
+var (
+	_ Dialog   = (*Theme)(nil)
+	_ ListItem = (*ThemeItem)(nil)
+)
+
+// NewTheme creates a new theme dialog, marking `current` as active.
+func NewTheme(com *common.Common, current string) (*Theme, error) {
+	th := &Theme{com: com}
+
+	help := help.New()
+	help.Styles = com.Styles.DialogHelpStyles()
+	th.help = help
+
+	th.list = list.NewFilterableList()
+	th.list.Focus()
+
+	th.input = textinput.New()
+	th.input.SetVirtualCursor(false)
+	th.input.Placeholder = "Type to filter"
+	th.input.SetStyles(com.Styles.TextInput)
+	th.input.Focus()
+
+	th.keyMap.Select = key.NewBinding(
+		key.WithKeys("enter", "ctrl+y"),
+		key.WithHelp("enter", "confirm"),
+	)
+	th.keyMap.Next = key.NewBinding(
+		key.WithKeys("down", "ctrl+n"),
+		key.WithHelp("↓", "next item"),
+	)
+	th.keyMap.Previous = key.NewBinding(
+		key.WithKeys("up", "ctrl+p"),
+		key.WithHelp("↑", "previous item"),
+	)
+	th.keyMap.UpDown = key.NewBinding(
+		key.WithKeys("up", "down"),
+		key.WithHelp("↑/↓", "choose"),
+	)
+	th.keyMap.Close = CloseKey
+
+	items := make([]list.FilterableItem, 0, len(styles.ThemeNames()))
+	for _, name := range styles.ThemeNames() {
+		items = append(items, newThemeItem(com.Styles, name, name == current))
+	}
+	th.list.SetItems(items...)
+	th.list.SetSelected(0)
+
+	return th, nil
+}
+
+func newThemeItem(t *styles.Styles, name string, isCurrent bool) *ThemeItem {
+	return &ThemeItem{
+		Versioned: list.NewVersioned(),
+		t:         t,
+		name:      name,
+		title:     name,
+		isCurrent: isCurrent,
+	}
+}
+
+// ID implements Dialog.
+func (t *Theme) ID() string { return ThemeID }
+
+// HandleMsg implements [Dialog].
+func (t *Theme) HandleMsg(msg tea.Msg) Action {
+	switch msg := msg.(type) {
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, t.keyMap.Close):
+			return ActionClose{}
+		case key.Matches(msg, t.keyMap.Previous):
+			t.list.Focus()
+			if t.list.IsSelectedFirst() {
+				t.list.SelectLast()
+				t.list.ScrollToBottom()
+				break
+			}
+			t.list.SelectPrev()
+			t.list.ScrollToSelected()
+		case key.Matches(msg, t.keyMap.Next):
+			t.list.Focus()
+			if t.list.IsSelectedLast() {
+				t.list.SelectFirst()
+				t.list.ScrollToTop()
+				break
+			}
+			t.list.SelectNext()
+			t.list.ScrollToSelected()
+		case key.Matches(msg, t.keyMap.Select):
+			selectedItem := t.list.SelectedItem()
+			if selectedItem == nil {
+				break
+			}
+			item, ok := selectedItem.(*ThemeItem)
+			if !ok {
+				break
+			}
+			return ActionApplyTheme{Name: item.name}
+		default:
+			var cmd tea.Cmd
+			t.input, cmd = t.input.Update(msg)
+			value := t.input.Value()
+			t.list.SetFilter(value)
+			t.list.ScrollToTop()
+			t.list.SetSelected(0)
+			return ActionCmd{cmd}
+		}
+	}
+	return nil
+}
+
+// Cursor returns the cursor position relative to the dialog.
+func (t *Theme) Cursor() *tea.Cursor {
+	return InputCursor(t.com.Styles, t.input.Cursor())
+}
+
+// ShortHelp implements [help.KeyMap].
+func (t *Theme) ShortHelp() []key.Binding {
+	return []key.Binding{
+		t.keyMap.UpDown,
+		t.keyMap.Select,
+		t.keyMap.Close,
+	}
+}
+
+// FullHelp implements [help.KeyMap].
+func (t *Theme) FullHelp() [][]key.Binding {
+	slice := []key.Binding{
+		t.keyMap.Select,
+		t.keyMap.Next,
+		t.keyMap.Previous,
+		t.keyMap.Close,
+	}
+	m := [][]key.Binding{}
+	for i := 0; i < len(slice); i += 4 {
+		end := min(i+4, len(slice))
+		m = append(m, slice[i:end])
+	}
+	return m
+}
+
+// Filter returns the filter value for the theme item.
+func (ti *ThemeItem) Filter() string { return ti.title }
+
+// ID returns the unique identifier for the theme.
+func (ti *ThemeItem) ID() string { return ti.name }
+
+// SetFocused sets the focus state of the theme item.
+func (ti *ThemeItem) SetFocused(focused bool) {
+	if ti.focused == focused {
+		return
+	}
+	ti.cache = nil
+	ti.focused = focused
+	if ti.Versioned != nil {
+		ti.Bump()
+	}
+}
+
+// SetMatch sets the fuzzy match for the theme item.
+func (ti *ThemeItem) SetMatch(m fuzzy.Match) {
+	if sameFuzzyMatch(ti.m, m) {
+		return
+	}
+	ti.cache = nil
+	ti.m = m
+	if ti.Versioned != nil {
+		ti.Bump()
+	}
+}
+
+// Render returns the string representation of the theme item.
+func (ti *ThemeItem) Render(width int) string {
+	info := ""
+	if ti.isCurrent {
+		info = "current"
+	}
+	listStyles := ListItemStyles{
+		ItemBlurred:     ti.t.Dialog.NormalItem,
+		ItemFocused:     ti.t.Dialog.SelectedItem,
+		InfoTextBlurred: ti.t.Dialog.ListItem.InfoBlurred,
+		InfoTextFocused: ti.t.Dialog.ListItem.InfoFocused,
+	}
+	return renderItem(listStyles, ti.title, info, ti.focused, width, ti.cache, &ti.m)
+}
+
+// Draw implements [Dialog].
+func (t *Theme) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	st := t.com.Styles
+	width := max(0, min(themeDialogMaxWidth, area.Dx()-st.Dialog.View.GetHorizontalBorderSize()))
+	innerWidth := width - st.Dialog.View.GetHorizontalFrameSize()
+	height := max(themeDialogMinHeight, min(themeDialogMaxHeight, area.Dy()-st.Dialog.View.GetVerticalBorderSize()))
+
+	t.input.SetWidth(dialogInputTextWidth(st, t.input, innerWidth))
+	t.list.SetSize(innerWidth, max(0, height-4))
+
+	rc := NewRenderContext(st, width)
+	rc.Title = "Theme"
+
+	inputView := st.Dialog.InputPrompt.Render(t.input.View())
+	rc.AddPart(inputView)
+
+	listView := st.Dialog.List.Height(t.list.Height()).Render(t.list.Render())
+	rc.AddPart(listView)
+
+	rc.Help = renderDialogHelp(st, &t.help, t, innerWidth)
+
+	view := rc.Render()
+	cur := t.Cursor()
+	DrawCenterCursor(scr, area, view, cur)
+	return cur
+}

--- a/internal/ui/dialog/theme_test.go
+++ b/internal/ui/dialog/theme_test.go
@@ -1,0 +1,57 @@
+package dialog
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+// themeTestWorkspace is a minimal [workspace.Workspace] stub.
+type themeTestWorkspace struct {
+	workspace.Workspace
+	cfg *config.Config
+}
+
+func (w *themeTestWorkspace) Config() *config.Config { return w.cfg }
+
+// TestThemeDialogListsAllThemes — the theme menu shows every selectable
+// theme and marks the current one.
+func TestThemeDialogListsAllThemes(t *testing.T) {
+	s := styles.CharmtonePantera()
+	com := &common.Common{
+		Styles:    &s,
+		Workspace: &themeTestWorkspace{cfg: &config.Config{}},
+	}
+	d, err := NewTheme(com, "dyad-mapper")
+	require.NoError(t, err)
+
+	items := d.list.FilteredItems()
+	require.Len(t, items, len(styles.ThemeNames()), "every theme is listed")
+
+	var names []string
+	for _, it := range items {
+		ti, ok := it.(*ThemeItem)
+		require.True(t, ok)
+		names = append(names, ti.name)
+		if ti.name == "dyad-mapper" {
+			require.True(t, ti.isCurrent, "the active theme is marked current")
+		}
+	}
+	require.Contains(t, names, "dyad-mapper")
+	require.Contains(t, names, "charmtone")
+}
+
+// TestDyadMapperIsARealTheme — the sensitive-eyes theme builds a complete
+// Styles object; sanity-check it carries the soft navy base.
+func TestDyadMapperIsARealTheme(t *testing.T) {
+	s := styles.DyadMapper()
+	require.NotNil(t, s)
+	require.NotEmpty(t, styles.ThemeNames())
+	// selecting it by name returns it
+	got := styles.ThemeForName("dyad-mapper")
+	require.Equal(t, s, got)
+}

--- a/internal/ui/model/keys.go
+++ b/internal/ui/model/keys.go
@@ -69,6 +69,7 @@ type KeyMap struct {
 	Sessions   key.Binding
 	Tab        key.Binding
 	ToggleYolo key.Binding
+	Theme      key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
@@ -88,6 +89,10 @@ func DefaultKeyMap() KeyMap {
 		Models: key.NewBinding(
 			key.WithKeys("ctrl+m", "ctrl+l"),
 			key.WithHelp("ctrl+l", "models"),
+		),
+		Theme: key.NewBinding(
+			key.WithKeys("ctrl+t"),
+			key.WithHelp("ctrl+t", "theme"),
 		),
 		Suspend: key.NewBinding(
 			key.WithKeys("ctrl+z"),

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -461,7 +461,9 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 	if cfg := com.Config(); cfg != nil {
 		if cfg.Options != nil && cfg.Options.TUI != nil && cfg.Options.TUI.Theme != "" {
 			ui.themeKey = cfg.Options.TUI.Theme
-			ui.applyTheme(styles.ThemeForName(cfg.Options.TUI.Theme))
+			// set the styles directly: refreshStyles() needs the header,
+			// layout and sidebar, which are not constructed yet at New
+			*ui.com.Styles = styles.ThemeForName(cfg.Options.TUI.Theme)
 		} else {
 			ui.themeKey = styles.ThemeKeyForProvider(cfg.Models[config.SelectedModelTypeLarge].Provider)
 		}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -459,7 +459,12 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 	// Seed the active theme key from the large model provider so the
 	// first model selection can correctly skip a redundant theme swap.
 	if cfg := com.Config(); cfg != nil {
-		ui.themeKey = styles.ThemeKeyForProvider(cfg.Models[config.SelectedModelTypeLarge].Provider)
+		if cfg.Options != nil && cfg.Options.TUI != nil && cfg.Options.TUI.Theme != "" {
+			ui.themeKey = cfg.Options.TUI.Theme
+			ui.applyTheme(styles.ThemeForName(cfg.Options.TUI.Theme))
+		} else {
+			ui.themeKey = styles.ThemeKeyForProvider(cfg.Models[config.SelectedModelTypeLarge].Provider)
+		}
 	}
 
 	// Seed the yolo cache once at construction; afterwards it is kept
@@ -2001,6 +2006,14 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		if cmd := m.handleSelectModel(msg); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+	case dialog.ActionApplyTheme:
+		m.dialog.CloseFrontDialog()
+		m.applyThemeByName(msg.Name)
+		if err := m.com.Workspace.SetConfigField(config.ScopeGlobal, "options.tui.theme", msg.Name); err != nil {
+			cmds = append(cmds, util.ReportError(err))
+			break
+		}
+		cmds = append(cmds, util.ReportInfo(fmt.Sprintf("theme: %s", msg.Name)))
 	case dialog.ActionSelectReasoningEffort:
 		if m.isAgentBusy() {
 			cmds = append(cmds, util.ReportWarn("Agent is busy, please wait..."))
@@ -2383,6 +2396,11 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			return true
 		case key.Matches(msg, m.keyMap.Models):
 			if cmd := m.openModelsDialog(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+			return true
+		case key.Matches(msg, m.keyMap.Theme):
+			if cmd := m.openThemeDialog(); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
 			return true
@@ -4014,12 +4032,23 @@ func (m *UI) cacheSidebarLogo(width int) {
 // invalidating the markdown renderer cache and re-rendering the entire
 // transcript for no visible change.
 func (m *UI) applyThemeForProvider(providerID string) {
+	// a user-chosen theme wins over the provider-derived default
+	if cfg := m.com.Config(); cfg != nil && cfg.Options != nil && cfg.Options.TUI != nil && cfg.Options.TUI.Theme != "" {
+		return
+	}
 	key := styles.ThemeKeyForProvider(providerID)
 	if key == m.themeKey {
 		return
 	}
 	m.themeKey = key
 	m.applyTheme(styles.ThemeForProvider(providerID))
+}
+
+// applyThemeByName swaps to a named theme and records it as the active key,
+// so the theme menu and the provider-derivation agree on what is applied.
+func (m *UI) applyThemeByName(name string) {
+	m.themeKey = name
+	m.applyTheme(styles.ThemeForName(name))
 }
 
 // applyTheme replaces the active styles with the given theme, drops the
@@ -4314,6 +4343,10 @@ func (m *UI) openDialog(id string) tea.Cmd {
 		if cmd := m.openReasoningDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
+	case dialog.ThemeID:
+		if cmd := m.openThemeDialog(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
 	case dialog.NotificationsID:
 		if cmd := m.openNotificationsDialog(); cmd != nil {
 			cmds = append(cmds, cmd)
@@ -4404,6 +4437,27 @@ func (m *UI) openReasoningDialog() tea.Cmd {
 	}
 
 	m.dialog.OpenDialog(reasoningDialog)
+	return nil
+}
+
+// openThemeDialog opens the theme picker dialog, marking the active theme.
+func (m *UI) openThemeDialog() tea.Cmd {
+	if m.dialog.ContainsDialog(dialog.ThemeID) {
+		m.dialog.BringToFront(dialog.ThemeID)
+		return nil
+	}
+
+	current := ""
+	if cfg := m.com.Config(); cfg != nil && cfg.Options != nil && cfg.Options.TUI != nil {
+		current = cfg.Options.TUI.Theme
+	}
+
+	themeDialog, err := dialog.NewTheme(m.com, current)
+	if err != nil {
+		return util.ReportError(err)
+	}
+
+	m.dialog.OpenDialog(themeDialog)
 	return nil
 }
 

--- a/internal/ui/styles/themes.go
+++ b/internal/ui/styles/themes.go
@@ -1,6 +1,8 @@
 package styles
 
 import (
+	"image/color"
+
 	"github.com/charmbracelet/x/exp/charmtone"
 )
 
@@ -113,4 +115,106 @@ func CharmtonePantera() Styles {
 // HypercrushObsidiana returns the Hypercrush dark theme.
 func HypercrushObsidiana() Styles {
 	return CharmtonePantera()
+}
+
+// ThemeNames returns the selectable theme ids, in menu order.
+func ThemeNames() []string {
+	return []string{ThemeCharmtone, ThemeHyper, ThemeDyadMapper}
+}
+
+// Theme ids.
+const (
+	ThemeCharmtone  = "charmtone"
+	ThemeHyper      = "hyper"
+	ThemeDyadMapper = "dyad-mapper"
+)
+
+// ThemeForName returns the Styles for a theme id, defaulting to
+// CharmtonePantera for unknown or empty ids.
+func ThemeForName(name string) Styles {
+	switch name {
+	case ThemeHyper:
+		return HypercrushObsidiana()
+	case ThemeDyadMapper:
+		return DyadMapper()
+	default:
+		return CharmtonePantera()
+	}
+}
+
+// DyadMapper returns the dyad-mapper theme: a soft, low-glare navy palette
+// made for sensitive eyes — built for Peter Lodri, blue eyes first, but
+// shared because sight is a gift. Dark desaturated blues, no pure white,
+// no pure black, every accent muted a step down from saturated.
+func DyadMapper() Styles {
+	navy := color.RGBA{R: 0x0B, G: 0x15, B: 0x26, A: 0xFF}
+	navy1 := color.RGBA{R: 0x10, G: 0x1D, B: 0x33, A: 0xFF}
+	navy2 := color.RGBA{R: 0x15, G: 0x26, B: 0x3F, A: 0xFF}
+	navy3 := color.RGBA{R: 0x1B, G: 0x30, B: 0x4F, A: 0xFF}
+	ice := color.RGBA{R: 0xE3, G: 0xEC, B: 0xF7, A: 0xFF}
+	ice1 := color.RGBA{R: 0xA8, G: 0xBB, B: 0xD4, A: 0xFF}
+	ice2 := color.RGBA{R: 0x8A, G: 0xA0, B: 0xBD, A: 0xFF}
+	ice3 := color.RGBA{R: 0x6B, G: 0x80, B: 0x9C, A: 0xFF}
+	azure := color.RGBA{R: 0x7C, G: 0xB8, B: 0xFF, A: 0xFF}
+	periwinkle := color.RGBA{R: 0x9D, G: 0xB4, B: 0xFF, A: 0xFF}
+	cyan := color.RGBA{R: 0x5E, G: 0xE0, B: 0xE6, A: 0xFF}
+	softGreen := color.RGBA{R: 0x8F, G: 0xE0, B: 0xA8, A: 0xFF}
+	softAmber := color.RGBA{R: 0xFF, G: 0xC8, B: 0x6B, A: 0xFF}
+	softCoral := color.RGBA{R: 0xFF, G: 0x8A, B: 0x80, A: 0xFF}
+	softRose := color.RGBA{R: 0xFF, G: 0x9E, B: 0x9E, A: 0xFF}
+	softLilac := color.RGBA{R: 0xB0, G: 0xB8, B: 0xFF, A: 0xFF}
+
+	s := quickStyle(quickStyleOpts{
+		primary:   azure,
+		secondary: periwinkle,
+		accent:    cyan,
+		keyword:   softLilac,
+
+		fgBase:       ice,
+		fgMoreSubtle: ice1,
+		fgSubtle:     ice2,
+		fgMostSubtle: ice3,
+
+		onPrimary: navy,
+
+		bgBase:         navy,
+		bgLeastVisible: navy1,
+		bgLessVisible:  navy2,
+		bgMostVisible:  navy3,
+
+		separator: navy2,
+
+		destructive:       softRose,
+		error:             softCoral,
+		warningSubtle:     color.RGBA{R: 0xFF, G: 0xD9, B: 0xA0, A: 0xFF},
+		warning:           softAmber,
+		attention:         color.RGBA{R: 0xFF, G: 0xB8, B: 0x8A, A: 0xFF},
+		busy:              softGreen,
+		info:              azure,
+		infoMoreSubtle:    navy3,
+		infoMostSubtle:    navy2,
+		success:           softGreen,
+		successMoreSubtle: navy3,
+		successMostSubtle: navy2,
+
+		// ANSI 16-color remap — soft versions, no glare
+		ansiBlack:         navy,
+		ansiRed:           softCoral,
+		ansiGreen:         softGreen,
+		ansiYellow:        softAmber,
+		ansiBlue:          azure,
+		ansiMagenta:       periwinkle,
+		ansiCyan:          cyan,
+		ansiWhite:         ice1,
+		ansiBrightBlack:   navy3,
+		ansiBrightRed:     softRose,
+		ansiBrightGreen:   color.RGBA{R: 0xB9, G: 0xEE, B: 0xC9, A: 0xFF},
+		ansiBrightYellow:  color.RGBA{R: 0xFF, G: 0xDE, B: 0xA0, A: 0xFF},
+		ansiBrightBlue:    color.RGBA{R: 0xA6, G: 0xCE, B: 0xFF, A: 0xFF},
+		ansiBrightMagenta: color.RGBA{R: 0xBF, G: 0xCC, B: 0xFF, A: 0xFF},
+		ansiBrightCyan:    color.RGBA{R: 0x9B, G: 0xEF, B: 0xF2, A: 0xFF},
+		ansiBrightWhite:   ice,
+	})
+
+	return s
 }


### PR DESCRIPTION
## The dyad-mapper theme

A soft, low-glare **navy** palette made for sensitive eyes — built for Peter Lodri, blue eyes first, but shared because sight is a gift:

- dark desaturated blues, **no pure white, no pure black**
- every accent muted a step down from saturated (soft azure primary, soft cyan accent, soft green/amber/coral statuses)
- ANSI 16 remap in the same soft register, so bang-mode shell output doesn't glare

## The theme menu

There was no way to choose a theme — the active one was derived from the selected provider. Now:

- a **Theme dialog** (filterable picker) lists every theme and marks the active one
- a **Theme menu point** in the commands dialog + **ctrl+t**
- selecting applies the theme immediately and persists it to `options.tui.theme`
- a user-chosen theme wins over the provider-derived default
- config: `TUIOptions.Theme` (`charmtone` | `hyper` | `dyad-mapper`)

## Tests

`TestThemeDialogListsAllThemes` (every theme listed, active marked) and `TestDyadMapperIsARealTheme` (builds a complete Styles, selectable by name).