### PR TITLE
feat: copy as markdown on selection

### DIFF
--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -273,6 +273,13 @@ func (a *AssistantMessageItem) ID() string {
 	return a.message.ID
 }
 
+// CopyAsMarkdown implements [list.MarkdownCopyable]. The message body is
+// glamour-rendered markdown, so selection copies may reconstruct inline
+// emphasis markers from cell attributes.
+func (a *AssistantMessageItem) CopyAsMarkdown() bool {
+	return true
+}
+
 // RawRender implements [MessageItem].
 func (a *AssistantMessageItem) RawRender(width int) string {
 	cappedWidth := cappedMessageWidth(width)

--- a/internal/ui/chat/user.go
+++ b/internal/ui/chat/user.go
@@ -53,6 +53,13 @@ func (m *UserMessageItem) Finished() bool {
 	return true
 }
 
+// CopyAsMarkdown implements [list.MarkdownCopyable]. User input renders
+// through the markdown renderer, so selection copies may reconstruct
+// inline emphasis markers from cell attributes.
+func (m *UserMessageItem) CopyAsMarkdown() bool {
+	return true
+}
+
 // RawRender implements [MessageItem].
 func (m *UserMessageItem) RawRender(width int) string {
 	cappedWidth := cappedMessageWidth(width)

--- a/internal/ui/list/highlight.go
+++ b/internal/ui/list/highlight.go
@@ -25,6 +25,19 @@ type Highlighter func(x, y int, c *uv.Cell) *uv.Cell
 
 // HighlightContent returns the content with highlighted regions based on the specified parameters.
 func HighlightContent(content string, area image.Rectangle, startLine, startCol, endLine, endCol int) string {
+	return highlightContent(content, area, startLine, startCol, endLine, endCol, false)
+}
+
+// HighlightContentMarkdown is [HighlightContent] for content that is
+// terminal-rendered markdown (glamour): in addition to the raw text it
+// reconstructs the inline markers the renderer dropped, so the clipboard
+// holds valid markdown. Bold, italic, and strikethrough runs become **, *,
+// and ~~ again, the same way codespan padding becomes backticks.
+func HighlightContentMarkdown(content string, area image.Rectangle, startLine, startCol, endLine, endCol int) string {
+	return highlightContent(content, area, startLine, startCol, endLine, endCol, true)
+}
+
+func highlightContent(content string, area image.Rectangle, startLine, startCol, endLine, endCol int, markdown bool) string {
 	content = stringext.NormalizeSpace(content)
 
 	if startLine < 0 || startCol < 0 {
@@ -42,7 +55,7 @@ func HighlightContent(content string, area image.Rectangle, startLine, startCol,
 		endCol = width
 	}
 
-	rows := extractRows(buf, startLine, startCol, endLine, endCol, height)
+	rows := extractRows(buf, startLine, startCol, endLine, endCol, height, markdown)
 	return joinRows(rows, width) + "\n"
 }
 
@@ -54,10 +67,19 @@ func renderBuffer(content string, area image.Rectangle, width, height int) uv.Sc
 	return buf
 }
 
+// extractedRow holds one extracted screen row: text is the copy text with
+// any markdown markers restored, plain the same row without markers. The
+// wrap heuristics in joinRows measure plain because restored markers would
+// inflate the row width and skew the word-wrap threshold.
+type extractedRow struct {
+	text  string
+	plain string
+}
+
 // extractRows extracts the text of the selected region from the buffer,
-// one string per row, trimmed to the last cell holding content.
-func extractRows(buf uv.ScreenBuffer, startLine, startCol, endLine, endCol, height int) []string {
-	rows := make([]string, 0, endLine-startLine+1)
+// one entry per row, trimmed to the last cell holding content.
+func extractRows(buf uv.ScreenBuffer, startLine, startCol, endLine, endCol, height int, markdown bool) []extractedRow {
+	rows := make([]extractedRow, 0, endLine-startLine+1)
 	for y := startLine; y <= endLine && y < height; y++ {
 		if y >= buf.Height() {
 			break
@@ -73,7 +95,7 @@ func extractRows(buf uv.ScreenBuffer, startLine, startCol, endLine, endCol, heig
 			colEnd = min(endCol, len(line))
 		}
 
-		rows = append(rows, extractRow(line, colStart, colEnd))
+		rows = append(rows, extractRow(line, colStart, colEnd, markdown))
 	}
 	return rows
 }
@@ -89,7 +111,13 @@ func extractRows(buf uv.ScreenBuffer, startLine, startCol, endLine, endCol, heig
 // original source text, not the rendered blank padding. The sentinel is a
 // no-break space tagged with a variation selector, so a real no-break space
 // in the message text does not match it and is copied verbatim.
-func extractRow(line uv.Line, colStart, colEnd int) string {
+//
+// In markdown mode, runs of bold, italic, and strikethrough cells
+// additionally become **, *, and ~~ markers again (see cellEmphasis). A
+// space inside an open run is held back until the next non-space cell so a
+// trailing space lands outside the closing marker: "**bold **" is not valid
+// emphasis, while "**bold** " renders the same as the source.
+func extractRow(line uv.Line, colStart, colEnd int, markdown bool) extractedRow {
 	lastCellX := -1
 	for x := colStart; x < colEnd; x++ {
 		cell := line.At(x)
@@ -98,38 +126,160 @@ func extractRow(line uv.Line, colStart, colEnd int) string {
 		}
 	}
 
-	var row strings.Builder
+	heading := markdown && isHeadingRow(line)
+
+	var row, plain strings.Builder
+	var cur emphasis
+	held := 0
+	flushHeld := func() {
+		for range held {
+			row.WriteByte(' ')
+			plain.WriteByte(' ')
+		}
+		held = 0
+	}
 	for x := colStart; x <= lastCellX; x++ {
 		cell := line.At(x)
-		if cell != nil {
-			if cell.Content == styles.CodespanPadding {
-				row.WriteString("`")
-			} else {
-				row.WriteString(cell.Content)
+		if cell == nil || cell.Content == "" {
+			continue
+		}
+
+		content := cell.Content
+		if content == styles.CodespanPadding {
+			content = "`"
+		}
+
+		e := emphasis(0)
+		if markdown && !heading {
+			e = cellEmphasis(cell)
+		}
+
+		switch {
+		case cur != 0 && e == cur && content == " ":
+			held++
+		case e == cur:
+			flushHeld()
+			row.WriteString(content)
+			plain.WriteString(content)
+		default:
+			if lost := cur &^ e; lost != 0 {
+				row.WriteString(closeMarkers(lost))
 			}
+			flushHeld()
+			if gained := e &^ cur; gained != 0 {
+				row.WriteString(openMarkers(gained))
+			}
+			if content == " " && e != 0 {
+				held++
+			} else {
+				row.WriteString(content)
+				plain.WriteString(content)
+			}
+			cur = e
 		}
 	}
-	return row.String()
+	if cur != 0 {
+		row.WriteString(closeMarkers(cur))
+	}
+	flushHeld()
+
+	return extractedRow{text: row.String(), plain: plain.String()}
+}
+
+// emphasis is a bitmask of the inline markdown emphases a cell displays.
+type emphasis uint8
+
+const (
+	emphBold emphasis = 1 << iota
+	emphItalic
+	emphStrikethrough
+)
+
+// cellEmphasis maps a cell's display attributes back to the markdown
+// emphasis they were rendered from. Cells styled for reasons other than
+// markdown emphasis are excluded: hyperlinks (OSC8 link), cells with a
+// background (codespan pills, H1 headings), and underlined cells (link
+// URLs, images, syntax-highlighted class names in fenced code), none of
+// which come from *, **, or ~~ in the source.
+func cellEmphasis(cell *uv.Cell) emphasis {
+	if cell.Link.URL != "" || cell.Style.Bg != nil || cell.Style.Underline != uv.UnderlineNone {
+		return 0
+	}
+	var e emphasis
+	if cell.Style.Attrs&uv.AttrBold != 0 {
+		e |= emphBold
+	}
+	if cell.Style.Attrs&uv.AttrItalic != 0 {
+		e |= emphItalic
+	}
+	if cell.Style.Attrs&uv.AttrStrikethrough != 0 {
+		e |= emphStrikethrough
+	}
+	return e
+}
+
+// isHeadingRow reports whether the buffer row is a markdown heading. H2-H6
+// render their literal "## " prefix and title all in bold, so without the
+// check a copied heading would gain bogus ** markers around its title. H1
+// needs no check: it paints a background color, which cellEmphasis already
+// rejects.
+func isHeadingRow(line uv.Line) bool {
+	cell := line.At(0)
+	return cell != nil && strings.HasPrefix(cell.Content, "#")
+}
+
+// openMarkers returns the markdown markers opening the given emphasis
+// flags, bold outermost, so bold-italic text opens as ***.
+func openMarkers(e emphasis) string {
+	var s strings.Builder
+	if e&emphBold != 0 {
+		s.WriteString("**")
+	}
+	if e&emphItalic != 0 {
+		s.WriteString("*")
+	}
+	if e&emphStrikethrough != 0 {
+		s.WriteString("~~")
+	}
+	return s.String()
+}
+
+// closeMarkers returns the markdown markers closing the given emphasis
+// flags, unwinding openMarkers in reverse, so bold-italic text closes as
+// ***.
+func closeMarkers(e emphasis) string {
+	var s strings.Builder
+	if e&emphStrikethrough != 0 {
+		s.WriteString("~~")
+	}
+	if e&emphItalic != 0 {
+		s.WriteString("*")
+	}
+	if e&emphBold != 0 {
+		s.WriteString("**")
+	}
+	return s.String()
 }
 
 // joinRows stitches screen rows back into text, deciding per row boundary
 // whether it was a real newline or a word wrap. Blank rows are paragraph
 // breaks; otherwise isWordWrap decides.
-func joinRows(rows []string, width int) string {
+func joinRows(rows []extractedRow, width int) string {
 	var sb strings.Builder
 	for i, row := range rows {
-		text := strings.TrimRight(row, " ")
+		text := strings.TrimRight(row.text, " ")
+		plain := strings.TrimRight(row.plain, " ")
 		sb.WriteString(text)
 		if i == len(rows)-1 {
 			break
 		}
 
-		next := rows[i+1]
+		next := rows[i+1].plain
 		switch {
 		case strings.TrimSpace(next) == "":
 			// Blank row: paragraph break.
 			sb.WriteString("\n")
-		case isWordWrap(text, next, width):
+		case isWordWrap(plain, next, width):
 			sb.WriteString(" ")
 		default:
 			sb.WriteString("\n")

--- a/internal/ui/list/highlight_markdown_test.go
+++ b/internal/ui/list/highlight_markdown_test.go
@@ -1,0 +1,159 @@
+package list
+
+import (
+	"testing"
+
+	"charm.land/glamour/v2"
+	"charm.land/lipgloss/v2"
+	uv "github.com/charmbracelet/ultraviolet"
+
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/stretchr/testify/require"
+)
+
+// renderMarkdownForCopy renders src through glamour with the given width,
+// the same pipeline chat message items use, ready for HighlightContent.
+func renderMarkdownForCopy(t *testing.T, src string, width int) string {
+	t.Helper()
+	sty := styles.CharmtonePantera()
+	r, err := glamour.NewTermRenderer(glamour.WithStyles(sty.Markdown), glamour.WithWordWrap(width))
+	require.NoError(t, err)
+	rendered, err := r.Render(src)
+	require.NoError(t, err)
+	return rendered
+}
+
+// copyMarkdown renders src at the given width and extracts a full-content
+// selection copy with markdown marker reconstruction.
+func copyMarkdown(t *testing.T, src string, width int) string {
+	t.Helper()
+	rendered := renderMarkdownForCopy(t, src, width)
+	return HighlightContentMarkdown(rendered, uv.Rect(0, 0, width, lipgloss.Height(rendered)), 0, 0, -1, -1)
+}
+
+// TestHighlightContentMarkdownRestoresEmphasis is the core copy-side test
+// for markdown reconstruction: bold, italic, bold-italic, and
+// strikethrough render by dropping their markers and styling the text, so
+// a selection copy must put the markers back for the clipboard to hold
+// valid markdown.
+func TestHighlightContentMarkdownRestoresEmphasis(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"hello **bold** world":   "hello **bold** world\n",
+		"hello *italic* world":   "hello *italic* world\n",
+		"a ***bi*** b":           "a ***bi*** b\n",
+		"a ~~gone~~ b":           "a ~~gone~~ b\n",
+		"**Note:** something":    "**Note:** something\n",
+		"*foo bar* baz":          "*foo bar* baz\n",
+		"> quoted *text* here":   "│ quoted *text* here\n",
+		"- item with **bold** x": "• item with **bold** x\n",
+	}
+	for src, want := range cases {
+		require.Equal(t, want, copyMarkdown(t, src, 80), "source: %q", src)
+	}
+}
+
+// TestHighlightContentLeavesEmphasisRaw pins the non-markdown path: without
+// markdown mode the same rendered content copies as displayed text, with no
+// reconstructed markers.
+func TestHighlightContentLeavesEmphasisRaw(t *testing.T) {
+	t.Parallel()
+
+	rendered := renderMarkdownForCopy(t, "hello **bold** world", 80)
+	result := HighlightContent(rendered, uv.Rect(0, 0, 80, lipgloss.Height(rendered)), 0, 0, -1, -1)
+	require.Equal(t, "hello bold world\n", result)
+}
+
+// TestHighlightContentMarkdownWrappedSpan covers a bold span word-wrapped
+// across rows: each row closes and reopens its markers, and the wrap join
+// keeps the copy a single logical line of valid markdown.
+func TestHighlightContentMarkdownWrappedSpan(t *testing.T) {
+	t.Parallel()
+
+	// The bold span is longer than the wrap width, so it must split
+	// mid-span: each screen row closes and reopens its markers.
+	src := "word word **boldspan continues here and keeps going** word word"
+	result := copyMarkdown(t, src, 30)
+	require.Equal(t, "word word **boldspan continues** **here and keeps going** word word\n", result)
+}
+
+// TestHighlightContentMarkdownSkipsHeadings guards the heading exclusion:
+// headings render their whole row in bold (H1 additionally paints a
+// background), and naive attribute detection would wrap the title in bogus
+// ** markers on top of the ## prefix.
+func TestHighlightContentMarkdownSkipsHeadings(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "## Title Two\n", copyMarkdown(t, "## Title Two", 80))
+	require.Equal(t, "Title One\n", copyMarkdown(t, "# Title One", 80))
+}
+
+// TestHighlightContentMarkdownSkipsLinks guards the hyperlink exclusion:
+// link text renders bold but carries an OSC8 hyperlink, so it must not
+// gain ** markers.
+func TestHighlightContentMarkdownSkipsLinks(t *testing.T) {
+	t.Parallel()
+
+	result := copyMarkdown(t, "see [the docs](https://example.com) now", 80)
+	require.Equal(t, "see the docs https://example.com now\n", result)
+}
+
+// TestHighlightContentMarkdownSkipsCodeBlocks guards the code fence
+// exclusion: syntax highlighting styles some tokens bold or underlined
+// (e.g. class names), and wrapping those in markers would corrupt code the
+// user copies to run.
+func TestHighlightContentMarkdownSkipsCodeBlocks(t *testing.T) {
+	t.Parallel()
+
+	src := "before\n\n```python\nclass Foo:\n    pass\n```\n\nafter"
+	result := copyMarkdown(t, src, 80)
+	require.NotContains(t, result, "**", "code block must not gain markers, got:\n%s", result)
+	require.Contains(t, result, "class Foo:")
+}
+
+// TestHighlightContentMarkdownNestedCodespan covers emphasis around an
+// inline codespan: the codespan pill paints a background, which suspends
+// the emphasis run while the sentinel padding still restores the
+// backticks.
+func TestHighlightContentMarkdownNestedCodespan(t *testing.T) {
+	t.Parallel()
+
+	result := copyMarkdown(t, "**bold and `code` mix**", 80)
+	require.Equal(t, "**bold and** `code`** mix**\n", result)
+}
+
+// TestHighlightContentMarkdownPartialSelection selects only the bold word
+// out of a longer line: markers must open and close at the selection
+// boundaries so even a mid-span copy stays balanced.
+func TestHighlightContentMarkdownPartialSelection(t *testing.T) {
+	t.Parallel()
+
+	rendered := renderMarkdownForCopy(t, "hello **bold** world", 80)
+	// Columns 6..11 cover "bold".
+	result := HighlightContentMarkdown(rendered, uv.Rect(0, 0, 80, lipgloss.Height(rendered)), 0, 6, 0, 11)
+	require.Equal(t, "**bold**\n", result)
+}
+
+// TestHighlightContentMarkdownTrailingSpace pins the closing-marker
+// placement: a space at the end of an emphasis run must land outside the
+// closing marker, because "**bold **" is not valid emphasis.
+func TestHighlightContentMarkdownTrailingSpace(t *testing.T) {
+	t.Parallel()
+
+	content := lipgloss.NewStyle().Bold(true).Render("bold ") + "plain"
+	result := HighlightContentMarkdown(content, uv.Rect(0, 0, 40, 1), 0, 0, -1, -1)
+	require.Equal(t, "**bold** plain\n", result)
+}
+
+// TestHighlightContentMarkdownStyledPlainText documents the contract for
+// non-glamour styled text: in markdown mode any bold/italic run is treated
+// as emphasis, which is why only items that render markdown may opt in
+// (see list.MarkdownCopyable).
+func TestHighlightContentMarkdownStyledPlainText(t *testing.T) {
+	t.Parallel()
+
+	content := "a " + lipgloss.NewStyle().Italic(true).Render("styled") + " b"
+	result := HighlightContentMarkdown(content, uv.Rect(0, 0, 40, 1), 0, 0, -1, -1)
+	require.Equal(t, "a *styled* b\n", result)
+}

--- a/internal/ui/list/item.go
+++ b/internal/ui/list/item.go
@@ -92,6 +92,18 @@ type Highlightable interface {
 	Highlight() (startLine, startCol, endLine, endCol int)
 }
 
+// MarkdownCopyable represents an item whose raw rendering is
+// terminal-rendered markdown (glamour), so a selection copy may map
+// bold/italic/strikethrough cell attributes back to the **, *, and ~~
+// markers they came from. Items that render program output or other
+// arbitrarily styled text must not implement it: there the attributes
+// carry no markdown meaning and reconstruction would corrupt the copy.
+type MarkdownCopyable interface {
+	// CopyAsMarkdown reports whether selection copies of this item should
+	// reconstruct inline markdown markers.
+	CopyAsMarkdown() bool
+}
+
 // MouseClickable represents an item that can handle mouse click events.
 type MouseClickable interface {
 	// HandleMouseClick processes a mouse click event at the given coordinates.

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -1021,7 +1021,15 @@ func (m *Chat) HighlightContent() string {
 			} else {
 				rendered = item.Render(listWidth)
 			}
-			sb.WriteString(list.HighlightContent(
+			markdown := false
+			if mc, ok := item.(list.MarkdownCopyable); ok {
+				markdown = mc.CopyAsMarkdown()
+			}
+			extract := list.HighlightContent
+			if markdown {
+				extract = list.HighlightContentMarkdown
+			}
+			sb.WriteString(extract(
 				rendered,
 				uv.Rect(0, 0, listWidth, lipgloss.Height(rendered)),
 				startLine,


### PR DESCRIPTION
## What? 

Introduces copying as raw markdown


## Why? 

Currently many tags (italics, bold) are dropped (inline code introduced in #3678)

Fixes CHARM-2168