### PR TITLE
fix: send tool definitions on summarization for Bedrock/litellm models

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -177,6 +177,7 @@ type sessionAgent struct {
 	sessions             session.Service
 	messages             message.Service
 	disableAutoSummarize bool
+	summarizeWithTools   bool
 	isYolo               bool
 	notify               pubsub.Publisher[notify.Notification]
 	runComplete          pubsub.Publisher[notify.RunComplete]
@@ -229,6 +230,7 @@ type SessionAgentOptions struct {
 	SystemPrompt         string
 	IsSubAgent           bool
 	DisableAutoSummarize bool
+	SummarizeWithTools   bool
 	IsYolo               bool
 	Sessions             session.Service
 	Messages             message.Service
@@ -249,6 +251,7 @@ func NewSessionAgent(
 		sessions:             opts.Sessions,
 		messages:             opts.Messages,
 		disableAutoSummarize: opts.DisableAutoSummarize,
+		summarizeWithTools:   opts.SummarizeWithTools,
 		tools:                csync.NewSliceFrom(opts.Tools),
 		isYolo:               opts.IsYolo,
 		notify:               opts.Notify,
@@ -1360,11 +1363,14 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 			slog.Error("Failed to flush pending message updates after summarize", "error", flushErr)
 		}
 	}()
-
+	agentOps := []fantasy.AgentOption{fantasy.WithSystemPrompt(string(summaryPrompt)), fantasy.WithUserAgent(userAgent)}
+	if a.summarizeWithTools {
+		toolChoiceNone := fantasy.ToolChoiceNone
+		agentOps = append(agentOps, fantasy.WithTools(a.tools.Copy()...), fantasy.WithToolChoice(toolChoiceNone))
+	}
 	agent := fantasy.NewAgent(
 		largeModel.Model,
-		fantasy.WithSystemPrompt(string(summaryPrompt)),
-		fantasy.WithUserAgent(userAgent),
+		agentOps...,
 	)
 	summaryMessage, err := a.messages.Create(ctx, sessionID, message.CreateMessageParams{
 		Role:             message.Assistant,

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -635,6 +635,7 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		SystemPrompt:         "",
 		IsSubAgent:           isSubAgent,
 		DisableAutoSummarize: c.cfg.Config().Options.DisableAutoSummarize,
+		SummarizeWithTools:   c.cfg.Config().Options.SummarizeWithTools,
 		IsYolo:               c.permissions.SkipRequests(),
 		Sessions:             c.sessions,
 		Messages:             c.messages,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -319,6 +319,7 @@ type Options struct {
 	Debug                bool        `json:"debug,omitempty" jsonschema:"description=Enable debug logging,default=false"`
 	DebugLSP             bool        `json:"debug_lsp,omitempty" jsonschema:"description=Enable debug logging for LSP servers,default=false"`
 	DisableAutoSummarize bool        `json:"disable_auto_summarize,omitempty" jsonschema:"description=Disable automatic conversation summarization,default=false"`
+	SummarizeWithTools   bool        `json:"summarize_with_tools,omitempty" jsonschema:"description=Send tool definitions on summarization requests. This is required to enable summarization for Bedrock/litellm hosted models that will reject tool-call history without a tools param.,default=false"`
 	// DataDirectory is where Crush keeps per-project state such as
 	// the SQLite database and workspace overrides. Relative paths are
 	// resolved against the working directory; absolute paths are used

--- a/internal/shellconfig/options.go
+++ b/internal/shellconfig/options.go
@@ -187,6 +187,7 @@ var optionSpecs = map[string]optionSpec{
 	// Boolean fields exposed positively but stored as their negation.
 	"metrics":              {jsonKey: "disable_metrics", kind: optBool, inverted: true},
 	"auto-summarize":       {jsonKey: "disable_auto_summarize", kind: optBool, inverted: true},
+	"summarize-with-tools": {jsonKey: "summarize_with_tools", kind: optBool},
 	"provider-auto-update": {jsonKey: "disable_provider_auto_update", kind: optBool, inverted: true},
 	"default-providers":    {jsonKey: "disable_default_providers", kind: optBool, inverted: true},
 


### PR DESCRIPTION
## What

Adds a `summarize_with_tools` option that attaches the current tool
definitions (with tool choice set to none) to summarization requests.
Available as a config key and a `crushrc` builtin. Defaults to off, so
existing behavior is unchanged.

## Why

Bedrock and litellm-hosted models reject a request when the message
history contains tool calls but the request itself carries no `tools`
parameter. Summarization requests never sent tools, so summarizing a
session that had used tools failed outright on those providers. Turning
this option on satisfies the provider requirement while tool choice
none keeps the model from actually calling anything during the summary.

## Notes

- Off by default; only users on Bedrock/litellm need to enable it.
- `schema.json` is regenerated automatically on merge to main, so it is
  intentionally not updated here.