### PR TITLE
 [3737] Pass reasoning effort to "known custom providers" (which are OpenAI-compatible)

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -952,16 +952,16 @@ func (c *coordinator) buildAgentModels(ctx context.Context, isSubAgent bool) (Mo
 	smallModel = newRequestTimeoutModel(smallModel, requestTimeout)
 
 	return Model{
-		Model:      largeModel,
-		CatwalkCfg: *largeCatwalkModel,
-		ModelCfg:   largeModelCfg,
-		FlatRate:   largeProviderCfg.FlatRate,
-	}, Model{
-		Model:      smallModel,
-		CatwalkCfg: *smallCatwalkModel,
-		ModelCfg:   smallModelCfg,
-		FlatRate:   smallProviderCfg.FlatRate,
-	}, nil
+			Model:      largeModel,
+			CatwalkCfg: *largeCatwalkModel,
+			ModelCfg:   largeModelCfg,
+			FlatRate:   largeProviderCfg.FlatRate,
+		}, Model{
+			Model:      smallModel,
+			CatwalkCfg: *smallCatwalkModel,
+			ModelCfg:   smallModelCfg,
+			FlatRate:   smallProviderCfg.FlatRate,
+		}, nil
 }
 
 func (c *coordinator) buildAnthropicProvider(baseURL, apiKey string, headers map[string]string, providerID string) (fantasy.Provider, error) {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -385,6 +385,13 @@ func effectiveReasoningEffort(model Model) string {
 	return ""
 }
 
+func setOpenAiEffortIfNecessary(mergedOptions map[string]any, shouldSetEffort bool, reasoningEffort string) {
+	_, hasReasoningEffort := mergedOptions["reasoning_effort"]
+	if !hasReasoningEffort && shouldSetEffort {
+		mergedOptions["reasoning_effort"] = reasoningEffort
+	}
+}
+
 func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.ProviderOptions {
 	options := fantasy.ProviderOptions{}
 
@@ -440,10 +447,7 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 
 	switch providerCfg.Type {
 	case openai.Name, azure.Name:
-		_, hasReasoningEffort := mergedOptions["reasoning_effort"]
-		if !hasReasoningEffort && shouldSetEffort {
-			mergedOptions["reasoning_effort"] = reasoningEffort
-		}
+		setOpenAiEffortIfNecessary(mergedOptions, shouldSetEffort, reasoningEffort)
 		if openai.IsResponsesModel(model.CatwalkCfg.ID) {
 			if openai.IsResponsesReasoningModel(model.CatwalkCfg.ID) {
 				mergedOptions["reasoning_summary"] = "auto"
@@ -628,6 +632,8 @@ func getProviderOptions(model Model, providerCfg config.ProviderConfig) fantasy.
 	default:
 		// Known custom providers are openai-compat under the hood.
 		if discover.IsKnownCustomProvider(string(providerCfg.Type)) {
+			setOpenAiEffortIfNecessary(mergedOptions, shouldSetEffort, reasoningEffort)
+
 			// Set "top_k" under "extra_body", as it is not part of the OpenAI protocol
 			// and will be explicitly omitted by Fantasy downstream.
 			topK := cmp.Or(model.ModelCfg.TopK, model.CatwalkCfg.Options.TopK)
@@ -946,16 +952,16 @@ func (c *coordinator) buildAgentModels(ctx context.Context, isSubAgent bool) (Mo
 	smallModel = newRequestTimeoutModel(smallModel, requestTimeout)
 
 	return Model{
-			Model:      largeModel,
-			CatwalkCfg: *largeCatwalkModel,
-			ModelCfg:   largeModelCfg,
-			FlatRate:   largeProviderCfg.FlatRate,
-		}, Model{
-			Model:      smallModel,
-			CatwalkCfg: *smallCatwalkModel,
-			ModelCfg:   smallModelCfg,
-			FlatRate:   smallProviderCfg.FlatRate,
-		}, nil
+		Model:      largeModel,
+		CatwalkCfg: *largeCatwalkModel,
+		ModelCfg:   largeModelCfg,
+		FlatRate:   largeProviderCfg.FlatRate,
+	}, Model{
+		Model:      smallModel,
+		CatwalkCfg: *smallCatwalkModel,
+		ModelCfg:   smallModelCfg,
+		FlatRate:   smallProviderCfg.FlatRate,
+	}, nil
 }
 
 func (c *coordinator) buildAnthropicProvider(baseURL, apiKey string, headers map[string]string, providerID string) (fantasy.Provider, error) {

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -534,6 +534,68 @@ func TestGetProviderOptionsReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestSetOpenAiEffortIfNecessary(t *testing.T) {
+	t.Run("sets reasoning_effort when should set and not already present", func(t *testing.T) {
+		opts := map[string]any{}
+		setOpenAiEffortIfNecessary(opts, true, "high")
+		assert.Equal(t, "high", opts["reasoning_effort"])
+	})
+
+	t.Run("does not set reasoning_effort when shouldSetEffort is false", func(t *testing.T) {
+		opts := map[string]any{}
+		setOpenAiEffortIfNecessary(opts, false, "high")
+		_, ok := opts["reasoning_effort"]
+		assert.False(t, ok)
+	})
+
+	t.Run("does not overwrite an existing reasoning_effort", func(t *testing.T) {
+		opts := map[string]any{"reasoning_effort": "low"}
+		setOpenAiEffortIfNecessary(opts, true, "high")
+		assert.Equal(t, "low", opts["reasoning_effort"])
+	})
+}
+
+func TestGetProviderOptionsReasoningEffortKnownCustomProvider(t *testing.T) {
+	// litellm, ollama, and omlx are known custom providers that are
+	// openai-compat under the hood; they should get reasoning_effort
+	// injected the same way openai-compat providers do.
+	tests := []struct {
+		name         string
+		providerType catwalk.Type
+	}{
+		{"litellm honors reasoning_effort", catwalk.Type("litellm")},
+		{"llamacpp honors reasoning_effort", catwalk.Type("llamacpp")},
+		{"lmstudio honors reasoning_effort", catwalk.Type("lmstudio")},
+		{"ollama honors reasoning_effort", catwalk.Type("ollama")},
+		{"omlx honors reasoning_effort", catwalk.Type("omlx")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			model := Model{
+				CatwalkCfg: catwalk.Model{
+					ID:              "some-model",
+					CanReason:       true,
+					ReasoningLevels: []string{"high"},
+				},
+				ModelCfg: config.SelectedModel{
+					Provider:        "test",
+					ReasoningEffort: "high",
+				},
+			}
+			providerCfg := config.ProviderConfig{ID: "test", Type: tc.providerType}
+
+			opts := getProviderOptions(model, providerCfg)
+
+			raw, ok := opts[openaicompat.Name]
+			require.True(t, ok, "options should be keyed under openaicompat.Name for type %q", tc.providerType)
+			parsed, ok := raw.(*openaicompat.ProviderOptions)
+			require.True(t, ok)
+			require.NotNil(t, parsed.ReasoningEffort)
+			assert.Equal(t, "high", string(*parsed.ReasoningEffort))
+		})
+	}
+}
+
 func TestIsUnauthorized(t *testing.T) {
 	t.Run("nil error", func(t *testing.T) {
 		assert.False(t, isUnauthorized(nil))


### PR DESCRIPTION
This passes the user selected reasoning level/effort to all known custom providers (which are OpenAI-compatible), resolving https://github.com/charmbracelet/crush/issues/3737.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
