### PR TITLE
fix(copilot): route grok models through responses api

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -78,6 +78,8 @@ var copilotResponsesModels = map[string]bool{
 	"gpt-5.6-luna":  true,
 	"gpt-5.6-terra": true,
 	"gpt-5.6-sol":   true,
+	"grok-4.5":      true,
+	"grok-4.6":      true,
 }
 
 // OpenCode models that user Anthropic Messages API instead of Chat Completions.

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -88,6 +88,15 @@ func agentResultWithText(text string) *fantasy.AgentResult {
 	}
 }
 
+func TestCopilotResponsesModels(t *testing.T) {
+	t.Parallel()
+
+	for _, modelID := range []string{"grok-4.5", "grok-4.6"} {
+		assert.True(t, copilotResponsesModels[modelID], modelID)
+	}
+	assert.False(t, copilotResponsesModels["gpt-4.1"])
+}
+
 func TestRunSubAgent(t *testing.T) {
 	const providerID = "test-provider"
 	providerCfg := config.ProviderConfig{ID: providerID}


### PR DESCRIPTION
## What does this do?

Routes GitHub Copilot's Grok 4.5 and Grok 4.6 models through the Responses API instead of the Chat Completions API.

## Why is this needed?

GitHub Copilot advertises both models as Responses-only. A focused query against Copilot's model-discovery endpoint returns:

```console
$ curl -s -H "Authorization: Bearer $(gh auth token)" \
    https://api.githubcopilot.com/models |
    jq '.data[] | select(.id == "grok-4.5" or .id == "grok-4.6") | {id, supported_endpoints}'
{
  "id": "grok-4.5",
  "supported_endpoints": [
    "/responses"
  ]
}
{
  "id": "grok-4.6",
  "supported_endpoints": [
    "/responses"
  ]
}
```

Crush currently selects the Copilot wire API through an explicit allowlist. Because these Grok model IDs are absent from that allowlist, Crush sends their requests to `/chat/completions`. Copilot then rejects Grok 4.6 with:

```text
bad request: model "grok-4.6" is not accessible via the /chat/completions endpoint
```

Adding both advertised Responses-only Grok models to the existing allowlist makes Crush use the endpoint required by Copilot. The change deliberately retains the current opt-in design rather than broadening Responses API use for other Copilot models.

## How was this tested?

- Added a regression test verifying that Grok 4.5 and Grok 4.6 opt into the Responses API.
- Kept a negative assertion for GPT-4.1 to ensure a Chat Completions model is not inadvertently routed through Responses.
- Ran `go test ./internal/agent` successfully.
- Ran `git diff --check` successfully.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

This is a bug fix, not a new feature, so the discussion requirement does not apply.
