### PR TITLE
fix(discover): keep a user-set supports_attachments in the LM Studio enricher

### DIFF
--- a/internal/discover/lmstudio.go
+++ b/internal/discover/lmstudio.go
@@ -94,8 +94,10 @@ func (e *lmstudioEnricher) EnrichModels(ctx context.Context, cfg Config, resolve
 			models[i].Name = meta.DisplayName
 		}
 
-		// Vision support from capabilities.
-		models[i].SupportsImages = meta.Capabilities.Vision
+		// Vision support from capabilities, if not already set by user.
+		if !models[i].SupportsImages {
+			models[i].SupportsImages = meta.Capabilities.Vision
+		}
 	}
 
 	return models, nil

--- a/internal/discover/lmstudio_test.go
+++ b/internal/discover/lmstudio_test.go
@@ -152,6 +152,27 @@ func TestLmstudioEnricher(t *testing.T) {
 		require.Equal(t, "User Name", result[0].Name)
 	})
 
+	t.Run("does not override user-set SupportsImages", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(lmstudioModelsResponse{
+				Models: []lmstudioModelEntry{
+					{Key: "m1", DisplayName: "API Name"},
+				},
+			})
+		}))
+		defer srv.Close()
+
+		cfg := Config{ID: "test-lmstudio", BaseURL: srv.URL}
+		models := []catwalk.Model{{ID: "m1", Name: "m1", SupportsImages: true}}
+
+		e := &lmstudioEnricher{}
+		result, err := e.EnrichModels(context.Background(), cfg, &mockResolver{}, models)
+		require.NoError(t, err)
+		require.True(t, result[0].SupportsImages)
+	})
+
 	t.Run("populates SupportsImages from capabilities.vision", func(t *testing.T) {
 		t.Parallel()
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
`internal/discover/lmstudio.go:97` assigns `SupportsImages` with no guard:

```go
// Vision support from capabilities.
models[i].SupportsImages = meta.Capabilities.Vision
```

The two fields above it in the same loop are guarded. `ContextWindow` at line 84 and `Name` at line 93 both check the existing value first.

The `Enricher` interface asks for that guard:

```go
// EnrichModels takes a slice of bare discovered models and returns
// them with metadata populated. Implementations should preserve
// existing non-zero fields (user overrides take precedence).
```

`DiscoverModels` says the same in its own doc comment, and `TestDiscoverModels_ExistingModelsWin` asserts it. The other three enrichers, `litellm.go:72`, `omlx.go:64` and `llamacpp.go:73`, guard every field they write.

## Effect

A user model declared with `supports_attachments: true` reaches the enricher through `config/load.go:413` -> `discover.go:131`. LM Studio omits `capabilities` for many entries, so `meta.Capabilities.Vision` is false and the user value is replaced on every config load.

The false value then disables images across the agent:

- `agent/tools/view.go:209` returns `This model (%s) does not support image data.`
- `agent/agent.go:1573` and `1594` strip file parts and drop attachments.
- `agent/agent.go:2184` replaces a media tool result with `[Image/media content not supported by this model]`.

## Change

Three lines in `lmstudio.go`, plus one test case.

```go
// Vision support from capabilities, if not already set by user.
if !models[i].SupportsImages {
    models[i].SupportsImages = meta.Capabilities.Vision
}
```

## Verification

New subtest `does not override user-set SupportsImages` in `internal/discover/lmstudio_test.go`. It fails before the change:

```
    lmstudio_test.go:173: Error: Should be true
--- FAIL: TestLmstudioEnricher/does_not_override_user-set_SupportsImages
```

and passes after it. No existing test changes. `go build ./...` passes, `go vet ./internal/discover/` is clean, and `go test ./internal/discover/... ./internal/config/...` passes.
