### PR TITLE
fix: flickering screen when inline code was present

### DIFF
--- a/internal/ui/styles/codespan_padding_test.go
+++ b/internal/ui/styles/codespan_padding_test.go
@@ -1,0 +1,33 @@
+package styles
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/rivo/uniseg"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCodespanPaddingIsOneCellWide guards the flicker regression from the
+// emoji-presentation variation selector: when the sentinel ended in U+FE0F,
+// ansi.StringWidth measured it as two cells wide while terminals rendered it
+// as one, and that mismatch made the frame differ repaint the line on every
+// frame. The sentinel must measure exactly one cell under every width
+// authority in play (glamour wraps with x/ansi, cells are stored with
+// uniseg).
+func TestCodespanPaddingIsOneCellWide(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 1, ansi.StringWidth(CodespanPadding),
+		"codespan padding must budget one cell, or word wrap disagrees with the terminal")
+	require.Equal(t, 1, uniseg.StringWidth(CodespanPadding),
+		"codespan padding must occupy one screen cell")
+
+	state := -1
+	cluster, _, w, _ := uniseg.FirstGraphemeClusterInString(CodespanPadding, state)
+	require.Equal(t, CodespanPadding, cluster, "padding must be a single grapheme cluster")
+	require.Equal(t, 1, w)
+
+	require.NotEqual(t, "\u00a0", CodespanPadding,
+		"sentinel must stay distinguishable from a real no-break space")
+}

--- a/internal/ui/styles/styles.go
+++ b/internal/ui/styles/styles.go
@@ -31,13 +31,20 @@ const (
 	// but selection copies recognize it and turn it back into the original
 	// backticks (see list.HighlightContent).
 	//
-	// It is a no-break space tagged with a variation selector: the pair is
-	// a single one-cell grapheme that renders as a blank and, being
-	// non-breaking, keeps word wrap from tearing a codespan between its
-	// padding and its text. The selector makes the sentinel distinct from
-	// a real no-break space in message text (pasted text, some LLM
-	// output), which a selection copy must preserve verbatim.
-	CodespanPadding string = "\u00a0\ufe0f"
+	// It is a no-break space tagged with the text-presentation variation
+	// selector (U+FE0E): the pair is a single one-cell grapheme that
+	// renders as a blank and, being non-breaking, keeps word wrap from
+	// tearing a codespan between its padding and its text. The selector
+	// makes the sentinel distinct from a real no-break space in message
+	// text (pasted text, some LLM output), which a selection copy must
+	// preserve verbatim.
+	//
+	// The selector must be U+FE0E, not the emoji-presentation U+FE0F:
+	// ansi.StringWidth measures any cluster ending in U+FE0F as two
+	// cells wide, while terminals render it as one, and that mismatch
+	// makes the frame differ repaint the line on every frame (visible
+	// as flicker).
+	CodespanPadding string = "\u00a0\ufe0e"
 
 	ToolPending string = "●"
 	ToolSuccess string = "✓"


### PR DESCRIPTION
## What?

Fixes the regression with #3678. Sentinel is now `"\u00a0\ufe0e"`


## Why?

`CodespanPadding` was `"\u00a0\ufe0f"` (NBSP + emoji variation selector-16). `ansi.StringWidth` measures any cluster ending in U+FE0F as 2 cells, while terminals render it as 1.

Every line with inline code was therefore budgeted wider than the terminal actually rendered, so the frame differ saw a mismatch on each frame and repainted the line constantly, visible as flicker (worse over SSH), triggered by typing because each keystroke produces frames.