### PR TITLE
fix(list): keep AtBottom honest when the top item is taller than the viewport

### DIFF
--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -125,10 +125,14 @@ func (l *List) AtBottom() bool {
 		return true
 	}
 
-	// Calculate the height from offsetIdx to the end.
+	// Calculate the height from offsetIdx to the end. The comparison is
+	// against the visible height (totalHeight minus the lines of the first
+	// item that are scrolled out of view), otherwise a first item taller
+	// than the viewport reports "not at bottom" while it is in fact
+	// pinned there.
 	var totalHeight int
 	for idx := l.offsetIdx; idx < len(l.items); idx++ {
-		if totalHeight > l.height {
+		if totalHeight-l.offsetLine > l.height {
 			// No need to calculate further, we're already past the viewport height
 			return false
 		}

--- a/internal/ui/list/list_test.go
+++ b/internal/ui/list/list_test.go
@@ -830,3 +830,44 @@ func totalRenderHits(items []*trackedItem) int {
 	}
 	return n
 }
+
+// tallItem renders a fixed number of lines, so tests can build lists
+// whose first visible item is taller than the viewport.
+type tallItem struct {
+	*Versioned
+	lines int
+}
+
+func newTallItem(lines int) *tallItem {
+	return &tallItem{Versioned: NewVersioned(), lines: lines}
+}
+
+func (t *tallItem) Render(width int) string {
+	return strings.TrimSuffix(strings.Repeat("x\n", t.lines), "\n")
+}
+
+func (t *tallItem) Finished() bool { return false }
+
+// TestList_AtBottom_TallFirstVisibleItem covers the case where the item
+// at offsetIdx is taller than the viewport: the accumulated height passes
+// the viewport height long before the end of the list, but the lines
+// scrolled out of view (offsetLine) make up the difference. AtBottom must
+// account for offsetLine before bailing out early.
+func TestList_AtBottom_TallFirstVisibleItem(t *testing.T) {
+	t.Parallel()
+
+	for _, gap := range []int{0, 1} {
+		l := NewList(newTallItem(50), newTallItem(3))
+		l.SetGap(gap)
+		l.SetSize(40, 10)
+
+		l.ScrollToBottom()
+		require.True(t, l.AtBottom(), "gap=%d: at bottom after ScrollToBottom", gap)
+
+		l.ScrollBy(-1)
+		require.False(t, l.AtBottom(), "gap=%d: not at bottom after scrolling up", gap)
+
+		l.ScrollBy(1)
+		require.True(t, l.AtBottom(), "gap=%d: back at bottom after scrolling down", gap)
+	}
+}


### PR DESCRIPTION
`List.AtBottom()` bails early with `totalHeight > l.height` but never subtracts `offsetLine`, so when the first visible item is taller than the viewport (a long streaming message with a tool call under it) the accumulator passes the viewport height on the second iteration and the list reports not-at-bottom while it is in fact pinned there.

Repro: a 50-line item followed by a 3-line one at height 10. After `ScrollToBottom()`, `offsetLine` is 43 and `AtBottom()` returns false.

Two visible symptoms in the chat view:

- Follow mode does not re-arm. `Chat.ScrollBy` re-enables follow via `else if m.AtBottom()`, so scrolling back down never sticks. `Chat.SetSize` loses its bottom anchor the same way.
- Streaming lags. `Chat.Draw` re-anchors with `if m.follow && !m.list.AtBottom()`, which under a false negative renders the whole list a second time on every frame.

The fix is to compare visible height instead. Test covers gap 0 and 1 plus the scroll-up/scroll-down round trip.

Predates the recent chat-scroll work; the Chat-layer re-anchor was compensating for it.