### PR TITLE
Revert "feat(ui): use framed-square glyph for image attachment icon

### DIFF
--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -42,7 +42,7 @@ const (
 	TodoPendingIcon    string = "•"
 	TodoInProgressIcon string = "→"
 
-	ImageIcon  string = "▣"
+	ImageIcon  string = "■"
 	TextIcon   string = "≡"
 	SkillIcon  string = "▲"
 	RemoveIcon string = "✕"


### PR DESCRIPTION
Reverts charmbracelet/crush#3339

@joestump, reverting this one as I don't think this icon renders well on various terminals.