### PR TITLE
fix(clipboard): only report copy success if it happens

### DIFF
--- a/internal/clipboard/clipboard.go
+++ b/internal/clipboard/clipboard.go
@@ -22,6 +22,9 @@ var (
 	// ErrEmpty is returned when the clipboard holds no data for the
 	// requested format.
 	ErrEmpty = errors.New("clipboard is empty or holds an unsupported format")
+	// ErrWriteFailed is returned when the platform has a clipboard but the
+	// written text is not there afterwards.
+	ErrWriteFailed = errors.New("clipboard write did not land")
 )
 
 // Init initializes the clipboard subsystem. On unsupported platforms it
@@ -30,10 +33,12 @@ func Init() error {
 	return initClipboard()
 }
 
-// WriteText writes plain text to the system clipboard. On unsupported
-// platforms it is a no-op.
-func WriteText(text string) {
-	writeText(text)
+// WriteText writes plain text to the system clipboard and reads it back to
+// confirm the write landed. It returns ErrUnsupported on platforms without a
+// clipboard or when Init did not succeed, and ErrWriteFailed when the
+// clipboard does not hold the text afterwards.
+func WriteText(text string) error {
+	return writeText(text)
 }
 
 // Read returns the clipboard contents for the given format. It returns

--- a/internal/clipboard/clipboard_not_supported.go
+++ b/internal/clipboard/clipboard_not_supported.go
@@ -6,7 +6,9 @@ func initClipboard() error {
 	return ErrUnsupported
 }
 
-func writeText(string) {}
+func writeText(string) error {
+	return ErrUnsupported
+}
 
 func read(Format) ([]byte, error) {
 	return nil, ErrUnsupported

--- a/internal/clipboard/clipboard_supported.go
+++ b/internal/clipboard/clipboard_supported.go
@@ -2,17 +2,45 @@
 
 package clipboard
 
-import "golang.design/x/clipboard"
+import (
+	"bytes"
+
+	"golang.design/x/clipboard"
+)
+
+// ready reports whether the native clipboard is usable. Touching the clipboard
+// after a failed initialization may panic, and golang.design's Init is
+// idempotent and cheap once it has run, so every entry point asks it again
+// rather than tracking initialization state of our own.
+func ready() bool {
+	return clipboard.Init() == nil
+}
 
 func initClipboard() error {
 	return clipboard.Init()
 }
 
-func writeText(text string) {
-	clipboard.Write(clipboard.FmtText, []byte(text))
+func writeText(text string) error {
+	if !ready() {
+		return ErrUnsupported
+	}
+	// A nil channel means the backend never took the clipboard; reading back
+	// catches the rest, where the write is accepted but the text is not served
+	// afterwards. Neither check subsumes the other: a failed write leaves an
+	// earlier identical copy in place, which reads back as a success.
+	if clipboard.Write(clipboard.FmtText, []byte(text)) == nil {
+		return ErrWriteFailed
+	}
+	if !bytes.Equal(clipboard.Read(clipboard.FmtText), []byte(text)) {
+		return ErrWriteFailed
+	}
+	return nil
 }
 
 func read(f Format) ([]byte, error) {
+	if !ready() {
+		return nil, ErrUnsupported
+	}
 	var format clipboard.Format
 	switch f {
 	case FormatText:

--- a/internal/ui/common/common.go
+++ b/internal/ui/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"image"
 	"os"
@@ -100,7 +101,8 @@ func IsFileTooBig(filePath string, sizeLimit int64) (bool, error) {
 
 // CopyToClipboard copies the given text to the clipboard using both OSC 52
 // (terminal escape sequence) and native clipboard for maximum compatibility.
-// Returns a command that reports success to the user with the given message.
+// Returns a command that reports the outcome to the user, using the given
+// message on success.
 func CopyToClipboard(text, successMessage string) tea.Cmd {
 	return CopyToClipboardWithCallback(text, successMessage, nil)
 }
@@ -108,14 +110,22 @@ func CopyToClipboard(text, successMessage string) tea.Cmd {
 // CopyToClipboardWithCallback copies text to clipboard and executes a callback
 // before showing the success message.
 // This is useful when you need to perform additional actions like clearing UI state.
+//
+// The callback and the success message only run when the copy is believed to
+// have worked, so callers can safely use the callback to discard the copied
+// state (a selection, say) without losing it on a failed copy.
 func CopyToClipboardWithCallback(text, successMessage string, callback tea.Cmd) tea.Cmd {
 	return tea.Sequence(
 		tea.SetClipboard(text),
 		func() tea.Msg {
-			clipboard.WriteText(text)
-			return nil
+			// OSC 52 above is fire and forget: the terminal never answers, so a
+			// platform without a native clipboard (an SSH session, say) gets the
+			// benefit of the doubt. Only a native clipboard that accepted the
+			// write and then does not hold the text is a real failure.
+			if err := clipboard.WriteText(text); errors.Is(err, clipboard.ErrWriteFailed) {
+				return util.NewWarnMsg("Failed to copy to clipboard")
+			}
+			return tea.Sequence(callback, util.ReportInfo(successMessage))()
 		},
-		callback,
-		util.ReportInfo(successMessage),
 	)
 }


### PR DESCRIPTION
Adds a check for whether the copy succeeded before reporting success

https://github.com/charmbracelet/crush/issues/1188#issuecomment-5448546928