### PR TITLE
feat(tui): paste text on right-click in editors

### DIFF
--- a/internal/ui/model/rightclick_paste_test.go
+++ b/internal/ui/model/rightclick_paste_test.go
@@ -1,0 +1,250 @@
+package model
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
+	"github.com/charmbracelet/crush/internal/ui/util"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClipboardText returns a clipboard reader stub with the given content.
+func fakeClipboardText(content string) func() ([]byte, error) {
+	return func() ([]byte, error) { return []byte(content), nil }
+}
+
+// rightClick builds a right-button mouse click at the given position.
+func rightClick(x, y int) tea.MouseClickMsg {
+	return tea.MouseClickMsg(tea.Mouse{X: x, Y: y, Button: uv.MouseRight})
+}
+
+// newPasteTestUI builds a chat UI with a computed layout and a stubbed
+// clipboard reader so tests never touch the real clipboard.
+func newPasteTestUI(t *testing.T, clipboardText string) *UI {
+	t.Helper()
+
+	u := newTestUI()
+	u.dialog = dialog.NewOverlay()
+	sty := u.com.Styles.Attachments
+	u.attachments = attachments.New(
+		attachments.NewRenderer(sty.Normal, sty.Deleting, sty.Image, sty.Text, sty.Skill, sty.Remove),
+		attachments.Keymap{},
+	)
+	u.readClipboardText = fakeClipboardText(clipboardText)
+	u.updateLayoutAndSize()
+	return u
+}
+
+// runMsg feeds a command result back through Update like Bubble Tea would.
+func runMsg(u *UI, msg tea.Msg) tea.Cmd {
+	_, cmd := u.Update(msg)
+	return cmd
+}
+
+func TestRightClickInEditorSchedulesPasteAndFocuses(t *testing.T) {
+	t.Parallel()
+
+	u := newPasteTestUI(t, "hello")
+	// Simulate focus elsewhere (e.g. chat output).
+	u.focus = uiFocusMain
+	u.textarea.Blur()
+
+	x := u.layout.editor.Min.X + 1
+	y := u.layout.editor.Min.Y + 1 // below the attachments row
+
+	_, cmd := u.Update(rightClick(x, y))
+	require.NotNil(t, cmd, "right-click in the editor must schedule the clipboard read")
+	require.Equal(t, uiFocusEditor, u.focus)
+	require.True(t, u.textarea.Focused(), "the textarea must be focused by the click")
+
+	// The command must read the clipboard and produce a tea.PasteMsg.
+	msg := cmd()
+	require.IsType(t, tea.PasteMsg{}, msg)
+	require.Equal(t, "hello", msg.(tea.PasteMsg).Content)
+}
+
+func TestRightClickPasteWorksOnLandingScreen(t *testing.T) {
+	t.Parallel()
+
+	u := newPasteTestUI(t, "hello")
+	u.state = uiLanding
+
+	_, cmd := u.Update(rightClick(u.layout.editor.Min.X+1, u.layout.editor.Min.Y+1))
+	require.NotNil(t, cmd, "right-click paste must also work on the landing screen")
+
+	runMsg(u, cmd())
+	require.Equal(t, "hello", u.textarea.Value())
+}
+
+func TestRightClickPasteFlowsThroughPasteMsgPath(t *testing.T) {
+	t.Parallel()
+
+	// CRLF must be normalized by handlePasteMsg, proving the clipboard
+	// content travels through tea.PasteMsg handling rather than being
+	// inserted directly into the textarea.
+	u := newPasteTestUI(t, "one\r\ntwo")
+
+	_, cmd := u.Update(rightClick(u.layout.editor.Min.X+1, u.layout.editor.Min.Y+1))
+	require.NotNil(t, cmd)
+
+	runMsg(u, cmd())
+	require.Equal(t, "one\ntwo", u.textarea.Value())
+}
+
+func TestRightClickInChatDoesNotPaste(t *testing.T) {
+	t.Parallel()
+
+	u := newPasteTestUI(t, "hello")
+
+	_, cmd := u.Update(rightClick(u.layout.main.Min.X+1, u.layout.main.Min.Y+1))
+	require.Nil(t, cmd, "right-click in chat output must not schedule a paste")
+	require.Empty(t, u.textarea.Value())
+}
+
+func TestRightClickInSidebarDoesNotPaste(t *testing.T) {
+	t.Parallel()
+
+	u := newPasteTestUI(t, "hello")
+
+	_, cmd := u.Update(rightClick(u.layout.sidebar.Min.X+1, u.layout.sidebar.Min.Y+1))
+	require.Nil(t, cmd, "right-click in the sidebar must not schedule a paste")
+	require.Empty(t, u.textarea.Value())
+}
+
+func TestRightClickOnAttachmentRemoveButtonDoesNotRemove(t *testing.T) {
+	t.Parallel()
+
+	u, removeX := newAttachmentClickTestUI(t)
+	u.readClipboardText = fakeClipboardText("hello")
+
+	_, cmd := u.Update(rightClick(u.layout.editor.Min.X+removeX, u.layout.editor.Min.Y))
+
+	require.Len(t, u.attachments.List(), 1, "right-click must not remove attachments")
+	if cmd != nil {
+		_, isPaste := cmd().(tea.PasteMsg)
+		require.False(t, isPaste, "right-click on an attachment chip must not paste")
+	}
+}
+
+func TestLeftClickInEditorIsNotPaste(t *testing.T) {
+	t.Parallel()
+
+	u := newPasteTestUI(t, "hello")
+
+	x := u.layout.editor.Min.X + 1
+	y := u.layout.editor.Min.Y + 1
+
+	_, cmd := u.Update(tea.MouseClickMsg(tea.Mouse{X: x, Y: y, Button: uv.MouseLeft}))
+	if cmd != nil {
+		_, isPaste := cmd().(tea.PasteMsg)
+		require.False(t, isPaste, "left-click must not produce a paste")
+	}
+	require.Empty(t, u.textarea.Value())
+	require.True(t, u.textareaMouseSelecting, "left-click still starts a selection gesture")
+}
+
+// stubPasteableInline is a minimal inline editor that accepts paste events.
+type stubPasteableInline struct {
+	dialog.InlineEditor
+	focused bool
+	pasted  []tea.PasteMsg
+}
+
+func (s *stubPasteableInline) SetFocused(focused bool) { s.focused = focused }
+func (s *stubPasteableInline) HandlePaste(msg tea.PasteMsg) tea.Cmd {
+	s.pasted = append(s.pasted, msg)
+	return nil
+}
+
+var _ dialog.PasteableEditor = (*stubPasteableInline)(nil)
+
+// stubPlainInline is a minimal inline editor without paste support.
+type stubPlainInline struct {
+	dialog.InlineEditor
+	focused bool
+}
+
+func (s *stubPlainInline) SetFocused(focused bool) { s.focused = focused }
+
+func TestRightClickPasteIntoPasteableInlineEditor(t *testing.T) {
+	t.Parallel()
+
+	u := newPasteTestUI(t, "inline")
+	inline := &stubPasteableInline{}
+	u.activeInline = inline
+	u.textarea.Blur() // production blurs the textarea while an inline editor is active
+
+	_, cmd := u.Update(rightClick(u.layout.editor.Min.X+1, u.layout.editor.Min.Y+1))
+	require.NotNil(t, cmd)
+	require.True(t, inline.focused, "the inline editor must be focused by the click")
+	require.False(t, u.textarea.Focused(), "the textarea must not steal focus from the inline editor")
+
+	runMsg(u, cmd())
+	require.Len(t, inline.pasted, 1)
+	require.Equal(t, "inline", inline.pasted[0].Content)
+	require.Empty(t, u.textarea.Value(), "the textarea must not receive the paste")
+}
+
+func TestRightClickNonPasteableInlineEditorDoesNotPaste(t *testing.T) {
+	t.Parallel()
+
+	u := newPasteTestUI(t, "hello")
+	inline := &stubPlainInline{}
+	u.activeInline = inline
+
+	_, cmd := u.Update(rightClick(u.layout.editor.Min.X+1, u.layout.editor.Min.Y+1))
+	require.Nil(t, cmd, "a non-pasteable inline editor must not receive text")
+	require.False(t, inline.focused, "a non-pasteable inline editor must not be focused by the click")
+	require.Empty(t, u.textarea.Value())
+}
+
+// pasteDialog is a dialog that records tea.PasteMsg deliveries.
+type pasteDialog struct {
+	pasted []tea.PasteMsg
+}
+
+func (*pasteDialog) ID() string { return "paste-dialog" }
+func (d *pasteDialog) HandleMsg(msg tea.Msg) dialog.Action {
+	if pm, ok := msg.(tea.PasteMsg); ok {
+		d.pasted = append(d.pasted, pm)
+	}
+	return nil
+}
+func (*pasteDialog) Draw(uv.Screen, uv.Rectangle) *tea.Cursor { return nil }
+
+var _ dialog.Dialog = (*pasteDialog)(nil)
+
+func TestRightClickWithDialogKeepsDialogRouting(t *testing.T) {
+	t.Parallel()
+
+	u := newPasteTestUI(t, "hello")
+	d := &pasteDialog{}
+	u.dialog.OpenDialog(d)
+
+	// Even over the editor area, an open dialog keeps event priority and
+	// the click is forwarded to it, not turned into a paste.
+	_, _ = u.Update(rightClick(u.layout.editor.Min.X+1, u.layout.editor.Min.Y+1))
+	require.Empty(t, d.pasted)
+	require.Empty(t, u.textarea.Value())
+
+	// The dialog still receives pastes through the ordinary path.
+	runMsg(u, tea.PasteMsg{Content: "via dialog"})
+	require.Len(t, d.pasted, 1)
+	require.Equal(t, "via dialog", d.pasted[0].Content)
+}
+
+func TestRightClickWithEmptyClipboardReportsError(t *testing.T) {
+	t.Parallel()
+
+	u := newPasteTestUI(t, "")
+
+	_, cmd := u.Update(rightClick(u.layout.editor.Min.X+1, u.layout.editor.Min.Y+1))
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	require.IsType(t, util.InfoMsg{}, msg, "an empty clipboard must surface the existing error feedback")
+	require.Empty(t, u.textarea.Value())
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -258,6 +258,11 @@ type UI struct {
 	// Draw call, used by the cursor positioning logic below.
 	inlineCursor *tea.Cursor
 
+	// readClipboardText reads text from the system clipboard. It is a
+	// field so tests can substitute a fake instead of touching the real
+	// clipboard.
+	readClipboardText func() ([]byte, error)
+
 	// Attachment list
 	attachments *attachments.Attachments
 
@@ -1030,6 +1035,18 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, cmd)
 			}
 			return m, tea.Batch(cmds...)
+		}
+
+		// An unmodified right-click is a paste request for the active
+		// editor, handled before the generic click routing below so it
+		// cannot activate buttons, remove attachments, change focus, or
+		// start a selection gesture. Right-clicks elsewhere fall through
+		// to the ordinary routing, which ignores non-left buttons.
+		if msg.Button == uv.MouseRight && msg.Mod == 0 {
+			if cmd := m.handleRightClickPaste(msg); cmd != nil {
+				cmds = append(cmds, cmd)
+				return m, tea.Batch(cmds...)
+			}
 		}
 
 		// Route clicks to inline editors that support mouse interaction.
@@ -4831,6 +4848,50 @@ func (m *UI) checkBangModeAfterPaste() {
 	m.setEditorPrompt(m.yoloModeCached())
 }
 
+// handleRightClickPaste treats an unmodified right mouse click as a
+// paste request when it lands on the text-editing surface: it focuses
+// the appropriate editor (the textarea, or the active inline editor if
+// it accepts paste events) and schedules the same clipboard-read command
+// used by the PasteText keybinding, so the resulting tea.PasteMsg flows
+// through the ordinary paste path.
+//
+// It returns nil for right-clicks anywhere else (chat, sidebar, the
+// attachment row, non-pasteable editors), leaving them to the ordinary
+// mouse routing, which ignores non-left buttons.
+func (m *UI) handleRightClickPaste(msg tea.MouseClickMsg) tea.Cmd {
+	if m.state != uiChat && m.state != uiLanding {
+		return nil
+	}
+
+	if m.activeInline != nil {
+		if _, ok := m.activeInline.(dialog.PasteableEditor); !ok || !image.Pt(msg.X, msg.Y).In(m.layout.editor) {
+			// No pasteable editor, or the click is outside the
+			// inline editor's rendered area.
+			return nil
+		}
+		m.focus = uiFocusEditor
+		m.activeInline.SetFocused(true)
+		m.sidebarScrollbarVisible = false
+		m.chat.Blur()
+		return m.pasteTextFromClipboard
+	}
+
+	// The textarea is rendered one row below the editor area's top;
+	// the first row holds the attachment chips (see forwardMouseToTextarea).
+	const attachmentsRow = 1
+	origin := image.Pt(m.layout.editor.Min.X, m.layout.editor.Min.Y+attachmentsRow)
+	area := image.Rectangle{Min: origin, Max: origin.Add(image.Pt(m.layout.editor.Dx(), m.textarea.Height()))}
+	if !image.Pt(msg.X, msg.Y).In(area) {
+		return nil
+	}
+
+	m.focus = uiFocusEditor
+	m.textarea.Focus()
+	m.sidebarScrollbarVisible = false
+	m.chat.Blur()
+	return m.pasteTextFromClipboard
+}
+
 // handlePasteMsg handles a paste message.
 func (m *UI) handlePasteMsg(msg tea.PasteMsg) tea.Cmd {
 	// Normalize \r\n before the textarea sanitizer sees it.
@@ -4953,7 +5014,11 @@ func (m *UI) handleFilePathPaste(path string) tea.Cmd {
 // pasteTextFromClipboard reads text from the system clipboard and returns a
 // tea.PasteMsg so it flows through the same paste logic as bracketed paste.
 func (m *UI) pasteTextFromClipboard() tea.Msg {
-	textData, err := clipboard.Read(clipboard.FormatText)
+	read := m.readClipboardText
+	if read == nil {
+		read = func() ([]byte, error) { return clipboard.Read(clipboard.FormatText) }
+	}
+	textData, err := read()
 	if err != nil || len(textData) == 0 {
 		return util.InfoMsg{
 			Type: util.InfoTypeError,


### PR DESCRIPTION
Fixes #1191

An unmodified right-click in the prompt/editor area now pastes clipboard text, using the same path as Ctrl+Shift+V. Right-clicking outside the editor (chat, sidebar, attachments) is a no-op. No new dependencies or config options.

Tested on Crush v0.92.0+ (nightly-3-g563d658b) in WSL2 (Debian stable) under Windows Terminal v1.24.11911.0.

Assisted-by: Kimi K3