### PR TITLE
docs(readme): note FSL Competing Use under License

### DIFF
--- a/README.md
+++ b/README.md
@@ -988,6 +988,8 @@ We’d love to hear your thoughts on this project. Need help? We gotchu. You can
 
 [FSL-1.1-MIT](https://github.com/charmbracelet/crush/raw/main/LICENSE.md)
 
+Until the MIT future grant takes effect, Competing Use is disallowed — see the Competing Use clause in [`LICENSE.md`](LICENSE.md).
+
 ---
 
 Part of [Charm](https://charm.land).


### PR DESCRIPTION
## Summary
- Clarify under `## License` that Competing Use is disallowed until the MIT future grant
- Point readers at the Competing Use clause in `LICENSE.md` (does not change the license)

## Why
Fixes #3681 — README previously linked FSL-1.1-MIT without mentioning the non-compete / Competing Use restriction.

## Testing
- N/A (docs-only README change)
