### PR TITLE
fix(message): AppendContent only appends to the first matching part

### DIFF
--- a/internal/message/content.go
+++ b/internal/message/content.go
@@ -282,20 +282,22 @@ func (m *Message) IsThinking() bool {
 }
 
 func (m *Message) AppendContent(delta string) {
-	found := false
+	// Append to the first existing TextContent part only. The sibling
+	// helpers (AddToolCall, AppendThoughtSignature, FinishThinking) all
+	// return after finding the first match; without that here, a message
+	// that ever ends up with multiple TextContent parts would see `delta`
+	// appended to every one of them, multiplying the visible response.
 	for i, part := range m.Parts {
 		if c, ok := part.(TextContent); ok {
 			m.Parts[i] = TextContent{Text: c.Text + delta}
-			found = true
+			return
 		}
 	}
-	if !found {
-		m.Parts = append(m.Parts, TextContent{Text: delta})
-	}
+	m.Parts = append(m.Parts, TextContent{Text: delta})
 }
 
 func (m *Message) AppendReasoningContent(delta string) {
-	found := false
+	// See AppendContent above - append to the first match only.
 	for i, part := range m.Parts {
 		if c, ok := part.(ReasoningContent); ok {
 			m.Parts[i] = ReasoningContent{
@@ -304,15 +306,13 @@ func (m *Message) AppendReasoningContent(delta string) {
 				StartedAt:  c.StartedAt,
 				FinishedAt: c.FinishedAt,
 			}
-			found = true
+			return
 		}
 	}
-	if !found {
-		m.Parts = append(m.Parts, ReasoningContent{
-			Thinking:  delta,
-			StartedAt: time.Now().Unix(),
-		})
-	}
+	m.Parts = append(m.Parts, ReasoningContent{
+		Thinking:  delta,
+		StartedAt: time.Now().Unix(),
+	})
 }
 
 func (m *Message) AppendThoughtSignature(signature string, toolCallID string) {

--- a/internal/message/content_test.go
+++ b/internal/message/content_test.go
@@ -173,3 +173,59 @@ func TestResetStreamedContentEmpty(t *testing.T) {
 	msg.ResetStreamedContent()
 	require.Empty(t, msg.Parts)
 }
+
+// TestAppendContent_OnlyAppendsToFirstMatch pins the defensive
+// single-match behavior of AppendContent: a delta must extend exactly
+// one TextContent part, even when Parts contains more than one. Without
+// the return after a match, the loop continues and appends `delta` to
+// every TextContent in Parts, quietly multiplying the visible response.
+// The sibling helpers in this file (AppendThoughtSignature,
+// FinishThinking) all single-match; this test guards that AppendContent
+// and AppendReasoningContent stay in the same family.
+func TestAppendContent_OnlyAppendsToFirstMatch(t *testing.T) {
+	t.Parallel()
+
+	m := &Message{
+		Parts: []ContentPart{
+			TextContent{Text: "first"},
+			TextContent{Text: "second"},
+		},
+	}
+
+	m.AppendContent(" delta")
+
+	require.Len(t, m.Parts, 2)
+	require.Equal(t, "first delta", m.Parts[0].(TextContent).Text)
+	require.Equal(t, "second", m.Parts[1].(TextContent).Text,
+		"second TextContent part must be untouched; AppendContent multi-matched")
+}
+
+func TestAppendContent_CreatesPartWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	m := &Message{Parts: []ContentPart{ToolCall{ID: "tc1"}}}
+	m.AppendContent("hello")
+
+	require.Len(t, m.Parts, 2)
+	tc, ok := m.Parts[1].(TextContent)
+	require.True(t, ok, "expected TextContent appended after ToolCall")
+	require.Equal(t, "hello", tc.Text)
+}
+
+func TestAppendReasoningContent_OnlyAppendsToFirstMatch(t *testing.T) {
+	t.Parallel()
+
+	m := &Message{
+		Parts: []ContentPart{
+			ReasoningContent{Thinking: "a", StartedAt: 1},
+			ReasoningContent{Thinking: "b", StartedAt: 2},
+		},
+	}
+
+	m.AppendReasoningContent(" delta")
+
+	require.Len(t, m.Parts, 2)
+	require.Equal(t, "a delta", m.Parts[0].(ReasoningContent).Thinking)
+	require.Equal(t, "b", m.Parts[1].(ReasoningContent).Thinking,
+		"second ReasoningContent part must be untouched")
+}


### PR DESCRIPTION
## What does this PR do?

Fixes `AppendContent` and `AppendReasoningContent` in `internal/message/content.go` so they append a streaming delta to only the **first** matching content part, not every match.

### The bug

Both helpers used a `found` flag set inside the loop without a `return`:

```go
found := false
for i, part := range m.Parts {
    if c, ok := part.(TextContent); ok {
        m.Parts[i] = TextContent{Text: c.Text + delta}
        found = true          // loop continues!
    }
}
if !found {
    m.Parts = append(m.Parts, TextContent{Text: delta})
}
```

So a `Message` whose `Parts` holds more than one `TextContent` gets `delta` appended to **every** one of them. With streaming, each chunk is appended repeatedly, so the visible response is multiplied by the number of matching parts — and it compounds across chunks.

### Why it matters now

There is no code path today that produces two `TextContent` parts on one `Message`, so this is latent, not active. But the sibling helpers in the same file — `AddToolCall`, `AppendThoughtSignature`, `FinishThinking` — all `return` after the first match. `AppendContent` is the odd one out, and the next feature that legitimately produces multiple text parts (e.g. interleaved tool output + narration) will silently multiply streamed output. This closes the gap and adds regression tests that pin the single-match contract for both helpers.

### Changes

- `internal/message/content.go`: replace the `found` flag with an early `return` after the first match, in both helpers. Behavior when zero parts match is unchanged (a new part is appended).
- `internal/message/content_test.go`: three tests — first-match-only for `AppendContent`, part creation when absent, first-match-only for `AppendReasoningContent`.

No API or wire-format changes. No behavior change for single-part messages.

### Supersedes

Supersedes PR 2956, whose branch (May 2026) had diverged from main far enough that a merge produced ~120 conflicting files. This PR applies the same 2-file fix on top of current `main` instead.
