### PR TITLE
fix: preserve first line indentation in tool call previews

### DIFF
--- a/internal/stringext/string.go
+++ b/internal/stringext/string.go
@@ -14,11 +14,13 @@ func Capitalize(text string) string {
 
 // NormalizeSpace normalizes whitespace in the given content string.
 // It replaces Windows-style line endings with Unix-style line endings,
-// converts tabs to four spaces, and trims leading and trailing whitespace.
+// converts tabs to four spaces, and trims leading and trailing newlines.
+// Per-line indentation is preserved: trimming spaces would eat the first
+// line's leading whitespace and corrupt indentation in code previews.
 func NormalizeSpace(content string) string {
 	content = strings.ReplaceAll(content, "\r\n", "\n")
 	content = strings.ReplaceAll(content, "\t", "    ")
-	content = strings.TrimSpace(content)
+	content = strings.Trim(content, "\n")
 	return content
 }
 

--- a/internal/stringext/string_test.go
+++ b/internal/stringext/string_test.go
@@ -7,6 +7,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNormalizeSpace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "empty string", input: "", expected: ""},
+		{name: "converts CRLF", input: "a\r\nb", expected: "a\nb"},
+		{name: "converts tabs to four spaces", input: "\ta", expected: "    a"},
+		{name: "trims leading newlines", input: "\n\nfoo", expected: "foo"},
+		{name: "trims trailing newlines", input: "foo\n\n", expected: "foo"},
+		{
+			name:     "preserves first line indentation",
+			input:    "\t\t\tresp, _ := json.Marshal()\n\t\t\t\t_ = resp\n",
+			expected: "            resp, _ := json.Marshal()\n                _ = resp",
+		},
+		{
+			name:     "preserves first line spaces",
+			input:    "   indented\n    more",
+			expected: "   indented\n    more",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, NormalizeSpace(tt.input))
+		})
+	}
+}
+
 func TestIsValidBase64(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Before

<img width="1054" height="554" alt="Screenshot 2026-08-26 at 11 28 55" src="https://github.com/user-attachments/assets/db318542-e52d-4120-8196-ad42d81f6f82" />

## After

<img width="954" height="554" alt="Screenshot 2026-08-26 at 11 39 35" src="https://github.com/user-attachments/assets/82387afc-6b26-4d90-a2bd-2e72d849b673" />
