### PR TITLE
fix: do not upload images if vision is not supported

### DIFF
--- a/internal/ui/common/common.go
+++ b/internal/ui/common/common.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"image"
 	"os"
+	"slices"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/clipboard"
@@ -20,6 +22,15 @@ const MaxAttachmentSize = int64(5 * 1024 * 1024)
 
 // AllowedImageTypes defines the permitted image file types.
 var AllowedImageTypes = []string{".jpg", ".jpeg", ".png"}
+
+// IsImagePath reports whether the given path has one of the allowed image
+// file extensions.
+func IsImagePath(path string) bool {
+	lowerPath := strings.ToLower(path)
+	return slices.ContainsFunc(AllowedImageTypes, func(ext string) bool {
+		return strings.HasSuffix(lowerPath, ext)
+	})
+}
 
 // Common defines common UI options and configurations.
 type Common struct {

--- a/internal/ui/common/common_test.go
+++ b/internal/ui/common/common_test.go
@@ -1,0 +1,30 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsImagePath(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"image.png",
+		"image.jpg",
+		"image.jpeg",
+		"dir/IMAGE.PNG",
+		"/abs/path/to/photo.Jpeg",
+	} {
+		require.True(t, IsImagePath(path), "expected %q to be an image path", path)
+	}
+
+	for _, path := range []string{
+		"file.txt",
+		"image.gif",
+		"image.png.txt",
+		"",
+	} {
+		require.False(t, IsImagePath(path), "expected %q to not be an image path", path)
+	}
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -3989,6 +3989,10 @@ func (m *UI) insertFileCompletion(path string) tea.Cmd {
 	heightCmd := m.handleTextareaHeightChange(prevHeight)
 
 	fileCmd := func() tea.Msg {
+		if !m.currentModelSupportsImages() && common.IsImagePath(path) {
+			return util.NewWarnMsg("The current model does not support image attachments")
+		}
+
 		absPath, _ := filepath.Abs(path)
 
 		if m.hasSession() {
@@ -4064,6 +4068,10 @@ func (m *UI) insertMCPResourceCompletion(item completions.ResourceCompletionValu
 		}
 		if mimeType == "" {
 			mimeType = "text/plain"
+		}
+
+		if !m.currentModelSupportsImages() && strings.HasPrefix(mimeType, "image/") {
+			return util.NewWarnMsg("The current model does not support image attachments")
 		}
 
 		return message.Attachment{
@@ -4609,6 +4617,9 @@ func (m *UI) openSessionsDialog() tea.Cmd {
 
 // openFilesDialog opens the file picker dialog.
 func (m *UI) openFilesDialog() tea.Cmd {
+	if !m.currentModelSupportsImages() {
+		return util.ReportWarn("The current model does not support image attachments")
+	}
 	if m.dialog.ContainsDialog(dialog.FilePickerID) {
 		// Bring to front
 		m.dialog.BringToFront(dialog.FilePickerID)
@@ -4919,16 +4930,7 @@ func (m *UI) handlePasteMsg(msg tea.PasteMsg) tea.Cmd {
 			if _, err := os.Stat(path); os.IsNotExist(err) {
 				return false
 			}
-
-			lowerPath := strings.ToLower(path)
-			isValid := false
-			for _, ext := range common.AllowedImageTypes {
-				if strings.HasSuffix(lowerPath, ext) {
-					isValid = true
-					break
-				}
-			}
-			if !isValid {
+			if !common.IsImagePath(path) {
 				return false
 			}
 		}
@@ -4939,6 +4941,9 @@ func (m *UI) handlePasteMsg(msg tea.PasteMsg) tea.Cmd {
 		cmd := m.updateTextareaWithPrevHeight(msg, prevHeight)
 		m.checkBangModeAfterPaste()
 		return cmd
+	}
+	if !m.currentModelSupportsImages() {
+		return util.ReportWarn("The current model does not support image attachments")
 	}
 
 	var cmds []tea.Cmd
@@ -5012,6 +5017,9 @@ func (m *UI) pasteTextFromClipboard() tea.Msg {
 // creates an attachment. If no image data is found, it falls back to
 // interpreting clipboard text as a file path.
 func (m *UI) pasteImageFromClipboard() tea.Msg {
+	if !m.currentModelSupportsImages() {
+		return util.NewWarnMsg("The current model does not support image attachments")
+	}
 	imageData, err := clipboard.Read(clipboard.FormatImage)
 	if int64(len(imageData)) > common.MaxAttachmentSize {
 		return util.InfoMsg{
@@ -5040,15 +5048,7 @@ func (m *UI) pasteImageFromClipboard() tea.Msg {
 		return nil // Clipboard does not contain an image or valid file path
 	}
 
-	lowerPath := strings.ToLower(path)
-	isAllowed := false
-	for _, ext := range common.AllowedImageTypes {
-		if strings.HasSuffix(lowerPath, ext) {
-			isAllowed = true
-			break
-		}
-	}
-	if !isAllowed {
+	if !common.IsImagePath(path) {
 		return util.NewInfoMsg("File type is not a supported image format")
 	}
 


### PR DESCRIPTION
## What?

Now every image attachment is blocked up front. When the current model doesn't support images, trying to attach one (via paste, mention, MCP resource, or file picker) shows a clear warning: "The current model does not support image attachments", instead of silently accepting it. Keyboard shortcuts and menu entries for adding images were already hidden for these models

<img width="875" height="534" alt="image" src="https://github.com/user-attachments/assets/60f31499-6f35-4c19-8f33-8c72586935da" />


## Why?

Silent data loss is the worst kind of failure. A user who pastes a screenshot alongside a question like "what's wrong with this error?" gets no answer to their actual question, and no explanation of why. They may not even realize the image never made it to the model, leading to confusing conversations where the assistant seems to be ignoring context.