### PR TITLE
fix: prevent MCP state updates from rebuilding agents endlessly

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lint:
-    uses: charmbracelet/meta/.github/workflows/lint.yml@main
+    uses: charmbracelet/meta/.github/workflows/lint.yml@ci/lint-go-version-from-gomod
     with:
       golangci_path: .golangci.yml
       golangci_version: v2.11

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -170,6 +170,7 @@ type EventType uint
 const (
 	EventStateChanged EventType = iota
 	EventToolsListChanged
+	EventToolRegistryChanged
 	EventPromptsListChanged
 	EventResourcesListChanged
 	// EventChannelMessage is published when a channel server pushes a

--- a/internal/agent/tools/mcp/tools.go
+++ b/internal/agent/tools/mcp/tools.go
@@ -7,11 +7,13 @@ import (
 	"fmt"
 	"iter"
 	"log/slog"
+	"reflect"
 	"slices"
 	"strings"
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -123,11 +125,20 @@ func RefreshTools(ctx context.Context, cfg *config.ConfigStore, name string) {
 		return
 	}
 
-	toolCount := updateTools(cfg, name, tools)
+	toolCount, toolsChanged := updateTools(cfg, name, tools)
 
 	prev, _ := states.Get(name)
+	previousToolCount := prev.Counts.Tools
 	prev.Counts.Tools = toolCount
 	updateState(name, StateConnected, nil, session, prev.Counts)
+	if toolsChanged && previousToolCount == toolCount {
+		broker.Publish(pubsub.UpdatedEvent, Event{
+			Type:   EventToolRegistryChanged,
+			Name:   name,
+			State:  StateConnected,
+			Counts: prev.Counts,
+		})
+	}
 }
 
 // registerSessionTools lists the tools a live session exposes and writes them
@@ -141,7 +152,8 @@ func registerSessionTools(ctx context.Context, cfg *config.ConfigStore, name str
 	if err != nil {
 		return 0, err
 	}
-	return updateTools(cfg, name, tools), nil
+	toolCount, _ := updateTools(cfg, name, tools)
+	return toolCount, nil
 }
 
 func getTools(ctx context.Context, session *ClientSession) ([]*Tool, error) {
@@ -155,17 +167,19 @@ func getTools(ctx context.Context, session *ClientSession) ([]*Tool, error) {
 	return result.Tools, nil
 }
 
-func updateTools(cfg *config.ConfigStore, name string, tools []*Tool) int {
+func updateTools(cfg *config.ConfigStore, name string, tools []*Tool) (int, bool) {
 	mcpCfg, ok := cfg.Config().MCP[name]
 	if ok {
 		tools = filterTools(mcpCfg, tools)
 	}
+	previous, hadPrevious := allTools.Get(name)
+	changed := !hadPrevious || !reflect.DeepEqual(previous, tools)
 	if len(tools) == 0 {
 		allTools.Del(name)
-		return 0
+		return 0, changed && len(previous) > 0
 	}
 	allTools.Set(name, tools)
-	return len(tools)
+	return len(tools), changed
 }
 
 // filterTools filters tools based on enabled_tools (allow list) and

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/charmbracelet/crush/internal/agent/notify"
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/lsp"
 	"github.com/charmbracelet/crush/internal/message"
@@ -37,17 +38,19 @@ type countingWorkspace struct {
 	lspStates map[string]workspace.LSPClientInfo
 	lspDiags  map[string]lsp.DiagnosticCounts
 
-	readyCalls      int
-	agentBusyCalls  int
-	queuedCalls     int
-	queueListCalls  int
-	permCalls       int
-	permSetCalls    int
-	clearQueueCalls int
-	cancelCalls     int
-	modelCalls      int
-	lspStateCalls   int
-	lspDiagCalls    int
+	readyCalls       int
+	agentBusyCalls   int
+	queuedCalls      int
+	queueListCalls   int
+	permCalls        int
+	permSetCalls     int
+	clearQueueCalls  int
+	cancelCalls      int
+	modelCalls       int
+	modelUpdateCalls int
+	mcpStateCalls    int
+	lspStateCalls    int
+	lspDiagCalls     int
 }
 
 func (w *countingWorkspace) AgentIsReady() bool { w.readyCalls++; return w.ready }
@@ -84,6 +87,16 @@ func (w *countingWorkspace) AgentCancel(string)     { w.cancelCalls++ }
 func (w *countingWorkspace) AgentModel() workspace.AgentModel {
 	w.modelCalls++
 	return w.model
+}
+
+func (w *countingWorkspace) UpdateAgentModel(context.Context) error {
+	w.modelUpdateCalls++
+	return nil
+}
+
+func (w *countingWorkspace) MCPGetStates() map[string]mcp.ClientInfo {
+	w.mcpStateCalls++
+	return nil
 }
 
 func (w *countingWorkspace) LSPGetStates() map[string]workspace.LSPClientInfo {
@@ -123,7 +136,8 @@ func (w *countingWorkspace) resetCounters() {
 	w.readyCalls, w.agentBusyCalls = 0, 0
 	w.queuedCalls, w.queueListCalls, w.permCalls = 0, 0, 0
 	w.permSetCalls, w.clearQueueCalls, w.cancelCalls = 0, 0, 0
-	w.modelCalls, w.lspStateCalls, w.lspDiagCalls = 0, 0, 0
+	w.modelCalls, w.modelUpdateCalls, w.mcpStateCalls = 0, 0, 0
+	w.lspStateCalls, w.lspDiagCalls = 0, 0
 }
 
 // newBusyUI builds a UI wired to the stub workspace with an active session
@@ -143,6 +157,7 @@ func newBusyUI(ws *countingWorkspace) *UI {
 		keyMap:      DefaultKeyMap(),
 		dialog:      dialog.NewOverlay(),
 		attachments: attachments.New(nil, attachments.Keymap{}),
+		mcpStates:   make(map[string]mcp.ClientInfo),
 	}
 }
 
@@ -675,12 +690,7 @@ func TestAgentModelChangedRefreshesModel(t *testing.T) {
 		"the refreshed model must land in the cache")
 }
 
-// TestMCPStateChangedRefreshesModel pins the fourth UpdateAgentModel call
-// site: an MCP state change rebuilds the agent, which can change the
-// effective model, so the memoized ready/model state must be re-fetched
-// off-thread afterwards — the edge the updateAgentModelCmd helper exists to
-// make unforgettable.
-func TestMCPStateChangedRefreshesModel(t *testing.T) {
+func TestMCPStateChangedRefreshesModelWhenToolsChange(t *testing.T) {
 	pinTTLs(t)
 
 	ws := &countingWorkspace{
@@ -692,18 +702,41 @@ func TestMCPStateChangedRefreshesModel(t *testing.T) {
 	m.agentModel = workspace.AgentModel{ModelCfg: config.SelectedModel{Model: "pre-mcp-model"}}
 	ws.resetCounters()
 
-	// handleStateChanged sequences the rebuild with agentModelChangedCmd;
-	// tea.Sequence's wrapper msg is unexported, so drive the two steps the
-	// way the runtime would: run the cmd (the stub records the call), then
-	// deliver the invalidation message.
-	_ = m.handleStateChanged()()
+	event := mcp.Event{
+		Name:   "server",
+		State:  mcp.StateConnected,
+		Counts: mcp.Counts{Tools: 1},
+	}
+	_ = m.handleStateChanged(event)()
 	_, cmd := m.Update(agentModelChangedMsg{})
-	require.True(t, m.busyFetchInFlight, "an MCP state change must schedule a ready/model refresh")
+	require.True(t, m.busyFetchInFlight, "an MCP tool change must schedule a ready/model refresh")
 	runCmds(m, cmd)
 
 	require.True(t, m.agentReady)
 	require.Equal(t, "post-mcp-model", m.agentModel.ModelCfg.Model,
-		"an MCP state change must refresh the memoized model")
+		"an MCP tool change must refresh the memoized model")
+}
+
+func TestMCPStateChangedDoesNotRebuildAgentWhenToolsAreUnchanged(t *testing.T) {
+	ws := &countingWorkspace{}
+	m := newBusyUI(ws)
+	m.mcpStates["server"] = mcp.ClientInfo{
+		Name:   "server",
+		State:  mcp.StateConnected,
+		Counts: mcp.Counts{Tools: 1},
+	}
+
+	event := mcp.Event{
+		Name:   "server",
+		State:  mcp.StateConnected,
+		Counts: mcp.Counts{Tools: 1, Prompts: 2},
+	}
+	msg := m.handleStateChanged(event)()
+
+	_, ok := msg.(mcpStateChangedMsg)
+	require.True(t, ok, "unchanged tools must only refresh cached MCP state")
+	require.Zero(t, ws.modelUpdateCalls, "unchanged tools must not rebuild the agent")
+	require.Equal(t, 1, ws.mcpStateCalls, "the MCP state cache must still refresh")
 }
 
 // TestLSPEventRefreshIsOffThreadAndDeduped pins the LSP side of the

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -959,9 +959,11 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.Payload.Type {
 		case mcp.EventStateChanged:
 			return m, tea.Batch(
-				m.handleStateChanged(),
+				m.handleStateChanged(msg.Payload),
 				m.loadMCPrompts,
 			)
+		case mcp.EventToolRegistryChanged:
+			return m, m.updateAgentModelCmd(nil)
 		case mcp.EventPromptsListChanged:
 			return m, handleMCPPromptsEvent(m.com.Workspace, msg.Payload.Name)
 		case mcp.EventToolsListChanged:
@@ -5139,13 +5141,27 @@ func (m *UI) runMCPPrompt(clientID, promptID string, arguments map[string]string
 	return tea.Sequence(cmds...)
 }
 
-func (m *UI) handleStateChanged() tea.Cmd {
-	return m.updateAgentModelCmd(func() tea.Msg {
-		m.com.Workspace.UpdateAgentModel(context.Background())
+func (m *UI) handleStateChanged(event mcp.Event) tea.Cmd {
+	previous := m.mcpStates[event.Name]
+	toolRegistryChanged := previous.Counts.Tools != event.Counts.Tools ||
+		(previous.State == mcp.StateConnected) != (event.State == mcp.StateConnected)
+
+	previous.Name = event.Name
+	previous.State = event.State
+	previous.Error = event.Error
+	previous.Counts = event.Counts
+	m.mcpStates[event.Name] = previous
+
+	refreshState := func() tea.Msg {
 		return mcpStateChangedMsg{
 			states: m.com.Workspace.MCPGetStates(),
 		}
-	})
+	}
+	if !toolRegistryChanged {
+		return refreshState
+	}
+
+	return m.updateAgentModelCmd(refreshState)
 }
 
 func handleMCPPromptsEvent(ws workspace.Workspace, name string) tea.Cmd {


### PR DESCRIPTION
## Summary

- keep MCP connection status refreshes from rebuilding the active agent when its effective tools are unchanged
- emit a dedicated registry-change event when an MCP server changes tool definitions without changing the tool count
- preserve agent refreshes when MCP tools connect, disconnect, or materially change

## Test plan

- `go test ./internal/agent/tools/mcp ./internal/ui/model`
- `go test ./...`

💘 Generated with Crush