### PR TITLE
fix(ui): fall back to OSC 9 notifications on iTerm2

### DIFF
--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -588,19 +588,27 @@ func (m *UI) sendNotification(n notification.Notification) tea.Cmd {
 // function that should be called once during initialization or when capabilities
 // change.
 func selectNotificationBackend(caps common.Capabilities, cfg *config.Config) notification.Backend {
+	// iTerm2 does not support OSC 99 or OSC 777; the legacy OSC 9 sequence is
+	// the only notification protocol it understands.
+	_, hasITermSession := caps.Env.LookupEnv("ITERM_SESSION_ID")
+	termProg, _ := caps.Env.LookupEnv("TERM_PROGRAM")
+	supportsOSC9 := hasITermSession ||
+		strings.Contains(strings.ToLower(termProg), "iterm") ||
+		strings.Contains(strings.ToLower(caps.TerminalVersion), "iterm2")
+
 	// Check for explicit user preference first.
 	if cfg != nil && cfg.Options != nil && cfg.Options.Notifications != "" {
 		switch cfg.Options.Notifications {
 		case "native":
 			if !notification.NativeSupported {
 				slog.Debug("Native notifications unavailable on this platform; using OSC backend", "osc99_supported", caps.OSC99Notifications)
-				return notification.NewOSCBackend(notification.Icon, caps.OSC99Notifications)
+				return notification.NewOSCBackend(notification.Icon, caps.OSC99Notifications, supportsOSC9)
 			}
 			slog.Debug("Using native backend (user preference)")
 			return notification.NewNativeBackend(notification.Icon)
 		case "osc":
 			slog.Debug("Using OSC backend (user preference)", "osc99_supported", caps.OSC99Notifications)
-			return notification.NewOSCBackend(notification.Icon, caps.OSC99Notifications)
+			return notification.NewOSCBackend(notification.Icon, caps.OSC99Notifications, supportsOSC9)
 		case "bell":
 			slog.Debug("Using bell backend (user preference)")
 			return notification.NewBellBackend()
@@ -620,7 +628,7 @@ func selectNotificationBackend(caps common.Capabilities, cfg *config.Config) not
 	// SSH sessions use terminal-based notifications (OSC 99 or 777).
 	if isSSH {
 		slog.Debug("Selected OSCBackend for SSH session", "osc99_supported", caps.OSC99Notifications)
-		return notification.NewOSCBackend(notification.Icon, caps.OSC99Notifications)
+		return notification.NewOSCBackend(notification.Icon, caps.OSC99Notifications, supportsOSC9)
 	}
 
 	// Local sessions: prefer OSC on macOS because the native backend (beeep)
@@ -629,7 +637,7 @@ func selectNotificationBackend(caps common.Capabilities, cfg *config.Config) not
 	// (illumos/solaris). OSC 99 provides a polished experience with icon support.
 	if runtime.GOOS == "darwin" || !notification.NativeSupported {
 		slog.Debug("Selected OSCBackend for local session", "osc99_supported", caps.OSC99Notifications, "native_supported", notification.NativeSupported)
-		return notification.NewOSCBackend(notification.Icon, caps.OSC99Notifications)
+		return notification.NewOSCBackend(notification.Icon, caps.OSC99Notifications, supportsOSC9)
 	}
 
 	// Non-macOS local sessions use native OS notifications if focus events are supported.

--- a/internal/ui/notification/notification.go
+++ b/internal/ui/notification/notification.go
@@ -4,7 +4,8 @@
 //   - NativeBackend: Uses the native OS notification system (macOS, Windows, Linux)
 //   - OSCBackend: Uses OSC escape sequences with automatic protocol detection.
 //     Prefers OSC 99 (modern standard with rich notifications) if supported,
-//     falling back to OSC 777 (urxvt extension, widely supported). Used for SSH sessions.
+//     then OSC 9 (iTerm2 legacy notifications), falling back to OSC 777
+//     (urxvt extension, widely supported). Used for SSH sessions.
 //   - BellBackend: Triggers the terminal bell character (\x07), causing an audible
 //     beep or visual flash. Works in virtually all terminals but provides no message text.
 //   - NoopBackend: A no-op backend that silently discards notifications. Used when

--- a/internal/ui/notification/notification_test.go
+++ b/internal/ui/notification/notification_test.go
@@ -63,7 +63,7 @@ func extractRawString(t *testing.T, cmd tea.Cmd) string {
 func TestOSCBackend_Send_OSC99(t *testing.T) {
 	t.Parallel()
 
-	backend := notification.NewOSCBackend(nil, true)
+	backend := notification.NewOSCBackend(nil, true, false)
 	s := extractRawString(t, backend.Send(notification.Notification{
 		Title:   "Crush is waiting...",
 		Message: "Agent's turn completed",
@@ -81,7 +81,7 @@ func TestOSCBackend_Send_OSC99(t *testing.T) {
 func TestOSCBackend_Send_OSC99_TitleOnly(t *testing.T) {
 	t.Parallel()
 
-	backend := notification.NewOSCBackend(nil, true)
+	backend := notification.NewOSCBackend(nil, true, false)
 	s := extractRawString(t, backend.Send(notification.Notification{
 		Title: "Crush is waiting...",
 	}))
@@ -96,7 +96,7 @@ func TestOSCBackend_Send_OSC99_WithIcon(t *testing.T) {
 	t.Parallel()
 
 	iconData := []byte("fake-png-data")
-	backend := notification.NewOSCBackend(iconData, true)
+	backend := notification.NewOSCBackend(iconData, true, false)
 	s := extractRawString(t, backend.Send(notification.Notification{
 		Title:   "Test",
 		Message: "With icon",
@@ -114,7 +114,7 @@ func TestOSCBackend_Send_OSC99_WithIcon(t *testing.T) {
 func TestOSCBackend_Send_OSC777(t *testing.T) {
 	t.Parallel()
 
-	backend := notification.NewOSCBackend(nil, false)
+	backend := notification.NewOSCBackend(nil, false, false)
 	s := extractRawString(t, backend.Send(notification.Notification{
 		Title:   "Test",
 		Message: "With body",
@@ -122,6 +122,75 @@ func TestOSCBackend_Send_OSC777(t *testing.T) {
 
 	require.Equal(t, "\x1b]777;notify;Test;With body\x07", s)
 	require.NotContains(t, s, "\x1b]99;")
+	require.NotContains(t, s, "\x1b]9;")
+}
+
+func TestOSCBackend_Send_OSC9(t *testing.T) {
+	t.Parallel()
+
+	backend := notification.NewOSCBackend(nil, false, true)
+	s := extractRawString(t, backend.Send(notification.Notification{
+		Title:   "Crush is waiting...",
+		Message: "Agent's turn completed",
+	}))
+
+	require.Equal(t, "\x1b]9;Crush is waiting...: Agent's turn completed\x07", s)
+}
+
+func TestOSCBackend_Send_OSC9_TitleOnly(t *testing.T) {
+	t.Parallel()
+
+	backend := notification.NewOSCBackend(nil, false, true)
+	s := extractRawString(t, backend.Send(notification.Notification{
+		Title: "Crush is waiting...",
+	}))
+
+	require.Equal(t, "\x1b]9;Crush is waiting...\x07", s)
+}
+
+func TestOSCBackend_Send_OSC9_MessageOnly(t *testing.T) {
+	t.Parallel()
+
+	backend := notification.NewOSCBackend(nil, false, true)
+	s := extractRawString(t, backend.Send(notification.Notification{
+		Message: "Agent's turn completed",
+	}))
+
+	require.Equal(t, "\x1b]9;Agent's turn completed\x07", s)
+}
+
+func TestOSCBackend_Send_OSC9_SanitizesControlChars(t *testing.T) {
+	t.Parallel()
+
+	backend := notification.NewOSCBackend(nil, false, true)
+	s := extractRawString(t, backend.Send(notification.Notification{
+		Title:   "Title",
+		Message: "line1\nline2\x1b]0;injected\x07",
+	}))
+
+	require.Equal(t, "\x1b]9;Title: line1 line2 ]0;injected \x07", s)
+}
+
+func TestOSCBackend_Send_OSC9_GuardsProgressCollision(t *testing.T) {
+	t.Parallel()
+
+	backend := notification.NewOSCBackend(nil, false, true)
+	s := extractRawString(t, backend.Send(notification.Notification{
+		Message: "4;50",
+	}))
+
+	require.Equal(t, "\x1b]9;Notification: 4;50\x07", s)
+}
+
+func TestOSCBackend_PrefersOSC99OverOSC9(t *testing.T) {
+	t.Parallel()
+
+	backend := notification.NewOSCBackend(nil, true, true)
+	s := extractRawString(t, backend.Send(notification.Notification{
+		Title: "Test",
+	}))
+
+	require.Contains(t, s, "\x1b]99;")
 	require.NotContains(t, s, "\x1b]9;")
 }
 

--- a/internal/ui/notification/osc.go
+++ b/internal/ui/notification/osc.go
@@ -77,28 +77,34 @@ func OSC99QuerySequence() string {
 
 // OSCBackend sends desktop notifications using OSC escape sequences. It
 // automatically selects the best available protocol: OSC 99 (modern standard)
-// if supported, falling back to OSC 777 (urxvt extension) otherwise.
+// if supported, OSC 9 (iTerm2 legacy notifications) if the terminal is known
+// to support it, falling back to OSC 777 (urxvt extension) otherwise.
 type OSCBackend struct {
 	icon       []byte
 	supports99 bool
+	supports9  bool
 	notifySeq  uint64
 }
 
 // NewOSCBackend creates a new OSC notification backend with automatic protocol
-// detection. If supports99 is true, it uses OSC 99; otherwise it falls back to
-// OSC 777.
-func NewOSCBackend(icon []byte, supports99 bool) *OSCBackend {
+// detection. If supports99 is true, it uses OSC 99; otherwise if supports9 is
+// true, it uses OSC 9 (iTerm2); otherwise it falls back to OSC 777.
+func NewOSCBackend(icon []byte, supports99, supports9 bool) *OSCBackend {
 	return &OSCBackend{
 		icon:       icon,
 		supports99: supports99,
+		supports9:  supports9,
 	}
 }
 
 // Send returns a [tea.Cmd] that writes OSC escape sequences to the terminal.
-// Uses OSC 99 if supported, otherwise OSC 777.
+// Uses OSC 99 if supported, otherwise OSC 9 (iTerm2), otherwise OSC 777.
 func (b *OSCBackend) Send(n Notification) tea.Cmd {
 	if b.supports99 {
 		return b.sendOSC99(n)
+	}
+	if b.supports9 {
+		return b.sendOSC9(n)
 	}
 	return b.sendOSC777(n)
 }
@@ -126,6 +132,40 @@ func (b *OSCBackend) sendOSC99(n Notification) tea.Cmd {
 	sb.WriteString(ansi.DesktopNotification("", "i="+id, "d=1", "a="+appName, "t="+notificationType))
 
 	return tea.Raw(sb.String())
+}
+
+// sendOSC9 sends the notification using the legacy OSC 9 sequence, the only
+// notification protocol understood by iTerm2. OSC 9 carries a single message,
+// so the title and body are combined.
+func (b *OSCBackend) sendOSC9(n Notification) tea.Cmd {
+	slog.Debug("Sending OSC 9 notification", "title", n.Title, "message", n.Message)
+
+	msg := n.Message
+	switch {
+	case n.Title == "":
+	case n.Message == "":
+		msg = n.Title
+	default:
+		msg = strings.TrimSpace(n.Title + ": " + n.Message)
+	}
+	return tea.Raw("\x1b]9;" + sanitizeOSC9Message(msg) + "\x07")
+}
+
+// sanitizeOSC9Message strips control characters and guards against messages
+// that would be misinterpreted as an OSC 9;4 progress report.
+func sanitizeOSC9Message(msg string) string {
+	msg = strings.Map(func(r rune) rune {
+		switch r {
+		case '\x07', '\x1b', '\n', '\r':
+			return ' '
+		}
+		return r
+	}, msg)
+	if msg == "4" || strings.HasPrefix(msg, "4;") {
+		// Avoid colliding with the OSC 9;4 progress bar sequence.
+		msg = "Notification: " + msg
+	}
+	return msg
 }
 
 func (b *OSCBackend) sendOSC777(n Notification) tea.Cmd {


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have read the Contributor License Agreement (CLA) and hereby sign the CLA.

~- [ ] I have created a discussion that was approved by a maintainer (for new features).~
(I dont think it is a new feature since it is just feature parity with iTerm2)

## Description

Desktop notifications never appear in iTerm2, even with "Send escape sequence-generated alerts" enabled and `notifications` set to `auto`/`on`.

**Why:** iTerm2 supports neither [OSC 99](https://sw.kovidgoyal.net/kitty/protocol-extensions/#notifications) (kitty) nor OSC 777 (urxvt). On macOS local sessions the auto-selected OSC backend prefers OSC 99 and falls back to OSC 777, and iTerm2 answers nothing to the OSC 99 capability query, so every notification sequence is silently dropped. iTerm2's only notification protocol is its legacy [OSC 9](https://iterm2.com/documentation/escape-codes.html) sequence (`ESC ] 9 ; message BEL`), which is what other agents (e.g. opencode) use successfully.

## Changes

- `OSCBackend` now selects between three protocols in priority order: OSC 99 → OSC 9 (iTerm2) → OSC 777.
- iTerm2 is detected via `ITERM_SESSION_ID`, `TERM_PROGRAM` containing `iterm`, or the XTVERSION report containing `iterm2`.
- OSC 9 carries a single message, so title and body are combined (`Title: Body`); control characters (`ESC`, `BEL`, `CR`, `LF`) are stripped to prevent sequence injection.
- Messages that would collide with iTerm2's `OSC 9;4` progress-bar protocol (see #1326) are prefixed to avoid being misread as progress reports.

## Reproduction

**Before:** run `crush` in iTerm2, unfocus the window, trigger a permission prompt or let a run finish → tab shows the activity dot but no macOS notification arrives.

**After:** the same scenario produces an iTerm2-generated notification (`ESC ] 9 ; Crush is waiting...: Permission required to execute "..." BEL`).

## Testing

- Updated/added unit tests in `internal/ui/notification/notification_test.go` covering: OSC 9 send (title-only, message-only, both), control-character sanitization, `OSC 9;4` collision guard, and OSC 99 priority over OSC 9.
- `go build ./...`, `go vet ./internal/ui/...` and `gofmt` clean; `go test` passes for `internal/ui/notification`, `internal/ui/model` and `internal/ui/dialog`.
- Manually verified on macOS 15 + iTerm2 3.6: notification banners now appear when the window is unfocused.

💘 Generated with Crush