### PR TITLE
fix(ui): highlight current model when picker opens (#3638)

### DIFF
--- a/internal/ui/dialog/models.go
+++ b/internal/ui/dialog/models.go
@@ -109,7 +109,6 @@ func NewModels(com *common.Common, isOnboarding bool) (*Models, error) {
 	m.help = help
 	m.list = NewModelsList(t)
 	m.list.Focus()
-	m.list.SetSelected(0)
 
 	m.input = textinput.New()
 	m.input.SetVirtualCursor(false)
@@ -490,10 +489,22 @@ func (m *Models) setProviderItems() error {
 
 	// Set model groups in the list.
 	m.list.SetGroups(groups...)
-	m.list.SetSelectedItem(selectedItemID)
+	m.list.Focus()
 	if selectedItemID != "" {
+		m.list.SetSelectedItem(selectedItemID)
+		// Ensure the current model is actually highlighted. If the provider
+		// list was stale or the model wasn't found, fall back to the first
+		// selectable model so the dialog never opens without a highlight.
+		if sel := m.list.SelectedItem(); sel == nil {
+			m.list.SelectFirst()
+		} else if mi, ok := sel.(*ModelItem); !ok || mi.ID() != selectedItemID {
+			m.list.SelectFirst()
+		}
 		m.list.ScrollToSelected()
 	} else {
+		// No current model (e.g., onboarding): highlight the first model
+		// instead of leaving the heading selected, so Enter is useful.
+		m.list.SelectFirst()
 		m.list.ScrollToTop()
 	}
 


### PR DESCRIPTION
## Summary
Fix the model picker (`ctrl+m`) not highlighting the active model on first open. After opening, toggling `Tab` twice (Small → Large) correctly highlighted it — initial build left the list without a focused selection.

## Root Cause / Motivation
`NewModels` called `m.list.SetSelected(0)` before any groups existed (so `Len==0` → `selected=-1`), then `setProviderItems` called `SetGroups` + `SetSelectedItem(currentModelID)` + `ScrollToSelected`. If the provider cache was stale or the current model wasn't found in the first build, the list stayed at `-1` (no highlight) or on a heading, while the second build after `Tab` found it. The `SelectedItem` check and `Focus()` were also missing, so the dialog could open unhighlighted and `Enter` did nothing.

## Changes
- `internal/ui/dialog/models.go:110` — remove premature `SetSelected(0)` before groups exist; rely on `setProviderItems` to set the correct selection.
- `internal/ui/dialog/models.go:490-508` — `Focus()` the list after `SetGroups`, verify `SetSelectedItem` actually selected the expected `selectedItemID`; fall back to `SelectFirst()` if not found so the dialog never opens without a highlight. When no current model (onboarding), explicitly `SelectFirst()` instead of `ScrollToTop` on a heading.

## Testing & Verification
- [x] `go vet ./internal/ui/dialog` PASS
- [x] `go test ./internal/ui/dialog -count=1` PASS
- [x] `go test ./internal/ui/list -count=1` PASS
- [x] Manual logic verification: `NewModelsList` + `SetGroups` + `SetSelectedItem("provider-a:model-2")` now correctly leaves `Selected()==2` and `Focused()==true` on first open; fallback to `SelectFirst()` when `selectedItemID==""` prevents heading highlight

## Related Work & Prior Art
- Closes #3638
- Related #839 (Japanese garble, same picker) and #3211 (`TruncateOutput` UTF-8 fix)
- Follow-up to `1320fcf5c` (`scroll to the properly select model`) and unmerged `fb7abdc7a` (`highlight a real model when picker opens unselected`)