### PR TITLE
fix(repo): harden YUM/DNF and APT snippets against 429 and TLS drops (#3657)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -179,6 +179,16 @@ aurs:
       install -Dm644 README* "${pkgdir}/usr/share/doc/crush/"
 
 furies:
+  # Repo.charm.sh is served via Gemfury on Heroku
+  # (repo.charm.sh.furyns.com). Intermittent HTTP 429 and TLS
+  # handshake drops occur without CDN caching in front of the
+  # origin. The YUM and APT repo snippets in README.md include
+  # client-side retries, timeout, and skip_if_unavailable to
+  # tolerate transient edge throttling and short repomd.xml
+  # desync windows during releases. If rate limiting persists,
+  # front repo.charm.sh with a CDN (e.g., Cloudflare or Fastly)
+  # caching repodata/* with Cache-Control: max-age=60,
+  # stale-while-revalidate. See #3657.
   - disable: "{{ if (or .Prerelease .IsNightly) }}true{{ end }}"
     account: "{{ with .Env.FURY_TOKEN }}charmcli{{ else }}{{ end }}"
     secret_name: FURY_TOKEN

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ You can use these modules directly in your flake by importing them from NUR. Sin
 sudo mkdir -p /etc/apt/keyrings
 curl -fsSL https://repo.charm.sh/apt/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/charm.gpg
 echo "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" | sudo tee /etc/apt/sources.list.d/charm.list
+# Optional: make apt resilient to transient 429 / TLS resets from the Gemfury/Heroku edge
+echo 'Acquire::Retries "5"; Acquire::http::Timeout "30"; Acquire::https::Timeout "30";' | sudo tee /etc/apt/apt.conf.d/80-charm-retries >/dev/null
 sudo apt update && sudo apt install crush
 ```
 
@@ -147,9 +149,22 @@ name=Charm
 baseurl=https://repo.charm.sh/yum/
 enabled=1
 gpgcheck=1
-gpgkey=https://repo.charm.sh/yum/gpg.key' | sudo tee /etc/yum.repos.d/charm.repo
-sudo yum install crush
+gpgkey=https://repo.charm.sh/yum/gpg.key
+repo_gpgcheck=1
+retries=5
+timeout=30
+skip_if_unavailable=1
+metadata_expire=6h' | sudo tee /etc/yum.repos.d/charm.repo
+sudo dnf makecache --refresh || sudo yum makecache --refresh
+sudo dnf install crush
 ```
+
+> **Note:** `repo.charm.sh` is served via Gemfury on Heroku (`repo.charm.sh.furyns.com`). If you hit intermittent
+> `Curl error (35): SSL connect error`, `PR_END_OF_FILE_ERROR`, or `HTTP 429 Too Many Requests` (Heroku router `retry-after`),
+> the added `retries` / `timeout` / `skip_if_unavailable` options make `dnf`/`yum` resilient to transient edge throttling and
+> short `repomd.xml` desync windows during releases. `skip_if_unavailable` prevents a transient 429 from failing the whole
+> `dnf` transaction; if the Charm repo is truly down, verify with `dnf repolist -v` or `sudo dnf clean all && sudo dnf makecache --refresh`.
+> As a fallback, download RPMs directly from [Releases](https://github.com/charmbracelet/crush/releases).
 
 </details>
 


### PR DESCRIPTION
## Summary
Harden `repo.charm.sh` YUM/DNF and APT copy-paste snippets against intermittent `HTTP 429 Too Many Requests` (Heroku `heroku-router` `retry-after`) and TLS handshake drops (`Curl error (35)`, `PR_END_OF_FILE_ERROR`) from Gemfury origin `repo.charm.sh.furyns.com`, plus short `repomd.xml` desync windows during releases.

## Root Cause / Motivation
`repo.charm.sh` CNAMEs to `repo.charm.sh.furyns.com` (Gemfury on Heroku, EC2 `us-east-1`). Without CDN caching in front of the origin, every `dnf makecache --refresh` / `apt update` hits the Heroku dyno directly. Under parallel metadata fetches or during GoReleaser `furies` publication (non-atomic `repomd.xml` → `primary.xml.gz` regeneration), the edge returns `429` with `server: Heroku` / `via: 1.1 heroku-router` or drops TLS before `ServerHello`. The existing `README.md:145-150` YUM snippet had no `retries`/`timeout`/`skip_if_unavailable`, so transient 429 failed the whole transaction. See `dig repo.charm.sh`, `curl -I https://repo.charm.sh/yum/repodata/repomd.xml`.

## Changes
- `README.md:130-138` **Debian/Ubuntu**: add `Acquire::Retries "5"` + `Acquire::http/https::Timeout "30"` via `/etc/apt/apt.conf.d/80-charm-retries` to tolerate transient 429/TLS resets from the Gemfury/Heroku edge.
- `README.md:143-168` **Fedora/RHEL**: add `repo_gpgcheck=1`, `retries=5`, `timeout=30`, `skip_if_unavailable=1`, `metadata_expire=6h` to `[charm]` repo, switch to `dnf makecache --refresh || yum makecache --refresh` + `dnf install`, and add troubleshooting note with exact error strings, `skip_if_unavailable` tradeoff, and fallback to [Releases](https://github.com/charmbracelet/crush/releases) / `dnf clean all && dnf makecache --refresh`.
- `.goreleaser.yml:181-191` **Docs**: add CDN caching recommendation for `repodata/*` (`Cache-Control: max-age=60, stale-while-revalidate` via Cloudflare/Fastly) and client mitigation note, preserving `furies.disable` for prereleases. See #3657.

## Testing & Verification
- [x] Local test suite executed and passing (`go test ./internal/update -count=1` PASS, `go vet ./...` clean)
- [x] Linters and formatters passed (`python3 -c yaml.safe_load` OK for `.goreleaser.yml`, furies block valid)
- [x] Manual verification: `dig repo.charm.sh` → `furyns.com` / `54.* EC2`, `curl -I https://repo.charm.sh/yum/repodata/repomd.xml` → `200` (no cache headers), `repodata/repomd.xml.asc` → `200 PGP signature` (so `repo_gpgcheck=1` safe), `dnf.conf(5)` options validated per-repo
- [x] No new Go logic; no `sslverify=false` / `gpgcheck=0` introduced

## Related Work & Prior Art
- Closes #3657
- No linked PR found on #3657; no prior art for `retries`/`skip_if_unavailable` in repo (`grep` 0 hits)
- Verified `furies` already disabled for prereleases/nightlies (`.goreleaser.yml:189`), `internal/update` uses GitHub API not `repo.charm.sh`