### PR TITLE
docs: add MindsHub custom provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,33 @@ model add deepseek/deepseek-chat \
   --price-cache-hit 0.07
 ```
 
+[MindsHub](https://mindshub.ai) is an OpenAI-compatible inference gateway
+that puts Claude, GPT, Kimi, DeepSeek, and other catalog models behind one
+API key and one bill. Don't forget to set `MINDSHUB_API_KEY` in your
+environment.
+
+```bash
+provider add mindshub --type openai-compat \
+  --base-url "https://api.mindshub.ai/v1" \
+  --api-key "$MINDSHUB_API_KEY"
+
+model add mindshub/sonnet \
+  --name "Claude Sonnet 5" \
+  --context-window 200000 \
+  --can-reason true \
+  --supports-images true \
+  --price-input 2 \
+  --price-output 10 \
+  --price-cache-create 2.5 \
+  --price-cache-hit 0.2
+```
+
+Any other alias from MindsHub's [model catalog](https://docs.mindshub.ai/inference/models)
+(`opus`, `kimi`, `deepseek`, `gpt`, `gpt-codex`, `gemini`, and more) works the
+same way — register it with another `model add mindshub/<alias>` line. See
+the [MindsHub inference docs](https://docs.mindshub.ai/inference/) for
+current aliases and pricing.
+
 #### Anthropic-Compatible APIs
 
 Custom Anthropic-compatible providers follow this format:

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -168,6 +168,21 @@ provider add deepseek \
   --api-key "${DEEPSEEK_API_KEY:?set DEEPSEEK_API_KEY}"
 ```
 
+[MindsHub](https://mindshub.ai) fronts multiple vendors' models (Claude,
+GPT, Kimi, DeepSeek, and more) behind one OpenAI-compatible API and key:
+
+```bash
+provider add mindshub \
+  --type openai-compat \
+  --base-url "https://api.mindshub.ai/v1" \
+  --api-key "${MINDSHUB_API_KEY:?set MINDSHUB_API_KEY}"
+
+model add mindshub/sonnet --name "Claude Sonnet 5" --context-window 200000
+```
+
+See the [MindsHub inference docs](https://docs.mindshub.ai/inference/) for
+the full catalog of aliases and pricing.
+
 Headers whose value resolves to the empty string (an unset `$VAR`, a
 `$(...)` that prints nothing, or a literal `""`) are dropped from the
 outgoing request. This makes env-gated headers safe:


### PR DESCRIPTION
## Summary

- Adds a ready-to-use `provider add` / `model add` example for [MindsHub](https://mindshub.ai) next to the existing DeepSeek OpenAI-compatible example, in both `README.md` (Custom Providers section) and `docs/config/README.md` (`provider add` reference).
- MindsHub is an OpenAI/Anthropic-compatible inference gateway that puts Claude, GPT, Kimi, DeepSeek, and other catalog models behind one API key and bill. See https://docs.mindshub.ai/inference/ for the full request/response reference and model catalog.

## Why docs-only

I looked into whether this warranted a code change (a curated built-in provider entry) before writing anything. Crush's own source tree has no committed/embedded provider catalog — the curated list (`internal/providers/configs/*.json`, one file per named provider) lives entirely in the separate [`charmbracelet/catwalk`](https://github.com/charmbracelet/catwalk) module that Crush depends on and fetches from at runtime (with a build-time embedded fallback baked into that module, not this repo). `ProviderConfig.Type` in `internal/config/config.go` only enumerates protocol *types* (`openai`, `openai-compat`, `anthropic`, `bedrock`, `google-vertex`, etc.), not individual vendor names, and MindsHub is fully served by the existing `openai-compat` type with zero code changes — the same mechanism the existing DeepSeek example demonstrates.

So the only meaningful, correct addition to *this* repo is a documented example that saves users from re-deriving the same `provider add`/`model add` invocation. (A first-class catalog entry with default models/pricing baked into the "embedded" fallback would be a separate PR against `charmbracelet/catwalk`.)

## Values used

Pricing/context-window figures come straight from MindsHub's docs:
- Price list (per 1M tokens) for the `sonnet` alias (Claude Sonnet 5): [billing](https://docs.mindshub.ai/inference/billing#price-list).
- `--context-window 200000`: MindsHub's own docs note this is "conservative for every current catalog model" ([VS Code guide](https://docs.mindshub.ai/inference/vscode)).

## Test plan

- [x] Docs-only change; verified rendering by inspecting the diff and cross-checking against the existing DeepSeek/custom-anthropic examples in the same file for flag/style consistency.
- [x] No Go files touched, so `go build` / `go test` / `golangci-lint` are unaffected by this change.

## Disclosure

I'm affiliated with MindsHub. Flagging that up front since this adds a documentation example for our own product, even though the change itself is a small, generic doc addition following the repo's existing DeepSeek example pattern.