### PR TITLE
fix(ui): preserve single line breaks in submitted user messages

### DIFF
--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -73,7 +73,7 @@ func (m *UserMessageItem) RawRender(width int) string {
 		return m.renderHighlighted(content, cappedWidth, height)
 	}
 
-	renderer := common.MarkdownRenderer(m.sty, cappedWidth)
+	renderer := common.UserMarkdownRenderer(m.sty, cappedWidth)
 	mu := common.LockMarkdownRenderer(renderer)
 
 	mu.Lock()
@@ -105,7 +105,7 @@ func (m *UserMessageItem) renderSkillInvocation(content string, width int) strin
 	var skill skillInvocation
 	if err := xml.Unmarshal([]byte(content), &skill); err != nil {
 		// If parsing fails, just render as markdown
-		renderer := common.MarkdownRenderer(m.sty, width)
+		renderer := common.UserMarkdownRenderer(m.sty, width)
 		mu := common.LockMarkdownRenderer(renderer)
 
 		mu.Lock()

--- a/internal/ui/chat/user_render_test.go
+++ b/internal/ui/chat/user_render_test.go
@@ -1,0 +1,132 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestUserItem builds a UserMessageItem carrying text.
+func newTestUserItem(t *testing.T, text string) *UserMessageItem {
+	t.Helper()
+	sty := styles.CharmtonePantera()
+	msg := &message.Message{
+		ID:    "user-1",
+		Role:  message.User,
+		Parts: []message.ContentPart{message.TextContent{Text: text}},
+	}
+	item := NewUserMessageItem(&sty, msg, nil)
+	userItem, ok := item.(*UserMessageItem)
+	require.True(t, ok, "NewUserMessageItem must return *UserMessageItem")
+	return userItem
+}
+
+// renderedLines returns the rendered message as trimmed, non-empty-aware
+// lines so assertions can talk about visual line structure without
+// depending on ANSI styling or trailing pad.
+func renderedLines(t *testing.T, text string, width int) []string {
+	t.Helper()
+	out := newTestUserItem(t, text).RawRender(width)
+	lines := strings.Split(out, "\n")
+	for i, l := range lines {
+		lines[i] = strings.TrimSpace(ansi.Strip(l))
+	}
+	return lines
+}
+
+// TestUserMessagePreservesSingleLineBreaks is the regression test for
+// charmbracelet/crush#3502: a user submitting
+//
+//	a
+//	b
+//
+//	c
+//
+// saw "a" and "b" collapsed onto one line ("ab"/"a b") in the chat
+// display, because user input was rendered through the standard
+// Markdown renderer where a lone newline is a soft break. The history
+// sent to the model was always correct; only the display was wrong.
+func TestUserMessagePreservesSingleLineBreaks(t *testing.T) {
+	t.Parallel()
+
+	lines := renderedLines(t, "a\nb\n\nc", 80)
+
+	var got []string
+	for _, l := range lines {
+		if l != "" {
+			got = append(got, l)
+		}
+	}
+	require.Equal(t, []string{"a", "b", "c"}, got,
+		"each typed line must render on its own visual line")
+
+	// The blank line the user typed between "b" and "c" must survive as a
+	// paragraph break, so this is not merely "everything got hard-wrapped".
+	joined := strings.Join(lines, "\n")
+	require.Contains(t, joined, "b\n\nc",
+		"the blank line between paragraphs must be preserved")
+}
+
+// TestUserMessageSoftWrapsLongLines guards the other direction: a
+// single long line that exceeds the render width must still soft wrap.
+// Preserving *authored* newlines must not disable wrapping.
+func TestUserMessageSoftWrapsLongLines(t *testing.T) {
+	t.Parallel()
+
+	long := "this is a single very long line of user input that comfortably exceeds the render width and therefore has to be soft wrapped by the renderer"
+	lines := renderedLines(t, long, 40)
+
+	var nonEmpty int
+	for _, l := range lines {
+		if l != "" {
+			nonEmpty++
+		}
+		require.LessOrEqual(t, len(l), 40,
+			"no rendered line may exceed the render width")
+	}
+	require.Greater(t, nonEmpty, 1,
+		"a line longer than the width must wrap onto multiple lines")
+}
+
+// TestUserMessageMarkdownConstructsUnaffected pins the blast radius of
+// the #3502 fix: preserving newlines must not disturb block-level
+// Markdown that users legitimately paste into the prompt.
+func TestUserMessageMarkdownConstructsUnaffected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "bullet list keeps one item per line",
+			input: "- one\n- two\n- three",
+			want:  []string{"one", "two", "three"},
+		},
+		{
+			name:  "numbered list keeps one item per line",
+			input: "1. first\n2. second",
+			want:  []string{"first", "second"},
+		},
+		{
+			name:  "fenced code block keeps its lines",
+			input: "```go\nfunc main() {\n\tx := 1\n}\n```",
+			want:  []string{"func main() {", "x := 1", "}"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			joined := strings.Join(renderedLines(t, tt.input, 80), "\n")
+			for _, w := range tt.want {
+				require.Contains(t, joined, w)
+			}
+		})
+	}
+}

--- a/internal/ui/common/markdown.go
+++ b/internal/ui/common/markdown.go
@@ -29,6 +29,7 @@ var (
 	mdCacheMu    sync.Mutex
 	mdCache      = map[int]*glamour.TermRenderer{}
 	quietMDCache = map[int]*glamour.TermRenderer{}
+	userMDCache  = map[int]*glamour.TermRenderer{}
 )
 
 // MarkdownRenderer returns a glamour [glamour.TermRenderer] configured with
@@ -54,6 +55,38 @@ func MarkdownRenderer(sty *styles.Styles, width int) *glamour.TermRenderer {
 		glamour.WithChromaFormatter(formatterName),
 	)
 	mdCache[width] = r
+	return r
+}
+
+// UserMarkdownRenderer returns a glamour [glamour.TermRenderer] configured like
+// [MarkdownRenderer] but with single line breaks preserved. Renderers are
+// memoized per width and shared across callers; call
+// InvalidateMarkdownRendererCache when the active styles change. Same
+// concurrency contract as [MarkdownRenderer]: serialize via
+// [LockMarkdownRenderer].
+//
+// User input is authored in a plain textarea, not written as Markdown source,
+// so a lone newline is a line the user deliberately typed. Standard Markdown
+// treats it as a soft break and joins the lines when rendering, which makes a
+// submitted message display differently from what was typed (see
+// charmbracelet/crush#3502). Preserving newlines keeps the display faithful.
+//
+// This is deliberately NOT applied to [MarkdownRenderer]: assistant output and
+// dialog copy are genuine Markdown, where soft-wrapping a paragraph across
+// source lines is normal and collapsing it is the correct rendering.
+func UserMarkdownRenderer(sty *styles.Styles, width int) *glamour.TermRenderer {
+	mdCacheMu.Lock()
+	defer mdCacheMu.Unlock()
+	if r, ok := userMDCache[width]; ok {
+		return r
+	}
+	r, _ := glamour.NewTermRenderer(
+		glamour.WithStyles(sty.Markdown),
+		glamour.WithWordWrap(width),
+		glamour.WithChromaFormatter(formatterName),
+		glamour.WithPreservedNewLines(),
+	)
+	userMDCache[width] = r
 	return r
 }
 
@@ -96,6 +129,7 @@ func InvalidateMarkdownRendererCache() {
 
 	mdCache = map[int]*glamour.TermRenderer{}
 	quietMDCache = map[int]*glamour.TermRenderer{}
+	userMDCache = map[int]*glamour.TermRenderer{}
 	rendererLocks = map[*glamour.TermRenderer]*sync.Mutex{}
 }
 


### PR DESCRIPTION
A user message typed as

    a
    b

    c

rendered in the chat as "a b" on one line. Only the display was affected — the content persisted to history and sent to the model was always correct.

User input is rendered through the shared Markdown renderer, where a lone newline is a soft break and adjacent lines are joined into one paragraph. That is correct for Markdown *source*, but user input is authored in a plain textarea: a newline there is a line the user deliberately typed, not soft wrapping.

Add UserMarkdownRenderer — same styles, width, and Chroma formatter as MarkdownRenderer, plus glamour's WithPreservedNewLines — and use it for user messages only. Assistant output and dialog copy keep the standard renderer, since those really are Markdown and collapsing soft-wrapped paragraphs is the correct rendering there.

The new renderer is memoized per width like its siblings and is cleared by InvalidateMarkdownRendererCache, so a style/palette change does not leave stale user renderers behind.

WithPreservedNewLines only affects soft breaks inside paragraphs and blockquotes: bullet lists, ordered lists, fenced code blocks, tables, and long-line soft wrapping all render byte-identically before and after. Tests cover the reported case, that long lines still wrap, and that those block constructs are unaffected.

Fixes #3502

Re-issue of #3505, which was closed when its fork was accidentally deleted; same change rebased onto current main.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).