### PR TITLE
fix(ui): show provider for models with duplicate names

### DIFF
--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -488,6 +488,8 @@ func (m *Models) setProviderItems() error {
 		}
 	}
 
+	showProviderForAmbiguousModels(groups)
+
 	// Set model groups in the list.
 	m.list.SetGroups(groups...)
 	m.list.SetSelectedItem(selectedItemID)
@@ -503,6 +505,36 @@ func (m *Models) setProviderItems() error {
 	}
 
 	return nil
+}
+
+// showProviderForAmbiguousModels shows the provider on models whose name is
+// offered by more than one provider. Several providers serve the same model
+// under an identical name, and while filtering the list the group headers
+// scroll out of view, leaving the entries indistinguishable.
+func showProviderForAmbiguousModels(groups []ModelGroup) {
+	providersByName := make(map[string]map[string]struct{})
+	for _, group := range groups {
+		for _, item := range group.Items {
+			if item.model.Name == "" {
+				continue
+			}
+			// Configured providers may not carry an ID, so fall back to the
+			// name to avoid collapsing them into a single key.
+			key := cmp.Or(string(item.prov.ID), item.prov.Name)
+			if providersByName[item.model.Name] == nil {
+				providersByName[item.model.Name] = make(map[string]struct{})
+			}
+			providersByName[item.model.Name][key] = struct{}{}
+		}
+	}
+
+	for _, group := range groups {
+		for _, item := range group.Items {
+			if len(providersByName[item.model.Name]) > 1 {
+				item.showProvider = true
+			}
+		}
+	}
 }
 
 func modelKey(providerID, modelID string) string {

--- a/internal/ui/dialog/models_test.go
+++ b/internal/ui/dialog/models_test.go
@@ -1,0 +1,102 @@
+package dialog
+
+import (
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestModelGroup(t *testing.T, providerID, providerName string, modelNames ...string) ModelGroup {
+	t.Helper()
+	s := styles.CharmtonePantera()
+	provider := catwalk.Provider{
+		ID:   catwalk.InferenceProvider(providerID),
+		Name: providerName,
+	}
+	items := make([]*ModelItem, 0, len(modelNames))
+	for _, name := range modelNames {
+		model := catwalk.Model{ID: providerID + ":" + name, Name: name}
+		items = append(items, NewModelItem(&s, provider, model, ModelTypeLarge, false))
+	}
+	return NewModelGroup(&s, providerName, true, items...)
+}
+
+// TestShowProviderForAmbiguousModelsAcrossProviders verifies that a model name
+// served by several providers shows the provider on every one of its entries.
+func TestShowProviderForAmbiguousModelsAcrossProviders(t *testing.T) {
+	t.Parallel()
+
+	groups := []ModelGroup{
+		newTestModelGroup(t, "openrouter", "OpenRouter", "Ox Alpha"),
+		newTestModelGroup(t, "aihubmix", "AIHubMix", "Ox Alpha"),
+		newTestModelGroup(t, "venice", "Venice", "Ox Alpha"),
+	}
+
+	showProviderForAmbiguousModels(groups)
+
+	for _, group := range groups {
+		require.True(t, group.Items[0].showProvider, "expected %q to show its provider", group.Title)
+	}
+}
+
+// TestShowProviderForAmbiguousModelsKeepsUniqueNamesUnchanged verifies that a
+// model offered by a single provider is left alone.
+func TestShowProviderForAmbiguousModelsKeepsUniqueNamesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	openrouter := newTestModelGroup(t, "openrouter", "OpenRouter", "Ox Alpha", "Sonnet 5")
+	groups := []ModelGroup{
+		openrouter,
+		newTestModelGroup(t, "aihubmix", "AIHubMix", "Ox Alpha"),
+	}
+
+	showProviderForAmbiguousModels(groups)
+
+	require.True(t, openrouter.Items[0].showProvider, "Ox Alpha is served by both providers")
+	require.False(t, openrouter.Items[1].showProvider, "Sonnet 5 is unique to OpenRouter")
+}
+
+// TestShowProviderForAmbiguousModelsIgnoresRecentDuplicates verifies that the
+// recently used group, which repeats entries from their own provider group,
+// does not make those models look ambiguous.
+func TestShowProviderForAmbiguousModelsIgnoresRecentDuplicates(t *testing.T) {
+	t.Parallel()
+
+	recent := newTestModelGroup(t, "openrouter", "OpenRouter", "Ox Alpha")
+	provider := newTestModelGroup(t, "openrouter", "OpenRouter", "Ox Alpha")
+
+	showProviderForAmbiguousModels([]ModelGroup{recent, provider})
+
+	require.False(t, recent.Items[0].showProvider)
+	require.False(t, provider.Items[0].showProvider)
+}
+
+// TestShowProviderForAmbiguousModelsFallsBackToProviderName verifies that
+// configured providers without an ID are told apart by their name.
+func TestShowProviderForAmbiguousModelsFallsBackToProviderName(t *testing.T) {
+	t.Parallel()
+
+	first := newTestModelGroup(t, "", "Local A", "Ox Alpha")
+	second := newTestModelGroup(t, "", "Local B", "Ox Alpha")
+
+	showProviderForAmbiguousModels([]ModelGroup{first, second})
+
+	require.True(t, first.Items[0].showProvider)
+	require.True(t, second.Items[0].showProvider)
+}
+
+// TestShowProviderForAmbiguousModelsIgnoresEmptyNames verifies that unnamed
+// models are not treated as sharing a name with one another.
+func TestShowProviderForAmbiguousModelsIgnoresEmptyNames(t *testing.T) {
+	t.Parallel()
+
+	first := newTestModelGroup(t, "openrouter", "OpenRouter", "")
+	second := newTestModelGroup(t, "aihubmix", "AIHubMix", "")
+
+	showProviderForAmbiguousModels([]ModelGroup{first, second})
+
+	require.False(t, first.Items[0].showProvider)
+	require.False(t, second.Items[0].showProvider)
+}


### PR DESCRIPTION
Closes #3643

Several providers serve the same model under an identical display name, so the model picker renders
those rows identically. Selecting the wrong one stores a valid API key against the wrong provider,
and the resulting `Unauthorized` names neither the provider nor the endpoint.

Filtering for `ox alpha` today gives three rows that read exactly the same, one each from
`aihubmix`, `openrouter` and `venice`. The group header does name the provider, but it is a separate
line that scrolls out of view as you arrow down a filtered list.

### Change

`setProviderItems` builds every normal row with `showProvider` set to `false`. The one place it is
`true` is the "Recently used" group, set there because that group's header cannot identify the
provider. This extends that same treatment to the case where a model name is shared across groups.

After the groups are assembled and before `SetGroups`, any model whose name is offered by more than
one provider has `showProvider` set. Nothing else changes: `renderItem` already caps the info column
at half the width and truncates it, and the fuzzy-match highlighting applies to the title only.

Rendered at 56 columns:

```
BEFORE                              AFTER
 Ox Alpha                            Ox Alpha              AIHubMix
 Ox Alpha                            Ox Alpha            OpenRouter
 Ox Alpha                            Ox Alpha                Venice
 Ox Alpha Free (Unlimited)           Ox Alpha Free (Unlimited)
```

Unambiguous names are untouched, so the rest of the catalogue looks exactly as it did.

### Notes

- Providers are counted by distinct identity, not by row, so a model appearing in both "Recently
  used" and its own provider group is not treated as ambiguous.
- Configured providers may not carry an ID, so the key falls back to the provider name rather than
  collapsing them all into one empty key.
- Models with an empty name are skipped, so they do not all collide on `""`.
- Two models with the same name under a *single* provider are deliberately not addressed — showing
  the provider cannot disambiguate rows that share one.

### Tests

Five cases in `internal/ui/dialog/models_test.go` covering the shared name, the unique name, the
recently-used duplicate, the ID-less provider fallback, and empty names. Three of them fail against
`main` without this change.
