### PR TITLE
resume: compact resume banner option

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -530,6 +530,10 @@ Available Keys:
   transparent bool              use the terminal background
   scrollbar string              control chat scrollbar visibility: default,
                                 always, or never
+  exit-banner default|compact|none
+                                control the post-session banner: default shows
+                                the Crush logo, compact shows only the resume
+                                hint, none hides it entirely
   completions-max-depth int     maximum directory depth shown by completions
   completions-max-items int     maximum items returned to completions
 ```
@@ -539,6 +543,7 @@ option ui compact true
 option ui diff unified
 option ui transparent true
 option ui scrollbar always
+option ui exit-banner compact
 option ui completions-max-depth 4
 option ui completions-max-items 200
 ```

--- a/internal/agent/tools/crush_info.go
+++ b/internal/agent/tools/crush_info.go
@@ -1,6 +1,7 @@
 package tools
 
 import (
+	"cmp"
 	"context"
 	_ "embed"
 	"fmt"
@@ -400,24 +401,19 @@ func writeOptions(b *strings.Builder, cfg *config.ConfigStore) {
 	opts = append(opts, kv{"auto_summarize", fmt.Sprintf("%v", autoSummarize)})
 
 	if c.Options.TUI != nil {
-		compactMode := c.Options.TUI.CompactMode
-		diffMode := c.Options.TUI.DiffMode
-		if diffMode == "" {
-			diffMode = "unified"
+		opts = append(opts, kv{"compact_mode", fmt.Sprintf("%v", c.Options.TUI.CompactMode)})
+		// An empty DiffMode means "follow the terminal width"; report that
+		// rather than an empty value.
+		opts = append(opts, kv{"diff_mode", cmp.Or(c.Options.TUI.DiffMode, "auto")})
+		opts = append(opts, kv{"scrollbar", c.Options.TUI.Scrollbar})
+		opts = append(opts, kv{"exit_banner", string(c.Options.TUI.ExitBanner)})
+		opts = append(opts, kv{"transparent", fmt.Sprintf("%v", c.Options.TUI.IsTransparent())})
+		// Report the completion limits only once the user has pinned them;
+		// see Completions.Limits for what zero means.
+		if depth, items := c.Options.TUI.Completions.Limits(); depth != 0 || items != 0 {
+			opts = append(opts, kv{"completions_max_depth", fmt.Sprintf("%d", depth)})
+			opts = append(opts, kv{"completions_max_items", fmt.Sprintf("%d", items)})
 		}
-		scrollbar := c.Options.TUI.Scrollbar
-		if scrollbar == "" {
-			scrollbar = config.ScrollbarDefault
-		}
-		exitBanner := c.Options.TUI.ExitBanner
-		if exitBanner == "" {
-			exitBanner = config.ExitBannerDefault
-		}
-
-		opts = append(opts, kv{"compact_mode", fmt.Sprintf("%v", compactMode)})
-		opts = append(opts, kv{"diff_mode", diffMode})
-		opts = append(opts, kv{"scrollbar", scrollbar})
-		opts = append(opts, kv{"exit_banner", string(exitBanner)})
 	}
 
 	slices.SortFunc(opts, func(a, b kv) int { return strings.Compare(a.key, b.key) })

--- a/internal/agent/tools/crush_info.go
+++ b/internal/agent/tools/crush_info.go
@@ -399,6 +399,27 @@ func writeOptions(b *strings.Builder, cfg *config.ConfigStore) {
 	autoSummarize := !c.Options.DisableAutoSummarize
 	opts = append(opts, kv{"auto_summarize", fmt.Sprintf("%v", autoSummarize)})
 
+	if c.Options.TUI != nil {
+		compactMode := c.Options.TUI.CompactMode
+		diffMode := c.Options.TUI.DiffMode
+		if diffMode == "" {
+			diffMode = "unified"
+		}
+		scrollbar := c.Options.TUI.Scrollbar
+		if scrollbar == "" {
+			scrollbar = config.ScrollbarDefault
+		}
+		exitBanner := c.Options.TUI.ExitBanner
+		if exitBanner == "" {
+			exitBanner = config.ExitBannerDefault
+		}
+
+		opts = append(opts, kv{"compact_mode", fmt.Sprintf("%v", compactMode)})
+		opts = append(opts, kv{"diff_mode", diffMode})
+		opts = append(opts, kv{"scrollbar", scrollbar})
+		opts = append(opts, kv{"exit_banner", string(exitBanner)})
+	}
+
 	slices.SortFunc(opts, func(a, b kv) int { return strings.Compare(a.key, b.key) })
 	b.WriteString("[options]\n")
 	for _, o := range opts {

--- a/internal/agent/tools/crush_info_test.go
+++ b/internal/agent/tools/crush_info_test.go
@@ -210,6 +210,49 @@ func TestCrushInfo_Options(t *testing.T) {
 	require.Contains(t, output, "debug = true")
 }
 
+func TestCrushInfo_TUIOptions(t *testing.T) {
+	t.Parallel()
+
+	transparent := true
+	depth, items := 3, 42
+	cfg := config.NewTestStore(&config.Config{
+		Providers: csync.NewMap[string, config.ProviderConfig](),
+		Options: &config.Options{
+			TUI: &config.TUIOptions{
+				CompactMode: true,
+				DiffMode:    config.DiffModeSplit,
+				Scrollbar:   config.ScrollbarNever,
+				ExitBanner:  config.ExitBannerCompact,
+				Transparent: &transparent,
+				Completions: config.Completions{MaxDepth: &depth, MaxItems: &items},
+			},
+		},
+	})
+
+	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	require.Contains(t, output, "compact_mode = true")
+	require.Contains(t, output, "diff_mode = split")
+	require.Contains(t, output, "scrollbar = never")
+	require.Contains(t, output, "exit_banner = compact")
+	require.Contains(t, output, "transparent = true")
+	require.Contains(t, output, "completions_max_depth = 3")
+	require.Contains(t, output, "completions_max_items = 42")
+}
+
+func TestCrushInfo_TUIOptionsUnpinnedCompletionsOmitted(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NewTestStore(&config.Config{
+		Providers: csync.NewMap[string, config.ProviderConfig](),
+		Options:   &config.Options{TUI: &config.TUIOptions{}},
+	})
+
+	output := buildCrushInfo(cfg, nil, nil, nil, nil)
+	require.Contains(t, output, "transparent = false")
+	require.NotContains(t, output, "completions_max_depth")
+	require.NotContains(t, output, "completions_max_items")
+}
+
 func TestCrushInfo_AutoSummarizeInversion(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -166,51 +166,81 @@ var heartbit = lipgloss.NewStyle().Foreground(charmtone.Dolly).SetString(`
            ▀▀▀▀▀▀
 `)
 
+// exitBannerFallbackWidth is used when stdout is not a terminal, so the
+// banner still wraps to something sane when output is piped or captured.
+const exitBannerFallbackWidth = 80
+
 // printSessionResume prints the session title and resume hint to stdout after
 // the TUI exits, so the user can resume the session with `crush -s <id>`.
 // Nothing is printed when there is no active session.
 func printSessionResume(model *ui.UI) {
-	out := colorprofile.NewWriter(os.Stderr, os.Environ())
-
-	t := styles.ThemeForProvider("")
-	crushLogo := logo.Render(t.Logo.GradCanvas, version.Version, true, logo.Opts{
-		FieldColor:   t.Logo.FieldColor,
-		TitleColorA:  t.Logo.TitleColorA,
-		TitleColorB:  t.Logo.TitleColorB,
-		CharmColor:   t.Logo.CharmColor,
-		VersionColor: t.Logo.VersionColor,
-		Hyper:        false,
-	})
+	banner := config.ExitBannerDefault
+	if cfg := model.Config(); cfg != nil && cfg.Options.TUI != nil && cfg.Options.TUI.ExitBanner != "" {
+		banner = cfg.Options.TUI.ExitBanner
+	}
+	if banner == config.ExitBannerNone {
+		return
+	}
 
 	sess := model.CurrentSession()
 	hasSession := sess != nil && sess.ID != ""
-
-	tw, _, _ := term.GetSize(os.Stdout.Fd())
-	style := lipgloss.NewStyle().Padding(1, 3)
-	contentWidth := tw - style.GetHorizontalFrameSize()
-
-	info := crushLogo +
-		"\nThanks for using Crush! " +
-		lipgloss.NewStyle().Width(contentWidth).Render(randomExitMessage())
-
-	if hasSession {
-		title := strings.ReplaceAll(sess.Title, "\n", " ")
-
-		labelWidth := lipgloss.Width("Session  ")
-		titleWidth := contentWidth - labelWidth
-		if titleWidth > 0 {
-			title = ansi.Truncate(title, titleWidth, "…")
-		}
-
-		hash := session.HashID(sess.ID)[:7]
-		sessionLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Session  ") + title
-		continueLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Continue ") + "crush -s " + hash
-		info += "\n\n" + sessionLine + "\n" + continueLine
+	// The compact banner is only the resume hint, so with no session there is
+	// nothing left to print and Crush exits silently.
+	if !banner.Full() && !hasSession {
+		return
 	}
 
-	body := style.Width(tw).Render(info)
+	style := lipgloss.NewStyle()
+	if banner.Full() {
+		style = style.Padding(1, 3)
+	}
 
-	fmt.Fprintln(out, body)
+	tw, _, _ := term.GetSize(os.Stdout.Fd())
+	if tw <= 0 {
+		tw = exitBannerFallbackWidth
+	}
+	contentWidth := tw - style.GetHorizontalFrameSize()
+
+	var info strings.Builder
+	if banner.Full() {
+		t := styles.ThemeForProvider("")
+		info.WriteString(logo.Render(t.Logo.GradCanvas, version.Version, true, logo.Opts{
+			FieldColor:   t.Logo.FieldColor,
+			TitleColorA:  t.Logo.TitleColorA,
+			TitleColorB:  t.Logo.TitleColorB,
+			CharmColor:   t.Logo.CharmColor,
+			VersionColor: t.Logo.VersionColor,
+			Hyper:        false,
+		}))
+		info.WriteString("\nThanks for using Crush! ")
+		info.WriteString(lipgloss.NewStyle().Width(contentWidth).Render(randomExitMessage()))
+	}
+	if hasSession {
+		if info.Len() > 0 {
+			info.WriteString("\n\n")
+		}
+		info.WriteString(sessionResumeLines(sess, contentWidth))
+	}
+
+	out := colorprofile.NewWriter(os.Stderr, os.Environ())
+	fmt.Fprintln(out, style.Render(info.String()))
+}
+
+// sessionResumeLines returns the "Session  <title>\nContinue crush -s <hash>"
+// pair used by the exit banner.
+func sessionResumeLines(sess *session.Session, contentWidth int) string {
+	title := strings.ReplaceAll(sess.Title, "\n", " ")
+
+	labelWidth := lipgloss.Width("Session  ")
+	titleWidth := contentWidth - labelWidth
+	if titleWidth > 0 {
+		title = ansi.Truncate(title, titleWidth, "…")
+	}
+
+	hash := session.HashID(sess.ID)[:7]
+	sessionLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Session  ") + title
+	continueLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Continue ") + "crush -s " + hash
+	return sessionLine + "\n" + continueLine
 }
 
 // copied from cobra:

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
-	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -38,9 +37,8 @@ import (
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/skills"
 	"github.com/charmbracelet/crush/internal/ui/common"
-	"github.com/charmbracelet/crush/internal/ui/logo"
+	"github.com/charmbracelet/crush/internal/ui/exitbanner"
 	ui "github.com/charmbracelet/crush/internal/ui/model"
-	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/charmbracelet/crush/internal/version"
 	"github.com/charmbracelet/crush/internal/workspace"
 	uv "github.com/charmbracelet/ultraviolet"
@@ -147,7 +145,11 @@ crush --continue
 			slog.Error("TUI run error", "error", err)
 			return errors.New("Crush crashed. If metrics are enabled, we were notified about it. If you'd like to report it, please copy the stacktrace above and open an issue at https://github.com/charmbracelet/crush/issues/new?template=bug.yml") //nolint:staticcheck
 		}
-		printSessionResume(model)
+		var banner config.ExitBanner
+		if cfg := com.Config(); cfg != nil {
+			banner = cfg.Options.TUI.ExitBanner
+		}
+		printSessionResume(model, banner)
 		return nil
 	},
 }
@@ -166,114 +168,21 @@ var heartbit = lipgloss.NewStyle().Foreground(charmtone.Dolly).SetString(`
            ▀▀▀▀▀▀
 `)
 
-// exitBannerFallbackWidth is used when stdout is not a terminal, so the
-// banner still wraps to something sane when output is piped or captured.
-const exitBannerFallbackWidth = 80
-
-// printSessionResume prints the session title and resume hint to stdout after
-// the TUI exits, so the user can resume the session with `crush -s <id>`.
-// Nothing is printed when there is no active session.
-func printSessionResume(model *ui.UI) {
-	banner := config.ExitBannerDefault
-	if cfg := model.Config(); cfg != nil && cfg.Options.TUI != nil && cfg.Options.TUI.ExitBanner != "" {
-		banner = cfg.Options.TUI.ExitBanner
-	}
-	if banner == config.ExitBannerNone {
-		return
-	}
-
-	sess := model.CurrentSession()
-	hasSession := sess != nil && sess.ID != ""
-	// The compact banner is only the resume hint, so with no session there is
-	// nothing left to print and Crush exits silently.
-	if !banner.Full() && !hasSession {
-		return
-	}
-
-	style := lipgloss.NewStyle()
-	if banner.Full() {
-		style = style.Padding(1, 3)
-	}
-
+// printSessionResume prints the exit banner after the TUI exits, including the
+// session title and the hint to resume it with `crush -s <id>`. The banner
+// style decides how much of that is shown; see config.ExitBanner.
+func printSessionResume(model *ui.UI, banner config.ExitBanner) {
 	tw, _, _ := term.GetSize(os.Stdout.Fd())
-	if tw <= 0 {
-		tw = exitBannerFallbackWidth
+	body := exitbanner.Render(banner, model.CurrentSession(), tw)
+	if body == "" {
+		return
 	}
-	contentWidth := tw - style.GetHorizontalFrameSize()
-
-	var info strings.Builder
-	if banner.Full() {
-		t := styles.ThemeForProvider("")
-		info.WriteString(logo.Render(t.Logo.GradCanvas, version.Version, true, logo.Opts{
-			FieldColor:   t.Logo.FieldColor,
-			TitleColorA:  t.Logo.TitleColorA,
-			TitleColorB:  t.Logo.TitleColorB,
-			CharmColor:   t.Logo.CharmColor,
-			VersionColor: t.Logo.VersionColor,
-			Hyper:        false,
-		}))
-		info.WriteString("\nThanks for using Crush! ")
-		info.WriteString(lipgloss.NewStyle().Width(contentWidth).Render(randomExitMessage()))
-	}
-	if hasSession {
-		if info.Len() > 0 {
-			info.WriteString("\n\n")
-		}
-		info.WriteString(sessionResumeLines(sess, contentWidth))
-	}
-
-	out := colorprofile.NewWriter(os.Stderr, os.Environ())
-	fmt.Fprintln(out, style.Render(info.String()))
-}
-
-// sessionResumeLines returns the "Session  <title>\nContinue crush -s <hash>"
-// pair used by the exit banner.
-func sessionResumeLines(sess *session.Session, contentWidth int) string {
-	title := strings.ReplaceAll(sess.Title, "\n", " ")
-
-	labelWidth := lipgloss.Width("Session  ")
-	titleWidth := contentWidth - labelWidth
-	if titleWidth > 0 {
-		title = ansi.Truncate(title, titleWidth, "…")
-	}
-
-	hash := session.HashID(sess.ID)[:7]
-	sessionLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Session  ") + title
-	continueLine := lipgloss.NewStyle().Foreground(charmtone.Charple).Render("Continue ") + "crush -s " + hash
-	return sessionLine + "\n" + continueLine
+	fmt.Fprintln(colorprofile.NewWriter(os.Stderr, os.Environ()), body)
 }
 
 // copied from cobra:
 const defaultVersionTemplate = `{{with .DisplayName}}{{printf "%s " .}}{{end}}{{printf "version %s" .Version}}
 `
-
-// randomExitMessage returns a random exit message.
-func randomExitMessage() string {
-	messages := []string{
-		"",
-		"See ya later.",
-		"You look great.",
-		"Have a gorgeous time.",
-		"Get some rest.",
-		"Come back soon.",
-		"You worked handsomely.",
-		"Time for a snack.",
-		"Who’s hungry?",
-		"That was fun.",
-		"See you at breakfast?",
-		"Time for a nap.",
-		"Who wants some spaghetti?",
-		"Take care of yourself.",
-		"Remember to hydrate.",
-		"Time for a swim?",
-		"You’re quite glamorous, you know.",
-		"Nice work.",
-		"You’re a sensation.",
-		"Where’s my eyeliner?",
-		"It’s tea time.",
-	}
-	return messages[rand.IntN(len(messages))]
-}
 
 func Execute() {
 	// FIXME: config.Load uses slog internally during provider resolution,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -278,6 +278,7 @@ type TUIOptions struct {
 	Completions Completions `json:"completions,omitzero" jsonschema:"description=Completions UI options"`
 	Transparent *bool       `json:"transparent,omitempty" jsonschema:"description=Enable transparent background for the TUI interface,default=false"`
 	Scrollbar   string      `json:"scrollbar,omitempty" jsonschema:"description=Chat scrollbar visibility,enum=default,enum=always,enum=never,default=default"`
+	ExitBanner  ExitBanner  `json:"exit_banner,omitempty" jsonschema:"description=Exit banner style after quitting Crush,enum=default,enum=compact,enum=none,default=default"`
 }
 
 // Completions defines options for the completions UI.
@@ -296,6 +297,20 @@ const (
 	ScrollbarAlways  = "always"  // Always show when content exceeds viewport
 	ScrollbarNever   = "never"   // Never show scrollbar
 )
+
+// ExitBanner selects what Crush prints after the TUI exits.
+type ExitBanner string
+
+const (
+	ExitBannerDefault ExitBanner = "default" // Full ASCII art logo with padding
+	ExitBannerCompact ExitBanner = "compact" // Session and resume lines only, no logo or padding
+	ExitBannerNone    ExitBanner = "none"    // No exit banner
+)
+
+// Full reports whether the banner carries the logo and its surrounding
+// padding. Only compact drops them, so an unrecognized value renders the
+// full banner rather than nothing.
+func (e ExitBanner) Full() bool { return e != ExitBannerCompact }
 
 type Permissions struct {
 	AllowedTools []string `json:"allowed_tools,omitempty" jsonschema:"description=List of tools that don't require permission prompts,example=bash,example=view"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -281,15 +281,30 @@ type TUIOptions struct {
 	ExitBanner  ExitBanner  `json:"exit_banner,omitempty" jsonschema:"description=Exit banner style after quitting Crush,enum=default,enum=compact,enum=none,default=default"`
 }
 
+// IsTransparent reports whether the TUI draws a transparent background. The
+// nil receiver and the unset pointer both mean opaque, so callers can ask
+// without unwrapping either.
+func (t *TUIOptions) IsTransparent() bool {
+	return t != nil && t.Transparent != nil && *t.Transparent
+}
+
 // Completions defines options for the completions UI.
 type Completions struct {
 	MaxDepth *int `json:"max_depth,omitempty" jsonschema:"description=Maximum depth for the ls tool,default=0,example=10"`
 	MaxItems *int `json:"max_items,omitempty" jsonschema:"description=Maximum number of items to return for the ls tool,default=1000,example=100"`
 }
 
+// Limits returns the configured completion limits. Zero means the user has not
+// pinned that limit, and callers fall back to their own built-in cap.
 func (c Completions) Limits() (depth, items int) {
 	return ptrValOr(c.MaxDepth, 0), ptrValOr(c.MaxItems, 0)
 }
+
+// Diff mode options.
+const (
+	DiffModeUnified = "unified" // Inline unified diffs
+	DiffModeSplit   = "split"   // Side-by-side diffs
+)
 
 // Scrollbar visibility options.
 const (
@@ -302,15 +317,16 @@ const (
 type ExitBanner string
 
 const (
-	ExitBannerDefault ExitBanner = "default" // Full ASCII art logo with padding
-	ExitBannerCompact ExitBanner = "compact" // Session and resume lines only, no logo or padding
-	ExitBannerNone    ExitBanner = "none"    // No exit banner
+	// ExitBannerDefault renders the full ASCII art logo with padding. It is
+	// also what the zero value and any unrecognized value fall back to.
+	ExitBannerDefault ExitBanner = "default"
+	// ExitBannerCompact renders only the session and resume lines, with no
+	// logo and no padding. With no active session it renders nothing at all,
+	// so Crush exits silently.
+	ExitBannerCompact ExitBanner = "compact"
+	// ExitBannerNone renders nothing.
+	ExitBannerNone ExitBanner = "none"
 )
-
-// Full reports whether the banner carries the logo and its surrounding
-// padding. Only compact drops them, so an unrecognized value renders the
-// full banner rather than nothing.
-func (e ExitBanner) Full() bool { return e != ExitBannerCompact }
 
 type Permissions struct {
 	AllowedTools []string `json:"allowed_tools,omitempty" jsonschema:"description=List of tools that don't require permission prompts,example=bash,example=view"`

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -536,13 +536,30 @@ func (c *Config) applyEnv(resolver VariableResolver) {
 	}
 }
 
-func (c *Config) setDefaults(workingDir, dataDir string) {
+// NormalizeOptions allocates Options and Options.TUI and fills in the option
+// defaults the UI relies on, so readers can dereference them without guarding.
+// Configs loaded from disk get this via setDefaults; configs arriving over the
+// wire from a Crush server need the same treatment before the UI reads them.
+//
+// DiffMode is deliberately left alone: the permissions dialog reads its zero
+// value as "choose split or unified from the terminal width".
+func (c *Config) NormalizeOptions() {
 	if c.Options == nil {
 		c.Options = &Options{}
 	}
 	if c.Options.TUI == nil {
 		c.Options.TUI = &TUIOptions{}
 	}
+	if c.Options.TUI.Scrollbar == "" {
+		c.Options.TUI.Scrollbar = ScrollbarDefault
+	}
+	if c.Options.TUI.ExitBanner == "" {
+		c.Options.TUI.ExitBanner = ExitBannerDefault
+	}
+}
+
+func (c *Config) setDefaults(workingDir, dataDir string) {
+	c.NormalizeOptions()
 	if len(c.Options.GlobalContextPaths) == 0 {
 		crushConfigDir := filepath.Dir(GlobalConfig())
 		c.Options.GlobalContextPaths = []string{

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -265,9 +265,34 @@ func TestConfig_setDefaults(t *testing.T) {
 		require.NotNil(t, cfg.MCP)
 		require.Equal(t, filepath.Join(workingDir, ".crush"), cfg.Options.DataDirectory)
 		require.Equal(t, "AGENTS.md", cfg.Options.InitializeAs)
+		// DiffMode is deliberately left empty: the permissions dialog treats
+		// the zero value as "pick split or unified based on terminal width".
+		require.Empty(t, cfg.Options.TUI.DiffMode)
+		require.Equal(t, ScrollbarDefault, cfg.Options.TUI.Scrollbar)
+		require.Equal(t, ExitBannerDefault, cfg.Options.TUI.ExitBanner)
 		for _, path := range defaultContextPaths {
 			require.Contains(t, cfg.Options.ContextPaths, path)
 		}
+	})
+
+	t.Run("sets TUI defaults only when unset", func(t *testing.T) {
+		cfg := &Config{}
+		workingDir := t.TempDir()
+
+		cfg.setDefaults(workingDir, "")
+
+		require.Empty(t, cfg.Options.TUI.DiffMode)
+		require.Equal(t, ScrollbarDefault, cfg.Options.TUI.Scrollbar)
+		require.Equal(t, ExitBannerDefault, cfg.Options.TUI.ExitBanner)
+
+		cfg.Options.TUI.DiffMode = DiffModeSplit
+		cfg.Options.TUI.Scrollbar = ScrollbarNever
+		cfg.Options.TUI.ExitBanner = ExitBannerCompact
+		cfg.setDefaults(workingDir, "")
+
+		require.Equal(t, DiffModeSplit, cfg.Options.TUI.DiffMode)
+		require.Equal(t, ScrollbarNever, cfg.Options.TUI.Scrollbar)
+		require.Equal(t, ExitBannerCompact, cfg.Options.TUI.ExitBanner)
 	})
 
 	t.Run("prunes orphaned OAuth token MCP entries but keeps real ones", func(t *testing.T) {

--- a/internal/shellconfig/options.go
+++ b/internal/shellconfig/options.go
@@ -206,7 +206,7 @@ var optionSpecs = map[string]optionSpec{
 // that live under options.tui rather than as top-level options.
 func optionUI(options map[string]any, args []string, stderr io.Writer) error {
 	if len(args) != 4 {
-		return usage(stderr, "usage: option ui <compact|diff|transparent|scrollbar|completions-max-depth|completions-max-items> <value>")
+		return usage(stderr, "usage: option ui <compact|diff|transparent|scrollbar|completions-max-depth|completions-max-items|exit-banner> <value>")
 	}
 
 	key := args[2]
@@ -234,6 +234,11 @@ func optionUI(options map[string]any, args []string, stderr io.Writer) error {
 			return usage(stderr, fmt.Sprintf("option ui scrollbar expects default, always, or never, got %q", value))
 		}
 		ui["scrollbar"] = value
+	case "exit-banner":
+		if value != "default" && value != "compact" && value != "none" {
+			return usage(stderr, fmt.Sprintf("option ui exit-banner expects default, compact, or none, got %q", value))
+		}
+		ui["exit_banner"] = value
 	case "completions-max-depth", "completions-max-items":
 		parsed, err := strconv.Atoi(value)
 		if err != nil || parsed < 0 {

--- a/internal/shellconfig/options_test.go
+++ b/internal/shellconfig/options_test.go
@@ -162,6 +162,24 @@ func TestOption_UIUnknownKey(t *testing.T) {
 	require.Contains(t, err.Error(), "unknown key")
 }
 
+func TestOption_UIExitBanner(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "crushrc")
+	jsonBytes, err := LoadShellConfig(t.Context(), path, []byte(`option ui exit-banner compact`))
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(jsonBytes, &result))
+
+	ui := result["options"].(map[string]any)["tui"].(map[string]any)
+	require.Equal(t, "compact", ui["exit_banner"])
+
+	_, err = LoadShellConfig(t.Context(), path, []byte(`option ui exit-banner bogus`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expects default, compact, or none")
+}
+
 func TestOption_BoolShorthand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -187,6 +187,7 @@ option reset <list-key>    # clear a list option back to empty
   `assisted-by`) and `attribution-generated-with` (boolean).
 - **UI settings**: `option ui compact BOOL`, `option ui diff unified|split`,
   `option ui transparent BOOL`, `option ui scrollbar default|always|never`,
+  `option ui exit-banner default|compact|none`,
   `option ui completions-max-depth N`, `option ui completions-max-items N`.
 - **List keys** (singular, one value per call, repeatable): `context-path`,
   `global-context-path`, `skill-path`, `disable-skill`. Use `option reset <key>`
@@ -200,6 +201,7 @@ option attribution-trailer-style assisted-by
 option attribution-generated-with true
 option ui compact true
 option ui diff unified
+option ui exit-banner compact
 ```
 
 > [!IMPORTANT] These skill paths are loaded by default and do NOT need

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -543,7 +543,7 @@ func (c *Commands) defaultCommands() []*CommandItem {
 
 	// Add transparent background toggle.
 	transparentLabel := "Disable Background Color"
-	if cfg != nil && cfg.Options != nil && cfg.Options.TUI.Transparent != nil && *cfg.Options.TUI.Transparent {
+	if cfg != nil && cfg.Options != nil && cfg.Options.TUI.IsTransparent() {
 		transparentLabel = "Enable Background Color"
 	}
 	commands = append(commands, NewCommandItem(c.com.Styles, "toggle_transparent", transparentLabel, "", ActionToggleTransparentBackground{}))

--- a/internal/ui/exitbanner/exitbanner.go
+++ b/internal/ui/exitbanner/exitbanner.go
@@ -1,0 +1,115 @@
+// Package exitbanner renders what Crush prints after the TUI exits.
+package exitbanner
+
+import (
+	"math/rand/v2"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/logo"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/version"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/exp/charmtone"
+)
+
+// FallbackWidth is used when stdout is not a terminal, so the banner still
+// wraps to something sane when output is piped or captured.
+const FallbackWidth = 80
+
+// Render returns the exit banner for the given style, or an empty string when
+// there is nothing to print. A nil or untitled session means the resume hint is
+// omitted, which for the compact banner leaves nothing at all.
+func Render(banner config.ExitBanner, sess *session.Session, width int) string {
+	if width <= 0 {
+		width = FallbackWidth
+	}
+	hasSession := sess != nil && sess.ID != ""
+
+	switch banner {
+	case config.ExitBannerNone:
+		return ""
+
+	case config.ExitBannerCompact:
+		if !hasSession {
+			return ""
+		}
+		return sessionResumeLines(sess, width)
+
+	default:
+		// Unrecognized values render the full banner rather than nothing.
+		style := lipgloss.NewStyle().Padding(1, 3)
+		contentWidth := width - style.GetHorizontalFrameSize()
+
+		sections := []string{logoSection(contentWidth)}
+		if hasSession {
+			sections = append(sections, sessionResumeLines(sess, contentWidth))
+		}
+		return style.Render(strings.Join(sections, "\n\n"))
+	}
+}
+
+// logoSection returns the ASCII art logo followed by the parting message.
+func logoSection(contentWidth int) string {
+	t := styles.ThemeForProvider("")
+	crushLogo := logo.Render(t.Logo.GradCanvas, version.Version, true, logo.Opts{
+		FieldColor:   t.Logo.FieldColor,
+		TitleColorA:  t.Logo.TitleColorA,
+		TitleColorB:  t.Logo.TitleColorB,
+		CharmColor:   t.Logo.CharmColor,
+		VersionColor: t.Logo.VersionColor,
+		Hyper:        false,
+	})
+	// Wrap the greeting and the message together: wrapping only the message
+	// leaves the greeting's own width unaccounted for and overflows the frame.
+	return crushLogo + "\n" +
+		lipgloss.NewStyle().Width(contentWidth).Render("Thanks for using Crush! "+randomExitMessage())
+}
+
+// sessionResumeLines returns the "Session  <title>\nContinue crush -s <hash>"
+// pair used by the exit banner.
+func sessionResumeLines(sess *session.Session, contentWidth int) string {
+	title := strings.ReplaceAll(sess.Title, "\n", " ")
+
+	labelWidth := lipgloss.Width("Session  ")
+	titleWidth := contentWidth - labelWidth
+	if titleWidth > 0 {
+		title = ansi.Truncate(title, titleWidth, "…")
+	}
+
+	hash := session.HashID(sess.ID)[:7]
+	label := lipgloss.NewStyle().Foreground(charmtone.Charple)
+	sessionLine := label.Render("Session  ") + title
+	continueLine := label.Render("Continue ") + "crush -s " + hash
+	return sessionLine + "\n" + continueLine
+}
+
+// randomExitMessage returns a random exit message.
+func randomExitMessage() string {
+	messages := []string{
+		"",
+		"See ya later.",
+		"You look great.",
+		"Have a gorgeous time.",
+		"Get some rest.",
+		"Come back soon.",
+		"You worked handsomely.",
+		"Time for a snack.",
+		"Who’s hungry?",
+		"That was fun.",
+		"See you at breakfast?",
+		"Time for a nap.",
+		"Who wants some spaghetti?",
+		"Take care of yourself.",
+		"Remember to hydrate.",
+		"Time for a swim?",
+		"You’re quite glamorous, you know.",
+		"Nice work.",
+		"You’re a sensation.",
+		"Where’s my eyeliner?",
+		"It’s tea time.",
+	}
+	return messages[rand.IntN(len(messages))]
+}

--- a/internal/ui/exitbanner/exitbanner_test.go
+++ b/internal/ui/exitbanner/exitbanner_test.go
@@ -1,0 +1,149 @@
+package exitbanner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func testSession() *session.Session {
+	return &session.Session{ID: "abc123def456", Title: "Fix the flaky test"}
+}
+
+func TestRender(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		banner  config.ExitBanner
+		sess    *session.Session
+		want    []string
+		notWant []string
+		empty   bool
+	}{
+		{
+			name:   "none prints nothing even with a session",
+			banner: config.ExitBannerNone,
+			sess:   testSession(),
+			empty:  true,
+		},
+		{
+			name:   "compact without a session prints nothing",
+			banner: config.ExitBannerCompact,
+			empty:  true,
+		},
+		{
+			name:   "compact with a session prints only the resume lines",
+			banner: config.ExitBannerCompact,
+			sess:   testSession(),
+			want:   []string{"Session", "Fix the flaky test", "Continue", "crush -s "},
+			// No logo, and no padding around the two lines.
+			notWant: []string{"Thanks for using Crush!"},
+		},
+		{
+			name:   "default with a session prints the logo and the resume lines",
+			banner: config.ExitBannerDefault,
+			sess:   testSession(),
+			want:   []string{"Thanks for using Crush!", "Session", "Fix the flaky test", "Continue"},
+		},
+		{
+			name:   "default without a session still prints the logo",
+			banner: config.ExitBannerDefault,
+			want:   []string{"Thanks for using Crush!"},
+			// The separator between logo and resume lines must not be left
+			// dangling when there is no session.
+			notWant: []string{"Continue"},
+		},
+		{
+			name:   "unrecognized values fall back to the full banner",
+			banner: config.ExitBanner("wat"),
+			sess:   testSession(),
+			want:   []string{"Thanks for using Crush!", "Continue"},
+		},
+		{
+			name: "zero value falls back to the full banner",
+			sess: testSession(),
+			want: []string{"Thanks for using Crush!", "Continue"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := Render(tt.banner, tt.sess, 100)
+			if tt.empty {
+				require.Empty(t, got)
+				return
+			}
+			require.NotEmpty(t, got)
+			for _, want := range tt.want {
+				require.Contains(t, got, want)
+			}
+			for _, notWant := range tt.notWant {
+				require.NotContains(t, got, notWant)
+			}
+		})
+	}
+}
+
+func TestRenderCompactIsExactlyTwoLines(t *testing.T) {
+	t.Parallel()
+
+	got := Render(config.ExitBannerCompact, testSession(), 100)
+	require.Len(t, strings.Split(got, "\n"), 2)
+}
+
+func TestRenderTruncatesLongTitles(t *testing.T) {
+	t.Parallel()
+
+	sess := testSession()
+	sess.Title = strings.Repeat("long ", 60)
+
+	got := Render(config.ExitBannerCompact, sess, 40)
+	for _, line := range strings.Split(got, "\n") {
+		require.LessOrEqual(t, ansi.StringWidth(line), 40, "line wider than the terminal: %q", line)
+	}
+	require.Contains(t, got, "…")
+}
+
+func TestRenderFlattensNewlinesInTitles(t *testing.T) {
+	t.Parallel()
+
+	sess := testSession()
+	sess.Title = "first\nsecond"
+
+	got := Render(config.ExitBannerCompact, sess, 100)
+	require.Len(t, strings.Split(got, "\n"), 2)
+	require.Contains(t, got, "first second")
+}
+
+func TestRenderFitsTheGivenWidth(t *testing.T) {
+	t.Parallel()
+
+	for _, width := range []int{40, 80, 200} {
+		for _, banner := range []config.ExitBanner{config.ExitBannerCompact, config.ExitBannerDefault} {
+			got := Render(banner, testSession(), width)
+			for _, line := range strings.Split(got, "\n") {
+				require.LessOrEqual(t, ansi.StringWidth(line), width,
+					"%s banner overflows width %d: %q", banner, width, line)
+			}
+		}
+	}
+}
+
+func TestRenderNonPositiveWidthUsesFallback(t *testing.T) {
+	t.Parallel()
+
+	sess := testSession()
+	sess.Title = strings.Repeat("long ", 60)
+
+	got := Render(config.ExitBannerCompact, sess, 0)
+	for _, line := range strings.Split(got, "\n") {
+		require.LessOrEqual(t, ansi.StringWidth(line), FallbackWidth)
+	}
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -4085,6 +4085,14 @@ func (m *UI) CurrentSession() *session.Session {
 	return m.session
 }
 
+// Config returns the active config.
+func (m *UI) Config() *config.Config {
+	if m.com == nil {
+		return nil
+	}
+	return m.com.Config()
+}
+
 // mimeOf detects the MIME type of the given content.
 func mimeOf(content []byte) string {
 	mimeBufferSize := min(512, len(content))

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -415,11 +415,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 	ta.KeyMap.CopySelection = key.NewBinding()
 	ta.Focus()
 
-	scrollbarMode := config.ScrollbarDefault
-	if cfg := com.Config(); cfg.Options.TUI != nil && cfg.Options.TUI.Scrollbar != "" {
-		scrollbarMode = cfg.Options.TUI.Scrollbar
-	}
-	ch := NewChat(com, scrollbarMode)
+	ch := NewChat(com, com.Config().Options.TUI.Scrollbar)
 
 	keyMap := DefaultKeyMap()
 
@@ -521,7 +517,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 	// disable indeterminate progress bar
 	ui.progressBarEnabled = opts.Progress == nil || *opts.Progress
 	// enable transparent mode
-	ui.isTransparent = opts.TUI.Transparent != nil && *opts.TUI.Transparent
+	ui.isTransparent = opts.TUI.IsTransparent()
 
 	return ui
 }
@@ -2015,7 +2011,7 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 				return util.ReportError(errors.New("configuration not found"))()
 			}
 
-			isTransparent := cfg.Options != nil && cfg.Options.TUI.Transparent != nil && *cfg.Options.TUI.Transparent
+			isTransparent := cfg.Options != nil && cfg.Options.TUI.IsTransparent()
 			newValue := !isTransparent
 			if err := m.com.Workspace.SetConfigField(config.ScopeGlobal, "options.tui.transparent", newValue); err != nil {
 				return util.ReportError(err)()
@@ -4083,14 +4079,6 @@ func (m *UI) hasSession() bool {
 // It is safe to call after the TUI has exited.
 func (m *UI) CurrentSession() *session.Session {
 	return m.session
-}
-
-// Config returns the active config.
-func (m *UI) Config() *config.Config {
-	if m.com == nil {
-		return nil
-	}
-	return m.com.Config()
 }
 
 // mimeOf detects the MIME type of the given content.

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -86,6 +86,7 @@ var (
 func NewClientWorkspace(c *client.Client, ws proto.Workspace) *ClientWorkspace {
 	if ws.Config != nil {
 		ws.Config.SetupAgents()
+		ws.Config.NormalizeOptions()
 	}
 	states := protoToSkillStates(ws.Skills)
 	mgr := skills.NewManager(nil, nil, states, skills.WithGlobalMirror())
@@ -111,6 +112,7 @@ func (w *ClientWorkspace) refreshWorkspace() {
 	}
 	if updated.Config != nil {
 		updated.Config.SetupAgents()
+		updated.Config.NormalizeOptions()
 	}
 	w.mu.Lock()
 	w.ws = *updated
@@ -923,6 +925,7 @@ func (w *ClientWorkspace) recoverWorkspace() error {
 	}
 	if created.Config != nil {
 		created.Config.SetupAgents()
+		created.Config.NormalizeOptions()
 	}
 	w.mu.Lock()
 	oldID := w.ws.ID

--- a/schema.json
+++ b/schema.json
@@ -815,6 +815,16 @@
           ],
           "description": "Chat scrollbar visibility",
           "default": "default"
+        },
+        "exit_banner": {
+          "type": "string",
+          "enum": [
+            "default",
+            "compact",
+            "none"
+          ],
+          "description": "Exit banner style after quitting Crush",
+          "default": "default"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
<img width="467" height="216" alt="image" src="https://github.com/user-attachments/assets/d159cace-6bdd-46b9-94fc-2d93c23a8a13" />

<img width="538" height="93" alt="image" src="https://github.com/user-attachments/assets/a75db291-a310-4fac-af7a-b001bf8f9c41" />

removes the indent on the full banner and adds a config option to use either a compact or no banner

### Config format

crushrc:
```bash
option ui exit-banner compact
option ui exit-banner none
option ui exit-banner default  # default
```

crush.json:
```json
{
  "options": {
    "tui": {
      "exit_banner": "compact"
    }
  }
}
```