### PR TITLE
crush #3645 Windows LSP path (fork PR)

### DIFF
--- a/internal/agent/tools/diagnostics.go
+++ b/internal/agent/tools/diagnostics.go
@@ -5,6 +5,8 @@ import (
 	_ "embed"
 	"fmt"
 	"log/slog"
+	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -142,7 +144,7 @@ func getDiagnostics(filePath string, manager *lsp.Manager) string {
 				slog.Error("Failed to convert diagnostic location URI to path", "uri", location, "error", err)
 				continue
 			}
-			isCurrentFile := path == filePath
+			isCurrentFile := sameDiagnosticPath(path, filePath)
 			for _, diag := range diags {
 				formattedDiag := formatDiagnostic(path, diag, lspName)
 				if isCurrentFile {
@@ -175,6 +177,18 @@ func getDiagnostics(filePath string, manager *lsp.Manager) string {
 	out := output.String()
 	slog.Debug("Diagnostics", "output", out)
 	return out
+}
+
+func sameDiagnosticPath(diagPath, filePath string) bool {
+	if filePath == "" {
+		return false
+	}
+	a := filepath.ToSlash(filepath.Clean(filepath.FromSlash(diagPath)))
+	b := filepath.ToSlash(filepath.Clean(filepath.FromSlash(filePath)))
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
 }
 
 func writeDiagnostics(output *strings.Builder, tag string, in []string) {

--- a/internal/agent/tools/diagnostics_path_test.go
+++ b/internal/agent/tools/diagnostics_path_test.go
@@ -1,0 +1,42 @@
+package tools
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestSameDiagnosticPath(t *testing.T) {
+	t.Parallel()
+
+	base := filepath.Join("proj", "src", "main.py")
+	if !sameDiagnosticPath(base, base) {
+		t.Fatalf("identical paths should match")
+	}
+	dotted := filepath.Join("proj", "src", ".", "main.py")
+	if !sameDiagnosticPath(dotted, base) {
+		t.Fatalf("Clean should collapse . segments: %q vs %q", dotted, base)
+	}
+	if sameDiagnosticPath(base, "") {
+		t.Fatalf("empty filePath is project-wide, not current-file")
+	}
+	if sameDiagnosticPath(base, filepath.Join("proj", "src", "other.py")) {
+		t.Fatalf("different files must not match")
+	}
+
+	slashy := filepath.ToSlash(base)
+	if !sameDiagnosticPath(slashy, base) {
+		t.Fatalf("ToSlash form should match native separators: %q vs %q", slashy, base)
+	}
+
+	if runtime.GOOS == "windows" {
+		winA := `C:\Users\x\proj\main.py`
+		winB := `C:/Users/x/proj/main.py`
+		if !sameDiagnosticPath(winA, winB) {
+			t.Fatalf("Windows mixed separators should match: %q vs %q", winA, winB)
+		}
+		if !sameDiagnosticPath(`C:\Users\X\proj\main.py`, `c:\users\x\proj\main.py`) {
+			t.Fatalf("Windows path compare should be case-insensitive")
+		}
+	}
+}


### PR DESCRIPTION
## What

- Compare LSP diagnostic paths with Clean + ToSlash (EqualFold on Windows) instead of raw ==.
- Pins TestSameDiagnosticPath for identical, dotted, slash, and empty filePath cases.

## Why

Fixes #3645. On Windows, current-file diagnostics were filed under project diagnostics because LSP URIs differ by separator or drive-letter case.
