### PR TITLE
fix: prevent TUI todo status from freezing under streaming contention

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -585,7 +585,7 @@ func (app *App) GetDefaultSmallModel(providerID string) config.SelectedModel {
 func (app *App) setupEvents() {
 	ctx, cancel := context.WithCancel(app.globalCtx)
 	app.eventsCtx = ctx
-	setupSubscriber(ctx, app.serviceEventsWG, "sessions", app.Sessions.Subscribe, app.events)
+	setupSubscriberMustDeliver(ctx, app.serviceEventsWG, "sessions", app.Sessions.Subscribe, app.events)
 	setupSubscriber(ctx, app.serviceEventsWG, "messages", app.Messages.Subscribe, app.events)
 	setupSubscriberMustDeliver(ctx, app.serviceEventsWG, "permissions", app.Permissions.Subscribe, app.events)
 	setupSubscriberMustDeliver(ctx, app.serviceEventsWG, "permissions-notifications", app.Permissions.SubscribeNotifications, app.events)


### PR DESCRIPTION
Session UpdateEvents were delivered through a lossy pubsub path that
silently dropped events when the subscriber channel saturated under
heavy streaming, leaving the TUI with stale todo status until the
next agent turn.

Switching sessions to `PublishMustDeliver` (bounded-blocking, 50ms timeout)
so todo state changes reliably reach the TUI. Other critical subscriptions
(permissions, run-completions, questions) already use this delivery mode.