### PR TITLE
fix(ui): align rename cursor under wide characters

### DIFF
--- a/internal/ui/dialog/sessions_item.go
+++ b/internal/ui/dialog/sessions_item.go
@@ -100,9 +100,29 @@ func (s *SessionItem) HandleInput(msg tea.Msg) tea.Cmd {
 	return cmd
 }
 
-// Cursor returns the cursor of the update title input
+// titleInputCursorX returns the column (in terminal cells) of the text
+// cursor inside the rename input. textinput positions the cursor by rune
+// count, which lands left of the actual column whenever wide (CJK) runes
+// precede it, so derive the column from the display width of the text
+// before the cursor.
+func titleInputCursorX(in textinput.Model) int {
+	runes := []rune(in.Value())
+	pos := min(in.Position(), len(runes))
+	x := ansi.StringWidth(string(runes[:pos]))
+	if w := in.Width(); w > 0 {
+		x = min(x, w)
+	}
+	return x
+}
+
+// Cursor returns the cursor of the update title input.
 func (s *SessionItem) Cursor() *tea.Cursor {
-	return s.updateTitleInput.Cursor()
+	cur := s.updateTitleInput.Cursor()
+	if cur == nil {
+		return nil
+	}
+	cur.X = titleInputCursorX(s.updateTitleInput)
+	return cur
 }
 
 // InfoText returns the secondary text shown on the right of the item.

--- a/internal/ui/dialog/sessions_item_test.go
+++ b/internal/ui/dialog/sessions_item_test.go
@@ -1,0 +1,42 @@
+package dialog
+
+import (
+	"testing"
+
+	"charm.land/bubbles/v2/textinput"
+)
+
+func TestTitleInputCursorX(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		value  string
+		cursor int
+		width  int
+		want   int
+	}{
+		{name: "ascii", value: "hello", cursor: 5, width: 0, want: 5},
+		{name: "cjk at end", value: "重命名对话abc", cursor: 8, width: 0, want: 13},
+		{name: "cjk mid", value: "重命名对话abc", cursor: 4, width: 0, want: 8},
+		{name: "cjk clamped", value: "重命名对话abc", cursor: 8, width: 10, want: 10},
+		{name: "empty", value: "", cursor: 0, width: 0, want: 0},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			in := textinput.New()
+			in.SetVirtualCursor(false)
+			in.SetValue(tt.value)
+			in.SetCursor(tt.cursor)
+			in.SetWidth(tt.width)
+
+			if got := titleInputCursorX(in); got != tt.want {
+				t.Fatalf("titleInputCursorX() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When renaming a session, the terminal cursor is misaligned when the title contains wide (CJK) characters such as Chinese.

## Cause
`bubbles/textinput` positions its real cursor by *rune count*, so the   cursor column equals the number of runes before the cursor plus the prompt   width. Wide characters occupy two terminal cells, so this underestimates   the true column. ASCII-only input is unaffected because rune count and   display width agree there.

## Fix
The rename input now derives the cursor column from the **display width**   of the text before the cursor (`titleInputCursorX`), clamped to the input   width when the text scrolls. ASCII input behaves exactly as before.

**Before:**

https://github.com/user-attachments/assets/1262c6f8-6cc2-40ef-a969-45a508b24dd0

**After:**

https://github.com/user-attachments/assets/b0720dc3-6e6e-4336-8a56-99a54bfbb5df

## Verification
Table-driven unit test `TestTitleInputCursorX` covers ASCII, CJK before   the cursor at start and end, over-width clamping, and empty input.