### PR TITLE
feat(ui): add command to save session summary to a file

### DIFF
--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -62,6 +62,11 @@ type (
 	ActionSummarize                   struct {
 		SessionID string
 	}
+	// ActionSaveSummary is a message to save the current session summary
+	// to a markdown file in the data directory.
+	ActionSaveSummary struct {
+		SessionID string
+	}
 	// ActionSelectReasoningEffort is a message indicating a reasoning effort
 	// has been selected.
 	ActionSelectReasoningEffort struct {

--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -55,6 +55,7 @@ type Commands struct {
 
 	sessionID  string
 	hasSession bool
+	hasSummary bool
 	hasTodos   bool
 	hasQueue   bool
 	selected   CommandType
@@ -78,12 +79,13 @@ type Commands struct {
 var _ Dialog = (*Commands)(nil)
 
 // NewCommands creates a new commands dialog.
-func NewCommands(com *common.Common, sessionID string, hasSession, hasTodos, hasQueue bool, customCommands []commands.CustomCommand, mcpPrompts []commands.MCPPrompt) (*Commands, error) {
+func NewCommands(com *common.Common, sessionID string, hasSession, hasSummary, hasTodos, hasQueue bool, customCommands []commands.CustomCommand, mcpPrompts []commands.MCPPrompt) (*Commands, error) {
 	c := &Commands{
 		com:            com,
 		selected:       SystemCommands,
 		sessionID:      sessionID,
 		hasSession:     hasSession,
+		hasSummary:     hasSummary,
 		hasTodos:       hasTodos,
 		hasQueue:       hasQueue,
 		customCommands: customCommands,
@@ -456,6 +458,11 @@ func (c *Commands) defaultCommands() []*CommandItem {
 	// Only show compact command if there's an active session
 	if c.hasSession {
 		commands = append(commands, NewCommandItem(c.com.Styles, "summarize", "Summarize Session", "", ActionSummarize{SessionID: c.sessionID}))
+	}
+
+	// Only show the save summary command if the session already has one
+	if c.hasSession && c.hasSummary {
+		commands = append(commands, NewCommandItem(c.com.Styles, "save_summary", "Save Session Summary", "", ActionSaveSummary{SessionID: c.sessionID}))
 	}
 
 	// Add reasoning toggle for models that support it

--- a/internal/ui/model/summary_export.go
+++ b/internal/ui/model/summary_export.go
@@ -1,0 +1,48 @@
+package model
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+)
+
+// summaryExportPath returns the file path where the given session's
+// summary is saved. The path is stable per session so repeated saves
+// overwrite the previous summary instead of accumulating files.
+func summaryExportPath(dataDirectory, sessionID string) string {
+	return filepath.Join(dataDirectory, "summaries", sessionID+".md")
+}
+
+// saveSummaryExport writes the session's latest summary message to a
+// markdown file inside dataDirectory and returns the written path.
+func saveSummaryExport(dataDirectory string, sess session.Session, msgs []message.Message) (string, error) {
+	if sess.SummaryMessageID == "" {
+		return "", fmt.Errorf("no summary available yet, run \"Summarize Session\" first")
+	}
+	var summary *message.Message
+	for i := range msgs {
+		if msgs[i].ID == sess.SummaryMessageID {
+			summary = &msgs[i]
+			break
+		}
+	}
+	if summary == nil {
+		return "", fmt.Errorf("summary message not found for this session")
+	}
+	content := strings.TrimSpace(summary.Content().Text)
+	if content == "" {
+		return "", fmt.Errorf("summary message is empty")
+	}
+	path := summaryExportPath(dataDirectory, sess.ID)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", fmt.Errorf("failed to create summaries directory: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return "", fmt.Errorf("failed to write summary: %w", err)
+	}
+	return path, nil
+}

--- a/internal/ui/model/summary_export_test.go
+++ b/internal/ui/model/summary_export_test.go
@@ -1,0 +1,98 @@
+package model
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSummaryExportPath(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t,
+		filepath.Join(".crush", "summaries", "sess-123.md"),
+		summaryExportPath(".crush", "sess-123"),
+	)
+}
+
+func TestSaveSummaryExport(t *testing.T) {
+	t.Parallel()
+
+	summaryMsg := message.Message{
+		ID:               "msg-1",
+		SessionID:        "sess-123",
+		Role:             message.Assistant,
+		IsSummaryMessage: true,
+		Parts:            []message.ContentPart{message.TextContent{Text: "## Summary\n\nWe refactored the parser.\n"}},
+	}
+	sess := session.Session{ID: "sess-123", SummaryMessageID: "msg-1"}
+	msgs := []message.Message{
+		{ID: "msg-0", SessionID: "sess-123", Role: message.User},
+		summaryMsg,
+	}
+
+	t.Run("writes summary content to file", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		path, err := saveSummaryExport(dir, sess, msgs)
+		require.NoError(t, err)
+		require.Equal(t, summaryExportPath(dir, "sess-123"), path)
+
+		b, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.Equal(t, "## Summary\n\nWe refactored the parser.", string(b))
+	})
+
+	t.Run("overwrites previous summary", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		updated := sess
+		updatedMsgs := []message.Message{
+			{ID: "msg-2", SessionID: "sess-123", IsSummaryMessage: true, Parts: []message.ContentPart{message.TextContent{Text: "newer summary"}}},
+		}
+		updated.SummaryMessageID = "msg-2"
+
+		path, err := saveSummaryExport(dir, sess, msgs)
+		require.NoError(t, err)
+
+		path2, err := saveSummaryExport(dir, updated, updatedMsgs)
+		require.NoError(t, err)
+		require.Equal(t, path, path2)
+
+		b, err := os.ReadFile(path2)
+		require.NoError(t, err)
+		require.Equal(t, "newer summary", string(b))
+	})
+
+	t.Run("errors when session has no summary", func(t *testing.T) {
+		t.Parallel()
+
+		noSummary := session.Session{ID: "sess-123"}
+		_, err := saveSummaryExport(t.TempDir(), noSummary, msgs)
+		require.Error(t, err)
+	})
+
+	t.Run("errors when summary message is missing", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := saveSummaryExport(t.TempDir(), sess, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("errors when summary has no text content", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		empty := []message.Message{
+			{ID: "msg-1", SessionID: "sess-123", IsSummaryMessage: true},
+		}
+		_, err := saveSummaryExport(dir, sess, empty)
+		require.Error(t, err)
+	})
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1962,6 +1962,13 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 			return nil
 		})
 		m.dialog.CloseDialog(dialog.CommandsID)
+	case dialog.ActionSaveSummary:
+		if m.isAgentBusy() {
+			cmds = append(cmds, util.ReportWarn("Agent is busy, please wait before saving the summary..."))
+			break
+		}
+		cmds = append(cmds, m.saveSummaryToFile(msg.SessionID))
+		m.dialog.CloseDialog(dialog.CommandsID)
 	case dialog.ActionToggleHelp:
 		m.status.ToggleHelp()
 		m.dialog.CloseDialog(dialog.CommandsID)
@@ -4505,9 +4512,10 @@ func (m *UI) openCommandsDialog() tea.Cmd {
 		sessionID = m.session.ID
 	}
 	hasTodos := hasSession && hasIncompleteTodos(m.session.Todos)
+	hasSummary := hasSession && m.session.SummaryMessageID != ""
 	hasQueue := m.promptQueue > 0
 
-	commands, err := dialog.NewCommands(m.com, sessionID, hasSession, hasTodos, hasQueue, m.customCommands, m.mcpPrompts)
+	commands, err := dialog.NewCommands(m.com, sessionID, hasSession, hasSummary, hasTodos, hasQueue, m.customCommands, m.mcpPrompts)
 	if err != nil {
 		return util.ReportError(err)
 	}
@@ -4815,6 +4823,30 @@ func (m *UI) newSession() tea.Cmd {
 		m.loadPromptHistory(),
 		m.reportCurrentSession(""),
 	)
+}
+
+// saveSummaryToFile writes the session's latest summary message to a
+// markdown file inside the data directory so it can be reused later,
+// e.g. as the initial context of a new session.
+func (m *UI) saveSummaryToFile(sessionID string) tea.Cmd {
+	return func() tea.Msg {
+		sess, err := m.com.Workspace.GetSession(context.Background(), sessionID)
+		if err != nil {
+			return util.ReportError(err)()
+		}
+		msgs, err := m.com.Workspace.ListMessages(context.Background(), sessionID)
+		if err != nil {
+			return util.ReportError(err)()
+		}
+		path, err := saveSummaryExport(m.com.Config().Options.DataDirectory, sess, msgs)
+		if err != nil {
+			return util.ReportError(err)()
+		}
+		return util.CmdHandler(util.InfoMsg{
+			Type: util.InfoTypeSuccess,
+			Msg:  "Summary saved to " + path,
+		})()
+	}
 }
 
 // checkBangModeAfterPaste engages bang mode when pasted text starts with


### PR DESCRIPTION
## Description

Implements the first option requested in #3599: a **"Save Session Summary"** command in the command palette that writes the session's latest summary to a markdown file, so it can be reused later (e.g. as the initial context of a new session) — especially useful inside terminal multiplexers like GNU `screen`, where copying rendered TUI output out of the terminal is impractical.

### What it does

- Adds a `Save Session Summary` palette entry, shown only when the current session has a summary (tracked via `Session.SummaryMessageID`)
- Writes the summary text to `<data_directory>/summaries/<sessionID>.md` — stable per session, so repeated saves overwrite instead of accumulating files
- Shows a success toast with the written path (or an error toast if no summary exists yet)
- Guards against running while the agent is busy, consistent with the existing Summarize action

### Scope note

The second option in #3599 (resetting/clearing context while keeping the summary) is intentionally left out of this PR. In-session compaction already happens today: after summarizing, prompt building slices history from `SummaryMessageID` onward (`getSessionMessages`), so token usage is already reduced without deleting anything. A hard-reset/truncation variant touches DB schema, the workspace RPC chain, and provider tool-call consistency — it overlaps heavily with the design discussions in #2382 and #2331 and deserves its own focused proposal.

### Implementation notes

- Works unchanged in client/server mode since it only uses the `Workspace` interface (`GetSession`/`ListMessages`) — no protocol changes
- Summary messages keep their whole text in a single `TextContent` part (`AppendContent` merges deltas), so extracting `Content().Text` is lossless
- The command lives next to `Summarize Session` and follows the same busy-guard + info-toast conventions

## Testing

- New unit tests in `internal/ui/model/summary_export_test.go` (testify + `t.Parallel()` + `t.TempDir()`): happy path, overwrite semantics, and error cases (no summary, missing message, empty content)
- `go build ./...` clean
- `go test ./internal/ui/...` — all packages pass
- `go vet` and `gofmt` clean

Closes #3599 (file-save half; see scope note above for the reset half)
