### PR TITLE
feat(provider): add OrcaRouter API key and PKCE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ That said, you can also set environment variables for preferred providers:
 | `HF_TOKEN`                  | Hugging Face Inference                             |
 | `CEREBRAS_API_KEY`          | Cerebras                                           |
 | `OPENROUTER_API_KEY`        | OpenRouter                                         |
+| `ORCAROUTER_API_KEY`        | OrcaRouter (API key)                               |
 | `IONET_API_KEY`             | io.net                                             |
 | `ALIBABA_SINGAPORE_API_KEY` | Alibaba (Singapore)                                |
 | `ALIBABA_US_API_KEY`        | Alibaba (United States)                            |
@@ -231,6 +232,19 @@ That said, you can also set environment variables for preferred providers:
 | `MOONSHOT_API_KEY`          | Moonshot                                           |
 
 [hyper]: https://hyper.charm.land
+
+OrcaRouter appears as two explicit choices in the model picker:
+
+- **OrcaRouter - API** accepts an existing API key or reads
+  `ORCAROUTER_API_KEY`.
+- **OrcaRouter - Auth** signs in through the browser using OAuth 2.0 with
+  PKCE. Crush stores the issued API key in its existing global configuration
+  and reuses it until it is revoked.
+
+The public defaults use `https://www.orcarouter.ai` for authentication and
+`https://api.orcarouter.ai/v1` for inference. Self-hosted installations can
+set `ORCA_BASE_URL`, or override the two origins independently with
+`ORCA_AUTH_BASE_URL` and `ORCA_API_BASE_URL`.
 
 Also note that Crush can support nearly any provider, including
 [Local Models](#local-models). For more info see

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -35,6 +35,7 @@ import (
 	"github.com/charmbracelet/crush/internal/message"
 	"github.com/charmbracelet/crush/internal/oauth"
 	"github.com/charmbracelet/crush/internal/oauth/copilot"
+	"github.com/charmbracelet/crush/internal/orcarouter"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/question"
@@ -1325,6 +1326,16 @@ func (c *coordinator) refreshTokenIfExpired(ctx context.Context, providerCfg con
 // user completes it (or the context is cancelled).
 func (c *coordinator) retryAfterUnauthorized(ctx context.Context, providerCfg config.ProviderConfig) error {
 	switch {
+	case providerCfg.ID == orcarouter.OAuthProviderID:
+		if c.notify == nil {
+			return errNoInteractiveAuth
+		}
+		slog.Info("OrcaRouter key was rejected, waiting for re-authentication", "provider", providerCfg.ID)
+		c.notify.Publish(pubsub.CreatedEvent, notify.Notification{
+			Type:       notify.TypeReAuthenticate,
+			ProviderID: providerCfg.ID,
+		})
+		return c.waitForInteractiveReauth(ctx, providerCfg.ID)
 	case providerCfg.OAuthToken != nil:
 		slog.Debug("Received 401. Refreshing token and retrying", "provider", providerCfg.ID)
 		if err := c.refreshOAuth2Token(ctx, providerCfg); err != nil {
@@ -1400,6 +1411,7 @@ func isUnauthorized(err error) bool {
 // nil if no refresh mechanism is configured for the provider.
 func (c *coordinator) makeAuthRefreshCallback(providerCfg config.ProviderConfig) func(context.Context, *fantasy.ProviderError) error {
 	if providerCfg.OAuthToken == nil &&
+		providerCfg.ID != orcarouter.OAuthProviderID &&
 		!strings.Contains(providerCfg.APIKeyTemplate, "$") &&
 		providerCfg.AWSAuthRefresh == "" {
 		return nil

--- a/internal/config/orcarouter.go
+++ b/internal/config/orcarouter.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/orcarouter"
+)
+
+type orcaRouterClient interface {
+	GetProviders(context.Context) ([]catwalk.Provider, error)
+}
+
+type realOrcaRouterClient struct{}
+
+func (realOrcaRouterClient) GetProviders(ctx context.Context) ([]catwalk.Provider, error) {
+	return orcarouter.FetchProviders(ctx)
+}
+
+var _ syncer[[]catwalk.Provider] = (*orcaRouterSync)(nil)
+
+type orcaRouterSync struct {
+	once       sync.Once
+	result     []catwalk.Provider
+	err        error
+	cache      cache[[]catwalk.Provider]
+	client     orcaRouterClient
+	autoupdate bool
+	init       atomic.Bool
+}
+
+func (s *orcaRouterSync) Init(client orcaRouterClient, path string, autoupdate bool) {
+	s.client = client
+	s.cache = newCache[[]catwalk.Provider](path)
+	s.autoupdate = autoupdate
+	s.init.Store(true)
+}
+
+func (s *orcaRouterSync) Get(ctx context.Context) ([]catwalk.Provider, error) {
+	if !s.init.Load() {
+		panic("called Get before Init")
+	}
+
+	s.once.Do(func() {
+		fallback, fallbackErr := orcarouter.Providers()
+		if fallbackErr != nil {
+			s.err = fallbackErr
+			return
+		}
+		if !s.autoupdate {
+			slog.Info("Using embedded OrcaRouter providers")
+			s.result = fallback
+			return
+		}
+
+		cached, _, cachedErr := s.cache.Get()
+		if len(cached) == 0 || cachedErr != nil {
+			cached = fallback
+		}
+		result, err := s.client.GetProviders(ctx)
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			slog.Warn("OrcaRouter providers not updated in time")
+			s.result = cached
+			return
+		}
+		if err != nil {
+			slog.Warn("Could not fetch OrcaRouter providers", "error", err)
+			s.result = cached
+			return
+		}
+		if len(result) == 0 {
+			s.result = cached
+			s.err = errors.New("empty OrcaRouter providers list")
+			return
+		}
+		s.result = result
+		s.err = s.cache.Store(result)
+	})
+	return s.result, s.err
+}

--- a/internal/config/provider.go
+++ b/internal/config/provider.go
@@ -147,8 +147,9 @@ func UpdateHyper(pathOrURL string) error {
 }
 
 var (
-	catwalkSyncer = &catwalkSync{}
-	hyperSyncer   = &hyperSync{}
+	catwalkSyncer    = &catwalkSync{}
+	hyperSyncer      = &hyperSync{}
+	orcaRouterSyncer = &orcaRouterSync{}
 )
 
 // Providers returns the list of providers, taking into account cached results
@@ -177,10 +178,11 @@ func Providers(cfg *Config, opts ...HyperTokenRefresher) ([]catwalk.Provider, er
 		ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 		defer cancel()
 
-		// Each goroutine owns its own error so the two can report
+		// Each goroutine owns its own error so all three can report
 		// independently without racing on a shared slice.
-		var catwalkErr, hyperErr error
+		var catwalkErr, hyperErr, orcaRouterErr error
 		var hyperProvider catwalk.Provider
+		var orcaRouterProviders []catwalk.Provider
 
 		wg.Go(func() {
 			if customProvidersOnly {
@@ -232,14 +234,44 @@ func Providers(cfg *Config, opts ...HyperTokenRefresher) ([]catwalk.Provider, er
 			hyperProvider = item
 		})
 
+		wg.Go(func() {
+			if customProvidersOnly {
+				return
+			}
+			orcaRouterSyncer.Init(
+				realOrcaRouterClient{},
+				cachePathFor("orcarouter"),
+				autoupdate,
+			)
+			items, err := orcaRouterSyncer.Get(ctx)
+			if err != nil {
+				orcaRouterErr = fmt.Errorf("Crush was unable to fetch updated information from OrcaRouter: %w", err) //nolint:staticcheck
+			}
+			orcaRouterProviders = items
+		})
+
 		wg.Wait()
 
-		if hyperProvider.ID != "" {
-			providerList = append([]catwalk.Provider{hyperProvider}, slices.Collect(providers.Seq())...)
-		} else {
-			providerList = slices.Collect(providers.Seq())
+		providerList = make([]catwalk.Provider, 0, 1+len(orcaRouterProviders)+providers.Len())
+		seen := make(map[catwalk.InferenceProvider]struct{})
+		appendUnique := func(provider catwalk.Provider) {
+			if provider.ID == "" {
+				return
+			}
+			if _, ok := seen[provider.ID]; ok {
+				return
+			}
+			seen[provider.ID] = struct{}{}
+			providerList = append(providerList, provider)
 		}
-		providerErr = errors.Join(catwalkErr, hyperErr)
+		appendUnique(hyperProvider)
+		for _, provider := range orcaRouterProviders {
+			appendUnique(provider)
+		}
+		for _, provider := range slices.Collect(providers.Seq()) {
+			appendUnique(provider)
+		}
+		providerErr = errors.Join(catwalkErr, hyperErr, orcaRouterErr)
 	})
 	return providerList, providerErr
 }

--- a/internal/config/provider_test.go
+++ b/internal/config/provider_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -19,6 +20,16 @@ func resetProviderState() {
 	providerErr = nil
 	catwalkSyncer = &catwalkSync{}
 	hyperSyncer = &hyperSync{}
+	orcaRouterSyncer = &orcaRouterSync{}
+}
+
+type mockOrcaRouterClient struct {
+	providers []catwalk.Provider
+	err       error
+}
+
+func (m *mockOrcaRouterClient) GetProviders(context.Context) ([]catwalk.Provider, error) {
+	return m.providers, m.err
 }
 
 func TestProviders_Integration_AutoUpdateDisabled(t *testing.T) {
@@ -339,6 +350,12 @@ func TestProviders_KeepsCatalogWhenCachingFails(t *testing.T) {
 			Models: []catwalk.Model{{ID: "hyper-1", Name: "Hyper Model"}},
 		},
 	}, unwritable, true)
+	orcaRouterSyncer.Init(&mockOrcaRouterClient{
+		providers: []catwalk.Provider{
+			{Name: "OrcaRouter - API", ID: "orcarouter"},
+			{Name: "OrcaRouter - Auth", ID: "orcarouter-oauth"},
+		},
+	}, unwritable, true)
 
 	catwalkProviders, catwalkErr := catwalkSyncer.Get(t.Context())
 	require.Error(t, catwalkErr, "cache write should fail")
@@ -347,14 +364,19 @@ func TestProviders_KeepsCatalogWhenCachingFails(t *testing.T) {
 	hyperProvider, hyperErr := hyperSyncer.Get(t.Context())
 	require.Error(t, hyperErr, "cache write should fail")
 	require.Equal(t, "Hyper", hyperProvider.Name)
+	orcaProviders, orcaErr := orcaRouterSyncer.Get(t.Context())
+	require.Error(t, orcaErr, "cache write should fail")
+	require.Len(t, orcaProviders, 2)
 
 	providers, err := Providers(&Config{Options: &Options{}})
 
 	// The failure is reported, but as a warning alongside a usable catalog.
 	require.Error(t, err)
-	require.Len(t, providers, 2)
+	require.Len(t, providers, 4)
 	require.Equal(t, catwalk.InferenceProvider("hyper"), providers[0].ID, "Hyper stays at the front")
-	require.Equal(t, catwalk.InferenceProvider("p1"), providers[1].ID)
+	require.Equal(t, catwalk.InferenceProvider("orcarouter"), providers[1].ID)
+	require.Equal(t, catwalk.InferenceProvider("orcarouter-oauth"), providers[2].ID)
+	require.Equal(t, catwalk.InferenceProvider("p1"), providers[3].ID)
 }
 
 // TestProviders_FallsBackToEmbeddedHyper checks that Hyper is still in the
@@ -373,15 +395,21 @@ func TestProviders_FallsBackToEmbeddedHyper(t *testing.T) {
 	hyperSyncer.Init(&mockHyperClient{
 		err: errors.New("network error"),
 	}, filepath.Join(tmpDir, "hyper.json"), true)
+	orcaRouterSyncer.Init(&mockOrcaRouterClient{
+		err: errors.New("network error"),
+	}, filepath.Join(tmpDir, "orcarouter.json"), true)
 
 	_, _ = catwalkSyncer.Get(t.Context())
 	_, _ = hyperSyncer.Get(t.Context())
+	_, _ = orcaRouterSyncer.Get(t.Context())
 
 	providers, err := Providers(&Config{Options: &Options{}})
 	require.NoError(t, err)
-	require.Len(t, providers, 2)
+	require.Len(t, providers, 4)
 	require.Equal(t, catwalk.InferenceProvider("hyper"), providers[0].ID)
 	require.NotEmpty(t, providers[0].Models, "the embedded Hyper provider carries models")
+	require.Equal(t, catwalk.InferenceProvider("orcarouter"), providers[1].ID)
+	require.NotEmpty(t, providers[1].Models, "the embedded OrcaRouter provider carries models")
 }
 
 // TestProviders_HonorsDisableDefaultProviders makes sure the embedded Hyper

--- a/internal/orcarouter/oauth.go
+++ b/internal/orcarouter/oauth.go
@@ -1,0 +1,256 @@
+package orcarouter
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const authorizationLifetime = 10 * time.Minute
+
+// Authorization is one loopback OAuth 2.0 + PKCE attempt.
+type Authorization struct {
+	URL string
+
+	authBase string
+	verifier string
+	state    string
+	server   *http.Server
+	result   chan callbackResult
+	cancel   context.CancelFunc
+	once     sync.Once
+}
+
+type callbackResult struct {
+	code string
+	err  error
+}
+
+// StartAuthorization creates a fresh S256 verifier and starts a loopback
+// callback listener before returning the browser authorization URL.
+func StartAuthorization() (*Authorization, error) {
+	authBase, err := AuthBaseURL()
+	if err != nil {
+		return nil, err
+	}
+	verifier, err := randomBase64URL(32)
+	if err != nil {
+		return nil, fmt.Errorf("generate PKCE verifier: %w", err)
+	}
+	state, err := randomBase64URL(24)
+	if err != nil {
+		return nil, fmt.Errorf("generate OAuth state: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), authorizationLifetime)
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(ctx, "tcp4", "127.0.0.1:0")
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("start OrcaRouter callback listener: %w", err)
+	}
+	a := &Authorization{
+		authBase: authBase,
+		verifier: verifier,
+		state:    state,
+		result:   make(chan callbackResult, 1),
+		cancel:   cancel,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/callback", a.handleCallback)
+	a.server = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	callbackURL := "http://" + listener.Addr().String() + "/callback"
+	a.URL, err = authorizationURL(authBase, callbackURL, verifier, state)
+	if err != nil {
+		cancel()
+		_ = listener.Close()
+		return nil, err
+	}
+
+	go func() {
+		<-ctx.Done()
+		a.finish(callbackResult{err: ctx.Err()})
+		_ = a.server.Close()
+	}()
+	go func() {
+		if serveErr := a.server.Serve(listener); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			a.finish(callbackResult{err: fmt.Errorf("serve OrcaRouter callback: %w", serveErr)})
+		}
+	}()
+
+	return a, nil
+}
+
+func authorizationURL(authBase, callbackURL, verifier, state string) (string, error) {
+	u, err := url.Parse(authBase)
+	if err != nil {
+		return "", fmt.Errorf("parse OrcaRouter auth URL: %w", err)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/auth"
+	q := u.Query()
+	q.Set("callback_url", callbackURL)
+	challenge := sha256.Sum256([]byte(verifier))
+	q.Set("code_challenge", base64.RawURLEncoding.EncodeToString(challenge[:]))
+	q.Set("code_challenge_method", "S256")
+	q.Set("state", state)
+	q.Set("app_name", "Crush")
+	q.Set("scope", "api")
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func randomBase64URL(size int) (string, error) {
+	raw := make([]byte, size)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func (a *Authorization) handleCallback(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	if r.URL.Query().Get("state") != a.state {
+		writeCallbackPage(w, http.StatusBadRequest, "Authorization could not be verified. You can close this tab.")
+		a.finish(callbackResult{err: errors.New("OrcaRouter authorization state mismatch")})
+		return
+	}
+	if authError := r.URL.Query().Get("error"); authError != "" {
+		writeCallbackPage(w, http.StatusBadRequest, "Authorization was declined. You can close this tab.")
+		a.finish(callbackResult{err: fmt.Errorf("OrcaRouter authorization failed: %s", safeOAuthError(authError))})
+		return
+	}
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		writeCallbackPage(w, http.StatusBadRequest, "Authorization code was missing. You can close this tab.")
+		a.finish(callbackResult{err: errors.New("OrcaRouter authorization code was missing")})
+		return
+	}
+
+	writeCallbackPage(w, http.StatusOK, "Authorization received. Return to Crush to continue.")
+	a.finish(callbackResult{code: code})
+}
+
+func writeCallbackPage(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; script-src 'unsafe-inline'; base-uri 'none'; form-action 'none'")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, callbackPage(message, status == http.StatusOK))
+}
+
+func callbackPage(message string, closeWindow bool) string {
+	script := `history.replaceState(null, "", location.pathname);`
+	if closeWindow {
+		script += `window.setTimeout(function () { window.close(); }, 50);`
+	}
+	return "<!doctype html><html><head><meta charset=\"utf-8\"><title>Crush</title></head>" +
+		"<body><main><h1>Crush</h1><p>" + html.EscapeString(message) + "</p></main>" +
+		"<script>" + script + "</script></body></html>"
+}
+
+func safeOAuthError(value string) string {
+	for _, r := range value {
+		switch {
+		case r == '_', r == '-', r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		default:
+			return "authorization_error"
+		}
+	}
+	if value == "" {
+		return "authorization_error"
+	}
+	return value
+}
+
+func (a *Authorization) finish(result callbackResult) {
+	a.once.Do(func() {
+		a.result <- result
+		a.cancel()
+	})
+}
+
+// Wait waits for the callback and exchanges the one-time code for a durable
+// OrcaRouter API key.
+func (a *Authorization) Wait(ctx context.Context) (key, scope string, err error) {
+	select {
+	case result := <-a.result:
+		if result.err != nil {
+			return "", "", result.err
+		}
+		return a.exchange(ctx, result.code)
+	case <-ctx.Done():
+		return "", "", ctx.Err()
+	}
+}
+
+func (a *Authorization) exchange(ctx context.Context, code string) (string, string, error) {
+	payload, err := json.Marshal(map[string]string{
+		"code":                  code,
+		"code_verifier":         a.verifier,
+		"code_challenge_method": "S256",
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("encode OrcaRouter code exchange: %w", err)
+	}
+	u, err := url.Parse(a.authBase)
+	if err != nil {
+		return "", "", fmt.Errorf("parse OrcaRouter token URL: %w", err)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/api/v1/auth/keys"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(payload))
+	if err != nil {
+		return "", "", fmt.Errorf("create OrcaRouter code exchange: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("exchange OrcaRouter authorization code: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", "", errors.New("read OrcaRouter code exchange response")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("exchange OrcaRouter authorization code: %s", resp.Status)
+	}
+
+	var result struct {
+		Key   string `json:"key"`
+		Scope string `json:"scope"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil || result.Key == "" {
+		return "", "", errors.New("decode OrcaRouter code exchange response")
+	}
+	if result.Scope != "api" {
+		return "", "", errors.New("OrcaRouter authorization returned an unexpected scope")
+	}
+	return result.Key, result.Scope, nil
+}
+
+// Cancel releases the loopback listener and invalidates the attempt.
+func (a *Authorization) Cancel() {
+	a.finish(callbackResult{err: context.Canceled})
+	_ = a.server.Close()
+}

--- a/internal/orcarouter/oauth_test.go
+++ b/internal/orcarouter/oauth_test.go
@@ -1,0 +1,142 @@
+package orcarouter
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthorizationUsesS256AndExchangesAtAuthOrigin(t *testing.T) {
+	var exchanged struct {
+		Code                string `json:"code"`
+		Verifier            string `json:"code_verifier"`
+		CodeChallengeMethod string `json:"code_challenge_method"`
+	}
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/auth/keys", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&exchanged))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"key":"sk-orca-test","scope":"api"}`))
+	}))
+	defer authServer.Close()
+	t.Setenv("ORCA_AUTH_BASE_URL", authServer.URL)
+	t.Setenv("ORCA_BASE_URL", "")
+
+	authorization, err := StartAuthorization()
+	require.NoError(t, err)
+	defer authorization.Cancel()
+	authorizeURL, err := url.Parse(authorization.URL)
+	require.NoError(t, err)
+	require.Equal(t, authServer.URL+"/auth", authorizeURL.Scheme+"://"+authorizeURL.Host+authorizeURL.Path)
+	require.Equal(t, "S256", authorizeURL.Query().Get("code_challenge_method"))
+	require.Equal(t, "Crush", authorizeURL.Query().Get("app_name"))
+	require.Equal(t, "api", authorizeURL.Query().Get("scope"))
+	require.NotEmpty(t, authorizeURL.Query().Get("state"))
+	require.NotEmpty(t, authorizeURL.Query().Get("code_challenge"))
+	require.NotContains(t, authorization.URL, "code_verifier")
+
+	callbackURL, err := url.Parse(authorizeURL.Query().Get("callback_url"))
+	require.NoError(t, err)
+	q := callbackURL.Query()
+	q.Set("code", "one-time-code")
+	q.Set("state", authorizeURL.Query().Get("state"))
+	callbackURL.RawQuery = q.Encode()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, callbackURL.String(), nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	callbackBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "no-referrer", resp.Header.Get("Referrer-Policy"))
+	require.Contains(t, string(callbackBody), "history.replaceState")
+	require.Contains(t, string(callbackBody), "window.close()")
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	key, scope, err := authorization.Wait(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "sk-orca-test", key)
+	require.Equal(t, "api", scope)
+	require.Equal(t, "one-time-code", exchanged.Code)
+	require.Equal(t, "S256", exchanged.CodeChallengeMethod)
+	require.NotEmpty(t, exchanged.Verifier)
+	require.NotContains(t, authorization.URL, exchanged.Verifier)
+	digest := sha256.Sum256([]byte(exchanged.Verifier))
+	require.Equal(t, authorizeURL.Query().Get("code_challenge"), base64.RawURLEncoding.EncodeToString(digest[:]))
+}
+
+func TestAuthorizationRejectsMismatchedStateWithoutExchange(t *testing.T) {
+	exchanges := 0
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		exchanges++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer authServer.Close()
+	t.Setenv("ORCA_AUTH_BASE_URL", authServer.URL)
+	t.Setenv("ORCA_BASE_URL", "")
+
+	authorization, err := StartAuthorization()
+	require.NoError(t, err)
+	defer authorization.Cancel()
+	authorizeURL, err := url.Parse(authorization.URL)
+	require.NoError(t, err)
+	callbackURL, err := url.Parse(authorizeURL.Query().Get("callback_url"))
+	require.NoError(t, err)
+	q := callbackURL.Query()
+	q.Set("code", "must-not-be-exchanged")
+	q.Set("state", "wrong-state")
+	callbackURL.RawQuery = q.Encode()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, callbackURL.String(), nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	callbackBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.Contains(t, string(callbackBody), "history.replaceState")
+	require.NotContains(t, string(callbackBody), "window.close()")
+
+	_, _, err = authorization.Wait(t.Context())
+	require.ErrorContains(t, err, "state mismatch")
+	require.Zero(t, exchanges)
+}
+
+func TestAuthorizationCancelReleasesWaiter(t *testing.T) {
+	authServer := httptest.NewServer(http.NotFoundHandler())
+	defer authServer.Close()
+	t.Setenv("ORCA_AUTH_BASE_URL", authServer.URL)
+	t.Setenv("ORCA_BASE_URL", "")
+
+	authorization, err := StartAuthorization()
+	require.NoError(t, err)
+	authorization.Cancel()
+	_, _, err = authorization.Wait(t.Context())
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestSuccessfulCallbackPageAttemptsToCloseBrowser(t *testing.T) {
+	page := callbackPage("Authorization received. Return to Crush to continue.", true)
+	require.Contains(t, page, "history.replaceState")
+	require.Contains(t, page, "window.close()")
+}
+
+func TestFailedCallbackPageStaysOpenAndEscapesMessage(t *testing.T) {
+	page := callbackPage(`<script>alert("unsafe")</script>`, false)
+	require.Contains(t, page, "history.replaceState")
+	require.NotContains(t, page, "window.close()")
+	require.NotContains(t, page, `<script>alert("unsafe")</script>`)
+	require.Contains(t, page, `&lt;script&gt;alert(&#34;unsafe&#34;)&lt;/script&gt;`)
+}

--- a/internal/orcarouter/provider.go
+++ b/internal/orcarouter/provider.go
@@ -1,0 +1,287 @@
+// Package orcarouter contains the shared OrcaRouter provider and endpoint
+// definitions used by configuration and authentication.
+package orcarouter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"charm.land/catwalk/pkg/catwalk"
+)
+
+const (
+	// APIProviderID identifies the pasted API-key authentication choice.
+	APIProviderID = "orcarouter"
+	// OAuthProviderID identifies the OrcaRouter account-login choice.
+	OAuthProviderID = "orcarouter-oauth"
+
+	defaultAuthBaseURL = "https://www.orcarouter.ai"
+	defaultAPIBaseURL  = "https://api.orcarouter.ai/v1"
+	maxCatalogBytes    = 4 << 20
+	maxCatalogModels   = 1000
+)
+
+// AuthBaseURL returns the authorization origin. An explicit auth origin wins
+// over the shared self-hosted origin.
+func AuthBaseURL() (string, error) {
+	return baseURL("ORCA_AUTH_BASE_URL", defaultAuthBaseURL, false)
+}
+
+// APIBaseURL returns the OpenAI-compatible inference endpoint. An explicit
+// API endpoint wins over the shared self-hosted origin.
+func APIBaseURL() (string, error) {
+	return baseURL("ORCA_API_BASE_URL", defaultAPIBaseURL, true)
+}
+
+func baseURL(explicitEnv, fallback string, appendV1 bool) (string, error) {
+	raw := os.Getenv(explicitEnv)
+	if raw == "" {
+		raw = os.Getenv("ORCA_BASE_URL")
+	}
+	if raw == "" {
+		raw = fallback
+	}
+	raw = strings.TrimRight(raw, "/")
+
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return "", fmt.Errorf("invalid OrcaRouter base URL in %s", explicitEnv)
+	}
+	if u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("invalid OrcaRouter base URL in %s", explicitEnv)
+	}
+	if u.Scheme != "https" && (u.Scheme != "http" || !isLoopbackHost(u.Hostname())) {
+		return "", fmt.Errorf("OrcaRouter base URL in %s must use HTTPS unless it is loopback", explicitEnv)
+	}
+	if appendV1 && !strings.HasSuffix(u.Path, "/v1") {
+		u.Path = strings.TrimRight(u.Path, "/") + "/v1"
+	}
+	return strings.TrimRight(u.String(), "/"), nil
+}
+
+func isLoopbackHost(host string) bool {
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+// Providers returns the two explicit authentication choices with a verified
+// offline model seed.
+func Providers() ([]catwalk.Provider, error) {
+	apiBase, err := APIBaseURL()
+	if err != nil {
+		return nil, err
+	}
+	return providersWithModels(apiBase, fallbackModels()), nil
+}
+
+func providersWithModels(apiBase string, models []catwalk.Model) []catwalk.Provider {
+	return []catwalk.Provider{
+		{
+			Name:                "OrcaRouter - API",
+			ID:                  APIProviderID,
+			APIKey:              "$ORCAROUTER_API_KEY",
+			APIEndpoint:         apiBase,
+			Type:                catwalk.TypeOpenAICompat,
+			DefaultLargeModelID: "openai/gpt-5.5",
+			DefaultSmallModelID: "google/gemini-3.5-flash",
+			Models:              slices.Clone(models),
+		},
+		{
+			Name:                "OrcaRouter - Auth",
+			ID:                  OAuthProviderID,
+			APIEndpoint:         apiBase,
+			Type:                catwalk.TypeOpenAICompat,
+			DefaultLargeModelID: "openai/gpt-5.5",
+			DefaultSmallModelID: "google/gemini-3.5-flash",
+			Models:              slices.Clone(models),
+		},
+	}
+}
+
+// FetchProviders refreshes both authentication choices from OrcaRouter's
+// public OpenAI-compatible model catalog.
+func FetchProviders(ctx context.Context) ([]catwalk.Provider, error) {
+	apiBase, err := APIBaseURL()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiBase+"/models", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create OrcaRouter catalog request: %w", err)
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch OrcaRouter catalog: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch OrcaRouter catalog: %s", resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxCatalogBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read OrcaRouter catalog: %w", err)
+	}
+	if len(body) > maxCatalogBytes {
+		return nil, fmt.Errorf("read OrcaRouter catalog: response exceeds %d bytes", maxCatalogBytes)
+	}
+
+	var response catalogResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("decode OrcaRouter catalog: %w", err)
+	}
+	if len(response.Data) > maxCatalogModels {
+		return nil, fmt.Errorf("decode OrcaRouter catalog: response exceeds %d models", maxCatalogModels)
+	}
+
+	seeds := make(map[string]catwalk.Model)
+	for _, model := range fallbackModels() {
+		seeds[model.ID] = model
+	}
+
+	models := make([]catwalk.Model, 0, len(response.Data))
+	seen := make(map[string]struct{}, len(response.Data))
+	for _, item := range response.Data {
+		if !validCatalogItem(item) {
+			continue
+		}
+		if _, ok := seen[item.ID]; ok {
+			continue
+		}
+		seen[item.ID] = struct{}{}
+
+		model := seeds[item.ID]
+		model.ID = item.ID
+		model.Name = item.Name
+		if model.Name == "" {
+			model.Name = item.ID
+		}
+		if item.ContextLength > 0 {
+			model.ContextWindow = item.ContextLength
+		} else if item.TopProvider.ContextLength > 0 {
+			model.ContextWindow = item.TopProvider.ContextLength
+		}
+		if item.MaxCompletionTokens > 0 {
+			model.DefaultMaxTokens = item.MaxCompletionTokens
+		} else if item.TopProvider.MaxCompletionTokens > 0 {
+			model.DefaultMaxTokens = item.TopProvider.MaxCompletionTokens
+		}
+		model.SupportsImages = model.SupportsImages || slices.Contains(item.Architecture.InputModalities, "image")
+		model.CostPer1MIn = parsePrice(item.Pricing.PromptPerMillion, item.Pricing.Prompt)
+		model.CostPer1MOut = parsePrice(item.Pricing.CompletionPerMillion, item.Pricing.Completion)
+		models = append(models, model)
+	}
+	if len(models) == 0 {
+		return nil, fmt.Errorf("decode OrcaRouter catalog: no OpenAI-compatible models")
+	}
+
+	return providersWithModels(apiBase, models), nil
+}
+
+type catalogResponse struct {
+	Data []catalogItem `json:"data"`
+}
+
+type catalogItem struct {
+	ID                     string   `json:"id"`
+	Name                   string   `json:"name"`
+	Object                 string   `json:"object"`
+	ContextLength          int64    `json:"context_length"`
+	MaxCompletionTokens    int64    `json:"max_completion_tokens"`
+	SupportedEndpointTypes []string `json:"supported_endpoint_types"`
+	Architecture           struct {
+		InputModalities []string `json:"input_modalities"`
+	} `json:"architecture"`
+	TopProvider struct {
+		ContextLength       int64 `json:"context_length"`
+		MaxCompletionTokens int64 `json:"max_completion_tokens"`
+	} `json:"top_provider"`
+	Pricing struct {
+		Prompt               string `json:"prompt"`
+		Completion           string `json:"completion"`
+		PromptPerMillion     string `json:"prompt_per_million"`
+		CompletionPerMillion string `json:"completion_per_million"`
+	} `json:"pricing"`
+}
+
+func validCatalogItem(item catalogItem) bool {
+	return item.ID != "" && len(item.ID) <= 256 &&
+		(item.Object == "" || item.Object == "model") &&
+		slices.Contains(item.SupportedEndpointTypes, "openai")
+}
+
+func parsePrice(perMillion, perToken string) float64 {
+	if value, err := strconv.ParseFloat(perMillion, 64); err == nil {
+		return value
+	}
+	value, err := strconv.ParseFloat(perToken, 64)
+	if err != nil {
+		return 0
+	}
+	return value * 1_000_000
+}
+
+func fallbackModels() []catwalk.Model {
+	reasoningLevels := []string{"low", "medium", "high", "xhigh"}
+	return []catwalk.Model{
+		{
+			ID:                     "openai/gpt-5.5",
+			Name:                   "OpenAI: GPT-5.5",
+			ContextWindow:          1_048_576,
+			DefaultMaxTokens:       128_000,
+			CanReason:              true,
+			ReasoningLevels:        slices.Clone(reasoningLevels),
+			DefaultReasoningEffort: "medium",
+			SupportsImages:         true,
+		},
+		{
+			ID:                     "anthropic/claude-opus-4.8",
+			Name:                   "Anthropic: Claude Opus 4.8",
+			ContextWindow:          1_000_000,
+			DefaultMaxTokens:       128_000,
+			CanReason:              true,
+			ReasoningLevels:        slices.Clone(reasoningLevels),
+			DefaultReasoningEffort: "medium",
+			SupportsImages:         true,
+		},
+		{
+			ID:                     "google/gemini-3.5-flash",
+			Name:                   "Google: Gemini 3.5 Flash",
+			ContextWindow:          1_048_576,
+			DefaultMaxTokens:       65_536,
+			CanReason:              true,
+			ReasoningLevels:        slices.Clone(reasoningLevels),
+			DefaultReasoningEffort: "medium",
+			SupportsImages:         true,
+		},
+		{
+			ID:                     "deepseek/deepseek-v4-pro",
+			Name:                   "DeepSeek: DeepSeek V4 Pro",
+			ContextWindow:          1_048_576,
+			DefaultMaxTokens:       384_000,
+			CanReason:              true,
+			ReasoningLevels:        slices.Clone(reasoningLevels),
+			DefaultReasoningEffort: "medium",
+		},
+		{
+			ID:                     "orcarouter/auto",
+			Name:                   "OrcaRouter Auto",
+			ContextWindow:          1_000_000,
+			DefaultMaxTokens:       64_000,
+			CanReason:              true,
+			ReasoningLevels:        slices.Clone(reasoningLevels),
+			DefaultReasoningEffort: "medium",
+			SupportsImages:         true,
+		},
+	}
+}

--- a/internal/orcarouter/provider_test.go
+++ b/internal/orcarouter/provider_test.go
@@ -1,0 +1,88 @@
+package orcarouter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvidersExposeSeparateAuthenticationChoices(t *testing.T) {
+	t.Setenv("ORCA_BASE_URL", "")
+	t.Setenv("ORCA_API_BASE_URL", "")
+
+	providers, err := Providers()
+	require.NoError(t, err)
+	require.Len(t, providers, 2)
+	require.Equal(t, APIProviderID, string(providers[0].ID))
+	require.Equal(t, "$ORCAROUTER_API_KEY", providers[0].APIKey)
+	require.Equal(t, OAuthProviderID, string(providers[1].ID))
+	require.Empty(t, providers[1].APIKey)
+	require.Equal(t, defaultAPIBaseURL, providers[0].APIEndpoint)
+	require.Equal(t, providers[0].APIEndpoint, providers[1].APIEndpoint)
+	require.NotEmpty(t, providers[0].Models)
+	require.Equal(t, providers[0].Models, providers[1].Models)
+}
+
+func TestFetchProvidersBoundsAndFiltersCatalog(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1/models", r.URL.Path)
+		require.Empty(t, r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`{
+			"data": [
+				{
+					"id": "openai/gpt-5.5",
+					"name": "GPT-5.5 live",
+					"object": "model",
+					"supported_endpoint_types": ["openai"],
+					"architecture": {"input_modalities": ["text", "image"]},
+					"top_provider": {"context_length": 1000, "max_completion_tokens": 200},
+					"pricing": {"prompt": "0.000002", "completion_per_million": "7"}
+				},
+				{"id": "anthropic-only", "object": "model", "supported_endpoint_types": ["anthropic"]},
+				{"id": "openai/gpt-5.5", "object": "model", "supported_endpoint_types": ["openai"]},
+				{"id": "", "object": "model", "supported_endpoint_types": ["openai"]}
+			]
+		}`))
+	}))
+	defer server.Close()
+	t.Setenv("ORCA_API_BASE_URL", server.URL)
+	t.Setenv("ORCA_BASE_URL", "")
+
+	providers, err := FetchProviders(t.Context())
+	require.NoError(t, err)
+	require.Len(t, providers, 2)
+	require.Len(t, providers[0].Models, 1)
+	model := providers[0].Models[0]
+	require.Equal(t, "openai/gpt-5.5", model.ID)
+	require.Equal(t, "GPT-5.5 live", model.Name)
+	require.Equal(t, int64(1000), model.ContextWindow)
+	require.Equal(t, int64(200), model.DefaultMaxTokens)
+	require.Equal(t, 2.0, model.CostPer1MIn)
+	require.Equal(t, 7.0, model.CostPer1MOut)
+	require.True(t, model.CanReason, "verified fallback metadata is preserved")
+	require.True(t, model.SupportsImages)
+}
+
+func TestBaseURLOverridesAreIndependentAndSecure(t *testing.T) {
+	t.Setenv("ORCA_BASE_URL", "https://shared.example/prefix")
+	t.Setenv("ORCA_AUTH_BASE_URL", "https://auth.example")
+	t.Setenv("ORCA_API_BASE_URL", "https://api.example/custom/v1")
+
+	authBase, err := AuthBaseURL()
+	require.NoError(t, err)
+	require.Equal(t, "https://auth.example", authBase)
+	apiBase, err := APIBaseURL()
+	require.NoError(t, err)
+	require.Equal(t, "https://api.example/custom/v1", apiBase)
+
+	t.Setenv("ORCA_AUTH_BASE_URL", "http://remote.example")
+	_, err = AuthBaseURL()
+	require.ErrorContains(t, err, "must use HTTPS")
+
+	t.Setenv("ORCA_AUTH_BASE_URL", "http://127.0.0.1:8080")
+	authBase, err = AuthBaseURL()
+	require.NoError(t, err)
+	require.Equal(t, "http://127.0.0.1:8080", authBase)
+}

--- a/internal/ui/dialog/actions.go
+++ b/internal/ui/dialog/actions.go
@@ -21,7 +21,9 @@ import (
 )
 
 // ActionClose is a message to close the current dialog.
-type ActionClose struct{}
+type ActionClose struct {
+	Cmd tea.Cmd
+}
 
 // ActionQuit is a message to quit the application.
 type ActionQuit = tea.QuitMsg
@@ -134,6 +136,7 @@ type (
 	// ActionInitiateOAuth is sent when the device auth is initiated
 	// successfully.
 	ActionInitiateOAuth struct {
+		AttemptID       uint64
 		DeviceCode      string
 		UserCode        string
 		ExpiresIn       int
@@ -143,12 +146,16 @@ type (
 
 	// ActionCompleteOAuth is sent when the device flow completes successfully.
 	ActionCompleteOAuth struct {
-		Token *oauth.Token
+		AttemptID uint64
+		Token     *oauth.Token
+		APIKey    string
+		Scope     string
 	}
 
 	// ActionOAuthErrored is sent when the device flow encounters an error.
 	ActionOAuthErrored struct {
-		Error error
+		AttemptID uint64
+		Error     error
 	}
 )
 

--- a/internal/ui/dialog/oauth.go
+++ b/internal/ui/dialog/oauth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
@@ -68,8 +69,13 @@ type OAuth struct {
 	expiresIn       int
 	interval        int
 	token           *oauth.Token
+	apiKey          string
+	grantedScope    string
+	attemptID       uint64
 	cancelFunc      context.CancelFunc
 }
+
+var oauthAttemptID atomic.Uint64
 
 var _ Dialog = (*OAuth)(nil)
 
@@ -91,6 +97,7 @@ func newOAuth(
 	m.model = model
 	m.modelType = modelType
 	m.oAuthProvider = oAuthProvider
+	m.attemptID = oauthAttemptID.Add(1)
 	m.width = 0 // Set dynamically in Draw().
 	m.State = OAuthStateInitializing
 
@@ -116,7 +123,29 @@ func newOAuth(
 	)
 	m.keyMap.Close = CloseKey
 
-	return &m, tea.Batch(m.spinner.Tick, m.oAuthProvider.initiateAuth)
+	return &m, tea.Batch(m.spinner.Tick, m.wrapOAuthCmd(m.oAuthProvider.initiateAuth))
+}
+
+func (m *OAuth) wrapOAuthCmd(cmd tea.Cmd) tea.Cmd {
+	if cmd == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		msg := cmd()
+		switch value := msg.(type) {
+		case ActionInitiateOAuth:
+			value.AttemptID = m.attemptID
+			return value
+		case ActionCompleteOAuth:
+			value.AttemptID = m.attemptID
+			return value
+		case ActionOAuthErrored:
+			value.AttemptID = m.attemptID
+			return value
+		default:
+			return msg
+		}
+	}
 }
 
 // ID implements Dialog.
@@ -171,20 +200,26 @@ func (m *OAuth) HandleMsg(msg tea.Msg) Action {
 				return nil
 
 			default:
-				return ActionClose{}
+				return ActionClose{Cmd: m.oAuthProvider.stopPolling}
 			}
 		}
 
 	case ActionInitiateOAuth:
+		if msg.AttemptID != m.attemptID {
+			return nil
+		}
 		m.deviceCode = msg.DeviceCode
 		m.userCode = msg.UserCode
 		m.expiresIn = msg.ExpiresIn
 		m.verificationURL = msg.VerificationURL
 		m.interval = msg.Interval
 		m.State = OAuthStateDisplay
-		return ActionCmd{m.oAuthProvider.startPolling(msg.DeviceCode, msg.ExpiresIn)}
+		return ActionCmd{m.wrapOAuthCmd(m.oAuthProvider.startPolling(msg.DeviceCode, msg.ExpiresIn))}
 
 	case ActionCompleteOAuth:
+		if msg.AttemptID != m.attemptID {
+			return nil
+		}
 		// The device flow finished and we have a token. Immediately
 		// persist it and fetch models in the background (this triggers a
 		// config reload that can take a few seconds), showing a spinner.
@@ -193,6 +228,8 @@ func (m *OAuth) HandleMsg(msg tea.Msg) Action {
 		// work behind a keypress.
 		m.State = OAuthStateSaving
 		m.token = msg.Token
+		m.apiKey = msg.APIKey
+		m.grantedScope = msg.Scope
 		return ActionCmd{tea.Batch(
 			m.oAuthProvider.stopPolling,
 			m.spinner.Tick,
@@ -200,6 +237,9 @@ func (m *OAuth) HandleMsg(msg tea.Msg) Action {
 		)}
 
 	case ActionOAuthErrored:
+		if msg.AttemptID != m.attemptID {
+			return nil
+		}
 		m.State = OAuthStateError
 		cmd := tea.Batch(m.oAuthProvider.stopPolling, util.ReportError(msg.Error))
 		return ActionCmd{cmd}
@@ -209,6 +249,8 @@ func (m *OAuth) HandleMsg(msg tea.Msg) Action {
 		// screen; the actual model selection happens when the user
 		// acknowledges it (fast, since the work is already done).
 		m.State = OAuthStateSuccess
+		m.apiKey = ""
+		m.token = nil
 		return nil
 
 	case oauthSaveErrMsg:
@@ -309,6 +351,26 @@ func (m *OAuth) innerDialogContent() string {
 			)
 
 	case OAuthStateDisplay:
+		if m.userCode == "" {
+			instructionText := instructionStyle.Render("Press ") +
+				enterKeyStyle.Render("enter") +
+				instructionStyle.Render(" to open the browser and authorize Crush.")
+			instructions := lipgloss.NewStyle().
+				Width(innerWidth).
+				Padding(0, 1).
+				Render(instructionText)
+			link := linkStyle.Hyperlink(m.verificationURL, "id=oauth-verify").Render(m.verificationURL)
+			url := statusTextStyle.
+				Width(innerWidth).
+				Padding(0, 1).
+				Render("Browser not opening? Copy this URL:\n" + link)
+			waiting := statusTextStyle.
+				Width(innerWidth).
+				Padding(0, 1).
+				Render(successStyle.Render(m.spinner.View()) + statusTextStyle.Render("Waiting for authorization..."))
+			return lipgloss.JoinVertical(lipgloss.Left, "", instructions, "", url, "", waiting, "")
+		}
+
 		// Render each text segment with its own style. Wrapping the
 		// whole concatenation in a single style would lose the text
 		// color after enterKeyStyle's reset code.
@@ -356,10 +418,14 @@ func (m *OAuth) innerDialogContent() string {
 		)
 
 	case OAuthStateSuccess:
+		message := "Authentication successful!"
+		if m.grantedScope != "" {
+			message = fmt.Sprintf("Authentication successful (scope: %s)!", m.grantedScope)
+		}
 		return successStyle.
 			Width(innerWidth).
 			Padding(1).
-			Render("Authentication successful!")
+			Render(message)
 
 	case OAuthStateSaving:
 		return lipgloss.NewStyle().
@@ -405,17 +471,16 @@ func (m *OAuth) ShortHelp() []key.Binding {
 		return nil
 
 	default:
-		return []key.Binding{
-			m.keyMap.Copy,
-			m.keyMap.CopyURL,
-			m.keyMap.Submit,
-			m.keyMap.Close,
+		result := []key.Binding{m.keyMap.CopyURL, m.keyMap.Submit, m.keyMap.Close}
+		if m.userCode != "" {
+			result = append([]key.Binding{m.keyMap.Copy}, result...)
 		}
+		return result
 	}
 }
 
 func (m *OAuth) copyCode() tea.Cmd {
-	if m.State != OAuthStateDisplay {
+	if m.State != OAuthStateDisplay || m.userCode == "" {
 		return nil
 	}
 	return common.CopyToClipboard(m.userCode, "Code copied to clipboard")
@@ -432,12 +497,20 @@ func (m *OAuth) copyCodeAndOpenURL() tea.Cmd {
 	if m.State != OAuthStateDisplay {
 		return nil
 	}
+	if m.userCode == "" {
+		return func() tea.Msg {
+			if err := browser.OpenURL(m.verificationURL); err != nil {
+				return ActionOAuthErrored{AttemptID: m.attemptID, Error: fmt.Errorf("failed to open browser: %w", err)}
+			}
+			return nil
+		}
+	}
 	return common.CopyToClipboardWithCallback(
 		m.userCode,
 		"Code copied and URL opened",
 		func() tea.Msg {
 			if err := browser.OpenURL(m.verificationURL); err != nil {
-				return ActionOAuthErrored{fmt.Errorf("failed to open browser: %w", err)}
+				return ActionOAuthErrored{AttemptID: m.attemptID, Error: fmt.Errorf("failed to open browser: %w", err)}
 			}
 			return nil
 		},
@@ -454,9 +527,17 @@ func (m *OAuth) saveCredential() tea.Cmd {
 		com      = m.com
 		provider = m.provider
 		token    = m.token
+		apiKey   = m.apiKey
 	)
 	return func() tea.Msg {
-		if err := com.Workspace.SetProviderAPIKey(config.ScopeGlobal, string(provider.ID), token); err != nil {
+		credential := any(token)
+		if apiKey != "" {
+			credential = apiKey
+		}
+		if credential == nil {
+			return oauthSaveErrMsg{err: fmt.Errorf("authentication returned no credential")}
+		}
+		if err := com.Workspace.SetProviderAPIKey(config.ScopeGlobal, string(provider.ID), credential); err != nil {
 			return oauthSaveErrMsg{err: fmt.Errorf("failed to save API key: %w", err)}
 		}
 		return oauthSaveDoneMsg{}

--- a/internal/ui/dialog/oauth_hyper.go
+++ b/internal/ui/dialog/oauth_hyper.go
@@ -47,7 +47,7 @@ func (m *OAuthHyper) initiateAuth() tea.Msg {
 	}
 
 	if err != nil {
-		return ActionOAuthErrored{fmt.Errorf("failed to initiate device auth: %w", err)}
+		return ActionOAuthErrored{Error: fmt.Errorf("failed to initiate device auth: %w", err)}
 	}
 
 	return ActionInitiateOAuth{
@@ -68,23 +68,23 @@ func (m *OAuthHyper) startPolling(deviceCode string, expiresIn int) tea.Cmd {
 			if ctx.Err() != nil {
 				return nil
 			}
-			return ActionOAuthErrored{err}
+			return ActionOAuthErrored{Error: err}
 		}
 
 		token, err := hyper.ExchangeToken(ctx, refreshToken)
 		if err != nil {
-			return ActionOAuthErrored{fmt.Errorf("token exchange failed: %w", err)}
+			return ActionOAuthErrored{Error: fmt.Errorf("token exchange failed: %w", err)}
 		}
 
 		introspect, err := hyper.IntrospectToken(ctx, token.AccessToken)
 		if err != nil {
-			return ActionOAuthErrored{fmt.Errorf("token introspection failed: %w", err)}
+			return ActionOAuthErrored{Error: fmt.Errorf("token introspection failed: %w", err)}
 		}
 		if !introspect.Active {
-			return ActionOAuthErrored{fmt.Errorf("access token is not active")}
+			return ActionOAuthErrored{Error: fmt.Errorf("access token is not active")}
 		}
 
-		return ActionCompleteOAuth{token}
+		return ActionCompleteOAuth{Token: token}
 	}
 }
 

--- a/internal/ui/dialog/oauth_orcarouter.go
+++ b/internal/ui/dialog/oauth_orcarouter.go
@@ -1,0 +1,84 @@
+package dialog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/orcarouter"
+	"github.com/charmbracelet/crush/internal/ui/common"
+)
+
+// NewOAuthOrcaRouter creates the OrcaRouter loopback PKCE dialog.
+func NewOAuthOrcaRouter(
+	com *common.Common,
+	isOnboarding bool,
+	provider catwalk.Provider,
+	model config.SelectedModel,
+	modelType config.SelectedModelType,
+) (*OAuth, tea.Cmd) {
+	return newOAuth(com, isOnboarding, provider, model, modelType, &OAuthOrcaRouter{})
+}
+
+// OAuthOrcaRouter adapts OrcaRouter's authorization-code flow to the shared
+// Crush OAuth dialog.
+type OAuthOrcaRouter struct {
+	mu            sync.Mutex
+	authorization *orcarouter.Authorization
+}
+
+var _ OAuthProvider = (*OAuthOrcaRouter)(nil)
+
+func (m *OAuthOrcaRouter) name() string {
+	return "OrcaRouter"
+}
+
+func (m *OAuthOrcaRouter) initiateAuth() tea.Msg {
+	authorization, err := orcarouter.StartAuthorization()
+	if err != nil {
+		return ActionOAuthErrored{Error: fmt.Errorf("failed to initiate OrcaRouter PKCE: %w", err)}
+	}
+	m.mu.Lock()
+	m.authorization = authorization
+	m.mu.Unlock()
+
+	return ActionInitiateOAuth{
+		ExpiresIn:       600,
+		VerificationURL: authorization.URL,
+	}
+}
+
+func (m *OAuthOrcaRouter) startPolling(_ string, _ int) tea.Cmd {
+	return func() tea.Msg {
+		m.mu.Lock()
+		authorization := m.authorization
+		m.mu.Unlock()
+		if authorization == nil {
+			return ActionOAuthErrored{Error: fmt.Errorf("OrcaRouter PKCE was not initialized")}
+		}
+
+		key, scope, err := authorization.Wait(context.Background())
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return ActionOAuthErrored{Error: err}
+		}
+		return ActionCompleteOAuth{APIKey: key, Scope: scope}
+	}
+}
+
+func (m *OAuthOrcaRouter) stopPolling() tea.Msg {
+	m.mu.Lock()
+	authorization := m.authorization
+	m.authorization = nil
+	m.mu.Unlock()
+	if authorization != nil {
+		authorization.Cancel()
+	}
+	return nil
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -41,6 +41,7 @@ import (
 	"github.com/charmbracelet/crush/internal/home"
 	"github.com/charmbracelet/crush/internal/lsp"
 	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/orcarouter"
 	"github.com/charmbracelet/crush/internal/permission"
 	"github.com/charmbracelet/crush/internal/pubsub"
 	"github.com/charmbracelet/crush/internal/question"
@@ -1880,6 +1881,9 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 	switch msg := action.(type) {
 	// Generic dialog messages
 	case dialog.ActionClose:
+		if msg.Cmd != nil {
+			cmds = append(cmds, msg.Cmd)
+		}
 		if isOnboarding && m.dialog.ContainsDialog(dialog.ModelsID) {
 			break
 		}
@@ -2396,6 +2400,8 @@ func (m *UI) openAuthenticationDialog(provider catwalk.Provider, model config.Se
 		dlg, cmd = dialog.NewOAuthHyper(m.com, isOnboarding, provider, model, modelType)
 	case catwalk.InferenceProviderCopilot:
 		dlg, cmd = dialog.NewOAuthCopilot(m.com, isOnboarding, provider, model, modelType)
+	case orcarouter.OAuthProviderID:
+		dlg, cmd = dialog.NewOAuthOrcaRouter(m.com, isOnboarding, provider, model, modelType)
 	default:
 		dlg, cmd = dialog.NewAPIKeyInput(m.com, isOnboarding, provider, model, modelType)
 	}


### PR DESCRIPTION
## Summary

- add explicit `OrcaRouter - API` and `OrcaRouter - Auth` choices to the model picker
- load the public model catalog from the OpenAI-compatible API with bounded responses, caching, and an embedded fallback
- implement OAuth 2.0 loopback PKCE with fresh S256 verifier/state values, durable API-key storage, cancellation, and interactive 401 reauthentication
- make shared OAuth dialogs ignore stale attempts and cancel listeners when dismissed
- scrub one-time callback parameters and attempt to close the successful callback tab, with a visible fallback when browser policy blocks closing

## Endpoints and security

- authentication and code exchange use `https://www.orcarouter.ai`
- model catalog and inference use `https://api.orcarouter.ai/v1`
- non-HTTPS overrides are rejected except for loopback development origins
- the PKCE verifier never leaves the local process; callback state and granted scope are validated before storing the key

## Testing

- `go test ./...`
- `go build ./...`
- `golangci-lint v2.13.2`: 0 issues
- `git diff --check`
- manual local verification of both provider choices and a successful browser PKCE flow (`scope: api`)
- live public model catalog check against `https://api.orcarouter.ai/v1/models`