### PR TITLE
feat: send x-opencode-session header to OpenCode providers

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -797,7 +797,7 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 		Prompt:           message.PromptWithTextAttachments(call.Prompt, call.Attachments),
 		Files:            files,
 		Messages:         history,
-		Headers:          sessionHeaders(call.SessionID),
+		Headers:          sessionHeaders(call.SessionID, largeModel.ModelCfg.Provider),
 		ProviderOptions:  call.ProviderOptions,
 		MaxOutputTokens:  maxOutputTokens,
 		TopP:             call.TopP,
@@ -1381,7 +1381,7 @@ func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fan
 	resp, err := agent.Stream(genCtx, fantasy.AgentStreamCall{
 		Prompt:          summaryPromptText,
 		Messages:        aiMsgs,
-		Headers:         sessionHeaders(sessionID),
+		Headers:         sessionHeaders(sessionID, largeModel.ModelCfg.Provider),
 		ProviderOptions: opts,
 		OnAuthRefresh:   onAuthRefresh,
 		ModelProvider: func() fantasy.LanguageModel {
@@ -1499,12 +1499,19 @@ func (a *sessionAgent) getCacheControlOptions() fantasy.ProviderOptions {
 //
 // We use the session hash is used instead of the raw UUID so the header
 // value is deterministic and opaque.
-func sessionHeaders(sessionID string) map[string]string {
+//
+// OpenCode providers (Go and Zen) additionally require the session hash
+// in a dedicated header for their own session tracking.
+func sessionHeaders(sessionID, providerID string) map[string]string {
 	hash := session.HashID(sessionID)
-	return map[string]string{
+	headers := map[string]string{
 		"x-session-id":       hash,
 		"x-session-affinity": hash,
 	}
+	if providerID == string(catwalk.InferenceProviderOpenCodeGo) || providerID == string(catwalk.InferenceProviderOpenCodeZen) {
+		headers["x-opencode-session"] = hash
+	}
+	return headers
 }
 
 func (a *sessionAgent) createUserMessage(ctx context.Context, call SessionAgentCall) (message.Message, error) {
@@ -1757,8 +1764,7 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 	}
 
 	streamCall := fantasy.AgentStreamCall{
-		Prompt:  fmt.Sprintf("Generate a concise title for the following content:\n\n%s\n <think>\n\n</think>", userPrompt),
-		Headers: sessionHeaders(sessionID),
+		Prompt: fmt.Sprintf("Generate a concise title for the following content:\n\n%s\n <think>\n\n</think>", userPrompt),
 		PrepareStep: func(callCtx context.Context, opts fantasy.PrepareStepFunctionOptions) (_ context.Context, prepared fantasy.PrepareStepResult, err error) {
 			prepared.Messages = opts.Messages
 			if systemPromptPrefix != "" {
@@ -1789,6 +1795,7 @@ func (a *sessionAgent) GenerateTitle(ctx context.Context, sessionID string, user
 			tok = attempt.model.CatwalkCfg.DefaultMaxTokens
 		}
 		agent := newAgent(attempt.model.Model, titlePrompt, tok)
+		streamCall.Headers = sessionHeaders(sessionID, attempt.model.ModelCfg.Provider)
 		resp, err = agent.Stream(ctx, streamCall)
 		if err == nil && resp.Response.FinishReason != fantasy.FinishReasonLength {
 			model = attempt.model

--- a/internal/agent/session_headers_test.go
+++ b/internal/agent/session_headers_test.go
@@ -1,0 +1,42 @@
+package agent
+
+import (
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSessionHeaders(t *testing.T) {
+	t.Parallel()
+
+	const sessionID = "0199c0a5-1111-7000-8000-000000000000"
+	hash := session.HashID(sessionID)
+
+	tests := []struct {
+		name       string
+		providerID string
+		opencode   bool
+	}{
+		{"opencode go", string(catwalk.InferenceProviderOpenCodeGo), true},
+		{"opencode zen", string(catwalk.InferenceProviderOpenCodeZen), true},
+		{"anthropic", string(catwalk.InferenceProviderAnthropic), false},
+		{"openai", string(catwalk.InferenceProviderOpenAI), false},
+		{"custom provider", "my-custom-provider", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			headers := sessionHeaders(sessionID, tt.providerID)
+			assert.Equal(t, hash, headers["x-session-id"])
+			assert.Equal(t, hash, headers["x-session-affinity"])
+			if tt.opencode {
+				assert.Equal(t, hash, headers["x-opencode-session"])
+			} else {
+				assert.NotContains(t, headers, "x-opencode-session")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3706 (draft: opening for early review; I still want to verify against a real OpenCode Go/Zen backend)

## Summary

- Per issue #3706, OpenCode (Go, and Zen per maintainer guidance) needs the per-conversation session hash in a dedicated `x-opencode-session` header on every LLM request, in addition to the standard `x-session-id`/`x-session-affinity` headers we already send.
- `sessionHeaders` now takes the provider ID and adds the OpenCode header only when the request is routed to `opencode-go` or `opencode-zen`. All other providers keep exactly the same headers as before.
- Applied at all three LLM call sites: main run, summarization, and title generation. Title generation sets the header per model attempt since small and large models can be from different providers.
- The header value is the existing XXH3 session hash (same value as `x-session-id`), not the raw UUID, so it stays deterministic and opaque.

## Testing

- New unit tests in `internal/agent/session_headers_test.go` cover: opencode-go, opencode-zen, and non-OpenCode providers (anthropic, openai, custom), asserting the header is present/absent and that the value matches the session hash.
- `go test ./internal/agent` passes.

Not yet verified end-to-end against the real OpenCode APIs. Note the vendor deadline mentioned in the issue: requests missing the header may error starting 2026-09-06.