### PR TITLE
fix(sessions): keep the deleted slot in view instead of jumping to top

### DIFF
--- a/internal/ui/dialog/sessions.go
+++ b/internal/ui/dialog/sessions.go
@@ -34,18 +34,17 @@ const (
 
 // Session is a session selector dialog.
 type Session struct {
-	com                *common.Common
-	help               help.Model
-	list               *list.FilterableList
-	input              textinput.Model
-	selectedSessionInx int
-	sessions           []session.Session
+	com      *common.Common
+	help     help.Model
+	list     *list.FilterableList
+	input    textinput.Model
+	sessions []session.Session
 
-	sessionsMode  sessionsMode
-	bodyArea      image.Rectangle
-	mouseScrolled bool
-	lastClickTime time.Time
-	lastClickID   string
+	sessionsMode        sessionsMode
+	bodyArea            image.Rectangle
+	scrolledToSelection bool
+	lastClickTime       time.Time
+	lastClickID         string
 
 	keyMap struct {
 		Select        key.Binding
@@ -75,9 +74,10 @@ func NewSessions(com *common.Common, selectedSessionID string) (*Session, error)
 	}
 
 	s.sessions = sessions
+	var selectedInx int
 	for i, sess := range sessions {
 		if sess.ID == selectedSessionID {
-			s.selectedSessionInx = i
+			selectedInx = i
 			break
 		}
 	}
@@ -88,7 +88,7 @@ func NewSessions(com *common.Common, selectedSessionID string) (*Session, error)
 	s.help = help
 	s.list = list.NewFilterableList(sessionItems(com.Styles, sessionsModeNormal, sessions...)...)
 	s.list.Focus()
-	s.list.SetSelected(s.selectedSessionInx)
+	s.list.SetSelected(selectedInx)
 
 	s.input = textinput.New()
 	s.input.SetVirtualCursor(false)
@@ -156,7 +156,6 @@ func (s *Session) HandleMsg(msg tea.Msg) Action {
 			case key.Matches(msg, s.keyMap.ConfirmDelete):
 				action := s.confirmDeleteSession()
 				s.list.SetItems(sessionItems(s.com.Styles, sessionsModeNormal, s.sessions...)...)
-				s.list.SelectFirst()
 				s.list.ScrollToSelected()
 				return action
 			case key.Matches(msg, s.keyMap.CancelDelete):
@@ -231,7 +230,6 @@ func (s *Session) HandleMsg(msg tea.Msg) Action {
 	case common.CoalescedWheelMsg:
 		if image.Pt(msg.Mouse.X, msg.Mouse.Y).In(s.sessionListArea()) {
 			s.list.ScrollBy(int(msg.DeltaY))
-			s.mouseScrolled = true
 		}
 	case tea.MouseClickMsg:
 		return s.handleMouseClick(msg)
@@ -291,11 +289,8 @@ func (s *Session) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	// Hide the timestamps uniformly when the widest would crowd the title.
 	applyInfoColumnVisibility(s.list.FilteredItems(), listWidth, sessionInfoMaxPercent)
 
-	// This makes it so we do not scroll the list if we don't have to
-	start, end := s.list.VisibleItemIndices()
-
-	// if selected index is outside visible range, scroll to it
-	if !s.mouseScrolled && (s.selectedSessionInx < start || s.selectedSessionInx > end) {
+	if !s.scrolledToSelection {
+		s.scrolledToSelection = true
 		s.list.ScrollToSelected()
 	}
 

--- a/internal/ui/dialog/sessions_mouse_test.go
+++ b/internal/ui/dialog/sessions_mouse_test.go
@@ -231,3 +231,69 @@ func TestSessionMouseClickIgnoresUnsupportedClicks(t *testing.T) {
 }
 
 var _ workspace.Workspace = (*sessionMouseWorkspace)(nil)
+
+func testSessions(n int) []session.Session {
+	sessions := make([]session.Session, n)
+	for i := range sessions {
+		sessions[i] = session.Session{
+			ID:    fmt.Sprintf("s%02d", i),
+			Title: fmt.Sprintf("Session %02d", i),
+		}
+	}
+	return sessions
+}
+
+func deleteSelectedSession(t *testing.T, dialog *Session) {
+	t.Helper()
+	dialog.HandleMsg(tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl})
+	require.Equal(t, sessionsModeDeleting, dialog.sessionsMode)
+	dialog.HandleMsg(tea.KeyPressMsg{Code: 'y'})
+	require.Equal(t, sessionsModeNormal, dialog.sessionsMode)
+}
+
+func TestSessionOpensScrolledToSelected(t *testing.T) {
+	t.Parallel()
+
+	dialog := newSessionMouseDialog(t, testSessions(40), "s30")
+	scr := uv.NewScreenBuffer(80, 30)
+	dialog.Draw(scr, image.Rect(0, 0, 80, 30))
+
+	require.True(t, dialog.list.SelectedItemInView())
+	require.Equal(t, "s30", dialog.selectedSessionItem().ID())
+}
+
+func TestSessionDeleteKeepsListPosition(t *testing.T) {
+	t.Parallel()
+
+	dialog := newSessionMouseDialog(t, testSessions(40), "s20")
+	scr := uv.NewScreenBuffer(80, 30)
+	dialog.Draw(scr, image.Rect(0, 0, 80, 30))
+	offset := dialog.list.Offset()
+	require.Positive(t, offset, "expected the dialog to open scrolled down")
+
+	deleteSelectedSession(t, dialog)
+
+	require.Equal(t, offset, dialog.list.Offset(), "deleting must not scroll the list")
+	require.Equal(t, "s21", dialog.selectedSessionItem().ID(), "selection must fall through to the next session")
+}
+
+func TestSessionDeleteAfterWheelScrollsSelectionBackIntoView(t *testing.T) {
+	t.Parallel()
+
+	dialog := newSessionMouseDialog(t, testSessions(40), "s00")
+	scr := uv.NewScreenBuffer(80, 30)
+	dialog.Draw(scr, image.Rect(0, 0, 80, 30))
+
+	// Wheel the selection out of view without moving it.
+	dialog.HandleMsg(common.CoalescedWheelMsg{
+		Mouse:  tea.Mouse{X: 10, Y: 10},
+		DeltaY: 15,
+	})
+	dialog.Draw(scr, image.Rect(0, 0, 80, 30))
+	require.False(t, dialog.list.SelectedItemInView(), "wheel must not drag the selection along")
+
+	deleteSelectedSession(t, dialog)
+
+	require.True(t, dialog.list.SelectedItemInView(), "deleting off-screen must show what it landed on")
+	require.Equal(t, "s01", dialog.selectedSessionItem().ID())
+}


### PR DESCRIPTION
when using the mouse to scroll the scroll state could get out of sync with the actual selected item causing weird jumps