### PR TITLE
fix: inline code copying

### DIFF
--- a/internal/ui/common/inlinecode_copy_test.go
+++ b/internal/ui/common/inlinecode_copy_test.go
@@ -1,0 +1,48 @@
+package common
+
+import (
+	"testing"
+
+	"charm.land/glamour/v2"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRenderedInlineCodeHasNoVisibleBackticks guards the display side of the
+// inline-code copy fix: codespans render blank padding (a no-break-space
+// sentinel), never the backticks themselves. The sentinel is what selection
+// copies turn back into backticks (see list.HighlightContent).
+func TestRenderedInlineCodeHasNoVisibleBackticks(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+
+	render := func(t *testing.T, r *glamour.TermRenderer, src string) string {
+		t.Helper()
+		mu := LockMarkdownRenderer(r)
+		mu.Lock()
+		defer mu.Unlock()
+		rendered, err := r.Render(src)
+		require.NoError(t, err)
+		return ansi.Strip(rendered)
+	}
+
+	for name, r := range map[string]*glamour.TermRenderer{
+		"markdown": MarkdownRenderer(&sty, 80),
+		"quiet":    QuietMarkdownRenderer(&sty, 80),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			actual := render(t, r, `message "this is `+"`code`"+`" ok`)
+
+			require.NotContains(t, actual, "`", "codespan backticks must not render on screen")
+			require.Contains(
+				t,
+				actual,
+				`this is `+styles.CodespanPadding+`code`+styles.CodespanPadding+`" ok`,
+				"codespan must render with the sentinel padding",
+			)
+		})
+	}
+}

--- a/internal/ui/list/highlight.go
+++ b/internal/ui/list/highlight.go
@@ -6,6 +6,7 @@ import (
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/stringext"
+	"github.com/charmbracelet/crush/internal/ui/styles"
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/ansi"
 )
@@ -81,6 +82,13 @@ func extractRows(buf uv.ScreenBuffer, startLine, startCol, endLine, endCol, heig
 // colEnd, trimmed to the last cell holding any content (including explicit
 // spaces: renderers like glamour pad rows with real space cells, so content
 // usually reaches the full width).
+//
+// Codespan padding cells are converted back into backticks: markdown inline
+// code renders blank padding in place of its backticks
+// ([styles.CodespanPadding]), and a copy of a selection must reproduce the
+// original source text, not the rendered blank padding. The sentinel is a
+// no-break space tagged with a variation selector, so a real no-break space
+// in the message text does not match it and is copied verbatim.
 func extractRow(line uv.Line, colStart, colEnd int) string {
 	lastCellX := -1
 	for x := colStart; x < colEnd; x++ {
@@ -94,7 +102,11 @@ func extractRow(line uv.Line, colStart, colEnd int) string {
 	for x := colStart; x <= lastCellX; x++ {
 		cell := line.At(x)
 		if cell != nil {
-			row.WriteString(cell.Content)
+			if cell.Content == styles.CodespanPadding {
+				row.WriteString("`")
+			} else {
+				row.WriteString(cell.Content)
+			}
 		}
 	}
 	return row.String()

--- a/internal/ui/list/highlight_test.go
+++ b/internal/ui/list/highlight_test.go
@@ -7,6 +7,7 @@ import (
 	"charm.land/glamour/v2"
 	"charm.land/lipgloss/v2"
 	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/charmbracelet/crush/internal/ui/styles"
 	"github.com/stretchr/testify/require"
@@ -89,4 +90,64 @@ func TestHighlightContentMarkdownList(t *testing.T) {
 	// must start on its own line.
 	require.Contains(t, result, "(space, wrap continuation)\n", "wrapped continuation must join with a space, got:\n%s", result)
 	require.Contains(t, result, "continuation)\n• Otherwise", "next list item must start on its own line, got:\n%s", result)
+}
+
+// TestHighlightContentRestoresCodespanBackticks guards the copy side of the
+// inline-code copy fix: markdown codespans render blank sentinel padding
+// instead of their backticks ([styles.CodespanPadding]), and a selection copy
+// must turn that padding back into the original backticks so the clipboard
+// matches the source text.
+func TestHighlightContentRestoresCodespanBackticks(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	r, err := glamour.NewTermRenderer(glamour.WithStyles(sty.Markdown), glamour.WithWordWrap(80))
+	require.NoError(t, err)
+	rendered, err := r.Render(`message "this is ` + "`code`" + `" ok`)
+	require.NoError(t, err)
+
+	require.NotContains(t, ansi.Strip(rendered), "`", "display must not show backticks")
+
+	result := HighlightContent(rendered, uv.Rect(0, 0, 80, lipgloss.Height(rendered)), 0, 0, -1, -1)
+	require.Contains(t, result, `"this is `+"`code`"+`" ok`, "copy must restore the codespan backticks, got:\n%s", result)
+}
+
+// TestHighlightContentPreservesRealNonBreakingSpaces is the regression test
+// for the sentinel collision: a real no-break space in the message text
+// (pasted text, LLM output, non-English typography) is not codespan padding
+// and must survive a selection copy verbatim, never turn into a backtick.
+func TestHighlightContentPreservesRealNonBreakingSpaces(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	r, err := glamour.NewTermRenderer(glamour.WithStyles(sty.Markdown), glamour.WithWordWrap(80))
+	require.NoError(t, err)
+	rendered, err := r.Render("question\u00a0: is `code` ok")
+	require.NoError(t, err)
+
+	result := HighlightContent(rendered, uv.Rect(0, 0, 80, lipgloss.Height(rendered)), 0, 0, -1, -1)
+	require.Contains(t, result, "question\u00a0: is `code` ok",
+		"copy must keep the real no-break space and restore only the codespan backticks, got:\n%q", result)
+
+	// Plain (unstyled) content with a real no-break space must also pass
+	// through untouched.
+	result = HighlightContent("foo\u00a0bar", uv.Rect(0, 0, 40, 1), 0, 0, -1, -1)
+	require.Equal(t, "foo\u00a0bar\n", result)
+}
+
+// TestHighlightContentRestoresWrappedCodespanBackticks is the narrow-width
+// variant: when the codespan pill wraps onto its own row, the copy must still
+// reassemble the pill into a single backticked span.
+func TestHighlightContentRestoresWrappedCodespanBackticks(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	width := 16
+	r, err := glamour.NewTermRenderer(glamour.WithStyles(sty.Markdown), glamour.WithWordWrap(width))
+	require.NoError(t, err)
+	rendered, err := r.Render("some text `codespan` and more words to force wrapping across rows")
+	require.NoError(t, err)
+
+	result := HighlightContent(rendered, uv.Rect(0, 0, width, lipgloss.Height(rendered)), 0, 0, -1, -1)
+	require.Contains(t, result, "`codespan`", "wrapped pill must reassemble in copy, got:\n%s", result)
 }

--- a/internal/ui/styles/quickstyle.go
+++ b/internal/ui/styles/quickstyle.go
@@ -251,8 +251,18 @@ func quickStyle(o quickStyleOpts) Styles {
 		},
 		Code: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix:          " ",
-				Suffix:          " ",
+				// Pad inline code with a no-break-space sentinel instead of
+				// a plain space. It displays identically, but selection
+				// copies turn it back into the original backticks (see
+				// [CodespanPadding] and list.HighlightContent); a plain
+				// space is indistinguishable from real text, so copies lost
+				// the backticks ("this is  code "). The sentinel carries a
+				// variation selector so copies can tell it apart from a
+				// real no-break space in the message text, and being
+				// non-breaking it keeps word wrap from tearing a codespan
+				// between its padding and its text.
+				Prefix:          CodespanPadding,
+				Suffix:          CodespanPadding,
 				Color:           hex(o.destructive),
 				BackgroundColor: hex(o.bgLessVisible),
 			},
@@ -491,8 +501,8 @@ func quickStyle(o quickStyleOpts) Styles {
 		},
 		Code: ansi.StyleBlock{
 			StylePrimitive: ansi.StylePrimitive{
-				Prefix:          " ",
-				Suffix:          " ",
+				Prefix:          CodespanPadding,
+				Suffix:          CodespanPadding,
 				Color:           plainFg,
 				BackgroundColor: plainBg,
 			},

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -26,6 +26,19 @@ const (
 
 	ArrowRightIcon string = "→"
 
+	// CodespanPadding is the padding rendered around inline code spans in
+	// markdown. It displays identically to the blank padding it replaced,
+	// but selection copies recognize it and turn it back into the original
+	// backticks (see list.HighlightContent).
+	//
+	// It is a no-break space tagged with a variation selector: the pair is
+	// a single one-cell grapheme that renders as a blank and, being
+	// non-breaking, keeps word wrap from tearing a codespan between its
+	// padding and its text. The selector makes the sentinel distinct from
+	// a real no-break space in message text (pasted text, some LLM
+	// output), which a selection copy must preserve verbatim.
+	CodespanPadding string = "\u00a0\ufe0f"
+
 	ToolPending string = "●"
 	ToolSuccess string = "✓"
 	ToolError   string = "×"


### PR DESCRIPTION
## What

Inline code still renders exactly as before (no visible backticks, same styling), but its padding is now an invisible non-breaking space that only the copy path recognizes and turns back into backticks. As a bonus, inline code can no longer be torn across two lines by word wrap.

## Why

Copying a selection that contains inline code produced mangled text — the backticks were replaced by stray spaces.