### PR TITLE
fix(skills): allow unicode letters and digits in skill names

### DIFF
--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/charlievieth/fastwalk"
 	"github.com/charmbracelet/crush/internal/pubsub"
+	"golang.org/x/text/unicode/norm"
 	"gopkg.in/yaml.v3"
 )
 
@@ -27,7 +28,7 @@ const (
 )
 
 var (
-	namePattern    = regexp.MustCompile(`^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$`)
+	namePattern    = regexp.MustCompile(`^[\p{L}\p{N}]+(-[\p{L}\p{N}]+)*$`)
 	promptReplacer = strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", "\"", "&quot;", "'", "&apos;")
 
 	latestStates   []*SkillState
@@ -124,10 +125,14 @@ func (s *Skill) Validate() error {
 		if len(s.Name) > MaxNameLength {
 			errs = append(errs, fmt.Errorf("name exceeds %d characters", MaxNameLength))
 		}
-		if !namePattern.MatchString(s.Name) {
+		// Compare in NFC form so that names written in one Unicode
+		// normalization match directories stored in another (e.g. macOS
+		// reports NFD filenames).
+		name := norm.NFC.String(s.Name)
+		if !namePattern.MatchString(name) {
 			errs = append(errs, errors.New("name must be alphanumeric with hyphens, no leading/trailing/consecutive hyphens"))
 		}
-		if s.Path != "" && !strings.EqualFold(filepath.Base(s.Path), s.Name) {
+		if s.Path != "" && !strings.EqualFold(norm.NFC.String(filepath.Base(s.Path)), name) {
 			errs = append(errs, fmt.Errorf("name %q must match directory %q", s.Name, filepath.Base(s.Path)))
 		}
 	}

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/unicode/norm"
 )
 
 func TestParse(t *testing.T) {
@@ -174,6 +175,50 @@ func TestSkillValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "valid name - accented latin",
+			skill:   Skill{Name: "redacteur-français", Description: "Some description.", Path: "/skills/redacteur-français"},
+			wantErr: false,
+		},
+		{
+			name:    "valid name - nfd name against nfc directory",
+			skill:   Skill{Name: norm.NFD.String("rédacteur-français"), Description: "Some description.", Path: "/skills/rédacteur-français"},
+			wantErr: false,
+		},
+		{
+			name:    "valid name - cjk",
+			skill:   Skill{Name: "写作者-指南", Description: "Some description.", Path: "/skills/写作者-指南"},
+			wantErr: false,
+		},
+		{
+			name:    "valid name - letters and digits",
+			skill:   Skill{Name: "café-2", Description: "Some description.", Path: "/skills/café-2"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid name - consecutive hyphens",
+			skill:   Skill{Name: "café--français", Description: "Some description."},
+			wantErr: true,
+			errMsg:  "alphanumeric with hyphens",
+		},
+		{
+			name:    "invalid name - trailing hyphen",
+			skill:   Skill{Name: "résumé-", Description: "Some description."},
+			wantErr: true,
+			errMsg:  "alphanumeric with hyphens",
+		},
+		{
+			name:    "invalid name - spaces",
+			skill:   Skill{Name: "café au lait", Description: "Some description."},
+			wantErr: true,
+			errMsg:  "alphanumeric with hyphens",
+		},
+		{
+			name:    "invalid name - punctuation",
+			skill:   Skill{Name: "résumé!", Description: "Some description."},
+			wantErr: true,
+			errMsg:  "alphanumeric with hyphens",
+		},
+		{
 			name:    "invalid name - starts with hyphen",
 			skill:   Skill{Name: "-my-skill", Description: "Some description."},
 			wantErr: true,
@@ -286,6 +331,22 @@ func TestDiscoverEmptyDir(t *testing.T) {
 	skills, states := DiscoverWithStates([]string{tmpDir})
 	require.Empty(t, states)
 	require.Empty(t, skills)
+}
+
+func TestDiscoverAccentedName(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	skillDir := filepath.Join(tmpDir, norm.NFD.String("redacteur-français"))
+	require.NoError(t, os.MkdirAll(skillDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: redacteur-français\ndescription: Rédige en français correctement accentué.\n---\n# Rédacteur\n"), 0o644))
+
+	skills, states := DiscoverWithStates([]string{tmpDir})
+	require.Len(t, states, 1)
+	require.Equal(t, StateNormal, states[0].State, "unexpected error: %v", states[0].Err)
+	require.Len(t, skills, 1)
+	require.Equal(t, "redacteur-français", skills[0].Name)
 }
 
 func TestDiscoverMissingPath(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes #3617. Skill names containing accented or other non-ASCII letters (`redacteur-français`, `写作者`) were rejected by validation because `namePattern` only allowed `[a-zA-Z0-9]`. The same SKILL.md loads fine in Claude Code, which shares the same skills directories, so users keeping one set of skills for both tools had to maintain two naming conventions.

### What changed

- **`internal/skills/skills.go`**
  - `namePattern` now uses Unicode categories: `^[\p{L}\p{N}]+(-[\p{L}\p{N}]+)*$`. Hyphen rules (no leading/trailing/consecutive) are unchanged, and spaces/punctuation are still rejected.
  - Validation and the name↔directory comparison now run in NFC form. Without this, a name composed as NFC in the front matter would fail to match its own directory on filesystems that store names NFD-decomposed (e.g. macOS), since combining marks are category `\p{M}`, not letters.
- **Tests**: new table cases for accented Latin, CJK, letter+digit mixes, NFD-name-vs-NFC-directory, and the still-invalid hyphen/space/punctuation forms; plus an integration test that discovers a skill whose directory is NFD-decomposed while the front matter is NFC.

`MaxNameLength` continues to count bytes, which stays conservative for multi-byte names.

## Testing

- `go test ./internal/skills/...` — all pass (18 validate subtests + discover integration case)
- `go build ./...`, `go vet`, `gofmt` clean
- Repro from the issue: a `~/.claude/skills/redacteur-français/SKILL.md` with `name: redacteur-français` now passes `Validate()` and is discovered normally

Closes #3617
