### PR TITLE
fix: make timeout configurable

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -487,6 +487,12 @@ String Keys:
   attribution-trailer-style string attribution trailer: none, co-authored-by,
                                    or assisted-by
 
+Integer Keys:
+  request-timeout int              seconds before an LLM request is aborted;
+                                   streaming responses are only aborted after
+                                   this much inactivity; 0 waits forever
+                                   (default 60)
+
 List Keys:
   context-path string             append a project context path
   global-context-path string      append a global context path

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1154,10 +1154,15 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		}
 		var fantasyErr *fantasy.Error
 		var providerErr *fantasy.ProviderError
+		var requestTimedOutErr *requestTimeoutError
 		const defaultTitle = "Provider Error"
 		linkStyle := lipgloss.NewStyle().Foreground(charmtone.Guac).Underline(true)
 		if isCancelErr {
 			currentAssistant.AddFinish(message.FinishReasonCanceled, "User canceled request", "")
+		} else if errors.As(err, &requestTimedOutErr) {
+			// Checked before the provider branches so a deadline our own
+			// request timeout imposed is never reported as a provider error.
+			currentAssistant.AddFinish(message.FinishReasonError, "Request timed out", requestTimedOutErr.userMessage())
 		} else if isHyper && errors.As(err, &providerErr) && providerErr.StatusCode == http.StatusUnauthorized {
 			currentAssistant.AddFinish(message.FinishReasonError, "Unauthorized", `Please re-authenticate with Hyper. You can also run "crush auth" to re-authenticate.`)
 		} else if errors.As(err, &providerErr) {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -875,6 +875,13 @@ func (c *coordinator) buildAgentModels(ctx context.Context, isSubAgent bool) (Mo
 		return Model{}, Model{}, err
 	}
 
+	// Bound each request with the configured timeout so unreachable or hung
+	// providers fail instead of blocking a session forever. The wrapper is
+	// applied per request, so retries get a fresh budget each attempt.
+	requestTimeout := c.cfg.Config().Options.GetRequestTimeout()
+	largeModel = newRequestTimeoutModel(largeModel, requestTimeout)
+	smallModel = newRequestTimeoutModel(smallModel, requestTimeout)
+
 	return Model{
 			Model:      largeModel,
 			CatwalkCfg: *largeCatwalkModel,

--- a/internal/agent/request_timeout.go
+++ b/internal/agent/request_timeout.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"charm.land/fantasy"
+)
+
+// requestTimeoutError reports that an LLM request exhausted its configured
+// request_timeout budget. For streaming requests this is an idle timeout:
+// it only fires when the provider sends nothing for the whole window, so a
+// slow but actively streaming response is never killed. It wraps the
+// underlying error so callers can still match [context.DeadlineExceeded]
+// through the chain.
+type requestTimeoutError struct {
+	timeout time.Duration
+	idle    bool
+	cause   error
+}
+
+func (e *requestTimeoutError) Error() string {
+	msg := fmt.Sprintf("LLM request timed out after %s", e.timeout)
+	if e.idle {
+		msg = fmt.Sprintf("LLM stream received no data for %s", e.timeout)
+	}
+	if e.cause != nil {
+		return fmt.Sprintf("%s: %v", msg, e.cause)
+	}
+	return msg
+}
+
+func (e *requestTimeoutError) Unwrap() error { return e.cause }
+
+// userMessage explains the timeout in the UI, including how long the request
+// ran before giving up and how to change the limit.
+func (e *requestTimeoutError) userMessage() string {
+	hint := "Increase the limit with \"option request-timeout SECONDS\" or set it to 0 to disable the timeout."
+	if e.idle {
+		return fmt.Sprintf("The model stopped sending data for %s. %s", e.timeout, hint)
+	}
+	return fmt.Sprintf("The model did not respond within %s. %s", e.timeout, hint)
+}
+
+// requestTimeoutModel wraps a [fantasy.LanguageModel] so requests are
+// bounded by the configured request_timeout. Non-streaming calls get a hard
+// per-request deadline, applied per call so fantasy's retry loop gives every
+// attempt a fresh budget — the same per-request semantics the provider SDKs
+// expose. Streams instead get an idle timeout: the budget resets whenever a
+// part arrives and only fires when the provider goes silent, so a slow but
+// actively streaming response is never aborted.
+type requestTimeoutModel struct {
+	fantasy.LanguageModel
+	timeout time.Duration
+}
+
+// newRequestTimeoutModel bounds each request to m with the given timeout. A
+// timeout of zero or less, or a nil model, returns m unchanged.
+func newRequestTimeoutModel(m fantasy.LanguageModel, timeout time.Duration) fantasy.LanguageModel {
+	if m == nil || timeout <= 0 {
+		return m
+	}
+	return requestTimeoutModel{LanguageModel: m, timeout: timeout}
+}
+
+// wrapTimedOut replaces err with the requestTimeoutError when this model's
+// own deadline fired. Other errors — user cancellation, outer deadlines,
+// provider failures — pass through unchanged. Cancellation errors caused by
+// our own timer report as [context.DeadlineExceeded] so callers never
+// mistake a timeout for a user cancellation.
+func wrapTimedOut(ctx context.Context, timeoutErr *requestTimeoutError, err error) error {
+	if err == nil || context.Cause(ctx) != timeoutErr {
+		return err
+	}
+	if errors.Is(err, context.Canceled) {
+		timeoutErr.cause = context.DeadlineExceeded
+	} else {
+		timeoutErr.cause = err
+	}
+	return timeoutErr
+}
+
+// Generate implements [fantasy.LanguageModel]. The request gets a hard
+// deadline: there is no incremental progress signal, so the whole call must
+// finish within the budget.
+func (m requestTimeoutModel) Generate(ctx context.Context, call fantasy.Call) (*fantasy.Response, error) {
+	timeoutErr := &requestTimeoutError{timeout: m.timeout}
+	ctx, cancel := context.WithTimeoutCause(ctx, m.timeout, timeoutErr)
+	defer cancel()
+	resp, err := m.LanguageModel.Generate(ctx, call)
+	return resp, wrapTimedOut(ctx, timeoutErr, err)
+}
+
+// Stream implements [fantasy.LanguageModel].
+//
+// The stream is consumed after Stream returns, so the timer must outlive
+// this call: it fires only after timeout seconds without any part arriving,
+// and is released when iteration ends, whether the stream finishes, breaks,
+// or the idle timeout aborts it. Both the initial connection and gaps
+// between parts share the same budget.
+func (m requestTimeoutModel) Stream(ctx context.Context, call fantasy.Call) (fantasy.StreamResponse, error) {
+	timeoutErr := &requestTimeoutError{timeout: m.timeout, idle: true}
+	ctx, cancel := context.WithCancelCause(ctx)
+	timer := time.AfterFunc(m.timeout, func() { cancel(timeoutErr) })
+
+	inner, err := m.LanguageModel.Stream(ctx, call)
+	if err != nil {
+		timer.Stop()
+		cancel(nil)
+		return nil, wrapTimedOut(ctx, timeoutErr, err)
+	}
+	return func(yield func(fantasy.StreamPart) bool) {
+		defer timer.Stop()
+		defer cancel(nil)
+		inner(func(part fantasy.StreamPart) bool {
+			timer.Reset(m.timeout)
+			part.Error = wrapTimedOut(ctx, timeoutErr, part.Error)
+			return yield(part)
+		})
+	}, nil
+}

--- a/internal/agent/request_timeout_test.go
+++ b/internal/agent/request_timeout_test.go
@@ -1,0 +1,286 @@
+package agent
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"charm.land/fantasy"
+	"charm.land/x/vcr"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeLanguageModel is a [fantasy.LanguageModel] stub that records the
+// context its methods were called with and can be configured with a custom
+// stream body.
+type fakeLanguageModel struct {
+	generateCtx context.Context
+	streamCtx   context.Context
+	stream      func(yield func(fantasy.StreamPart) bool)
+}
+
+func (f *fakeLanguageModel) Generate(ctx context.Context, _ fantasy.Call) (*fantasy.Response, error) {
+	f.generateCtx = ctx
+	return &fantasy.Response{}, nil
+}
+
+func (f *fakeLanguageModel) Stream(ctx context.Context, _ fantasy.Call) (fantasy.StreamResponse, error) {
+	f.streamCtx = ctx
+	if f.stream == nil {
+		return func(yield func(fantasy.StreamPart) bool) {
+			yield(fantasy.StreamPart{})
+		}, nil
+	}
+	return f.stream, nil
+}
+
+func (f *fakeLanguageModel) GenerateObject(context.Context, fantasy.ObjectCall) (*fantasy.ObjectResponse, error) {
+	return &fantasy.ObjectResponse{}, nil
+}
+
+func (f *fakeLanguageModel) StreamObject(context.Context, fantasy.ObjectCall) (fantasy.ObjectStreamResponse, error) {
+	return nil, nil
+}
+
+func (f *fakeLanguageModel) Provider() string { return "fake" }
+func (f *fakeLanguageModel) Model() string    { return "fake-model" }
+
+func TestNewRequestTimeoutModel_Disabled(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeLanguageModel{}
+	require.Same(t, inner, newRequestTimeoutModel(inner, 0))
+	require.Same(t, inner, newRequestTimeoutModel(inner, -time.Second))
+}
+
+func TestRequestTimeoutModel_GenerateDeadline(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeLanguageModel{}
+	m := newRequestTimeoutModel(inner, 5*time.Minute)
+
+	_, err := m.Generate(t.Context(), fantasy.Call{})
+	require.NoError(t, err)
+
+	_, ok := inner.generateCtx.Deadline()
+	require.True(t, ok, "Generate should run under a deadline")
+}
+
+func TestRequestTimeoutModel_StreamDeadlineOutlivesCall(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeLanguageModel{}
+	m := newRequestTimeoutModel(inner, 5*time.Minute)
+
+	stream, err := m.Stream(t.Context(), fantasy.Call{})
+	require.NoError(t, err)
+
+	require.NoError(t, inner.streamCtx.Err(), "the idle timer must not fire while the stream is being consumed")
+
+	for range stream {
+	}
+
+	require.ErrorIs(t, inner.streamCtx.Err(), context.Canceled, "the stream context should be released after the stream ends")
+}
+
+func TestRequestTimeoutModel_StreamAbortsWhenIdle(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeLanguageModel{}
+	// A stream that outlives the idle window: it waits for the context to
+	// be done and reports what it observed.
+	streamObserved := make(chan error, 1)
+	inner.stream = func(yield func(fantasy.StreamPart) bool) {
+		<-inner.streamCtx.Done()
+		streamObserved <- inner.streamCtx.Err()
+	}
+	m := newRequestTimeoutModel(inner, 10*time.Millisecond)
+	stream, err := m.Stream(t.Context(), fantasy.Call{})
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range stream {
+		}
+	}()
+
+	select {
+	case err := <-streamObserved:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream was not aborted by the idle timeout")
+	}
+	<-done
+}
+
+func TestRequestTimeoutModel_ActiveStreamSurvives(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeLanguageModel{}
+	// A stream that keeps sending data: total runtime exceeds the timeout,
+	// but every gap is shorter than the idle window, so it must finish.
+	inner.stream = func(yield func(fantasy.StreamPart) bool) {
+		for range 6 {
+			time.Sleep(10 * time.Millisecond)
+			if !yield(fantasy.StreamPart{}) {
+				return
+			}
+		}
+	}
+	m := newRequestTimeoutModel(inner, 25*time.Millisecond)
+	stream, err := m.Stream(t.Context(), fantasy.Call{})
+	require.NoError(t, err)
+
+	parts := 0
+	for part := range stream {
+		require.NoError(t, part.Error)
+		parts++
+	}
+	require.Equal(t, 6, parts)
+}
+
+// blockingModel blocks until the context is done and then returns the
+// context error, the way a hung provider request would.
+type blockingModel struct {
+	fakeLanguageModel
+}
+
+func (b *blockingModel) Generate(ctx context.Context, _ fantasy.Call) (*fantasy.Response, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestRequestTimeoutModel_GenerateReportsTimeout(t *testing.T) {
+	t.Parallel()
+
+	m := newRequestTimeoutModel(&blockingModel{}, 10*time.Millisecond)
+
+	_, err := m.Generate(t.Context(), fantasy.Call{})
+	require.Error(t, err)
+
+	var timeoutErr *requestTimeoutError
+	require.ErrorAs(t, err, &timeoutErr)
+	require.Equal(t, 10*time.Millisecond, timeoutErr.timeout)
+	require.ErrorIs(t, err, context.DeadlineExceeded, "the deadline must stay detectable through the chain")
+	require.Contains(t, err.Error(), "timed out after 10ms")
+}
+
+func TestRequestTimeoutModel_StreamReportsTimeout(t *testing.T) {
+	t.Parallel()
+
+	inner := &fakeLanguageModel{}
+	// A provider stream that fails with the context error once the deadline
+	// fires, mirroring how SDKs surface mid-stream aborts.
+	inner.stream = func(yield func(fantasy.StreamPart) bool) {
+		<-inner.streamCtx.Done()
+		yield(fantasy.StreamPart{Error: inner.streamCtx.Err()})
+	}
+	m := newRequestTimeoutModel(inner, 10*time.Millisecond)
+	stream, err := m.Stream(t.Context(), fantasy.Call{})
+	require.NoError(t, err)
+
+	var got error
+	for part := range stream {
+		if part.Error != nil {
+			got = part.Error
+		}
+	}
+
+	var timeoutErr *requestTimeoutError
+	require.ErrorAs(t, got, &timeoutErr)
+	require.ErrorIs(t, got, context.DeadlineExceeded)
+}
+
+func TestRequestTimeoutModel_ParentCancelPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	m := newRequestTimeoutModel(&blockingModel{}, 5*time.Minute)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := m.Generate(ctx, fantasy.Call{})
+	require.ErrorIs(t, err, context.Canceled)
+
+	var timeoutErr *requestTimeoutError
+	require.NotErrorAs(t, err, &timeoutErr, "user cancellation must not be reported as a timeout")
+}
+
+func TestRequestTimeoutErrorMessages(t *testing.T) {
+	t.Parallel()
+
+	err := &requestTimeoutError{timeout: time.Second}
+	require.Equal(t, "LLM request timed out after 1s", err.Error())
+	require.Contains(t, err.userMessage(), "1s")
+	require.Contains(t, err.userMessage(), "request-timeout")
+
+	err.cause = context.DeadlineExceeded
+	require.Equal(t, "LLM request timed out after 1s: context deadline exceeded", err.Error())
+
+	idle := &requestTimeoutError{timeout: 2 * time.Second, idle: true}
+	require.Equal(t, "LLM stream received no data for 2s", idle.Error())
+	require.Contains(t, idle.userMessage(), "stopped sending data for 2s")
+	require.Contains(t, idle.userMessage(), "request-timeout")
+}
+
+// timeoutOnlyModel streams a single error part shaped exactly like the one
+// requestTimeoutModel produces when its deadline fires.
+type timeoutOnlyModel struct {
+	fakeLanguageModel
+}
+
+func (m *timeoutOnlyModel) Stream(context.Context, fantasy.Call) (fantasy.StreamResponse, error) {
+	timeoutErr := &requestTimeoutError{timeout: time.Second, idle: true, cause: context.DeadlineExceeded}
+	return func(yield func(fantasy.StreamPart) bool) {
+		yield(fantasy.StreamPart{Type: fantasy.StreamPartTypeError, Error: timeoutErr})
+	}, nil
+}
+
+// TestRequestTimeoutRunFinishMessage pins what the user sees when a request
+// exhausts its timeout: a "Request timed out" finish that names the elapsed
+// budget and how to change it, instead of a bare provider error.
+func TestRequestTimeoutRunFinishMessage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows for now")
+	}
+
+	env := testEnv(t)
+	model := &timeoutOnlyModel{}
+	agent, err := coderAgent(vcr.NewRecorder(t), env, model, model)
+	require.NoError(t, err)
+
+	session, err := env.sessions.Create(t.Context(), "timeout session")
+	require.NoError(t, err)
+
+	_, err = agent.Run(t.Context(), SessionAgentCall{
+		Prompt:          "Hello",
+		SessionID:       session.ID,
+		MaxOutputTokens: 10000,
+	})
+	require.Error(t, err)
+
+	msgs, err := env.messages.List(t.Context(), session.ID)
+	require.NoError(t, err)
+
+	var finish *message.Finish
+	for _, msg := range msgs {
+		if msg.Role != message.Assistant {
+			continue
+		}
+		if part := msg.FinishPart(); part != nil {
+			finish = part
+		}
+	}
+	require.NotNil(t, finish, "the assistant message should carry a finish part")
+	require.Equal(t, message.FinishReasonError, finish.Reason)
+	require.Equal(t, "Request timed out", finish.Message)
+	require.Contains(t, finish.Details, "stopped sending data for 1s")
+	require.Contains(t, finish.Details, "request-timeout")
+}

--- a/internal/agent/testdata/TestRequestTimeoutRunFinishMessage.yaml
+++ b/internal/agent/testdata/TestRequestTimeoutRunFinishMessage.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -378,6 +378,29 @@ type Options struct {
 	Progress                  *bool        `json:"progress,omitempty" jsonschema:"description=Show indeterminate progress updates during long operations,default=true"`
 	Notifications             string       `json:"notifications,omitempty" jsonschema:"description=Notification style to use. Options: auto (default)\\, native\\, osc\\, bell\\, disabled. Auto selects based on environment: native for local sessions\\, osc for SSH (with automatic OSC 99/777 detection).,enum=auto,enum=native,enum=osc,enum=bell,enum=disabled,default=auto"`
 	DisabledSkills            []string     `json:"disabled_skills,omitempty" jsonschema:"description=List of skill names to disable and hide from the agent,example=crush-config"`
+	RequestTimeout            *int         `json:"request_timeout,omitempty" jsonschema:"description=Timeout in seconds for each LLM API request. Streaming responses are aborted only after this much inactivity\\, so slow but active streams are never killed. 0 disables it\\, negative values are invalid.,default=60,example=120,example=300,example=0"`
+}
+
+// DefaultRequestTimeout bounds each LLM API request when the user has not
+// configured a timeout. Slow or unreachable providers fail after it instead
+// of blocking a session forever; streamed responses are only aborted after
+// this much inactivity, and users running slow local models can raise or
+// disable it via options.request_timeout.
+const DefaultRequestTimeout = time.Minute
+
+// GetRequestTimeout returns the per-request timeout for LLM API calls (a
+// hard deadline for non-streaming requests and an idle timeout for
+// streams), or zero when disabled. The nil receiver and the unset field
+// both mean DefaultRequestTimeout, so callers can ask without unwrapping
+// either.
+func (o *Options) GetRequestTimeout() time.Duration {
+	if o == nil || o.RequestTimeout == nil {
+		return DefaultRequestTimeout
+	}
+	if *o.RequestTimeout <= 0 {
+		return 0
+	}
+	return time.Duration(*o.RequestTimeout) * time.Second
 }
 
 type MCPs map[string]MCPConfig

--- a/internal/config/options_request_timeout_test.go
+++ b/internal/config/options_request_timeout_test.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestOptionsGetRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		options  *Options
+		expected time.Duration
+	}{
+		{
+			name:     "nil options",
+			options:  nil,
+			expected: DefaultRequestTimeout,
+		},
+		{
+			name:     "unset field",
+			options:  &Options{},
+			expected: DefaultRequestTimeout,
+		},
+		{
+			name:     "disabled",
+			options:  &Options{RequestTimeout: ptr(0)},
+			expected: 0,
+		},
+		{
+			name:     "negative disables too",
+			options:  &Options{RequestTimeout: ptr(-1)},
+			expected: 0,
+		},
+		{
+			name:     "seconds to duration",
+			options:  &Options{RequestTimeout: ptr(300)},
+			expected: 5 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, tt.options.GetRequestTimeout())
+		})
+	}
+}
+
+func TestOptionsRequestTimeoutFromJSON(t *testing.T) {
+	t.Parallel()
+
+	var cfg Config
+	require.NoError(t, json.Unmarshal([]byte(`{"options":{"request_timeout":300}}`), &cfg))
+	require.Equal(t, 300, *cfg.Options.RequestTimeout)
+	require.Equal(t, 5*time.Minute, cfg.Options.GetRequestTimeout())
+}

--- a/internal/shellconfig/options.go
+++ b/internal/shellconfig/options.go
@@ -31,6 +31,8 @@ import (
 //	option metrics false
 //	option debug true
 //	option auto-lsp false
+//	option request-timeout 300
+//	option request-timeout 0
 //
 // Boolean shortcuts: for boolean fields, omitting the value sets it to true.
 func handleOption(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) error {
@@ -139,6 +141,18 @@ func handleOption(ctx context.Context, args []string, stdin io.Reader, stdout, s
 		slog.Info("Option set in shell config", "key", key, "value", o[spec.jsonKey])
 		return nil
 
+	case optInt:
+		if val == "" {
+			return usage(stderr, fmt.Sprintf("option: %s requires a value", key))
+		}
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return usage(stderr, fmt.Sprintf("option: %s expects a number of seconds, got %q", key, val))
+		}
+		o[spec.jsonKey] = n
+		slog.Info("Option set in shell config", "key", key, "value", n)
+		return nil
+
 	default: // optString
 		if val == "" {
 			return usage(stderr, fmt.Sprintf("option: %s requires a value", key))
@@ -156,6 +170,7 @@ const (
 	optString optionKind = iota
 	optBool
 	optList
+	optInt
 )
 
 // optionSpec describes one user-facing option key: the JSON field it writes,
@@ -194,6 +209,9 @@ var optionSpecs = map[string]optionSpec{
 	"notifications":  {jsonKey: "notifications", kind: optString},
 	"data-directory": {jsonKey: "data_directory", kind: optString},
 	"initialize-as":  {jsonKey: "initialize_as", kind: optString},
+
+	// Integer fields, in seconds.
+	"request-timeout": {jsonKey: "request_timeout", kind: optInt},
 
 	// List fields. Keys are singular because each call appends one value.
 	"context-path":        {jsonKey: "context_paths", kind: optList},

--- a/internal/shellconfig/options_test.go
+++ b/internal/shellconfig/options_test.go
@@ -227,3 +227,33 @@ func TestOption_UnknownKey(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unknown key")
 }
+
+func TestOption_RequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	script := `option request-timeout 300
+option request-timeout 0`
+	path := filepath.Join(dir, "crushrc")
+
+	jsonBytes, err := LoadShellConfig(t.Context(), path, []byte(script))
+	require.NoError(t, err)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal(jsonBytes, &result))
+
+	opts := result["options"].(map[string]any)
+	require.Equal(t, float64(0), opts["request_timeout"])
+}
+
+func TestOption_RequestTimeoutInvalid(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	script := `option request-timeout soon`
+	path := filepath.Join(dir, "crushrc")
+
+	_, err := LoadShellConfig(t.Context(), path, []byte(script))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expects a number of seconds")
+}

--- a/internal/skills/builtin/crush-config/SKILL.md
+++ b/internal/skills/builtin/crush-config/SKILL.md
@@ -348,6 +348,7 @@ The `$schema` property enables IDE autocomplete but is optional.
 | `permissions deny bash`              | `options.disabled_tools = ["bash"]`                    |
 | `option skill-path ./skills`         | `options.skills_paths = ["./skills"]`                  |
 | `option metrics false`               | `options.disable_metrics = true`                       |
+| `option request-timeout 300`          | `options.request_timeout = 300`                        |
 | `option attribution-trailer-style none` | `options.attribution.trailer_style = "none"`        |
 | `option attribution-generated-with false` | `options.attribution.generated_with = false`       |
 


### PR DESCRIPTION
## What?

Makes model hang timeout configurable via `request-timeout` in bash and `request_timeout` in json.

## Why?

Fixes #3658 