### PR TITLE
fix(dialog): keep list selection when a key doesn't change the filter

### DIFF
--- a/internal/ui/dialog/commands.go
+++ b/internal/ui/dialog/commands.go
@@ -228,11 +228,14 @@ func (c *Commands) HandleMsg(msg tea.Msg) Action {
 					}
 				}
 			}
+			query := c.input.Value()
 			c.input, cmd = c.input.Update(msg)
-			value := c.input.Value()
-			c.list.SetFilter(value)
-			c.list.ScrollToTop()
-			c.list.SetSelected(0)
+			// Only reset the cursor when the query actually changed.
+			if value := c.input.Value(); value != query {
+				c.list.SetFilter(value)
+				c.list.ScrollToTop()
+				c.list.SetSelected(0)
+			}
 			return ActionCmd{cmd}
 		}
 	}

--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -222,12 +222,15 @@ func (m *Models) HandleMsg(msg tea.Msg) Action {
 			}
 		default:
 			var cmd tea.Cmd
+			query := m.input.Value()
 			m.input, cmd = m.input.Update(msg)
-			value := m.input.Value()
 			m.list.Focus()
-			m.list.SetFilter(value)
-			m.list.SelectFirst()
-			m.list.ScrollToTop()
+			// Only reset the cursor when the query actually changed.
+			if value := m.input.Value(); value != query {
+				m.list.SetFilter(value)
+				m.list.SelectFirst()
+				m.list.ScrollToTop()
+			}
 			return ActionCmd{cmd}
 		}
 	}

--- a/internal/ui/dialog/notifications.go
+++ b/internal/ui/dialog/notifications.go
@@ -155,11 +155,14 @@ func (n *Notifications) HandleMsg(msg tea.Msg) Action {
 			return ActionSelectNotificationStyle{Style: notifItem.style.ID}
 		default:
 			var cmd tea.Cmd
+			query := n.input.Value()
 			n.input, cmd = n.input.Update(msg)
-			value := n.input.Value()
-			n.list.SetFilter(value)
-			n.list.ScrollToTop()
-			n.list.SetSelected(0)
+			// Only reset the cursor when the query actually changed.
+			if value := n.input.Value(); value != query {
+				n.list.SetFilter(value)
+				n.list.ScrollToTop()
+				n.list.SetSelected(0)
+			}
 			return ActionCmd{cmd}
 		}
 	}

--- a/internal/ui/dialog/reasoning.go
+++ b/internal/ui/dialog/reasoning.go
@@ -146,11 +146,14 @@ func (r *Reasoning) HandleMsg(msg tea.Msg) Action {
 			return ActionSelectReasoningEffort{Effort: reasoningItem.effort}
 		default:
 			var cmd tea.Cmd
+			query := r.input.Value()
 			r.input, cmd = r.input.Update(msg)
-			value := r.input.Value()
-			r.list.SetFilter(value)
-			r.list.ScrollToTop()
-			r.list.SetSelected(0)
+			// Only reset the cursor when the query actually changed.
+			if value := r.input.Value(); value != query {
+				r.list.SetFilter(value)
+				r.list.ScrollToTop()
+				r.list.SetSelected(0)
+			}
 			return ActionCmd{cmd}
 		}
 	}

--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -209,11 +209,16 @@ func (s *Session) HandleMsg(msg tea.Msg) Action {
 				}
 			default:
 				var cmd tea.Cmd
+				query := s.input.Value()
 				s.input, cmd = s.input.Update(msg)
-				value := s.input.Value()
-				s.list.SetFilter(value)
-				s.list.ScrollToTop()
-				s.list.SetSelected(0)
+				// Only reset the cursor when the query actually changed.
+				// Terminals report bare modifier presses as key events, and
+				// those must leave the selection alone.
+				if value := s.input.Value(); value != query {
+					s.list.SetFilter(value)
+					s.list.ScrollToTop()
+					s.list.SetSelected(0)
+				}
 				return ActionCmd{cmd}
 			}
 		}

--- a/internal/ui/dialog/sessions_test.go
+++ b/internal/ui/dialog/sessions_test.go
@@ -1,0 +1,88 @@
+package dialog
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/crush/internal/workspace"
+	"github.com/stretchr/testify/require"
+)
+
+// sessionsWorkspace is a minimal [workspace.Workspace] stub that only serves
+// a fixed session list.
+type sessionsWorkspace struct {
+	workspace.Workspace
+	sessions []session.Session
+}
+
+func (w *sessionsWorkspace) ListSessions(context.Context) ([]session.Session, error) {
+	return w.sessions, nil
+}
+
+func newTestSessions(t *testing.T, count int) *Session {
+	t.Helper()
+
+	sessions := make([]session.Session, count)
+	for i := range sessions {
+		sessions[i] = session.Session{
+			ID:    fmt.Sprintf("session-%d", i),
+			Title: fmt.Sprintf("Session %d", i),
+		}
+	}
+
+	s := styles.CharmtonePantera()
+	com := &common.Common{
+		Styles:    &s,
+		Workspace: &sessionsWorkspace{sessions: sessions},
+	}
+	dialog, err := NewSessions(com, "")
+	require.NoError(t, err)
+	return dialog
+}
+
+// TestSessions_ModifierKeysKeepSelection verifies that a bare modifier key
+// press does not move the selection. Terminals that report modifier presses
+// on their own used to reset the cursor to the first session, so ctrl+r
+// renamed the wrong one.
+func TestSessions_ModifierKeysKeepSelection(t *testing.T) {
+	t.Parallel()
+
+	modifiers := []tea.KeyPressMsg{
+		{Code: tea.KeyLeftCtrl},
+		{Code: tea.KeyRightCtrl},
+		{Code: tea.KeyLeftShift},
+		{Code: tea.KeyRightShift},
+		{Code: tea.KeyLeftAlt},
+		{Code: tea.KeyRightAlt},
+	}
+
+	for _, msg := range modifiers {
+		t.Run(msg.String(), func(t *testing.T) {
+			t.Parallel()
+
+			s := newTestSessions(t, 5)
+			s.list.SetSelected(2)
+
+			s.HandleMsg(msg)
+			require.Equal(t, 2, s.list.Selected())
+		})
+	}
+}
+
+// TestSessions_TypingFiltersAndResetsSelection verifies that keys which do
+// change the filter still reset the selection to the first match.
+func TestSessions_TypingFiltersAndResetsSelection(t *testing.T) {
+	t.Parallel()
+
+	s := newTestSessions(t, 5)
+	s.list.SetSelected(2)
+
+	s.HandleMsg(keyMsg('3'))
+	require.Equal(t, "3", s.input.Value())
+	require.Equal(t, 0, s.list.Selected())
+}


### PR DESCRIPTION
Pressing a bare modifier (ctrl, shift, alt) in the session dialog jumped the selection back to the first session, so ctrl+r renamed the wrong one.

Terminals that report modifier key-downs send them as key events, and they fell through to the filter branch, which reset the filter and selected index 0 whether or not the query had actually changed. Guarding on the query value fixes it, and stops left/right and other unbound keys from throwing the list to the top while you're typing a filter.

The same four lines were copy-pasted into the commands, models, notifications and reasoning dialogs, so all five are fixed.

fixes #3534
