### PR TITLE
test(config): pin declared custom model id over catalog dated alias

### DIFF
--- a/internal/config/custom_model_id_load_test.go
+++ b/internal/config/custom_model_id_load_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"charm.land/catwalk/pkg/embedded"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadHonorsDeclaredCustomModelIDOverEmbeddedCatalog pins the #2649
+// crush.json shape end-to-end: with disable_provider_auto_update and a
+// declared short id that collides with the embedded catalog's dated default
+// small model, Load keeps the declared short id on the small slot and the
+// novel id on the large slot.
+func TestLoadHonorsDeclaredCustomModelIDOverEmbeddedCatalog(t *testing.T) {
+	const (
+		shortID = "claude-haiku-4-5"
+		datedID = "claude-haiku-4-5-20251001"
+		novelID = "my-truly-novel-model"
+	)
+
+	// Preconditions: the real embedded Anthropic catalog still ships the
+	// dated alias as default small. If that ever changes, this pin needs a
+	// fresh colliding pair rather than a silent pass.
+	var foundDated bool
+	for _, p := range embedded.GetAll() {
+		if string(p.ID) != "anthropic" {
+			continue
+		}
+		require.Equal(t, datedID, p.DefaultSmallModelID,
+			"embedded anthropic default small must still be the dated haiku alias")
+		for _, m := range p.Models {
+			if m.ID == datedID {
+				foundDated = true
+				break
+			}
+		}
+	}
+	require.True(t, foundDated, "embedded anthropic catalog must contain %s", datedID)
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "crush.json")
+	crushJSON := `{
+  "$schema": "https://charm.land/crush.json",
+  "options": { "disable_provider_auto_update": true },
+  "providers": {
+    "anthropic": {
+      "base_url": "https://proxy.example/anthropic",
+      "api_key": "test-key",
+      "models": [
+        {
+          "id": "claude-haiku-4-5",
+          "name": "Custom short haiku",
+          "cost_per_1m_in": 1,
+          "cost_per_1m_out": 5,
+          "cost_per_1m_in_cached": 1.25,
+          "cost_per_1m_out_cached": 0.1,
+          "context_window": 200000,
+          "default_max_tokens": 64000,
+          "can_reason": true,
+          "supports_attachments": true
+        },
+        {
+          "id": "my-truly-novel-model",
+          "name": "Novel",
+          "cost_per_1m_in": 1,
+          "cost_per_1m_out": 5,
+          "cost_per_1m_in_cached": 1.25,
+          "cost_per_1m_out_cached": 0.1,
+          "context_window": 200000,
+          "default_max_tokens": 64000,
+          "can_reason": true,
+          "supports_attachments": true
+        }
+      ]
+    }
+  },
+  "models": {
+    "large": { "model": "my-truly-novel-model", "provider": "anthropic" },
+    "small": { "model": "claude-haiku-4-5", "provider": "anthropic" }
+  }
+}`
+	require.NoError(t, os.WriteFile(configPath, []byte(crushJSON), 0o600))
+
+	t.Setenv("CRUSH_GLOBAL_CONFIG", dir)
+	t.Setenv("CRUSH_GLOBAL_DATA", dir)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	resetProviderState()
+	t.Cleanup(resetProviderState)
+
+	store, err := Load(dir, dir, false)
+	require.NoError(t, err)
+	cfg := store.Config()
+
+	small := cfg.Models[SelectedModelTypeSmall]
+	require.Equal(t, "anthropic", small.Provider)
+	require.Equal(t, shortID, small.Model, "declared short id must win over catalog dated alias")
+
+	large := cfg.Models[SelectedModelTypeLarge]
+	require.Equal(t, "anthropic", large.Provider)
+	require.Equal(t, novelID, large.Model, "novel id must pass through unchanged")
+
+	gotShort := cfg.GetModel("anthropic", shortID)
+	require.NotNil(t, gotShort)
+	require.Equal(t, shortID, gotShort.ID)
+	require.Equal(t, "Custom short haiku", gotShort.Name)
+
+	gotNovel := cfg.GetModel("anthropic", novelID)
+	require.NotNil(t, gotNovel)
+	require.Equal(t, novelID, gotNovel.ID)
+
+	// Dated catalog entry remains available under its own id; it must not
+	// replace the declared short id on either slot.
+	gotDated := cfg.GetModel("anthropic", datedID)
+	require.NotNil(t, gotDated, "catalog dated alias should still be mergeable by exact id")
+	require.Equal(t, datedID, gotDated.ID)
+	require.NotEqual(t, datedID, small.Model)
+	require.NotEqual(t, datedID, large.Model)
+}

--- a/internal/config/custom_model_id_test.go
+++ b/internal/config/custom_model_id_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/charmbracelet/crush/internal/env"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeclaredCustomModelIDWinsOverCatalogDatedAlias pins #2649:
+// when providers.<name>.models[] declares a short id that sits alongside a
+// catalog dated alias (e.g. claude-haiku-4-5 vs claude-haiku-4-5-20251001),
+// configureProviders keeps the declared entry first (exact-ID dedup) and
+// resolveSelectedModels retains the declared short id — it must not fall
+// back to the dated catalog default.
+func TestDeclaredCustomModelIDWinsOverCatalogDatedAlias(t *testing.T) {
+	const (
+		shortID = "claude-haiku-4-5"
+		datedID = "claude-haiku-4-5-20251001"
+		novelID = "my-truly-novel-model"
+	)
+
+	knownProviders := []catwalk.Provider{
+		{
+			ID:                  catwalk.InferenceProviderAnthropic,
+			Name:                "Anthropic",
+			APIKey:              "$ANTHROPIC_API_KEY",
+			APIEndpoint:         "https://api.anthropic.com/v1",
+			DefaultLargeModelID: "claude-opus-4-20250514",
+			DefaultSmallModelID: datedID,
+			Models: []catwalk.Model{
+				{ID: "claude-opus-4-20250514", Name: "Opus", DefaultMaxTokens: 32000},
+				{ID: datedID, Name: "Haiku dated", DefaultMaxTokens: 64000},
+			},
+		},
+	}
+
+	cfg := &Config{
+		Providers: csync.NewMap[string, ProviderConfig](),
+		Models: map[SelectedModelType]SelectedModel{
+			SelectedModelTypeLarge: {Provider: "anthropic", Model: novelID},
+			SelectedModelTypeSmall: {Provider: "anthropic", Model: shortID},
+		},
+	}
+	cfg.Providers.Set("anthropic", ProviderConfig{
+		APIKey:  "test-key",
+		BaseURL: "https://proxy.example/anthropic",
+		Models: []catwalk.Model{
+			{
+				ID:               shortID,
+				Name:             "Custom short haiku",
+				DefaultMaxTokens: 64000,
+			},
+			{
+				ID:               novelID,
+				Name:             "Novel",
+				DefaultMaxTokens: 64000,
+			},
+		},
+	})
+	cfg.setDefaults("/tmp", "")
+
+	envMap := env.NewFromMap(map[string]string{
+		"ANTHROPIC_API_KEY": "test-key",
+	})
+	resolver := NewShellVariableResolver(envMap)
+	err := cfg.configureProviders(context.Background(), testStore(cfg), envMap, resolver, knownProviders)
+	require.NoError(t, err)
+
+	pc, ok := cfg.Providers.Get("anthropic")
+	require.True(t, ok)
+	require.GreaterOrEqual(t, len(pc.Models), 2)
+
+	// Declared short id is first and exact-ID dedup does not collapse it into
+	// the dated catalog entry (they are distinct ids).
+	require.Equal(t, shortID, pc.Models[0].ID)
+	require.Equal(t, "Custom short haiku", pc.Models[0].Name)
+
+	var sawDated, sawNovel bool
+	for _, m := range pc.Models {
+		switch m.ID {
+		case datedID:
+			sawDated = true
+		case novelID:
+			sawNovel = true
+		}
+	}
+	require.True(t, sawDated, "catalog dated alias should still be present under its own id")
+	require.True(t, sawNovel, "novel declared id should pass through unchanged")
+
+	gotShort := cfg.GetModel("anthropic", shortID)
+	require.NotNil(t, gotShort, "declared short id must resolve")
+	require.Equal(t, shortID, gotShort.ID)
+	require.Equal(t, "Custom short haiku", gotShort.Name)
+
+	gotNovel := cfg.GetModel("anthropic", novelID)
+	require.NotNil(t, gotNovel)
+	require.Equal(t, novelID, gotNovel.ID)
+
+	resolved, err := resolveSelectedModels(cfg, knownProviders)
+	require.NoError(t, err)
+	require.False(t, resolved.SmallFallback, "short id must not fall back to catalog default")
+	require.False(t, resolved.LargeFallback, "novel id must not fall back")
+	require.Equal(t, shortID, resolved.Small.Model)
+	require.Equal(t, "anthropic", resolved.Small.Provider)
+	require.Equal(t, novelID, resolved.Large.Model)
+	require.Equal(t, "anthropic", resolved.Large.Provider)
+}


### PR DESCRIPTION
## Summary

Pins the #2649 expectation as regression tests only — production on `main` already keeps a user-declared `providers.<name>.models[]` id on the wire when it sits alongside an embedded catalog dated alias (exact-ID merge in `configureProviders`; `resolveSelectedModels` / `GetModel` look up by exact id).

- Declared colliding short id (e.g. `claude-haiku-4-5`) wins over catalog `claude-haiku-4-5-20251001`; small slot does not fall back to the dated default.
- Novel declared ids pass through unchanged.
- Full `config.Load` of the issue's `crush.json` shape against the real embedded catalog with `disable_provider_auto_update: true`.

No production change; fabricating one would be churn. These tests guard the merge + Load path so a future alias-expansion step cannot reintroduce the reported proxy 400.

Fixes #2649

## Test plan

- [x] `go test ./internal/config/ -run 'TestDeclaredCustomModelIDWinsOverCatalogDatedAlias|TestLoadHonorsDeclaredCustomModelIDOverEmbeddedCatalog'`
- [x] `go test ./internal/config/`
- [x] `go vet ./internal/config/`
- [ ] CI green on this PR