### PR TITLE
noninteractive: add --reasoning-effort flag with model validation

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -264,7 +264,7 @@ func (app *App) resolveSession(ctx context.Context, continueSessionID string, us
 
 // RunNonInteractive runs the application in non-interactive mode with the
 // given prompt, printing to stdout.
-func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt, largeModel, smallModel string, hideSpinner bool, continueSessionID string, useLast bool) error {
+func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt, largeModel, smallModel, reasoningEffort string, hideSpinner bool, continueSessionID string, useLast bool) error {
 	slog.Info("Running in non-interactive mode")
 
 	// Re-initialize the coder agent without interactive-only tools.
@@ -278,6 +278,17 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 	if largeModel != "" || smallModel != "" {
 		if err := app.overrideModelsForNonInteractive(ctx, largeModel, smallModel); err != nil {
 			return fmt.Errorf("failed to override models: %w", err)
+		}
+	}
+
+	// The reasoning effort applies to the model that will actually run.
+	// On a continued session without an explicit model override, the
+	// model is resolved later from the session's last assistant message,
+	// so the override is applied after that restore instead.
+	deferredEffort := (continueSessionID != "" || useLast) && largeModel == "" && smallModel == ""
+	if reasoningEffort != "" && !deferredEffort {
+		if err := app.overrideReasoningEffort(ctx, reasoningEffort); err != nil {
+			return err
 		}
 	}
 
@@ -345,6 +356,12 @@ func (app *App) RunNonInteractive(ctx context.Context, output io.Writer, prompt,
 		}
 	} else {
 		slog.Info("Created session for non-interactive run", "session_id", sess.ID)
+	}
+
+	if reasoningEffort != "" && deferredEffort {
+		if err := app.overrideReasoningEffort(ctx, reasoningEffort); err != nil {
+			return err
+		}
 	}
 
 	// Automatically approve all permission requests for this non-interactive
@@ -544,6 +561,28 @@ func (app *App) overrideModelsForNonInteractive(ctx context.Context, largeModel,
 		app.config.OverridePreferredModel(config.SelectedModelTypeSmall, smallCfg)
 	}
 
+	return app.AgentCoordinator.UpdateModels(ctx)
+}
+
+// overrideReasoningEffort validates the requested reasoning effort against
+// the large model in effect for this run (which may have been overridden by
+// --model or restored from a continued session) and applies it as an
+// in-memory override.
+func (app *App) overrideReasoningEffort(ctx context.Context, reasoningEffort string) error {
+	cfg := app.config.Config()
+	selected, ok := cfg.Models[config.SelectedModelTypeLarge]
+	if !ok {
+		return fmt.Errorf("no large model selected; set one with the --model flag or 'model large'")
+	}
+	if err := cfg.ValidateReasoningEffort(selected.Provider, selected.Model, reasoningEffort); err != nil {
+		return err
+	}
+	selected.ReasoningEffort = reasoningEffort
+	slog.Info("Overriding reasoning effort for non-interactive run",
+		"provider", selected.Provider,
+		"model", selected.Model,
+		"reasoning_effort", reasoningEffort)
+	app.config.OverridePreferredModel(config.SelectedModelTypeLarge, selected)
 	return app.AgentCoordinator.UpdateModels(ctx)
 }
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -53,6 +53,11 @@ crush run --quiet "Generate a README for this project"
 # Run in verbose mode (show logs)
 crush run --verbose "Generate a README for this project"
 
+# Use a specific reasoning effort
+# Levels depend on the model, unsupported values are rejected
+# with the accepted values listed
+crush run --reasoning-effort high "What is the meaning of life?"
+
 # Continue a previous session
 crush run --session {session-id} "Follow up on your last response"
 
@@ -62,12 +67,13 @@ crush run --continue "Follow up on your last response"
   `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var (
-			quiet, _      = cmd.Flags().GetBool("quiet")
-			verbose, _    = cmd.Flags().GetBool("verbose")
-			largeModel, _ = cmd.Flags().GetString("model")
-			smallModel, _ = cmd.Flags().GetString("small-model")
-			sessionID, _  = cmd.Flags().GetString("session")
-			useLast, _    = cmd.Flags().GetBool("continue")
+			quiet, _           = cmd.Flags().GetBool("quiet")
+			verbose, _         = cmd.Flags().GetBool("verbose")
+			largeModel, _      = cmd.Flags().GetString("model")
+			smallModel, _      = cmd.Flags().GetString("small-model")
+			reasoningEffort, _ = cmd.Flags().GetString("reasoning-effort")
+			sessionID, _       = cmd.Flags().GetString("session")
+			useLast, _         = cmd.Flags().GetBool("continue")
 		)
 
 		// Cancel on SIGINT or SIGTERM.
@@ -125,7 +131,7 @@ crush run --continue "Follow up on your last response"
 				slog.SetDefault(slog.New(log.New(os.Stderr)))
 			}
 
-			return runNonInteractive(ctx, c, ws, prompt, largeModel, smallModel, quiet || verbose, sessionID, useLast)
+			return runNonInteractive(ctx, c, ws, prompt, largeModel, smallModel, reasoningEffort, quiet || verbose, sessionID, useLast)
 		}
 
 		ws, cleanup, err := setupLocalWorkspace(cmd)
@@ -154,7 +160,7 @@ crush run --continue "Follow up on your last response"
 			sessionID = sess.ID
 		}
 
-		return appWs.App().RunNonInteractive(ctx, os.Stdout, prompt, largeModel, smallModel, quiet || verbose, sessionID, useLast)
+		return appWs.App().RunNonInteractive(ctx, os.Stdout, prompt, largeModel, smallModel, reasoningEffort, quiet || verbose, sessionID, useLast)
 	},
 }
 
@@ -163,6 +169,7 @@ func init() {
 	runCmd.Flags().BoolP("verbose", "v", false, "Show logs")
 	runCmd.Flags().StringP("model", "m", "", "Model to use. Accepts 'model' or 'provider/model' to disambiguate models with the same name across providers")
 	runCmd.Flags().String("small-model", "", "Small model to use. If not provided, uses the default small model for the provider")
+	runCmd.Flags().String("reasoning-effort", "", "Reasoning effort for the model (e.g. low, medium, high). Levels depend on the model; unsupported values are rejected with the accepted values listed")
 	runCmd.Flags().StringP("session", "s", "", "Continue a previous session by ID")
 	runCmd.Flags().BoolP("continue", "C", false, "Continue the most recent session")
 	runCmd.MarkFlagsMutuallyExclusive("session", "continue")
@@ -174,7 +181,7 @@ func runNonInteractive(
 	ctx context.Context,
 	c *client.Client,
 	ws *proto.Workspace,
-	prompt, largeModel, smallModel string,
+	prompt, largeModel, smallModel, reasoningEffort string,
 	hideSpinner bool,
 	continueSessionID string,
 	useLast bool,
@@ -187,6 +194,17 @@ func runNonInteractive(
 	if largeModel != "" || smallModel != "" {
 		if err := overrideModels(ctx, c, ws, largeModel, smallModel); err != nil {
 			return fmt.Errorf("failed to override models: %w", err)
+		}
+	}
+
+	// The reasoning effort applies to the model that will actually run.
+	// On a continued session without an explicit model override, the
+	// model is resolved later from the session's last assistant message,
+	// so the override is applied after that restore instead.
+	deferredEffort := (continueSessionID != "" || useLast) && largeModel == "" && smallModel == ""
+	if reasoningEffort != "" && !deferredEffort {
+		if err := overrideReasoningEffort(ctx, c, ws.ID, reasoningEffort); err != nil {
+			return err
 		}
 	}
 
@@ -248,6 +266,12 @@ func runNonInteractive(
 		}
 	} else {
 		slog.Info("Created session for non-interactive run", "session_id", sess.ID)
+	}
+
+	if reasoningEffort != "" && deferredEffort {
+		if err := overrideReasoningEffort(ctx, c, ws.ID, reasoningEffort); err != nil {
+			return err
+		}
 	}
 
 	events, err := c.SubscribeEvents(ctx, ws.ID)
@@ -593,6 +617,34 @@ func restoreModelFromSession(ctx context.Context, c *client.Client, ws *proto.Wo
 	}
 
 	return c.UpdateAgent(ctx, ws.ID)
+}
+
+// overrideReasoningEffort validates the requested reasoning effort against
+// the large model in effect for this run (which may have been overridden by
+// --model or restored from a continued session) and applies it on the
+// server.
+func overrideReasoningEffort(ctx context.Context, c *client.Client, wsID, reasoningEffort string) error {
+	cfg, err := c.GetConfig(ctx, wsID)
+	if err != nil {
+		return fmt.Errorf("failed to get config: %w", err)
+	}
+
+	selected, ok := cfg.Models[config.SelectedModelTypeLarge]
+	if !ok {
+		return fmt.Errorf("no large model selected; set one with the --model flag or 'model large'")
+	}
+	if err := cfg.ValidateReasoningEffort(selected.Provider, selected.Model, reasoningEffort); err != nil {
+		return err
+	}
+	selected.ReasoningEffort = reasoningEffort
+	slog.Info("Overriding reasoning effort for non-interactive run",
+		"provider", selected.Provider,
+		"model", selected.Model,
+		"reasoning_effort", reasoningEffort)
+	if err := c.UpdatePreferredModel(ctx, wsID, config.ScopeWorkspace, config.SelectedModelTypeLarge, selected); err != nil {
+		return fmt.Errorf("failed to set reasoning effort: %w", err)
+	}
+	return c.UpdateAgent(ctx, wsID)
 }
 
 type modelMatch struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -827,6 +827,26 @@ func (c *Config) GetModel(provider, model string) *catwalk.Model {
 	return nil
 }
 
+// ValidateReasoningEffort checks that effort is a reasoning level the
+// given provider/model supports. It returns an error listing the accepted
+// levels when the model cannot use it.
+func (c *Config) ValidateReasoningEffort(provider, modelID, effort string) error {
+	model := c.GetModel(provider, modelID)
+	if model == nil {
+		return fmt.Errorf("model %q not found for provider %q", modelID, provider)
+	}
+	if len(model.ReasoningLevels) == 0 {
+		return fmt.Errorf("model %q does not support reasoning effort", modelID)
+	}
+	if slices.Contains(model.ReasoningLevels, effort) {
+		return nil
+	}
+	return fmt.Errorf(
+		"model %q does not support reasoning effort %q, accepted values: %s",
+		modelID, effort, strings.Join(model.ReasoningLevels, ", "),
+	)
+}
+
 // IsModelAvailable returns true if the provider is enabled and the model
 // exists in its catalog. Unlike GetModel, it rejects disabled providers.
 func (c *Config) IsModelAvailable(provider, model string) bool {

--- a/internal/config/reasoning_effort_test.go
+++ b/internal/config/reasoning_effort_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"testing"
+
+	"charm.land/catwalk/pkg/catwalk"
+	"github.com/charmbracelet/crush/internal/csync"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_ValidateReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	newConfig := func(models ...catwalk.Model) *Config {
+		return &Config{
+			Providers: csync.NewMapFrom(map[string]ProviderConfig{
+				"openai": {
+					ID:     "openai",
+					Models: models,
+				},
+			}),
+		}
+	}
+
+	t.Run("supported effort passes", func(t *testing.T) {
+		t.Parallel()
+		cfg := newConfig(catwalk.Model{
+			ID:              "gpt-5",
+			CanReason:       true,
+			ReasoningLevels: []string{"low", "medium", "high"},
+		})
+		require.NoError(t, cfg.ValidateReasoningEffort("openai", "gpt-5", "high"))
+	})
+
+	t.Run("unsupported effort lists accepted values", func(t *testing.T) {
+		t.Parallel()
+		cfg := newConfig(catwalk.Model{
+			ID:              "gpt-5",
+			CanReason:       true,
+			ReasoningLevels: []string{"low", "medium", "high"},
+		})
+		err := cfg.ValidateReasoningEffort("openai", "gpt-5", "ultra")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not support reasoning effort")
+		require.Contains(t, err.Error(), `"ultra"`)
+		require.Contains(t, err.Error(), "accepted values: low, medium, high")
+	})
+
+	t.Run("model without reasoning levels rejects any effort", func(t *testing.T) {
+		t.Parallel()
+		cfg := newConfig(catwalk.Model{ID: "gpt-4o"})
+		err := cfg.ValidateReasoningEffort("openai", "gpt-4o", "low")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not support reasoning effort")
+	})
+
+	t.Run("unknown model errors", func(t *testing.T) {
+		t.Parallel()
+		cfg := newConfig(catwalk.Model{ID: "gpt-4o"})
+		err := cfg.ValidateReasoningEffort("openai", "gpt-5", "low")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("empty effort is rejected like any other value", func(t *testing.T) {
+		t.Parallel()
+		cfg := newConfig(catwalk.Model{
+			ID:              "gpt-5",
+			CanReason:       true,
+			ReasoningLevels: []string{"low", "medium", "high"},
+		})
+		require.Error(t, cfg.ValidateReasoningEffort("openai", "gpt-5", ""))
+	})
+}


### PR DESCRIPTION
This revision adds a `--reasoning-effort` flag to `crush run`.

The value is validated against the model that will actually run: either the `--model` value specified, the configured model, or the model restored from the session on `--continue`/`--session`.
- Unsupported levels will fail with error, listing the model's accepted values. Models without reasoning levels reject the flag outright.
- Non-client/server runs apply the override in memory; client/server runs update it through the same workspace model API as `--model`.

Usage:

```bash
# Set reasoning effort for the run
crush run --reasoning-effort high "What’s for dinner?"

# Combine with a model override
crush run --model openai/gpt-5 --reasoning-effort low "Let’s make spaghetti"

# Validated against the model restored from the session
crush run --continue --reasoning-effort high "Oh my"
```

Errors look like:

```
Model "glm-5.3" does not support reasoning effort "moewmax", accepted values: low, medium, high.
```

```
ERROR
Model "gpt-4o" does not support reasoning effort.
```