### PR TITLE
fix(mcp): open the standalone SSE stream for channel-enabled servers

### DIFF
--- a/internal/agent/tools/mcp/channel.go
+++ b/internal/agent/tools/mcp/channel.go
@@ -289,6 +289,19 @@ type channelTransport struct {
 func (t *channelTransport) unwrapTransport() mcp.Transport { return t.inner }
 
 func (t *channelTransport) Connect(ctx context.Context) (mcp.Connection, error) {
+	// Streamable HTTP must NOT be wrapped. The SDK starts the standalone SSE
+	// stream — the hanging GET every server-initiated notification rides — from
+	// sessionUpdated, which it reaches by type-asserting this connection to its
+	// unexported clientConnection interface. A wrapper declared in another
+	// package cannot implement that interface's unexported method, so the assert
+	// fails silently (the ok is discarded), the stream is never opened, and every
+	// push is rejected with "stream not connected or already closed" while the
+	// session still initializes and answers pings. Filter below the connection
+	// instead, in the HTTP round-tripper, and hand the SDK the real thing.
+	if inner, ok := t.inner.(*mcp.StreamableClientTransport); ok {
+		installChannelSSEFilter(inner, t.name, t.gate)
+		return inner.Connect(ctx)
+	}
 	conn, err := t.inner.Connect(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/agent/tools/mcp/channel_sse.go
+++ b/internal/agent/tools/mcp/channel_sse.go
@@ -1,0 +1,232 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"unicode/utf8"
+
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// The standalone SSE stream is the hanging GET that a streamable-HTTP MCP
+// server uses to push server-initiated notifications. For channel-enabled
+// Interception note: channel notifications must be filtered below the go-sdk
+// connection layer for streamable-HTTP transports. The SDK only starts the
+// standalone SSE stream by type-asserting the connection returned from
+// Transport.Connect to its internal connection type; wrapping the connection
+// (as channelConn does for other transports) silently defeats that assert,
+// so the stream is never opened and every doorbell is rejected server-side
+// with "stream not connected or already closed".
+
+// installChannelSSEFilter wires the SSE-filtering round-tripper into a
+// streamable-HTTP transport.
+func installChannelSSEFilter(t *mcp.StreamableClientTransport, name string, gate *channelGate) {
+	inner := http.RoundTripper(http.DefaultTransport)
+	if t.HTTPClient != nil && t.HTTPClient.Transport != nil {
+		inner = t.HTTPClient.Transport
+	}
+	t.HTTPClient = &http.Client{Transport: &channelSSEFilter{
+		inner: inner,
+		name:  name,
+		gate:  gate,
+	}}
+}
+
+// channelSSEFilter is an http.RoundTripper that watches event-stream
+// response bodies. It filters notifications/claude/channel events out of
+// every stream (doorbells may ride any SSE body, in practice the standalone
+// GET) and dispatches them through the channel gate.
+type channelSSEFilter struct {
+	inner http.RoundTripper
+	name  string
+	gate  *channelGate
+}
+
+func (f *channelSSEFilter) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := f.inner.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	standalone := req.Method == http.MethodGet &&
+		req.Header.Get("Accept") == "text/event-stream"
+	if resp.StatusCode != http.StatusOK ||
+		!isEventStreamContentType(resp.Header.Get("Content-Type")) {
+		return resp, nil
+	}
+	resp.Body = &channelSSEBody{
+		ctx:        req.Context(),
+		body:       resp.Body,
+		filter:     f,
+		standalone: standalone,
+	}
+	return resp, nil
+}
+
+func isEventStreamContentType(ct string) bool {
+	const prefix = "text/event-stream"
+	if len(ct) < len(prefix) {
+		return false
+	}
+	ct = ct[:len(prefix)]
+	for i := 0; i < len(ct); i++ {
+		c := ct[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		if c != prefix[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// maxUnboundedBuffer caps how many bytes are held waiting for an event
+// boundary. A doorbell is capped far below this (parseChannelParams enforces
+// maxChannelContentBytes), so anything this large is not a channel event and
+// is forwarded to the SDK untouched rather than buffered forever.
+const maxUnboundedBuffer = 1 << 20
+
+// channelSSEBody filters one event-stream body. Complete events are checked
+// for the channel notification method; matching events are dispatched to the
+// gate and stripped, everything else passes through unchanged and in order.
+type channelSSEBody struct {
+	ctx        context.Context
+	body       io.ReadCloser
+	filter     *channelSSEFilter
+	standalone bool
+
+	out     bytes.Buffer // filtered bytes not yet consumed by the reader
+	buf     []byte       // raw bytes awaiting an event boundary
+	eof     bool
+	readErr error
+}
+
+// Read returns filtered stream data, blocking on the underlying body only
+// when no filtered bytes are available.
+func (b *channelSSEBody) Read(p []byte) (int, error) {
+	for b.out.Len() == 0 {
+		if b.eof {
+			if b.readErr != nil {
+				return 0, b.readErr
+			}
+			return 0, io.EOF
+		}
+		if err := b.pump(); err != nil {
+			return 0, err
+		}
+	}
+	return b.out.Read(p)
+}
+
+// pump reads more raw bytes from the stream, extracts any complete events,
+// and appends the filtered result to the output buffer.
+func (b *channelSSEBody) pump() error {
+	chunk := make([]byte, 4096)
+	n, err := b.body.Read(chunk)
+	if n > 0 {
+		b.buf = append(b.buf, chunk[:n]...)
+		b.extractEvents()
+	}
+	if err == nil {
+		return nil
+	}
+	// Stream ended: flush anything left (a trailing event without a final
+	// blank line) before propagating EOF/error to the reader.
+	b.out.Write(b.buf)
+	b.buf = nil
+	b.eof = true
+	b.readErr = err
+	if b.standalone {
+	}
+	return nil
+}
+
+// extractEvents drains complete events from buf. An SSE event ends at a
+// blank line; both \n\n and \r\n\r\n are accepted as delimiters. If buf
+// grows past maxUnboundedBuffer without a boundary the data is forwarded
+// as-is: it cannot be a valid doorbell (those are size-capped) and holding
+// it would stall the stream.
+func (b *channelSSEBody) extractEvents() {
+	for len(b.buf) > 0 {
+		end := eventBoundary(b.buf)
+		if end < 0 {
+			if len(b.buf) > maxUnboundedBuffer {
+				b.out.Write(b.buf)
+				b.buf = nil
+			}
+			return
+		}
+		event := b.buf[:end]
+		b.buf = b.buf[end:]
+		b.handleEvent(event)
+	}
+}
+
+// eventBoundary returns the length of the first event in data (including the
+// terminating blank line), or -1 if no complete event is buffered.
+func eventBoundary(data []byte) int {
+	if i := bytes.Index(data, []byte("\r\n\r\n")); i >= 0 {
+		return i + 4
+	}
+	if i := bytes.Index(data, []byte("\n\n")); i >= 0 {
+		return i + 2
+	}
+	return -1
+}
+
+// handleEvent inspects one complete SSE event. Events whose data decodes to
+// a notifications/claude/channel request are dispatched through the channel
+// gate and dropped from the stream; all other events pass through to the
+// SDK untouched.
+func (b *channelSSEBody) handleEvent(event []byte) {
+	raw := eventData(event)
+	if raw == nil || !utf8.Valid(raw) || !bytes.Contains(raw, []byte(channelNotificationMethod)) {
+		b.out.Write(event)
+		return
+	}
+	msg, err := jsonrpc.DecodeMessage(raw)
+	if err != nil {
+		b.out.Write(event)
+		return
+	}
+	req, ok := msg.(*jsonrpc.Request)
+	if !ok || req.IsCall() || req.Method != channelNotificationMethod {
+		b.out.Write(event)
+		return
+	}
+	if parsed := b.filter.gate.accept(req.Params); parsed != nil {
+		publishChannelMessage(b.ctx, b.filter.name, parsed)
+	}
+}
+
+// eventData joins the data lines of an SSE event into the JSON-RPC payload.
+// Returns nil for comments (keepalives) and events without data.
+func eventData(event []byte) []byte {
+	var lines [][]byte
+	for _, line := range bytes.Split(event, []byte("\n")) {
+		line = bytes.TrimSuffix(line, []byte("\r"))
+		if len(line) == 0 || line[0] == ':' {
+			continue
+		}
+		name, value, found := bytes.Cut(line, []byte(":"))
+		if !found || string(name) != "data" {
+			continue
+		}
+		value = bytes.TrimPrefix(value, []byte(" "))
+		lines = append(lines, value)
+	}
+	if len(lines) == 0 {
+		return nil
+	}
+	return bytes.Join(lines, []byte("\n"))
+}
+
+// Close implements io.Closer.
+func (b *channelSSEBody) Close() error {
+	if b.standalone {
+	}
+	return b.body.Close()
+}

--- a/internal/agent/tools/mcp/channel_sse.go
+++ b/internal/agent/tools/mcp/channel_sse.go
@@ -13,6 +13,8 @@ import (
 
 // The standalone SSE stream is the hanging GET that a streamable-HTTP MCP
 // server uses to push server-initiated notifications. For channel-enabled
+// servers it is the stream that notifications/claude/channel doorbells ride.
+//
 // Interception note: channel notifications must be filtered below the go-sdk
 // connection layer for streamable-HTTP transports. The SDK only starts the
 // standalone SSE stream by type-asserting the connection returned from

--- a/internal/agent/tools/mcp/channel_sse.go
+++ b/internal/agent/tools/mcp/channel_sse.go
@@ -50,17 +50,14 @@ func (f *channelSSEFilter) RoundTrip(req *http.Request) (*http.Response, error) 
 	if err != nil {
 		return resp, err
 	}
-	standalone := req.Method == http.MethodGet &&
-		req.Header.Get("Accept") == "text/event-stream"
 	if resp.StatusCode != http.StatusOK ||
 		!isEventStreamContentType(resp.Header.Get("Content-Type")) {
 		return resp, nil
 	}
 	resp.Body = &channelSSEBody{
-		ctx:        req.Context(),
-		body:       resp.Body,
-		filter:     f,
-		standalone: standalone,
+		ctx:    req.Context(),
+		body:   resp.Body,
+		filter: f,
 	}
 	return resp, nil
 }
@@ -93,10 +90,9 @@ const maxUnboundedBuffer = 1 << 20
 // for the channel notification method; matching events are dispatched to the
 // gate and stripped, everything else passes through unchanged and in order.
 type channelSSEBody struct {
-	ctx        context.Context
-	body       io.ReadCloser
-	filter     *channelSSEFilter
-	standalone bool
+	ctx    context.Context
+	body   io.ReadCloser
+	filter *channelSSEFilter
 
 	out     bytes.Buffer // filtered bytes not yet consumed by the reader
 	buf     []byte       // raw bytes awaiting an event boundary
@@ -139,8 +135,6 @@ func (b *channelSSEBody) pump() error {
 	b.buf = nil
 	b.eof = true
 	b.readErr = err
-	if b.standalone {
-	}
 	return nil
 }
 
@@ -226,7 +220,5 @@ func eventData(event []byte) []byte {
 
 // Close implements io.Closer.
 func (b *channelSSEBody) Close() error {
-	if b.standalone {
-	}
 	return b.body.Close()
 }

--- a/internal/agent/tools/mcp/channel_sse_test.go
+++ b/internal/agent/tools/mcp/channel_sse_test.go
@@ -1,0 +1,240 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// newStreamableChannelServer starts a minimal streamable-HTTP MCP server that
+// answers the legacy initialize handshake, advertises the claude/channel
+// capability, and serves a standalone SSE GET stream. The returned record
+// channel reports what the client actually did on the wire.
+type streamableRecord struct {
+	sawGET      chan struct{}
+	sawDiscover chan struct{}
+}
+
+func newStreamableChannelServer(t *testing.T, name string, doorbell func(w http.ResponseWriter)) (*httptest.Server, *streamableRecord) {
+	t.Helper()
+	rec := &streamableRecord{sawGET: make(chan struct{}, 4), sawDiscover: make(chan struct{}, 4)}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/mcp", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			select {
+			case rec.sawGET <- struct{}{}:
+			default:
+			}
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			if doorbell != nil {
+				doorbell(w)
+			}
+			<-r.Context().Done()
+		case http.MethodPost:
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var req struct {
+				ID     json.RawMessage `json:"id"`
+				Method string          `json:"method"`
+			}
+			require.NoError(t, json.Unmarshal(body, &req))
+			id := string(bytes.Trim(req.ID, "null"))
+			if id == "" {
+				id = "1"
+			}
+			if req.Method == "initialize" {
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Mcp-Session-Id", "test-session")
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + id + `,"result":{"protocolVersion":"2025-06-18","capabilities":{"experimental":{"claude/channel":{}}},"serverInfo":{"name":"t","version":"0"}}}`))
+				return
+			}
+			if req.Method == "notifications/initialized" {
+				w.WriteHeader(http.StatusAccepted)
+				return
+			}
+			// Anything else (e.g. server/discover) is refused so the SDK
+			// falls back to the legacy initialize handshake.
+			select {
+			case rec.sawDiscover <- struct{}{}:
+			default:
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + id + `,"error":{"code":-32601,"message":"method not found"}}`))
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+// TestChannelStreamableStandaloneSSEOpens is the regression test for the
+// doorbell deadness: the go-sdk only opens the standalone SSE stream by
+// type-asserting the connection from Transport.Connect to its internal type,
+// so a transport wrapper that wraps the connection silently suppresses the
+// stream and the session stays ping-alive but doorbell-deaf. The filter must
+// live below the connection (see channel_sse.go), leaving the connection
+// unwrapped so the stream opens and doorbells flow.
+func TestChannelStreamableStandaloneSSEOpens(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	doorbell := func(w http.ResponseWriter) {
+		time.Sleep(50 * time.Millisecond)
+		_, _ = w.Write([]byte("event: message\ndata: " +
+			`{"jsonrpc":"2.0","method":"notifications/claude/channel","params":{"content":"knock knock"}}` +
+			"\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+	const name = "chan-sse"
+	srv, rec := newStreamableChannelServer(t, name, doorbell)
+
+	sub := broker.Subscribe(ctx)
+	gate := newChannelGate()
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush", Version: "test"}, nil)
+	transport := &channelTransport{
+		inner: &mcp.StreamableClientTransport{Endpoint: srv.URL + "/mcp"},
+		name:  name,
+		gate:  gate,
+	}
+	session, err := client.Connect(ctx, transport, nil)
+	require.NoError(t, err)
+	defer session.Close()
+
+	select {
+	case <-rec.sawGET:
+	case <-time.After(5 * time.Second):
+		t.Fatal("client never opened the standalone SSE GET stream")
+	}
+
+	// Mirror createSession: resolve the gate after Connect and publish
+	// anything that arrived during negotiation.
+	for _, raw := range gate.resolve(true) {
+		publishChannelMessage(ctx, name, raw)
+	}
+
+	for {
+		select {
+		case ev := <-sub:
+			// The broker is package-global and other tests publish on it;
+			// only our own doorbell completes the test.
+			if ev.Payload.Type != EventChannelMessage || ev.Payload.Name != name {
+				continue
+			}
+			require.Contains(t, ev.Payload.ChannelMessage, "knock knock")
+			return
+		case <-ctx.Done():
+			t.Fatal("timed out waiting for doorbell over the standalone SSE stream")
+		}
+	}
+}
+
+// TestChannelSSEFilterLeavesNonChannelEventsForSDK verifies the filter is
+// transparent for ordinary notifications: they pass through unchanged and
+// the SDK dispatches them (here: a tools/list_changed-shaped notification
+// would reach the session, and a ping request is answered normally).
+func TestChannelSSEFilterLeavesNonChannelEventsForSDK(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	const name = "chan-pass"
+	ping := func(w http.ResponseWriter) {
+		time.Sleep(50 * time.Millisecond)
+		_, _ = w.Write([]byte("event: message\ndata: " +
+			`{"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","data":"hi"}}` +
+			"\n\n"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}
+	srv, _ := newStreamableChannelServer(t, name, ping)
+
+	gate := newChannelGate()
+	gotLogging := make(chan struct{}, 1)
+	client := mcp.NewClient(&mcp.Implementation{Name: "crush", Version: "test"}, &mcp.ClientOptions{
+		//nolint:staticcheck // SA1019: only non-channel notification the SDK dispatches without extra capability negotiation
+		LoggingMessageHandler: func(context.Context, *mcp.LoggingMessageRequest) {
+			gotLogging <- struct{}{}
+		},
+	})
+	transport := &channelTransport{
+		inner: &mcp.StreamableClientTransport{Endpoint: srv.URL + "/mcp"},
+		name:  name,
+		gate:  gate,
+	}
+	session, err := client.Connect(ctx, transport, nil)
+	require.NoError(t, err)
+	defer session.Close()
+	gate.resolve(false) // closed: channel events would be dropped, others pass
+
+	select {
+	case <-gotLogging:
+	case <-time.After(5 * time.Second):
+		t.Fatal("non-channel notification did not reach the SDK handler")
+	}
+}
+
+// TestEventFilterStripsDoorbellAndKeepsKeepalive pins the parser: a doorbell is
+// removed from the stream the SDK sees, everything else passes through byte for
+// byte, including comment keepalives.
+func TestEventFilterStripsDoorbellAndKeepsKeepalive(t *testing.T) {
+	t.Parallel()
+	gate := newChannelGate()
+	// Resolve closed so the stripped doorbell is dropped instead of
+	// published to the package-global broker other tests subscribe to.
+	gate.resolve(false)
+	ctx := context.Background()
+	body := io.NopCloser(bytes.NewReader([]byte(
+		": ok\n\n" +
+			"event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"other/notification\"}\n\n" +
+			"event: message\ndata: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/claude/channel\",\"params\":{\"content\":\"hi\"}}\n\n" +
+			": ping\n\n",
+	)))
+	b := &channelSSEBody{
+		ctx:        ctx,
+		body:       body,
+		filter:     &channelSSEFilter{name: "chan-filter", gate: gate},
+		standalone: true,
+	}
+	out, err := io.ReadAll(b)
+	require.NoError(t, err)
+	require.NotContains(t, string(out), "claude/channel", "doorbell must be stripped")
+	require.Contains(t, string(out), "other/notification")
+	require.Contains(t, string(out), ": ok")
+}
+
+// TestChannelDoorbellBufferedUntilGateResolves verifies undecided-gate
+// buffering survives the HTTP-layer path: a doorbell arriving before the
+// gate resolves is published once it opens.
+func TestChannelDoorbellBufferedUntilGateResolves(t *testing.T) {
+	t.Parallel()
+	gate := newChannelGate()
+	raw := json.RawMessage(`{"content":"buffered"}`)
+	require.Nil(t, gate.accept(raw), "undecided gate must buffer")
+	require.Empty(t, gate.resolve(false))
+	require.Nil(t, gate.accept(raw), "resolved-closed gate must drop")
+
+	gate2 := newChannelGate()
+	require.Nil(t, gate2.accept(raw))
+	buffered := gate2.resolve(true)
+	require.Len(t, buffered, 1)
+	require.Equal(t, raw, buffered[0])
+}

--- a/internal/agent/tools/mcp/channel_sse_test.go
+++ b/internal/agent/tools/mcp/channel_sse_test.go
@@ -209,10 +209,9 @@ func TestEventFilterStripsDoorbellAndKeepsKeepalive(t *testing.T) {
 			": ping\n\n",
 	)))
 	b := &channelSSEBody{
-		ctx:        ctx,
-		body:       body,
-		filter:     &channelSSEFilter{name: "chan-filter", gate: gate},
-		standalone: true,
+		ctx:    ctx,
+		body:   body,
+		filter: &channelSSEFilter{name: "chan-filter", gate: gate},
 	}
 	out, err := io.ReadAll(b)
 	require.NoError(t, err)


### PR DESCRIPTION
## The problem

A channel-enabled streamable-HTTP MCP server never delivers a single server-initiated notification.

`channelTransport.Connect` wraps the connection in `channelConn` so channel notifications can be filtered out of the stream the SDK sees. But the SDK starts the **standalone SSE stream** — the hanging GET every server-initiated notification rides — from `sessionUpdated`, which it reaches by type-asserting the connection:

```go
// go-sdk v1.7.0, mcp/client.go
if hc, ok := cs.mcpConn.(clientConnection); ok {
    hc.sessionUpdated(cs.state)
}
```

`clientConnection` embeds `Connection` plus an **unexported** `sessionUpdated` method, so a wrapper type declared in another package can never satisfy it. The assertion fails, and because `ok` is discarded it fails *silently*: the standalone stream is simply never opened.

Nothing looks wrong from the outside. The session initializes, `tools/call` works, and pings are answered over ordinary POSTs — so every liveness signal is green while the server rejects each push with `stream not connected or already closed`.

We hit this in production against a homegrown streamable-HTTP MCP server that pushes work notifications. It cost a while to find precisely because the failure is invisible from the client: no error, no log, a perfectly healthy-looking session.

## The fix

For streamable-HTTP transports, filter **below** the connection instead of wrapping it. An `http.RoundTripper` watches event-stream bodies, strips the channel notifications and forwards everything else byte for byte, so the SDK receives the real connection, the type assertion succeeds, and the standalone stream opens and reconnects on its own.

Other transport types keep the existing `channelConn` wrapper — stdio has no standalone-stream semantics to lose, so there is nothing to break there.

## Test

`TestChannelStreamableStandaloneSSEOpens` drives the **real** go-sdk client against a minimal streamable-HTTP test server and asserts the standalone GET is opened and a doorbell reaches the channel broker. Without the fix it fails with:

```
channel_sse_test.go:124: client never opened the standalone SSE GET stream
```

Using the real client rather than a transport mock is deliberate — a mock would have asserted the wrapper's own behaviour and missed this entirely.

Also covered: non-channel notifications pass through untouched, keepalive comments survive, and the doorbell gate's buffering semantics are preserved.

`go build ./...`, `go vet` and `go test ./...` are clean on this branch.

## Notes

Happy to adjust the shape — if you would rather see the filter live somewhere else, or want the `Connect` branch keyed differently, say the word and I will rework it. The behaviour change is confined to streamable-HTTP channel transports.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.com/claude-code).
