### PR TITLE
fix(agent): count every prompt token bucket in the session usage

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1858,7 +1858,7 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 		cost = 0
 	}
 
-	promptTokens := resp.TotalUsage.InputTokens + resp.TotalUsage.CacheCreationTokens
+	promptTokens := resp.TotalUsage.InputTokens + resp.TotalUsage.CacheCreationTokens + resp.TotalUsage.CacheReadTokens
 	completionTokens := resp.TotalUsage.OutputTokens
 
 	// Atomically update only title and usage fields to avoid overriding other
@@ -1940,7 +1940,7 @@ func updateSessionTokenCounters(session *session.Session, usage fantasy.Usage) {
 	if usage.OutputTokens != 0 {
 		session.CompletionTokens = usage.OutputTokens
 	}
-	if promptTokens := usage.InputTokens + usage.CacheReadTokens; promptTokens != 0 {
+	if promptTokens := usage.InputTokens + usage.CacheCreationTokens + usage.CacheReadTokens; promptTokens != 0 {
 		session.PromptTokens = promptTokens
 	}
 }

--- a/internal/agent/usage_fallback_test.go
+++ b/internal/agent/usage_fallback_test.go
@@ -215,6 +215,25 @@ func TestUpdateSessionUsageSkipsEstimatedCost(t *testing.T) {
 	require.True(t, currentSession.EstimatedUsage)
 }
 
+func TestUpdateSessionUsageCountsEveryPromptBucket(t *testing.T) {
+	t.Parallel()
+
+	agent := &sessionAgent{}
+	currentSession := &session.Session{ID: "session-id"}
+	model := Model{CatwalkCfg: catwalk.Model{CostPer1MIn: 10, CostPer1MOut: 20}}
+	usage := fantasy.Usage{
+		InputTokens:         50,
+		CacheCreationTokens: 30000,
+		CacheReadTokens:     1200,
+		OutputTokens:        400,
+	}
+
+	agent.updateSessionUsage(model, currentSession, usage, nil, false)
+
+	require.Equal(t, int64(31250), currentSession.PromptTokens)
+	require.Equal(t, int64(400), currentSession.CompletionTokens)
+}
+
 func TestUpdateSessionUsageKeepsCountersForZeroUsage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Two places compute the prompt token count, and each one leaves out a different bucket.

`internal/agent/agent.go:1943`

```go
if promptTokens := usage.InputTokens + usage.CacheReadTokens; promptTokens != 0 {
```

`internal/agent/agent.go:1861`

```go
promptTokens := resp.TotalUsage.InputTokens + resp.TotalUsage.CacheCreationTokens
```

## Why all three belong in the sum

fantasy reports the prompt in three disjoint buckets.

- `providers/anthropic/anthropic.go:1418-1423` maps `input_tokens`, `cache_creation_input_tokens` and `cache_read_input_tokens` to three separate fields. The Anthropic API excludes both cache counts from `input_tokens`.
- `providers/openai/language_model_hooks.go:226` sets `inputTokens = max(PromptTokens - CachedTokens, 0)` and puts `CachedTokens` in `CacheReadTokens`. OpenAI has no cache creation bucket, so that field stays 0.

`updateSessionUsage` at `agent.go:1908-1911` already treats them as disjoint. It prices `CacheCreationTokens`, `CacheReadTokens` and `InputTokens` on three separate rates. That would double charge if the buckets overlapped.

## Effect

An Anthropic turn that writes the cache reports input 50, cache creation 30000, cache read 1200.

| value | before | correct |
|---|---|---|
| `session.PromptTokens` | 1250 | 31250 |
| `session.Cost` | 0.11901 | 0.11901 |

The cost is right, the token count is 25 times low.

`agent.go:1045` is the consumer:

```go
tokens := currentSession.CompletionTokens + currentSession.PromptTokens
remaining := cw - tokens
```

That is the auto-summarize stop condition. An undercounted prompt makes `remaining` look large, so compaction runs far too late on a cached session.

## Change

One extra term at each of the two sites.

## Verification

New test `TestUpdateSessionUsageCountsEveryPromptBucket` in `internal/agent/usage_fallback_test.go`. With the change reverted it fails:

```
expected: 31250
actual  : 1250
```

`go build ./...` passes. `go vet ./internal/agent/` is clean. `go test ./internal/agent/...` passes, including the seven existing `TestUpdateSessionUsage*` cases. No existing test changes.
