### PR TITLE
fix(windows): set console code page to UTF-8 to fix GBK garble (#3656)

### DIFF
--- a/internal/cmd/root_windows.go
+++ b/internal/cmd/root_windows.go
@@ -4,11 +4,25 @@
 package cmd
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 
 	"golang.org/x/sys/windows"
 )
+
+func init() {
+	// Set console code pages to UTF-8 to prevent garbled Chinese output on
+	// Windows systems with GBK locale (cp936). See #3656 and #839.
+	// Errors are ignored when not attached to a console (piped or detached).
+	_ = windows.SetConsoleCP(65001)
+	_ = windows.SetConsoleOutputCP(65001)
+
+	// Ensure child processes use UTF-8 even when stdout is piped, where the
+	// console code page is ignored. This covers python -c print cases.
+	_ = os.Setenv("PYTHONIOENCODING", "utf-8")
+	_ = os.Setenv("PYTHONUTF8", "1")
+}
 
 func detachProcess(c *exec.Cmd) {
 	if c.SysProcAttr == nil {


### PR DESCRIPTION
## Summary
Fix garbled Chinese (GBK/cp936) output on Windows with Chinese locale by setting the console code page to UTF-8 (65001) at startup. Bubble Tea assumes UTF-8, but `conhost` on `zh-CN` defaults to 936, so `你好` is mis-decoded as `涓ソ`.

## Root Cause / Motivation
Crush assumes UTF-8 end-to-end (`internal/cmd/root.go:135` `tea.NewProgram`, `internal/shell/*`), but Windows `GetConsoleCP()`/`GetConsoleOutputCP()` defaults to 936 on GBK systems. No code ever called `SetConsoleCP(65001)`/`SetConsoleOutputCP(65001)`. The TUI writes UTF-8 bytes that the console interprets as GBK, and the shell captures piped output (e.g. `python -c "print('你好')"` via `mvdan.cc/sh`) as GBK bytes then treats as UTF-8. Same root cause as #839 (Japanese cp932). PR #3211 fixed `TruncateOutput` splitting UTF-8 but not the console code page.

## Changes
- `internal/cmd/root_windows.go:13-26` — add `init()` (Windows build tag) that calls `windows.SetConsoleCP(65001)` and `windows.SetConsoleOutputCP(65001)`. Errors ignored when not attached to a console (piped/redirected or detached `crush server` with `DETACHED_PROCESS`).
- Also set `os.Setenv("PYTHONIOENCODING","utf-8")` and `os.Setenv("PYTHONUTF8","1")` so piped children (where console CP is ignored) still emit UTF-8, covering the `python -c` repro.

## Testing & Verification
- [x] Local test suite executed and passing (`go vet ./internal/cmd` PASS, `GOOS=windows go vet ./internal/cmd` PASS, `GOOS=windows go build ./...` PASS, `go test ./internal/cmd -count=1` PASS)
- [x] Linters and formatters passed (`gofmt`/`gofumpt` clean, import grouping stdlib/internal, comments capital/period)
- [x] Manual verification concept: `SetConsoleCP`/`SetConsoleOutputCP` from `golang.org/x/sys/windows v0.47.0` exist at `windows/zsyscall_windows.go:3236`, `windows.CP_UTF8` not exported so literal `65001` used, build tag `//go:build windows` + legacy `// +build windows` matches `internal/cmd/root_windows.go:1-2` and `server_windows.go:1-2`
- [x] No new dependencies, no secrets, minimal diff (1 file, 14 lines)

## Related Work & Prior Art
- Closes #3656
- Related #839 (Japanese garble), fixed in part by #3211 (`fix(bash): keep TruncateOutput from splitting UTF-8 characters` — byte-slice truncation → `utf8.RuneStart`)
- No prior `SetConsoleCP`/`65001` usage in repo (`grep` 0 hits)