### PR TITLE
fix(mcp): fix sessionless mcp servers (e.g. github mcp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,10 +275,10 @@ if [[ $HOSTNAME == "babysquid" ]]; then
     source ~/my-stuff/babysquid.sh
 fi
 
-# Add an MCP server, with a GitHub API token stored in 1password.
+# Add an MCP server, with a GitHub API token stored in 1Password.
 mcp add github \
   --type http \
-  --url "https://api.githubcopilot.com/mcp/" \
+  --url "https://api.github.com/mcp/" \
   --header Authorization "Bearer $(op read 'op://my-secret-key')"
 ```
 
@@ -373,7 +373,7 @@ mcp add filesystem --command node --args /path/to/mcp-server.js \
   --timeout 10 --disabled-tools some-tool-name --env NODE_ENV production
 
 # Add a GitHub MCP server that uses an API token.
-mcp add github --type http --url "https://api.githubcopilot.com/mcp/" \
+mcp add github --type http --url https://api.github.com/mcp/ \
   --timeout 10 --header Authorization "Bearer $GH_PAT" \
   --disabled-tools create_issue --disabled-tools create_pull_request
 
@@ -411,7 +411,7 @@ credentials directly. All values support shell expansion:
   "mcp": {
     "github": {
       "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/",
+      "url": "https://api.github.com/mcp/",
       "oauth": true,
       "oauth_client_id": "Iv1.abc123def456",
       "oauth_client_secret": "$GITHUB_MCP_SECRET",
@@ -425,6 +425,20 @@ When `oauth_client_id` is set, Crush skips dynamic client registration
 and authenticates as the specified client. When omitted, Crush attempts
 dynamic registration automatically (works with Linear, Notion, and other
 servers that support RFC 7591).
+
+#### Sessionless servers
+
+Some HTTP MCP servers are sessionless — they never issue a
+`Mcp-Session-Id` and reject the `subscriptions/listen` stream Crush opens
+for list-changed notifications, which would otherwise break the
+connection. Crush auto-detects known sessionless servers (GitHub MCP,
+`api.githubcopilot.com/mcp`), so those need no extra configuration.
+
+For other sessionless servers, mark them explicitly with
+`"sessionless": true` (or `--sessionless true` in `crushrc`); set it to
+`false` to force the default behavior for an auto-detected URL. The
+tradeoff is that a sessionless server won't push live
+tool/prompt/resource list-changed notifications.
 
 ### Hooks
 

--- a/internal/agent/tools/mcp/init.go
+++ b/internal/agent/tools/mcp/init.go
@@ -901,36 +901,46 @@ func createSession(ctx context.Context, cfg *config.ConfigStore, name string, m 
 	channelGate := newChannelGate()
 	transport = &channelTransport{inner: transport, name: name, gate: channelGate}
 
+	// When the server is marked Sessionless, the tools/prompts/resources
+	// list-changed handlers are omitted. The go-sdk opens a SEP-2575
+	// "subscriptions/listen" stream whenever any of those handlers is set
+	// (client.go), and sessionless streamable-HTTP servers such as GitHub MCP
+	// answer that POST with 404 ("session not found"), which the SDK treats
+	// as fatal and tears the connection down. Setting the flag lets those
+	// servers connect at the cost of live list-changed notifications.
+	opts := &mcp.ClientOptions{
+		LoggingMessageHandler: func(ctx context.Context, req *mcp.LoggingMessageRequest) {
+			level := parseLevel(string(req.Params.Level))
+			slog.Log(ctx, level, "MCP log", "name", name, "logger", req.Params.Logger, "data", req.Params.Data)
+		},
+	}
+	if !m.IsSessionless(resolver) {
+		opts.ToolListChangedHandler = func(context.Context, *mcp.ToolListChangedRequest) {
+			broker.Publish(pubsub.UpdatedEvent, Event{
+				Type: EventToolsListChanged,
+				Name: name,
+			})
+		}
+		opts.PromptListChangedHandler = func(context.Context, *mcp.PromptListChangedRequest) {
+			broker.Publish(pubsub.UpdatedEvent, Event{
+				Type: EventPromptsListChanged,
+				Name: name,
+			})
+		}
+		opts.ResourceListChangedHandler = func(context.Context, *mcp.ResourceListChangedRequest) {
+			broker.Publish(pubsub.UpdatedEvent, Event{
+				Type: EventResourcesListChanged,
+				Name: name,
+			})
+		}
+	}
 	client := mcp.NewClient(
 		&mcp.Implementation{
 			Name:    "crush",
 			Version: version.Version,
 			Title:   "Crush",
 		},
-		&mcp.ClientOptions{
-			ToolListChangedHandler: func(context.Context, *mcp.ToolListChangedRequest) {
-				broker.Publish(pubsub.UpdatedEvent, Event{
-					Type: EventToolsListChanged,
-					Name: name,
-				})
-			},
-			PromptListChangedHandler: func(context.Context, *mcp.PromptListChangedRequest) {
-				broker.Publish(pubsub.UpdatedEvent, Event{
-					Type: EventPromptsListChanged,
-					Name: name,
-				})
-			},
-			ResourceListChangedHandler: func(context.Context, *mcp.ResourceListChangedRequest) {
-				broker.Publish(pubsub.UpdatedEvent, Event{
-					Type: EventResourcesListChanged,
-					Name: name,
-				})
-			},
-			LoggingMessageHandler: func(ctx context.Context, req *mcp.LoggingMessageRequest) {
-				level := parseLevel(string(req.Params.Level))
-				slog.Log(ctx, level, "MCP log", "name", name, "logger", req.Params.Logger, "data", req.Params.Data)
-			},
-		},
+		opts,
 	)
 
 	session, err := client.Connect(mcpCtx, transport, nil)

--- a/internal/agent/tools/mcp/init_test.go
+++ b/internal/agent/tools/mcp/init_test.go
@@ -2,9 +2,14 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"maps"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
+	"sync/atomic"
 	"testing"
 
 	"github.com/charmbracelet/crush/internal/config"
@@ -818,4 +823,103 @@ func TestBeginAuth_Concurrent(t *testing.T) {
 	_, cancel2, err := BeginAuth(cfg, name)
 	require.NoError(t, err)
 	cancel2()
+}
+
+// TestCreateSession_Sessionless pins the Sessionless opt-out
+// for sessionless streamable-HTTP servers such as GitHub MCP. Those servers
+// complete the SEP-2575 server/discover probe without ever issuing a
+// Mcp-Session-Id, then answer the follow-up "subscriptions/listen" POST
+// (which the go-sdk opens whenever any tools/prompts/resources list-changed
+// handler is registered) with HTTP 404. The SDK maps that 404 to
+// mcp.ErrSessionMissing and fails the whole connection asynchronously, so
+// the next RPC (here tools/list) errors. With Sessionless set, the
+// handlers are omitted, no listen stream is opened, and the server works.
+//
+// The stub server mimics GitHub: it answers server/discover (no session
+// id), 404s any subscriptions/listen, and serves tools/list.
+func TestCreateSession_Sessionless(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	newStub := func(t *testing.T) (*httptest.Server, *atomic.Int64) {
+		t.Helper()
+		listenTotal := new(atomic.Int64)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			var req struct {
+				ID     any    `json:"id"`
+				Method string `json:"method"`
+			}
+			_ = json.Unmarshal(body, &req)
+
+			writeResult := func(result any) {
+				w.Header().Set("Content-Type", "application/json")
+				resp, _ := json.Marshal(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      req.ID,
+					"result":  result,
+				})
+				_, _ = w.Write(resp)
+			}
+
+			switch req.Method {
+			case "server/discover":
+				// Sessionless: deliberately no Mcp-Session-Id header.
+				writeResult(map[string]any{
+					"supportedVersions": []string{"2026-07-28"},
+					"capabilities":      map[string]any{},
+				})
+			case "subscriptions/listen":
+				listenTotal.Add(1)
+				http.Error(w, "session not found", http.StatusNotFound)
+			case "tools/list":
+				writeResult(map[string]any{"tools": []any{}})
+			default:
+				http.Error(w, "unexpected method", http.StatusNotFound)
+			}
+		}))
+		t.Cleanup(srv.Close)
+		return srv, listenTotal
+	}
+
+	resolver := config.NewShellVariableResolver(env.NewFromMap(map[string]string{
+		"PATH": os.Getenv("PATH"),
+	}))
+
+	t.Run("disabled connects with no listen stream", func(t *testing.T) {
+		srv, listenTotal := newStub(t)
+		const name = "sessionless-disabled"
+		states.Del(name)
+		t.Cleanup(func() { states.Del(name) })
+
+		sessionless := true
+		cfg := config.MCPConfig{Type: config.MCPHttp, URL: srv.URL, Timeout: 15, Sessionless: &sessionless}
+		sess, err := createSession(t.Context(), nil, name, cfg, resolver, false)
+		require.NoError(t, err, "Sessionless must let a sessionless server connect")
+		require.NotNil(t, sess)
+		t.Cleanup(func() { sess.Close() })
+
+		_, err = sess.ListTools(t.Context(), &mcp.ListToolsParams{})
+		require.NoError(t, err)
+		require.Zero(t, listenTotal.Load(), "no subscriptions/listen stream should be opened when disabled")
+	})
+
+	t.Run("default opens listen stream and breaks sessionless server", func(t *testing.T) {
+		srv, listenTotal := newStub(t)
+		const name = "sessionless-default"
+		states.Del(name)
+		t.Cleanup(func() { states.Del(name) })
+
+		// Connect itself succeeds; the listen stream fails asynchronously
+		// and poisons the connection, so the subsequent tools/list fails.
+		cfg := config.MCPConfig{Type: config.MCPHttp, URL: srv.URL, Timeout: 15}
+		sess, err := createSession(t.Context(), nil, name, cfg, resolver, false)
+		require.NoError(t, err)
+		require.NotNil(t, sess)
+		t.Cleanup(func() { sess.Close() })
+
+		_, err = sess.ListTools(t.Context(), &mcp.ListToolsParams{})
+		require.Error(t, err, "default handlers open a listen stream that the sessionless server 404s")
+		require.Contains(t, err.Error(), "session not found")
+		require.GreaterOrEqual(t, listenTotal.Load(), int64(1), "expected the listen stream attempt")
+	})
 }

--- a/internal/agent/tools/mcp/lifecycle.go
+++ b/internal/agent/tools/mcp/lifecycle.go
@@ -179,9 +179,18 @@ func mcpConfigEqual(a, b config.MCPConfig) bool {
 		slices.Equal(a.DisabledTools, b.DisabledTools) &&
 		slices.Equal(a.EnabledTools, b.EnabledTools) &&
 		a.Timeout == b.Timeout &&
+		boolPtrEqual(a.Sessionless, b.Sessionless) &&
 		maps.Equal(a.Headers, b.Headers) &&
 		a.OAuth == b.OAuth &&
 		a.OAuthClientID == b.OAuthClientID &&
 		a.OAuthClientSecret == b.OAuthClientSecret &&
 		a.OAuthCallbackPort == b.OAuthCallbackPort
+}
+
+// boolPtrEqual compares two *bool by value, treating two nils as equal.
+func boolPtrEqual(a, b *bool) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -201,6 +201,19 @@ type MCPConfig struct {
 	EnabledTools  []string          `json:"enabled_tools,omitempty" jsonschema:"description=Allow list of tools from this MCP server,example=get-library-doc"`
 	Timeout       int               `json:"timeout,omitempty" jsonschema:"description=Timeout in seconds for MCP server connections,default=10,example=30,example=60,example=120"`
 
+	// Sessionless marks a server that does not maintain an MCP session (it
+	// never issues a Mcp-Session-Id). When true, Crush omits the
+	// tools/prompts/resources list-changed handlers: the go-sdk opens a
+	// SEP-2575 "subscriptions/listen" stream whenever any of those handlers
+	// is set, and sessionless streamable-HTTP servers (e.g. GitHub MCP)
+	// answer that POST with 404 ("session not found"), which the SDK treats
+	// as fatal. The cost is no live list-changed notifications from this
+	// server.
+	//
+	// When nil, Crush auto-detects a set of known sessionless servers (see
+	// IsSessionless); set it explicitly to override that detection.
+	Sessionless *bool `json:"sessionless,omitempty" jsonschema:"description=Mark a sessionless MCP server (no Mcp-Session-Id) so Crush skips the subscriptions/listen stream it would otherwise reject. Leave unset to auto-detect known sessionless servers (e.g. GitHub MCP),default=false"`
+
 	// Headers are HTTP headers for HTTP/SSE MCP servers. Values run
 	// through shell expansion at MCP startup, so $VAR and $(cmd)
 	// work. A header whose value resolves to the empty string (unset
@@ -438,6 +451,33 @@ func (m MCPConfig) ResolvedURL(r VariableResolver) (string, error) {
 		return "", fmt.Errorf("url: %w", err)
 	}
 	return v, nil
+}
+
+// knownSessionlessMCPs is the set of MCP endpoint URLs (normalized, no
+// trailing slash) that are known not to maintain an MCP session — they
+// never issue a Mcp-Session-Id and reject the SEP-2575
+// "subscriptions/listen" stream. Add an entry when a server is confirmed to
+// behave this way.
+var knownSessionlessMCPs = map[string]struct{}{
+	"https://api.github.com/mcp":        {},
+	"https://api.githubcopilot.com/mcp": {},
+}
+
+// IsSessionless reports whether the server should be treated as sessionless.
+// An explicit Sessionless value wins; when unset, the resolved URL is matched
+// against knownSessionlessMCPs (trailing slash ignored). The URL is resolved
+// through r so $VAR-expanded endpoints are detected too; on a resolution
+// error the explicit value (or false) is used.
+func (m MCPConfig) IsSessionless(r VariableResolver) bool {
+	if m.Sessionless != nil {
+		return *m.Sessionless
+	}
+	url, err := m.ResolvedURL(r)
+	if err != nil {
+		return false
+	}
+	_, ok := knownSessionlessMCPs[strings.TrimSuffix(url, "/")]
+	return ok
 }
 
 // ResolvedHeaders returns m.Headers with every value expanded through

--- a/internal/config/mcp_sessionless_test.go
+++ b/internal/config/mcp_sessionless_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/env"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMCPConfig_IsSessionless(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewShellVariableResolver(env.NewFromMap(map[string]string{
+		"GH_MCP_HOST": "api.githubcopilot.com",
+	}))
+	boolPtr := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name string
+		cfg  MCPConfig
+		want bool
+	}{
+		{
+			name: "explicit true wins over unknown url",
+			cfg:  MCPConfig{Type: MCPHttp, URL: "https://mcp.example.com/", Sessionless: boolPtr(true)},
+			want: true,
+		},
+		{
+			name: "explicit false overrides known sessionless url",
+			cfg:  MCPConfig{Type: MCPHttp, URL: "https://api.githubcopilot.com/mcp/", Sessionless: boolPtr(false)},
+			want: false,
+		},
+		{
+			name: "known githubcopilot url auto-detected",
+			cfg:  MCPConfig{Type: MCPHttp, URL: "https://api.githubcopilot.com/mcp/"},
+			want: true,
+		},
+		{
+			name: "known github url auto-detected",
+			cfg:  MCPConfig{Type: MCPHttp, URL: "https://api.github.com/mcp/"},
+			want: true,
+		},
+		{
+			name: "known url without trailing slash auto-detected",
+			cfg:  MCPConfig{Type: MCPHttp, URL: "https://api.githubcopilot.com/mcp"},
+			want: true,
+		},
+		{
+			name: "known url reached via $VAR expansion",
+			cfg:  MCPConfig{Type: MCPHttp, URL: "https://$GH_MCP_HOST/mcp/"},
+			want: true,
+		},
+		{
+			name: "unknown url defaults to false",
+			cfg:  MCPConfig{Type: MCPHttp, URL: "https://mcp.example.com/mcp"},
+			want: false,
+		},
+		{
+			name: "empty url defaults to false",
+			cfg:  MCPConfig{Type: MCPHttp},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.cfg.IsSessionless(resolver))
+		})
+	}
+}

--- a/internal/shellconfig/mcp.go
+++ b/internal/shellconfig/mcp.go
@@ -15,6 +15,7 @@ import (
 //	    [--env KEY VALUE ...] [--url URL] [--header KEY VALUE ...]
 //	    [--timeout N] [--disabled true|false]
 //	    [--disabled-tools TOOL ...] [--enabled-tools TOOL ...]
+//	    [--sessionless true|false]
 //	    [--oauth true|false] [--oauth-client-id ID]
 //	    [--oauth-client-secret SECRET] [--oauth-callback-port PORT]
 //	mcp remove <name>   (alias: rm)
@@ -52,6 +53,7 @@ var mcpAddFlags = []flagSpec{
 	{name: "--disabled", jsonKey: "disabled", kind: flagBool, op: opSet},
 	{name: "--disabled-tools", jsonKey: "disabled_tools", kind: flagString, op: opAppend},
 	{name: "--enabled-tools", jsonKey: "enabled_tools", kind: flagString, op: opAppend},
+	{name: "--sessionless", jsonKey: "sessionless", kind: flagBool, op: opSet},
 	{name: "--oauth", jsonKey: "oauth", kind: flagBool, op: opSet},
 	{name: "--oauth-client-id", jsonKey: "oauth_client_id", kind: flagString, op: opSet},
 	{name: "--oauth-client-secret", jsonKey: "oauth_client_secret", kind: flagString, op: opSet},
@@ -60,7 +62,7 @@ var mcpAddFlags = []flagSpec{
 
 func mcpAdd(b *ConfigBuilder, args []string, stderr io.Writer) error {
 	if len(args) < 3 {
-		return usage(stderr, "usage: mcp add <name> --type stdio|sse|http [--command CMD] [--args ARG ...] [--env KEY VALUE ...] [--url URL] [--header KEY VALUE ...] [--timeout N] [--disabled true|false] [--disabled-tools TOOL ...] [--enabled-tools TOOL ...] [--oauth true|false] [--oauth-client-id ID] [--oauth-client-secret SECRET] [--oauth-callback-port PORT]")
+		return usage(stderr, "usage: mcp add <name> --type stdio|sse|http [--command CMD] [--args ARG ...] [--env KEY VALUE ...] [--url URL] [--header KEY VALUE ...] [--timeout N] [--disabled true|false] [--disabled-tools TOOL ...] [--enabled-tools TOOL ...] [--sessionless true|false] [--oauth true|false] [--oauth-client-id ID] [--oauth-client-secret SECRET] [--oauth-callback-port PORT]")
 	}
 	name := args[2]
 	slog.Info("MCP server defined in shell config", "name", name)

--- a/schema.json
+++ b/schema.json
@@ -295,6 +295,11 @@
             120
           ]
         },
+        "sessionless": {
+          "type": "boolean",
+          "description": "Mark a sessionless MCP server (no Mcp-Session-Id) so Crush skips the subscriptions/listen stream it would otherwise reject. Leave unset to auto-detect known sessionless servers (e.g. GitHub MCP)",
+          "default": false
+        },
         "headers": {
           "additionalProperties": {
             "type": "string"


### PR DESCRIPTION
The go-sdk v1.7.0 opens a SEP-2575 "subscriptions/listen" stream whenever any tools/prompts/resources list-changed handler is registered. Sessionless streamable-HTTP servers such as GitHub MCP never issue a Mcp-Session-Id and answer that POST with 404 ("session not found"), which the SDK treats as fatal and tears the connection down.

Add a `sessionless` MCP config option (`--sessionless` in crushrc). It is a *bool: when unset, Crush auto-detects known sessionless endpoints (api.github.com/mcp, api.githubcopilot.com/mcp) so GitHub MCP works out of the box; setting it explicitly overrides detection. When a server is sessionless, the list-changed handlers are omitted so the listen stream is never opened, at the cost of live list-changed notifications.

Assisted-by: Crush:kimi-k3