### PR TITLE
ui-perf: memoize rendered frames for scroll-only updates

### DIFF
--- a/internal/ui/list/list.go
+++ b/internal/ui/list/list.go
@@ -226,6 +226,28 @@ func (l *List) Overflows(height int) bool {
 	return false
 }
 
+// ItemsVersion folds every item's version into one number. It changes
+// whenever any item in this list mutates in a way that affects its rendered
+// output, since that is exactly the contract [Versioned.Bump] carries.
+//
+// It reads one field per item and renders nothing, so it is cheap enough to
+// call once per frame. Callers that memoize a whole rendered frame fold it
+// into their cache key to pick up item mutations they do not otherwise know
+// about.
+func (l *List) ItemsVersion() uint64 {
+	var v uint64
+	for _, item := range l.items {
+		v = v*31 + item.Version()
+	}
+	return v
+}
+
+// ScrollPosition returns the index of the first visible item and the line
+// offset into it. Unlike Offset it is O(1) and does not render items.
+func (l *List) ScrollPosition() (offsetIdx, offsetLine int) {
+	return l.offsetIdx, l.offsetLine
+}
+
 // Offset returns the current scroll offset in lines from the top.
 func (l *List) Offset() int {
 	offset := 0

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -538,6 +538,51 @@ func (m *Chat) Blur() {
 	m.list.Blur()
 }
 
+// ScrollPosition returns the list's first visible item index and the line
+// offset into it.
+func (m *Chat) ScrollPosition() (offsetIdx, offsetLine int) {
+	return m.list.ScrollPosition()
+}
+
+// Selected returns the index of the selected item.
+func (m *Chat) Selected() int {
+	return m.list.Selected()
+}
+
+// Focused returns whether the chat list is focused.
+func (m *Chat) Focused() bool {
+	return m.list.Focused()
+}
+
+// RenderState captures everything about the chat that affects its rendered
+// output and is not carried by item versions. Anything added to Chat that
+// Draw reads belongs here, so callers that memoize whole frames stay correct
+// without knowing Chat's internals.
+type RenderState struct {
+	OffsetIdx        int
+	OffsetLine       int
+	Selected         int
+	Focused          bool
+	ScrollbarVisible bool
+	// ItemsVersion changes when any message mutates its rendered output.
+	ItemsVersion uint64
+}
+
+// RenderState returns the current render-affecting chat state. It renders
+// nothing; the only non-constant part is the item version fold, which reads
+// one field per message.
+func (m *Chat) RenderState() RenderState {
+	offsetIdx, offsetLine := m.ScrollPosition()
+	return RenderState{
+		OffsetIdx:        offsetIdx,
+		OffsetLine:       offsetLine,
+		Selected:         m.Selected(),
+		Focused:          m.Focused(),
+		ScrollbarVisible: m.scrollbarVisible,
+		ItemsVersion:     m.list.ItemsVersion(),
+	}
+}
+
 // AtBottom returns whether the chat list is currently scrolled to the bottom.
 func (m *Chat) AtBottom() bool {
 	return m.list.AtBottom()

--- a/internal/ui/model/framecache.go
+++ b/internal/ui/model/framecache.go
@@ -1,0 +1,281 @@
+package model
+
+import (
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+const (
+	// frameCacheTTL bounds how long a memoized frame may be served after it
+	// was rendered. It is a safety valve: even if a state change slips past
+	// invalidation, a stale frame is replaced within one TTL of the next
+	// update, and by the idle GC within two TTLs when there is none.
+	frameCacheTTL = 3 * time.Second
+
+	// frameCacheMaxEntries caps the number of memoized frames. A frame is
+	// the full styled screen as text; at a large terminal with heavily
+	// styled chat content this can reach several hundred KB each, so the
+	// cap bounds worst-case memory to roughly 10-20 MB.
+	frameCacheMaxEntries = 32
+)
+
+// frameGCMsg is sent on a timer to sweep expired frames when the UI is
+// otherwise idle, so a burst of scrolling does not pin memory indefinitely.
+type frameGCMsg struct{}
+
+// frameKey identifies a rendered frame for a given chat scroll position.
+// Everything else that affects the frame (layout, dialogs, items, sidebar
+// content, textarea) invalidates the whole cache via reset, so the key only
+// needs to capture what a scroll-only update is allowed to change. State
+// that is read live at render time rather than delivered by a message
+// (e.g. the agent busy flag) can lag for at most one TTL within a scroll
+// burst; the TTL is the safety valve for that.
+type frameKey struct {
+	width, height int
+	chat          RenderState
+}
+
+type frameEntry struct {
+	content string
+	cursor  *tea.Cursor
+	// at is the render time and drives TTL expiry; lastUsed is the last hit
+	// and drives eviction, so a hot frame (e.g. the clamped bottom during
+	// overscroll) is kept while still expiring on schedule.
+	at       time.Time
+	lastUsed time.Time
+}
+
+// frameCache memoizes fully rendered frames keyed by chat scroll position.
+//
+// Bubble Tea calls View after every Update, so a flood of wheel events pays
+// for a full redraw per event even when the scroll offset did not move
+// (clamped at the top or bottom) or moved back to a position rendered a
+// moment ago. Serving those frames from memory keeps the event loop
+// draining instead of blocking input behind redraw work.
+type frameCache struct {
+	entries map[frameKey]*frameEntry
+	ttl     time.Duration
+	max     int
+	now     func() time.Time
+
+	hits, misses int
+	// putSkips counts frames dropped because the state moved while Draw
+	// was rendering them.
+	putSkips int
+}
+
+func newFrameCache(ttl time.Duration, maxEntries int) *frameCache {
+	return &frameCache{
+		entries: make(map[frameKey]*frameEntry, maxEntries),
+		ttl:     ttl,
+		max:     maxEntries,
+		now:     time.Now,
+	}
+}
+
+// Len returns the number of memoized frames, including expired ones that
+// have not yet been swept.
+func (c *frameCache) Len() int {
+	return len(c.entries)
+}
+
+func (c *frameCache) expired(e *frameEntry, now time.Time) bool {
+	return now.Sub(e.at) > c.ttl
+}
+
+// get returns the memoized frame for key if present and within TTL.
+func (c *frameCache) get(key frameKey) (string, *tea.Cursor, bool) {
+	e, ok := c.entries[key]
+	if !ok {
+		c.misses++
+		return "", nil, false
+	}
+	now := c.now()
+	if c.expired(e, now) {
+		delete(c.entries, key)
+		c.misses++
+		return "", nil, false
+	}
+	c.hits++
+	e.lastUsed = now
+	if e.cursor == nil {
+		return e.content, nil, true
+	}
+	cur := *e.cursor
+	return e.content, &cur, true
+}
+
+// put memoizes a frame, sweeping expired entries first and evicting the
+// least recently used entry when the cache is full.
+func (c *frameCache) put(key frameKey, content string, cursor *tea.Cursor) {
+	now := c.now()
+	c.gc(now)
+	if _, ok := c.entries[key]; !ok && len(c.entries) >= c.max {
+		c.evictLRU()
+	}
+	var cur *tea.Cursor
+	if cursor != nil {
+		copied := *cursor
+		cur = &copied
+	}
+	c.entries[key] = &frameEntry{content: content, cursor: cur, at: now, lastUsed: now}
+}
+
+// gc removes every entry older than the TTL.
+func (c *frameCache) gc(now time.Time) {
+	for key, e := range c.entries {
+		if c.expired(e, now) {
+			delete(c.entries, key)
+		}
+	}
+}
+
+func (c *frameCache) evictLRU() {
+	var (
+		victimKey frameKey
+		victim    *frameEntry
+	)
+	for key, e := range c.entries {
+		if victim == nil || e.lastUsed.Before(victim.lastUsed) {
+			victimKey, victim = key, e
+		}
+	}
+	if victim != nil {
+		delete(c.entries, victimKey)
+	}
+}
+
+// reset drops every memoized frame. Called whenever an update may have
+// changed anything other than the chat scroll position.
+func (c *frameCache) reset() {
+	if len(c.entries) == 0 {
+		return
+	}
+	clear(c.entries)
+}
+
+// markScrollOnly flags the current update as having changed nothing but the
+// chat scroll position or selection, which lets View serve a memoized frame
+// for that position. Update arms the idle GC timer when the flag is set; it
+// is not returned here so callers that sequence their commands do not put a
+// blocking tick ahead of real work.
+func (m *UI) markScrollOnly() {
+	m.scrollOnlyUpdate = true
+}
+
+// invalidateFrames forces the next View to drop all memoized frames, even if
+// the current update was marked scroll-only.
+func (m *UI) invalidateFrames() {
+	m.frameDirty = true
+}
+
+// beginFrameUpdate clears the per-update memoization flag so a flag left
+// over from an update whose View never consumed it cannot leak into this
+// one.
+func (m *UI) beginFrameUpdate() {
+	m.scrollOnlyUpdate = false
+	m.frameSkipPut = false
+}
+
+// endFrameUpdate returns the command that arms the idle GC timer when this
+// update was scroll-only, the coming View can actually memoize a frame, and
+// no timer is pending.
+func (m *UI) endFrameUpdate() tea.Cmd {
+	if !m.scrollOnlyUpdate || !m.frameCacheable() {
+		return nil
+	}
+	return m.armFrameGC()
+}
+
+// frameCacheable reports whether the current UI state renders frames that
+// may be memoized.
+func (m *UI) frameCacheable() bool {
+	return m.frames != nil && m.state == uiChat && !m.dialog.HasDialogs()
+}
+
+func (m *UI) armFrameGC() tea.Cmd {
+	if m.frames == nil || m.frameGCArmed {
+		return nil
+	}
+	m.frameGCArmed = true
+	return tea.Tick(m.frames.ttl, func(time.Time) tea.Msg { return frameGCMsg{} })
+}
+
+// handleFrameGC sweeps expired frames. The sweep itself changes nothing
+// visible, so the update is marked scroll-only to avoid discarding
+// still-valid frames; Update re-arms the timer through endFrameUpdate while
+// frames remain. When the sweep empties the cache the UI has been idle for a
+// full TTL: the frame rendered by the following View is not memoized so
+// nothing stays pinned and the timer is left disarmed until the next scroll.
+func (m *UI) handleFrameGC() {
+	m.frameGCArmed = false
+	if m.frames == nil {
+		return
+	}
+	m.frames.gc(m.frames.now())
+	if m.frames.Len() == 0 {
+		m.frameSkipPut = true
+		return
+	}
+	m.scrollOnlyUpdate = true
+}
+
+// frameKeyNow returns the key for the current state without touching the
+// per-update flags.
+func (m *UI) frameKeyNow() (frameKey, bool) {
+	if m.frames == nil || !m.frameCacheable() {
+		return frameKey{}, false
+	}
+	return frameKey{
+		width:  m.width,
+		height: m.height,
+		chat:   m.chat.RenderState(),
+	}, true
+}
+
+// currentFrameKey consumes the per-update memoization flags, resets the cache
+// when the update was not scroll-only, and returns the key for the frame
+// about to be rendered. ok is false when the current state is not cacheable.
+func (m *UI) currentFrameKey() (key frameKey, ok bool) {
+	scrollOnly := m.scrollOnlyUpdate && !m.frameDirty
+	m.scrollOnlyUpdate = false
+	m.frameDirty = false
+	if m.frames == nil {
+		return frameKey{}, false
+	}
+	if !scrollOnly {
+		m.frames.reset()
+	}
+	if !m.frameCacheable() {
+		return frameKey{}, false
+	}
+	return m.frameKeyNow()
+}
+
+// storeFrame memoizes a freshly rendered frame under key. If Draw changed
+// the layout while rendering (frameDirty set after currentFrameKey consumed
+// it) the frame no longer matches the key and every earlier frame is stale,
+// so the cache is reset instead. GC-triggered renders are not stored so the
+// cache drains fully when idle.
+func (m *UI) storeFrame(key frameKey, content string, cursor *tea.Cursor) {
+	if m.frameDirty {
+		m.frameDirty = false
+		m.frames.reset()
+		return
+	}
+	if m.frameSkipPut {
+		m.frameSkipPut = false
+		return
+	}
+	// Re-read the key after Draw. Rendering an item may bump its version
+	// (the list does the same re-read for the same reason), and Draw may
+	// re-anchor the list in follow mode. Either way the frame no longer
+	// depicts the state key describes, so storing it would serve a frame
+	// under a position it does not match.
+	if now, ok := m.frameKeyNow(); !ok || now != key {
+		m.frames.putSkips++
+		return
+	}
+	m.frames.put(key, content, cursor)
+}

--- a/internal/ui/model/framecache_bench_test.go
+++ b/internal/ui/model/framecache_bench_test.go
@@ -1,0 +1,95 @@
+package model
+
+import "testing"
+
+// clamped overscroll at the bottom: the case the PR targets.
+func BenchmarkView_ClampedOverscroll_Cached(b *testing.B) {
+	u := newFrameTestUI(b)
+	u.chat.ScrollToBottom()
+	u.View()
+	b.ResetTimer()
+	for b.Loop() {
+		u.beginFrameUpdate()
+		u.markScrollOnly()
+		_ = u.chat.ScrollBy(5)
+		u.View()
+	}
+	b.ReportMetric(float64(u.frames.hits), "hits")
+	b.ReportMetric(float64(u.frames.misses), "misses")
+}
+
+func BenchmarkView_ClampedOverscroll_Uncached(b *testing.B) {
+	u := newFrameTestUI(b)
+	u.frames = nil
+	u.chat.ScrollToBottom()
+	u.View()
+	b.ResetTimer()
+	for b.Loop() {
+		u.beginFrameUpdate()
+		_ = u.chat.ScrollBy(5)
+		u.View()
+	}
+}
+
+// moving scroll: every frame is a new position, so the cache only costs.
+func BenchmarkView_MovingScroll_Cached(b *testing.B) {
+	u := newFrameTestUI(b)
+	u.chat.ScrollToTop()
+	u.View()
+	b.ResetTimer()
+	i := 0
+	for b.Loop() {
+		u.beginFrameUpdate()
+		u.markScrollOnly()
+		if i%150 == 149 {
+			u.chat.ScrollToTop()
+		} else {
+			_ = u.chat.ScrollBy(1)
+		}
+		i++
+		u.View()
+	}
+	b.ReportMetric(float64(u.frames.hits), "hits")
+	b.ReportMetric(float64(u.frames.misses), "misses")
+}
+
+func BenchmarkView_MovingScroll_Uncached(b *testing.B) {
+	u := newFrameTestUI(b)
+	u.frames = nil
+	u.chat.ScrollToTop()
+	u.View()
+	b.ResetTimer()
+	i := 0
+	for b.Loop() {
+		u.beginFrameUpdate()
+		if i%150 == 149 {
+			u.chat.ScrollToTop()
+		} else {
+			_ = u.chat.ScrollBy(1)
+		}
+		i++
+		u.View()
+	}
+}
+
+// how much does the 32-entry LRU buy over a single-frame cache?
+func benchOscillate(b *testing.B, maxEntries int) {
+	u := newFrameTestUI(b)
+	u.frames = newFrameCache(frameCacheTTL, maxEntries)
+	u.chat.ScrollToTop()
+	u.View()
+	// wander within a small window, the best case for an LRU
+	deltas := []int{1, 1, -1, 2, -2, 1, -1, -1}
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		u.beginFrameUpdate()
+		u.markScrollOnly()
+		_ = u.chat.ScrollBy(deltas[i%len(deltas)])
+		u.View()
+	}
+	b.ReportMetric(float64(u.frames.hits), "hits")
+	b.ReportMetric(float64(u.frames.misses), "misses")
+}
+
+func BenchmarkView_Oscillate_LRU1(b *testing.B)  { benchOscillate(b, 1) }
+func BenchmarkView_Oscillate_LRU32(b *testing.B) { benchOscillate(b, 32) }

--- a/internal/ui/model/framecache_oracle_test.go
+++ b/internal/ui/model/framecache_oracle_test.go
@@ -1,0 +1,150 @@
+package model
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/ui/chat"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/stretchr/testify/require"
+)
+
+// viewChecked renders through the cache, then renders the same state again
+// with memoization disabled and requires the two to agree. Probing with
+// frames == nil neither resets nor stores, so it does not perturb the cache.
+func viewChecked(t *testing.T, u *UI, what string) tea.View {
+	t.Helper()
+	got := u.View()
+	saved := u.frames
+	u.frames = nil
+	want := u.View()
+	u.frames = saved
+	require.Equal(t, want.Content, got.Content, "stale memoized frame after %s", what)
+	return got
+}
+
+// A diagonal trackpad scroll over a selected shell block changes the block's
+// horizontal offset. Vertical scroll clamped at the bottom leaves the scroll
+// position unchanged, so the frame must be invalidated by the item's version
+// rather than by the position.
+func TestDiagonalWheelOverShellItem(t *testing.T) {
+	u := newFrameTestUI(t)
+	wide := strings.Repeat("wide output column ", 30)
+	u.chat.SetMessages(chat.NewShellItem(u.com.Styles, "ls", wide+"\n"+wide, 0))
+	u.updateLayoutAndSize()
+	u.chat.ScrollToBottom()
+	u.chat.SetSelected(0)
+	require.True(t, u.chat.IsSelectedShellItem())
+	viewChecked(t, u, "initial render")
+
+	u.Update(common.CoalescedWheelMsg{
+		Mouse:  tea.Mouse{X: u.layout.main.Min.X + 1, Y: u.layout.main.Min.Y + 1},
+		DeltaX: 8, // pan the shell block right
+		DeltaY: 1, // clamped: already at the bottom
+	})
+	viewChecked(t, u, "diagonal wheel over a shell block")
+}
+
+// The scrollbar's visibility flag in ScrollbarDefault mode is not part of
+// frameKey, so a clamped scroll that reveals the scrollbar hits the cache.
+func TestScrollbarDefault_ClampedScrollRevealsScrollbar(t *testing.T) {
+	u := newFrameTestUI(t)
+	u.chat.scrollbarMode = config.ScrollbarDefault
+	u.chat.scrollbarVisible = false
+	u.chat.ScrollToBottom()
+	viewChecked(t, u, "initial render")
+
+	// Wheel down at the bottom: clamped, so offsets do not move, but
+	// ScrollBy still calls showScrollbar and sets scrollbarVisible.
+	u.beginFrameUpdate()
+	u.markScrollOnly()
+	_ = u.chat.ScrollBy(5)
+	u.endFrameUpdate()
+	require.True(t, u.chat.scrollbarVisible, "scroll must reveal the scrollbar")
+	viewChecked(t, u, "clamped scroll that reveals the scrollbar")
+}
+
+// op is one user action that the PR treats as (or routes through) a
+// scroll-only update.
+type op struct {
+	name string
+	run  func(u *UI) tea.Cmd
+}
+
+func wheel(u *UI, dx, dy float64) tea.Cmd {
+	_, cmd := u.Update(common.CoalescedWheelMsg{
+		Mouse:  tea.Mouse{X: u.layout.main.Min.X + 1, Y: u.layout.main.Min.Y + 1},
+		DeltaX: dx, DeltaY: dy,
+	})
+	return cmd
+}
+
+func keyOp(k rune) func(*UI) tea.Cmd {
+	return func(u *UI) tea.Cmd {
+		_, cmd := u.Update(tea.KeyPressMsg{Code: k})
+		return cmd
+	}
+}
+
+var frameOps = []op{
+	{"wheel down", func(u *UI) tea.Cmd { return wheel(u, 0, 1) }},
+	{"wheel up", func(u *UI) tea.Cmd { return wheel(u, 0, -1) }},
+	{"wheel down x5", func(u *UI) tea.Cmd { return wheel(u, 0, 5) }},
+	{"wheel up x5", func(u *UI) tea.Cmd { return wheel(u, 0, -5) }},
+	{"wheel diagonal", func(u *UI) tea.Cmd { return wheel(u, 4, 1) }},
+	{"wheel diagonal back", func(u *UI) tea.Cmd { return wheel(u, -4, -1) }},
+	{"key up", keyOp(tea.KeyUp)},
+	{"key down", keyOp(tea.KeyDown)},
+	{"pgup", keyOp(tea.KeyPgUp)},
+	{"pgdown", keyOp(tea.KeyPgDown)},
+	{"frame gc", func(u *UI) tea.Cmd { _, cmd := u.Update(frameGCMsg{}); return cmd }},
+	{"scrollbar hide timer", func(u *UI) tea.Cmd {
+		_, cmd := u.Update(scrollbarHideMsg{seq: u.chat.scrollbarHideSeq})
+		return cmd
+	}},
+}
+
+func runFrameSweep(t *testing.T, u *UI, seed int64) {
+	t.Helper()
+	rng := rand.New(rand.NewSource(seed))
+	u.chat.ScrollToBottom()
+	viewChecked(t, u, "initial render")
+	before := u.frames.putSkips
+	for i := range 200 {
+		o := frameOps[rng.Intn(len(frameOps))]
+		o.run(u)
+		viewChecked(t, u, fmt.Sprintf("step %d: %s", i, o.name))
+	}
+	t.Logf("frames dropped because state moved during Draw: %d", u.frames.putSkips-before)
+}
+
+func TestFrameSweep_ScrollbarAlways(t *testing.T) {
+	u := newFrameTestUI(t)
+	u.chat.Focus()
+	runFrameSweep(t, u, 1)
+}
+
+func TestFrameSweep_ScrollbarDefault(t *testing.T) {
+	u := newFrameTestUI(t)
+	u.chat.Focus()
+	u.chat.scrollbarMode = config.ScrollbarDefault
+	runFrameSweep(t, u, 2)
+}
+
+func TestFrameSweep_WithShellItems(t *testing.T) {
+	u := newFrameTestUI(t)
+	u.chat.Focus()
+	wide := strings.Repeat("wide output column ", 20)
+	items := frameTestItems("line")
+	items[3] = chat.NewShellItem(u.com.Styles, "ls -la", wide+"\n"+wide+"\n"+wide, 0)
+	items[40] = chat.NewShellItem(u.com.Styles, "cat big.txt", wide+"\n"+wide, 0)
+	u.chat.SetMessages(items...)
+	u.updateLayoutAndSize()
+	u.chat.ScrollToTop()
+	u.chat.SetSelected(3)
+	runFrameSweep(t, u, 3)
+}

--- a/internal/ui/model/framecache_test.go
+++ b/internal/ui/model/framecache_test.go
@@ -1,0 +1,472 @@
+package model
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/ui/attachments"
+	"github.com/charmbracelet/crush/internal/ui/chat"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/ui/dialog"
+	"github.com/charmbracelet/crush/internal/ui/list"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestFrameCache(ttl time.Duration, maxEntries int) (*frameCache, *time.Time) {
+	now := time.Unix(1_000_000, 0)
+	c := newFrameCache(ttl, maxEntries)
+	c.now = func() time.Time { return now }
+	return c, &now
+}
+
+func TestFrameCache_PutGet(t *testing.T) {
+	t.Parallel()
+	c, _ := newTestFrameCache(time.Second, 4)
+	key := frameKey{width: 80, height: 24, chat: RenderState{OffsetIdx: 1}}
+
+	_, _, ok := c.get(key)
+	require.False(t, ok)
+
+	c.put(key, "frame", &tea.Cursor{Position: tea.Position{X: 1, Y: 2}})
+	content, cursor, ok := c.get(key)
+	require.True(t, ok)
+	require.Equal(t, "frame", content)
+	require.NotNil(t, cursor)
+	require.Equal(t, 1, cursor.X)
+	require.Equal(t, 2, cursor.Y)
+	require.Equal(t, 1, c.hits)
+	require.Equal(t, 1, c.misses)
+}
+
+func TestFrameCache_CursorIsCopied(t *testing.T) {
+	t.Parallel()
+	c, _ := newTestFrameCache(time.Second, 4)
+	key := frameKey{width: 80, height: 24}
+	orig := &tea.Cursor{Position: tea.Position{X: 1}}
+	c.put(key, "frame", orig)
+	orig.X = 99
+
+	_, cursor, ok := c.get(key)
+	require.True(t, ok)
+	require.Equal(t, 1, cursor.X)
+	cursor.X = 42
+
+	_, again, _ := c.get(key)
+	require.Equal(t, 1, again.X)
+}
+
+func TestFrameCache_TTLExpiry(t *testing.T) {
+	t.Parallel()
+	c, now := newTestFrameCache(time.Second, 4)
+	key := frameKey{width: 80, height: 24}
+	c.put(key, "frame", nil)
+
+	*now = now.Add(time.Second)
+	_, _, ok := c.get(key)
+	require.True(t, ok, "entry at exactly TTL should still be served")
+
+	*now = now.Add(time.Millisecond)
+	_, _, ok = c.get(key)
+	require.False(t, ok, "entry past TTL must not be served")
+	require.Equal(t, 0, c.Len(), "expired entry must be dropped on read")
+}
+
+func TestFrameCache_GCSweepsExpired(t *testing.T) {
+	t.Parallel()
+	c, now := newTestFrameCache(time.Second, 8)
+	for i := range 4 {
+		c.put(frameKey{chat: RenderState{OffsetIdx: i}}, "old", nil)
+	}
+	*now = now.Add(2 * time.Second)
+	for i := range 2 {
+		c.put(frameKey{chat: RenderState{OffsetIdx: 10 + i}}, "new", nil)
+	}
+	require.Equal(t, 2, c.Len(), "put must sweep expired entries")
+
+	*now = now.Add(2 * time.Second)
+	c.gc(*now)
+	require.Equal(t, 0, c.Len())
+}
+
+func TestFrameCache_EvictsLeastRecentlyUsedWhenFull(t *testing.T) {
+	t.Parallel()
+	c, now := newTestFrameCache(time.Minute, 3)
+	for i := range 3 {
+		c.put(frameKey{chat: RenderState{OffsetIdx: i}}, "frame", nil)
+		*now = now.Add(time.Millisecond)
+	}
+	require.Equal(t, 3, c.Len())
+
+	// Touch the oldest entry so it becomes the most recently used.
+	_, _, ok := c.get(frameKey{chat: RenderState{OffsetIdx: 0}})
+	require.True(t, ok)
+	*now = now.Add(time.Millisecond)
+
+	c.put(frameKey{chat: RenderState{OffsetIdx: 3}}, "frame", nil)
+	require.Equal(t, 3, c.Len())
+	_, _, ok = c.get(frameKey{chat: RenderState{OffsetIdx: 1}})
+	require.False(t, ok, "least recently used entry must be evicted")
+	for _, idx := range []int{0, 2, 3} {
+		_, _, ok := c.get(frameKey{chat: RenderState{OffsetIdx: idx}})
+		require.True(t, ok, "entry %d must survive", idx)
+	}
+}
+
+func TestFrameCache_HitDoesNotExtendTTL(t *testing.T) {
+	t.Parallel()
+	c, now := newTestFrameCache(time.Second, 4)
+	key := frameKey{chat: RenderState{OffsetIdx: 0}}
+	c.put(key, "frame", nil)
+	for range 5 {
+		*now = now.Add(150 * time.Millisecond)
+		_, _, ok := c.get(key)
+		require.True(t, ok)
+	}
+	*now = now.Add(300 * time.Millisecond)
+	_, _, ok := c.get(key)
+	require.False(t, ok, "repeated hits must not keep a frame alive past its TTL")
+}
+
+func TestFrameCache_OverwriteDoesNotEvict(t *testing.T) {
+	t.Parallel()
+	c, _ := newTestFrameCache(time.Minute, 2)
+	c.put(frameKey{chat: RenderState{OffsetIdx: 0}}, "a", nil)
+	c.put(frameKey{chat: RenderState{OffsetIdx: 1}}, "b", nil)
+	c.put(frameKey{chat: RenderState{OffsetIdx: 1}}, "b2", nil)
+	require.Equal(t, 2, c.Len())
+	content, _, ok := c.get(frameKey{chat: RenderState{OffsetIdx: 0}})
+	require.True(t, ok)
+	require.Equal(t, "a", content)
+}
+
+func TestFrameCache_Reset(t *testing.T) {
+	t.Parallel()
+	c, _ := newTestFrameCache(time.Minute, 4)
+	c.put(frameKey{chat: RenderState{OffsetIdx: 0}}, "a", nil)
+	c.reset()
+	require.Equal(t, 0, c.Len())
+	c.reset()
+}
+
+// stubDialog is an empty dialog used to exercise the dialog-open path.
+type stubDialog struct{}
+
+func (stubDialog) ID() string                               { return "stub" }
+func (stubDialog) HandleMsg(tea.Msg) dialog.Action          { return nil }
+func (stubDialog) Draw(uv.Screen, uv.Rectangle) *tea.Cursor { return nil }
+
+// focusableTestItem is a testMessageItem that participates in selection so
+// the chat scroll handlers behave as they do with real message items.
+type focusableTestItem struct {
+	testMessageItem
+	focused bool
+}
+
+func (m *focusableTestItem) SetFocused(focused bool) { m.focused = focused }
+
+var _ list.Focusable = (*focusableTestItem)(nil)
+
+// newFrameTestUI returns a chat UI with a frame cache and enough items to
+// scroll, sized so layout is stable across Views.
+func newFrameTestUI(t testing.TB) *UI {
+	t.Helper()
+	u := newTestUI()
+	u.com.Workspace = &testWorkspace{cfg: &config.Config{}}
+	u.frames = newFrameCache(time.Minute, 8)
+	u.dialog = dialog.NewOverlay()
+	u.keyMap = DefaultKeyMap()
+	u.focus = uiFocusMain
+	u.status = NewStatus(u.com, u)
+	u.attachments = attachments.New(nil, attachments.Keymap{})
+	u.chat.scrollbarMode = config.ScrollbarAlways
+	u.chat.SetMessages(frameTestItems("line")...)
+	u.updateLayoutAndSize()
+	return u
+}
+
+func frameTestItems(prefix string) []chat.MessageItem {
+	items := make([]chat.MessageItem, 0, 200)
+	for i := range 200 {
+		items = append(items, &focusableTestItem{
+			testMessageItem: testMessageItem{id: strconv.Itoa(i), text: prefix + " " + strconv.Itoa(i)},
+		})
+	}
+	return items
+}
+
+// scrollOnlyUpdate simulates a scroll-only Update followed by View.
+func scrollOnlyUpdate(u *UI, lines int) tea.View {
+	u.beginFrameUpdate()
+	u.markScrollOnly()
+	_ = u.chat.ScrollBy(lines)
+	u.endFrameUpdate()
+	return u.View()
+}
+
+func TestView_ScrollOnlyUpdateHitsCache(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+
+	first := u.View()
+	require.Equal(t, 0, u.frames.hits)
+	require.Equal(t, 1, u.frames.Len(), "fresh frame must be memoized")
+
+	// A non-scroll update resets the cache and renders again.
+	second := u.View()
+	require.Equal(t, 0, u.frames.hits)
+	require.Equal(t, 2, u.frames.misses)
+	require.Equal(t, first.Content, second.Content)
+
+	// A scroll-only update at the same position is served from cache.
+	u.markScrollOnly()
+	third := u.View()
+	require.Equal(t, 1, u.frames.hits)
+	require.Equal(t, first.Content, third.Content)
+	require.False(t, u.scrollOnlyUpdate, "flag must be consumed by View")
+}
+
+func TestView_ScrollAwayAndBackHitsCache(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+	u.chat.ScrollToTop()
+
+	top := u.View()
+	down := scrollOnlyUpdate(u, 4)
+	require.NotEqual(t, top.Content, down.Content, "scrolling must change the frame")
+	require.Equal(t, 0, u.frames.hits)
+	require.Equal(t, 2, u.frames.Len())
+
+	back := scrollOnlyUpdate(u, -4)
+	require.Equal(t, 1, u.frames.hits, "returning to a rendered position must hit")
+	require.Equal(t, top.Content, back.Content)
+
+	again := scrollOnlyUpdate(u, 4)
+	require.Equal(t, 2, u.frames.hits)
+	require.Equal(t, down.Content, again.Content)
+}
+
+func TestView_ClampedOverscrollHitsCache(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+	u.chat.ScrollToBottom()
+	bottom := u.View()
+
+	for range 5 {
+		v := scrollOnlyUpdate(u, 5)
+		require.Equal(t, bottom.Content, v.Content)
+	}
+	require.Equal(t, 5, u.frames.hits, "overscroll at the bottom must be served from cache")
+	require.Equal(t, 1, u.frames.Len())
+}
+
+func TestView_ContentChangeBetweenScrollsIsNotStale(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+	u.chat.ScrollToTop()
+	before := u.View()
+
+	// A message update is not scroll-only: the cache must reset.
+	u.beginFrameUpdate()
+	u.chat.SetMessages(frameTestItems("changed")...)
+	u.chat.ScrollToTop()
+	u.endFrameUpdate()
+	after := u.View()
+	require.NotEqual(t, before.Content, after.Content)
+	require.Equal(t, 0, u.frames.hits)
+
+	// A following scroll-only View at the same key serves the new content.
+	u.markScrollOnly()
+	v := u.View()
+	require.Equal(t, 1, u.frames.hits)
+	require.Equal(t, after.Content, v.Content)
+}
+
+func TestView_LayoutChangeOverridesScrollOnly(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+
+	u.View()
+	require.Equal(t, 1, u.frames.Len())
+
+	u.markScrollOnly()
+	u.updateSize()
+	u.View()
+	require.Equal(t, 0, u.frames.hits, "layout change must not serve a memoized frame")
+	require.False(t, u.frameDirty)
+}
+
+func TestView_LayoutChangeDuringDrawIsNotStoredUnderStaleKey(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+	u.View()
+	require.Equal(t, 1, u.frames.Len())
+
+	// Resize without recomputing layout: Draw detects the drift, calls
+	// updateSize, and sets frameDirty after the key was computed.
+	u.markScrollOnly()
+	u.width += 10
+	u.View()
+	require.Equal(t, 0, u.frames.hits)
+	require.Equal(t, 0, u.frames.Len(), "frame drawn under a changed layout must not be memoized")
+	require.False(t, u.frameDirty, "dirty flag must not leak into the next update")
+
+	u.View()
+	require.Equal(t, 1, u.frames.Len())
+}
+
+func TestView_DialogDisablesCache(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+	u.View()
+	require.Equal(t, 1, u.frames.Len())
+
+	u.dialog.OpenDialog(stubDialog{})
+	u.View()
+	require.Equal(t, 0, u.frames.Len(), "opening a dialog must drop memoized frames")
+
+	u.markScrollOnly()
+	u.View()
+	require.Equal(t, 0, u.frames.hits)
+	require.Equal(t, 0, u.frames.Len(), "frames must not be memoized while a dialog is open")
+}
+
+func TestFrameGC_ArmsOnceAndDrainsWhenIdle(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+
+	u.beginFrameUpdate()
+	require.Nil(t, u.endFrameUpdate(), "non-scroll update must not arm the GC timer")
+
+	u.markScrollOnly()
+	require.NotNil(t, u.endFrameUpdate(), "first scroll-only update must arm the GC timer")
+	require.True(t, u.frameGCArmed)
+	require.Nil(t, u.endFrameUpdate(), "must not double-arm")
+	u.View()
+	require.Equal(t, 1, u.frames.Len())
+
+	// GC while frames are still fresh: nothing swept, frame served, re-armed.
+	u.beginFrameUpdate()
+	u.handleFrameGC()
+	require.True(t, u.scrollOnlyUpdate, "GC must not invalidate frames")
+	require.NotNil(t, u.endFrameUpdate(), "GC must re-arm while frames remain")
+	u.View()
+	require.Equal(t, 1, u.frames.hits)
+
+	// GC after everything expired: cache drains and the render is not stored.
+	now := time.Now()
+	u.frames.now = func() time.Time { return now.Add(2 * time.Minute) }
+	u.beginFrameUpdate()
+	u.handleFrameGC()
+	require.False(t, u.scrollOnlyUpdate)
+	require.True(t, u.frameSkipPut)
+	require.Nil(t, u.endFrameUpdate(), "GC must stop once the cache is empty")
+	u.View()
+	require.Equal(t, 0, u.frames.Len(), "post-drain render must not be memoized")
+	require.False(t, u.frameSkipPut)
+	require.False(t, u.frameGCArmed)
+}
+
+func TestKeyScroll_DoesNotSequenceGCTick(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+	u.chat.Focus()
+	u.chat.ScrollToBottom()
+
+	u.beginFrameUpdate()
+	cmd := u.handleKeyPressMsg(tea.KeyPressMsg{Code: tea.KeyPgUp})
+	require.True(t, u.scrollOnlyUpdate)
+	require.False(t, u.frameGCArmed, "key handler must not arm the GC timer itself")
+	require.Nil(t, cmd, "scroll key with no animations must produce no sequenced cmds")
+	require.NotNil(t, u.endFrameUpdate())
+}
+
+func TestUpdate_WheelScrollThroughUpdateHitsCache(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+	u.chat.ScrollToBottom()
+	u.chat.SetSelected(u.chat.Len() - 1)
+	bottom := u.View()
+
+	wheel := common.CoalescedWheelMsg{
+		Mouse:  tea.Mouse{X: u.layout.main.Min.X + 1, Y: u.layout.main.Min.Y + 1},
+		DeltaY: 1,
+	}
+	_, cmd := u.Update(wheel)
+	require.NotNil(t, cmd, "first scroll-only update must return the GC arm")
+	require.True(t, u.frameGCArmed)
+	v := u.View()
+	require.Equal(t, 1, u.frames.hits, "clamped wheel scroll must be served from cache")
+	require.Equal(t, bottom.Content, v.Content)
+
+	_, _ = u.Update(wheel)
+	u.View()
+	require.Equal(t, 2, u.frames.hits)
+
+	// Scrolling up moves to a new position (and may move the selection):
+	// a miss. Scrolling back down and then overscrolling again must hit
+	// the frame rendered on the way back.
+	up := wheel
+	up.DeltaY = -1
+	_, _ = u.Update(up)
+	moved := u.View()
+	require.NotEqual(t, bottom.Content, moved.Content)
+	require.Equal(t, 2, u.frames.hits)
+	_, _ = u.Update(wheel)
+	back := u.View()
+	_, _ = u.Update(wheel)
+	again := u.View()
+	require.Equal(t, 3, u.frames.hits)
+	require.Equal(t, back.Content, again.Content)
+	require.True(t, u.chat.AtBottom())
+}
+
+func TestUpdate_FrameGCMsgReArmsThroughUpdate(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+	u.View()
+
+	u.markScrollOnly()
+	require.NotNil(t, u.endFrameUpdate())
+	u.View()
+	require.Equal(t, 1, u.frames.Len())
+
+	_, cmd := u.Update(frameGCMsg{})
+	require.NotNil(t, cmd, "GC through Update must re-arm while frames remain")
+	require.True(t, u.frameGCArmed)
+	u.View()
+	require.Equal(t, 2, u.frames.hits, "GC must not discard fresh frames")
+
+	now := time.Now()
+	u.frames.now = func() time.Time { return now.Add(2 * time.Minute) }
+	_, cmd = u.Update(frameGCMsg{})
+	require.Nil(t, cmd, "GC through Update must disarm once drained")
+	require.False(t, u.frameGCArmed)
+	u.View()
+	require.Equal(t, 0, u.frames.Len())
+}
+
+func TestUpdate_DirtyFromNonCacheableViewResetsNextScrollOnlyView(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+	u.View()
+	require.Equal(t, 1, u.frames.Len())
+
+	// A layout change inside a scroll-only update while a dialog is open
+	// leaves frameDirty behind; the next scroll-only view after the dialog
+	// closes must not serve the pre-change frame.
+	u.dialog.OpenDialog(stubDialog{})
+	u.markScrollOnly()
+	u.updateSize()
+	u.View()
+	require.Equal(t, 0, u.frames.Len())
+
+	u.dialog.CloseFrontDialog()
+	u.markScrollOnly()
+	u.View()
+	require.Equal(t, 0, u.frames.hits)
+	require.Equal(t, 1, u.frames.Len())
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -214,6 +214,15 @@ type UI struct {
 	focus uiFocusState
 	state uiState
 
+	// Frame memoization (see framecache.go). scrollOnlyUpdate is set by
+	// handlers that change nothing but the chat scroll position; frameDirty
+	// overrides it when a layout change happens in the same update.
+	frames           *frameCache
+	scrollOnlyUpdate bool
+	frameDirty       bool
+	frameSkipPut     bool
+	frameGCArmed     bool
+
 	keyMap KeyMap
 	keyenh tea.KeyboardEnhancementsMsg
 
@@ -465,6 +474,7 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 		completions:         comp,
 		attachments:         attachments,
 		todoSpinner:         todoSpinner,
+		frames:              newFrameCache(frameCacheTTL, frameCacheMaxEntries),
 		lspStates:           make(map[string]workspace.LSPClientInfo),
 		mcpStates:           make(map[string]mcp.ClientInfo),
 		notifyBackend:       notification.NoopBackend{},
@@ -712,6 +722,7 @@ func (m *UI) loadMCPrompts() tea.Msg {
 // Update handles updates to the UI model.
 func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmds []tea.Cmd
+	m.beginFrameUpdate()
 	// Update terminal capabilities
 	m.caps.Update(msg)
 	switch msg := msg.(type) {
@@ -1228,6 +1239,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if lines == 0 {
 				break
 			}
+			m.markScrollOnly()
 			if cmd := m.chat.ScrollByAndAnimate(lines); cmd != nil {
 				cmds = append(cmds, cmd)
 			}
@@ -1244,6 +1256,8 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+	case frameGCMsg:
+		m.handleFrameGC()
 	case anim.StepMsg:
 		if m.state == uiChat {
 			if cmd := m.chat.Animate(msg); cmd != nil {
@@ -1421,6 +1435,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	// This logic gets triggered on any message type, but should it?
+	prevPlaceholder := m.textarea.Placeholder
 	switch m.focus {
 	case uiFocusMain:
 	case uiFocusEditor:
@@ -1436,6 +1451,9 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.textarea.Placeholder = "Yolo mode!"
 		}
 	}
+	if m.textarea.Placeholder != prevPlaceholder {
+		m.invalidateFrames()
+	}
 
 	// TTL backstop: schedule an off-thread re-probe for any memoized
 	// workspace state that has gone stale. Never does IO on this
@@ -1444,7 +1462,12 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	// at this point this can only handle [message.Attachment] message, and we
 	// should return all cmds anyway.
-	_ = m.attachments.Update(msg)
+	if m.attachments.Update(msg) {
+		m.invalidateFrames()
+	}
+	if cmd := m.endFrameUpdate(); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
 	return m, tea.Batch(cmds...)
 }
 
@@ -2857,6 +2880,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 			case key.Matches(msg, m.keyMap.Chat.Expand):
 				m.chat.ToggleExpandedSelectedItem()
 			case key.Matches(msg, m.keyMap.Chat.Up):
+				m.markScrollOnly()
 				if cmd := m.chat.ScrollByAndAnimate(-1); cmd != nil {
 					cmds = append(cmds, cmd)
 				}
@@ -2867,6 +2891,7 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					}
 				}
 			case key.Matches(msg, m.keyMap.Chat.Down):
+				m.markScrollOnly()
 				if cmd := m.chat.ScrollByAndAnimate(1); cmd != nil {
 					cmds = append(cmds, cmd)
 				}
@@ -2887,21 +2912,25 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 					cmds = append(cmds, cmd)
 				}
 			case key.Matches(msg, m.keyMap.Chat.HalfPageUp):
+				m.markScrollOnly()
 				if cmd := m.chat.ScrollByAndAnimate(-m.chat.Height() / 2); cmd != nil {
 					cmds = append(cmds, cmd)
 				}
 				m.chat.SelectFirstInView()
 			case key.Matches(msg, m.keyMap.Chat.HalfPageDown):
+				m.markScrollOnly()
 				if cmd := m.chat.ScrollByAndAnimate(m.chat.Height() / 2); cmd != nil {
 					cmds = append(cmds, cmd)
 				}
 				m.chat.SelectLastInView()
 			case key.Matches(msg, m.keyMap.Chat.PageUp):
+				m.markScrollOnly()
 				if cmd := m.chat.ScrollByAndAnimate(-m.chat.Height()); cmd != nil {
 					cmds = append(cmds, cmd)
 				}
 				m.chat.SelectFirstInView()
 			case key.Matches(msg, m.keyMap.Chat.PageDown):
+				m.markScrollOnly()
 				if cmd := m.chat.ScrollByAndAnimate(m.chat.Height()); cmd != nil {
 					cmds = append(cmds, cmd)
 				}
@@ -3175,6 +3204,16 @@ func (m *UI) View() tea.View {
 	v.ReportFocus = m.caps.ReportFocusEvents
 	v.WindowTitle = "crush " + home.Short(m.com.Workspace.WorkingDir())
 
+	key, cacheable := m.currentFrameKey()
+	if cacheable {
+		if content, cursor, ok := m.frames.get(key); ok {
+			v.Content = content
+			v.Cursor = cursor
+			m.applyProgressBar(&v)
+			return v
+		}
+	}
+
 	canvas := uv.NewScreenBuffer(m.width, m.height)
 	v.Cursor = m.Draw(canvas, canvas.Bounds())
 
@@ -3188,13 +3227,22 @@ func (m *UI) View() tea.View {
 	content = strings.Join(contentLines, "\n")
 
 	v.Content = content
+	if cacheable {
+		m.storeFrame(key, content, v.Cursor)
+	}
+	m.applyProgressBar(&v)
+
+	return v
+}
+
+// applyProgressBar attaches the terminal progress bar while the agent is
+// busy. Kept outside the frame cache so the randomized value stays fresh.
+func (m *UI) applyProgressBar(v *tea.View) {
 	if m.progressBarEnabled && m.sendProgressBar && m.isAgentBusy() {
 		// HACK: use a random percentage to prevent ghostty from hiding it
 		// after a timeout.
 		v.ProgressBar = tea.NewProgressBar(tea.ProgressBarIndeterminate, rand.Intn(100))
 	}
-
-	return v
 }
 
 // ShortHelp implements [help.KeyMap].
@@ -3600,6 +3648,8 @@ func (m *UI) updateTextareaWithPrevHeight(msg tea.Msg, prevHeight int) tea.Cmd {
 
 // updateSize updates the sizes of UI components based on the current layout.
 func (m *UI) updateSize() {
+	m.invalidateFrames()
+
 	// Set status width
 	m.status.SetWidth(m.layout.status.Dx())
 

--- a/internal/ui/model/ui_test.go
+++ b/internal/ui/model/ui_test.go
@@ -117,3 +117,11 @@ type testWorkspace struct {
 func (w *testWorkspace) Config() *config.Config {
 	return w.cfg
 }
+
+func (w *testWorkspace) WorkingDir() string {
+	return "/tmp/crush-test"
+}
+
+func (w *testWorkspace) AgentIsReady() bool {
+	return false
+}


### PR DESCRIPTION
Bubble Tea runs Update+View synchronously per message, so a flood of wheel events pays for a full redraw each even when the scroll offset is clamped or returns to a recent position. Cache frames keyed by chat scroll position with a 3s TTL, LRU cap of 32, sweep-on-put and an idle GC tick so memory cannot grow unbounded. Only chat scroll handlers mark an update as scroll-only; everything else resets the cache, and layout changes during Draw discard the frame.

Co-Authored-By: Tai Groot <amittai.groot@gsa.gov>