### PR TITLE
fix(copilot): route GPT-6 Astra through Responses API

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -78,6 +78,7 @@ var copilotResponsesModels = map[string]bool{
 	"gpt-5.6-luna":  true,
 	"gpt-5.6-terra": true,
 	"gpt-5.6-sol":   true,
+	"gpt-6-astra":   true,
 	"grok-4.5":      true,
 	"grok-4.6":      true,
 }

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -91,7 +91,7 @@ func agentResultWithText(text string) *fantasy.AgentResult {
 func TestCopilotResponsesModels(t *testing.T) {
 	t.Parallel()
 
-	for _, modelID := range []string{"grok-4.5", "grok-4.6"} {
+	for _, modelID := range []string{"gpt-6-astra", "grok-4.5", "grok-4.6"} {
 		assert.True(t, copilotResponsesModels[modelID], modelID)
 	}
 	assert.False(t, copilotResponsesModels["gpt-4.1"])


### PR DESCRIPTION
## What does this do?

Routes GitHub Copilot's GPT-6 Astra model through the Responses API instead of the Chat Completions API.

## Why is this needed?

Crush selects the Copilot wire API through an explicit allowlist. GPT-6 Astra is absent from that allowlist, so Crush sends its requests to `/chat/completions`. Copilot rejects them with:

```text
bad request: model "gpt-6-astra" is not accessible via the /chat/completions endpoint
```

Adding GPT-6 Astra to the existing Responses API allowlist makes Crush use the endpoint required by Copilot. This change retains the current opt-in design and does not alter routing for other Copilot models.

## How was this tested?

- Added a regression assertion verifying that GPT-6 Astra opts into the Responses API.
- Kept the negative assertion for GPT-4.1 to ensure a Chat Completions model is not routed through Responses.
- Ran `go test ./internal/agent` successfully.
- Built the local binary with `go build -o ./bin/crush-local .`.
- Confirmed the installed Crush fails with the `/chat/completions` error:

  ```console
  crush run --quiet --model copilot/gpt-6-astra "Reply with exactly OK"
  ```

- Confirmed the patched local binary succeeds and returns `OK`:

  ```console
  ./bin/crush-local run --quiet --model copilot/gpt-6-astra "Reply with exactly OK"
  ```

- Ran `git diff --check` successfully.

## Checklist

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

This is a bug fix, not a new feature, so the discussion requirement does not apply.
