### PR TITLE
fix: stop long reasoning traces from running away with the heap

### DIFF
--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -91,14 +91,39 @@ type pendingState struct {
 	// the debounce window.
 	timer *time.Timer
 
-	// lastFlushed is the snapshot most recently written to SQL. Used
-	// as the baseline for terminal-state detection.
-	lastFlushed Message
+	// baseline is the projection of the snapshot most recently
+	// written to SQL that terminal-state detection needs. Used as the
+	// baseline for [shouldFlushNow].
+	baseline flushBaseline
 
 	// hasFlushed is false until the first successful write for this
-	// ID; until then lastFlushed is the zero value and must not be
+	// ID; until then baseline is the zero value and must not be
 	// treated as a real prior state.
 	hasFlushed bool
+}
+
+// flushBaseline is the compact projection of a flushed [Message] that
+// [shouldFlushNow] compares against. Pending state lives for as long
+// as the process does, so it retains this instead of the whole
+// Message: a finished stream would otherwise pin its parts — reasoning
+// text, tool inputs, tool results — on the heap forever.
+type flushBaseline struct {
+	toolCallsFinished   []bool
+	reasoningFinishedAt int64
+}
+
+// newFlushBaseline projects the fields [shouldFlushNow] reads out of a
+// flushed message.
+func newFlushBaseline(m *Message) flushBaseline {
+	calls := m.ToolCalls()
+	finished := make([]bool, len(calls))
+	for i, c := range calls {
+		finished[i] = c.Finished
+	}
+	return flushBaseline{
+		toolCallsFinished:   finished,
+		reasoningFinishedAt: m.ReasoningContent().FinishedAt,
+	}
 }
 
 type service struct {
@@ -243,9 +268,9 @@ func (s *service) Update(ctx context.Context, msg Message) error {
 	p.latest = cloned
 	p.dirty = true
 
-	var prev *Message
+	var prev *flushBaseline
 	if p.hasFlushed {
-		prev = &p.lastFlushed
+		prev = &p.baseline
 	}
 	terminal := shouldFlushNow(prev, &cloned)
 
@@ -303,15 +328,16 @@ func (s *service) FlushAll(ctx context.Context) error {
 
 // flushOne drains a single message ID. When syncCaller is true the
 // caller is willing to wait through a concurrent in-flight flush so
-// that, on return, lastFlushed equals latest at the moment of return.
+// that, on return, the flushed state equals latest at the moment of
+// return.
 // When false (timer-fired path) we bail if another flusher is already
 // running; that flusher will pick up the trailing dirty bit.
 //
 // Order matters: a sync caller must wait for any in-flight flush to
 // drain even when the buffer is currently clean — that in-flight
 // write has not yet updated the SQL row, so returning early would
-// violate the contract that on success lastFlushed reflects the most
-// recent state.
+// violate the contract that on success the flushed state reflects the
+// most recent state.
 func (s *service) flushOne(ctx context.Context, id string, syncCaller bool) error {
 	for {
 		s.mu.Lock()
@@ -342,11 +368,11 @@ func (s *service) flushOne(ctx context.Context, id string, syncCaller bool) erro
 		snap := p.latest
 		// Decide whether this snapshot represents a terminal event
 		// against the prior baseline. We must do this before resetting
-		// dirty/flushing because shouldFlushNow looks at p.lastFlushed
+		// dirty/flushing because shouldFlushNow looks at p.baseline
 		// (which is what was on disk before this write).
-		var prev *Message
+		var prev *flushBaseline
 		if p.hasFlushed {
-			prev = &p.lastFlushed
+			prev = &p.baseline
 		}
 		isTerminal := shouldFlushNow(prev, &snap)
 		p.flushing = true
@@ -358,7 +384,7 @@ func (s *service) flushOne(ctx context.Context, id string, syncCaller bool) erro
 		s.mu.Lock()
 		p.flushing = false
 		if err == nil {
-			p.lastFlushed = snap
+			p.baseline = newFlushBaseline(&snap)
 			p.hasFlushed = true
 		} else {
 			// Restore dirty so the next caller retries.
@@ -367,6 +393,13 @@ func (s *service) flushOne(ctx context.Context, id string, syncCaller bool) erro
 		// If a delta arrived during the SQL write and we are a sync
 		// caller, the user expects that delta to land too.
 		wasDirty := p.dirty
+		if !wasDirty {
+			// Nothing left to write, so drop the snapshot. Pending
+			// entries outlive the streams that created them; holding
+			// latest here would pin every finished message's parts
+			// for the life of the process.
+			p.latest = Message{}
+		}
 		s.mu.Unlock()
 
 		if err != nil {
@@ -416,16 +449,16 @@ func (s *service) write(ctx context.Context, msg Message) error {
 // finished, the tool-call set grew, a tool call transitioned to
 // finished, or reasoning just finished. prev is the last-flushed
 // snapshot (or nil if no write has landed yet).
-func shouldFlushNow(prev, next *Message) bool {
+func shouldFlushNow(prev *flushBaseline, next *Message) bool {
 	if next.IsFinished() {
 		return true
 	}
 
-	var prevCalls []ToolCall
+	var prevCalls []bool
 	var prevReasoningFinishedAt int64
 	if prev != nil {
-		prevCalls = prev.ToolCalls()
-		prevReasoningFinishedAt = prev.ReasoningContent().FinishedAt
+		prevCalls = prev.toolCallsFinished
+		prevReasoningFinishedAt = prev.reasoningFinishedAt
 	}
 	nextCalls := next.ToolCalls()
 	if len(nextCalls) != len(prevCalls) {
@@ -433,7 +466,7 @@ func shouldFlushNow(prev, next *Message) bool {
 	}
 	for i := range nextCalls {
 		// Bounds-safe: lengths are equal here.
-		if nextCalls[i].Finished != prevCalls[i].Finished {
+		if nextCalls[i].Finished != prevCalls[i] {
 			return true
 		}
 		// A tool call's input only matters once it has landed (Finished

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -2,6 +2,7 @@ package message
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -692,4 +693,36 @@ func TestUpdate_StructuralFlushUsesMustDeliver(t *testing.T) {
 				"structural terminal event must not be silently dropped via lossy Publish")
 		})
 	}
+}
+
+// TestPendingStateDoesNotRetainPayload guards the fix for the
+// unbounded heap growth reported in #3162: pending entries live for the
+// life of the service, so once a message is fully flushed they must
+// hold bookkeeping only, never the message parts.
+func TestPendingStateDoesNotRetainPayload(t *testing.T) {
+	t.Parallel()
+
+	svc, sessionID := newTestService(t, WithDebounce(time.Millisecond))
+	s := svc.(*service)
+
+	msg, err := svc.Create(t.Context(), sessionID, CreateMessageParams{
+		Role:  Assistant,
+		Parts: []ContentPart{},
+	})
+	require.NoError(t, err)
+
+	msg.AppendReasoningContent(strings.Repeat("x", 64*1024))
+	msg.AddToolCall(ToolCall{ID: "tc-1", Name: "bash", Finished: true})
+	msg.AddFinish(FinishReasonEndTurn, "", "")
+	require.NoError(t, svc.Update(t.Context(), msg))
+	require.NoError(t, svc.Flush(t.Context(), msg.ID))
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := s.pending[msg.ID]
+	require.NotNil(t, p)
+	require.False(t, p.dirty)
+	require.Empty(t, p.latest.Parts, "flushed pending state still pins the message parts")
+	require.True(t, p.hasFlushed)
+	require.Equal(t, []bool{true}, p.baseline.toolCallsFinished)
 }

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -726,3 +726,85 @@ func TestPendingStateDoesNotRetainPayload(t *testing.T) {
 	require.True(t, p.hasFlushed)
 	require.Equal(t, []bool{true}, p.baseline.toolCallsFinished)
 }
+
+// TestShouldFlushNow_AgainstCompactBaseline pins terminal detection to the
+// projection stored in flushBaseline rather than to a full Message snapshot.
+//
+// The existing structural tests all assert the positive direction, which a
+// broken projection would still satisfy: an empty baseline yields a tool-call
+// length mismatch, so it flushes for the wrong reason. The load-bearing case
+// is the negative one — after a flush, a delta that changes nothing structural
+// must stay buffered. That only holds if the baseline carries the prior
+// finished flags and reasoning finish time accurately.
+func TestShouldFlushNow_AgainstCompactBaseline(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T) (Service, Message) {
+		t.Helper()
+		svc, sessionID := newTestService(t, WithDebounce(time.Hour))
+		msg, err := svc.Create(t.Context(), sessionID, CreateMessageParams{Role: Assistant})
+		require.NoError(t, err)
+
+		// Land a baseline: one unfinished tool call, reasoning still open.
+		msg.AppendReasoningContent("thinking")
+		msg.AddToolCall(ToolCall{ID: "tc1", Name: "view", Finished: false})
+		require.NoError(t, svc.Update(t.Context(), msg))
+		got, err := svc.Get(t.Context(), msg.ID)
+		require.NoError(t, err)
+		require.Len(t, got.ToolCalls(), 1)
+		require.False(t, got.ToolCalls()[0].Finished)
+		return svc, msg
+	}
+
+	t.Run("non-structural delta stays buffered", func(t *testing.T) {
+		t.Parallel()
+		svc, msg := setup(t)
+
+		// Same tool call, same finished flag, reasoning still open. A
+		// baseline that lost the projection would see a length or flag
+		// mismatch here and flush.
+		msg.AppendReasoningContent(" some more")
+		require.NoError(t, svc.Update(t.Context(), msg))
+
+		got, err := svc.Get(t.Context(), msg.ID)
+		require.NoError(t, err)
+		require.Equal(t, "thinking", got.ReasoningContent().Thinking,
+			"a non-structural delta must not trigger a sync flush against the compact baseline")
+	})
+
+	t.Run("finished flip flushes", func(t *testing.T) {
+		t.Parallel()
+		svc, msg := setup(t)
+
+		msg.AddToolCall(ToolCall{ID: "tc1", Name: "view", Input: "{}", Finished: true})
+		require.NoError(t, svc.Update(t.Context(), msg))
+
+		got, err := svc.Get(t.Context(), msg.ID)
+		require.NoError(t, err)
+		require.True(t, got.ToolCalls()[0].Finished)
+	})
+
+	t.Run("new tool call flushes", func(t *testing.T) {
+		t.Parallel()
+		svc, msg := setup(t)
+
+		msg.AddToolCall(ToolCall{ID: "tc2", Name: "bash", Finished: false})
+		require.NoError(t, svc.Update(t.Context(), msg))
+
+		got, err := svc.Get(t.Context(), msg.ID)
+		require.NoError(t, err)
+		require.Len(t, got.ToolCalls(), 2)
+	})
+
+	t.Run("reasoning end flushes", func(t *testing.T) {
+		t.Parallel()
+		svc, msg := setup(t)
+
+		msg.FinishThinking()
+		require.NoError(t, svc.Update(t.Context(), msg))
+
+		got, err := svc.Get(t.Context(), msg.ID)
+		require.NoError(t, err)
+		require.NotZero(t, got.ReasoningContent().FinishedAt)
+	})
+}

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -558,6 +558,9 @@ func (a *AssistantMessageItem) renderThinking(thinking string, width int) string
 	renderer := common.QuietMarkdownRenderer(a.sty, width)
 	rendered := a.streamingThinking.Render(thinking, width, renderer)
 	rendered = strings.TrimSpace(rendered)
+	// The renderer already knows this count from its cached prefix, so
+	// take it rather than rescanning a document that only grows.
+	renderedLines := a.streamingThinking.LastLines()
 
 	// Count lines and, for the windowed view modes, slice the tail
 	// WITHOUT splitting the entire rendered document. Splitting a
@@ -568,7 +571,7 @@ func (a *AssistantMessageItem) renderThinking(thinking string, width int) string
 	var totalLines int
 	switch a.thinkingViewMode {
 	case thinkingCollapsed:
-		totalLines = countLines(rendered)
+		totalLines = renderedLines
 		if totalLines > maxCollapsedThinkingHeight {
 			tail, hidden := tailLines(rendered, maxCollapsedThinkingHeight, totalLines)
 			hint := a.sty.Messages.ThinkingTruncationHint.Render(
@@ -579,7 +582,7 @@ func (a *AssistantMessageItem) renderThinking(thinking string, width int) string
 			lines = strings.Split(rendered, "\n")
 		}
 	case thinkingTailWindow:
-		totalLines = countLines(rendered)
+		totalLines = renderedLines
 		if totalLines > maxExpandedThinkingTailLines {
 			tail, hidden := tailLines(rendered, maxExpandedThinkingTailLines, totalLines)
 			hint := a.sty.Messages.ThinkingTruncationHint.Render(

--- a/internal/ui/chat/incremental_glamour_test.go
+++ b/internal/ui/chat/incremental_glamour_test.go
@@ -951,3 +951,37 @@ func TestStreamingMarkdown_RelaxedBoundaryRespectsHazards(t *testing.T) {
 		})
 	}
 }
+
+// TestStreamingMarkdown_LastLinesMatchesOutput pins the incrementally
+// tracked line count to the value a fresh countLines would produce.
+// renderThinking sizes its "N lines hidden" truncation hint from
+// LastLines, so any drift here shows up as a wrong number on screen.
+func TestStreamingMarkdown_LastLinesMatchesOutput(t *testing.T) {
+	t.Parallel()
+
+	const width = 80
+
+	docs := map[string]string{
+		"blank-line-free prose": longProse(400),
+		"paragraphs":            strings.Repeat("A paragraph of reasoning that runs on for a while.\n\n", 120),
+		"mixed":                 longProse(60) + "\n\n" + strings.Repeat("- a list item\n", 30) + "\n\n" + longProse(200),
+		"fenced":                "```go\nfunc main() {}\n```\n\n" + longProse(200),
+		"table":                 "| a | b |\n| - | - |\n| 1 | 2 |\n\n" + longProse(200),
+	}
+
+	for name, doc := range docs {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			r := newTestRenderer(t, width)
+			var sm streamingMarkdown
+			for i, p := range progressivePrefixes(doc, 60) {
+				if p == "" {
+					continue
+				}
+				out := sm.Render(p, width, r)
+				require.Equalf(t, countLines(strings.TrimSpace(out)), sm.LastLines(),
+					"step %d (len=%d): tracked line count must match the output", i, len(p))
+			}
+		})
+	}
+}

--- a/internal/ui/chat/incremental_glamour_test.go
+++ b/internal/ui/chat/incremental_glamour_test.go
@@ -1,6 +1,7 @@
 package chat
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -850,4 +851,103 @@ func TestAssistantStreamingContent_ResetOnClearCache(t *testing.T) {
 		"clearCache must Reset the streaming-markdown cache")
 	require.Equal(t, "", item.streamingContent.stablePrefixRender)
 	require.Equal(t, 0, item.streamingContent.width)
+}
+
+// -----------------------------------------------------------------------
+// Relaxed boundary (#3162). Prose holding no blank line never satisfies
+// the blank-line predicate, so before relaxBoundaryAfter the cache never
+// advances and every flush re-renders the whole document. Past that much
+// unstable tail we cut at a plain newline instead — but only where the
+// same hazard checks pass.
+// -----------------------------------------------------------------------
+
+// longProse returns n lines of plain prose joined by single newlines,
+// so the document holds no blank-line separator anywhere.
+func longProse(n int) string {
+	lines := make([]string, n)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("Let me reconsider step %d: the constraint holds for every branch here.", i)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func TestStreamingMarkdown_RelaxedBoundaryAdvancesOnLongProse(t *testing.T) {
+	t.Parallel()
+
+	const width = 80
+	doc := longProse(400)
+	require.Greater(t, len(doc), relaxBoundaryAfter*2,
+		"sanity check: doc must outgrow the relax threshold")
+	require.Equal(t, -1, findSafeMarkdownBoundary(doc),
+		"sanity check: no blank lines, no safe boundary")
+
+	r := newTestRenderer(t, width)
+	var sm streamingMarkdown
+
+	var lastOut string
+	for _, p := range progressivePrefixes(doc, 40) {
+		if p == "" {
+			continue
+		}
+		lastOut = sm.Render(p, width, r)
+		require.NotEmpty(t, lastOut)
+		require.True(t, strings.HasPrefix(p, sm.stablePrefix),
+			"stable prefix must stay a literal prefix of the content")
+	}
+
+	require.NotEmpty(t, sm.stablePrefix,
+		"relaxed boundary must advance the cache once the tail outgrows the threshold")
+	visible := stripANSI(lastOut)
+	require.Contains(t, visible, "step 0:", "head of the trace must survive")
+	require.Contains(t, visible, "step 399:", "tail of the trace must survive")
+}
+
+func TestStreamingMarkdown_RelaxedBoundaryRespectsHazards(t *testing.T) {
+	t.Parallel()
+
+	const width = 80
+
+	tests := []struct {
+		name string
+		doc  string
+	}{
+		{
+			// Every line holds a pipe, so lineOpensConstruct rejects
+			// each candidate and the table is never split.
+			name: "long table",
+			doc: func() string {
+				rows := make([]string, 1200)
+				rows[0] = "| col a | col b | col c |"
+				rows[1] = "| ----- | ----- | ----- |"
+				for i := 2; i < len(rows); i++ {
+					rows[i] = fmt.Sprintf("| %d | %d | %d |", i, i*2, i*3)
+				}
+				return strings.Join(rows, "\n")
+			}(),
+		},
+		{
+			// An open fence makes the parity odd at every candidate
+			// inside it, so no cut lands in the code block.
+			name: "open code fence",
+			doc:  "```go\n" + longProse(400),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Greater(t, len(tc.doc), relaxBoundaryAfter*2)
+
+			r := newTestRenderer(t, width)
+			var sm streamingMarkdown
+			for _, p := range progressivePrefixes(tc.doc, 40) {
+				if p == "" {
+					continue
+				}
+				require.NotEmpty(t, sm.Render(p, width, r))
+			}
+			require.Equal(t, "", sm.stablePrefix,
+				"cache must not advance across an unsafe construct")
+		})
+	}
 }

--- a/internal/ui/chat/streaming_markdown.go
+++ b/internal/ui/chat/streaming_markdown.go
@@ -146,6 +146,9 @@ func (s *streamingMarkdown) Render(content string, width int, renderer *glamour.
 func (s *streamingMarkdown) tryAdvanceFromEmpty(content string, width int, renderer *glamour.TermRenderer) {
 	boundary := findSafeMarkdownBoundary(content)
 	if boundary <= 0 {
+		boundary = s.relaxedBoundary(content, 0)
+	}
+	if boundary <= 0 {
 		return
 	}
 	prefix := content[:boundary]
@@ -171,7 +174,10 @@ func (s *streamingMarkdown) tryAdvanceFromEmpty(content string, width int, rende
 func (s *streamingMarkdown) findBoundaryAfter(content string) int {
 	// When there is no stable prefix, fall back to the full scan.
 	if len(s.stablePrefix) == 0 {
-		return findSafeMarkdownBoundary(content)
+		if b := findSafeMarkdownBoundary(content); b > 0 {
+			return b
+		}
+		return s.relaxedBoundary(content, 0)
 	}
 
 	// Scan blank-line candidates from latest to earliest, but only
@@ -182,10 +188,67 @@ func (s *streamingMarkdown) findBoundaryAfter(content string) int {
 			return p
 		}
 	}
+	if b := s.relaxedBoundary(content, len(s.stablePrefix)); b > len(s.stablePrefix) {
+		return b
+	}
 	// No new boundary found after the stable prefix. Return the
 	// stable prefix length so the caller takes the "boundary <=
 	// len(stablePrefix)" path (render trailing fresh, keep cache).
 	return len(s.stablePrefix)
+}
+
+// relaxBoundaryAfter bounds how much unstable tail a flush will
+// re-render. Prose holding no blank line never satisfies the
+// blank-line predicate, so the cache never advances and every flush
+// re-renders the whole document: O(n) per tick, O(n^2) over a turn. A
+// reasoning trace that reaches a few hundred KB burns tens of GB of
+// churn that way, which is enough to outrun the GC (#3162).
+const relaxBoundaryAfter = 8 << 10
+
+// relaxedBoundaryCandidates caps how many newline candidates one
+// flush will validate, keeping the search cost flat when none of them
+// pass.
+const relaxedBoundaryCandidates = 8
+
+// relaxedBoundary looks for a cut at a plain newline once the tail
+// after `after` has outgrown [relaxBoundaryAfter]. Candidates are
+// still validated by the same predicate the blank-line search uses,
+// so every construct check survives; the only conservatism given up
+// is paragraph wrapping across the cut, which costs one re-wrap at a
+// point the reader has usually already scrolled past.
+//
+// Returns -1 while the tail is still small, and when no candidate
+// validates — the caller then behaves exactly as it did before.
+// Content with no newline at all has nothing to cut on and stays on
+// the full-render path.
+func (s *streamingMarkdown) relaxedBoundary(content string, after int) int {
+	if len(content)-after <= relaxBoundaryAfter {
+		return -1
+	}
+	tried := 0
+	for p := newlineBefore(content, len(content)); p > after; p = newlineBefore(content, p-1) {
+		if s.isSafeBoundaryIncremental(content, p) {
+			return p
+		}
+		if tried++; tried >= relaxedBoundaryCandidates {
+			break
+		}
+	}
+	return -1
+}
+
+// newlineBefore returns the byte offset of the first character AFTER
+// the latest newline that ends strictly before `until`, or -1 when
+// there is none.
+func newlineBefore(content string, until int) int {
+	if until <= 0 {
+		return -1
+	}
+	nl := strings.LastIndexByte(content[:until], '\n')
+	if nl < 0 {
+		return -1
+	}
+	return nl + 1
 }
 
 // isSafeBoundaryIncremental validates a boundary candidate at

--- a/internal/ui/chat/streaming_markdown.go
+++ b/internal/ui/chat/streaming_markdown.go
@@ -43,6 +43,22 @@ type streamingMarkdown struct {
 	// fence parity), so the delta scan always starts outside a fence.
 	baseFenceCount    int
 	baseHasListMarker bool
+
+	// stablePrefixLines is the line count of stablePrefixRender, and
+	// lastLines the line count of whatever the most recent Render
+	// returned. Callers need the count to size a truncation hint;
+	// tracking it alongside the prefix keeps that O(trail) rather than
+	// a fresh O(document) scan on every flush.
+	stablePrefixLines int
+	lastLines         int
+}
+
+// LastLines reports the number of lines in the string the most recent
+// [streamingMarkdown.Render] returned, with surrounding whitespace
+// trimmed. Equivalent to countLines on that trimmed string, without
+// rescanning it.
+func (s *streamingMarkdown) LastLines() int {
+	return s.lastLines
 }
 
 // Reset drops every cached field. After Reset the next Render call
@@ -53,6 +69,8 @@ func (s *streamingMarkdown) Reset() {
 	s.stablePrefixRender = ""
 	s.baseFenceCount = 0
 	s.baseHasListMarker = false
+	s.stablePrefixLines = 0
+	s.lastLines = 0
 }
 
 // Render returns the glamour render of content at the given width,
@@ -77,9 +95,15 @@ func (s *streamingMarkdown) Render(content string, width int, renderer *glamour.
 	full := func() string {
 		out, err := renderer.Render(content)
 		if err != nil {
-			return content
+			out = content
+		} else {
+			out = strings.TrimSuffix(out, "\n")
 		}
-		return strings.TrimSuffix(out, "\n")
+		// Counted against the trimmed form: that is what the
+		// windowing callers measure, and the glue paths below
+		// already return trimmed output.
+		s.lastLines = countLines(trimGlamourMargins(out))
+		return out
 	}
 
 	// Width change OR content not a prefix-extension: drop cache,
@@ -108,7 +132,7 @@ func (s *streamingMarkdown) Render(content string, width int, renderer *glamour.
 		// Cached prefix already covers an at-least-as-late
 		// boundary. Render the trailing partial fresh and glue.
 		trail := content[len(s.stablePrefix):]
-		return glueRenders(s.stablePrefixRender, s.renderTrailing(trail, renderer))
+		return s.glue(s.stablePrefixRender, s.stablePrefixLines, s.renderTrailing(trail, renderer))
 	}
 
 	// boundary > len(stablePrefix): we have a NEW chunk of safe
@@ -116,6 +140,7 @@ func (s *streamingMarkdown) Render(content string, width int, renderer *glamour.
 	// promote the boundary, then render the remaining trail.
 	newChunk := content[len(s.stablePrefix):boundary]
 	newChunkRender := s.renderTrailing(newChunk, renderer)
+	s.stablePrefixLines = glueLines(s.stablePrefixRender, s.stablePrefixLines, newChunkRender)
 	s.stablePrefixRender = glueRenders(s.stablePrefixRender, newChunkRender)
 	s.stablePrefix = content[:boundary]
 	// Update cumulative state for the new stable prefix.
@@ -126,9 +151,30 @@ func (s *streamingMarkdown) Render(content string, width int, renderer *glamour.
 	if trail == "" {
 		// boundary == len(content): no trailing content. Returning
 		// the cached prefix render directly is correct.
+		s.lastLines = s.stablePrefixLines
 		return s.stablePrefixRender
 	}
-	return glueRenders(s.stablePrefixRender, s.renderTrailing(trail, renderer))
+	return s.glue(s.stablePrefixRender, s.stablePrefixLines, s.renderTrailing(trail, renderer))
+}
+
+// glue joins a prefix render to a trailing render and records the line
+// count of the result, given the prefix's already-known count.
+func (s *streamingMarkdown) glue(prefix string, prefixLines int, trail string) string {
+	s.lastLines = glueLines(prefix, prefixLines, trail)
+	return glueRenders(prefix, trail)
+}
+
+// glueLines returns the line count [glueRenders] would produce, without
+// scanning the prefix.
+func glueLines(prefix string, prefixLines int, trail string) int {
+	if prefix == "" {
+		return countLines(trail)
+	}
+	if trail == "" {
+		return prefixLines
+	}
+	// glueRenders joins with a blank line between the two renders.
+	return prefixLines + 1 + countLines(trail)
 }
 
 // tryAdvanceFromEmpty seeds the cache from a fresh state. We've
@@ -158,6 +204,7 @@ func (s *streamingMarkdown) tryAdvanceFromEmpty(content string, width int, rende
 	}
 	s.stablePrefix = prefix
 	s.stablePrefixRender = trimGlamourMargins(out)
+	s.stablePrefixLines = countLines(s.stablePrefixRender)
 	s.width = width
 	// Seed cumulative state for incremental boundary search.
 	s.baseFenceCount = countFenceLines(prefix)
@@ -203,7 +250,11 @@ func (s *streamingMarkdown) findBoundaryAfter(content string) int {
 // re-renders the whole document: O(n) per tick, O(n^2) over a turn. A
 // reasoning trace that reaches a few hundred KB burns tens of GB of
 // churn that way, which is enough to outrun the GC (#3162).
-const relaxBoundaryAfter = 8 << 10
+// Sized just above a prose paragraph so structured text never reaches
+// it: the blank-line boundary fires first and the tail stays small.
+// Only prose with no paragraph breaks at all gets cut here, and it has
+// no reflow left to protect.
+const relaxBoundaryAfter = 2 << 10
 
 // relaxedBoundaryCandidates caps how many newline candidates one
 // flush will validate, keeping the search cost flat when none of them

--- a/internal/ui/model/renderbench_test.go
+++ b/internal/ui/model/renderbench_test.go
@@ -1,0 +1,99 @@
+package model
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/chat"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+func benchStyles() *styles.Styles {
+	return common.DefaultCommon(nil).Styles
+}
+
+// buildSession returns n alternating user/assistant items, each assistant
+// carrying a reasoning trace and a text body, as a session that has already
+// scrolled well past the viewport.
+func buildSession(n int) []chat.MessageItem {
+	sty := benchStyles()
+	items := make([]chat.MessageItem, 0, n*2)
+	for i := range n {
+		um := &message.Message{ID: fmt.Sprintf("u%d", i), Role: message.User}
+		um.AppendContent(fmt.Sprintf("Question %d: can you walk me through how the cache invalidation works here?", i))
+		items = append(items, chat.NewUserMessageItem(sty, um, nil))
+
+		am := &message.Message{ID: fmt.Sprintf("a%d", i), Role: message.Assistant}
+		for j := range 20 {
+			am.AppendReasoningContent(fmt.Sprintf("Considering angle %d of question %d in some detail.\n", j, i))
+		}
+		am.FinishThinking()
+		am.AppendContent(strings.Repeat("Here is a paragraph of the answer body that wraps across lines. ", 12))
+		am.AddFinish(message.FinishReasonEndTurn, "", "")
+		items = append(items, chat.NewAssistantMessageItem(sty, am))
+	}
+	return items
+}
+
+func benchDraw(b *testing.B, items []chat.MessageItem, mutate func(i int)) {
+	u := newTestUI()
+	u.chat.SetMessages(items...)
+	u.updateLayoutAndSize()
+	const w, h = 140, 40
+	scr := uv.NewScreenBuffer(w, h)
+	area := uv.Rect(0, 0, w, h)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; b.Loop(); i++ {
+		if mutate != nil {
+			mutate(i)
+		}
+		u.chat.Draw(scr, area)
+	}
+}
+
+// BenchmarkDrawIdle is the steady-state cost: nothing changed since the
+// last frame. This is what a spinner tick costs.
+func BenchmarkDrawIdle(b *testing.B) {
+	for _, n := range []int{10, 100, 400} {
+		b.Run(fmt.Sprintf("msgs=%d", n*2), func(b *testing.B) {
+			benchDraw(b, buildSession(n), nil)
+		})
+	}
+}
+
+// BenchmarkDrawStreaming is a frame during an active turn: the last
+// assistant message grows by one reasoning delta per frame. The two
+// shapes matter because the stable-prefix cache in streamingMarkdown
+// advances on blank lines, so a trace with paragraph breaks keeps a
+// small trailing partial while one without grows its trail up to
+// relaxBoundaryAfter.
+func BenchmarkDrawStreaming(b *testing.B) {
+	shapes := []struct {
+		name       string
+		blankEvery int
+	}{
+		{"no-blank-lines", 0},
+		{"blank-every-8", 8},
+	}
+	for _, sh := range shapes {
+		b.Run(sh.name, func(b *testing.B) {
+			items := buildSession(10)
+			live := &message.Message{ID: "live", Role: message.Assistant}
+			item := chat.NewAssistantMessageItem(benchStyles(), live).(*chat.AssistantMessageItem)
+			items = append(items, item)
+			benchDraw(b, items, func(i int) {
+				live.AppendReasoningContent(fmt.Sprintf("Delta %d of the reasoning trace here.\n", i))
+				if sh.blankEvery > 0 && i%sh.blankEvery == sh.blankEvery-1 {
+					live.AppendReasoningContent("\n")
+				}
+				item.SetMessage(live)
+			})
+		})
+	}
+}


### PR DESCRIPTION
Three commits from chasing #3162, where a user's terminal grew to 50 GB of anonymous heap and was OOM-killed six times.

### `fix(message)`: stop pending state pinning flushed messages

`service.pending` entries are only removed by `Delete`, so every message ID that ever streamed left an entry behind holding two full `Message` snapshots — reasoning text, tool inputs, tool results — for the life of the process.

`shouldFlushNow` only reads three things out of that baseline, so keep those instead of the message:

```go
type flushBaseline struct {
	toolCallsFinished   []bool
	reasoningFinishedAt int64
}
```

Plus clearing `latest` once a flush lands clean. Pending state now holds bookkeeping, which is what it was for.

### `fix(chat)`: bound the streaming markdown fallback on blank-line-free prose

The stable-prefix cache in `streaming_markdown.go` can only advance to a **blank line** (`blankLineBefore` requires `\n\n`). A reasoning trace holding none never advances it, so every flush re-renders the whole document: O(n) per tick, O(n²) over a turn.

Measured on a trace grown to 141 KB over 2000 flushes:

| trace shape | before | after |
|---|---|---|
| blank line every 10 lines | 0.80 GB allocated | 0.80 GB (unchanged) |
| **no blank lines** | **19.67 GB** | **1.67 GB** |

That 19.67 GB is what v0.79.0 did. 3295a085c (v0.81.0) fixed the case it was tested against and left the pathological one untouched.

Past 8 KB of unstable tail we now cut at a plain newline, still validated by `isSafeBoundaryIncremental` — the *same* predicate the blank-line search uses. So every hazard check survives: `lineOpensConstruct` rejects any line containing a pipe so tables never split, fence parity keeps cuts out of code blocks, and lists, block quotes, indented code and setext all still bail. Only the paragraph-wrap conservatism is given up, and only where prose has outgrown it.

### `perf(chat)`: cut streaming frame cost on long reasoning traces

Profiling a streaming frame put 54% of it in one call: glamour re-rendering the trailing partial, thirty times a second. `glueRenders`, which I had expected to matter, was 0.28%. Trail size is the only lever.

- Threshold 8 KB → 2 KB. A prose paragraph is ~400 bytes, so structured text never reaches it; only prose with no paragraph breaks gets cut, and that has no reflow left to protect.
- `LastLines()` tracks the stable prefix's line count, so the truncation hint stops rescanning a document that only grows. Pinned by a test asserting `LastLines() == countLines(output)` across five document shapes.

| | before | after |
|---|---|---|
| idle frame | 86 µs, 8 allocs | 86 µs, **3 allocs** |
| streaming, paragraphed | 1.01 ms, 22k allocs | **0.86 ms** |
| streaming, no blank lines | 2.85 ms, 117k allocs | **1.19 ms, 41k** |

Adds `BenchmarkDraw{Idle,Streaming}` so this stays measurable. Idle is flat from 20 to 800 messages, which is worth knowing: the list and per-item caches are doing their job, and the streaming path was the only problem.

### Not closing #3162 yet

The mechanism explains every number in that report — anonymous heap only, file-rss under 2 MB, single process, roughly a minute, and "the TUI is also very laggy" is the same CPU burn seen from the other side. Both providers in that config, DeepSeek and Xiaomi MiMo, are long-reasoning models. But the reporter is on v0.79.0 and never sent a pprof, so it is measured, not confirmed.

### Upstream

The remaining ~54% of a streaming frame is inside Glamour. Two companion PRs cut a 17 KB render from 498k allocations to 8.3k and make it 2.24x faster, output byte-identical:

- charmbracelet/lipgloss#737
- charmbracelet/glamour#614
