### PR TITLE
fix(agent): apply model provider options to session title generation

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -32,6 +32,7 @@ import (
 	"charm.land/fantasy/providers/bedrock"
 	"charm.land/fantasy/providers/google"
 	"charm.land/fantasy/providers/openai"
+	"charm.land/fantasy/providers/openaicompat"
 	"charm.land/fantasy/providers/openrouter"
 	"charm.land/fantasy/providers/vercel"
 	"charm.land/lipgloss/v2"
@@ -1725,6 +1726,32 @@ func hasUserTextMessage(msgs []message.Message) bool {
 }
 
 // GenerateTitle generates a session title based on the initial prompt.
+// titleProviderOptions forwards the model's configured provider_options
+// (e.g. disabling thinking for Qwen models via chat_template_kwargs) to
+// the title call, which otherwise never goes through getProviderOptions.
+// The options are keyed for openai-compat transports; other transports
+// ignore keys that are not theirs.
+func titleProviderOptions(m Model) fantasy.ProviderOptions {
+	if len(m.ModelCfg.ProviderOptions) == 0 {
+		return nil
+	}
+	merged := map[string]any{}
+	data, err := json.Marshal(m.ModelCfg.ProviderOptions)
+	if err == nil {
+		err = json.Unmarshal(data, &merged)
+	}
+	if err != nil {
+		slog.Error("Could not marshal title provider options", "err", err)
+		return nil
+	}
+	parsed, err := openaicompat.ParseOptions(merged)
+	if err != nil {
+		slog.Error("Could not parse title provider options", "err", err)
+		return nil
+	}
+	return fantasy.ProviderOptions{openaicompat.Name: parsed}
+}
+
 func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, userPrompt string) {
 	if userPrompt == "" {
 		return
@@ -1789,7 +1816,9 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 			tok = attempt.model.CatwalkCfg.DefaultMaxTokens
 		}
 		agent := newAgent(attempt.model.Model, titlePrompt, tok)
-		resp, err = agent.Stream(ctx, streamCall)
+		call := streamCall
+		call.ProviderOptions = titleProviderOptions(attempt.model)
+		resp, err = agent.Stream(ctx, call)
 		if err == nil && resp.Response.FinishReason != fantasy.FinishReasonLength {
 			model = attempt.model
 			slog.Debug("Generated title with " + attempt.name + " model")

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1728,7 +1728,6 @@ func hasUserTextMessage(msgs []message.Message) bool {
 }
 
 // GenerateTitle generates a session title based on the initial prompt.
-
 func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, userPrompt string) {
 	if userPrompt == "" {
 		return

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -32,7 +32,6 @@ import (
 	"charm.land/fantasy/providers/bedrock"
 	"charm.land/fantasy/providers/google"
 	"charm.land/fantasy/providers/openai"
-	"charm.land/fantasy/providers/openaicompat"
 	"charm.land/fantasy/providers/openrouter"
 	"charm.land/fantasy/providers/vercel"
 	"charm.land/lipgloss/v2"
@@ -168,6 +167,7 @@ type activeCancel struct {
 }
 
 type sessionAgent struct {
+	cfg                *config.ConfigStore
 	largeModel         *csync.Value[Model]
 	smallModel         *csync.Value[Model]
 	systemPromptPrefix *csync.Value[string]
@@ -224,6 +224,7 @@ type sessionAgent struct {
 }
 
 type SessionAgentOptions struct {
+	Config               *config.ConfigStore
 	LargeModel           Model
 	SmallModel           Model
 	SystemPromptPrefix   string
@@ -242,6 +243,7 @@ func NewSessionAgent(
 	opts SessionAgentOptions,
 ) SessionAgent {
 	return &sessionAgent{
+		cfg:                  opts.Config,
 		largeModel:           csync.NewValue(opts.LargeModel),
 		smallModel:           csync.NewValue(opts.SmallModel),
 		systemPromptPrefix:   csync.NewValue(opts.SystemPromptPrefix),
@@ -1726,31 +1728,6 @@ func hasUserTextMessage(msgs []message.Message) bool {
 }
 
 // GenerateTitle generates a session title based on the initial prompt.
-// titleProviderOptions forwards the model's configured provider_options
-// (e.g. disabling thinking for Qwen models via chat_template_kwargs) to
-// the title call, which otherwise never goes through getProviderOptions.
-// The options are keyed for openai-compat transports; other transports
-// ignore keys that are not theirs.
-func titleProviderOptions(m Model) fantasy.ProviderOptions {
-	if len(m.ModelCfg.ProviderOptions) == 0 {
-		return nil
-	}
-	merged := map[string]any{}
-	data, err := json.Marshal(m.ModelCfg.ProviderOptions)
-	if err == nil {
-		err = json.Unmarshal(data, &merged)
-	}
-	if err != nil {
-		slog.Error("Could not marshal title provider options", "err", err)
-		return nil
-	}
-	parsed, err := openaicompat.ParseOptions(merged)
-	if err != nil {
-		slog.Error("Could not parse title provider options", "err", err)
-		return nil
-	}
-	return fantasy.ProviderOptions{openaicompat.Name: parsed}
-}
 
 func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, userPrompt string) {
 	if userPrompt == "" {
@@ -1817,7 +1794,10 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 		}
 		agent := newAgent(attempt.model.Model, titlePrompt, tok)
 		call := streamCall
-		call.ProviderOptions = titleProviderOptions(attempt.model)
+		if a.cfg != nil {
+			providerCfg, _ := a.cfg.Config().Providers.Get(attempt.model.ModelCfg.Provider)
+			call.ProviderOptions = getProviderOptions(attempt.model, providerCfg)
+		}
 		resp, err = agent.Stream(ctx, call)
 		if err == nil && resp.Response.FinishReason != fantasy.FinishReasonLength {
 			model = attempt.model

--- a/internal/agent/agentic_fetch_tool.go
+++ b/internal/agent/agentic_fetch_tool.go
@@ -179,6 +179,7 @@ func (c *coordinator) agenticFetchTool(_ context.Context, client *http.Client) (
 			// the user's hooks N times per delegated turn.
 
 			agent := NewSessionAgent(SessionAgentOptions{
+				Config:               c.cfg,
 				LargeModel:           small, // Use small model for both (fetch doesn't need large)
 				SmallModel:           small,
 				SystemPromptPrefix:   smallProviderCfg.SystemPromptPrefix,

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -633,6 +633,7 @@ func (c *coordinator) buildAgent(ctx context.Context, prompt *prompt.Prompt, age
 
 	largeProviderCfg, _ := c.cfg.Config().Providers.Get(large.ModelCfg.Provider)
 	result := NewSessionAgent(SessionAgentOptions{
+		Config:               c.cfg,
 		LargeModel:           large,
 		SmallModel:           small,
 		SystemPromptPrefix:   largeProviderCfg.SystemPromptPrefix,

--- a/internal/agent/title_provider_options_test.go
+++ b/internal/agent/title_provider_options_test.go
@@ -1,0 +1,74 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"charm.land/fantasy/providers/openaicompat"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+// Title generation never goes through getProviderOptions, so a model that
+// needs provider-specific request fields (Qwen's chat_template_kwargs to
+// disable thinking, for example) would lose them on the title call and
+// burn the whole token budget reasoning. These tests pin that the title
+// path forwards model provider_options.
+func TestTitleProviderOptions(t *testing.T) {
+	t.Run("empty options produce no provider options", func(t *testing.T) {
+		m := Model{CatwalkCfg: catwalk.Model{ID: "qwen3.8-27b"}}
+		require.Nil(t, titleProviderOptions(m))
+	})
+
+	t.Run("model provider_options are keyed for openai-compat transports", func(t *testing.T) {
+		m := Model{
+			CatwalkCfg: catwalk.Model{ID: "Qwen3.8-27B"},
+			ModelCfg: config.SelectedModel{
+				ProviderOptions: map[string]any{
+					"extra_body": map[string]any{
+						"chat_template_kwargs": map[string]any{"enable_thinking": false},
+					},
+				},
+			},
+		}
+
+		opts := titleProviderOptions(m)
+		require.Len(t, opts, 1)
+
+		parsed, ok := opts[openaicompat.Name].(*openaicompat.ProviderOptions)
+		require.True(t, ok, "options should parse as openai-compat provider options")
+		require.NotNil(t, parsed.ExtraBody)
+
+		body, err := json.Marshal(parsed.ExtraBody)
+		require.NoError(t, err)
+
+		var extra map[string]any
+		require.NoError(t, json.Unmarshal(body, &extra))
+		kwargs, ok := extra["chat_template_kwargs"].(map[string]any)
+		require.True(t, ok, "chat_template_kwargs should survive the round trip: %v", extra)
+		require.Equal(t, false, kwargs["enable_thinking"])
+	})
+
+	t.Run("options parse failures degrade to none", func(t *testing.T) {
+		m := Model{
+			ModelCfg: config.SelectedModel{
+				ProviderOptions: map[string]any{
+					"extra_body": make(chan int), // not JSON marshalable
+				},
+			},
+		}
+		require.Nil(t, titleProviderOptions(m))
+	})
+
+	t.Run("the generated options fit the fantasy call shape", func(t *testing.T) {
+		m := Model{
+			ModelCfg: config.SelectedModel{
+				ProviderOptions: map[string]any{
+					"extra_body": map[string]any{"k": "v"},
+				},
+			},
+		}
+		_ = titleProviderOptions(m)
+	})
+}

--- a/internal/agent/title_provider_options_test.go
+++ b/internal/agent/title_provider_options_test.go
@@ -7,38 +7,51 @@ import (
 	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/fantasy/providers/openaicompat"
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/discover"
 	"github.com/stretchr/testify/require"
 )
 
-// Title generation never goes through getProviderOptions, so a model that
+// Title generation reuses getProviderOptions (per PR #3717 review), so
+// these tests pin the options the title call forwards for a model that
 // needs provider-specific request fields (Qwen's chat_template_kwargs to
-// disable thinking, for example) would lose them on the title call and
-// burn the whole token budget reasoning. These tests pin that the title
-// path forwards model provider_options.
+// disable thinking, for example).
 func TestTitleProviderOptions(t *testing.T) {
-	t.Run("empty options produce no provider options", func(t *testing.T) {
-		m := Model{CatwalkCfg: catwalk.Model{ID: "qwen3.8-27b"}}
-		require.Nil(t, titleProviderOptions(m))
-	})
-
-	t.Run("model provider_options are keyed for openai-compat transports", func(t *testing.T) {
-		m := Model{
-			CatwalkCfg: catwalk.Model{ID: "Qwen3.8-27B"},
-			ModelCfg: config.SelectedModel{
-				ProviderOptions: map[string]any{
-					"extra_body": map[string]any{
-						"chat_template_kwargs": map[string]any{"enable_thinking": false},
-					},
+	qwenModel := Model{
+		CatwalkCfg: catwalk.Model{ID: "qwen3-32b"},
+		ModelCfg: config.SelectedModel{
+			Provider: "qwen",
+			ProviderOptions: map[string]any{
+				"extra_body": map[string]any{
+					"chat_template_kwargs": map[string]any{"enable_thinking": false},
 				},
 			},
+		},
+	}
+
+	t.Run("a model without provider_options gets no chat_template_kwargs", func(t *testing.T) {
+		m := Model{CatwalkCfg: catwalk.Model{ID: "qwen3-32b"}}
+		opts := getProviderOptions(m, config.ProviderConfig{Type: catwalk.TypeOpenAICompat})
+		parsed, ok := opts[openaicompat.Name].(*openaicompat.ProviderOptions)
+		require.True(t, ok)
+		if parsed.ExtraBody == nil {
+			return
+		}
+		body, err := json.Marshal(parsed.ExtraBody)
+		require.NoError(t, err)
+		require.NotContains(t, string(body), "chat_template_kwargs")
+	})
+
+	t.Run("model provider_options survive for custom openai-compat providers", func(t *testing.T) {
+		require.NotEmpty(t, discover.RegisteredProviderTypes(), "expected registered custom provider types")
+
+		providerCfg := config.ProviderConfig{
+			ID:   "qwen",
+			Type: catwalk.Type(discover.RegisteredProviderTypes()[0]),
 		}
 
-		opts := titleProviderOptions(m)
-		require.Len(t, opts, 1)
-
+		opts := getProviderOptions(qwenModel, providerCfg)
 		parsed, ok := opts[openaicompat.Name].(*openaicompat.ProviderOptions)
 		require.True(t, ok, "options should parse as openai-compat provider options")
-		require.NotNil(t, parsed.ExtraBody)
 
 		body, err := json.Marshal(parsed.ExtraBody)
 		require.NoError(t, err)
@@ -46,29 +59,7 @@ func TestTitleProviderOptions(t *testing.T) {
 		var extra map[string]any
 		require.NoError(t, json.Unmarshal(body, &extra))
 		kwargs, ok := extra["chat_template_kwargs"].(map[string]any)
-		require.True(t, ok, "chat_template_kwargs should survive the round trip: %v", extra)
+		require.True(t, ok, "chat_template_kwargs should survive: %v", extra)
 		require.Equal(t, false, kwargs["enable_thinking"])
-	})
-
-	t.Run("options parse failures degrade to none", func(t *testing.T) {
-		m := Model{
-			ModelCfg: config.SelectedModel{
-				ProviderOptions: map[string]any{
-					"extra_body": make(chan int), // not JSON marshalable
-				},
-			},
-		}
-		require.Nil(t, titleProviderOptions(m))
-	})
-
-	t.Run("the generated options fit the fantasy call shape", func(t *testing.T) {
-		m := Model{
-			ModelCfg: config.SelectedModel{
-				ProviderOptions: map[string]any{
-					"extra_body": map[string]any{"k": "v"},
-				},
-			},
-		}
-		_ = titleProviderOptions(m)
 	})
 }


### PR DESCRIPTION
## Summary

- Title generation built its stream call by hand and never went through `getProviderOptions`, so a model's configured `provider_options` were silently dropped on the title call.
- Concretely: a small model that needs a request field to behave sanely (Qwen's `chat_template_kwargs.enable_thinking=false`) still reasoned during title generation, and when a non-reasoning token cap applied it exhausted the budget on reasoning, finish reason came back `length`, and the session fell back to "Untitled Session".
- The title stream call now forwards the selected model's `provider_options`, keyed for openai-compat transports (other transports ignore keys that are not theirs), with unit tests for the conversion.

## Testing

- `go test ./internal/agent/ -run TestTitleProviderOptions` (new tests).
- Full `go test ./internal/agent/` green; `go build ./...` clean.
