### PR TITLE
Scope allow-for-session grants to the command, not all bash

### DIFF
--- a/internal/agent/tools/bash.go
+++ b/internal/agent/tools/bash.go
@@ -9,6 +9,7 @@ import (
 	"html/template"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -35,6 +36,44 @@ type BashPermissionsParams struct {
 	WorkingDir          string `json:"working_dir"`
 	RunInBackground     bool   `json:"run_in_background"`
 	AutoBackgroundAfter int    `json:"auto_background_after"`
+}
+
+// permissionSubjectScope derives a stable grant scope from a shell command so
+// that an allow-for-session covers the invocation the user approved instead
+// of every command in the working directory. Each &&, ||, or ; separated
+// segment contributes its first two significant tokens (skipping flags, env
+// assignments, and redirections); pipeline stages are ignored because they
+// only consume the primary stage's streams. Subjects are sorted, deduped,
+// and joined with "+". The empty command yields "bash".
+func permissionSubjectScope(command string) string {
+	flat := strings.NewReplacer("&&", "\n", "||", "\n", ";", "\n").Replace(command)
+	var subjects []string
+	for _, seg := range strings.Split(flat, "\n") {
+		if idx := strings.Index(seg, "|"); idx >= 0 {
+			seg = seg[:idx]
+		}
+		var toks []string
+		for _, tok := range strings.Fields(seg) {
+			if strings.HasPrefix(tok, "-") || strings.ContainsAny(tok, "<>") {
+				continue
+			}
+			if eq := strings.IndexByte(tok, '='); eq > 0 && !strings.Contains(tok[:eq], "/") {
+				continue
+			}
+			toks = append(toks, filepath.Base(tok))
+			if len(toks) == 2 {
+				break
+			}
+		}
+		if len(toks) > 0 {
+			subjects = append(subjects, strings.Join(toks, " "))
+		}
+	}
+	if len(subjects) == 0 {
+		return "bash"
+	}
+	slices.Sort(subjects)
+	return strings.Join(slices.Compact(subjects), "+")
 }
 
 type BashResponseMetadata struct {
@@ -235,6 +274,7 @@ func NewBashTool(permissions permission.Service, workingDir string, attribution 
 						Action:      "execute",
 						Description: fmt.Sprintf("Execute command: %s", params.Command),
 						Params:      BashPermissionsParams(params),
+						Subject:     permissionSubjectScope(params.Command),
 					},
 				)
 				if err != nil {

--- a/internal/agent/tools/bash_subject_test.go
+++ b/internal/agent/tools/bash_subject_test.go
@@ -1,0 +1,35 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPermissionSubjectScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{"simple build", "swift build", "swift build"},
+		{"pipeline keeps primary", "swift build 2>&1 | tail -20", "swift build"},
+		{"env prefix skipped", "FOO=1 swift test", "swift test"},
+		{"flags skipped", "swift test --verbose --parallel", "swift test"},
+		{"absolute path basenamed", "/usr/bin/grep pattern file.txt", "grep pattern"},
+		{"relative script", "./deploy.sh production", "deploy.sh production"},
+		{"chained sorted deduped", "git commit && git status && git commit", "git commit+git status"},
+		{"compound keeps both", "swift build && ./run_tests.sh", "run_tests.sh+swift build"},
+		{"redirect only args", "make 2>/dev/null", "make"},
+		{"empty falls back", "", "bash"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, permissionSubjectScope(tt.cmd))
+		})
+	}
+}

--- a/internal/backend/permission.go
+++ b/internal/backend/permission.go
@@ -24,6 +24,7 @@ func (b *Backend) GrantPermission(workspaceID string, req proto.PermissionGrant)
 		Action:      req.Permission.Action,
 		Params:      req.Permission.Params,
 		Path:        req.Permission.Path,
+		Subject:     req.Permission.Subject,
 	}
 
 	switch req.Action {

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -43,6 +43,11 @@ type CreatePermissionRequest struct {
 	Action      string `json:"action"`
 	Params      any    `json:"params"`
 	Path        string `json:"path"`
+	// Subject narrows a grant to a specific invocation of a tool beyond
+	// Path. For bash it is the command's binary plus subcommand (e.g.
+	// "git commit") so an allow-for-session does not implicitly approve
+	// every command runnable in the working directory.
+	Subject string `json:"subject"`
 }
 
 type PermissionNotification struct {
@@ -60,6 +65,8 @@ type PermissionRequest struct {
 	Action      string `json:"action"`
 	Params      any    `json:"params"`
 	Path        string `json:"path"`
+	// Subject mirrors CreatePermissionRequest.Subject.
+	Subject string `json:"subject"`
 }
 
 type Service interface {
@@ -90,6 +97,9 @@ type PermissionKey struct {
 	ToolName  string
 	Action    string
 	Path      string
+	// Subject mirrors PermissionRequest.Subject. An empty Subject keeps the
+	// pre-existing behavior of covering every tool action at the path.
+	Subject string
 }
 
 type permissionService struct {
@@ -166,6 +176,7 @@ func (s *permissionService) GrantPersistent(permission PermissionRequest) bool {
 			ToolName:  permission.ToolName,
 			Action:    permission.Action,
 			Path:      permission.Path,
+			Subject:   permission.Subject,
 		}, true)
 	})
 }
@@ -243,6 +254,7 @@ func (s *permissionService) Request(ctx context.Context, opts CreatePermissionRe
 		Description: opts.Description,
 		Action:      opts.Action,
 		Params:      opts.Params,
+		Subject:     opts.Subject,
 	}
 
 	if _, ok := s.sessionPermissions.Get(PermissionKey{
@@ -250,6 +262,7 @@ func (s *permissionService) Request(ctx context.Context, opts CreatePermissionRe
 		ToolName:  permission.ToolName,
 		Action:    permission.Action,
 		Path:      permission.Path,
+		Subject:   permission.Subject,
 	}); ok {
 		s.notificationBroker.Publish(pubsub.CreatedEvent, PermissionNotification{
 			ToolCallID: opts.ToolCallID,

--- a/internal/permission/permission_subject_test.go
+++ b/internal/permission/permission_subject_test.go
@@ -1,0 +1,109 @@
+package permission
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubjectScopedPersistentGrants(t *testing.T) {
+	service := NewPermissionService("/tmp", false, []string{})
+
+	req := CreatePermissionRequest{
+		SessionID:   "subject-session",
+		ToolCallID:  "call-build",
+		ToolName:    "bash",
+		Description: "Execute command: swift build",
+		Action:      "execute",
+		Path:        "/tmp",
+		Subject:     "swift build",
+	}
+
+	events := service.Subscribe(t.Context())
+
+	var granted bool
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		granted, _ = service.Request(t.Context(), req)
+	}()
+
+	event := <-events
+	require.Equal(t, "swift build", event.Payload.Subject)
+	require.True(t, service.GrantPersistent(event.Payload))
+	<-done
+	require.True(t, granted, "first request should be granted")
+
+	// The same subject auto-approves even with different trailing args;
+	// a matching grant publishes a notification but never a new prompt.
+	same := req
+	same.ToolCallID = "call-build-2"
+	same.Description = "Execute command: swift build --explicit"
+	ok, err := service.Request(t.Context(), same)
+	require.NoError(t, err)
+	assert.True(t, ok, "same subject should auto-approve")
+
+	// A different subject must still prompt. With no respondent, the
+	// request times out, which is how we prove no silent grant happened.
+	other := CreatePermissionRequest{
+		SessionID:   "subject-session",
+		ToolCallID:  "call-rm",
+		ToolName:    "bash",
+		Description: "Execute command: rm -rf /tmp/x",
+		Action:      "execute",
+		Path:        "/tmp",
+		Subject:     "rm -rf",
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+
+	prompted := make(chan bool, 1)
+	go func() {
+		g, err := service.Request(ctx, other)
+		prompted <- g && err == nil
+	}()
+
+	select {
+	case ev := <-events:
+		assert.Equal(t, "rm -rf", ev.Payload.Subject, "prompt should carry the new subject")
+		<-prompted
+	case <-time.After(3 * time.Second):
+		t.Fatal("different subject should have prompted")
+	}
+}
+
+func TestEmptySubjectKeepsLegacyBehavior(t *testing.T) {
+	service := NewPermissionService("/tmp", false, []string{})
+
+	req := CreatePermissionRequest{
+		SessionID:   "legacy-session",
+		ToolCallID:  "call-legacy",
+		ToolName:    "file_tool",
+		Description: "Edit file",
+		Action:      "write",
+		Path:        "/tmp/notes.md",
+	}
+
+	events := service.Subscribe(t.Context())
+
+	var granted bool
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		granted, _ = service.Request(t.Context(), req)
+	}()
+
+	event := <-events
+	require.True(t, service.GrantPersistent(event.Payload))
+	<-done
+	require.True(t, granted)
+
+	same := req
+	same.ToolCallID = "call-legacy-2"
+	ok, err := service.Request(t.Context(), same)
+	require.NoError(t, err)
+	assert.True(t, ok, "empty subject should behave like the old tool+action+path key")
+}

--- a/internal/proto/permission.go
+++ b/internal/proto/permission.go
@@ -13,6 +13,7 @@ type CreatePermissionRequest struct {
 	Action      string `json:"action"`
 	Params      any    `json:"params"`
 	Path        string `json:"path"`
+	Subject     string `json:"subject"`
 }
 
 // PermissionNotification represents a notification about a permission change.
@@ -32,6 +33,7 @@ type PermissionRequest struct {
 	Action      string `json:"action"`
 	Params      any    `json:"params"`
 	Path        string `json:"path"`
+	Subject     string `json:"subject"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface. This is needed

--- a/internal/server/events.go
+++ b/internal/server/events.go
@@ -68,6 +68,7 @@ func wrapEvent(ev any) *pubsub.Payload {
 				Action:      e.Payload.Action,
 				Path:        e.Payload.Path,
 				Params:      e.Payload.Params,
+				Subject:     e.Payload.Subject,
 			},
 		})
 	case pubsub.Event[permission.PermissionNotification]:

--- a/internal/ui/dialog/permissions.go
+++ b/internal/ui/dialog/permissions.go
@@ -472,6 +472,11 @@ func (p *Permissions) renderHeader(contentWidth int) string {
 		if params, ok := p.permission.Params.(tools.BashPermissionsParams); ok {
 			lines = append(lines, p.renderKeyValue("Desc", params.Description, contentWidth))
 		}
+		// Make the remembered scope of "Allow for Session" explicit rather
+		// than letting it implicitly mean every command in the directory.
+		if p.permission.Subject != "" {
+			lines = append(lines, p.renderKeyValue("Session grant", p.permission.Subject, contentWidth))
+		}
 	case tools.DownloadToolName:
 		if params, ok := p.permission.Params.(tools.DownloadPermissionsParams); ok {
 			lines = append(lines, p.renderKeyValue("URL", params.URL, contentWidth))

--- a/internal/workspace/client_workspace.go
+++ b/internal/workspace/client_workspace.go
@@ -349,6 +349,7 @@ func (w *ClientWorkspace) PermissionGrant(perm permission.PermissionRequest) boo
 			Action:      perm.Action,
 			Path:        perm.Path,
 			Params:      perm.Params,
+			Subject:     perm.Subject,
 		},
 		Action: proto.PermissionAllow,
 	})
@@ -366,6 +367,7 @@ func (w *ClientWorkspace) PermissionGrantPersistent(perm permission.PermissionRe
 			Action:      perm.Action,
 			Path:        perm.Path,
 			Params:      perm.Params,
+			Subject:     perm.Subject,
 		},
 		Action: proto.PermissionAllowForSession,
 	})
@@ -383,6 +385,7 @@ func (w *ClientWorkspace) PermissionDeny(perm permission.PermissionRequest) bool
 			Action:      perm.Action,
 			Path:        perm.Path,
 			Params:      perm.Params,
+			Subject:     perm.Subject,
 		},
 		Action: proto.PermissionDeny,
 	})


### PR DESCRIPTION
## Problem

"Allow for Session" on a bash permission prompt stores only `{session, tool, action, path}` (`PermissionKey`). The actual command is carried in `Params` but discarded when the grant is recorded. So approving `swift build` silently approves every command later run in that directory — including `rm -rf` — with no further prompt. The dialog label ("Bash") honestly reflects a scope far broader than what users think they are approving.

## Change

Thread a `Subject` through the request, the wire format, and the session grant key:

- `permission.PermissionKey` gains `Subject`; `GrantPersistent` records it and `Request` matches on it.
- The bash tool derives the subject from the command: the primary binaries across `&&`/`||`/`;` segments (e.g. `swift build`; `run_tests.sh+swift build` when chained). Pipeline stages and flags are ignored — they filter or qualify the primary stage, not widen it.
- The permission dialog renders the scope next to bash commands, so the remembered grant is explicit rather than implied.

The field is additive: all other tools send an empty subject and keep their exact existing tool+action+path behavior.

## Why this layer

PreToolUse hooks can already implement per-command policy (`decision: allow` short-circuits the prompt), but that requires every user to write and maintain a hook. This makes the sane default scope a property of the grant itself.

## Testing

- New unit tests for subject derivation (pipelines, env prefixes, flags, chaining, relative paths, empty fallback) and for the service: same-subject auto-approve, different-subject still prompts, empty-subject legacy behavior preserved.
- Full `build.yml` matrix (ubuntu/macos/windows, `-race`) via CI — no compilation or behavior changes for tools that leave `Subject` empty.


💘 Generated with Crush