### PR TITLE
ui-perf: stop coalesced wheel scrolls from rewinding to the selection

### DIFF
--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -544,6 +544,11 @@ func (m *Chat) ScrollPosition() (offsetIdx, offsetLine int) {
 	return m.list.ScrollPosition()
 }
 
+// Offset returns the scroll offset in lines from the top of the list.
+func (m *Chat) Offset() int {
+	return m.list.Offset()
+}
+
 // Selected returns the index of the selected item.
 func (m *Chat) Selected() int {
 	return m.list.Selected()
@@ -810,6 +815,28 @@ func (m *Chat) SelectLastInView() {
 			m.list.SetSelected(i)
 			return
 		}
+	}
+}
+
+// SelectNearestInView moves an out-of-view selection to the visible edge
+// nearest to it: the top row when the selection is above the viewport, the
+// bottom row when it is below. With no selection, scrolledUp picks the
+// bottom row (the content the user is moving towards) and otherwise the
+// top row.
+func (m *Chat) SelectNearestInView(scrolledUp bool) {
+	startIdx, _ := m.list.VisibleItemIndices()
+	sel := m.list.Selected()
+	switch {
+	case sel < 0:
+		if scrolledUp {
+			m.SelectLastInView()
+		} else {
+			m.SelectFirstInView()
+		}
+	case sel < startIdx:
+		m.SelectFirstInView()
+	default:
+		m.SelectLastInView()
 	}
 }
 

--- a/internal/ui/model/scroll_test.go
+++ b/internal/ui/model/scroll_test.go
@@ -1,0 +1,45 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyChatScroll_LargeDeltaIsNotRewoundBySelection(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+	u.chat.ScrollToBottom()
+	u.chat.SelectLast()
+	before := u.chat.Offset()
+
+	u.applyChatScroll(-60)
+	require.Equal(t, before-60, u.chat.Offset(), "selection follow must not rewind the viewport")
+	require.True(t, u.chat.SelectedItemInView())
+
+	u.applyChatScroll(60)
+	require.True(t, u.chat.AtBottom())
+	require.Equal(t, u.chat.Len()-1, u.chat.Selected(), "reaching the bottom must select the last item")
+}
+
+func TestApplyChatScroll_OutOfViewSelectionGoesToNearestEdge(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+	u.chat.ScrollToBottom()
+
+	// Selection far above the viewport, user scrolls up: it should land on
+	// the top row (nearest edge), not jump to the bottom row.
+	u.chat.SetSelected(0)
+	u.applyChatScroll(-5)
+	got := u.chat.Selected()
+	u.chat.SelectFirstInView()
+	require.Equal(t, u.chat.Selected(), got, "selection above viewport must snap to the top edge")
+
+	// Selection below the viewport, user scrolls down: bottom row.
+	u.chat.ScrollToTop()
+	u.chat.SetSelected(u.chat.Len() - 1)
+	u.applyChatScroll(5)
+	got = u.chat.Selected()
+	u.chat.SelectLastInView()
+	require.Equal(t, u.chat.Selected(), got, "selection below viewport must snap to the bottom edge")
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -706,6 +706,23 @@ func (m *UI) loadCustomCommands() tea.Cmd {
 	}
 }
 
+// applyChatScroll scrolls the chat by lines and, if the selection is then
+// outside the viewport, moves it to the nearest visible edge. The selection
+// is moved rather than scrolled to so a large coalesced delta is applied in
+// full instead of being rewound to the selected item.
+func (m *UI) applyChatScroll(lines int) tea.Cmd {
+	cmd := m.chat.ScrollByAndAnimate(lines)
+	if m.chat.SelectedItemInView() {
+		return cmd
+	}
+	if lines > 0 && m.chat.AtBottom() {
+		m.chat.SelectLast()
+		return cmd
+	}
+	m.chat.SelectNearestInView(lines < 0)
+	return cmd
+}
+
 // loadMCPrompts loads the MCP prompts asynchronously.
 func (m *UI) loadMCPrompts() tea.Msg {
 	prompts, err := m.com.Workspace.ListMCPPrompts(context.Background())
@@ -1240,20 +1257,8 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				break
 			}
 			m.markScrollOnly()
-			if cmd := m.chat.ScrollByAndAnimate(lines); cmd != nil {
+			if cmd := m.applyChatScroll(lines); cmd != nil {
 				cmds = append(cmds, cmd)
-			}
-			if !m.chat.SelectedItemInView() {
-				if lines < 0 {
-					m.chat.SelectPrev()
-				} else if m.chat.AtBottom() {
-					m.chat.SelectLast()
-				} else {
-					m.chat.SelectNext()
-				}
-				if cmd := m.chat.ScrollToSelectedAndAnimate(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
 			}
 		}
 	case frameGCMsg:


### PR DESCRIPTION
With delta coalescing, one wheel message can carry many lines of
scroll, but the handler only moved the selection one item and then
scrolled back to it, undoing most of the delta. Move an out-of-view
selection to the nearest visible edge instead so the full coalesced
delta is applied.

Co-Authored-By: Tai Groot <amittai.groot@gsa.gov>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>