### PR TITLE
session picker: add mouse support

### DIFF
--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -2,7 +2,9 @@ package dialog
 
 import (
 	"context"
+	"image"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
@@ -18,6 +20,8 @@ import (
 
 // SessionsID is the identifier for the session selector dialog.
 const SessionsID = "session"
+
+const sessionDoubleClickThreshold = 400 * time.Millisecond
 
 type sessionsMode uint8
 
@@ -37,7 +41,11 @@ type Session struct {
 	selectedSessionInx int
 	sessions           []session.Session
 
-	sessionsMode sessionsMode
+	sessionsMode  sessionsMode
+	bodyArea      image.Rectangle
+	mouseScrolled bool
+	lastClickTime time.Time
+	lastClickID   string
 
 	keyMap struct {
 		Select        key.Binding
@@ -217,8 +225,49 @@ func (s *Session) HandleMsg(msg tea.Msg) Action {
 				return ActionCmd{cmd}
 			}
 		}
+	case common.CoalescedWheelMsg:
+		if image.Pt(msg.Mouse.X, msg.Mouse.Y).In(s.sessionListArea()) {
+			s.list.ScrollBy(int(msg.DeltaY))
+			s.mouseScrolled = true
+		}
+	case tea.MouseClickMsg:
+		return s.handleMouseClick(msg)
 	}
 	return nil
+}
+
+func (s *Session) handleMouseClick(msg tea.MouseClickMsg) Action {
+	if msg.Button != tea.MouseLeft || s.sessionsMode != sessionsModeNormal {
+		s.resetMouseClick()
+		return nil
+	}
+	area := s.sessionListArea()
+	area.Max.X = min(area.Max.X, area.Min.X+s.list.Width())
+	point := image.Pt(msg.X, msg.Y)
+	if !point.In(area) {
+		s.resetMouseClick()
+		return nil
+	}
+	index, _ := s.list.ItemIndexAtPosition(point.X-area.Min.X, point.Y-area.Min.Y)
+	if index < 0 {
+		s.resetMouseClick()
+		return nil
+	}
+	sessionItem := s.list.ItemAt(index).(*SessionItem)
+	now := time.Now()
+	if s.lastClickID == sessionItem.ID() && now.Sub(s.lastClickTime) <= sessionDoubleClickThreshold {
+		s.resetMouseClick()
+		return ActionSelectSession{sessionItem.Session}
+	}
+	s.lastClickTime = now
+	s.lastClickID = sessionItem.ID()
+	s.list.SetSelected(index)
+	return nil
+}
+
+func (s *Session) resetMouseClick() {
+	s.lastClickTime = time.Time{}
+	s.lastClickID = ""
 }
 
 // Cursor returns the cursor position relative to the dialog.
@@ -229,6 +278,7 @@ func (s *Session) Cursor() *tea.Cursor {
 // Draw implements [Dialog].
 func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	t := s.com.Styles
+	s.bodyArea = image.Rectangle{}
 	width := max(0, min(defaultDialogMaxWidth, area.Dx()-t.Dialog.View.GetHorizontalBorderSize()))
 	height := max(0, min(defaultDialogHeight, area.Dy()-t.Dialog.View.GetVerticalBorderSize()))
 	innerWidth := width - t.Dialog.View.GetHorizontalFrameSize()
@@ -242,7 +292,7 @@ func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	start, end := s.list.VisibleItemIndices()
 
 	// if selected index is outside visible range, scroll to it
-	if s.selectedSessionInx < start || s.selectedSessionInx > end {
+	if !s.mouseScrolled && (s.selectedSessionInx < start || s.selectedSessionInx > end) {
 		s.list.ScrollToSelected()
 	}
 
@@ -306,15 +356,59 @@ func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 		cur = s.Cursor()
 		rc.AddPart(inputView)
 	}
-	listView := t.Dialog.List.Height(s.list.Height()).Render(s.list.Render())
-	listView = joinScrollbar(t, listView, listHeight, listTotalHeight, listHeight, s.list.Offset())
-	rc.AddPart(listView)
+	bodyView := t.Dialog.List.Height(s.list.Height()).Render(s.list.Render())
+	bodyView = joinScrollbar(t, bodyView, listHeight, listTotalHeight, listHeight, s.list.Offset())
+	rc.AddPart(bodyView)
 	rc.Help = renderDialogHelp(t, &s.help, s, innerWidth)
 
 	view := rc.Render()
+	s.updateSessionListArea(area, view, bodyView, rc.Help, rc.ViewStyle, t.Dialog.List, innerWidth, listHeight)
 
 	DrawCenterCursor(scr, area, view, cur)
 	return cur
+}
+
+func (s *Session) updateSessionListArea(
+	area uv.Rectangle,
+	view string,
+	bodyView string,
+	helpView string,
+	viewStyle lipgloss.Style,
+	bodyStyle lipgloss.Style,
+	bodyWidth int,
+	bodyHeight int,
+) {
+	viewWidth, viewHeight := lipgloss.Size(view)
+	dialogArea := common.CenterRect(area, min(viewWidth, area.Dx()), min(viewHeight, area.Dy()))
+	bodyViewTop := dialogArea.Max.Y -
+		viewStyle.GetMarginBottom() -
+		viewStyle.GetBorderBottomSize() -
+		viewStyle.GetPaddingBottom() -
+		lipgloss.Height(helpView) -
+		lipgloss.Height(bodyView)
+	bodyMin := image.Pt(
+		dialogArea.Min.X+
+			viewStyle.GetMarginLeft()+
+			viewStyle.GetBorderLeftSize()+
+			viewStyle.GetPaddingLeft()+
+			bodyStyle.GetMarginLeft()+
+			bodyStyle.GetBorderLeftSize()+
+			bodyStyle.GetPaddingLeft(),
+		bodyViewTop+
+			bodyStyle.GetMarginTop()+
+			bodyStyle.GetBorderTopSize()+
+			bodyStyle.GetPaddingTop(),
+	)
+	s.bodyArea = image.Rect(
+		bodyMin.X,
+		bodyMin.Y,
+		bodyMin.X+bodyWidth,
+		bodyMin.Y+bodyHeight,
+	).Intersect(dialogArea).Intersect(area)
+}
+
+func (s *Session) sessionListArea() image.Rectangle {
+	return s.bodyArea
 }
 
 func (s *Session) selectedSessionItem() *SessionItem {

--- a/internal/ui/dialog/sessions_mouse_test.go
+++ b/internal/ui/dialog/sessions_mouse_test.go
@@ -1,0 +1,233 @@
+package dialog
+
+import (
+	"context"
+	"fmt"
+	"image"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/stretchr/testify/require"
+)
+
+type sessionMouseWorkspace struct {
+	workspace.Workspace
+	sessions []session.Session
+}
+
+func (w *sessionMouseWorkspace) ListSessions(context.Context) ([]session.Session, error) {
+	return w.sessions, nil
+}
+
+func (w *sessionMouseWorkspace) AgentIsReady() bool {
+	return false
+}
+
+func newSessionMouseDialog(t *testing.T, sessions []session.Session, selectedSessionID string) *Session {
+	t.Helper()
+
+	sty := styles.CharmtonePantera()
+	dialog, err := NewSessions(&common.Common{
+		Workspace: &sessionMouseWorkspace{sessions: sessions},
+		Styles:    &sty,
+	}, selectedSessionID)
+	require.NoError(t, err)
+	return dialog
+}
+
+func TestSessionMouseWheelScrollsListUnderPointer(t *testing.T) {
+	t.Parallel()
+
+	sessions := make([]session.Session, 40)
+	for i := range sessions {
+		sessions[i] = session.Session{
+			ID:    fmt.Sprintf("s%02d", i),
+			Title: fmt.Sprintf("Session %02d", i),
+		}
+	}
+	dialog := newSessionMouseDialog(t, sessions, "s00")
+
+	scr := uv.NewScreenBuffer(80, 30)
+	dialog.Draw(scr, image.Rect(0, 0, 80, 30))
+	require.Zero(t, dialog.list.Offset())
+
+	dialog.HandleMsg(common.CoalescedWheelMsg{
+		Mouse:  tea.Mouse{X: 10, Y: 10},
+		DeltaY: 3,
+	})
+	require.Equal(t, 3, dialog.list.Offset())
+	require.Equal(t, "s00", dialog.selectedSessionItem().ID())
+
+	// Rendering must preserve the offset chosen by the wheel event.
+	dialog.Draw(scr, image.Rect(0, 0, 80, 30))
+	require.Equal(t, 3, dialog.list.Offset())
+
+	// Wheel movement outside the rendered list has no effect.
+	dialog.HandleMsg(common.CoalescedWheelMsg{
+		Mouse:  tea.Mouse{X: 0, Y: 0},
+		DeltaY: 3,
+	})
+	require.Equal(t, 3, dialog.list.Offset())
+}
+
+func TestSessionMouseClickHighlightsEntry(t *testing.T) {
+	t.Parallel()
+
+	dialog := newSessionMouseDialog(t, []session.Session{
+		{ID: "s1", Title: "First"},
+		{ID: "s2", Title: "Second"},
+		{ID: "s3", Title: "Third"},
+	}, "s1")
+	scr := uv.NewScreenBuffer(80, 30)
+	dialog.Draw(scr, image.Rect(0, 0, 80, 30))
+	listArea := dialog.sessionListArea()
+	require.False(t, listArea.Empty())
+
+	action := dialog.HandleMsg(tea.MouseClickMsg(tea.Mouse{
+		X:      listArea.Min.X,
+		Y:      listArea.Min.Y + 1,
+		Button: tea.MouseLeft,
+	}))
+
+	require.Nil(t, action)
+	require.Equal(t, "s2", dialog.selectedSessionItem().ID())
+}
+
+func TestSessionMouseDoubleClickOpensEntryLikeEnter(t *testing.T) {
+	t.Parallel()
+
+	dialog := newSessionMouseDialog(t, []session.Session{
+		{ID: "s1", Title: "First"},
+		{ID: "s2", Title: "Second"},
+	}, "s1")
+	scr := uv.NewScreenBuffer(80, 30)
+	dialog.Draw(scr, image.Rect(0, 0, 80, 30))
+	listArea := dialog.sessionListArea()
+	click := tea.MouseClickMsg(tea.Mouse{
+		X:      listArea.Min.X,
+		Y:      listArea.Min.Y + 1,
+		Button: tea.MouseLeft,
+	})
+
+	require.Nil(t, dialog.HandleMsg(click))
+	enterAction := dialog.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	doubleClickAction := dialog.HandleMsg(click)
+
+	require.Equal(t, enterAction, doubleClickAction)
+	selected, ok := doubleClickAction.(ActionSelectSession)
+	require.True(t, ok)
+	require.Equal(t, "s2", selected.Session.ID)
+}
+
+func TestSessionMouseDoubleClickExpires(t *testing.T) {
+	t.Parallel()
+
+	dialog := newSessionMouseDialog(t, []session.Session{
+		{ID: "s1", Title: "First"},
+		{ID: "s2", Title: "Second"},
+	}, "s1")
+	scr := uv.NewScreenBuffer(80, 30)
+	dialog.Draw(scr, image.Rect(0, 0, 80, 30))
+	listArea := dialog.sessionListArea()
+	click := tea.MouseClickMsg(tea.Mouse{
+		X:      listArea.Min.X,
+		Y:      listArea.Min.Y + 1,
+		Button: tea.MouseLeft,
+	})
+
+	require.Nil(t, dialog.HandleMsg(click))
+	dialog.lastClickTime = time.Now().Add(-sessionDoubleClickThreshold - time.Millisecond)
+	require.Nil(t, dialog.HandleMsg(click))
+	require.Equal(t, "s2", dialog.selectedSessionItem().ID())
+}
+
+func TestSessionMouseClickSelectsFirstVisibleEntryAfterScroll(t *testing.T) {
+	t.Parallel()
+
+	sessions := make([]session.Session, 40)
+	for i := range sessions {
+		sessions[i] = session.Session{
+			ID:    fmt.Sprintf("s%02d", i),
+			Title: fmt.Sprintf("Session %02d", i),
+		}
+	}
+	dialog := newSessionMouseDialog(t, sessions, "s00")
+	scr := uv.NewScreenBuffer(80, 30)
+	dialog.Draw(scr, image.Rect(0, 0, 80, 30))
+	listArea := dialog.sessionListArea()
+	dialog.HandleMsg(common.CoalescedWheelMsg{
+		Mouse:  tea.Mouse{X: listArea.Min.X, Y: listArea.Min.Y},
+		DeltaY: 3,
+	})
+	require.Equal(t, 3, dialog.list.Offset())
+
+	action := dialog.HandleMsg(tea.MouseClickMsg(tea.Mouse{
+		X:      listArea.Min.X,
+		Y:      listArea.Min.Y,
+		Button: tea.MouseLeft,
+	}))
+
+	require.Nil(t, action)
+	require.Equal(t, "s03", dialog.selectedSessionItem().ID())
+}
+
+func TestSessionMouseClickIgnoresUnsupportedClicks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		point  func(image.Rectangle) image.Point
+		button tea.MouseButton
+		mode   sessionsMode
+	}{
+		{
+			name:   "outside list",
+			point:  func(image.Rectangle) image.Point { return image.Pt(0, 0) },
+			button: tea.MouseLeft,
+			mode:   sessionsModeNormal,
+		},
+		{
+			name:   "right button",
+			point:  func(area image.Rectangle) image.Point { return image.Pt(area.Min.X, area.Min.Y+1) },
+			button: tea.MouseRight,
+			mode:   sessionsModeNormal,
+		},
+		{
+			name:   "deleting mode",
+			point:  func(area image.Rectangle) image.Point { return image.Pt(area.Min.X, area.Min.Y+1) },
+			button: tea.MouseLeft,
+			mode:   sessionsModeDeleting,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dialog := newSessionMouseDialog(t, []session.Session{
+				{ID: "s1", Title: "First"},
+				{ID: "s2", Title: "Second"},
+			}, "s1")
+			scr := uv.NewScreenBuffer(80, 30)
+			dialog.Draw(scr, image.Rect(0, 0, 80, 30))
+			dialog.sessionsMode = tt.mode
+			point := tt.point(dialog.sessionListArea())
+
+			action := dialog.HandleMsg(tea.MouseClickMsg(tea.Mouse{
+				X:      point.X,
+				Y:      point.Y,
+				Button: tt.button,
+			}))
+
+			require.Nil(t, action)
+			require.Equal(t, "s1", dialog.selectedSessionItem().ID())
+		})
+	}
+}
+
+var _ workspace.Workspace = (*sessionMouseWorkspace)(nil)

--- a/internal/ui/model/dialog_mouse_test.go
+++ b/internal/ui/model/dialog_mouse_test.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/stretchr/testify/require"
+)
+
+type dialogMouseActionMsg struct{}
+
+type mouseActionDialog struct{}
+
+func (*mouseActionDialog) ID() string {
+	return "mouse-action"
+}
+
+func (*mouseActionDialog) HandleMsg(msg tea.Msg) dialog.Action {
+	if _, ok := msg.(tea.MouseClickMsg); !ok {
+		return nil
+	}
+	return dialog.ActionCmd{Cmd: func() tea.Msg { return dialogMouseActionMsg{} }}
+}
+
+func (*mouseActionDialog) Draw(uv.Screen, uv.Rectangle) *tea.Cursor {
+	return nil
+}
+
+func TestMouseClickExecutesDialogActionCommand(t *testing.T) {
+	t.Parallel()
+
+	m := newTestUI()
+	m.dialog = dialog.NewOverlay()
+	m.dialog.OpenDialog(new(mouseActionDialog))
+
+	_, cmd := m.Update(tea.MouseClickMsg(tea.Mouse{Button: tea.MouseLeft}))
+	require.NotNil(t, cmd)
+	require.IsType(t, dialogMouseActionMsg{}, cmd())
+}
+
+var _ dialog.Dialog = (*mouseActionDialog)(nil)

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1011,7 +1011,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.MouseClickMsg:
 		// Pass mouse events to dialogs first if any are open.
 		if m.dialog.HasDialogs() {
-			m.dialog.Update(msg)
+			if cmd := m.handleDialogMsg(msg); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
 			return m, tea.Batch(cmds...)
 		}
 


### PR DESCRIPTION
Should support scrolling, single-click to highlight, and double-click to open. Highlight isn't very meaningful right now so requiring an "extra" click to open feels weird, but it'll soon mean something and using single-click for open now, then later changing it to highlight would be worse imo.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>