### PR TITLE
fix(config): resolve the provider cache through the global data dir

### DIFF
--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -19,7 +18,6 @@ import (
 	"charm.land/catwalk/pkg/embedded"
 	"github.com/charmbracelet/crush/internal/agent/hyper"
 	"github.com/charmbracelet/crush/internal/csync"
-	"github.com/charmbracelet/crush/internal/home"
 	"github.com/charmbracelet/x/etag"
 )
 
@@ -33,25 +31,10 @@ var (
 	providerErr  error
 )
 
-// file to cache provider data
+// file to cache provider data. It resolves through GlobalConfigData so the
+// catalog follows CRUSH_GLOBAL_DATA like the rest of the data directory.
 func cachePathFor(name string) string {
-	xdgDataHome := os.Getenv("XDG_DATA_HOME")
-	if xdgDataHome != "" {
-		return filepath.Join(xdgDataHome, appName, name+".json")
-	}
-
-	// return the path to the main data directory
-	// for windows, it should be in `%LOCALAPPDATA%/crush/`
-	// for linux and macOS, it should be in `$HOME/.local/share/crush/`
-	if runtime.GOOS == "windows" {
-		localAppData := os.Getenv("LOCALAPPDATA")
-		if localAppData == "" {
-			localAppData = filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Local")
-		}
-		return filepath.Join(localAppData, appName, name+".json")
-	}
-
-	return filepath.Join(home.Dir(), ".local", "share", appName, name+".json")
+	return filepath.Join(filepath.Dir(GlobalConfigData()), name+".json")
 }
 
 // UpdateProviders updates the Catwalk providers list from a specified source.

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -274,29 +274,37 @@ func TestCache_GetInvalidJSON(t *testing.T) {
 
 func TestCachePathFor(t *testing.T) {
 	tests := []struct {
-		name        string
-		xdgDataHome string
-		expected    string
+		name            string
+		crushGlobalData string
+		xdgDataHome     string
+		expected        string
 	}{
+		{
+			name:            "with CRUSH_GLOBAL_DATA",
+			crushGlobalData: "/scratch/data",
+			expected:        "/scratch/data/providers.json",
+		},
+		{
+			name:            "CRUSH_GLOBAL_DATA takes priority over XDG_DATA_HOME",
+			crushGlobalData: "/scratch/data",
+			xdgDataHome:     "/custom/data",
+			expected:        "/scratch/data/providers.json",
+		},
 		{
 			name:        "with XDG_DATA_HOME",
 			xdgDataHome: "/custom/data",
 			expected:    "/custom/data/crush/providers.json",
 		},
 		{
-			name:        "without XDG_DATA_HOME",
-			xdgDataHome: "",
-			expected:    "", // Will use platform-specific default.
+			name:     "without either",
+			expected: "", // Will use platform-specific default.
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.xdgDataHome != "" {
-				t.Setenv("XDG_DATA_HOME", tt.xdgDataHome)
-			} else {
-				t.Setenv("XDG_DATA_HOME", "")
-			}
+			t.Setenv("CRUSH_GLOBAL_DATA", tt.crushGlobalData)
+			t.Setenv("XDG_DATA_HOME", tt.xdgDataHome)
 
 			result := cachePathFor("providers")
 			if tt.expected != "" {


### PR DESCRIPTION
`CRUSH_GLOBAL_DATA` redirects the data directory, but the provider catalog ignores it. A run with the variable set writes `projects.json` into the scratch directory and still rewrites `providers.json` and `hyper.json` in the real one. Reported as #3530.

`cachePathFor` in `internal/config/provider.go` rebuilt the platform data directory itself. It read `XDG_DATA_HOME`, then the Windows default, then the Unix default, and never `CRUSH_GLOBAL_DATA`. `GlobalConfigData` in `internal/config/load.go` already resolves all four, and it is what the rest of the data directory uses.

The fix resolves the cache path through `GlobalConfigData` instead of rebuilding it. That removes 20 lines of duplicated platform logic. `runtime` and `home` were only used by that block, so the imports go too.

`cachePathFor` is the only place that builds these two paths. All four call sites go through it, so the catalog follows the override everywhere.

Paths do not change when `CRUSH_GLOBAL_DATA` is unset. `XDG_DATA_HOME=/custom/data` still gives `/custom/data/crush/providers.json`, and the Windows and Unix defaults resolve to the same directory `GlobalConfigData` returns. When both variables are set, `CRUSH_GLOBAL_DATA` now wins, which matches every other consumer.

`TestCachePathFor` gains two cases: the override on its own, and the override against `XDG_DATA_HOME`. Both fail when the fix is reverted. The two existing cases still pass, which is the check that nothing else moved.

`go build ./...` passes. `go test ./... -count=1` passes with no failures. `golangci-lint run` at the CI-pinned v2.13.1 reports 0 issues on `./internal/config/...`. `gofumpt -l` lists neither changed file.

Fixes #3530
