### PR TITLE
ui-perf: drive all spinners from one shared animation clock

### DIFF
--- a/internal/format/spinner.go
+++ b/internal/format/spinner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/crush/internal/ui/anim"
@@ -22,7 +23,13 @@ type model struct {
 	anim   *anim.Anim
 }
 
-func (m model) Init() tea.Cmd  { return m.anim.Start() }
+type tickMsg struct{}
+
+func tick() tea.Cmd {
+	return tea.Tick(anim.FrameInterval(), func(time.Time) tea.Msg { return tickMsg{} })
+}
+
+func (m model) Init() tea.Cmd  { return tick() }
 func (m model) View() tea.View { return tea.NewView(m.anim.Render()) }
 
 // Update implements tea.Model.
@@ -34,9 +41,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.cancel()
 			return m, tea.Quit
 		}
-	case anim.StepMsg:
-		cmd := m.anim.Animate(msg)
-		return m, cmd
+	case tickMsg:
+		m.anim.Advance()
+		return m, tick()
 	}
 	return m, nil
 }

--- a/internal/ui/anim/anim.go
+++ b/internal/ui/anim/anim.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/zeebo/xxh3"
 
-	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/lucasb-eyer/go-colorful"
 
@@ -59,8 +58,8 @@ var (
 	ellipsisFrames = []string{".", "..", "...", ""}
 )
 
-// Internal ID management. Used during animating to ensure that frame messages
-// are received only by spinner components that sent them.
+// Internal ID management. The ID seeds the deterministic birth schedule so
+// two spinners built from the same settings do not animate in lockstep.
 var lastID atomic.Int64
 
 func nextID() int {
@@ -87,15 +86,11 @@ func settingsHash(opts Settings) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-// StepMsg is a message type used to trigger the next step in the animation.
-// Gen carries the generation of the tick chain that produced it. A chain
-// started by a later Start() bumps the Anim's generation, so ticks from an
-// older chain (mismatched Gen) are dropped instead of advancing the frame.
-// This is what keeps a single spinner from being driven by two concurrent
-// tick chains (which would render as a doubled, double-speed animation).
-type StepMsg struct {
-	ID  string
-	Gen int64
+// FrameInterval returns how long each animation frame stays on screen. The
+// UI drives every Anim from one clock ticking at this interval; Anim
+// instances never schedule themselves.
+func FrameInterval() time.Duration {
+	return time.Second / time.Duration(fps)
 }
 
 // Settings defines settings for the animation.
@@ -138,19 +133,12 @@ type Anim struct {
 	initialized      atomic.Bool
 	cyclingFrames    [][]string           // frames for the cycling characters
 	step             atomic.Int64         // current main frame step (wraps)
-	framesSinceStart atomic.Int64         // total Animate ticks (does not wrap)
+	framesSinceStart atomic.Int64         // total Advance frames (does not wrap)
 	ellipsisStep     atomic.Int64         // current ellipsis frame step
 	ellipsisFrames   *csync.Slice[string] // ellipsis animation frames
 	id               string
 	suffix           func() string
 	suffixColor      color.Color
-
-	// gen identifies the currently armed tick chain. Start() bumps it and
-	// stamps every emitted StepMsg with the new value; Animate() drops ticks
-	// whose Gen does not match (unless Gen is the zero wildcard). Re-arming
-	// therefore supersedes any in-flight chain instead of running a second
-	// one concurrently, and Stop() bumps it to kill a chain outright.
-	gen atomic.Int64
 }
 
 // New creates a new Anim instance with the specified width and label.
@@ -394,34 +382,10 @@ func (a *Anim) Width() (w int) {
 	return w
 }
 
-// Start starts the animation. It bumps the generation so any tick chain
-// started by a previous Start() is superseded: its in-flight StepMsgs carry
-// the old generation and are dropped by Animate() instead of advancing the
-// frame a second time. Without this, re-arming a spinner that still has a
-// live chain (e.g. reloading a session whose message never got a Finish
-// part) would run two chains concurrently and render a doubled animation.
-func (a *Anim) Start() tea.Cmd {
-	a.gen.Add(1)
-	return a.Step()
-}
-
-// Stop kills any in-flight tick chain without starting a new one. It bumps
-// the generation so outstanding StepMsgs no longer match; the next one to
-// arrive is dropped and the chain terminates.
-func (a *Anim) Stop() {
-	a.gen.Add(1)
-}
-
-// Animate advances the animation to the next step.
-func (a *Anim) Animate(msg StepMsg) tea.Cmd {
-	if msg.ID != a.id {
-		return nil
-	}
-	// Drop ticks from a superseded chain.
-	if msg.Gen != a.gen.Load() {
-		return nil
-	}
-
+// Advance moves the animation forward by one frame. It is called by the
+// UI's shared animation clock for every visible spinner; the Anim itself
+// never schedules ticks.
+func (a *Anim) Advance() bool {
 	step := a.step.Add(1)
 	if int(step) >= len(a.cyclingFrames) {
 		a.step.Store(0)
@@ -437,7 +401,7 @@ func (a *Anim) Animate(msg StepMsg) tea.Cmd {
 	} else if !a.initialized.Load() && int(frames) >= maxBirthSteps {
 		a.initialized.Store(true)
 	}
-	return a.Step()
+	return true
 }
 
 // Render renders the current state of the animation.
@@ -495,16 +459,6 @@ func (a *Anim) Render() string {
 	}
 
 	return b.String()
-}
-
-// Step is a command that triggers the next step in the animation. The
-// emitted StepMsg carries the current generation so Animate() can tell
-// whether this tick still belongs to the armed chain.
-func (a *Anim) Step() tea.Cmd {
-	gen := a.gen.Load()
-	return tea.Tick(time.Second/time.Duration(fps), func(t time.Time) tea.Msg {
-		return StepMsg{ID: a.id, Gen: gen}
-	})
 }
 
 // makeGradientRamp() returns a slice of colors blended between the given keys.

--- a/internal/ui/anim/anim_test.go
+++ b/internal/ui/anim/anim_test.go
@@ -2,237 +2,72 @@ package anim
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
-// TestStartSupersedesPreviousChain verifies that calling Start() twice
-// does not result in two concurrent tick chains advancing the same Anim.
-// The second Start() bumps the generation, so ticks from the first chain
-// (carrying the old generation) are dropped by Animate().
-func TestStartSupersedesPreviousChain(t *testing.T) {
+// TestFrameInterval covers the shared animation clock: every Anim in the
+// UI is driven by a single tea.Tick chain at this interval.
+func TestFrameInterval(t *testing.T) {
 	t.Parallel()
-
-	a := New(Settings{ID: "test", Size: 5})
-
-	// First chain.
-	cmd1 := a.Start()
-	gen1 := a.gen.Load()
-	require.Equal(t, int64(1), gen1)
-
-	// Second chain supersedes the first.
-	cmd2 := a.Start()
-	gen2 := a.gen.Load()
-	require.Equal(t, int64(2), gen2)
-
-	// Execute both commands to get their StepMsgs.
-	msg1 := cmd1().(StepMsg)
-	msg2 := cmd2().(StepMsg)
-
-	require.Equal(t, gen1, msg1.Gen, "first chain carries old generation")
-	require.Equal(t, gen2, msg2.Gen, "second chain carries new generation")
-
-	// The old-generation tick must be dropped.
-	framesBefore := a.framesSinceStart.Load()
-	next := a.Animate(msg1)
-	require.Nil(t, next, "old-generation tick must not schedule another step")
-	require.Equal(t, framesBefore, a.framesSinceStart.Load(),
-		"old-generation tick must not advance the frame")
-
-	// The new-generation tick must advance.
-	next = a.Animate(msg2)
-	require.NotNil(t, next, "current-generation tick must schedule another step")
-	require.Equal(t, framesBefore+1, a.framesSinceStart.Load(),
-		"current-generation tick must advance the frame")
+	require.Equal(t, time.Second/time.Duration(fps), FrameInterval())
 }
 
-// TestStopKillsChain verifies that Stop() bumps the generation so any
-// in-flight tick chain is terminated.
-func TestStopKillsChain(t *testing.T) {
+// TestAdvanceMovesStep verifies that each Advance call advances the frame
+// step counter and wraps it so the prerendered frames loop.
+func TestAdvanceMovesStep(t *testing.T) {
 	t.Parallel()
 
 	a := New(Settings{ID: "test", Size: 5})
-	cmd := a.Start()
-	msg := cmd().(StepMsg)
 
-	a.Stop()
-	require.NotEqual(t, msg.Gen, a.gen.Load(), "Stop must bump the generation")
-
-	// The in-flight tick must be dropped.
-	framesBefore := a.framesSinceStart.Load()
-	next := a.Animate(msg)
-	require.Nil(t, next, "tick after Stop must not schedule another step")
-	require.Equal(t, framesBefore, a.framesSinceStart.Load(),
-		"tick after Stop must not advance the frame")
-}
-
-// TestForeignIDStillDropped verifies that the existing ID gate still works
-// alongside the generation gate.
-func TestForeignIDStillDropped(t *testing.T) {
-	t.Parallel()
-
-	a := New(Settings{ID: "test", Size: 5})
-	cmd := a.Start()
-	msg := cmd().(StepMsg)
-
-	framesBefore := a.framesSinceStart.Load()
-	next := a.Animate(StepMsg{ID: "other", Gen: msg.Gen})
-	require.Nil(t, next)
-	require.Equal(t, framesBefore, a.framesSinceStart.Load(),
-		"foreign ID must not advance the frame")
-}
-
-// TestStepMsgCarriesGeneration verifies that Step() stamps the current
-// generation into the emitted StepMsg.
-func TestStepMsgCarriesGeneration(t *testing.T) {
-	t.Parallel()
-
-	a := New(Settings{ID: "test", Size: 5})
-	require.Equal(t, int64(0), a.gen.Load(), "fresh Anim starts at generation 0")
-
-	cmd := a.Step()
-	msg := cmd().(StepMsg)
-	require.Equal(t, int64(0), msg.Gen, "Step before Start carries gen 0")
-
-	a.Start()
-	cmd = a.Step()
-	msg = cmd().(StepMsg)
-	require.Equal(t, int64(1), msg.Gen, "Step after Start carries gen 1")
-}
-
-// TestAnimateSchedulesNextStep verifies the normal happy path: a matching
-// tick advances the frame and schedules the next step.
-func TestAnimateSchedulesNextStep(t *testing.T) {
-	t.Parallel()
-
-	a := New(Settings{ID: "test", Size: 5})
-	cmd := a.Start()
-	msg := cmd().(StepMsg)
-
-	next := a.Animate(msg)
-	require.NotNil(t, next, "matching tick must schedule the next step")
-
-	// The next command should also produce a StepMsg with the same gen.
-	nextMsg := next().(StepMsg)
-	require.Equal(t, msg.Gen, nextMsg.Gen, "chained tick must carry the same generation")
-	require.Equal(t, msg.ID, nextMsg.ID)
-}
-
-// TestSingleChainAdvances verifies that a single Start() produces a
-// working chain that advances frames on each tick.
-func TestSingleChainAdvances(t *testing.T) {
-	t.Parallel()
-
-	a := New(Settings{ID: "test", Size: 5})
-	cmd := a.Start()
-	require.NotNil(t, cmd)
-
-	msg := cmd().(StepMsg)
-	require.Equal(t, "test", msg.ID)
-	require.Equal(t, int64(1), msg.Gen)
-
-	// Advance a few frames.
-	for range 5 {
-		next := a.Animate(msg)
-		require.NotNil(t, next)
-		msg = next().(StepMsg)
+	require.Equal(t, int64(0), a.framesSinceStart.Load())
+	for range prerenderedFrames * 3 {
+		require.True(t, a.Advance(), "an advance must report that output changed")
 	}
-	require.Equal(t, int64(5), a.framesSinceStart.Load())
+	require.Equal(t, int64(prerenderedFrames*3), a.framesSinceStart.Load(),
+		"every frame must be counted")
+	require.Less(t, int(a.step.Load()), len(a.cyclingFrames),
+		"step must wrap within the prerendered frame range")
 }
 
-// TestConcurrentStartDoesNotDoubleAdvance simulates the bug scenario:
-// two Start() calls produce two chains, and both chains' ticks arrive.
-// Only the second chain's ticks should advance the frame.
-func TestConcurrentStartDoesNotDoubleAdvance(t *testing.T) {
+// TestAdvanceInitializesBirth verifies that the birth animation completes
+// after maxBirthSteps frames and that the ellipsis only animates once all
+// characters have been initialized.
+func TestAdvanceInitializesBirth(t *testing.T) {
 	t.Parallel()
 
-	a := New(Settings{ID: "test", Size: 5})
+	a := New(Settings{ID: "test", Size: 5, Label: "Generating"})
+	require.False(t, a.initialized.Load())
 
-	cmd1 := a.Start()
-	cmd2 := a.Start()
-
-	msg1 := cmd1().(StepMsg)
-	msg2 := cmd2().(StepMsg)
-
-	// Interleave ticks from both chains.
-	frames := int64(0)
-	for range 10 {
-		if next := a.Animate(msg1); next != nil {
-			frames++
-			msg1 = next().(StepMsg)
-		}
-		if next := a.Animate(msg2); next != nil {
-			frames++
-			msg2 = next().(StepMsg)
-		}
+	ellipsisBefore := int(a.ellipsisStep.Load())
+	for range maxBirthSteps - 1 {
+		a.Advance()
 	}
+	require.False(t, a.initialized.Load(), "birth must not complete before maxBirthSteps frames")
 
-	// Only chain 2 should have advanced. Chain 1's ticks are all dropped
-	// after the first Start() supersedes it.
-	require.Equal(t, int64(10), a.framesSinceStart.Load(),
-		"only the latest chain should advance the frame")
-	require.Equal(t, frames, a.framesSinceStart.Load())
+	a.Advance()
+	require.True(t, a.initialized.Load())
+
+	for i := 1; i <= ellipsisAnimSpeed*2; i++ {
+		a.Advance()
+	}
+	require.NotEqual(t, ellipsisBefore, int(a.ellipsisStep.Load()),
+		"the ellipsis must animate once initialized")
 }
 
-// TestMultipleAnimsIndependent verifies that two Anim instances with
-// different IDs don't interfere with each other.
-func TestMultipleAnimsIndependent(t *testing.T) {
+// TestAdvanceIndependentInstances verifies that two Anim instances advance
+// their own counters; the shared clock simply calls Advance on each.
+func TestAdvanceIndependentInstances(t *testing.T) {
 	t.Parallel()
 
 	a1 := New(Settings{ID: "a1", Size: 5})
 	a2 := New(Settings{ID: "a2", Size: 5})
 
-	cmd1 := a1.Start()
-	cmd2 := a2.Start()
-
-	msg1 := cmd1().(StepMsg)
-	msg2 := cmd2().(StepMsg)
-
-	// Advance a1 only.
-	a1.Animate(msg1)
+	a1.Advance()
 	require.Equal(t, int64(1), a1.framesSinceStart.Load())
 	require.Equal(t, int64(0), a2.framesSinceStart.Load())
 
-	// Advance a2 only.
-	a2.Animate(msg2)
-	require.Equal(t, int64(1), a1.framesSinceStart.Load())
+	a2.Advance()
 	require.Equal(t, int64(1), a2.framesSinceStart.Load())
-
-	// Cross-talk: a1's tick must not advance a2.
-	a2.Animate(msg1)
-	require.Equal(t, int64(1), a2.framesSinceStart.Load())
-}
-
-// TestStopThenStart verifies that Stop() followed by Start() produces a
-// working chain with a fresh generation.
-func TestStopThenStart(t *testing.T) {
-	t.Parallel()
-
-	a := New(Settings{ID: "test", Size: 5})
-	cmd := a.Start()
-	msg := cmd().(StepMsg)
-
-	a.Stop()
-	genAfterStop := a.gen.Load()
-
-	cmd = a.Start()
-	msg2 := cmd().(StepMsg)
-	require.Equal(t, genAfterStop+1, msg2.Gen)
-
-	// Old tick must be dropped.
-	require.Nil(t, a.Animate(msg))
-
-	// New tick must work.
-	require.NotNil(t, a.Animate(msg2))
-}
-
-// TestAnimateWithoutStart verifies that Animate works on a fresh Anim
-// whose generation is still zero, matching a zero-gen StepMsg.
-func TestAnimateWithoutStart(t *testing.T) {
-	t.Parallel()
-
-	a := New(Settings{ID: "test", Size: 5})
-	msg := StepMsg{ID: "test", Gen: 0}
-	next := a.Animate(msg)
-	require.NotNil(t, next, "matching gen-0 tick must advance a fresh Anim")
 }

--- a/internal/ui/chat/agent.go
+++ b/internal/ui/chat/agent.go
@@ -4,12 +4,10 @@ import (
 	"encoding/json"
 	"strings"
 
-	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/tree"
 	"github.com/charmbracelet/crush/internal/agent"
 	"github.com/charmbracelet/crush/internal/message"
-	"github.com/charmbracelet/crush/internal/ui/anim"
 	"github.com/charmbracelet/crush/internal/ui/styles"
 )
 
@@ -52,34 +50,37 @@ func NewAgentToolMessageItem(
 	return t
 }
 
-// Animate progresses the message animation if it should be spinning.
+// Advance implements [Animatable].
 //
-// Bumps the parent's F6 list-cache version on both the parent-tick and
-// nested-tick branches. Nested tools are not list entries of their
-// own — their IDs map to this parent's index in idInxMap
-// (internal/ui/model/chat.go:240-246) and their renders are embedded
-// inline in this parent's output — so the list only checks the
-// parent's version. Without the bump, the list cache would serve the
-// previously rendered frame indefinitely and the spinner would appear
-// frozen.
-func (a *AgentToolMessageItem) Animate(msg anim.StepMsg) tea.Cmd {
+// Advances the parent's own spinner and every spinning nested tool in
+// one frame, bumping the parent's F6 list-cache version. Nested tools
+// are not list entries of their own — their IDs map to this parent's
+// index in idInxMap and their renders are embedded inline in this
+// parent's output — so the list only checks the parent's version.
+// Without the bump, the list cache would serve the previously rendered
+// frame indefinitely and the spinner would appear frozen.
+func (a *AgentToolMessageItem) Advance() bool {
 	if a.result != nil || a.Status() == ToolStatusCanceled {
-		return nil
+		return false
 	}
-	if msg.ID == a.ID() {
+	changed := a.anim.Advance()
+	changed = advanceNested(a.nestedTools) || changed
+	if changed {
 		a.Bump()
-		return a.anim.Animate(msg)
 	}
-	for _, nestedTool := range a.nestedTools {
-		if msg.ID != nestedTool.ID() {
-			continue
-		}
-		if s, ok := nestedTool.(Animatable); ok {
-			a.Bump()
-			return s.Animate(msg)
+	return changed
+}
+
+// advanceNested advances every spinning animatable tool in tools and
+// reports whether any of them changed.
+func advanceNested(tools []ToolMessageItem) bool {
+	changed := false
+	for _, nestedTool := range tools {
+		if s, ok := nestedTool.(Animatable); ok && s.Spinning() && s.Advance() {
+			changed = true
 		}
 	}
-	return nil
+	return changed
 }
 
 // NestedTools returns the nested tools.
@@ -224,31 +225,19 @@ func NewAgenticFetchToolMessageItem(
 	return t
 }
 
-// Animate progresses the message animation if it should be spinning.
-// See [AgentToolMessageItem.Animate] for the parent-bump rationale —
-// without an override, the embedded base.Animate would (a) drop
-// StepMsgs whose ID matches a nested child instead of the parent
-// (anim.Animate's ID check at internal/ui/anim/anim.go:326-329
-// silently returns nil), and (b) never invalidate the parent's
-// list-cache entry on a parent tick.
-func (a *AgenticFetchToolMessageItem) Animate(msg anim.StepMsg) tea.Cmd {
+// Advance implements [Animatable]. See [AgentToolMessageItem.Advance]
+// for the parent-bump rationale; without an override the embedded base
+// Advance would never advance the nested children.
+func (a *AgenticFetchToolMessageItem) Advance() bool {
 	if a.result != nil || a.Status() == ToolStatusCanceled {
-		return nil
+		return false
 	}
-	if msg.ID == a.ID() {
+	changed := a.anim.Advance()
+	changed = advanceNested(a.nestedTools) || changed
+	if changed {
 		a.Bump()
-		return a.anim.Animate(msg)
 	}
-	for _, nestedTool := range a.nestedTools {
-		if msg.ID != nestedTool.ID() {
-			continue
-		}
-		if s, ok := nestedTool.(Animatable); ok {
-			a.Bump()
-			return s.Animate(msg)
-		}
-	}
-	return nil
+	return changed
 }
 
 // NestedTools returns the nested tools.

--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -245,27 +245,24 @@ func NewAssistantMessageItem(sty *styles.Styles, message *message.Message) Messa
 	return a
 }
 
-// StartAnimation starts the assistant message animation if it should be spinning.
-func (a *AssistantMessageItem) StartAnimation() tea.Cmd {
-	if !a.isSpinning() {
-		return nil
-	}
-	return a.anim.Start()
+// Spinning implements [Animatable].
+func (a *AssistantMessageItem) Spinning() bool {
+	return a.isSpinning()
 }
 
-// Animate progresses the assistant message animation if it should be spinning.
-func (a *AssistantMessageItem) Animate(msg anim.StepMsg) tea.Cmd {
-	if !a.isSpinning() {
-		return nil
+// Advance implements [Animatable].
+func (a *AssistantMessageItem) Advance() bool {
+	if !a.isSpinning() || !a.anim.Advance() {
+		return false
 	}
 	// Bump the F6 list-cache version so the next draw re-renders
-	// this item: a spinner tick mutates anim's internal frame
-	// counter, which changes the rendered output but is invisible
-	// to the per-section content hashes. Without the bump the
-	// list cache would serve the previously rendered frame
-	// indefinitely and the spinner would appear frozen.
+	// this item: a spinner frame mutates anim's internal counter,
+	// which changes the rendered output but is invisible to the
+	// per-section content hashes. Without the bump the list cache
+	// would serve the previously rendered frame indefinitely and
+	// the spinner would appear frozen.
 	a.Bump()
-	return a.anim.Animate(msg)
+	return true
 }
 
 // ID implements MessageItem.
@@ -674,8 +671,7 @@ func (a *AssistantMessageItem) isSpinning() bool {
 // sub-section caches whose source text or extras changed are
 // invalidated; the others survive and serve cache hits on the next
 // RawRender.
-func (a *AssistantMessageItem) SetMessage(msg *message.Message) tea.Cmd {
-	wasSpinning := a.isSpinning()
+func (a *AssistantMessageItem) SetMessage(msg *message.Message) {
 	a.message = msg
 	// Bump the F6 version even if the underlying *message.Message
 	// pointer is identical: callers may have mutated the message in
@@ -687,16 +683,14 @@ func (a *AssistantMessageItem) SetMessage(msg *message.Message) tea.Cmd {
 	// section's source hash, so an unchanged section keeps its prefix
 	// cache valid while a changed section forces a miss naturally.
 	// Section caches themselves are content-keyed, so they do not
-	// need an explicit drop here either.
-	if !wasSpinning && a.isSpinning() {
-		return a.StartAnimation()
-	}
-	return nil
+	// need an explicit drop here either. If the message started
+	// spinning the UI's animation clock picks it up on the next
+	// update.
 }
 
 // Finished implements list.Item. The assistant message is freezable
 // once the message reports IsFinished() and is no longer spinning
-// (no animation tick remains pending). Streaming tail animation is
+// (no animation frame remains pending). Streaming tail animation is
 // caught by isSpinning, so freezing only kicks in once the turn is
 // fully terminal. The list cache invalidates the entry on the next
 // version bump if anything (focus, highlight, expansion) changes.

--- a/internal/ui/chat/messages.go
+++ b/internal/ui/chat/messages.go
@@ -10,7 +10,6 @@ import (
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/message"
-	"github.com/charmbracelet/crush/internal/ui/anim"
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/common"
 	"github.com/charmbracelet/crush/internal/ui/list"
@@ -29,10 +28,17 @@ type Identifiable interface {
 	ID() string
 }
 
-// Animatable is an interface for items that support animation.
+// Animatable is an interface for items that support animation. Items do
+// not schedule their own frames: the UI runs a single animation clock and
+// calls Advance on every visible item that reports Spinning.
 type Animatable interface {
-	StartAnimation() tea.Cmd
-	Animate(msg anim.StepMsg) tea.Cmd
+	// Spinning reports whether the item currently shows a running
+	// animation and therefore needs clock ticks.
+	Spinning() bool
+	// Advance moves the animation forward by one frame and reports
+	// whether the rendered output changed. Implementations must bump
+	// their version when it did so the list cache re-renders the item.
+	Advance() bool
 }
 
 // Expandable is an interface for items that can be expanded or collapsed.

--- a/internal/ui/chat/shell.go
+++ b/internal/ui/chat/shell.go
@@ -121,21 +121,18 @@ func (s *ShellItem) ID() string          { return s.id }
 func (s *ShellItem) FilterValue() string { return s.command }
 func (s *ShellItem) Finished() bool      { return !s.pending }
 
-// StartAnimation starts the spinner animation for pending shell items.
-func (s *ShellItem) StartAnimation() tea.Cmd {
-	if !s.pending {
-		return nil
-	}
-	return s.anim.Start()
+// Spinning implements [Animatable].
+func (s *ShellItem) Spinning() bool {
+	return s.pending
 }
 
-// Animate advances the spinner animation for pending shell items.
-func (s *ShellItem) Animate(msg anim.StepMsg) tea.Cmd {
-	if !s.pending {
-		return nil
+// Advance advances the spinner animation for pending shell items.
+func (s *ShellItem) Advance() bool {
+	if !s.pending || !s.anim.Advance() {
+		return false
 	}
 	s.Bump()
-	return s.anim.Animate(msg)
+	return true
 }
 
 func (s *ShellItem) Render(width int) string {

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -300,32 +300,24 @@ func (t *baseToolMessageItem) ID() string {
 	return t.toolCall.ID
 }
 
-// StartAnimation starts the assistant message animation if it should be spinning.
-func (t *baseToolMessageItem) StartAnimation() tea.Cmd {
-	if !t.isSpinning() {
-		return nil
-	}
-	return t.anim.Start()
+// Spinning implements [Animatable].
+func (t *baseToolMessageItem) Spinning() bool {
+	return t.isSpinning()
 }
 
-// Animate progresses the assistant message animation if it should be spinning.
+// Advance implements [Animatable].
 //
 // Bumps the F6 list-cache version so the next draw re-renders this
-// item: a spinner tick mutates anim's internal frame counter, which
-// changes the rendered output but is invisible to the per-item
-// caches. Without the bump the list cache would serve the previously
-// rendered frame indefinitely and the spinner would appear frozen.
-// The ID gate keeps unrelated ticks (routed here by a future change
-// to chat.Animate's dispatch) from churning the cache.
-func (t *baseToolMessageItem) Animate(msg anim.StepMsg) tea.Cmd {
-	if !t.isSpinning() {
-		return nil
-	}
-	if msg.ID != t.toolCall.ID {
-		return nil
+// item: a spinner frame mutates anim's internal counter, which changes
+// the rendered output but is invisible to the per-item caches. Without
+// the bump the list cache would serve the previously rendered frame
+// indefinitely and the spinner would appear frozen.
+func (t *baseToolMessageItem) Advance() bool {
+	if !t.isSpinning() || !t.anim.Advance() {
+		return false
 	}
 	t.Bump()
-	return t.anim.Animate(msg)
+	return true
 }
 
 // RawRender implements [MessageItem].

--- a/internal/ui/chat/version_bump_test.go
+++ b/internal/ui/chat/version_bump_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/charmbracelet/crush/internal/config"
 	"github.com/charmbracelet/crush/internal/message"
-	"github.com/charmbracelet/crush/internal/ui/anim"
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/list"
 	"github.com/charmbracelet/crush/internal/ui/styles"
@@ -169,13 +168,13 @@ func TestBaseToolMessageItem_MutatorsBumpVersion(t *testing.T) {
 	})
 }
 
-// TestAssistantMessageItem_AnimateBumpsVersion covers the spinner
-// regression: while the assistant message is spinning, every
-// anim.StepMsg fed through Animate must bump Version() so the
-// list-level cache invalidates and the next draw re-renders the
-// advanced spinner frame. Without this bump the cached entry's
-// version stays put and the spinner appears frozen.
-func TestAssistantMessageItem_AnimateBumpsVersion(t *testing.T) {
+// TestAssistantMessageItem_AdvanceBumpsVersion covers the spinner
+// regression: while the assistant message is spinning, every clock
+// frame fed through Advance must bump Version() so the list-level
+// cache invalidates and the next draw re-renders the advanced spinner
+// frame. Without this bump the cached entry's version stays put and
+// the spinner appears frozen.
+func TestAssistantMessageItem_AdvanceBumpsVersion(t *testing.T) {
 	t.Parallel()
 
 	sty := styles.CharmtonePantera()
@@ -187,12 +186,13 @@ func TestAssistantMessageItem_AnimateBumpsVersion(t *testing.T) {
 		},
 	}
 	item := NewAssistantMessageItem(&sty, streaming).(*AssistantMessageItem)
+	require.True(t, item.Spinning())
 
-	requireBump(t, "Animate", item, func() {
-		item.Animate(anim.StepMsg{})
+	requireBump(t, "Advance", item, func() {
+		item.Advance()
 	})
 
-	// A non-spinning item must not bump on Animate: the bump only
+	// A non-spinning item must not bump on Advance: the bump only
 	// makes sense while the spinner is live, and a stray bump on a
 	// finished item would needlessly invalidate frozen entries.
 	finished := &message.Message{
@@ -205,9 +205,10 @@ func TestAssistantMessageItem_AnimateBumpsVersion(t *testing.T) {
 	}
 	item.SetMessage(finished)
 	require.True(t, item.Finished(), "item must report Finished() once the message finishes")
+	require.False(t, item.Spinning())
 	before := item.Version()
-	item.Animate(anim.StepMsg{})
-	require.Equal(t, before, item.Version(), "Animate must not bump Version() on a non-spinning item")
+	item.Advance()
+	require.Equal(t, before, item.Version(), "Advance must not bump Version() on a non-spinning item")
 }
 
 // TestAssistantMessageItem_FinishedTransition covers §4.5.1: a
@@ -417,14 +418,13 @@ func requireNoBump(t *testing.T, name string, item versionedItem, mutate func())
 		"%s must not bump Version() (before=%d, after=%d)", name, before, after)
 }
 
-// TestBaseToolMessageItem_AnimateBumpsVersion is the spinner
+// TestBaseToolMessageItem_AdvanceBumpsVersion is the spinner
 // regression test for non-agent tools: while the tool is spinning,
-// every anim.StepMsg whose ID matches the tool must bump Version()
-// so the list-level cache invalidates and the next draw re-renders
-// the advanced spinner frame. Foreign IDs must not bump (they would
-// churn the cache on every frame), and a finished tool must not
-// bump on any ID (the entry is frozen and stays frozen).
-func TestBaseToolMessageItem_AnimateBumpsVersion(t *testing.T) {
+// every clock frame must bump Version() so the list-level cache
+// invalidates and the next draw re-renders the advanced spinner
+// frame. A finished tool must not bump (the entry is frozen and stays
+// frozen) and must report that it no longer needs frames.
+func TestBaseToolMessageItem_AdvanceBumpsVersion(t *testing.T) {
 	t.Parallel()
 
 	sty := styles.CharmtonePantera()
@@ -433,43 +433,32 @@ func TestBaseToolMessageItem_AnimateBumpsVersion(t *testing.T) {
 	v := item.(versionedItem)
 	a, ok := item.(Animatable)
 	require.True(t, ok, "base tool message item must implement Animatable")
+	require.True(t, a.Spinning())
 
-	// Spinning + matching ID → bump.
-	requireBump(t, "Animate[spinning,own ID]", v, func() {
-		a.Animate(anim.StepMsg{ID: tc.ID})
+	requireBump(t, "Advance[spinning]", v, func() {
+		a.Advance()
 	})
 
-	// Spinning + foreign ID → no bump. Routing this StepMsg here at
-	// all would mean a future chat.Animate refactor; the item must
-	// be defensive against it so we don't churn the list cache.
-	requireNoBump(t, "Animate[spinning,foreign ID]", v, func() {
-		a.Animate(anim.StepMsg{ID: "some-other-tool"})
-	})
-
-	// Finished → no bump on any ID. The entry is frozen; a stray
-	// bump would needlessly invalidate frozen entries.
+	// Finished → no bump. The entry is frozen; a stray bump would
+	// needlessly invalidate frozen entries.
 	tcFinished := tc
 	tcFinished.Finished = true
 	item.SetToolCall(tcFinished)
 	item.SetResult(&message.ToolResult{ToolCallID: tc.ID, Content: "ok"})
 	require.True(t, item.Finished(), "tool must report Finished() once the result lands")
+	require.False(t, a.Spinning(), "finished tool must not request frames")
 
-	requireNoBump(t, "Animate[finished,own ID]", v, func() {
-		a.Animate(anim.StepMsg{ID: tc.ID})
-	})
-	requireNoBump(t, "Animate[finished,foreign ID]", v, func() {
-		a.Animate(anim.StepMsg{ID: "some-other-tool"})
+	requireNoBump(t, "Advance[finished]", v, func() {
+		a.Advance()
 	})
 }
 
-// TestAgentToolMessageItem_AnimateBumpsVersion is the spinner
-// regression test for agent tools. The parent must bump on both
-// the parent-tick branch (msg.ID == parent.ID()) and the
-// nested-tick branch (msg.ID == nested.ID()) because the list
-// only checks the parent's version — nested tools are not list
-// entries of their own. Unrelated IDs must not bump, and a parent
-// with a result must not bump on any ID.
-func TestAgentToolMessageItem_AnimateBumpsVersion(t *testing.T) {
+// TestAgentToolMessageItem_AdvanceBumpsVersion is the spinner
+// regression test for agent tools. One clock frame must advance the
+// parent and every spinning nested tool and bump the parent, because
+// the list only checks the parent's version — nested tools are not
+// list entries of their own. A parent with a result must not bump.
+func TestAgentToolMessageItem_AdvanceBumpsVersion(t *testing.T) {
 	t.Parallel()
 
 	sty := styles.CharmtonePantera()
@@ -479,42 +468,32 @@ func TestAgentToolMessageItem_AnimateBumpsVersion(t *testing.T) {
 	childTC := message.ToolCall{ID: "agent-child", Name: "bash", Input: `{}`, Finished: false}
 	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, "")
 	parent.AddNestedTool(child)
+	childV := child.(versionedItem)
 
-	// Spinning + parent's own ID → parent bumps.
-	requireBump(t, "Animate[spinning,parent ID]", parent, func() {
-		parent.Animate(anim.StepMsg{ID: parentTC.ID})
+	requireBump(t, "Advance[spinning,parent]", parent, func() {
+		parent.Advance()
+	})
+	// The nested child must have advanced in the same frame.
+	requireBump(t, "Advance[spinning,nested]", childV, func() {
+		parent.Advance()
 	})
 
-	// Spinning + nested child ID → parent bumps. The list only
-	// invalidates on the parent; without this the nested
-	// spinner's frame would never reach the screen even though
-	// the nested anim's step has advanced.
-	requireBump(t, "Animate[spinning,nested ID]", parent, func() {
-		parent.Animate(anim.StepMsg{ID: childTC.ID})
-	})
-
-	// Spinning + unrelated ID → no bump.
-	requireNoBump(t, "Animate[spinning,foreign ID]", parent, func() {
-		parent.Animate(anim.StepMsg{ID: "unrelated"})
-	})
-
-	// Once the parent has a result, neither branch bumps.
+	// Once the parent has a result, nothing bumps.
 	parent.SetResult(&message.ToolResult{ToolCallID: parentTC.ID, Content: "done"})
-	requireNoBump(t, "Animate[finished,parent ID]", parent, func() {
-		parent.Animate(anim.StepMsg{ID: parentTC.ID})
+	require.False(t, parent.Spinning())
+	requireNoBump(t, "Advance[finished,parent]", parent, func() {
+		parent.Advance()
 	})
-	requireNoBump(t, "Animate[finished,nested ID]", parent, func() {
-		parent.Animate(anim.StepMsg{ID: childTC.ID})
+	requireNoBump(t, "Advance[finished,nested]", childV, func() {
+		parent.Advance()
 	})
 }
 
-// TestAgenticFetchToolMessageItem_AnimateBumpsVersion is the
-// agentic-fetch counterpart of the agent-tool Animate bump test.
-// Without an explicit override the embedded base Animate would
-// drop nested-child StepMsgs at anim.Animate's ID check and never
-// bump the parent on its own ticks; this test locks in the
-// override.
-func TestAgenticFetchToolMessageItem_AnimateBumpsVersion(t *testing.T) {
+// TestAgenticFetchToolMessageItem_AdvanceBumpsVersion is the
+// agentic-fetch counterpart of the agent-tool Advance bump test.
+// Without an explicit override the embedded base Advance would never
+// advance the nested children; this test locks in the override.
+func TestAgenticFetchToolMessageItem_AdvanceBumpsVersion(t *testing.T) {
 	t.Parallel()
 
 	sty := styles.CharmtonePantera()
@@ -524,23 +503,21 @@ func TestAgenticFetchToolMessageItem_AnimateBumpsVersion(t *testing.T) {
 	childTC := message.ToolCall{ID: "fetch-child", Name: "fetch", Input: `{}`, Finished: false}
 	child := NewToolMessageItem(&sty, "msg", childTC, nil, false, "")
 	parent.AddNestedTool(child)
+	childV := child.(versionedItem)
 
-	requireBump(t, "Animate[spinning,parent ID]", parent, func() {
-		parent.Animate(anim.StepMsg{ID: parentTC.ID})
+	requireBump(t, "Advance[spinning,parent]", parent, func() {
+		parent.Advance()
 	})
-	requireBump(t, "Animate[spinning,nested ID]", parent, func() {
-		parent.Animate(anim.StepMsg{ID: childTC.ID})
-	})
-	requireNoBump(t, "Animate[spinning,foreign ID]", parent, func() {
-		parent.Animate(anim.StepMsg{ID: "unrelated"})
+	requireBump(t, "Advance[spinning,nested]", childV, func() {
+		parent.Advance()
 	})
 
 	parent.SetResult(&message.ToolResult{ToolCallID: parentTC.ID, Content: "done"})
-	requireNoBump(t, "Animate[finished,parent ID]", parent, func() {
-		parent.Animate(anim.StepMsg{ID: parentTC.ID})
+	requireNoBump(t, "Advance[finished,parent]", parent, func() {
+		parent.Advance()
 	})
-	requireNoBump(t, "Animate[finished,nested ID]", parent, func() {
-		parent.Animate(anim.StepMsg{ID: childTC.ID})
+	requireNoBump(t, "Advance[finished,nested]", childV, func() {
+		parent.Advance()
 	})
 }
 

--- a/internal/ui/model/anim_clock_test.go
+++ b/internal/ui/model/anim_clock_test.go
@@ -1,0 +1,243 @@
+package model
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/ui/chat"
+	"github.com/stretchr/testify/require"
+)
+
+// spinTestItem is a chat item with a controllable spinner.
+type spinTestItem struct {
+	testMessageItem
+	spinning bool
+	advances int
+	version  uint64
+}
+
+func (s *spinTestItem) Spinning() bool  { return s.spinning }
+func (s *spinTestItem) Version() uint64 { return s.version }
+func (s *spinTestItem) Finished() bool  { return !s.spinning }
+func (s *spinTestItem) Advance() bool {
+	if !s.spinning {
+		return false
+	}
+	s.advances++
+	s.version++
+	return true
+}
+
+var _ chat.Animatable = (*spinTestItem)(nil)
+
+// neutralMsg is an update that changes nothing; it exercises the Update tail.
+type neutralMsg struct{}
+
+// newAnimTestUI builds a chat UI whose last item spins and whose first item
+// spins but is far above the viewport.
+func newAnimTestUI(t *testing.T) (u *UI, top, bottom *spinTestItem) {
+	t.Helper()
+	u = newFrameTestUI(t)
+	items := make([]chat.MessageItem, 0, 200)
+	top = &spinTestItem{testMessageItem: testMessageItem{id: "top", text: "top"}, spinning: true}
+	items = append(items, top)
+	for i := 1; i < 199; i++ {
+		items = append(items, &focusableTestItem{testMessageItem: testMessageItem{id: strconv.Itoa(i), text: "line"}})
+	}
+	bottom = &spinTestItem{testMessageItem: testMessageItem{id: "bottom", text: "bottom\n1\n2\n3\n4\n5"}, spinning: true}
+	items = append(items, bottom)
+	u.chat.SetMessages(items...)
+	u.chat.ScrollToBottom()
+	return u, top, bottom
+}
+
+func TestAnimClock_StartsFromUpdateTailWhenSpinnerVisible(t *testing.T) {
+	t.Parallel()
+	u, _, _ := newAnimTestUI(t)
+	require.False(t, u.chat.animRunning)
+
+	_, cmd := u.Update(neutralMsg{})
+	require.NotNil(t, cmd, "an update with a visible spinner must arm the clock")
+	require.True(t, u.chat.animRunning)
+
+	_, _ = u.Update(neutralMsg{})
+	require.True(t, u.chat.animRunning, "clock must not be double-armed")
+}
+
+func TestAnimClock_TickAdvancesOnlyVisibleSpinners(t *testing.T) {
+	t.Parallel()
+	u, top, bottom := newAnimTestUI(t)
+	_, _ = u.Update(neutralMsg{})
+
+	_, cmd := u.Update(animTickMsg{gen: u.chat.animGen})
+	require.NotNil(t, cmd, "tick with a visible spinner must re-arm")
+	require.Equal(t, 1, bottom.advances)
+	require.Equal(t, 0, top.advances, "off-screen spinner must not advance")
+	require.True(t, u.chat.animRunning)
+
+	_, _ = u.Update(animTickMsg{gen: u.chat.animGen})
+	require.Equal(t, 2, bottom.advances)
+}
+
+func TestAnimClock_StopsWhenNothingVisibleSpins(t *testing.T) {
+	t.Parallel()
+	u, _, bottom := newAnimTestUI(t)
+	_, _ = u.Update(neutralMsg{})
+	require.True(t, u.chat.animRunning)
+
+	bottom.spinning = false
+	_, _ = u.Update(animTickMsg{gen: u.chat.animGen})
+	require.False(t, u.chat.animRunning, "clock must stop when nothing visible is spinning")
+	_, _ = u.Update(neutralMsg{})
+	require.False(t, u.chat.animRunning, "clock must stay off while nothing visible is spinning")
+}
+
+func TestAnimClock_IdleTickIsScrollOnly(t *testing.T) {
+	t.Parallel()
+	u, _, bottom := newAnimTestUI(t)
+	_, _ = u.Update(neutralMsg{})
+	u.View()
+	require.Equal(t, 1, u.frames.Len())
+
+	bottom.spinning = false
+	_, _ = u.Update(animTickMsg{gen: u.chat.animGen})
+	u.View()
+	require.Equal(t, 1, u.frames.hits, "a tick that advanced nothing must serve the memoized frame")
+}
+
+func TestAnimClock_RestartsWhenScrollRevealsSpinner(t *testing.T) {
+	t.Parallel()
+	u, top, bottom := newAnimTestUI(t)
+	bottom.spinning = false
+	_, _ = u.Update(neutralMsg{})
+	require.False(t, u.chat.animRunning, "no visible spinner: clock stays off")
+
+	u.chat.ScrollToTop()
+	_, _ = u.Update(neutralMsg{})
+	require.True(t, u.chat.animRunning, "revealing a spinner must arm the clock")
+	_, _ = u.Update(animTickMsg{gen: u.chat.animGen})
+	require.Equal(t, 1, top.advances)
+}
+
+func TestAnimClock_TickOutsideChatStops(t *testing.T) {
+	t.Parallel()
+	u, _, _ := newAnimTestUI(t)
+	_, _ = u.Update(neutralMsg{})
+	require.True(t, u.chat.animRunning)
+
+	u.state = uiLanding
+	_, _ = u.Update(animTickMsg{gen: u.chat.animGen})
+	require.False(t, u.chat.animRunning)
+}
+
+func TestAnimClock_TickKeepsFollowPinned(t *testing.T) {
+	t.Parallel()
+	u, _, _ := newAnimTestUI(t)
+	_, _ = u.Update(neutralMsg{})
+	u.chat.ScrollToBottom()
+	require.True(t, u.chat.Follow())
+	// Drift up a little while the (tall) bottom spinner is still in view,
+	// as happens when an animated item changes height.
+	u.chat.ScrollBy(-3)
+	u.chat.follow = true
+	require.False(t, u.chat.AtBottom())
+
+	_, _ = u.Update(animTickMsg{gen: u.chat.animGen})
+	require.True(t, u.chat.AtBottom(), "a frame while following must re-pin to the bottom")
+}
+
+func TestAnimClock_ReArmsIfTickWasLost(t *testing.T) {
+	t.Parallel()
+	u, _, _ := newAnimTestUI(t)
+	now := time.Now()
+	u.chat.animNow = func() time.Time { return now }
+
+	_, cmd := u.Update(neutralMsg{})
+	require.NotNil(t, cmd)
+	require.True(t, u.chat.animRunning)
+
+	// Still within the grace window: no second clock.
+	now = now.Add(animClockLostAfter / 2)
+	require.Nil(t, u.chat.EnsureAnimating())
+
+	// The tick never came back; a new clock must be armed.
+	now = now.Add(animClockLostAfter)
+	require.NotNil(t, u.chat.EnsureAnimating(), "a lost tick must not freeze spinners forever")
+	require.True(t, u.chat.animRunning)
+}
+
+func TestAnimClock_StaleGenerationTickIsIgnored(t *testing.T) {
+	t.Parallel()
+	u, _, bottom := newAnimTestUI(t)
+	now := time.Now()
+	u.chat.animNow = func() time.Time { return now }
+
+	_, _ = u.Update(neutralMsg{})
+	stale := animTickMsg{gen: u.chat.animGen}
+
+	// The event loop stalls; the watchdog arms a replacement clock.
+	now = now.Add(2 * animClockLostAfter)
+	_, _ = u.Update(neutralMsg{})
+	current := u.chat.animGen
+	require.NotEqual(t, stale.gen, current)
+
+	// The delayed tick from the old clock arrives: it must neither
+	// advance nor re-arm, leaving exactly one live clock.
+	require.Nil(t, u.handleAnimTick(stale), "stale tick must return nothing")
+	_, _ = u.Update(stale)
+	require.Equal(t, 0, bottom.advances, "stale tick must not advance")
+	require.True(t, u.chat.animRunning)
+	require.Equal(t, current, u.chat.animGen, "stale tick must not arm another clock")
+
+	_, _ = u.Update(animTickMsg{gen: current})
+	require.Equal(t, 1, bottom.advances)
+	require.Equal(t, current+1, u.chat.animGen, "current tick re-arms exactly once")
+}
+
+func TestAnimClock_TickWithoutFollowLeavesScrollAlone(t *testing.T) {
+	t.Parallel()
+	u, _, _ := newAnimTestUI(t)
+	_, _ = u.Update(neutralMsg{})
+	u.chat.ScrollBy(-2)
+	require.False(t, u.chat.Follow())
+	before := u.chat.Offset()
+
+	_, _ = u.Update(animTickMsg{gen: u.chat.animGen})
+	require.Equal(t, before, u.chat.Offset())
+}
+
+// throttledTestItem changes its output only every other frame, like a
+// spinner whose rendered form is stable across some frames.
+type throttledTestItem struct {
+	spinTestItem
+	frames int
+}
+
+func (l *throttledTestItem) Advance() bool {
+	l.frames++
+	if l.frames%2 != 0 {
+		return false
+	}
+	l.version++
+	return true
+}
+
+func TestAnimClock_UnchangedFrameIsScrollOnlyButKeepsClock(t *testing.T) {
+	t.Parallel()
+	u := newFrameTestUI(t)
+	item := &throttledTestItem{spinTestItem: spinTestItem{testMessageItem: testMessageItem{id: "th", text: "th"}, spinning: true}}
+	u.chat.SetMessages(item)
+	_, _ = u.Update(neutralMsg{})
+	u.View()
+	require.True(t, u.chat.animRunning)
+
+	_, _ = u.Update(animTickMsg{gen: u.chat.animGen})
+	require.True(t, u.chat.animRunning, "a spinning item that did not change this frame must keep the clock running")
+	u.View()
+	require.Equal(t, 1, u.frames.hits, "an unchanged frame must serve the memoized frame")
+
+	_, _ = u.Update(animTickMsg{gen: u.chat.animGen})
+	u.View()
+	require.Equal(t, 1, u.frames.hits, "a changed frame must redraw")
+}

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -91,10 +91,24 @@ type Chat struct {
 	list     *list.List
 	idInxMap map[string]int // Map of message IDs to their indices in the list
 
-	// Animation visibility optimization: track animations paused due to items
-	// being scrolled out of view. When items become visible again, their
-	// animations are restarted.
-	pausedAnimations map[string]struct{}
+	// animRunning is true while the shared animation clock has a tick
+	// outstanding. The clock stops itself when no visible item is spinning
+	// and is re-armed by EnsureAnimating once one is. animGen identifies
+	// the current clock: a tick carrying an older generation belongs to a
+	// clock that was superseded and is ignored, so a delayed tick can
+	// never run alongside a replacement. animArmedAt lets EnsureAnimating
+	// recover if a tick is ever lost.
+	animRunning bool
+	animGen     uint64
+	animArmedAt time.Time
+	// animNow is an injectable clock for tests (nil == real time).
+	animNow func() time.Time
+
+	// animAllowed gates the shared clock. setSessionMessages clears it when
+	// reloading a session whose agent is not busy so ghost spinners (an
+	// assistant message that never got a Finish part) stay still; the
+	// message handlers re-enable it when new work arrives.
+	animAllowed bool
 
 	// Mouse state
 	mouseDown     bool
@@ -165,10 +179,10 @@ type chatDrawCache struct {
 // messages.
 func NewChat(com *common.Common, scrollbarMode string) *Chat {
 	c := &Chat{
-		com:              com,
-		idInxMap:         make(map[string]int),
-		pausedAnimations: make(map[string]struct{}),
-		scrollbarMode:    scrollbarMode,
+		com:           com,
+		idInxMap:      make(map[string]int),
+		scrollbarMode: scrollbarMode,
+		animAllowed:   true,
 	}
 	l := list.NewList()
 	l.SetGap(1)
@@ -403,7 +417,6 @@ func (m *Chat) InvalidateRenderCaches() {
 // SetMessages sets the chat messages to the provided list of message items.
 func (m *Chat) SetMessages(msgs ...chat.MessageItem) tea.Cmd {
 	m.idInxMap = make(map[string]int)
-	m.pausedAnimations = make(map[string]struct{})
 	m.scrollbarVisible = false // Reset scrollbar visibility on new session load
 
 	items := make([]list.Item, len(msgs))
@@ -463,69 +476,116 @@ func (m *Chat) UpdateNestedToolIDs(containerID string) {
 	}
 }
 
-// Animate animates items in the chat list. Only propagates animation messages
-// to visible items to save CPU. When items are not visible, their animation ID
-// is tracked so it can be restarted when they become visible again.
-func (m *Chat) Animate(msg anim.StepMsg) tea.Cmd {
-	idx, ok := m.idInxMap[msg.ID]
-	if !ok {
-		return nil
-	}
+// animTickMsg is the shared animation clock. One tick advances every
+// visible spinner by a frame; there is one live clock at a time regardless
+// of how many items are animating. gen is the clock generation the tick
+// was armed for.
+type animTickMsg struct{ gen uint64 }
 
-	animatable, ok := m.list.ItemAt(idx).(chat.Animatable)
-	if !ok {
-		return nil
+// hasVisibleAnimation reports whether any item in the viewport is spinning.
+func (m *Chat) hasVisibleAnimation() bool {
+	if m.list.Len() == 0 {
+		return false
 	}
-
-	// Check if item is currently visible.
 	startIdx, endIdx := m.list.VisibleItemIndices()
-	isVisible := idx >= startIdx && idx <= endIdx
-
-	if !isVisible {
-		// Item not visible - pause animation by not propagating.
-		// Track it so we can restart when it becomes visible.
-		m.pausedAnimations[msg.ID] = struct{}{}
-		return nil
+	for idx := startIdx; idx <= endIdx; idx++ {
+		if animatable, ok := m.list.ItemAt(idx).(chat.Animatable); ok && animatable.Spinning() {
+			return true
+		}
 	}
-
-	// Item is visible - remove from paused set and animate.
-	delete(m.pausedAnimations, msg.ID)
-	return animatable.Animate(msg)
+	return false
 }
 
-// RestartPausedVisibleAnimations restarts animations for items that were paused
-// due to being scrolled out of view but are now visible again.
-func (m *Chat) RestartPausedVisibleAnimations() tea.Cmd {
-	if len(m.pausedAnimations) == 0 {
+// animClockLostAfter is how long an armed clock may go without its tick
+// arriving before EnsureAnimating assumes the command was lost and arms a
+// new one. Generous enough that a slow frame never trips it.
+const animClockLostAfter = 2 * time.Second
+
+// SetAnimationsAllowed gates the shared animation clock. It is cleared
+// when a session is reloaded whose agent is not busy so ghost spinners (an
+// assistant message that never got a Finish part) stay still, and re-enabled
+// whenever new messages arrive for the current session.
+func (m *Chat) SetAnimationsAllowed(allowed bool) {
+	m.animAllowed = allowed
+}
+
+// EnsureAnimating starts the shared animation clock if a visible item is
+// spinning and no tick is outstanding. Update calls it in its tail on
+// every message so any change that puts a spinner on screen (new message,
+// tool update, scroll, session load) starts the clock without per-call-site
+// wiring. It is the only place a tick is armed apart from Tick itself.
+func (m *Chat) EnsureAnimating() tea.Cmd {
+	if !m.animAllowed {
+		m.animRunning = false
 		return nil
 	}
+	if m.animRunning && m.now().Sub(m.animArmedAt) < animClockLostAfter {
+		return nil
+	}
+	if !m.hasVisibleAnimation() {
+		m.animRunning = false
+		return nil
+	}
+	return m.armAnimClock()
+}
 
+func (m *Chat) armAnimClock() tea.Cmd {
+	m.animRunning = true
+	m.animArmedAt = m.now()
+	m.animGen++
+	gen := m.animGen
+	return tea.Tick(anim.FrameInterval(), func(time.Time) tea.Msg {
+		return animTickMsg{gen: gen}
+	})
+}
+
+func (m *Chat) now() time.Time {
+	if m.animNow != nil {
+		return m.animNow()
+	}
+	return time.Now()
+}
+
+// stopAnimating marks the clock as stopped so the next EnsureAnimating
+// re-arms it. Called while consuming the current clock's tick; bumping
+// the generation also retires that clock in case the tick was not the
+// current one.
+func (m *Chat) stopAnimating(msg animTickMsg) {
+	if msg.gen != m.animGen {
+		return
+	}
+	m.animRunning = false
+}
+
+// Tick advances every visible spinning item by one frame. It reports
+// whether any rendered output changed and returns the next tick while a
+// visible item is still spinning; when none is, the clock stops and no
+// command is returned. Ticks from a superseded clock generation are
+// ignored so they cannot re-arm a second clock.
+func (m *Chat) Tick(msg animTickMsg) (changed bool, cmd tea.Cmd) {
+	if msg.gen != m.animGen {
+		return false, nil
+	}
+	m.animRunning = false
+	if m.list.Len() == 0 {
+		return false, nil
+	}
+	spinning := false
 	startIdx, endIdx := m.list.VisibleItemIndices()
-	var cmds []tea.Cmd
-
-	for id := range m.pausedAnimations {
-		idx, ok := m.idInxMap[id]
-		if !ok {
-			// Item no longer exists.
-			delete(m.pausedAnimations, id)
+	for idx := startIdx; idx <= endIdx; idx++ {
+		animatable, ok := m.list.ItemAt(idx).(chat.Animatable)
+		if !ok || !animatable.Spinning() {
 			continue
 		}
-
-		if idx >= startIdx && idx <= endIdx {
-			// Item is now visible - restart its animation.
-			if animatable, ok := m.list.ItemAt(idx).(chat.Animatable); ok {
-				if cmd := animatable.StartAnimation(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
-			}
-			delete(m.pausedAnimations, id)
+		spinning = true
+		if animatable.Advance() {
+			changed = true
 		}
 	}
-
-	if len(cmds) == 0 {
-		return nil
+	if !spinning {
+		return changed, nil
 	}
-	return tea.Batch(cmds...)
+	return changed, m.armAnimClock()
 }
 
 // Focus sets the focus state of the chat component.
@@ -663,37 +723,13 @@ func (m *Chat) HideScrollbar(seq int) {
 	}
 }
 
-// ScrollToTopAndAnimate scrolls the chat view to the top and returns a command to restart
-// any paused animations that are now visible.
-func (m *Chat) ScrollToTopAndAnimate() tea.Cmd {
-	return tea.Batch(m.ScrollToTop(), m.RestartPausedVisibleAnimations())
-}
-
-// ScrollToBottomAndAnimate scrolls the chat view to the bottom and returns a command to
-// restart any paused animations that are now visible.
-func (m *Chat) ScrollToBottomAndAnimate() tea.Cmd {
-	return tea.Batch(m.ScrollToBottom(), m.RestartPausedVisibleAnimations())
-}
-
 // ScrollToBottomAndSelectLast scrolls the chat view to the bottom, selects
 // the last item, and returns a command to restart any paused animations that
 // are now visible.
 func (m *Chat) ScrollToBottomAndSelectLast() tea.Cmd {
-	cmd := m.ScrollToBottomAndAnimate()
+	m.ScrollToBottom()
 	m.SelectLast()
-	return cmd
-}
-
-// ScrollByAndAnimate scrolls the chat view by the given number of line deltas and returns
-// a command to restart any paused animations that are now visible.
-func (m *Chat) ScrollByAndAnimate(lines int) tea.Cmd {
-	return tea.Batch(m.ScrollBy(lines), m.RestartPausedVisibleAnimations())
-}
-
-// ScrollToSelectedAndAnimate scrolls the chat view to the selected item and returns a
-// command to restart any paused animations that are now visible.
-func (m *Chat) ScrollToSelectedAndAnimate() tea.Cmd {
-	return tea.Batch(m.ScrollToSelected(), m.RestartPausedVisibleAnimations())
+	return nil
 }
 
 // SelectedItemInView returns whether the selected item is currently in view.
@@ -843,7 +879,6 @@ func (m *Chat) SelectNearestInView(scrolledUp bool) {
 // ClearMessages removes all messages from the chat list.
 func (m *Chat) ClearMessages() {
 	m.idInxMap = make(map[string]int)
-	m.pausedAnimations = make(map[string]struct{})
 	m.scrollbarVisible = false
 	m.list.SetItems()
 	m.ClearMouse()
@@ -868,9 +903,6 @@ func (m *Chat) RemoveMessage(id string) {
 			m.idInxMap[item.ID()] = i
 		}
 	}
-
-	// Clean up any paused animations for this message
-	delete(m.pausedAnimations, id)
 }
 
 // MessageItem returns the message item with the given ID, or nil if not found.

--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -468,10 +468,10 @@ func TestBackstopRefreshesStaleCaches(t *testing.T) {
 }
 
 // TestSetSessionMessagesGatesAnimationsOnBusy verifies that reloading a
-// session does not start spinner animations when the agent is not busy.
+// session does not run spinner animations when the agent is not busy.
 // A session that was killed mid-generation can persist an assistant message
-// with no Finish part, which still reports isSpinning() even though nothing
-// is running. Starting animations for it would leave a ghost "working"
+// with no Finish part, which still reports Spinning() even though nothing
+// is running. Arming the clock for it would leave a ghost "working"
 // spinner after the session is reloaded.
 func TestSetSessionMessagesGatesAnimationsOnBusy(t *testing.T) {
 	pinTTLs(t)
@@ -492,14 +492,21 @@ func TestSetSessionMessagesGatesAnimationsOnBusy(t *testing.T) {
 		},
 	}
 
-	// When the agent is not busy, setSessionMessages must not start animations.
+	// When the agent is not busy, setSessionMessages must freeze the
+	// animation clock so the ghost spinner stays still.
 	cmd := m.setSessionMessages(msgs)
 	require.Nil(t, cmd, "setSessionMessages must not start animations when agent is idle")
+	require.False(t, m.chat.animAllowed, "an idle session reload must freeze the animation clock")
+	require.Nil(t, m.chat.EnsureAnimating(), "a frozen clock must not arm while idle")
+	require.False(t, m.chat.animRunning)
 
-	// When the agent is busy, animations should start.
+	// When the agent is busy, the clock may run for the same message.
 	warmCaches(m, true)
 	cmd = m.setSessionMessages(msgs)
-	require.NotNil(t, cmd, "setSessionMessages must start animations when agent is busy")
+	require.Nil(t, cmd, "setSessionMessages must not arm the clock itself")
+	require.True(t, m.chat.animAllowed, "setSessionMessages must allow animations when agent is busy")
+	require.NotNil(t, m.chat.EnsureAnimating(), "a visible spinning message must arm the clock")
+	require.True(t, m.chat.animRunning)
 }
 
 // TestStaleBusyRefreshDiscardedAndReDispatched pins the generation guard for

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -47,7 +47,6 @@ import (
 	"github.com/charmbracelet/crush/internal/session"
 	"github.com/charmbracelet/crush/internal/skills"
 	"github.com/charmbracelet/crush/internal/stringext"
-	"github.com/charmbracelet/crush/internal/ui/anim"
 	"github.com/charmbracelet/crush/internal/ui/attachments"
 	"github.com/charmbracelet/crush/internal/ui/chat"
 	"github.com/charmbracelet/crush/internal/ui/common"
@@ -710,17 +709,16 @@ func (m *UI) loadCustomCommands() tea.Cmd {
 // outside the viewport, moves it to the nearest visible edge. The selection
 // is moved rather than scrolled to so a large coalesced delta is applied in
 // full instead of being rewound to the selected item.
-func (m *UI) applyChatScroll(lines int) tea.Cmd {
-	cmd := m.chat.ScrollByAndAnimate(lines)
+func (m *UI) applyChatScroll(lines int) {
+	m.chat.ScrollBy(lines)
 	if m.chat.SelectedItemInView() {
-		return cmd
+		return
 	}
 	if lines > 0 && m.chat.AtBottom() {
 		m.chat.SelectLast()
-		return cmd
+		return
 	}
 	m.chat.SelectNearestInView(lines < 0)
-	return cmd
 }
 
 // loadMCPrompts loads the MCP prompts asynchronously.
@@ -1013,9 +1011,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.handlePermissionNotification(msg.Payload)
 	case pubsub.Event[question.Request]:
 		m.openBatchFormDialog(msg.Payload)
-		if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
+		m.chat.ScrollToBottom()
 		if cmd := m.sendNotification(notification.Notification{
 			Title:   "Crush is waiting...",
 			Message: fmt.Sprintf("%d questions need your input", len(msg.Payload.Questions)),
@@ -1043,9 +1039,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.updateLayoutAndSize()
 		if m.state == uiChat && m.chat.Follow() {
-			if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
-				cmds = append(cmds, cmd)
-			}
+			m.chat.ScrollToBottom()
 		}
 	case tea.KeyboardEnhancementsMsg:
 		m.keyenh = msg
@@ -1156,24 +1150,16 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				break
 			}
 			if msg.Y <= 0 {
-				if cmd := m.chat.ScrollByAndAnimate(-1); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollBy(-1)
 				if !m.chat.SelectedItemInView() {
 					m.chat.SelectPrev()
-					if cmd := m.chat.ScrollToSelectedAndAnimate(); cmd != nil {
-						cmds = append(cmds, cmd)
-					}
+					m.chat.ScrollToSelected()
 				}
 			} else if msg.Y >= m.chat.Height()-1 {
-				if cmd := m.chat.ScrollByAndAnimate(1); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollBy(1)
 				if !m.chat.SelectedItemInView() {
 					m.chat.SelectNext()
-					if cmd := m.chat.ScrollToSelectedAndAnimate(); cmd != nil {
-						cmds = append(cmds, cmd)
-					}
+					m.chat.ScrollToSelected()
 				}
 			}
 
@@ -1257,22 +1243,13 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				break
 			}
 			m.markScrollOnly()
-			if cmd := m.applyChatScroll(lines); cmd != nil {
-				cmds = append(cmds, cmd)
-			}
+			m.applyChatScroll(lines)
 		}
 	case frameGCMsg:
 		m.handleFrameGC()
-	case anim.StepMsg:
-		if m.state == uiChat {
-			if cmd := m.chat.Animate(msg); cmd != nil {
-				cmds = append(cmds, cmd)
-			}
-			if m.chat.Follow() {
-				if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
-			}
+	case animTickMsg:
+		if cmd := m.handleAnimTick(msg); cmd != nil {
+			cmds = append(cmds, cmd)
 		}
 	case scrollbarHideMsg:
 		if m.state == uiChat {
@@ -1337,9 +1314,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if item := m.chat.MessageItem(msg.PendingID); item != nil {
 			if shellItem, ok := item.(*chat.ShellItem); ok {
 				shellItem.AppendOutput(msg.Chunk)
-				if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollToBottom()
 			}
 		}
 		// Continue draining the stream channel.
@@ -1366,9 +1341,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if item := m.chat.MessageItem(msg.PendingID); item != nil {
 				if shellItem, ok := item.(*chat.ShellItem); ok {
 					shellItem.Complete(msg.Output, msg.ExitCode)
-					if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
-						cmds = append(cmds, cmd)
-					}
+					m.chat.ScrollToBottom()
 					completed = true
 				}
 			}
@@ -1376,9 +1349,7 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if !completed {
 			item := chat.NewShellItem(m.com.Styles, msg.Command, msg.Output, msg.ExitCode)
 			m.chat.AppendMessages(item)
-			if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
-				cmds = append(cmds, cmd)
-			}
+			m.chat.ScrollToBottom()
 		}
 		cmds = append(cmds, m.loadPromptHistory())
 	case hyperRefreshDoneMsg:
@@ -1470,10 +1441,40 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.attachments.Update(msg) {
 		m.invalidateFrames()
 	}
+	// Any update may have put a spinner on screen (new message, tool update,
+	// scroll, session load); make sure the clock is running. This is the
+	// sole place the clock is armed so a tick never sits inside a caller's
+	// tea.Sequence.
+	if m.state == uiChat {
+		if cmd := m.chat.EnsureAnimating(); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
 	if cmd := m.endFrameUpdate(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
 	return m, tea.Batch(cmds...)
+}
+
+// handleAnimTick advances every visible spinner by one frame. A tick that
+// changed nothing visible is scroll-only so the frame cache survives; one
+// that did keeps the view pinned to the bottom while following, since
+// animated items can change height.
+func (m *UI) handleAnimTick(msg animTickMsg) tea.Cmd {
+	if m.state != uiChat {
+		m.chat.stopAnimating(msg)
+		m.markScrollOnly()
+		return nil
+	}
+	changed, cmd := m.chat.Tick(msg)
+	if !changed {
+		m.markScrollOnly()
+		return cmd
+	}
+	if m.chat.Follow() {
+		m.chat.ScrollToBottom()
+	}
+	return cmd
 }
 
 // setSessionMessages sets the messages for the current session in the chat
@@ -1513,24 +1514,14 @@ func (m *UI) setSessionMessages(msgs []message.Message) tea.Cmd {
 	// If the user switches between sessions while the agent is working we
 	// want to make sure the animations are shown. Gate on the agent actually
 	// being busy: a session that was killed mid-generation can persist an
-	// assistant message with no Finish part, which still reports isSpinning()
-	// even though nothing is running. Starting animations for it here would
+	// assistant message with no Finish part, which still reports Spinning()
+	// even though nothing is running. Allowing the clock for it here would
 	// leave a ghost "working" spinner (and a second one alongside any tool
-	// spinner) after the session is reloaded.
-	if m.isAgentBusy() {
-		for _, item := range items {
-			if animatable, ok := item.(chat.Animatable); ok {
-				if cmd := animatable.StartAnimation(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
-			}
-		}
-	}
+	// spinner) after the session is reloaded. Messages arriving for the
+	// session re-enable the clock.
+	m.chat.SetAnimationsAllowed(m.isAgentBusy())
 
 	if cmd := m.chat.SetMessages(items...); cmd != nil {
-		cmds = append(cmds, cmd)
-	}
-	if cmd := m.chat.RestartPausedVisibleAnimations(); cmd != nil {
 		cmds = append(cmds, cmd)
 	}
 	m.chat.SelectLast()
@@ -1655,39 +1646,19 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 		}
 		m.lastUserMessageTime = msg.CreatedAt
 		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil, m.com.Workspace.WorkingDir())
-		for _, item := range items {
-			if animatable, ok := item.(chat.Animatable); ok {
-				if cmd := animatable.StartAnimation(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
-			}
-		}
 		m.chat.AppendMessages(items...)
-		if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
+		m.chat.ScrollToBottom()
 	case message.Assistant:
 		items := chat.ExtractMessageItems(m.com.Styles, &msg, nil, m.com.Workspace.WorkingDir())
-		for _, item := range items {
-			if animatable, ok := item.(chat.Animatable); ok {
-				if cmd := animatable.StartAnimation(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
-			}
-		}
 		m.chat.AppendMessages(items...)
 		if m.chat.Follow() {
-			if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
-				cmds = append(cmds, cmd)
-			}
+			m.chat.ScrollToBottom()
 		}
 		if chat.ShouldShowAssistantInfo(&msg) {
 			infoItem := chat.NewAssistantInfoItem(m.com.Styles, &msg, m.com.Config(), time.Unix(m.lastUserMessageTime, 0))
 			m.chat.AppendMessages(infoItem)
 			if m.chat.Follow() {
-				if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollToBottom()
 			}
 		}
 	case message.Tool:
@@ -1700,9 +1671,7 @@ func (m *UI) appendSessionMessage(msg message.Message) tea.Cmd {
 			if toolMsgItem, ok := toolItem.(chat.ToolMessageItem); ok {
 				toolMsgItem.SetResult(&tr)
 				if m.chat.Follow() {
-					if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
-						cmds = append(cmds, cmd)
-					}
+					m.chat.ScrollToBottom()
 				}
 			}
 		}
@@ -1742,18 +1711,15 @@ func (m *UI) handleClickFocus(msg tea.MouseClickMsg) (cmd tea.Cmd) {
 // calls as well that is why we need to handle creating/updating each tool call
 // message too.
 func (m *UI) updateSessionMessage(msg message.Message) tea.Cmd {
+	// A message update means work is active; the animation clock may have
+	// been frozen by a non-busy session reload (ghost-spinner guard).
+	m.chat.SetAnimationsAllowed(true)
 	var cmds []tea.Cmd
 	existingItem := m.chat.MessageItem(msg.ID)
 
 	if existingItem != nil {
 		if assistantItem, ok := existingItem.(*chat.AssistantMessageItem); ok {
-			// SetMessage returns a StartAnimation Cmd when the message
-			// transitions back to spinning (e.g. its streamed content was
-			// reset for a retry). Propagate it so the spinner re-arms
-			// instead of freezing.
-			if cmd := assistantItem.SetMessage(&msg); cmd != nil {
-				cmds = append(cmds, cmd)
-			}
+			assistantItem.SetMessage(&msg)
 		}
 	}
 
@@ -1793,19 +1759,10 @@ func (m *UI) updateSessionMessage(msg message.Message) tea.Cmd {
 		}
 	}
 
-	for _, item := range items {
-		if animatable, ok := item.(chat.Animatable); ok {
-			if cmd := animatable.StartAnimation(); cmd != nil {
-				cmds = append(cmds, cmd)
-			}
-		}
-	}
-
 	m.chat.AppendMessages(items...)
 	if m.chat.Follow() {
-		if cmd := m.chat.ScrollToBottomAndSelectLast(); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
+		m.chat.ScrollToBottom()
+		m.chat.SelectLast()
 	}
 
 	return tea.Sequence(cmds...)
@@ -1826,6 +1783,9 @@ func (m *UI) handleChildSessionMessage(event pubsub.Event[message.Message]) tea.
 	if !ok {
 		return nil
 	}
+	// Nested tool activity means the agent is running; the animation clock
+	// may have been frozen by a non-busy session reload.
+	m.chat.SetAnimationsAllowed(true)
 
 	// Find the parent agent tool item.
 	var agentItem chat.NestedToolContainer
@@ -1869,11 +1829,6 @@ func (m *UI) handleChildSessionMessage(event pubsub.Event[message.Message]) tea.
 			if simplifiable, ok := nestedItem.(chat.Compactable); ok {
 				simplifiable.SetCompact(true)
 			}
-			if animatable, ok := nestedItem.(chat.Animatable); ok {
-				if cmd := animatable.StartAnimation(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
-			}
 			nestedTools = append(nestedTools, nestedItem)
 		}
 	}
@@ -1895,9 +1850,8 @@ func (m *UI) handleChildSessionMessage(event pubsub.Event[message.Message]) tea.
 	m.chat.UpdateNestedToolIDs(toolCallID)
 
 	if m.chat.Follow() {
-		if cmd := m.chat.ScrollToBottomAndSelectLast(); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
+		m.chat.ScrollToBottom()
+		m.chat.SelectLast()
 	}
 
 	return tea.Sequence(cmds...)
@@ -2886,69 +2840,45 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				m.chat.ToggleExpandedSelectedItem()
 			case key.Matches(msg, m.keyMap.Chat.Up):
 				m.markScrollOnly()
-				if cmd := m.chat.ScrollByAndAnimate(-1); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollBy(-1)
 				if !m.chat.SelectedItemInView() {
 					m.chat.SelectPrev()
-					if cmd := m.chat.ScrollToSelectedAndAnimate(); cmd != nil {
-						cmds = append(cmds, cmd)
-					}
+					m.chat.ScrollToSelected()
 				}
 			case key.Matches(msg, m.keyMap.Chat.Down):
 				m.markScrollOnly()
-				if cmd := m.chat.ScrollByAndAnimate(1); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollBy(1)
 				if !m.chat.SelectedItemInView() {
 					m.chat.SelectNext()
-					if cmd := m.chat.ScrollToSelectedAndAnimate(); cmd != nil {
-						cmds = append(cmds, cmd)
-					}
+					m.chat.ScrollToSelected()
 				}
 			case key.Matches(msg, m.keyMap.Chat.UpOneItem):
 				m.chat.SelectPrev()
-				if cmd := m.chat.ScrollToSelectedAndAnimate(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollToSelected()
 			case key.Matches(msg, m.keyMap.Chat.DownOneItem):
 				m.chat.SelectNext()
-				if cmd := m.chat.ScrollToSelectedAndAnimate(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollToSelected()
 			case key.Matches(msg, m.keyMap.Chat.HalfPageUp):
 				m.markScrollOnly()
-				if cmd := m.chat.ScrollByAndAnimate(-m.chat.Height() / 2); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollBy(-m.chat.Height() / 2)
 				m.chat.SelectFirstInView()
 			case key.Matches(msg, m.keyMap.Chat.HalfPageDown):
 				m.markScrollOnly()
-				if cmd := m.chat.ScrollByAndAnimate(m.chat.Height() / 2); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollBy(m.chat.Height() / 2)
 				m.chat.SelectLastInView()
 			case key.Matches(msg, m.keyMap.Chat.PageUp):
 				m.markScrollOnly()
-				if cmd := m.chat.ScrollByAndAnimate(-m.chat.Height()); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollBy(-m.chat.Height())
 				m.chat.SelectFirstInView()
 			case key.Matches(msg, m.keyMap.Chat.PageDown):
 				m.markScrollOnly()
-				if cmd := m.chat.ScrollByAndAnimate(m.chat.Height()); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollBy(m.chat.Height())
 				m.chat.SelectLastInView()
 			case key.Matches(msg, m.keyMap.Chat.Home):
-				if cmd := m.chat.ScrollToTopAndAnimate(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollToTop()
 				m.chat.SelectFirst()
 			case key.Matches(msg, m.keyMap.Chat.End):
-				if cmd := m.chat.ScrollToBottomAndSelectLast(); cmd != nil {
-					cmds = append(cmds, cmd)
-				}
+				m.chat.ScrollToBottomAndSelectLast()
 			default:
 				if ok, cmd := m.chat.HandleKeyMsg(msg); ok {
 					cmds = append(cmds, cmd)
@@ -3577,7 +3507,7 @@ func (m *UI) handleTextareaHeightChange(prevHeight int) tea.Cmd {
 	}
 	m.updateLayoutAndSize()
 	if m.state == uiChat && m.chat.Follow() {
-		return m.chat.ScrollToBottomAndAnimate()
+		m.chat.ScrollToBottom()
 	}
 	return nil
 }
@@ -4402,13 +4332,11 @@ func (m *UI) runShellCommandInternal(command string, isFirstMessage bool) tea.Cm
 
 	// Append a pending shell item immediately so the user sees feedback.
 	pendingItem := chat.NewPendingShellItem(m.com.Styles, command)
+	// Bang mode runs without the agent, so re-enable the animation clock
+	// that a non-busy session reload may have frozen.
+	m.chat.SetAnimationsAllowed(true)
 	m.chat.AppendMessages(pendingItem)
-	if cmd := m.chat.ScrollToBottomAndAnimate(); cmd != nil {
-		cmds = append(cmds, cmd)
-	}
-	if cmd := pendingItem.StartAnimation(); cmd != nil {
-		cmds = append(cmds, cmd)
-	}
+	m.chat.ScrollToBottom()
 
 	// Stream output via channel. The progress callback writes chunks
 	// to streamCh; a reader cmd converts them to shellStreamMsg values.


### PR DESCRIPTION
Every anim.Anim used to schedule its own 20Hz tea.Tick chain, so N
running spinners meant N full Update+View passes per frame, each also
resetting the frame cache and re-pinning follow mode. Replace the
per-item chains with a single animTickMsg owned by Chat: one tick per
frame advances every visible spinner, the clock stops itself when
nothing visible spins, and Update's tail re-arms it whenever a spinner
appears. Ticks carry a generation so a delayed tick can never run
alongside a replacement clock, and frames that change nothing are
served from the frame cache. Animatable becomes Spinning/Advance;
pausedAnimations, RestartPausedVisibleAnimations and startItemAnimations
are gone.

Co-authored-by: Tai Groot <amittai.groot@gsa.gov>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>