### PR TITLE
feat(ui): pressing space keeps the current title when renaming

### DIFF
--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -56,6 +56,7 @@ type Session struct {
 		Rename        key.Binding
 		ConfirmRename key.Binding
 		CancelRename  key.Binding
+		KeepTitle     key.Binding
 		ConfirmDelete key.Binding
 		CancelDelete  key.Binding
 		Close         key.Binding
@@ -127,6 +128,10 @@ func NewSessions(com *common.Common, selectedSessionID string) (*Session, error)
 	s.keyMap.CancelRename = key.NewBinding(
 		key.WithKeys("esc"),
 		key.WithHelp("esc", "cancel"),
+	)
+	s.keyMap.KeepTitle = key.NewBinding(
+		key.WithKeys("space"),
+		key.WithHelp("space", "keep current title"),
 	)
 	s.keyMap.ConfirmDelete = key.NewBinding(
 		key.WithKeys("y"),
@@ -461,7 +466,7 @@ func (s *Session) confirmRenameSession() Action {
 	}
 
 	newTitle := strings.TrimSpace(sessionItem.InputValue())
-	if newTitle == "" {
+	if newTitle == "" || newTitle == sessionItem.Session.Title {
 		return nil
 	}
 	session := sessionItem.Session
@@ -512,8 +517,9 @@ func (s *Session) ShortHelp() []key.Binding {
 		}
 	case sessionsModeUpdating:
 		return []key.Binding{
-			s.keyMap.ConfirmRename,
 			s.keyMap.CancelRename,
+			s.keyMap.KeepTitle,
+			s.keyMap.ConfirmRename,
 		}
 	default:
 		return []key.Binding{
@@ -545,8 +551,9 @@ func (s *Session) FullHelp() [][]key.Binding {
 		}
 	case sessionsModeUpdating:
 		slice = []key.Binding{
-			s.keyMap.ConfirmRename,
 			s.keyMap.CancelRename,
+			s.keyMap.KeepTitle,
+			s.keyMap.ConfirmRename,
 		}
 	}
 	for i := 0; i < len(slice); i += 4 {

--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -466,7 +466,7 @@ func (s *Session) confirmRenameSession() Action {
 	}
 
 	newTitle := strings.TrimSpace(sessionItem.InputValue())
-	if newTitle == "" || newTitle == sessionItem.Session.Title {
+	if newTitle == "" || newTitle == sessionItem.Title {
 		return nil
 	}
 	session := sessionItem.Session

--- a/internal/ui/dialog/sessions_item.go
+++ b/internal/ui/dialog/sessions_item.go
@@ -50,8 +50,13 @@ type SessionItem struct {
 	m                fuzzy.Match
 	cache            map[int]string
 	updateTitleInput textinput.Model
-	focused          bool
-	hideInfo         bool
+	// promoteOnSpace reports whether the current title is still shown only
+	// as a ghost placeholder. While set, a leading space keeps the title by
+	// promoting it to an editable value; typing any other character simply
+	// replaces the ghost with the typed text.
+	promoteOnSpace bool
+	focused        bool
+	hideInfo       bool
 }
 
 // Finished implements list.Item. Session items are render-stable
@@ -92,6 +97,20 @@ func (s *SessionItem) InputValue() string {
 
 // HandleInput forwards input message to the update title input
 func (s *SessionItem) HandleInput(msg tea.Msg) tea.Cmd {
+	keyMsg, ok := msg.(tea.KeyPressMsg)
+	if s.promoteOnSpace {
+		s.promoteOnSpace = false
+		// A leading space keeps the ghost title by promoting it to an
+		// editable value without inserting the space. Anything else simply
+		// types over the ghost title, which is still empty at this point.
+		if ok && keyMsg.Text == " " && s.Title != "" {
+			s.updateTitleInput.SetValue(s.Title)
+			if s.Versioned != nil {
+				s.Bump()
+			}
+			return nil
+		}
+	}
 	var cmd tea.Cmd
 	s.updateTitleInput, cmd = s.updateTitleInput.Update(msg)
 	if s.Versioned != nil {
@@ -147,7 +166,7 @@ func (s *SessionItem) Render(width int) string {
 			const cursorPadding = 1
 			inputWidth := max(0, width-styles.ItemFocused.GetHorizontalFrameSize()-cursorPadding)
 			s.updateTitleInput.SetWidth(inputWidth)
-			s.updateTitleInput.Placeholder = ansi.Truncate(s.Title, width, "…")
+			s.updateTitleInput.Placeholder = ansi.Truncate(s.Title, inputWidth, "…")
 			return styles.ItemFocused.Render(s.updateTitleInput.View())
 		}
 	}
@@ -264,6 +283,10 @@ func sessionItems(t *styles.Styles, mode sessionsMode, sessions ...session.Sessi
 			inputStyle := t.TextInput
 			inputStyle.Focused.Placeholder = t.Dialog.Sessions.RenamingPlaceholder
 			item.updateTitleInput.SetStyles(inputStyle)
+			// The current title starts out as a ghost placeholder. Typing
+			// any character replaces it; a leading space keeps it by
+			// promoting it to an editable value (see HandleInput).
+			item.promoteOnSpace = true
 			item.updateTitleInput.Focus()
 		}
 		items[i] = item


### PR DESCRIPTION
## Summary
When renaming a session (ctrl+s → ctrl+r), the input starts empty and the current title is only shown as a dim placeholder. You have to retype the whole name and cannot tweak part of the existing title.

This PR makes the title a **ghost placeholder** and lets you keep it as a   starting point:

- Typing any character still replaces the title in one step.  
- Pressing **space** first keeps the current title: the ghost text becomes editable with the cursor at the end, ready to append or edit part of the name.
- A hint, `space keep current title`, appears in the help bar next to `esc cancel`, since the shortcut is otherwise easy to miss.   
- Confirming an unchanged title no longer rewrites the session.

## Demo

https://github.com/user-attachments/assets/2636514c-b81a-42a0-a0b6-840ad47b526e

Close #3752