### PR TITLE
fix: weird indentation on code blocks

### DIFF
--- a/internal/ui/xchroma/chroma.go
+++ b/internal/ui/xchroma/chroma.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image/color"
 	"io"
+	"strings"
 	"sync"
 
 	"charm.land/lipgloss/v2"
@@ -77,10 +78,26 @@ func Formatter(bgColor color.Color, processValue func(string) string) chroma.For
 				s = s.Foreground(lipgloss.Color(entry.Colour.String()))
 			}
 
-			if _, err := fmt.Fprint(w, s.Render(value)); err != nil {
+			if _, err := fmt.Fprint(w, renderLines(s, value)); err != nil {
 				return err
 			}
 		}
 		return nil
 	})
+}
+
+// renderLines styles each line of value separately, joining them with plain
+// newlines. Tokens may contain trailing or embedded newlines (e.g. Chroma's
+// CommentSingle includes the line terminator), and rendering a multi-line
+// string through Lip Gloss makes it equalize line widths, padding the line
+// after a comment with stray spaces and corrupting its indentation.
+func renderLines(s lipgloss.Style, value string) string {
+	if !strings.Contains(value, "\n") {
+		return s.Render(value)
+	}
+	lines := strings.Split(value, "\n")
+	for i, line := range lines {
+		lines[i] = s.Render(line)
+	}
+	return strings.Join(lines, "\n")
 }

--- a/internal/ui/xchroma/chroma_test.go
+++ b/internal/ui/xchroma/chroma_test.go
@@ -1,0 +1,45 @@
+package xchroma
+
+import (
+	"bytes"
+	"image/color"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatterPreservesIndentationAfterComments(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		// JavaScript's CommentSingle token includes the trailing newline.
+		"js": "function f() {\n  // comment\n  const x = 1;\n  const y = 2; // inline\n}\n",
+		"go": "func main() {\n\t// comment\n\tprintln(1)\n}\n",
+		"sh": "if true; then\n  # comment\n  echo hi\nfi\n",
+		"py": "def f():\n    # comment\n    x = 1\n",
+	}
+
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			lexer := chroma.Coalesce(MatchLexer("file." + name))
+			require.NotNil(t, lexer)
+			it, err := lexer.Tokenise(nil, src)
+			require.NoError(t, err)
+
+			var buf bytes.Buffer
+			require.NoError(t, Formatter(color.Black, nil).Format(&buf, styles.Get("charm"), it))
+
+			got := ansi.Strip(buf.String())
+			// Lip Gloss expands tabs, so compare against the tab-expanded
+			// source; what matters is that no stray padding is added.
+			want := strings.ReplaceAll(src, "\t", "    ")
+			require.Equal(t, strings.Split(want, "\n"), strings.Split(got, "\n"))
+		})
+	}
+}

--- a/internal/ui/xchroma/zod_test.go
+++ b/internal/ui/xchroma/zod_test.go
@@ -1,0 +1,35 @@
+package xchroma
+
+import (
+	"bytes"
+	"fmt"
+	"image/color"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/styles"
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestZodCase(t *testing.T) {
+	src := "// Schema for user application preferences, validated on settings save\nconst UserPreferences = z.object({\n  theme: z.enum([\"light\"]).default(\"system\"),\n});\n"
+	lexer := chroma.Coalesce(MatchLexer("file.ts"))
+	it, err := lexer.Tokenise(nil, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for tok := it(); tok != chroma.EOF; tok = it() {
+		fmt.Printf("  %-30s %q\n", tok.Type, tok.Value)
+	}
+
+	it2, _ := lexer.Tokenise(nil, src)
+	var buf bytes.Buffer
+	if err := Formatter(color.Black, nil).Format(&buf, styles.Get("charm"), it2); err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println("--- stripped output ---")
+	for i, line := range strings.Split(ansi.Strip(buf.String()), "\n") {
+		fmt.Printf("%d|%s|\n", i, strings.ReplaceAll(line, " ", "·"))
+	}
+}


### PR DESCRIPTION
## What?

In `chroma.go`, token values are no longer passed to `lipgloss.Style.Render()` as-is. A new `renderLines` helper splits each token value on newlines, styles each line individually, and joins the results back with plain newlines. A regression test (`TestFormatterPreservesIndentationAfterComments`) covers Go, JavaScript, Bash, and Python sources containing both standalone and inline comments.

## Why?

Fixes #3626 