### PR TITLE
fix: keep `top_k` for known custom providers

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -651,7 +651,7 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 
 					fallbackMergeOptions := make(map[string]any)
 					fallbackMergeOptions["extra_body"] = make(map[string]any)
-					fallbackMergeOptions["extra_body"].(map[string]any)["top_k"] = topK
+					fallbackMergeOptions["extra_body"].(map[string]any)["top_k"] = *topK
 					parsed, err := openaicompat.ParseOptions(fallbackMergeOptions)
 					if err == nil {
 						options[openaicompat.Name] = parsed

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -51,7 +51,6 @@ import (
 	"charm.land/fantasy/providers/openrouter"
 	"charm.land/fantasy/providers/vercel"
 	openaisdk "github.com/openai/openai-go/v3/option"
-	"github.com/qjebbs/go-jsons"
 )
 
 // Coordinator errors.
@@ -666,7 +665,6 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 							"error", err,
 						)
 					}
-
 				}
 			}
 		}
@@ -947,16 +945,16 @@ func (c *coordinator) buildAgentModels(ctx context.Context, isSubAgent bool) (Mo
 	smallModel = newRequestTimeoutModel(smallModel, requestTimeout)
 
 	return Model{
-			Model:      largeModel,
-			CatwalkCfg: *largeCatwalkModel,
-			ModelCfg:   largeModelCfg,
-			FlatRate:   largeProviderCfg.FlatRate,
-		}, Model{
-			Model:      smallModel,
-			CatwalkCfg: *smallCatwalkModel,
-			ModelCfg:   smallModelCfg,
-			FlatRate:   smallProviderCfg.FlatRate,
-		}, nil
+		Model:      largeModel,
+		CatwalkCfg: *largeCatwalkModel,
+		ModelCfg:   largeModelCfg,
+		FlatRate:   largeProviderCfg.FlatRate,
+	}, Model{
+		Model:      smallModel,
+		CatwalkCfg: *smallCatwalkModel,
+		ModelCfg:   smallModelCfg,
+		FlatRate:   smallProviderCfg.FlatRate,
+	}, nil
 }
 
 func (c *coordinator) buildAnthropicProvider(baseURL, apiKey string, headers map[string]string, providerID string) (fantasy.Provider, error) {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -947,16 +947,16 @@ func (c *coordinator) buildAgentModels(ctx context.Context, isSubAgent bool) (Mo
 	smallModel = newRequestTimeoutModel(smallModel, requestTimeout)
 
 	return Model{
-		Model:      largeModel,
-		CatwalkCfg: *largeCatwalkModel,
-		ModelCfg:   largeModelCfg,
-		FlatRate:   largeProviderCfg.FlatRate,
-	}, Model{
-		Model:      smallModel,
-		CatwalkCfg: *smallCatwalkModel,
-		ModelCfg:   smallModelCfg,
-		FlatRate:   smallProviderCfg.FlatRate,
-	}, nil
+			Model:      largeModel,
+			CatwalkCfg: *largeCatwalkModel,
+			ModelCfg:   largeModelCfg,
+			FlatRate:   largeProviderCfg.FlatRate,
+		}, Model{
+			Model:      smallModel,
+			CatwalkCfg: *smallCatwalkModel,
+			ModelCfg:   smallModelCfg,
+			FlatRate:   smallProviderCfg.FlatRate,
+		}, nil
 }
 
 func (c *coordinator) buildAnthropicProvider(baseURL, apiKey string, headers map[string]string, providerID string) (fantasy.Provider, error) {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -653,9 +653,9 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 						"error", err,
 					)
 
-					fallbackMergeOptions := make(map[string]any)
-					fallbackMergeOptions["extra_body"] = make(map[string]any)
-					fallbackMergeOptions["extra_body"].(map[string]any)["top_k"] = *topK
+					fallbackMergeOptions := map[string]any{
+						"extra_body": map[string]any{"top_k": *topK},
+					}
 					parsed, err := openaicompat.ParseOptions(fallbackMergeOptions)
 					if err == nil {
 						options[openaicompat.Name] = parsed

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -630,7 +630,8 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 		if discover.IsKnownCustomProvider(string(providerCfg.Type)) {
 			// Set "top_k" under "extra_body", as it is not part of the OpenAI protocol
 			// and will be explicitly omitted by Fantasy downstream.
-			if topK := cmp.Or(model.ModelCfg.TopK, model.CatwalkCfg.Options.TopK); topK != nil {
+			topK := cmp.Or(model.ModelCfg.TopK, model.CatwalkCfg.Options.TopK)
+			if topK != nil {
 				extraBody, hasExtraBody := mergedOptions["extra_body"].(map[string]any)
 				if !hasExtraBody {
 					extraBody = make(map[string]any)
@@ -644,6 +645,21 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 			parsed, err := openaicompat.ParseOptions(mergedOptions)
 			if err == nil {
 				options[openaicompat.Name] = parsed
+			} else {
+				if topK != nil {
+					slog.Warn("Failed to parse provider_options, falling back to top_k only", "err", err)
+
+					fallbackMergeOptions := make(map[string]any)
+					fallbackMergeOptions["extra_body"] = make(map[string]any)
+					fallbackMergeOptions["extra_body"].(map[string]any)["top_k"] = topK
+					parsed, err := openaicompat.ParseOptions(fallbackMergeOptions)
+					if err == nil {
+						options[openaicompat.Name] = parsed
+					} else {
+						slog.Warn("Failed to parse fallback provider options, this should never happen", "err", err)
+					}
+
+				}
 			}
 		}
 	}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -626,8 +626,7 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 		}
 
 	default:
-		// Known custom providers (litellm, llamacpp, lmstudio, ollama, omlx) are
-		// openai-compat under the hood.
+		// Known custom providers are openai-compat under the hood.
 		if discover.IsKnownCustomProvider(string(providerCfg.Type)) {
 			// Set "top_k" under "extra_body", as it is not part of the OpenAI protocol
 			// and will be explicitly omitted by Fantasy downstream.

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -647,7 +647,11 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 				options[openaicompat.Name] = parsed
 			} else {
 				if topK != nil {
-					slog.Warn("Failed to parse provider_options, falling back to top_k only", "err", err)
+					slog.Warn(
+						"Failed to parse provider_options, falling back to top_k only",
+						"provider", providerCfg.ID,
+						"error", err,
+					)
 
 					fallbackMergeOptions := make(map[string]any)
 					fallbackMergeOptions["extra_body"] = make(map[string]any)
@@ -656,7 +660,11 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 					if err == nil {
 						options[openaicompat.Name] = parsed
 					} else {
-						slog.Warn("Failed to parse fallback provider options, this should never happen", "err", err)
+						slog.Warn(
+							"Failed to parse fallback provider options, this should never happen",
+							"provider", providerCfg.ID,
+							"error", err,
+						)
 					}
 
 				}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -1462,9 +1462,9 @@ type subAgentParams struct {
 }
 
 // callTopK returns topK for use on fantasy.Call.TopK, suppressing it for
-// known custom providers (litellm, ollama, omlx): getProviderOptions already
-// carries top_k for them via extra_body, and passing it here too makes
-// Fantasy emit a spurious "top_k unsupported" warning for every turn.
+// known custom providers: getProviderOptions already carries top_k for
+// them via extra_body, and passing it here too makes Fantasy emit a
+// spurious "top_k unsupported" warning for every turn.
 func callTopK(providerCfg config.ProviderConfig, topK *int64) *int64 {
 	if discover.IsKnownCustomProvider(string(providerCfg.Type)) {
 		return nil

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -331,7 +331,7 @@ func (c *coordinator) run(ctx context.Context, accept *AcceptedRun, sessionID st
 			ProviderOptions:  mergedOptions,
 			Temperature:      temp,
 			TopP:             topP,
-			TopK:             topK,
+			TopK:             callTopK(providerCfg, topK),
 			FrequencyPenalty: freqPenalty,
 			PresencePenalty:  presPenalty,
 			OnComplete:       onComplete,
@@ -626,9 +626,22 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 		}
 
 	default:
-		// Known custom providers (litellm, ollama, omlx) are
+		// Known custom providers (litellm, llamacpp, lmstudio, ollama, omlx) are
 		// openai-compat under the hood.
 		if discover.IsKnownCustomProvider(string(providerCfg.Type)) {
+			// Set "top_k" under "extra_body", as it is not part of the OpenAI protocol
+			// and will be explicitly omitted by Fantasy downstream.
+			if topK := cmp.Or(model.ModelCfg.TopK, model.CatwalkCfg.Options.TopK); topK != nil {
+				extraBody, hasExtraBody := mergedOptions["extra_body"].(map[string]any)
+				if !hasExtraBody {
+					extraBody = make(map[string]any)
+					mergedOptions["extra_body"] = extraBody
+				}
+				if _, hasTopK := extraBody["top_k"]; !hasTopK {
+					extraBody["top_k"] = *topK
+				}
+			}
+
 			parsed, err := openaicompat.ParseOptions(mergedOptions)
 			if err == nil {
 				options[openaicompat.Name] = parsed
@@ -911,16 +924,16 @@ func (c *coordinator) buildAgentModels(ctx context.Context, isSubAgent bool) (Mo
 	smallModel = newRequestTimeoutModel(smallModel, requestTimeout)
 
 	return Model{
-			Model:      largeModel,
-			CatwalkCfg: *largeCatwalkModel,
-			ModelCfg:   largeModelCfg,
-			FlatRate:   largeProviderCfg.FlatRate,
-		}, Model{
-			Model:      smallModel,
-			CatwalkCfg: *smallCatwalkModel,
-			ModelCfg:   smallModelCfg,
-			FlatRate:   smallProviderCfg.FlatRate,
-		}, nil
+		Model:      largeModel,
+		CatwalkCfg: *largeCatwalkModel,
+		ModelCfg:   largeModelCfg,
+		FlatRate:   largeProviderCfg.FlatRate,
+	}, Model{
+		Model:      smallModel,
+		CatwalkCfg: *smallCatwalkModel,
+		ModelCfg:   smallModelCfg,
+		FlatRate:   smallProviderCfg.FlatRate,
+	}, nil
 }
 
 func (c *coordinator) buildAnthropicProvider(baseURL, apiKey string, headers map[string]string, providerID string) (fantasy.Provider, error) {
@@ -1449,6 +1462,17 @@ type subAgentParams struct {
 	SessionSetup func(sessionID string)
 }
 
+// callTopK returns topK for use on fantasy.Call.TopK, suppressing it for
+// known custom providers (litellm, ollama, omlx): getProviderOptions already
+// carries top_k for them via extra_body, and passing it here too makes
+// Fantasy emit a spurious "top_k unsupported" warning for every turn.
+func callTopK(providerCfg config.ProviderConfig, topK *int64) *int64 {
+	if discover.IsKnownCustomProvider(string(providerCfg.Type)) {
+		return nil
+	}
+	return topK
+}
+
 // runSubAgent runs a sub-agent and handles session management and cost accumulation.
 // It creates a sub-session, runs the agent with the given prompt, and propagates
 // the cost to the parent session.
@@ -1486,7 +1510,7 @@ func (c *coordinator) runSubAgent(ctx context.Context, params subAgentParams) (f
 			ProviderOptions:  getProviderOptions(model, providerCfg),
 			Temperature:      model.ModelCfg.Temperature,
 			TopP:             model.ModelCfg.TopP,
-			TopK:             model.ModelCfg.TopK,
+			TopK:             callTopK(providerCfg, model.ModelCfg.TopK),
 			FrequencyPenalty: model.ModelCfg.FrequencyPenalty,
 			PresencePenalty:  model.ModelCfg.PresencePenalty,
 			NonInteractive:   true,

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -51,6 +51,7 @@ import (
 	"charm.land/fantasy/providers/openrouter"
 	"charm.land/fantasy/providers/vercel"
 	openaisdk "github.com/openai/openai-go/v3/option"
+	"github.com/qjebbs/go-jsons"
 )
 
 // Coordinator errors.
@@ -945,16 +946,16 @@ func (c *coordinator) buildAgentModels(ctx context.Context, isSubAgent bool) (Mo
 	smallModel = newRequestTimeoutModel(smallModel, requestTimeout)
 
 	return Model{
-		Model:      largeModel,
-		CatwalkCfg: *largeCatwalkModel,
-		ModelCfg:   largeModelCfg,
-		FlatRate:   largeProviderCfg.FlatRate,
-	}, Model{
-		Model:      smallModel,
-		CatwalkCfg: *smallCatwalkModel,
-		ModelCfg:   smallModelCfg,
-		FlatRate:   smallProviderCfg.FlatRate,
-	}, nil
+			Model:      largeModel,
+			CatwalkCfg: *largeCatwalkModel,
+			ModelCfg:   largeModelCfg,
+			FlatRate:   largeProviderCfg.FlatRate,
+		}, Model{
+			Model:      smallModel,
+			CatwalkCfg: *smallCatwalkModel,
+			ModelCfg:   smallModelCfg,
+			FlatRate:   smallProviderCfg.FlatRate,
+		}, nil
 }
 
 func (c *coordinator) buildAnthropicProvider(baseURL, apiKey string, headers map[string]string, providerID string) (fantasy.Provider, error) {

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -687,6 +687,33 @@ func TestGetProviderOptionsTopKExtraBody(t *testing.T) {
 	})
 }
 
+func TestGetProviderOptionsMalformedFallback(t *testing.T) {
+	model := Model{
+		CatwalkCfg: catwalk.Model{ID: "llama3"},
+		ModelCfg: config.SelectedModel{
+			Provider:        "ollama",
+			TopK:            ptr(int64(40)),
+			ProviderOptions: map[string]any{"user": 5.0},
+		},
+	}
+	providerCfg := config.ProviderConfig{ID: "test", Type: "ollama"}
+
+	opts := getProviderOptions(model, providerCfg)
+
+	raw, ok := opts[openaicompat.Name]
+	require.True(t, ok, "malformed provider_options should still fall back to top_k")
+	parsed, ok := raw.(*openaicompat.ProviderOptions)
+	require.True(t, ok)
+
+	// The malformed fields are dropped; only the injected top_k survives.
+	assert.Nil(t, parsed.User)
+	assert.Nil(t, parsed.ReasoningEffort)
+	require.Len(t, parsed.ExtraBody, 1)
+	topK, ok := parsed.ExtraBody["top_k"].(int64)
+	require.True(t, ok)
+	assert.Equal(t, int64(40), topK)
+}
+
 func TestCallTopK(t *testing.T) {
 	knownCustomProviderCfg := config.ProviderConfig{ID: "ollama", Type: "ollama"}
 

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -592,7 +592,7 @@ func TestGetProviderOptionsReasoningEffortFallback(t *testing.T) {
 
 func TestGetProviderOptionsTopKExtraBody(t *testing.T) {
 	// "ollama" has a registered discover.Enricher, so it is treated as a
-	// known custom provider (litellm/ollama/omlx) speaking openai-compat.
+	// known custom provider speaking openai-compat.
 	knownCustomProviderCfg := config.ProviderConfig{ID: "ollama", Type: "ollama"}
 
 	t.Run("model top_k is injected into extra_body for known custom providers", func(t *testing.T) {

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -589,3 +589,144 @@ func TestGetProviderOptionsReasoningEffortFallback(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "enabled", thinking["type"])
 }
+
+func TestGetProviderOptionsTopKExtraBody(t *testing.T) {
+	// "ollama" has a registered discover.Enricher, so it is treated as a
+	// known custom provider (litellm/ollama/omlx) speaking openai-compat.
+	knownCustomProviderCfg := config.ProviderConfig{ID: "ollama", Type: "ollama"}
+
+	t.Run("model top_k is injected into extra_body for known custom providers", func(t *testing.T) {
+		model := Model{
+			CatwalkCfg: catwalk.Model{ID: "llama3"},
+			ModelCfg:   config.SelectedModel{Provider: "ollama", TopK: ptr(int64(40))},
+		}
+
+		opts := getProviderOptions(model, knownCustomProviderCfg)
+
+		raw, ok := opts[openaicompat.Name]
+		require.True(t, ok)
+		parsed, ok := raw.(*openaicompat.ProviderOptions)
+		require.True(t, ok)
+		topK, ok := parsed.ExtraBody["top_k"].(int64)
+		require.True(t, ok)
+		assert.Equal(t, int64(40), topK)
+	})
+
+	t.Run("falls back to catwalk top_k when the model config has none", func(t *testing.T) {
+		model := Model{
+			CatwalkCfg: catwalk.Model{
+				ID:      "llama3",
+				Options: catwalk.ModelOptions{TopK: ptr(int64(64))},
+			},
+			ModelCfg: config.SelectedModel{Provider: "ollama"},
+		}
+
+		opts := getProviderOptions(model, knownCustomProviderCfg)
+
+		raw, ok := opts[openaicompat.Name]
+		require.True(t, ok)
+		parsed, ok := raw.(*openaicompat.ProviderOptions)
+		require.True(t, ok)
+		topK, ok := parsed.ExtraBody["top_k"].(int64)
+		require.True(t, ok)
+		assert.Equal(t, int64(64), topK)
+	})
+
+	t.Run("does not set extra_body when no top_k is configured anywhere", func(t *testing.T) {
+		model := Model{
+			CatwalkCfg: catwalk.Model{ID: "llama3"},
+			ModelCfg:   config.SelectedModel{Provider: "ollama"},
+		}
+
+		opts := getProviderOptions(model, knownCustomProviderCfg)
+
+		raw, ok := opts[openaicompat.Name]
+		require.True(t, ok)
+		parsed, ok := raw.(*openaicompat.ProviderOptions)
+		require.True(t, ok)
+		_, hasTopK := parsed.ExtraBody["top_k"]
+		assert.False(t, hasTopK)
+	})
+
+	t.Run("does not overwrite an explicitly configured extra_body.top_k", func(t *testing.T) {
+		model := Model{
+			CatwalkCfg: catwalk.Model{ID: "llama3"},
+			ModelCfg: config.SelectedModel{
+				Provider: "ollama",
+				TopK:     ptr(int64(40)),
+				ProviderOptions: map[string]any{
+					"extra_body": map[string]any{"top_k": 7},
+				},
+			},
+		}
+
+		opts := getProviderOptions(model, knownCustomProviderCfg)
+
+		raw, ok := opts[openaicompat.Name]
+		require.True(t, ok)
+		parsed, ok := raw.(*openaicompat.ProviderOptions)
+		require.True(t, ok)
+		assert.EqualValues(t, 7, parsed.ExtraBody["top_k"])
+	})
+
+	t.Run("is not injected for providers outside the known-custom-provider default branch", func(t *testing.T) {
+		model := Model{
+			CatwalkCfg: catwalk.Model{ID: "glm-5.2"},
+			ModelCfg:   config.SelectedModel{Provider: "zai", TopK: ptr(int64(40))},
+		}
+		providerCfg := config.ProviderConfig{ID: string(catwalk.InferenceProviderZAI), Type: openaicompat.Name}
+
+		opts := getProviderOptions(model, providerCfg)
+
+		raw, ok := opts[openaicompat.Name]
+		require.True(t, ok)
+		parsed, ok := raw.(*openaicompat.ProviderOptions)
+		require.True(t, ok)
+		_, hasTopK := parsed.ExtraBody["top_k"]
+		assert.False(t, hasTopK)
+	})
+}
+
+func TestCallTopK(t *testing.T) {
+	knownCustomProviderCfg := config.ProviderConfig{ID: "ollama", Type: "ollama"}
+
+	tests := []struct {
+		name        string
+		providerCfg config.ProviderConfig
+		want        *int64
+	}{
+		{
+			name:        "suppressed for known custom providers",
+			providerCfg: knownCustomProviderCfg,
+			want:        nil,
+		},
+		{
+			name:        "passed through for openai-compat hosted providers",
+			providerCfg: config.ProviderConfig{ID: "zai", Type: openaicompat.Name},
+			want:        ptr(int64(40)),
+		},
+		{
+			name:        "passed through for anthropic",
+			providerCfg: config.ProviderConfig{ID: "anthropic", Type: catwalk.Type(anthropic.Name)},
+			want:        ptr(int64(40)),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := callTopK(tc.providerCfg, ptr(int64(40)))
+			if tc.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, *tc.want, *got)
+		})
+	}
+
+	t.Run("nil input stays nil regardless of provider", func(t *testing.T) {
+		assert.Nil(t, callTopK(knownCustomProviderCfg, nil))
+		assert.Nil(t, callTopK(config.ProviderConfig{Type: openaicompat.Name}, nil))
+	})
+}
+
+func ptr[T any](v T) *T { return &v }


### PR DESCRIPTION
Resolves https://github.com/charmbracelet/crush/issues/3729.

Note that while I have implemented the fix in the `default` branch of the `getProviderOptions` `switch` (which covers "known custom providers"- "lmstudio", "llamacpp", "ollama", etc) I am currently leaving the `openai-compat` type untouched, as I am assuming that is defined in its own branch for a reason, and perhaps should continue to conform to [OpenAI's protocol not supporting "topK"](https://github.com/charmbracelet/fantasy/blob/8a31daebf0dcd4a9a453d5de0c04497f6ecdf3fc/providers/openai/language_model.go#L262-L267). But let me know if this treatment should be applies to the `openai-compat` branch as well.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
