### PR TITLE
fix: bump mcp sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/jordanella/go-ansi-paintbrush v0.0.0-20240728195301-b7ad996ecf3d
 	github.com/lucasb-eyer/go-colorful v1.4.1
 	github.com/mattn/go-isatty v0.0.24
-	github.com/modelcontextprotocol/go-sdk v1.7.0
+	github.com/modelcontextprotocol/go-sdk v1.7.1-0.20260825092617-32404652e60b
 	github.com/ncruces/go-sqlite3 v0.35.3
 	github.com/nxadm/tail v1.4.11
 	github.com/openai/openai-go/v3 v3.54.0

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,8 @@ github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwX
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
-github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
+github.com/modelcontextprotocol/go-sdk v1.7.1-0.20260825092617-32404652e60b h1:QngUm4mnRlQWHv5rkqPeMCr6mqSz3aFGc3u0Rc00qsM=
+github.com/modelcontextprotocol/go-sdk v1.7.1-0.20260825092617-32404652e60b/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/mango v0.1.0 h1:DZQK45d2gGbql1arsYA4vfg4d7I9Hfx5rX/GCmzsAvI=

--- a/internal/oauth/mcp/handler.go
+++ b/internal/oauth/mcp/handler.go
@@ -181,6 +181,10 @@ func NewHandler(
 		AuthorizationCodeFetcher: receiver.fetchAuthorizationCode,
 		RequestRefreshToken:      true,
 		NewTokenSource:           newTokenSource,
+		// Some servers (e.g. Sentry) send the RFC 9207 iss parameter
+		// without advertising it in their metadata. Accept a matching
+		// unadvertised iss instead of failing the flow.
+		AcceptUnadvertisedIss: true,
 		// Use a metadata-fixing HTTP client so trailing-slash issuers in
 		// OAuth metadata responses don't trip the SDK's strict RFC 8414
 		// validation. Also rewrite internal-cluster redirects back to the


### PR DESCRIPTION
## What?og

Bumps MCP go-sdk to [32404652e60b](<https://github.com/modelcontextprotocol/go-sdk/commit/32404652e60b>)

## Why?

Fixes #3701