### PR TITLE
fix(bash-config): fix swap of cache create and cache hit

### DIFF
--- a/internal/config/shellconfig_provider_test.go
+++ b/internal/config/shellconfig_provider_test.go
@@ -49,8 +49,8 @@ model large myllm/foo-1 --provider-options '{"timeout":30}'`)
 	model := p.Models[0]
 	require.Equal(t, 1.25, model.CostPer1MIn)
 	require.Equal(t, 5.0, model.CostPer1MOut)
-	require.Equal(t, 2.0, model.CostPer1MOutCached)
-	require.Equal(t, 0.25, model.CostPer1MInCached)
+	require.Equal(t, 2.0, model.CostPer1MInCached)
+	require.Equal(t, 0.25, model.CostPer1MOutCached)
 
 	large := cfg.Models[config.SelectedModelTypeLarge]
 	require.Equal(t, "myllm", large.Provider)

--- a/internal/shellconfig/model.go
+++ b/internal/shellconfig/model.go
@@ -68,8 +68,8 @@ var modelAddFlags = []flagSpec{
 	{name: "--supports-images", jsonKey: "supports_attachments", kind: flagBool, op: opSet},
 	{name: "--price-input", jsonKey: "cost_per_1m_in", kind: flagFloat, op: opSet},
 	{name: "--price-output", jsonKey: "cost_per_1m_out", kind: flagFloat, op: opSet},
-	{name: "--price-cache-create", jsonKey: "cost_per_1m_out_cached", kind: flagFloat, op: opSet},
-	{name: "--price-cache-hit", jsonKey: "cost_per_1m_in_cached", kind: flagFloat, op: opSet},
+	{name: "--price-cache-create", jsonKey: "cost_per_1m_in_cached", kind: flagFloat, op: opSet},
+	{name: "--price-cache-hit", jsonKey: "cost_per_1m_out_cached", kind: flagFloat, op: opSet},
 	{name: "--reasoning-effort", jsonKey: "default_reasoning_effort", kind: flagString, op: opSet},
 }
 

--- a/internal/shellconfig/model_test.go
+++ b/internal/shellconfig/model_test.go
@@ -59,8 +59,8 @@ model add anthropic/claude-x --price-input 3 --price-output 15 --price-cache-cre
 	model := result["providers"].(map[string]any)["anthropic"].(map[string]any)["models"].([]any)[0].(map[string]any)
 	require.Equal(t, 3.0, model["cost_per_1m_in"])
 	require.Equal(t, 15.0, model["cost_per_1m_out"])
-	require.Equal(t, 3.75, model["cost_per_1m_out_cached"])
-	require.Equal(t, 0.3, model["cost_per_1m_in_cached"])
+	require.Equal(t, 3.75, model["cost_per_1m_in_cached"])
+	require.Equal(t, 0.3, model["cost_per_1m_out_cached"])
 }
 
 func TestModelAddRejectsLegacyPricingFlags(t *testing.T) {


### PR DESCRIPTION
## Problem

`model add` maps two pricing flags to the wrong JSON keys:

```go
{name: "--price-cache-create", jsonKey: "cost_per_1m_out_cached", ...},
{name: "--price-cache-hit",    jsonKey: "cost_per_1m_in_cached",  ...},
```

The cost calculation reads them the other way round, at `internal/agent/agent.go:1846`:

```go
cost := modelConfig.CostPer1MInCached/1e6*float64(resp.TotalUsage.CacheCreationTokens) +
    modelConfig.CostPer1MOutCached/1e6*float64(resp.TotalUsage.CacheReadTokens) + ...
```

`CostPer1MInCached` prices cache **creation**, and `CostPer1MOutCached` prices cache **reads**. So `--price-cache-create` must write `cost_per_1m_in_cached`, and `--price-cache-hit` must write `cost_per_1m_out_cached`.

Every other entry in the five flag tables maps its name to the matching key. These two are the only pair that crosses over.

## Effect

Declaring a custom model with real Anthropic prices, where cache write is 1.25x input and cache read is 0.1x input:

```
model add anthropic/claude-x --price-input 3 --price-output 15 \
  --price-cache-create 3.75 --price-cache-hit 0.3
```

| | 1M cache-creation tokens | 1M cache-read tokens |
|---|---|---|
| before | $0.30 (should be $3.75) | $3.75 (should be $0.30) |
| after | $3.75 | $0.30 |

Cache writes were billed at the read price and cache reads at the write price, so reported cost was wrong by the write/read ratio in both directions. For this pricing that is 12.5x.

I measured this by loading the config above through `loadCrushSh` and reading the two fields the cost formula consumes.

## Change

Swap the two `jsonKey` values. No flag name, help text or default changes.

## Tests

Two existing tests asserted the swapped result, so they change with the fix:

- `internal/shellconfig/model_test.go:62` - `TestModelAddPricingFlags` passes `--price-cache-create 3.75 --price-cache-hit 0.3` and expected 3.75 in `cost_per_1m_out_cached`.
- `internal/config/shellconfig_provider_test.go:52` - expected `--price-cache-create 2` in `CostPer1MOutCached`.

Both now assert the mapping that `agent.go` consumes. I checked for other places that encode this pair; only `internal/swagger/docs.go` mentions the keys, and it just declares the schema fields.

```
go build ./...
go test ./internal/...          no failures
go vet ./internal/config/... ./internal/shellconfig/...
gofmt -l                        clean
```
