### PR TITLE
fix(tools): truncate sourcegraph results with TruncateOutput

### DIFF
--- a/internal/agent/tools/sourcegraph.go
+++ b/internal/agent/tools/sourcegraph.go
@@ -182,7 +182,7 @@ func formatSourcegraphResults(result map[string]any, contextWindow, maxResults i
 		formatSourcegraphResult(&buffer, i, res, contextWindow)
 	}
 
-	return buffer.String(), nil
+	return TruncateOutput(buffer.String()), nil
 }
 
 func writeSourcegraphErrors(buffer *strings.Builder, result map[string]any) bool {

--- a/internal/agent/tools/sourcegraph_test.go
+++ b/internal/agent/tools/sourcegraph_test.go
@@ -81,6 +81,44 @@ func TestFormatSourcegraphResultsRespectsCount(t *testing.T) {
 	require.NotContains(t, got, "owner/repo/second.go")
 }
 
+func TestFormatSourcegraphResultsTruncatesHugeFileContent(t *testing.T) {
+	t.Parallel()
+
+	huge := strings.Repeat("x", MaxOutputLength+1)
+	result := map[string]any{
+		"data": map[string]any{
+			"search": map[string]any{
+				"results": map[string]any{
+					"matchCount":  float64(1),
+					"resultCount": float64(1),
+					"results": []any{
+						map[string]any{
+							"__typename": "FileMatch",
+							"repository": map[string]any{"name": "owner/repo"},
+							"file": map[string]any{
+								"path":    "huge.go",
+								"content": "match\n" + huge,
+							},
+							"lineMatches": []any{
+								map[string]any{
+									"lineNumber": float64(1),
+									"preview":    "match",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := formatSourcegraphResults(result, 1, 10)
+	require.NoError(t, err)
+	require.Contains(t, got, "lines truncated]")
+	require.LessOrEqual(t, len(got), MaxOutputLength+128)
+	require.NotContains(t, got, huge)
+}
+
 func TestFormatSourcegraphResultsErrorsAndNoResults(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Cap Sourcegraph tool output with the existing `TruncateOutput` helper so one huge `file.content` cannot dump megabytes into the session.

## Why

Fixes #3733. `formatSourcegraphResults` reprinted whole file windows with no byte cap. bash already uses `MaxOutputLength=30000`; this path did not.

## What

- Run the joined Sourcegraph result string through `TruncateOutput` before `NewTextResponse`.
- Pin `TestFormatSourcegraphResultsTruncatesHugeFileContent`.
- No bash.go / fetch / MCP / StopWhen edits.

## Test

```
go test ./internal/agent/tools -run TestFormatSourcegraph
go test ./internal/agent/tools
```
