### PR TITLE
fix(lsp): normalize diagnostic paths on Windows

### DIFF
--- a/internal/agent/tools/diagnostics.go
+++ b/internal/agent/tools/diagnostics.go
@@ -5,6 +5,8 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
+	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -142,7 +144,7 @@ func getDiagnostics(filePath string, manager *lsp.Manager) string {
 				slog.Error("Failed to convert diagnostic location URI to path", "uri", location, "error", err)
 				continue
 			}
-			isCurrentFile := path == filePath
+			isCurrentFile := pathsEqual(path, filePath)
 			for _, diag := range diags {
 				formattedDiag := formatDiagnostic(path, diag, lspName)
 				if isCurrentFile {
@@ -175,6 +177,23 @@ func getDiagnostics(filePath string, manager *lsp.Manager) string {
 	out := output.String()
 	slog.Debug("Diagnostics", "output", out)
 	return out
+}
+
+func pathsEqual(a, b string) bool {
+	if runtime.GOOS != "windows" {
+		return a == b
+	}
+
+	return strings.EqualFold(cleanDiagnosticPath(a), cleanDiagnosticPath(b))
+}
+
+func cleanDiagnosticPath(path string) string {
+	if strings.HasPrefix(strings.ToLower(path), "file://") {
+		if parsed, err := protocol.DocumentURI(path).Path(); err == nil {
+			path = parsed
+		}
+	}
+	return filepath.Clean(path)
 }
 
 func writeDiagnostics(output *strings.Builder, tag string, in []string) {

--- a/internal/agent/tools/diagnostics_test.go
+++ b/internal/agent/tools/diagnostics_test.go
@@ -1,0 +1,32 @@
+package tools
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathsEqual(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS != "windows" {
+		require.True(t, pathsEqual("/workspace/main.go", "/workspace/main.go"))
+		require.False(t, pathsEqual("/workspace/main.go", "/workspace/MAIN.go"))
+		require.False(t, pathsEqual(`/workspace\\main.go`, "/workspace/main.go"))
+		return
+	}
+
+	require.True(t, pathsEqual(
+		`C:/Users/Dev/project/main.py`,
+		`c:\users\dev\project\main.py`,
+	))
+	require.True(t, pathsEqual(
+		`file:///C:/Users/Dev/project/main.py`,
+		`c:\users\dev\project\main.py`,
+	))
+	require.False(t, pathsEqual(
+		`C:/Users/Dev/project/main.py`,
+		`C:/Users/Dev/project/other.py`,
+	))
+}


### PR DESCRIPTION
Fixes #3645.

Normalize diagnostic and requested file paths before comparing them on Windows, including separator, drive-letter case, and `file://` URI differences. POSIX path comparison remains unchanged.

Validation:
- `go test -p 2 ./internal/agent/tools`
- `go test -race -p 2 ./internal/agent/tools`
- `go vet ./internal/agent/tools`
- Windows amd64 test cross-compilation