### PR TITLE
feat: add ChatGPT OAuth with reusable provider flows

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -910,16 +910,16 @@ func (c *coordinator) buildAgentModels(ctx context.Context, isSubAgent bool) (Mo
 	smallModel = newRequestTimeoutModel(smallModel, requestTimeout)
 
 	return Model{
-			Model:      largeModel,
-			CatwalkCfg: *largeCatwalkModel,
-			ModelCfg:   largeModelCfg,
-			FlatRate:   largeProviderCfg.FlatRate,
-		}, Model{
-			Model:      smallModel,
-			CatwalkCfg: *smallCatwalkModel,
-			ModelCfg:   smallModelCfg,
-			FlatRate:   smallProviderCfg.FlatRate,
-		}, nil
+		Model:      largeModel,
+		CatwalkCfg: *largeCatwalkModel,
+		ModelCfg:   largeModelCfg,
+		FlatRate:   largeProviderCfg.FlatRate,
+	}, Model{
+		Model:      smallModel,
+		CatwalkCfg: *smallCatwalkModel,
+		ModelCfg:   smallModelCfg,
+		FlatRate:   smallProviderCfg.FlatRate,
+	}, nil
 }
 
 func (c *coordinator) buildAnthropicProvider(baseURL, apiKey string, headers map[string]string, providerID string) (fantasy.Provider, error) {
@@ -954,12 +954,17 @@ func (c *coordinator) buildAnthropicProvider(baseURL, apiKey string, headers map
 	return anthropic.New(opts...)
 }
 
-func (c *coordinator) buildOpenaiProvider(baseURL, apiKey string, headers map[string]string) (fantasy.Provider, error) {
+func (c *coordinator) buildOpenaiProvider(baseURL, apiKey string, headers map[string]string, providerCfg config.ProviderConfig, isSubAgent bool) (fantasy.Provider, error) {
+	if providerCfg.OAuthToken != nil && apiKey == "" {
+		apiKey = "crush-oauth"
+	}
 	opts := []openai.Option{
 		openai.WithAPIKey(apiKey),
 		openai.WithUseResponsesAPI(),
 	}
-	if c.cfg.Config().Options.Debug {
+	if p := oauth.Get(providerCfg.ID); p != nil && providerCfg.OAuthToken != nil {
+		opts = append(opts, openai.WithHTTPClient(p.WrapClient(nil, providerCfg.OAuthToken, isSubAgent, c.cfg.Config().Options.Debug)))
+	} else if c.cfg.Config().Options.Debug {
 		httpClient := log.NewHTTPClient()
 		opts = append(opts, openai.WithHTTPClient(httpClient))
 	}
@@ -1164,7 +1169,7 @@ func (c *coordinator) buildProvider(providerCfg config.ProviderConfig, model con
 
 	switch providerCfg.Type {
 	case openai.Name:
-		return c.buildOpenaiProvider(baseURL, apiKey, headers)
+		return c.buildOpenaiProvider(baseURL, apiKey, headers, providerCfg, isSubAgent)
 	case anthropic.Name:
 		return c.buildAnthropicProvider(baseURL, apiKey, headers, providerCfg.ID)
 	case openrouter.Name:

--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -6,12 +6,14 @@ import (
 	"os"
 	"os/signal"
 
+	"charm.land/catwalk/pkg/catwalk"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/clipboard"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/charmbracelet/crush/internal/oauth/copilot"
-	"github.com/charmbracelet/crush/internal/oauth/hyper"
+	_ "github.com/charmbracelet/crush/internal/oauth/hyper"
+	_ "github.com/charmbracelet/crush/internal/oauth/openai"
 	"github.com/charmbracelet/crush/internal/workspace"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -23,13 +25,16 @@ var loginCmd = &cobra.Command{
 	Short:   "Login Crush to a platform",
 	Long: `Login Crush to a specified platform.
 The platform should be provided as an argument.
-Available platforms are: hyper, copilot.`,
+Available platforms are: hyper, copilot, openai.`,
 	Example: `
 # Authenticate with Charm Hyper
 crush login
 
 # Authenticate with GitHub Copilot
 crush login copilot
+
+# Authenticate with OpenAI (ChatGPT / Codex)
+crush login openai
 
 # Force re-authentication even if already logged in
 crush login -f copilot
@@ -39,6 +44,9 @@ crush login -f copilot
 		"copilot",
 		"github",
 		"github-copilot",
+		"openai",
+		"chatgpt",
+		"codex",
 	},
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -48,19 +56,19 @@ crush login -f copilot
 		}
 		defer cleanup()
 
-		provider := "hyper"
+		platform := "hyper"
 		if len(args) > 0 {
-			provider = args[0]
+			platform = args[0]
 		}
 		force, _ := cmd.Flags().GetBool("force")
-		switch provider {
-		case "hyper":
-			return loginHyper(ws, force)
-		case "copilot", "github", "github-copilot":
-			return loginCopilot(ws, force)
-		default:
-			return fmt.Errorf("unknown platform: %s", args[0])
+
+		targetID := normalizePlatform(platform)
+		p := oauth.Get(targetID)
+		if p == nil {
+			return fmt.Errorf("unknown platform: %s", platform)
 		}
+
+		return loginOAuth(ws, p, force)
 	},
 }
 
@@ -68,112 +76,88 @@ func init() {
 	loginCmd.Flags().BoolP("force", "f", false, "Force re-authentication even if already logged in")
 }
 
-func loginHyper(ws workspace.Workspace, force bool) error {
+func normalizePlatform(platform string) string {
+	switch platform {
+	case "github", "github-copilot":
+		return string(catwalk.InferenceProviderCopilot)
+	case "chatgpt", "codex":
+		return string(catwalk.InferenceProviderOpenAI)
+	default:
+		return platform
+	}
+}
+
+func loginOAuth(ws workspace.Workspace, p oauth.Provider, force bool) error {
 	ctx := getLoginContext()
 
 	if !force {
 		cfg := ws.Config()
 		if cfg != nil {
-			if pc, ok := cfg.Providers.Get("hyper"); ok && pc.OAuthToken != nil {
-				fmt.Println("You are already logged in to Hyper.")
+			if pc, ok := cfg.Providers.Get(p.ID()); ok && pc.OAuthToken != nil {
+				fmt.Printf("You are already logged in to %s.\n", p.Name())
 				fmt.Println("Use --force to re-authenticate.")
 				return nil
 			}
 		}
 	}
 
-	resp, err := hyper.InitiateDeviceAuth(ctx)
-	if err != nil {
-		return err
-	}
-
-	clipboard.WriteText(resp.UserCode)
-	fmt.Println("The following code should be on clipboard already:")
-
-	fmt.Println()
-	lipgloss.Println(lipgloss.NewStyle().Bold(true).Render(resp.UserCode))
-	fmt.Println()
-	fmt.Println("Press enter to open this URL, and then paste it there:")
-	fmt.Println()
-	lipgloss.Println(lipgloss.NewStyle().Hyperlink(resp.VerificationURL, "id=hyper").Render(resp.VerificationURL))
-	fmt.Println()
-	waitEnter()
-	if err := browser.OpenURL(resp.VerificationURL); err != nil {
-		fmt.Println("Could not open the URL. You'll need to manually open the URL in your browser.")
-	}
-
-	fmt.Println("Exchanging authorization code...")
-	refreshToken, err := hyper.PollForToken(ctx, resp.DeviceCode, resp.ExpiresIn)
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("Exchanging refresh token for access token...")
-	token, err := hyper.ExchangeToken(ctx, refreshToken)
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("Verifying access token...")
-	introspect, err := hyper.IntrospectToken(ctx, token.AccessToken)
-	if err != nil {
-		return fmt.Errorf("token introspection failed: %w", err)
-	}
-	if !introspect.Active {
-		return fmt.Errorf("access token is not active")
-	}
-
-	if err := ws.SetProviderAPIKey(config.ScopeGlobal, "hyper", token); err != nil {
-		return err
-	}
-
-	fmt.Println()
-	fmt.Println("You're now authenticated with Hyper!")
-	return nil
-}
-
-func loginCopilot(ws workspace.Workspace, force bool) error {
-	loginCtx := getLoginContext()
-
-	if !force {
-		cfg := ws.Config()
-		if cfg != nil {
-			if pc, ok := cfg.Providers.Get("copilot"); ok && pc.OAuthToken != nil {
-				fmt.Println("You are already logged in to GitHub Copilot.")
-				fmt.Println("Use --force to re-authenticate.")
+	// For GitHub Copilot, check disk token first if available.
+	if p.ID() == string(catwalk.InferenceProviderCopilot) {
+		if diskToken, hasDiskToken := copilot.RefreshTokenFromDisk(); hasDiskToken {
+			fmt.Println("Found existing GitHub Copilot token on disk. Using it to authenticate...")
+			tok, err := copilot.RefreshToken(ctx, diskToken)
+			if err == nil {
+				if err := ws.SetProviderAPIKey(config.ScopeGlobal, p.ID(), tok); err != nil {
+					return err
+				}
+				fmt.Println()
+				fmt.Printf("You're now authenticated with %s!\n", p.Name())
 				return nil
 			}
 		}
 	}
 
-	diskToken, hasDiskToken := copilot.RefreshTokenFromDisk()
 	var token *oauth.Token
 
-	switch {
-	case hasDiskToken:
-		fmt.Println("Found existing GitHub Copilot token on disk. Using it to authenticate...")
-
-		t, err := copilot.RefreshToken(loginCtx, diskToken)
+	switch prov := p.(type) {
+	case oauth.BrowserFlowProvider:
+		session, err := prov.StartBrowserFlow(ctx)
 		if err != nil {
-			return fmt.Errorf("unable to refresh token from disk: %w", err)
+			return err
+		}
+		defer session.Close()
+
+		fmt.Printf("Press enter to open this URL and authenticate with %s:\n\n", p.Name())
+		lipgloss.Println(lipgloss.NewStyle().Hyperlink(session.URL(), "id="+p.ID()).Render(session.URL()))
+		fmt.Println()
+		waitEnter()
+		if err := browser.OpenURL(session.URL()); err != nil {
+			fmt.Println("Could not open the URL. You'll need to manually open the URL in your browser.")
+		}
+
+		fmt.Println("Waiting for authorization in browser...")
+		t, err := session.Wait(ctx)
+		if err != nil {
+			return err
 		}
 		token = t
-	default:
-		fmt.Println("Requesting device code from GitHub...")
-		dc, err := copilot.RequestDeviceCode(loginCtx)
+
+	case oauth.DeviceFlowProvider:
+		dc, err := prov.RequestDeviceCode(ctx)
 		if err != nil {
 			return err
 		}
 
-		clipboard.WriteText(dc.UserCode)
-		fmt.Println()
-		fmt.Println("The following code should be on clipboard already:")
-		fmt.Println()
-		lipgloss.Println(lipgloss.NewStyle().Bold(true).Render(dc.UserCode))
-		fmt.Println()
-		fmt.Println("Press enter to open this URL and authenticate with GitHub Copilot:")
-		fmt.Println()
-		lipgloss.Println(lipgloss.NewStyle().Hyperlink(dc.VerificationURI, "id=copilot").Render(dc.VerificationURI))
+		if dc.UserCode != "" {
+			clipboard.WriteText(dc.UserCode)
+			fmt.Println("The following code should be on clipboard already:")
+			fmt.Println()
+			lipgloss.Println(lipgloss.NewStyle().Bold(true).Render(dc.UserCode))
+			fmt.Println()
+		}
+
+		fmt.Printf("Press enter to open this URL and authenticate with %s:\n\n", p.Name())
+		lipgloss.Println(lipgloss.NewStyle().Hyperlink(dc.VerificationURI, "id="+p.ID()).Render(dc.VerificationURI))
 		fmt.Println()
 		waitEnter()
 		if err := browser.OpenURL(dc.VerificationURI); err != nil {
@@ -181,8 +165,7 @@ func loginCopilot(ws workspace.Workspace, force bool) error {
 		}
 
 		fmt.Println("Waiting for authorization...")
-
-		t, err := copilot.PollForToken(loginCtx, dc)
+		t, err := prov.PollForToken(ctx, dc)
 		if err == copilot.ErrNotAvailable {
 			fmt.Println()
 			fmt.Println("GitHub Copilot is unavailable for this account. To signup, go to the following page:")
@@ -197,14 +180,24 @@ func loginCopilot(ws workspace.Workspace, force bool) error {
 			return err
 		}
 		token = t
+
+	default:
+		return fmt.Errorf("platform %s does not support interactive login", p.Name())
 	}
 
-	if err := ws.SetProviderAPIKey(config.ScopeGlobal, "copilot", token); err != nil {
+	if err := ws.SetProviderAPIKey(config.ScopeGlobal, p.ID(), token); err != nil {
 		return err
 	}
 
+	// After authenticating with Hyper, re-fetch the provider catalog.
+	if p.ID() == "hyper" {
+		if storeWs, ok := ws.(interface{ RefetchHyperProvider(context.Context) error }); ok {
+			_ = storeWs.RefetchHyperProvider(ctx)
+		}
+	}
+
 	fmt.Println()
-	fmt.Println("You're now authenticated with GitHub Copilot!")
+	fmt.Printf("You're now authenticated with %s!\n", p.Name())
 	return nil
 }
 

--- a/internal/cmd/login_test.go
+++ b/internal/cmd/login_test.go
@@ -19,3 +19,17 @@ func TestLoginCmd_ForceFlag(t *testing.T) {
 	require.NotNil(t, flag)
 	require.Equal(t, "f", flag.Shorthand)
 }
+
+func TestLoginCmd_ValidArgs(t *testing.T) {
+	t.Parallel()
+
+	validPlatforms := map[string]bool{}
+	for _, p := range loginCmd.ValidArgs {
+		validPlatforms[p] = true
+	}
+	require.True(t, validPlatforms["hyper"])
+	require.True(t, validPlatforms["copilot"])
+	require.True(t, validPlatforms["openai"])
+	require.True(t, validPlatforms["chatgpt"])
+	require.True(t, validPlatforms["codex"])
+}

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -10,6 +10,10 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/client"
 	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/oauth"
+	_ "github.com/charmbracelet/crush/internal/oauth/copilot"
+	_ "github.com/charmbracelet/crush/internal/oauth/hyper"
+	_ "github.com/charmbracelet/crush/internal/oauth/openai"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/spf13/cobra"
 )
@@ -27,19 +31,25 @@ var logoutCmd = &cobra.Command{
 	Long: `Logout Crush from a specified platform, removing stored credentials.
 The platform should be provided as an argument.
 If no argument is given, a list of logged-in platforms will be shown.
-Available platforms are: hyper, copilot.`,
+Available platforms are: hyper, copilot, openai.`,
 	Example: `
 # Sign out from Charm Hyper
 crush logout hyper
 
 # Sign out from GitHub Copilot
 crush logout copilot
+
+# Sign out from OpenAI
+crush logout openai
   `,
 	ValidArgs: []cobra.Completion{
 		"hyper",
 		"copilot",
 		"github",
 		"github-copilot",
+		"openai",
+		"chatgpt",
+		"codex",
 	},
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -55,22 +65,29 @@ crush logout copilot
 			defer func() { _, _ = fmt.Fprintf(os.Stderr, ansi.ResetProgressBar) }()
 		}
 
-		var provider string
+		var platform string
 		if len(args) == 0 {
-			provider, err = pickLoggedInProvider(c, ws.ID)
+			platform, err = pickLoggedInProvider(c, ws.ID)
 			if err != nil {
 				return err
 			}
-			if provider == "" {
+			if platform == "" {
 				return nil
 			}
 		} else {
-			provider = args[0]
+			platform = args[0]
+		}
+
+		targetID := normalizePlatform(platform)
+		p := oauth.Get(targetID)
+		displayName := targetID
+		if p != nil {
+			displayName = p.Name()
 		}
 
 		force, _ := cmd.Flags().GetBool("force")
 		if !force {
-			fmt.Print(logoutPromptStyle.Render(fmt.Sprintf("Are you sure you want to logout %s? (y/N) ", provider)))
+			fmt.Print(logoutPromptStyle.Render(fmt.Sprintf("Are you sure you want to logout %s? (y/N) ", displayName)))
 			var response string
 			_, err := fmt.Scanln(&response)
 			if err != nil || (response != "y" && response != "Y" && response != "yes" && response != "Yes" && response != "YES") {
@@ -79,42 +96,21 @@ crush logout copilot
 			}
 		}
 
-		switch provider {
-		case "hyper":
-			return logoutHyper(c, ws.ID)
-		case "copilot", "github", "github-copilot":
-			return logoutCopilot(c, ws.ID)
-		default:
-			return fmt.Errorf("unknown platform: %s", provider)
-		}
+		return logoutProvider(c, ws.ID, targetID, displayName)
 	},
 }
 
-func logoutHyper(c *client.Client, wsID string) error {
+func logoutProvider(c *client.Client, wsID, providerID, displayName string) error {
 	ctx := getLogoutContext()
 
 	if err := cmp.Or(
-		c.RemoveConfigField(ctx, wsID, config.ScopeGlobal, "providers.hyper.api_key"),
-		c.RemoveConfigField(ctx, wsID, config.ScopeGlobal, "providers.hyper.oauth"),
+		c.RemoveConfigField(ctx, wsID, config.ScopeGlobal, fmt.Sprintf("providers.%s.api_key", providerID)),
+		c.RemoveConfigField(ctx, wsID, config.ScopeGlobal, fmt.Sprintf("providers.%s.oauth", providerID)),
 	); err != nil {
 		return err
 	}
 
-	fmt.Println(logoutHeaderStyle.Render("Successfully logged out of Hyper."))
-	return nil
-}
-
-func logoutCopilot(c *client.Client, wsID string) error {
-	ctx := getLogoutContext()
-
-	if err := cmp.Or(
-		c.RemoveConfigField(ctx, wsID, config.ScopeGlobal, "providers.copilot.api_key"),
-		c.RemoveConfigField(ctx, wsID, config.ScopeGlobal, "providers.copilot.oauth"),
-	); err != nil {
-		return err
-	}
-
-	fmt.Println(logoutHeaderStyle.Render("Successfully logged out of GitHub Copilot."))
+	fmt.Println(logoutHeaderStyle.Render(fmt.Sprintf("Successfully logged out of %s.", displayName)))
 	return nil
 }
 
@@ -131,17 +127,10 @@ func pickLoggedInProvider(c *client.Client, wsID string) (string, error) {
 		name string
 	}
 
-	// Only OAuth-based providers support login/logout. Keep this list in sync
-	// with the switch in RunE and the login command.
-	oauthProviders := map[string]string{
-		"hyper":   "Hyper",
-		"copilot": "GitHub Copilot",
-	}
-
 	var loggedIn []loggedInProvider
-	for id, name := range oauthProviders {
-		if p, ok := cfg.Providers.Get(id); ok && p.OAuthToken != nil {
-			loggedIn = append(loggedIn, loggedInProvider{id: id, name: name})
+	for _, p := range oauth.All() {
+		if prov, ok := cfg.Providers.Get(p.ID()); ok && prov.OAuthToken != nil {
+			loggedIn = append(loggedIn, loggedInProvider{id: p.ID(), name: p.Name()})
 		}
 	}
 

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -19,6 +19,7 @@ import (
 	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/charmbracelet/crush/internal/oauth/copilot"
 	"github.com/charmbracelet/crush/internal/oauth/hyper"
+	_ "github.com/charmbracelet/crush/internal/oauth/openai"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 	"golang.org/x/sync/singleflight"
@@ -587,7 +588,11 @@ func (s *ConfigStore) SetProviderAPIKey(scope Scope, providerID string, apiKey a
 		}
 		setKeyOrToken = func() {
 			providerConfig.APIKey = v.AccessToken
-			providerConfig.OAuthToken = v
+			if providerConfig.OAuthToken != nil {
+				*providerConfig.OAuthToken = *v
+			} else {
+				providerConfig.OAuthToken = v
+			}
 			switch providerID {
 			case string(catwalk.InferenceProviderCopilot):
 				providerConfig.SetupGitHubCopilot()
@@ -864,6 +869,9 @@ func (s *ConfigStore) exchange(ctx context.Context, providerID, refreshToken str
 	if s.exchangeToken != nil {
 		return s.exchangeToken(ctx, providerID, refreshToken)
 	}
+	if p := oauth.Get(providerID); p != nil {
+		return p.RefreshToken(ctx, refreshToken)
+	}
 	switch providerID {
 	case string(catwalk.InferenceProviderCopilot):
 		return copilot.RefreshToken(ctx, refreshToken)
@@ -904,7 +912,11 @@ func (s *ConfigStore) refreshLockPath(providerID string) string {
 
 // applyToken updates the in-memory provider config with the given token.
 func (s *ConfigStore) applyToken(providerConfig ProviderConfig, token *oauth.Token, providerID string) error {
-	providerConfig.OAuthToken = token
+	if providerConfig.OAuthToken != nil {
+		*providerConfig.OAuthToken = *token
+	} else {
+		providerConfig.OAuthToken = token
+	}
 	providerConfig.APIKey = token.AccessToken
 	if providerID == string(catwalk.InferenceProviderCopilot) {
 		providerConfig.SetupGitHubCopilot()

--- a/internal/config/store_test.go
+++ b/internal/config/store_test.go
@@ -721,6 +721,7 @@ func TestRefreshOAuthToken_UsesDiskTokenWhenDifferent(t *testing.T) {
 	// Verify the in-memory token was updated to the disk token
 	updatedConfig, ok := store.config.Providers.Get("hyper")
 	require.True(t, ok)
+	require.Same(t, oldToken, updatedConfig.OAuthToken)
 	require.Equal(t, "newer-access-token", updatedConfig.APIKey)
 	require.Equal(t, "newer-access-token", updatedConfig.OAuthToken.AccessToken)
 	require.Equal(t, "refresh-abc", updatedConfig.OAuthToken.RefreshToken)

--- a/internal/oauth/browser_flow.go
+++ b/internal/oauth/browser_flow.go
@@ -1,0 +1,213 @@
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/oauth/callback"
+)
+
+// PKCE holds a code verifier and its S256 code challenge.
+type PKCE struct {
+	Verifier  string
+	Challenge string
+}
+
+// GeneratePKCE creates cryptographically secure PKCE values.
+func GeneratePKCE() (PKCE, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return PKCE{}, fmt.Errorf("generate PKCE random bytes: %w", err)
+	}
+	verifier := base64.RawURLEncoding.EncodeToString(b)
+	hash := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(hash[:])
+	return PKCE{
+		Verifier:  verifier,
+		Challenge: challenge,
+	}, nil
+}
+
+// BrowserFlowConfig defines the parameters for a browser-based PKCE flow.
+type BrowserFlowConfig struct {
+	Port         int
+	CallbackPath string
+	Subject      string
+	AuthURL      func(redirectURI string, pkce PKCE, state string) string
+	Exchange     func(ctx context.Context, code, redirectURI string, pkce PKCE) (*Token, error)
+}
+
+type browserSession struct {
+	url      string
+	server   *http.Server
+	listener net.Listener
+	result   chan browserResult
+	ctx      context.Context
+	cancel   context.CancelFunc
+	closeMu  sync.Mutex
+	closed   bool
+}
+
+type browserResult struct {
+	token *Token
+	err   error
+}
+
+// StartBrowserFlow starts a loopback HTTP listener and prepares the browser session.
+func StartBrowserFlow(ctx context.Context, cfg BrowserFlowConfig) (BrowserSession, error) {
+	pkce, err := GeneratePKCE()
+	if err != nil {
+		return nil, err
+	}
+
+	stateBytes := make([]byte, 24)
+	if _, err := rand.Read(stateBytes); err != nil {
+		return nil, fmt.Errorf("generate state: %w", err)
+	}
+	state := base64.RawURLEncoding.EncodeToString(stateBytes)
+
+	addr := fmt.Sprintf("127.0.0.1:%d", cfg.Port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		if cfg.Port != 0 {
+			return nil, fmt.Errorf("start OAuth callback server on port %d: %w (port may be in use)", cfg.Port, err)
+		}
+		return nil, fmt.Errorf("start OAuth callback server: %w", err)
+	}
+
+	port := listener.Addr().(*net.TCPAddr).Port
+	cbPath := cfg.CallbackPath
+	if cbPath == "" {
+		cbPath = "/auth/callback"
+	}
+
+	redirectURI := fmt.Sprintf("http://localhost:%d%s", port, cbPath)
+	authURL := cfg.AuthURL(redirectURI, pkce, state)
+
+	flowCtx, cancel := context.WithCancel(ctx)
+	session := &browserSession{
+		url:      authURL,
+		listener: listener,
+		result:   make(chan browserResult, 1),
+		ctx:      flowCtx,
+		cancel:   cancel,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(cbPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		queryState := r.URL.Query().Get("state")
+		if state == "" || queryState != state {
+			_ = callback.Write(w, callback.Result{
+				Subject:          cfg.Subject,
+				ErrorCode:        "invalid_state",
+				ErrorDescription: "State parameter mismatch or missing.",
+			})
+			return
+		}
+
+		if errParam := r.URL.Query().Get("error"); errParam != "" {
+			errDesc := r.URL.Query().Get("error_description")
+			_ = callback.Write(w, callback.Result{
+				Subject:          cfg.Subject,
+				ErrorCode:        errParam,
+				ErrorDescription: errDesc,
+			})
+			session.finish(nil, fmt.Errorf("OAuth error: %s - %s", errParam, errDesc))
+			return
+		}
+
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			_ = callback.Write(w, callback.Result{
+				Subject:          cfg.Subject,
+				ErrorCode:        "missing_code",
+				ErrorDescription: "Authorization code not returned by provider.",
+			})
+			session.finish(nil, errors.New("missing authorization code"))
+			return
+		}
+
+		token, exchangeErr := cfg.Exchange(session.ctx, code, redirectURI, pkce)
+		if exchangeErr != nil {
+			_ = callback.Write(w, callback.Result{
+				Subject:          cfg.Subject,
+				ErrorCode:        "exchange_failed",
+				ErrorDescription: exchangeErr.Error(),
+			})
+			session.finish(nil, exchangeErr)
+			return
+		}
+
+		_ = callback.Write(w, callback.Result{
+			Subject: cfg.Subject,
+		})
+		session.finish(token, nil)
+	})
+
+	session.server = &http.Server{
+		Handler:      mux,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+	}
+
+	go func() {
+		if serveErr := session.server.Serve(listener); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			session.finish(nil, serveErr)
+		}
+	}()
+
+	return session, nil
+}
+
+func (s *browserSession) URL() string {
+	return s.url
+}
+
+func (s *browserSession) Wait(ctx context.Context) (*Token, error) {
+	select {
+	case res := <-s.result:
+		s.Close()
+		return res.token, res.err
+	case <-s.ctx.Done():
+		s.Close()
+		return nil, s.ctx.Err()
+	case <-ctx.Done():
+		s.Close()
+		return nil, ctx.Err()
+	}
+}
+
+func (s *browserSession) finish(token *Token, err error) {
+	select {
+	case s.result <- browserResult{token: token, err: err}:
+	default:
+	}
+}
+
+func (s *browserSession) Close() {
+	s.closeMu.Lock()
+	defer s.closeMu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	s.cancel()
+	if s.server != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = s.server.Shutdown(ctx)
+	}
+}

--- a/internal/oauth/browser_flow_test.go
+++ b/internal/oauth/browser_flow_test.go
@@ -1,0 +1,89 @@
+package oauth_test
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrowserFlow_Success(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var capturedState string
+	session, err := oauth.StartBrowserFlow(ctx, oauth.BrowserFlowConfig{
+		Port:    0,
+		Subject: "Test Service",
+		AuthURL: func(redirectURI string, pkce oauth.PKCE, state string) string {
+			capturedState = state
+			return redirectURI + "?state=" + state
+		},
+		Exchange: func(ctx context.Context, code, redirectURI string, pkce oauth.PKCE) (*oauth.Token, error) {
+			require.Equal(t, "test-auth-code", code)
+			require.NotEmpty(t, pkce.Verifier)
+			return &oauth.Token{
+				AccessToken:  "access-123",
+				RefreshToken: "refresh-456",
+			}, nil
+		},
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	u, err := url.Parse(session.URL())
+	require.NoError(t, err)
+
+	callbackURL := "http://" + u.Host + u.Path + "?code=test-auth-code&state=" + capturedState
+	resp, err := http.Get(callbackURL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	tok, err := session.Wait(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, tok)
+	require.Equal(t, "access-123", tok.AccessToken)
+	require.Equal(t, "refresh-456", tok.RefreshToken)
+}
+
+func TestBrowserFlow_StateMismatch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var capturedState string
+	session, err := oauth.StartBrowserFlow(ctx, oauth.BrowserFlowConfig{
+		Port:    0,
+		Subject: "Test Service",
+		AuthURL: func(redirectURI string, pkce oauth.PKCE, state string) string {
+			capturedState = state
+			return redirectURI + "?state=" + state
+		},
+		Exchange: func(ctx context.Context, code, redirectURI string, pkce oauth.PKCE) (*oauth.Token, error) {
+			return &oauth.Token{AccessToken: "access-123"}, nil
+		},
+	})
+	require.NoError(t, err)
+	defer session.Close()
+
+	u, err := url.Parse(session.URL())
+	require.NoError(t, err)
+
+	callbackURL := "http://" + u.Host + u.Path + "?code=test-auth-code&state=wrong-state"
+	resp, err := http.Get(callbackURL)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	callbackURL = "http://" + u.Host + u.Path + "?code=test-auth-code&state=" + capturedState
+	resp, err = http.Get(callbackURL)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	tok, err := session.Wait(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "access-123", tok.AccessToken)
+}

--- a/internal/oauth/copilot/provider.go
+++ b/internal/oauth/copilot/provider.go
@@ -1,0 +1,70 @@
+package copilot
+
+import (
+	"context"
+	"net/http"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/oauth"
+)
+
+func init() {
+	oauth.Register(&Provider{})
+}
+
+// Provider implements oauth.DeviceFlowProvider for GitHub Copilot.
+type Provider struct{}
+
+var (
+	_ oauth.Provider           = (*Provider)(nil)
+	_ oauth.DeviceFlowProvider = (*Provider)(nil)
+)
+
+func (p *Provider) ID() string {
+	return string(catwalk.InferenceProviderCopilot)
+}
+
+func (p *Provider) Name() string {
+	return "GitHub Copilot"
+}
+
+func (p *Provider) HasAuthChoices() bool {
+	return false
+}
+
+func (p *Provider) SupportedFlows() oauth.FlowType {
+	return oauth.FlowDevice
+}
+
+func (p *Provider) RefreshToken(ctx context.Context, rt string) (*oauth.Token, error) {
+	return RefreshToken(ctx, rt)
+}
+
+func (p *Provider) RequestDeviceCode(ctx context.Context) (*oauth.DeviceCode, error) {
+	dc, err := RequestDeviceCode(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &oauth.DeviceCode{
+		DeviceCode:      dc.DeviceCode,
+		UserCode:        dc.UserCode,
+		VerificationURI: dc.VerificationURI,
+		ExpiresIn:       dc.ExpiresIn,
+		Interval:        dc.Interval,
+	}, nil
+}
+
+func (p *Provider) PollForToken(ctx context.Context, code *oauth.DeviceCode) (*oauth.Token, error) {
+	dc := &DeviceCode{
+		DeviceCode:      code.DeviceCode,
+		UserCode:        code.UserCode,
+		VerificationURI: code.VerificationURI,
+		ExpiresIn:       code.ExpiresIn,
+		Interval:        code.Interval,
+	}
+	return PollForToken(ctx, dc)
+}
+
+func (p *Provider) WrapClient(base *http.Client, token *oauth.Token, isSubAgent, debug bool) *http.Client {
+	return NewClient(isSubAgent, debug)
+}

--- a/internal/oauth/hyper/provider.go
+++ b/internal/oauth/hyper/provider.go
@@ -1,0 +1,80 @@
+package hyper
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/charmbracelet/crush/internal/oauth"
+)
+
+func init() {
+	oauth.Register(&Provider{})
+}
+
+// Provider implements oauth.DeviceFlowProvider for Charm Hyper.
+type Provider struct{}
+
+var (
+	_ oauth.Provider           = (*Provider)(nil)
+	_ oauth.DeviceFlowProvider = (*Provider)(nil)
+)
+
+func (p *Provider) ID() string {
+	return "hyper"
+}
+
+func (p *Provider) Name() string {
+	return "Hyper"
+}
+
+func (p *Provider) HasAuthChoices() bool {
+	return false
+}
+
+func (p *Provider) SupportedFlows() oauth.FlowType {
+	return oauth.FlowDevice
+}
+
+func (p *Provider) RefreshToken(ctx context.Context, rt string) (*oauth.Token, error) {
+	return ExchangeToken(ctx, rt)
+}
+
+func (p *Provider) RequestDeviceCode(ctx context.Context) (*oauth.DeviceCode, error) {
+	resp, err := InitiateDeviceAuth(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &oauth.DeviceCode{
+		DeviceCode:      resp.DeviceCode,
+		UserCode:        resp.UserCode,
+		VerificationURI: resp.VerificationURL,
+		ExpiresIn:       resp.ExpiresIn,
+	}, nil
+}
+
+func (p *Provider) PollForToken(ctx context.Context, code *oauth.DeviceCode) (*oauth.Token, error) {
+	rt, err := PollForToken(ctx, code.DeviceCode, code.ExpiresIn)
+	if err != nil {
+		return nil, err
+	}
+	token, err := ExchangeToken(ctx, rt)
+	if err != nil {
+		return nil, err
+	}
+	introspect, err := IntrospectToken(ctx, token.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+	if !introspect.Active {
+		return nil, errors.New("access token is not active")
+	}
+	return token, nil
+}
+
+func (p *Provider) WrapClient(base *http.Client, token *oauth.Token, isSubAgent, debug bool) *http.Client {
+	if base != nil {
+		return base
+	}
+	return http.DefaultClient
+}

--- a/internal/oauth/openai/codex.go
+++ b/internal/oauth/openai/codex.go
@@ -1,0 +1,210 @@
+package openai
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/oauth"
+)
+
+const (
+	// ClientID is the public OAuth client ID registered for Codex CLI desktop flow.
+	ClientID = "app_EMoamEEZ73f0CkXaXp7hrann"
+	// Issuer is the OpenAI authorization server.
+	Issuer = "https://auth.openai.com"
+	// CodexEndpoint is the ChatGPT backend responses endpoint for Codex.
+	CodexEndpoint = "https://chatgpt.com/backend-api/codex/responses"
+	// CallbackPort is the loopback port registered for the desktop client.
+	CallbackPort = 1455
+)
+
+// HTTPClient allows tests to mock outgoing OAuth requests.
+var HTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+// Claims contains untrusted metadata extracted from the JWT token.
+type Claims struct {
+	ChatGPTAccountID        string `json:"chatgpt_account_id"`
+	ChatGPTComputeResidency string `json:"chatgpt_compute_residency"`
+	Organizations           []struct {
+		ID string `json:"id"`
+	} `json:"organizations"`
+	Auth *struct {
+		ChatGPTAccountID        string `json:"chatgpt_account_id"`
+		ChatGPTComputeResidency string `json:"chatgpt_compute_residency"`
+	} `json:"https://api.openai.com/auth"`
+}
+
+// ParseJWTClaims extracts metadata from an untrusted JWT payload without signature verification.
+func ParseJWTClaims(token string) (*Claims, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 || parts[1] == "" {
+		return nil, errors.New("invalid JWT structure")
+	}
+
+	payload := parts[1]
+	// Handle unpadded and padded base64url.
+	decoded, err := base64.RawURLEncoding.DecodeString(payload)
+	if err != nil {
+		decoded, err = base64.URLEncoding.DecodeString(payload)
+		if err != nil {
+			return nil, fmt.Errorf("decode JWT payload: %w", err)
+		}
+	}
+
+	var claims Claims
+	if err := json.Unmarshal(decoded, &claims); err != nil {
+		return nil, fmt.Errorf("unmarshal JWT claims: %w", err)
+	}
+
+	return &claims, nil
+}
+
+// ExtractAccountID resolves the effective ChatGPT account ID from token claims.
+func ExtractAccountID(claims *Claims) string {
+	if claims == nil {
+		return ""
+	}
+	if claims.ChatGPTAccountID != "" {
+		return claims.ChatGPTAccountID
+	}
+	if claims.Auth != nil && claims.Auth.ChatGPTAccountID != "" {
+		return claims.Auth.ChatGPTAccountID
+	}
+	if len(claims.Organizations) > 0 {
+		return claims.Organizations[0].ID
+	}
+	return ""
+}
+
+// ExtractResidency resolves the compute residency constraint from token claims.
+func ExtractResidency(claims *Claims) string {
+	if claims == nil {
+		return ""
+	}
+	residency := claims.ChatGPTComputeResidency
+	if claims.Auth != nil && claims.Auth.ChatGPTComputeResidency != "" {
+		residency = claims.Auth.ChatGPTComputeResidency
+	}
+	if residency == "no_constraint" {
+		return ""
+	}
+	return residency
+}
+
+// AuthorizeURL builds the browser authorization URL with PKCE and state.
+func AuthorizeURL(redirectURI string, pkce oauth.PKCE, state string) string {
+	vals := url.Values{
+		"response_type":              {"code"},
+		"client_id":                  {ClientID},
+		"redirect_uri":               {redirectURI},
+		"scope":                      {"openid profile email offline_access"},
+		"code_challenge":             {pkce.Challenge},
+		"code_challenge_method":      {"S256"},
+		"id_token_add_organizations": {"true"},
+		"codex_cli_simplified_flow":  {"true"},
+		"state":                      {state},
+		"originator":                 {"crush"},
+	}
+	return Issuer + "/oauth/authorize?" + vals.Encode()
+}
+
+type tokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	IDToken      string `json:"id_token"`
+	ExpiresIn    int    `json:"expires_in"`
+}
+
+func exchange(ctx context.Context, vals url.Values) (*oauth.Token, error) {
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		Issuer+"/oauth/token",
+		strings.NewReader(vals.Encode()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &oauth.TokenExchangeError{
+			StatusCode: resp.StatusCode,
+			Body:       string(body),
+		}
+	}
+
+	var tr tokenResponse
+	if err := json.Unmarshal(body, &tr); err != nil {
+		return nil, fmt.Errorf("unmarshal token response: %w", err)
+	}
+
+	tok := &oauth.Token{
+		AccessToken:  tr.AccessToken,
+		RefreshToken: tr.RefreshToken,
+		IDToken:      tr.IDToken,
+		ExpiresIn:    tr.ExpiresIn,
+		Extra:        make(map[string]string),
+	}
+	tok.SetExpiresAt()
+
+	// Extract claims from ID token first, falling back to access token.
+	claims, err := ParseJWTClaims(tr.IDToken)
+	if err != nil || claims == nil {
+		claims, _ = ParseJWTClaims(tr.AccessToken)
+	}
+	tok.AccountID = ExtractAccountID(claims)
+	if res := ExtractResidency(claims); res != "" {
+		tok.Extra["residency"] = res
+	}
+
+	return tok, nil
+}
+
+// ExchangeCode exchanges an authorization code and PKCE verifier for tokens.
+func ExchangeCode(ctx context.Context, code, redirectURI string, pkce oauth.PKCE) (*oauth.Token, error) {
+	vals := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+		"client_id":     {ClientID},
+		"code_verifier": {pkce.Verifier},
+	}
+	return exchange(ctx, vals)
+}
+
+// RefreshToken exchanges a refresh token for a fresh token pair.
+func RefreshToken(ctx context.Context, refreshToken string) (*oauth.Token, error) {
+	vals := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+		"client_id":     {ClientID},
+	}
+	token, err := exchange(ctx, vals)
+	if err != nil {
+		return nil, err
+	}
+	if token.RefreshToken == "" {
+		token.RefreshToken = refreshToken
+	}
+	return token, nil
+}

--- a/internal/oauth/openai/codex_test.go
+++ b/internal/oauth/openai/codex_test.go
@@ -1,0 +1,164 @@
+package openai_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/charmbracelet/crush/internal/oauth/openai"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTestJWT(payload map[string]any) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	data, _ := json.Marshal(payload)
+	claims := base64.RawURLEncoding.EncodeToString(data)
+	return header + "." + claims + ".signature"
+}
+
+func TestParseJWTClaims(t *testing.T) {
+	t.Parallel()
+
+	jwt := makeTestJWT(map[string]any{
+		"chatgpt_account_id":        "acc_12345",
+		"chatgpt_compute_residency": "us",
+	})
+
+	claims, err := openai.ParseJWTClaims(jwt)
+	require.NoError(t, err)
+	require.NotNil(t, claims)
+	require.Equal(t, "acc_12345", openai.ExtractAccountID(claims))
+	require.Equal(t, "us", openai.ExtractResidency(claims))
+}
+
+func TestParseJWTClaims_NestedAuth(t *testing.T) {
+	t.Parallel()
+
+	jwt := makeTestJWT(map[string]any{
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id":        "acc_nested",
+			"chatgpt_compute_residency": "eu",
+		},
+	})
+
+	claims, err := openai.ParseJWTClaims(jwt)
+	require.NoError(t, err)
+	require.NotNil(t, claims)
+	require.Equal(t, "acc_nested", openai.ExtractAccountID(claims))
+	require.Equal(t, "eu", openai.ExtractResidency(claims))
+}
+
+func TestParseJWTClaims_OrganizationFallback(t *testing.T) {
+	t.Parallel()
+
+	jwt := makeTestJWT(map[string]any{
+		"organizations": []map[string]any{
+			{"id": "org_primary"},
+		},
+	})
+
+	claims, err := openai.ParseJWTClaims(jwt)
+	require.NoError(t, err)
+	require.NotNil(t, claims)
+	require.Equal(t, "org_primary", openai.ExtractAccountID(claims))
+}
+
+func TestAuthorizeURL(t *testing.T) {
+	t.Parallel()
+
+	pkce := oauth.PKCE{
+		Verifier:  "verifier-abc",
+		Challenge: "challenge-xyz",
+	}
+	rawURL := openai.AuthorizeURL("http://localhost:1455/auth/callback", pkce, "state-123")
+	u, err := url.Parse(rawURL)
+	require.NoError(t, err)
+
+	q := u.Query()
+	require.Equal(t, "code", q.Get("response_type"))
+	require.Equal(t, openai.ClientID, q.Get("client_id"))
+	require.Equal(t, "http://localhost:1455/auth/callback", q.Get("redirect_uri"))
+	require.Equal(t, "challenge-xyz", q.Get("code_challenge"))
+	require.Equal(t, "S256", q.Get("code_challenge_method"))
+	require.Equal(t, "state-123", q.Get("state"))
+}
+
+func TestRefreshToken(t *testing.T) {
+	origClient := openai.HTTPClient
+	defer func() { openai.HTTPClient = origClient }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "refresh_token", r.Form.Get("grant_type"))
+		require.Equal(t, "rt-123", r.Form.Get("refresh_token"))
+		require.Equal(t, openai.ClientID, r.Form.Get("client_id"))
+
+		jwt := makeTestJWT(map[string]any{
+			"chatgpt_account_id": "acc-refreshed",
+		})
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "at-new",
+			"refresh_token": "rt-new",
+			"id_token":      jwt,
+			"expires_in":    3600,
+		})
+	}))
+	defer server.Close()
+
+	// Redirect request to mock server via Transport
+	openai.HTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			targetURL, _ := url.Parse(server.URL + req.URL.Path)
+			req.URL = targetURL
+			return http.DefaultTransport.RoundTrip(req)
+		}),
+	}
+
+	tok, err := openai.RefreshToken(context.Background(), "rt-123")
+	require.NoError(t, err)
+	require.NotNil(t, tok)
+	require.Equal(t, "at-new", tok.AccessToken)
+	require.Equal(t, "rt-new", tok.RefreshToken)
+	require.Equal(t, "acc-refreshed", tok.AccountID)
+}
+
+func TestRefreshToken_PreservesExistingRefreshToken(t *testing.T) {
+	origClient := openai.HTTPClient
+	defer func() { openai.HTTPClient = origClient }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "rt-existing", r.Form.Get("refresh_token"))
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "at-new",
+			"expires_in":   3600,
+		})
+	}))
+	defer server.Close()
+
+	openai.HTTPClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			targetURL, _ := url.Parse(server.URL + req.URL.Path)
+			req.URL = targetURL
+			return http.DefaultTransport.RoundTrip(req)
+		}),
+	}
+
+	tok, err := openai.RefreshToken(context.Background(), "rt-existing")
+	require.NoError(t, err)
+	require.Equal(t, "rt-existing", tok.RefreshToken)
+}
+
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/oauth/openai/provider.go
+++ b/internal/oauth/openai/provider.go
@@ -1,0 +1,73 @@
+package openai
+
+import (
+	"context"
+	"net/http"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/log"
+	"github.com/charmbracelet/crush/internal/oauth"
+)
+
+func init() {
+	oauth.Register(&Provider{})
+}
+
+// Provider implements the generic oauth.Provider for OpenAI Codex.
+type Provider struct{}
+
+var (
+	_ oauth.Provider            = (*Provider)(nil)
+	_ oauth.BrowserFlowProvider = (*Provider)(nil)
+)
+
+func (p *Provider) ID() string {
+	return string(catwalk.InferenceProviderOpenAI)
+}
+
+func (p *Provider) Name() string {
+	return "OpenAI (ChatGPT / Codex)"
+}
+
+func (p *Provider) HasAuthChoices() bool {
+	return true
+}
+
+func (p *Provider) SupportedFlows() oauth.FlowType {
+	return oauth.FlowBrowser
+}
+
+func (p *Provider) RefreshToken(ctx context.Context, rt string) (*oauth.Token, error) {
+	return RefreshToken(ctx, rt)
+}
+
+func (p *Provider) StartBrowserFlow(ctx context.Context) (oauth.BrowserSession, error) {
+	return oauth.StartBrowserFlow(ctx, oauth.BrowserFlowConfig{
+		Port:         CallbackPort,
+		CallbackPath: "/auth/callback",
+		Subject:      "OpenAI Codex",
+		AuthURL:      AuthorizeURL,
+		Exchange:     ExchangeCode,
+	})
+}
+
+func (p *Provider) WrapClient(base *http.Client, token *oauth.Token, isSubAgent, debug bool) *http.Client {
+	var rt http.RoundTripper
+	if base != nil && base.Transport != nil {
+		rt = base.Transport
+	} else if debug {
+		rt = log.NewHTTPClient().Transport
+	} else {
+		rt = http.DefaultTransport
+	}
+
+	transport := &Transport{
+		Base:       rt,
+		Token:      token,
+		Originator: "crush",
+	}
+
+	return &http.Client{
+		Transport: transport,
+	}
+}

--- a/internal/oauth/openai/transport.go
+++ b/internal/oauth/openai/transport.go
@@ -1,0 +1,104 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/charmbracelet/crush/internal/oauth"
+)
+
+// Transport intercepts requests and routes authenticated OpenAI calls to the ChatGPT Codex backend.
+type Transport struct {
+	Base       http.RoundTripper
+	Token      *oauth.Token
+	Originator string
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.Base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	if t.Token == nil {
+		return base.RoundTrip(req)
+	}
+
+	cloned := req.Clone(req.Context())
+	hostname := cloned.URL.Hostname()
+	isOfficial := strings.EqualFold(hostname, "api.openai.com") || strings.EqualFold(hostname, "chatgpt.com")
+
+	// Security safeguard: Never send ChatGPT OAuth credentials to third-party endpoints.
+	if !isOfficial {
+		cloned.Header.Del("Authorization")
+		cloned.Header.Del("ChatGPT-Account-Id")
+		cloned.Header.Del("x-openai-internal-codex-residency")
+		return base.RoundTrip(cloned)
+	}
+
+	path := cloned.URL.Path
+	isRewriteTarget := strings.Contains(path, "/responses") || strings.Contains(path, "/chat/completions")
+
+	if isRewriteTarget {
+		endpointURL, err := url.Parse(CodexEndpoint)
+		if err == nil {
+			cloned.URL = endpointURL
+			cloned.Host = endpointURL.Host
+		}
+
+		cloned.Header.Set("Authorization", "Bearer "+t.Token.AccessToken)
+		if t.Token.AccountID != "" {
+			cloned.Header.Set("ChatGPT-Account-Id", t.Token.AccountID)
+		}
+		if res := t.Token.Extra["residency"]; res != "" {
+			cloned.Header.Set("x-openai-internal-codex-residency", res)
+		}
+
+		originator := t.Originator
+		if originator == "" {
+			originator = "crush"
+		}
+		cloned.Header.Set("originator", originator)
+
+		if cloned.Header.Get("User-Agent") == "" {
+			cloned.Header.Set("User-Agent", "crush")
+		}
+
+		// Sanitize request body: remove max_output_tokens which Codex backend rejects.
+		if cloned.Body != nil && cloned.Body != http.NoBody {
+			bodyBytes, err := io.ReadAll(cloned.Body)
+			_ = cloned.Body.Close()
+			if err == nil {
+				cleaned := sanitizeCodexBody(bodyBytes)
+				cloned.Body = io.NopCloser(bytes.NewReader(cleaned))
+				cloned.ContentLength = int64(len(cleaned))
+			}
+		}
+	}
+
+	return base.RoundTrip(cloned)
+}
+
+func sanitizeCodexBody(data []byte) []byte {
+	if len(data) == 0 {
+		return data
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return data
+	}
+	if _, ok := raw["max_output_tokens"]; !ok {
+		return data
+	}
+	delete(raw, "max_output_tokens")
+	cleaned, err := json.Marshal(raw)
+	if err != nil {
+		return data
+	}
+	return cleaned
+}

--- a/internal/oauth/openai/transport_test.go
+++ b/internal/oauth/openai/transport_test.go
@@ -1,0 +1,93 @@
+package openai_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/charmbracelet/crush/internal/oauth/openai"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransport_RewriteOfficial(t *testing.T) {
+	t.Parallel()
+
+	token := &oauth.Token{
+		AccessToken: "test-access-token",
+		AccountID:   "test-account-id",
+		Extra: map[string]string{
+			"residency": "us",
+		},
+	}
+
+	var capturedReq *http.Request
+	var capturedBody []byte
+
+	mockBase := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		capturedReq = req
+		if req.Body != nil {
+			capturedBody, _ = io.ReadAll(req.Body)
+		}
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	})
+
+	tr := &openai.Transport{
+		Base:       mockBase,
+		Token:      token,
+		Originator: "crush",
+	}
+
+	body := []byte(`{"model":"gpt-4o","max_output_tokens":4096,"messages":[{"role":"user","content":"hello"}]}`)
+	req, err := http.NewRequest(http.MethodPost, "https://api.openai.com/v1/responses", bytes.NewReader(body))
+	require.NoError(t, err)
+
+	_, err = tr.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, capturedReq)
+
+	require.Equal(t, "chatgpt.com", capturedReq.URL.Host)
+	require.Equal(t, "/backend-api/codex/responses", capturedReq.URL.Path)
+	require.Equal(t, "Bearer test-access-token", capturedReq.Header.Get("Authorization"))
+	require.Equal(t, "test-account-id", capturedReq.Header.Get("ChatGPT-Account-Id"))
+	require.Equal(t, "us", capturedReq.Header.Get("x-openai-internal-codex-residency"))
+	require.Equal(t, "crush", capturedReq.Header.Get("originator"))
+
+	// Ensure max_output_tokens was stripped
+	require.NotContains(t, string(capturedBody), "max_output_tokens")
+	require.Contains(t, string(capturedBody), `"model":"gpt-4o"`)
+}
+
+func TestTransport_SafeguardNonOfficial(t *testing.T) {
+	t.Parallel()
+
+	token := &oauth.Token{
+		AccessToken: "secret-token",
+		AccountID:   "secret-account",
+	}
+
+	var capturedReq *http.Request
+	mockBase := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		capturedReq = req
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	})
+
+	tr := &openai.Transport{
+		Base:  mockBase,
+		Token: token,
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://custom-proxy.example.com/v1/chat/completions", nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer custom-key")
+	req.Header.Set("ChatGPT-Account-Id", "some-account")
+
+	_, err = tr.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, capturedReq)
+
+	require.Equal(t, "custom-proxy.example.com", capturedReq.URL.Host)
+	require.Empty(t, capturedReq.Header.Get("Authorization"))
+	require.Empty(t, capturedReq.Header.Get("ChatGPT-Account-Id"))
+}

--- a/internal/oauth/provider.go
+++ b/internal/oauth/provider.go
@@ -1,0 +1,64 @@
+package oauth
+
+import (
+	"context"
+	"net/http"
+)
+
+// FlowType defines which OAuth flows a provider supports.
+type FlowType int
+
+const (
+	// FlowBrowser represents the authorization code flow with PKCE on loopback.
+	FlowBrowser FlowType = 1 << iota
+	// FlowDevice represents RFC 8628 device authorization flow.
+	FlowDevice
+)
+
+// DeviceCode represents a device authorization response.
+type DeviceCode struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+// BrowserSession represents an active loopback browser authorization session.
+type BrowserSession interface {
+	// URL returns the authorization URL that must be opened in a browser.
+	URL() string
+	// Wait waits for the user to complete authorization or context cancellation.
+	Wait(ctx context.Context) (*Token, error)
+	// Close cleanly stops the callback listener. Safe to call multiple times.
+	Close()
+}
+
+// Provider represents an OAuth-capable model or service provider.
+type Provider interface {
+	// ID returns the unique identifier matching the Catwalk provider ID.
+	ID() string
+	// Name returns the human-readable display name.
+	Name() string
+	// HasAuthChoices reports whether the provider supports both OAuth and API keys.
+	HasAuthChoices() bool
+	// SupportedFlows returns the bitmask of supported authentication flows.
+	SupportedFlows() FlowType
+	// RefreshToken exchanges a refresh token for a fresh OAuth token.
+	RefreshToken(ctx context.Context, refreshToken string) (*Token, error)
+	// WrapClient wraps the HTTP client for authenticated requests.
+	WrapClient(base *http.Client, token *Token, isSubAgent, debug bool) *http.Client
+}
+
+// BrowserFlowProvider is implemented by providers supporting browser PKCE flows.
+type BrowserFlowProvider interface {
+	Provider
+	StartBrowserFlow(ctx context.Context) (BrowserSession, error)
+}
+
+// DeviceFlowProvider is implemented by providers supporting RFC 8628 device flow.
+type DeviceFlowProvider interface {
+	Provider
+	RequestDeviceCode(ctx context.Context) (*DeviceCode, error)
+	PollForToken(ctx context.Context, code *DeviceCode) (*Token, error)
+}

--- a/internal/oauth/registry.go
+++ b/internal/oauth/registry.go
@@ -1,0 +1,56 @@
+package oauth
+
+import (
+	"slices"
+	"sync"
+)
+
+var (
+	providersMu sync.RWMutex
+	providers   = make(map[string]Provider)
+)
+
+// Register registers an OAuth provider.
+func Register(p Provider) {
+	providersMu.Lock()
+	defer providersMu.Unlock()
+	providers[p.ID()] = p
+}
+
+// Get returns the registered OAuth provider for the given ID, or nil if not registered.
+func Get(id string) Provider {
+	providersMu.RLock()
+	defer providersMu.RUnlock()
+	return providers[id]
+}
+
+// IsSupported reports whether the given provider ID has an OAuth implementation.
+func IsSupported(id string) bool {
+	return Get(id) != nil
+}
+
+// HasAuthChoices reports whether the provider offers both OAuth and API key auth.
+func HasAuthChoices(id string) bool {
+	p := Get(id)
+	return p != nil && p.HasAuthChoices()
+}
+
+// All returns all registered OAuth providers sorted by ID.
+func All() []Provider {
+	providersMu.RLock()
+	defer providersMu.RUnlock()
+	list := make([]Provider, 0, len(providers))
+	for _, p := range providers {
+		list = append(list, p)
+	}
+	slices.SortFunc(list, func(a, b Provider) int {
+		if a.ID() < b.ID() {
+			return -1
+		}
+		if a.ID() > b.ID() {
+			return 1
+		}
+		return 0
+	})
+	return list
+}

--- a/internal/oauth/registry_test.go
+++ b/internal/oauth/registry_test.go
@@ -1,0 +1,54 @@
+package oauth_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/stretchr/testify/require"
+)
+
+type mockProvider struct {
+	id      string
+	name    string
+	choices bool
+	flows   oauth.FlowType
+}
+
+func (m *mockProvider) ID() string                     { return m.id }
+func (m *mockProvider) Name() string                   { return m.name }
+func (m *mockProvider) HasAuthChoices() bool           { return m.choices }
+func (m *mockProvider) SupportedFlows() oauth.FlowType { return m.flows }
+func (m *mockProvider) RefreshToken(ctx context.Context, rt string) (*oauth.Token, error) {
+	return &oauth.Token{AccessToken: "refreshed-" + rt}, nil
+}
+func (m *mockProvider) WrapClient(base *http.Client, token *oauth.Token, isSubAgent, debug bool) *http.Client {
+	return base
+}
+
+func TestRegistry(t *testing.T) {
+	mock := &mockProvider{
+		id:      "test-prov",
+		name:    "Test Provider",
+		choices: true,
+		flows:   oauth.FlowBrowser,
+	}
+
+	oauth.Register(mock)
+
+	require.True(t, oauth.IsSupported("test-prov"))
+	require.True(t, oauth.HasAuthChoices("test-prov"))
+
+	p := oauth.Get("test-prov")
+	require.NotNil(t, p)
+	require.Equal(t, "test-prov", p.ID())
+	require.Equal(t, "Test Provider", p.Name())
+
+	tok, err := p.RefreshToken(context.Background(), "my-rt")
+	require.NoError(t, err)
+	require.Equal(t, "refreshed-my-rt", tok.AccessToken)
+
+	require.False(t, oauth.IsSupported("non-existent"))
+	require.False(t, oauth.HasAuthChoices("non-existent"))
+}

--- a/internal/oauth/token.go
+++ b/internal/oauth/token.go
@@ -26,11 +26,14 @@ type OAuthClient struct {
 
 // Token represents an OAuth2 token.
 type Token struct {
-	AccessToken  string       `json:"access_token"`
-	RefreshToken string       `json:"refresh_token,omitempty"`
-	ExpiresIn    int          `json:"expires_in"`
-	ExpiresAt    int64        `json:"expires_at"`
-	Client       *OAuthClient `json:"client,omitempty"`
+	AccessToken  string            `json:"access_token"`
+	RefreshToken string            `json:"refresh_token,omitempty"`
+	ExpiresIn    int               `json:"expires_in"`
+	ExpiresAt    int64             `json:"expires_at"`
+	AccountID    string            `json:"account_id,omitempty"`
+	IDToken      string            `json:"id_token,omitempty"`
+	Extra        map[string]string `json:"extra,omitempty"`
+	Client       *OAuthClient      `json:"client,omitempty"`
 }
 
 // SetExpiresAt calculates and sets the ExpiresAt field based on the

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -150,6 +150,19 @@ type (
 	ActionOAuthErrored struct {
 		Error error
 	}
+
+	// ActionSelectAuthMethod is sent when the user chooses between OAuth and API Key.
+	ActionSelectAuthMethod struct {
+		Provider  catwalk.Provider
+		Model     config.SelectedModel
+		ModelType config.SelectedModelType
+		UseOAuth  bool
+	}
+
+	// ActionCloseOAuth is sent when an OAuth dialog is closed, allowing cleanup.
+	ActionCloseOAuth struct {
+		Cmd tea.Cmd
+	}
 )
 
 // ActionCmd represents an action that carries a [tea.Cmd] to be passed to the

--- a/internal/ui/dialog/auth_method.go
+++ b/internal/ui/dialog/auth_method.go
@@ -1,0 +1,105 @@
+package dialog
+
+import (
+	"fmt"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/catwalk/pkg/catwalk"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// AuthMethodID is the identifier of the authentication method dialog.
+const AuthMethodID = "auth_method"
+
+// AuthMethod lets providers with both OAuth and API-key credentials choose
+// their authentication method explicitly.
+type AuthMethod struct {
+	com       *common.Common
+	provider  catwalk.Provider
+	model     config.SelectedModel
+	modelType config.SelectedModelType
+	selected  int
+}
+
+// NewAuthMethod creates a dialog to choose between OAuth and API key.
+func NewAuthMethod(
+	com *common.Common,
+	provider catwalk.Provider,
+	model config.SelectedModel,
+	modelType config.SelectedModelType,
+) *AuthMethod {
+	return &AuthMethod{
+		com:       com,
+		provider:  provider,
+		model:     model,
+		modelType: modelType,
+	}
+}
+
+func (m *AuthMethod) ID() string {
+	return AuthMethodID
+}
+
+func (m *AuthMethod) HandleMsg(msg tea.Msg) Action {
+	keyMsg, ok := msg.(tea.KeyPressMsg)
+	if !ok {
+		return nil
+	}
+
+	switch {
+	case key.Matches(keyMsg, CloseKey):
+		return ActionClose{}
+	case key.Matches(keyMsg, key.NewBinding(key.WithKeys("up", "down", "tab"))):
+		m.selected = 1 - m.selected
+		return nil
+	case key.Matches(keyMsg, key.NewBinding(key.WithKeys("enter", "ctrl+y"))):
+		return ActionSelectAuthMethod{
+			Provider:  m.provider,
+			Model:     m.model,
+			ModelType: m.modelType,
+			UseOAuth:  m.selected == 0,
+		}
+	}
+	return nil
+}
+
+func (m *AuthMethod) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
+	t := m.com.Styles
+	title := common.DialogTitle(
+		t,
+		t.Dialog.Title.Render(fmt.Sprintf("Authenticate with %s", m.provider.Name)),
+		52,
+		t.Dialog.TitleGradFromColor,
+		t.Dialog.TitleGradToColor,
+	)
+
+	oauthLabel := "Sign in via OAuth (Subscription)"
+	if p := oauth.Get(string(m.provider.ID)); p != nil {
+		oauthLabel = fmt.Sprintf("Sign in via %s (OAuth)", p.Name())
+	}
+	apiKeyLabel := fmt.Sprintf("Enter %s API key", m.provider.Name)
+
+	first := "  " + oauthLabel
+	second := "  " + apiKeyLabel
+
+	selectedStyle := lipgloss.NewStyle().Bold(true).Foreground(t.Dialog.TitleGradToColor)
+	if m.selected == 0 {
+		first = selectedStyle.Render("> " + oauthLabel)
+	} else {
+		second = selectedStyle.Render("> " + apiKeyLabel)
+	}
+
+	helpText := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render("↑/↓ choose • enter select • esc cancel")
+	content := lipgloss.JoinVertical(lipgloss.Left, title, "", first, second, "", helpText)
+	width := min(64, area.Dx())
+	DrawCenter(scr, area, t.Dialog.View.Width(width).Render(content))
+	return nil
+}
+
+func (m *AuthMethod) FullHelp() [][]key.Binding { return nil }
+func (m *AuthMethod) ShortHelp() []key.Binding  { return nil }

--- a/internal/ui/dialog/auth_method_test.go
+++ b/internal/ui/dialog/auth_method_test.go
@@ -1,0 +1,55 @@
+package dialog_test
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthMethod_ToggleAndSelect(t *testing.T) {
+	t.Parallel()
+
+	com := &common.Common{}
+	provider := catwalk.Provider{
+		ID:   "openai",
+		Name: "OpenAI",
+	}
+	model := config.SelectedModel{
+		Provider: "openai",
+		Model:    "gpt-4o",
+	}
+
+	dlg := dialog.NewAuthMethod(com, provider, model, config.SelectedModelTypeLarge)
+	require.Equal(t, dialog.AuthMethodID, dlg.ID())
+
+	// Default selection is OAuth (index 0)
+	action := dlg.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	selectAction, ok := action.(dialog.ActionSelectAuthMethod)
+	require.True(t, ok)
+	require.True(t, selectAction.UseOAuth)
+	require.Equal(t, "openai", string(selectAction.Provider.ID))
+
+	// Down arrow toggles to API key (index 1)
+	dlg.HandleMsg(tea.KeyPressMsg{Code: tea.KeyDown})
+	action = dlg.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	selectAction, ok = action.(dialog.ActionSelectAuthMethod)
+	require.True(t, ok)
+	require.False(t, selectAction.UseOAuth)
+
+	// Up arrow toggles back to OAuth (index 0)
+	dlg.HandleMsg(tea.KeyPressMsg{Code: tea.KeyUp})
+	action = dlg.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEnter})
+	selectAction, ok = action.(dialog.ActionSelectAuthMethod)
+	require.True(t, ok)
+	require.True(t, selectAction.UseOAuth)
+
+	// Esc cancels dialog
+	action = dlg.HandleMsg(tea.KeyPressMsg{Code: tea.KeyEscape})
+	_, ok = action.(dialog.ActionClose)
+	require.True(t, ok)
+}

--- a/internal/ui/dialog/oauth.go
+++ b/internal/ui/dialog/oauth.go
@@ -2,6 +2,7 @@ package dialog
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -71,7 +72,120 @@ type OAuth struct {
 	cancelFunc      context.CancelFunc
 }
 
-var _ Dialog = (*OAuth)(nil)
+// NewOAuthGeneric creates an OAuth dialog from a registered oauth.Provider.
+func NewOAuthGeneric(
+	com *common.Common,
+	isOnboarding bool,
+	provider catwalk.Provider,
+	model config.SelectedModel,
+	modelType config.SelectedModelType,
+	p oauth.Provider,
+) (*OAuth, tea.Cmd) {
+	return newOAuth(com, isOnboarding, provider, model, modelType, &genericOAuthBridge{p: p})
+}
+
+// NewOAuthForProvider creates an OAuth dialog if the provider is registered in oauth.Registry.
+func NewOAuthForProvider(
+	com *common.Common,
+	isOnboarding bool,
+	provider catwalk.Provider,
+	model config.SelectedModel,
+	modelType config.SelectedModelType,
+) (*OAuth, tea.Cmd) {
+	p := oauth.Get(string(provider.ID))
+	if p == nil {
+		return nil, nil
+	}
+	return NewOAuthGeneric(com, isOnboarding, provider, model, modelType, p)
+}
+
+type genericOAuthBridge struct {
+	p          oauth.Provider
+	session    oauth.BrowserSession
+	cancelFunc context.CancelFunc
+}
+
+func (g *genericOAuthBridge) name() string {
+	return g.p.Name()
+}
+
+func (g *genericOAuthBridge) initiateAuth() tea.Msg {
+	ctx := context.Background()
+	switch prov := g.p.(type) {
+	case oauth.BrowserFlowProvider:
+		session, err := prov.StartBrowserFlow(ctx)
+		if err != nil {
+			return ActionOAuthErrored{Error: fmt.Errorf("failed to start browser auth: %w", err)}
+		}
+		g.session = session
+		return ActionInitiateOAuth{
+			VerificationURL: session.URL(),
+		}
+	case oauth.DeviceFlowProvider:
+		dc, err := prov.RequestDeviceCode(ctx)
+		if err != nil {
+			return ActionOAuthErrored{Error: fmt.Errorf("failed to request device code: %w", err)}
+		}
+		return ActionInitiateOAuth{
+			DeviceCode:      dc.DeviceCode,
+			UserCode:        dc.UserCode,
+			VerificationURL: dc.VerificationURI,
+			ExpiresIn:       dc.ExpiresIn,
+			Interval:        dc.Interval,
+		}
+	default:
+		return ActionOAuthErrored{Error: fmt.Errorf("provider %s does not support OAuth", g.p.Name())}
+	}
+}
+
+func (g *genericOAuthBridge) startPolling(deviceCode string, expiresIn int) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithCancel(context.Background())
+		g.cancelFunc = cancel
+
+		switch prov := g.p.(type) {
+		case oauth.BrowserFlowProvider:
+			if g.session == nil {
+				return ActionOAuthErrored{Error: errors.New("browser session not initialized")}
+			}
+			tok, err := g.session.Wait(ctx)
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return nil
+				}
+				return ActionOAuthErrored{Error: err}
+			}
+			return ActionCompleteOAuth{Token: tok}
+
+		case oauth.DeviceFlowProvider:
+			code := &oauth.DeviceCode{
+				DeviceCode: deviceCode,
+				ExpiresIn:  expiresIn,
+			}
+			tok, err := prov.PollForToken(ctx, code)
+			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return nil
+				}
+				return ActionOAuthErrored{Error: err}
+			}
+			return ActionCompleteOAuth{Token: tok}
+
+		default:
+			return ActionOAuthErrored{Error: errors.New("unsupported flow")}
+		}
+	}
+}
+
+func (g *genericOAuthBridge) stopPolling() tea.Msg {
+	if g.cancelFunc != nil {
+		g.cancelFunc()
+	}
+	if g.session != nil {
+		g.session.Close()
+	}
+	return nil
+}
 
 // newOAuth creates a new device flow component.
 func newOAuth(
@@ -171,7 +285,7 @@ func (m *OAuth) HandleMsg(msg tea.Msg) Action {
 				return nil
 
 			default:
-				return ActionClose{}
+				return ActionCloseOAuth{Cmd: m.oAuthProvider.stopPolling}
 			}
 		}
 
@@ -312,22 +426,28 @@ func (m *OAuth) innerDialogContent() string {
 		// Render each text segment with its own style. Wrapping the
 		// whole concatenation in a single style would lose the text
 		// color after enterKeyStyle's reset code.
-		instructionText := instructionStyle.Render("Press ") +
-			enterKeyStyle.Render("enter") +
-			instructionStyle.Render(" to copy the code below and open the browser.")
+		instructionText := instructionStyle.Render("Press ") + enterKeyStyle.Render("enter")
+		if m.userCode == "" {
+			instructionText += instructionStyle.Render(" to open the browser and authenticate.")
+		} else {
+			instructionText += instructionStyle.Render(" to copy the code below and open the browser.")
+		}
 		instructions := lipgloss.NewStyle().
 			Width(innerWidth).
 			Padding(0, 1).
 			Render(instructionText)
 
-		codeBox := lipgloss.NewStyle().
-			Width(innerWidth).
-			Height(7).
-			Align(lipgloss.Center, lipgloss.Center).
-			Background(t.Dialog.OAuth.UserCodeBg).
-			Render(
-				t.Dialog.OAuth.UserCode.Render(m.userCode),
-			)
+		var codeBox string
+		if m.userCode != "" {
+			codeBox = lipgloss.NewStyle().
+				Width(innerWidth).
+				Height(7).
+				Align(lipgloss.Center, lipgloss.Center).
+				Background(t.Dialog.OAuth.UserCodeBg).
+				Render(
+					t.Dialog.OAuth.UserCode.Render(m.userCode),
+				)
+		}
 
 		link := linkStyle.Hyperlink(m.verificationURL, "id=oauth-verify").Render(m.verificationURL)
 		url := statusTextStyle.
@@ -335,25 +455,24 @@ func (m *OAuth) innerDialogContent() string {
 			Padding(0, 1).
 			Render("Browser not opening? Pay a visit to:\n" + link)
 
+		waitingMsg := "Verifying..."
+		if m.userCode == "" {
+			waitingMsg = "Waiting for browser authentication..."
+		}
 		waiting := statusTextStyle.
 			Width(innerWidth).
 			Padding(0, 1).
 			Render(
-				successStyle.Render(m.spinner.View()) + statusTextStyle.Render("Verifying..."),
+				successStyle.Render(m.spinner.View()) + statusTextStyle.Render(waitingMsg),
 			)
 
-		return lipgloss.JoinVertical(
-			lipgloss.Left,
-			"",
-			instructions,
-			"",
-			codeBox,
-			"",
-			url,
-			"",
-			waiting,
-			"",
-		)
+		elements := []string{"", instructions, ""}
+		if codeBox != "" {
+			elements = append(elements, codeBox, "")
+		}
+		elements = append(elements, url, "", waiting, "")
+
+		return lipgloss.JoinVertical(lipgloss.Left, elements...)
 
 	case OAuthStateSuccess:
 		return successStyle.
@@ -405,6 +524,13 @@ func (m *OAuth) ShortHelp() []key.Binding {
 		return nil
 
 	default:
+		if m.userCode == "" {
+			return []key.Binding{
+				m.keyMap.CopyURL,
+				key.NewBinding(key.WithKeys("enter", "ctrl+y"), key.WithHelp("enter", "open")),
+				m.keyMap.Close,
+			}
+		}
 		return []key.Binding{
 			m.keyMap.Copy,
 			m.keyMap.CopyURL,
@@ -432,12 +558,20 @@ func (m *OAuth) copyCodeAndOpenURL() tea.Cmd {
 	if m.State != OAuthStateDisplay {
 		return nil
 	}
+	if m.userCode == "" {
+		return func() tea.Msg {
+			if err := browser.OpenURL(m.verificationURL); err != nil {
+				return util.NewErrorMsg(fmt.Errorf("failed to open browser, open the displayed URL manually: %w", err))
+			}
+			return nil
+		}
+	}
 	return common.CopyToClipboardWithCallback(
 		m.userCode,
 		"Code copied and URL opened",
 		func() tea.Msg {
 			if err := browser.OpenURL(m.verificationURL); err != nil {
-				return ActionOAuthErrored{fmt.Errorf("failed to open browser: %w", err)}
+				return util.NewErrorMsg(fmt.Errorf("failed to open browser, open the displayed URL manually: %w", err))
 			}
 			return nil
 		},

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -41,6 +41,7 @@ import (
 	"github.com/charmbracelet/crush/internal/home"
 	"github.com/charmbracelet/crush/internal/lsp"
 	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/question"
@@ -1881,6 +1882,16 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 
 	switch msg := action.(type) {
 	// Generic dialog messages
+	case dialog.ActionCloseOAuth:
+		m.dialog.CloseFrontDialog()
+		if msg.Cmd != nil {
+			cmds = append(cmds, msg.Cmd)
+		}
+		if isOnboarding {
+			if cmd := m.openModelsDialog(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+		}
 	case dialog.ActionClose:
 		if isOnboarding && m.dialog.ContainsDialog(dialog.ModelsID) {
 			break
@@ -2043,6 +2054,11 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 
 	case dialog.ActionSelectModel:
 		if cmd := m.handleSelectModel(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	case dialog.ActionSelectAuthMethod:
+		m.dialog.CloseDialog(dialog.AuthMethodID)
+		if cmd := m.openAuthenticationDialogWithMethod(msg.Provider, msg.Model, msg.ModelType, msg.UseOAuth); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
 	case dialog.ActionSelectReasoningEffort:
@@ -2386,6 +2402,21 @@ func (m *UI) handleSelectModel(msg dialog.ActionSelectModel) tea.Cmd {
 }
 
 func (m *UI) openAuthenticationDialog(provider catwalk.Provider, model config.SelectedModel, modelType config.SelectedModelType) tea.Cmd {
+	// If the provider supports both OAuth and API key, prompt the user to choose.
+	if oauth.HasAuthChoices(string(provider.ID)) {
+		m.dialog.OpenDialogWithGrace(dialog.NewAuthMethod(m.com, provider, model, modelType))
+		return nil
+	}
+
+	return m.openAuthenticationDialogWithMethod(provider, model, modelType, oauth.IsSupported(string(provider.ID)))
+}
+
+func (m *UI) openAuthenticationDialogWithMethod(
+	provider catwalk.Provider,
+	model config.SelectedModel,
+	modelType config.SelectedModelType,
+	useOAuth bool,
+) tea.Cmd {
 	var (
 		dlg dialog.Dialog
 		cmd tea.Cmd
@@ -2393,12 +2424,11 @@ func (m *UI) openAuthenticationDialog(provider catwalk.Provider, model config.Se
 		isOnboarding = m.state == uiOnboarding
 	)
 
-	switch provider.ID {
-	case "hyper":
-		dlg, cmd = dialog.NewOAuthHyper(m.com, isOnboarding, provider, model, modelType)
-	case catwalk.InferenceProviderCopilot:
-		dlg, cmd = dialog.NewOAuthCopilot(m.com, isOnboarding, provider, model, modelType)
-	default:
+	if useOAuth && oauth.IsSupported(string(provider.ID)) {
+		dlg, cmd = dialog.NewOAuthForProvider(m.com, isOnboarding, provider, model, modelType)
+	}
+
+	if dlg == nil {
 		dlg, cmd = dialog.NewAPIKeyInput(m.com, isOnboarding, provider, model, modelType)
 	}
 


### PR DESCRIPTION
# What?

- Add ChatGPT/Codex subscription authentication to the CLI and TUI.
- Introduce a provider registry and shared OAuth abstractions for browser and device authorization flows.
- Migrate the existing Hyper and GitHub Copilot login flows to the shared OAuth infrastructure.
- Add explicit OAuth/API-key authentication selection for OpenAI.
- Route authenticated OpenAI requests through the ChatGPT Codex backend while preventing OAuth credentials from being sent to third-party endpoints.

# Why?

ChatGPT Plus and Pro subscribers currently cannot easily use their Codex subscription with Crush without configuring a separate OpenAI Platform API key.

This adds subscription-based authentication while making Crush's OAuth implementation easier to extend for future providers. OpenAI API-key and ChatGPT OAuth authentication are treated separately rather than being used simultaneously.

# Relationship to #3654

This PR addresses the same user-facing need as #3654 but takes a different architectural approach:

- OAuth providers are registered behind shared interfaces instead of being wired into each login surface individually.
- The CLI and TUI share provider-independent OAuth orchestration.
- Existing Hyper and GitHub Copilot authentication are migrated to the same infrastructure.
- OpenAI uses the browser callback flow in both the CLI and TUI.
- The abstraction is intended to simplify adding providers such as Kimi For Coding or xAI in the future.

# Testing

- Added coverage for the OAuth registry and browser callback flow.
- Added OpenAI token exchange and transport tests.
- Added authentication-method dialog and CLI argument tests.
- Verified that ChatGPT credentials are not forwarded to third-party OpenAI-compatible endpoints.

**🤖 AI-generated content disclosure:**

This PR was developed with assistance from Gemini 3.8 Flash in Antigravity CLI and GPT-5.6 Sol in Crush, but the implementation has been verified, and tested by a human in the loop (me).

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).