### PR TITLE
fix(run): fail loud when models.large does not resolve

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -281,6 +281,11 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 		}
 	}
 
+	if cfg := app.config.Config(); cfg != nil {
+		m := cfg.Models[config.SelectedModelTypeLarge]
+		fmt.Fprintf(os.Stderr, "crush run: %s/%s\n", m.Provider, m.Model)
+	}
+
 	var (
 		spinner   *format.Spinner
 		stderrTTY bool

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -281,10 +281,7 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 		}
 	}
 
-	if cfg := app.config.Config(); cfg != nil {
-		m := cfg.Models[config.SelectedModelTypeLarge]
-		fmt.Fprintf(os.Stderr, "crush run: %s/%s\n", m.Provider, m.Model)
-	}
+	fmt.Fprintln(os.Stderr, app.config.Config().ResolvedLargeLine())
 
 	var (
 		spinner   *format.Spinner

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -108,6 +108,10 @@ crush run --continue "Follow up on your last response"
 				return fmt.Errorf("no providers configured - please run 'crush' to set up a provider interactively")
 			}
 
+			if err := refuseUnresolvedLarge(largeModel, ws.Config); err != nil {
+				return err
+			}
+
 			clientWs := workspace.NewClientWorkspace(c, *ws)
 			if err := clientWs.InitCoderAgentNonInteractive(ctx); err != nil {
 				return fmt.Errorf("failed to initialize agent: %w", err)
@@ -138,6 +142,10 @@ crush run --continue "Follow up on your last response"
 
 		if !ws.Config().IsConfigured() {
 			return fmt.Errorf("no providers configured - please run 'crush' to set up a provider interactively")
+		}
+
+		if err := refuseUnresolvedLarge(largeModel, ws.Config()); err != nil {
+			return err
 		}
 
 		if verbose {
@@ -188,7 +196,13 @@ func runNonInteractive(
 		if err := overrideModels(ctx, c, ws, largeModel, smallModel); err != nil {
 			return fmt.Errorf("failed to override models: %w", err)
 		}
+		cfg, err := c.GetConfig(ctx, ws.ID)
+		if err == nil {
+			ws.Config = cfg
+		}
 	}
+
+	fmt.Fprintln(os.Stderr, resolvedLargeLine(ws.Config))
 
 	var (
 		spinner   *format.Spinner
@@ -474,6 +488,30 @@ func waitForAgent(ctx context.Context, c *client.Client, wsID string) error {
 		case <-time.After(200 * time.Millisecond):
 		}
 	}
+}
+
+// refuseUnresolvedLarge fails crush run when models.large was set and
+// did not resolve. -m / --model wins and skips this check. Interactive
+// TUI is not gated here.
+func refuseUnresolvedLarge(cliLarge string, cfg *config.Config) error {
+	if cliLarge != "" || cfg == nil || !cfg.LargeFallback {
+		return nil
+	}
+	requested := cfg.LargeConfigured
+	id := requested.Model
+	if requested.Provider != "" && requested.Model != "" {
+		id = requested.Provider + "/" + requested.Model
+	}
+	return fmt.Errorf("models.large %s does not resolve; crush run refusing to start (pass -m provider/model to override)", id)
+}
+
+// resolvedLargeLine is the default-verbosity model pin for headless runs.
+func resolvedLargeLine(cfg *config.Config) string {
+	if cfg == nil {
+		return "crush run: unknown/unknown"
+	}
+	m := cfg.Models[config.SelectedModelTypeLarge]
+	return fmt.Sprintf("crush run: %s/%s", m.Provider, m.Model)
 }
 
 // overrideModels resolves model strings and updates the workspace

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -197,7 +197,9 @@ func runNonInteractive(
 			return fmt.Errorf("failed to override models: %w", err)
 		}
 		cfg, err := c.GetConfig(ctx, ws.ID)
-		if err == nil {
+		if err != nil {
+			slog.Debug("failed to refresh config after model override", "error", err)
+		} else {
 			ws.Config = cfg
 		}
 	}
@@ -506,12 +508,10 @@ func refuseUnresolvedLarge(cliLarge string, cfg *config.Config) error {
 }
 
 // resolvedLargeLine is the default-verbosity model pin for headless runs.
+// Shared implementation lives on config.Config so app.RunNonInteractive can
+// use the same printer without importing cmd.
 func resolvedLargeLine(cfg *config.Config) string {
-	if cfg == nil {
-		return "crush run: unknown/unknown"
-	}
-	m := cfg.Models[config.SelectedModelTypeLarge]
-	return fmt.Sprintf("crush run: %s/%s", m.Provider, m.Model)
+	return cfg.ResolvedLargeLine()
 }
 
 // overrideModels resolves model strings and updates the workspace

--- a/internal/cmd/run_model_test.go
+++ b/internal/cmd/run_model_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefuseUnresolvedLarge_FailsWhenConfiguredMissesCatalog(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Models: map[config.SelectedModelType]config.SelectedModel{
+			config.SelectedModelTypeLarge: {Provider: "openai", Model: "first-can-reason"},
+		},
+		LargeFallback: true,
+		LargeConfigured: config.SelectedModel{
+			Provider: "ghost",
+			Model:    "missing",
+		},
+	}
+
+	err := refuseUnresolvedLarge("", cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ghost/missing")
+	require.Contains(t, strings.ToLower(err.Error()), "refusing")
+}
+
+func TestRefuseUnresolvedLarge_CLIOverrideWins(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		LargeFallback: true,
+		LargeConfigured: config.SelectedModel{
+			Provider: "ghost",
+			Model:    "missing",
+		},
+	}
+
+	require.NoError(t, refuseUnresolvedLarge("openai/gpt-4o", cfg))
+}
+
+func TestRefuseUnresolvedLarge_NoFallbackContinues(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Models: map[config.SelectedModelType]config.SelectedModel{
+			config.SelectedModelTypeLarge: {Provider: "openai", Model: "gpt-4o"},
+		},
+	}
+
+	require.NoError(t, refuseUnresolvedLarge("", cfg))
+}
+
+func TestResolvedLargeLine_DefaultVerbosity(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Models: map[config.SelectedModelType]config.SelectedModel{
+			config.SelectedModelTypeLarge: {Provider: "openai", Model: "gpt-4o"},
+		},
+	}
+
+	require.Equal(t, "crush run: openai/gpt-4o", resolvedLargeLine(cfg))
+}
+
+func TestRunCmd_NoNewModelFlags(t *testing.T) {
+	t.Parallel()
+
+	require.NotNil(t, runCmd.Flags().Lookup("model"))
+	require.NotNil(t, runCmd.Flags().Lookup("small-model"))
+	require.Nil(t, runCmd.Flags().Lookup("strict-models"))
+	require.Nil(t, runCmd.Flags().Lookup("fail-loud"))
+	require.Nil(t, runCmd.Flags().Lookup("require-large"))
+}

--- a/internal/cmd/run_model_test.go
+++ b/internal/cmd/run_model_test.go
@@ -66,6 +66,21 @@ func TestResolvedLargeLine_DefaultVerbosity(t *testing.T) {
 	require.Equal(t, "crush run: openai/gpt-4o", resolvedLargeLine(cfg))
 }
 
+func TestResolvedLargeLine_ZeroValue(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "crush run: model unresolved", resolvedLargeLine(nil))
+	require.Equal(t, "crush run: model unresolved", resolvedLargeLine(&config.Config{}))
+	require.Equal(t, "crush run: model unresolved", resolvedLargeLine(&config.Config{
+		Models: map[config.SelectedModelType]config.SelectedModel{},
+	}))
+	require.Equal(t, "crush run: model unresolved", resolvedLargeLine(&config.Config{
+		Models: map[config.SelectedModelType]config.SelectedModel{
+			config.SelectedModelTypeLarge: {},
+		},
+	}))
+}
+
 func TestRunCmd_NoNewModelFlags(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -736,6 +736,14 @@ type Config struct {
 	Env map[string]string `json:"env,omitempty" jsonschema:"description=Environment variables to set on startup"`
 
 	Agents map[string]Agent `json:"-"`
+
+	// LargeFallback is true when models.large was set but did not resolve
+	// against the catalog. Interactive TUI still uses the default; crush
+	// run refuses to start unless -m / --model overrides.
+	LargeFallback bool `json:"large_fallback,omitempty" jsonschema:"-"`
+
+	// LargeConfigured is the models.large value before fallback.
+	LargeConfigured SelectedModel `json:"large_configured,omitempty" jsonschema:"-"`
 }
 
 // cloneForWrite returns a copy of c that the store's typed field mutators

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -853,6 +853,20 @@ func (c *Config) LargeModel() *catwalk.Model {
 	return c.GetModel(model.Provider, model.Model)
 }
 
+// ResolvedLargeLine is the default-verbosity model pin for headless crush run.
+// Missing or zero-value large selection prints "crush run: model unresolved"
+// rather than "crush run: /".
+func (c *Config) ResolvedLargeLine() string {
+	if c == nil {
+		return "crush run: model unresolved"
+	}
+	m, ok := c.Models[SelectedModelTypeLarge]
+	if !ok || m.Provider == "" || m.Model == "" {
+		return "crush run: model unresolved"
+	}
+	return fmt.Sprintf("crush run: %s/%s", m.Provider, m.Model)
+}
+
 func (c *Config) SmallModel() *catwalk.Model {
 	model, ok := c.Models[SelectedModelTypeSmall]
 	if !ok {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -143,8 +143,7 @@ func Load(workingDir, dataDir string, debug bool) (*ConfigStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure selected models: %w", err)
 	}
-	cfg.Models[SelectedModelTypeLarge] = resolved.Large
-	cfg.Models[SelectedModelTypeSmall] = resolved.Small
+	applyResolvedModels(cfg, resolved)
 
 	// Persist any fallback corrections while we still hold writeMu.
 	if resolved.LargeFallback {
@@ -782,10 +781,22 @@ func (c *Config) defaultModelSelection(knownProviders []catwalk.Provider) (large
 // resolvedModels holds the result of resolving user-configured model
 // selections against the provider catalog.
 type resolvedModels struct {
-	Large         SelectedModel
-	Small         SelectedModel
-	LargeFallback bool // true if Large was corrected to a default
-	SmallFallback bool // true if Small was corrected to a default
+	Large           SelectedModel
+	Small           SelectedModel
+	LargeConfigured SelectedModel
+	LargeFallback   bool // true if Large was corrected to a default
+	SmallFallback   bool // true if Small was corrected to a default
+}
+
+// applyResolvedModels copies resolution results onto cfg. It does not persist.
+func applyResolvedModels(cfg *Config, resolved resolvedModels) {
+	if cfg.Models == nil {
+		cfg.Models = make(map[SelectedModelType]SelectedModel)
+	}
+	cfg.Models[SelectedModelTypeLarge] = resolved.Large
+	cfg.Models[SelectedModelTypeSmall] = resolved.Small
+	cfg.LargeFallback = resolved.LargeFallback
+	cfg.LargeConfigured = resolved.LargeConfigured
 }
 
 // resolveSelectedModels validates the user's configured model selections
@@ -803,6 +814,7 @@ func resolveSelectedModels(cfg *Config, knownProviders []catwalk.Provider) (reso
 
 	largeModelSelected, largeModelConfigured := cfg.Models[SelectedModelTypeLarge]
 	if largeModelConfigured {
+		result.LargeConfigured = largeModelSelected
 		if largeModelSelected.Model != "" {
 			large.Model = largeModelSelected.Model
 		}

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -1910,11 +1910,12 @@ func TestConfig_configureSelectedModels(t *testing.T) {
 
 		resolved, resolveErr := resolveSelectedModels(cfg, knownProviders)
 		require.NoError(t, resolveErr)
-		cfg.Models[SelectedModelTypeLarge] = resolved.Large
-		cfg.Models[SelectedModelTypeSmall] = resolved.Small
+		applyResolvedModels(cfg, resolved)
 
 		// In-memory falls back to default.
 		require.True(t, resolved.LargeFallback)
+		require.Equal(t, "ghost", cfg.LargeConfigured.Provider)
+		require.Equal(t, "missing", cfg.LargeConfigured.Model)
 		require.Equal(t, "openai", cfg.Models[SelectedModelTypeLarge].Provider)
 		require.Equal(t, "large-model", cfg.Models[SelectedModelTypeLarge].Model)
 

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -1269,8 +1269,7 @@ func (s *ConfigStore) reloadFromDiskLocked(ctx context.Context) error {
 		if resolveErr != nil {
 			setupErr = fmt.Errorf("failed to configure selected models during reload: %w", resolveErr)
 		} else {
-			cfg.Models[SelectedModelTypeLarge] = resolved.Large
-			cfg.Models[SelectedModelTypeSmall] = resolved.Small
+			applyResolvedModels(cfg, resolved)
 			s.SetupAgents()
 		}
 	}


### PR DESCRIPTION
Headless `crush run` ignored an explicit `models.large` miss and substituted the first catalog model that resolved, with no default-verbosity pin. That silently contaminates CI/benchmarks.

If `models.large` is set and does not resolve, `crush run` now refuses to start. `-m` / `--model` still wins. Always print `crush run: provider/model` on stderr at default verbosity. Interactive TUI fallback is unchanged. No new flags.

Pin: `go test ./internal/cmd -run 'TestRefuseUnresolvedLarge|TestResolvedLargeLine|TestRunCmd_NoNewModelFlags'` and `go test ./internal/config -run 'TestConfig_configureSelectedModels/reload_mode'`

Closes #3671
