### PR TITLE
fix(config): honor providers.json when auto-update is disabled

### DIFF
--- a/internal/config/catwalk.go
+++ b/internal/config/catwalk.go
@@ -43,6 +43,12 @@ func (s *catwalkSync) Get(ctx context.Context) ([]catwalk.Provider, error) {
 	// sees the same outcome, not just the one that won the once.
 	s.once.Do(func() {
 		if !s.autoupdate {
+			cached, _, cachedErr := s.cache.Get()
+			if len(cached) > 0 && cachedErr == nil {
+				slog.Info("Using cached Catwalk providers (auto-update disabled)")
+				s.result = cached
+				return
+			}
 			slog.Info("Using embedded Catwalk providers")
 			s.result = embedded.GetAll()
 			return

--- a/internal/config/catwalk_test.go
+++ b/internal/config/catwalk_test.go
@@ -62,10 +62,37 @@ func TestCatwalkSync_GetWithAutoUpdateDisabled(t *testing.T) {
 	require.NotEmpty(t, providers)
 	require.Equal(t, 0, client.callCount, "Client should not be called when autoupdate is disabled")
 
-	// Should return embedded providers.
+	// No cache file: fall back to embedded providers.
 	for _, p := range providers {
 		require.NotEqual(t, "should-not-be-used", p.Name)
 	}
+}
+
+func TestCatwalkSync_GetWithAutoUpdateDisabledUsesCache(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	path := tmpDir + "/providers.json"
+
+	cachedProviders := []catwalk.Provider{
+		{Name: "Cached Manual Update", ID: "cached-manual"},
+	}
+	data, err := json.Marshal(cachedProviders)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+
+	syncer := &catwalkSync{}
+	client := &mockCatwalkClient{
+		providers: []catwalk.Provider{{Name: "should-not-be-used"}},
+	}
+
+	syncer.Init(client, path, false)
+
+	providers, err := syncer.Get(t.Context())
+	require.NoError(t, err)
+	require.Len(t, providers, 1)
+	require.Equal(t, "Cached Manual Update", providers[0].Name)
+	require.Equal(t, 0, client.callCount, "Client should not be called when autoupdate is disabled")
 }
 
 func TestCatwalkSync_GetFreshProviders(t *testing.T) {


### PR DESCRIPTION
Closes #3691

When `disable_provider_auto_update` is set, Catwalk sync skipped `providers.json` and never surfaced cached models via `crush update-models`.

If autoupdate is false, `cache.Get()` first; a non-empty cache is the catalog. Empty/error still uses `embedded.GetAll()`. The network client is not called.

`go test ./internal/config -run TestCatwalkSync_GetWithAutoUpdateDisabled` PASS on `ee854ed6`.