### PR TITLE
feat(config): make the auto-summarize thresholds configurable

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -59,6 +59,24 @@ const (
 	smallContextWindowRatio     = 0.2
 )
 
+// autoSummarizeThreshold returns how many tokens may remain in a context
+// window of cw tokens before the session is summarized. Windows above
+// largeContextWindowThreshold keep a flat buffer, smaller ones reserve a
+// share of the window. A configured buffer or ratio only replaces the
+// default of its own regime.
+func autoSummarizeThreshold(cw int64, ratio float64, buffer int64) int64 {
+	if cw > largeContextWindowThreshold {
+		if buffer > 0 {
+			return buffer
+		}
+		return largeContextWindowBuffer
+	}
+	if ratio > 0 {
+		return int64(float64(cw) * ratio)
+	}
+	return int64(float64(cw) * smallContextWindowRatio)
+}
+
 var userAgent = fmt.Sprintf("Charm-Crush/%s (https://charm.land/crush)", version.Version)
 
 //go:embed templates/title.md
@@ -177,6 +195,8 @@ type sessionAgent struct {
 	sessions             session.Service
 	messages             message.Service
 	disableAutoSummarize bool
+	autoSummarizeRatio   float64
+	autoSummarizeBuffer  int64
 	isYolo               bool
 	notify               pubsub.Publisher[notify.Notification]
 	runComplete          pubsub.Publisher[notify.RunComplete]
@@ -229,6 +249,8 @@ type SessionAgentOptions struct {
 	SystemPrompt         string
 	IsSubAgent           bool
 	DisableAutoSummarize bool
+	AutoSummarizeRatio   float64
+	AutoSummarizeBuffer  int64
 	IsYolo               bool
 	Sessions             session.Service
 	Messages             message.Service
@@ -249,6 +271,8 @@ func NewSessionAgent(
 		sessions:             opts.Sessions,
 		messages:             opts.Messages,
 		disableAutoSummarize: opts.DisableAutoSummarize,
+		autoSummarizeRatio:   opts.AutoSummarizeRatio,
+		autoSummarizeBuffer:  opts.AutoSummarizeBuffer,
 		tools:                csync.NewSliceFrom(opts.Tools),
 		isYolo:               opts.IsYolo,
 		notify:               opts.Notify,
@@ -1044,12 +1068,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 				}
 				tokens := currentSession.CompletionTokens + currentSession.PromptTokens
 				remaining := cw - tokens
-				var threshold int64
-				if cw > largeContextWindowThreshold {
-					threshold = largeContextWindowBuffer
-				} else {
-					threshold = int64(float64(cw) * smallContextWindowRatio)
-				}
+				threshold := autoSummarizeThreshold(cw, a.autoSummarizeRatio, a.autoSummarizeBuffer)
 				if (remaining <= threshold) && !a.disableAutoSummarize {
 					shouldSummarize = true
 					return true

--- a/internal/agent/agentic_fetch_tool.go
+++ b/internal/agent/agentic_fetch_tool.go
@@ -184,6 +184,8 @@ func (c *coordinator) agenticFetchTool(_ context.Context, client *http.Client) (
 				SystemPromptPrefix:   smallProviderCfg.SystemPromptPrefix,
 				SystemPrompt:         systemPrompt,
 				DisableAutoSummarize: c.cfg.Config().Options.DisableAutoSummarize,
+				AutoSummarizeRatio:   c.cfg.Config().Options.AutoSummarizeRatio,
+				AutoSummarizeBuffer:  c.cfg.Config().Options.AutoSummarizeBuffer,
 				IsYolo:               c.permissions.SkipRequests(),
 				Sessions:             c.sessions,
 				Messages:             c.messages,

--- a/internal/agent/auto_summarize_test.go
+++ b/internal/agent/auto_summarize_test.go
@@ -1,0 +1,33 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutoSummarizeThreshold(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		contextWindow int64
+		ratio         float64
+		buffer        int64
+		want          int64
+	}{
+		{"large window keeps the flat buffer", 400_000, 0, 0, largeContextWindowBuffer},
+		{"small window reserves a fifth", 100_000, 0, 0, 20_000},
+		{"200k is not large enough for the buffer", 200_000, 0, 0, 40_000},
+		{"buffer replaces the flat default", 400_000, 0, 40_000, 40_000},
+		{"buffer leaves small windows alone", 100_000, 0, 40_000, 20_000},
+		{"ratio replaces the small window default", 100_000, 0.3, 0, 30_000},
+		{"ratio leaves large windows alone", 400_000, 0.3, 0, largeContextWindowBuffer},
+		{"each setting covers its own regime", 400_000, 0.3, 40_000, 40_000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, autoSummarizeThreshold(tc.contextWindow, tc.ratio, tc.buffer))
+		})
+	}
+}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -635,6 +635,8 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 		SystemPrompt:         "",
 		IsSubAgent:           isSubAgent,
 		DisableAutoSummarize: c.cfg.Config().Options.DisableAutoSummarize,
+		AutoSummarizeRatio:   c.cfg.Config().Options.AutoSummarizeRatio,
+		AutoSummarizeBuffer:  c.cfg.Config().Options.AutoSummarizeBuffer,
 		IsYolo:               c.permissions.SkipRequests(),
 		Sessions:             c.sessions,
 		Messages:             c.messages,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -363,6 +363,14 @@ type Options struct {
 	Debug                bool        `json:"debug,omitempty" jsonschema:"description=Enable debug logging,default=false"`
 	DebugLSP             bool        `json:"debug_lsp,omitempty" jsonschema:"description=Enable debug logging for LSP servers,default=false"`
 	DisableAutoSummarize bool        `json:"disable_auto_summarize,omitempty" jsonschema:"description=Disable automatic conversation summarization,default=false"`
+	// AutoSummarizeRatio is the share of a context window of up to 200k
+	// tokens that is kept free before the session is summarized. Zero keeps
+	// the default of 0.2.
+	AutoSummarizeRatio float64 `json:"auto_summarize_ratio,omitempty" jsonschema:"description=Share of a context window of up to 200k tokens kept free before the session is summarized (default 0.2),minimum=0,exclusiveMaximum=1,example=0.3"`
+	// AutoSummarizeBuffer is the number of tokens kept free in a context
+	// window above 200k tokens before the session is summarized. Zero keeps
+	// the default of 20000.
+	AutoSummarizeBuffer int64 `json:"auto_summarize_buffer,omitempty" jsonschema:"description=Tokens kept free in a context window above 200k tokens before the session is summarized (default 20000),minimum=0,example=40000"`
 	// DataDirectory is where Crush keeps per-project state such as
 	// the SQLite database and workspace overrides. Relative paths are
 	// resolved against the working directory; absolute paths are used

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -649,6 +649,19 @@ func (c *Config) setDefaults(workingDir, dataDir string) {
 	}
 
 	c.Options.InitializeAs = cmp.Or(c.Options.InitializeAs, defaultInitializeAs)
+
+	// A ratio of 1 or more would summarize on every step and negative values
+	// mean nothing, so fall back to the defaults instead of wedging a session.
+	if ratio := c.Options.AutoSummarizeRatio; ratio < 0 || ratio >= 1 {
+		if ratio != 0 {
+			slog.Warn("Ignoring out-of-range auto_summarize_ratio, expected a value above 0 and below 1", "ratio", ratio)
+		}
+		c.Options.AutoSummarizeRatio = 0
+	}
+	if buffer := c.Options.AutoSummarizeBuffer; buffer < 0 {
+		slog.Warn("Ignoring negative auto_summarize_buffer", "buffer", buffer)
+		c.Options.AutoSummarizeBuffer = 0
+	}
 }
 
 // powernapDefaults caches the powernap default LSP server catalog. The

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -425,6 +425,31 @@ func TestConfig_setDefaults(t *testing.T) {
 	})
 }
 
+func TestConfig_setDefaults_autoSummarize(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name               string
+		ratio, wantRatio   float64
+		buffer, wantBuffer int64
+	}{
+		{"unset keeps zero", 0, 0, 0, 0},
+		{"in range is kept", 0.3, 0.3, 40_000, 40_000},
+		{"ratio of one is dropped", 1, 0, 0, 0},
+		{"ratio above one is dropped", 2.5, 0, 0, 0},
+		{"negative ratio is dropped", -0.5, 0, 0, 0},
+		{"negative buffer is dropped", 0, 0, -1, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{Options: &Options{AutoSummarizeRatio: tc.ratio, AutoSummarizeBuffer: tc.buffer}}
+			cfg.setDefaults(t.TempDir(), "")
+			require.InDelta(t, tc.wantRatio, cfg.Options.AutoSummarizeRatio, 1e-9)
+			require.Equal(t, tc.wantBuffer, cfg.Options.AutoSummarizeBuffer)
+		})
+	}
+}
+
 func TestConfig_configureProviders(t *testing.T) {
 	knownProviders := []catwalk.Provider{
 		{

--- a/schema.json
+++ b/schema.json
@@ -496,6 +496,23 @@
           "description": "Disable automatic conversation summarization",
           "default": false
         },
+        "auto_summarize_ratio": {
+          "type": "number",
+          "exclusiveMaximum": 1,
+          "minimum": 0,
+          "description": "Share of a context window of up to 200k tokens kept free before the session is summarized (default 0.2)",
+          "examples": [
+            0.3
+          ]
+        },
+        "auto_summarize_buffer": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Tokens kept free in a context window above 200k tokens before the session is summarized (default 20000)",
+          "examples": [
+            40000
+          ]
+        },
         "data_directory": {
           "type": "string",
           "description": "Directory for storing application data. Relative paths are resolved against the working directory; absolute paths are used as-is.",


### PR DESCRIPTION
Two `options` fields, `auto_summarize_ratio` and `auto_summarize_buffer`, expose the thresholds that decide when a session gets summarized. Each replaces only the default of its own regime: the ratio applies to context windows of up to 200k tokens, where 20% is kept free today, and the buffer to larger windows, where it's a flat 20k tokens. Left unset, nothing changes.

A ratio outside 0..1 or a negative buffer is logged and ignored, since a ratio of 1 would summarize on every step. The shape is @espetro's from the issue thread. I had a single-ratio version on a branch first, but the point about a ratio reserving far more on a 1M window is fair, and this diff is smaller. No crushrc `option` keys yet, those can follow once the fields settle.

Closes #3564
