### PR TITLE
fix(cmd): accept `crush serve` as an alias for `crush server`

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Crush has preliminary support for hooks. For details, see
 ### Sharing a workspace across clients
 
 When Crush is run against a shared backend (for example two TUIs talking to
-the same `crush serve`), clients are grouped into **workspaces** keyed by
+the same `crush server`), clients are grouped into **workspaces** keyed by
 their resolved `--cwd`. Two clients with the same `--cwd` join the same
 underlying workspace, so they share the session list, message history,
 permission queue, LSP, and MCP state.

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -25,8 +25,9 @@ func init() {
 }
 
 var serverCmd = &cobra.Command{
-	Use:   "server",
-	Short: "Start the Crush server",
+	Aliases: []string{"serve"},
+	Use:     "server",
+	Short:   "Start the Crush server",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		dataDir, err := cmd.Flags().GetString("data-dir")
 		if err != nil {

--- a/internal/cmd/server_alias_test.go
+++ b/internal/cmd/server_alias_test.go
@@ -7,9 +7,17 @@ import (
 )
 
 // TestServerCmdAcceptsServeAlias guards the `serve` alias on `crush server`.
-// The README describes the shared backend as "crush serve", and cobra does no
-// prefix matching, so without the alias that invocation fails with "unknown
-// command" — the documented name and the real one have to agree.
+//
+// `serve` is the spelling people reach for — the README itself said "crush
+// serve" until the commit that added this test, which is how the mismatch was
+// found. Cobra does no prefix matching and EnablePrefixMatching is off, so
+// without an explicit alias that invocation dies with `unknown command
+// "serve" for "crush"` rather than starting a server.
+//
+// Note that fang does not render Aliases in help output, so this test is the
+// only place the alias is written down. Don't delete it as unmotivated: the
+// motivation is that the alias has no other discoverability, not that some
+// doc currently spells it that way.
 func TestServerCmdAcceptsServeAlias(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/server_alias_test.go
+++ b/internal/cmd/server_alias_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestServerCmdAcceptsServeAlias guards the `serve` alias on `crush server`.
+// The README describes the shared backend as "crush serve", and cobra does no
+// prefix matching, so without the alias that invocation fails with "unknown
+// command" — the documented name and the real one have to agree.
+func TestServerCmdAcceptsServeAlias(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "server", serverCmd.Name(), "the canonical name stays `server`")
+	require.Contains(t, serverCmd.Aliases, "serve", "`crush serve` must resolve to the server command")
+}
+
+// TestServeResolvesFromRoot checks the alias through the actual command
+// lookup rootCmd performs, rather than only asserting on the Aliases slice.
+func TestServeResolvesFromRoot(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"server", "serve"} {
+		cmd, _, err := rootCmd.Find([]string{name})
+		require.NoError(t, err, "rootCmd should resolve %q", name)
+		require.Equal(t, "server", cmd.Name(), "%q should resolve to the server command", name)
+	}
+}


### PR DESCRIPTION
## The problem

The README describes the shared backend as:

> When Crush is run against a shared backend (for example two TUIs talking to the same `crush serve`) …

But the command is declared `Use: "server"` with no aliases, and cobra does no prefix matching, so the invocation the docs suggest doesn't exist:

```console
$ crush serve
Error: unknown command "serve" for "crush"
```

## The change

- Add `serve` as an alias on `serverCmd`. `server` stays canonical — this only makes the second spelling resolve.
- Correct the README prose to the canonical name.

Two lines of behaviour change, and it fixes the docs in both directions: the sentence becomes true, and the invocation people reach for regardless of the docs starts working.

```go
var serverCmd = &cobra.Command{
	Aliases: []string{"serve"},
	Use:     "server",
	Short:   "Start the Crush server",
```

## Tests

`internal/cmd/server_alias_test.go` asserts the canonical name is still `server` and that the alias is present, then resolves both spellings through `rootCmd.Find` rather than only inspecting the `Aliases` slice — so the test fails if the alias is declared but never wired into command lookup.

```console
$ go test ./internal/cmd/
ok  	github.com/charmbracelet/crush/internal/cmd	0.791s
```

`gofmt` and `go vet ./internal/cmd/` are both clean.

## Context

Found while writing documentation for `crush server` and checking the prose against `internal/cmd/server.go`.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.ai).
