### PR TITLE
fix(ui): restore scrolling in MCP completions dropdown

### DIFF
--- a/internal/ui/completions/completions.go
+++ b/internal/ui/completions/completions.go
@@ -295,6 +295,16 @@ func (c *Completions) HasItems() bool {
 	return len(c.filtered) > 0
 }
 
+// ScrollBy scrolls the completions list by the given number of lines.
+// The list renders in reverse order, so wheel deltas are inverted here to
+// match the visual scroll direction users expect.
+func (c *Completions) ScrollBy(lines int) {
+	if !c.open || lines == 0 || len(c.filtered) == 0 {
+		return
+	}
+	c.list.ScrollBy(-lines)
+}
+
 // Update handles key events for the completions.
 func (c *Completions) Update(msg tea.KeyPressMsg) (tea.Msg, bool) {
 	if !c.open {
@@ -308,6 +318,14 @@ func (c *Completions) Update(msg tea.KeyPressMsg) (tea.Msg, bool) {
 
 	case key.Matches(msg, c.keyMap.Down):
 		c.selectNext()
+		return nil, true
+
+	case key.Matches(msg, c.keyMap.PageUp):
+		c.list.ScrollBy(c.list.Height())
+		return nil, true
+
+	case key.Matches(msg, c.keyMap.PageDown):
+		c.list.ScrollBy(-c.list.Height())
 		return nil, true
 
 	case key.Matches(msg, c.keyMap.UpInsert):

--- a/internal/ui/completions/completions_test.go
+++ b/internal/ui/completions/completions_test.go
@@ -1,8 +1,10 @@
 package completions
 
 import (
+	"fmt"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -105,4 +107,55 @@ func TestFilterPrefersPathSegmentExact(t *testing.T) {
 	first, ok := filtered[0].(*CompletionItem)
 	require.True(t, ok)
 	require.Equal(t, "internal/ui/chat/mcp.go", first.Text())
+}
+
+func TestScrollByRevealsOverflowItems(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	files := make([]FileCompletionValue, 20)
+	for i := range files {
+		files[i] = FileCompletionValue{Path: fmt.Sprintf("internal/pkg/file-%02d.go", i)}
+	}
+	c.SetItems(files, nil)
+
+	startBefore := c.list.Offset()
+	c.ScrollBy(5)
+	startAfter := c.list.Offset()
+	require.NotEqual(t, startBefore, startAfter)
+}
+
+func TestPageDownScrollsOverflowItems(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	files := make([]FileCompletionValue, 20)
+	for i := range files {
+		files[i] = FileCompletionValue{Path: fmt.Sprintf("internal/pkg/file-%02d.go", i)}
+	}
+	c.SetItems(files, nil)
+
+	startBefore := c.list.Offset()
+	_, handled := c.Update(tea.KeyPressMsg{Code: tea.KeyPgDown})
+	require.True(t, handled)
+	startAfter := c.list.Offset()
+	require.NotEqual(t, startBefore, startAfter)
+}
+
+func TestSelectNextScrollsSelectedItemIntoView(t *testing.T) {
+	t.Parallel()
+
+	c := New(lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle())
+	files := make([]FileCompletionValue, 20)
+	for i := range files {
+		files[i] = FileCompletionValue{Path: fmt.Sprintf("internal/pkg/file-%02d.go", i)}
+	}
+	c.SetItems(files, nil)
+
+	for range 15 {
+		_, handled := c.Update(tea.KeyPressMsg{Code: tea.KeyDown})
+		require.True(t, handled)
+	}
+
+	require.True(t, c.list.SelectedItemInView())
 }

--- a/internal/ui/completions/keys.go
+++ b/internal/ui/completions/keys.go
@@ -8,6 +8,8 @@ import (
 type KeyMap struct {
 	Down,
 	Up,
+	PageDown,
+	PageUp,
 	Select,
 	Cancel key.Binding
 	DownInsert,
@@ -24,6 +26,14 @@ func DefaultKeyMap() KeyMap {
 		Up: key.NewBinding(
 			key.WithKeys("up"),
 			key.WithHelp("up", "move up"),
+		),
+		PageDown: key.NewBinding(
+			key.WithKeys("pgdown"),
+			key.WithHelp("pgdown", "page down"),
+		),
+		PageUp: key.NewBinding(
+			key.WithKeys("pgup"),
+			key.WithHelp("pgup", "page up"),
 		),
 		Select: key.NewBinding(
 			key.WithKeys("enter", "tab", "ctrl+y"),

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -921,6 +921,13 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Batch(cmds...)
 		}
 
+		if m.completionsOpen && m.state == uiChat && m.focus == uiFocusEditor {
+			if lines := int(msg.DeltaY); lines != 0 {
+				m.completions.ScrollBy(lines)
+			}
+			return m, tea.Batch(cmds...)
+		}
+
 		// Otherwise handle mouse wheel for chat. Use the coalesced delta
 		// directly as the line count. Terminals like Ghostty send DeltaY=3
 		// per physical wheel tick (matching their native scrollback), while


### PR DESCRIPTION
## Summary

Restore scrolling for the @-triggered completions popup when the MCP/files list overflows the visible height.

## Motivation

Fixes #3641. After wheel input was centralized on `CoalescedWheelMsg`, the completions popup stopped receiving mouse wheel events. With the list rendered in reverse order, uninverted wheel deltas were also a no-op at offset 0, so overflow entries became unreachable.

## Changes

- Route `CoalescedWheelMsg` to completions while the popup is open in the editor
- Add `Completions.ScrollBy` with reverse-list sign compensation
- Add PageUp/PageDown keyboard navigation for the popup
- Add regression tests for overflow scrolling

## Tests

- `go test ./internal/ui/completions/... -count=1` — PASS
- composer-2.5 review — APPROVE

## Notes

Chat wheel scrolling is unchanged when completions are closed. Arrow-key navigation was already working via `ScrollToSelected`; this change focuses on wheel and page navigation.