### PR TITLE
feat(tui): add configurable custom status line

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -555,8 +555,26 @@ option ui transparent true
 option ui mouse false
 option ui scrollbar always
 option ui exit-banner compact
+option ui status-line '~/bin/statusline.sh'
 option ui completions-max-depth 4
 option ui completions-max-items 200
+```
+
+The status line command re-runs about once a second with a JSON payload on
+stdin describing the current session, and its first line of stdout is
+rendered at the very bottom of the TUI (empty output hides the line):
+
+```json
+{
+  "session_id": "0b2d1b3e-…",
+  "title": "Fix login flow",
+  "cwd": "~/dev/app",
+  "model": { "id": "claude-sonnet-5", "display_name": "Claude Sonnet 5", "provider": "anthropic" },
+  "workspace": { "current_dir": "~/dev/app", "project_dir": "~/dev/app" },
+  "context": { "used_tokens": 21043, "context_window": 200000, "percentage": 10.5 },
+  "cost": { "total_cost_usd": 0.12 },
+  "version": "v0.93.1"
+}
 ```
 
 > [!IMPORTANT]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -275,11 +275,27 @@ type TUIOptions struct {
 	// Here we can add themes later or any TUI related options
 	//
 
-	Completions Completions `json:"completions,omitzero" jsonschema:"description=Completions UI options"`
-	Transparent *bool       `json:"transparent,omitempty" jsonschema:"description=Enable transparent background for the TUI interface,default=false"`
-	Scrollbar   string      `json:"scrollbar,omitempty" jsonschema:"description=Chat scrollbar visibility,enum=default,enum=always,enum=never,default=default"`
-	Mouse       *bool       `json:"mouse,omitempty" jsonschema:"description=Enable terminal mouse capture for selection\\, clicks\\, and scrolling in the TUI. Disable to let the terminal emulator or tmux handle text selection and copy/paste,default=true"`
-	ExitBanner  ExitBanner  `json:"exit_banner,omitempty" jsonschema:"description=Exit banner style after quitting Crush,enum=default,enum=compact,enum=none,default=default"`
+	Completions Completions       `json:"completions,omitzero" jsonschema:"description=Completions UI options"`
+	Transparent *bool             `json:"transparent,omitempty" jsonschema:"description=Enable transparent background for the TUI interface,default=false"`
+	Scrollbar   string            `json:"scrollbar,omitempty" jsonschema:"description=Chat scrollbar visibility,enum=default,enum=always,enum=never,default=default"`
+	Mouse       *bool             `json:"mouse,omitempty" jsonschema:"description=Enable terminal mouse capture for selection\\, clicks\\, and scrolling in the TUI. Disable to let the terminal emulator or tmux handle text selection and copy/paste,default=true"`
+	ExitBanner  ExitBanner        `json:"exit_banner,omitempty" jsonschema:"description=Exit banner style after quitting Crush,enum=default,enum=compact,enum=none,default=default"`
+	StatusLine  *StatusLineConfig `json:"status_line,omitempty" jsonschema:"description=Custom status line rendered at the bottom of the TUI"`
+}
+
+// StatusLineConfig configures a user-provided status line rendered at the
+// bottom of the TUI. The command runs periodically with a JSON payload
+// describing the current session on stdin, and its first output line is
+// displayed below the help bar.
+type StatusLineConfig struct {
+	Command string `json:"command" jsonschema:"description=Shell command that receives the session JSON payload on stdin and prints the status line to stdout,example=~/bin/statusline.sh"`
+}
+
+// StatusLineEnabled reports whether a custom status line is configured. The
+// nil receiver and an empty command both mean disabled, so callers can ask
+// without unwrapping either.
+func (t *TUIOptions) StatusLineEnabled() bool {
+	return t != nil && t.StatusLine != nil && t.StatusLine.Command != ""
 }
 
 // IsTransparent reports whether the TUI draws a transparent background. The

--- a/internal/shellconfig/options.go
+++ b/internal/shellconfig/options.go
@@ -224,7 +224,7 @@ var optionSpecs = map[string]optionSpec{
 // that live under options.tui rather than as top-level options.
 func optionUI(options map[string]any, args []string, stderr io.Writer) error {
 	if len(args) != 4 {
-		return usage(stderr, "usage: option ui <compact|diff|transparent|mouse|scrollbar|completions-max-depth|completions-max-items|exit-banner> <value>")
+		return usage(stderr, "usage: option ui <compact|diff|transparent|mouse|scrollbar|completions-max-depth|completions-max-items|exit-banner|status-line> <value>")
 	}
 
 	key := args[2]
@@ -257,6 +257,11 @@ func optionUI(options map[string]any, args []string, stderr io.Writer) error {
 			return usage(stderr, fmt.Sprintf("option ui exit-banner expects default, compact, or none, got %q", value))
 		}
 		ui["exit_banner"] = value
+	case "status-line":
+		if value == "" {
+			return usage(stderr, "option ui status-line expects a shell command")
+		}
+		ui["status_line"] = map[string]any{"command": value}
 	case "completions-max-depth", "completions-max-items":
 		parsed, err := strconv.Atoi(value)
 		if err != nil || parsed < 0 {

--- a/internal/ui/model/statusline.go
+++ b/internal/ui/model/statusline.go
@@ -1,0 +1,209 @@
+package model
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/crush/internal/config"
+	"github.com/charmbracelet/crush/internal/ui/common"
+	"github.com/charmbracelet/crush/internal/version"
+	uv "github.com/charmbracelet/ultraviolet"
+	"github.com/charmbracelet/x/ansi"
+)
+
+const (
+	// statusLineInterval is how often the status line command re-runs.
+	statusLineInterval = time.Second
+	// statusLineTimeout bounds a single status line command run. Slow or
+	// hung scripts leave the previous output in place instead of blocking
+	// the refresh loop forever.
+	statusLineTimeout = 5 * time.Second
+)
+
+// statusLineTickMsg schedules the next status line refresh.
+type statusLineTickMsg struct{}
+
+// statusLineOutputMsg carries the latest status line content. An empty
+// content string hides the status line.
+type statusLineOutputMsg struct {
+	content string
+}
+
+// StatusLine renders the output of a user-provided status line command at
+// the bottom of the TUI. The command receives a JSON payload describing the
+// current session on stdin and its first output line is displayed as-is,
+// truncated to the available width.
+type StatusLine struct {
+	com     *common.Common
+	content string
+	width   int
+}
+
+// NewStatus creates a status line model. It is only constructed when a
+// status line command is configured.
+func NewStatusLine(com *common.Common) *StatusLine {
+	return &StatusLine{com: com}
+}
+
+// SetContent updates the rendered content.
+func (s *StatusLine) SetContent(content string) {
+	s.content = content
+}
+
+// SetWidth sets the width used to truncate the status line.
+func (s *StatusLine) SetWidth(width int) {
+	s.width = width
+}
+
+// Draw draws the status line onto the screen.
+func (s *StatusLine) Draw(scr uv.Screen, area uv.Rectangle) {
+	if s.content == "" || area.Dx() <= 0 || area.Dy() <= 0 {
+		return
+	}
+	line := strings.TrimRight(s.content, "\r\n")
+	if idx := strings.IndexByte(line, '\n'); idx >= 0 {
+		line = line[:idx]
+	}
+	line = ansi.Truncate(line, min(area.Dx(), s.width), "…")
+	uv.NewStyledString(line).Draw(scr, area)
+}
+
+// statusLineTick schedules the periodic status line refresh. The first tick
+// fires after one interval so startup is not blocked on an external command.
+func statusLineTick() tea.Cmd {
+	return tea.Tick(statusLineInterval, func(time.Time) tea.Msg {
+		return statusLineTickMsg{}
+	})
+}
+
+// runStatusLine executes the configured status line command with the JSON
+// payload on stdin and returns its trimmed output. On failure the command's
+// stderr (or the execution error) is returned instead, so misconfiguration
+// is visible instead of silently rendering nothing.
+func runStatusLine(command string, payload []byte) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), statusLineTimeout)
+		defer cancel()
+		name, args := statusLineShellCommand(command)
+		cmd := exec.CommandContext(ctx, name, args...)
+		cmd.Stdin = bytes.NewReader(payload)
+		out, err := cmd.Output()
+		content := string(out)
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+				content = string(exitErr.Stderr)
+			} else {
+				content = err.Error()
+			}
+		}
+		return statusLineOutputMsg{content: strings.TrimSpace(content)}
+	}
+}
+
+// statusLineShellCommand wraps the user command in a shell so pipes, env
+// expansion, and quoted arguments behave the way status line scripts expect.
+func statusLineShellCommand(command string) (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", []string{"/C", command}
+	}
+	return "sh", []string{"-c", command}
+}
+
+// StatusLinePayload is the JSON document written to the status line
+// command's stdin on every refresh. Field names follow the Claude Code
+// status line contract where there is an equivalent, so existing scripts
+// port with minimal changes.
+type StatusLinePayload struct {
+	SessionID string              `json:"session_id,omitempty"`
+	Title     string              `json:"title,omitempty"`
+	Cwd       string              `json:"cwd,omitempty"`
+	Model     StatusLineModel     `json:"model"`
+	Workspace StatusLineWorkspace `json:"workspace"`
+	Context   StatusLineContext   `json:"context"`
+	Cost      StatusLineCost      `json:"cost"`
+	Version   string              `json:"version,omitempty"`
+}
+
+// StatusLineModel describes the selected model.
+type StatusLineModel struct {
+	ID          string `json:"id,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+	Provider    string `json:"provider,omitempty"`
+}
+
+// StatusLineWorkspace describes the workspace directories.
+type StatusLineWorkspace struct {
+	CurrentDir string `json:"current_dir,omitempty"`
+	ProjectDir string `json:"project_dir,omitempty"`
+}
+
+// StatusLineContext describes token usage relative to the context window.
+type StatusLineContext struct {
+	UsedTokens     int64   `json:"used_tokens,omitempty"`
+	ContextWindow  int64   `json:"context_window,omitempty"`
+	Percentage     float64 `json:"percentage,omitempty"`
+	EstimatedUsage bool    `json:"estimated_usage,omitempty"`
+}
+
+// StatusLineCost describes the accumulated session cost.
+type StatusLineCost struct {
+	TotalCostUSD float64 `json:"total_cost_usd,omitempty"`
+}
+
+// buildStatusLinePayload snapshots the current session state into the JSON
+// payload handed to the status line command.
+func (m *UI) buildStatusLinePayload() StatusLinePayload {
+	payload := StatusLinePayload{
+		Version: version.Version,
+	}
+	if m.com.Workspace != nil {
+		payload.Cwd = m.com.Workspace.WorkingDir()
+		payload.Workspace.CurrentDir = payload.Cwd
+	}
+	if m.session != nil {
+		s := m.session
+		payload.SessionID = s.ID
+		payload.Title = s.Title
+		payload.Context.UsedTokens = s.PromptTokens + s.CompletionTokens
+		payload.Context.EstimatedUsage = s.EstimatedUsage
+		payload.Cost.TotalCostUSD = s.Cost
+	}
+	if model := m.selectedLargeModel(); model != nil {
+		payload.Model.ID = model.ModelCfg.Model
+		payload.Model.DisplayName = model.CatwalkCfg.Name
+		payload.Model.Provider = model.ModelCfg.Provider
+		payload.Context.ContextWindow = model.CatwalkCfg.ContextWindow
+	}
+	if payload.Context.ContextWindow > 0 {
+		payload.Context.Percentage = float64(payload.Context.UsedTokens) / float64(payload.Context.ContextWindow) * 100
+	}
+	return payload
+}
+
+// statusLineRefresh returns the command that runs the configured status
+// line command with a fresh payload snapshot and re-arms the tick.
+func (m *UI) statusLineRefresh() tea.Cmd {
+	if m.statusLine == nil {
+		return nil
+	}
+	cfg := config.StatusLineConfig{}
+	if c := m.com.Config(); c != nil && c.Options != nil && c.Options.TUI != nil {
+		cfg = *c.Options.TUI.StatusLine
+	}
+	payload, err := json.Marshal(m.buildStatusLinePayload())
+	if err != nil {
+		payload = []byte("{}")
+	}
+	return tea.Batch(
+		runStatusLine(cfg.Command, payload),
+		statusLineTick(),
+	)
+}

--- a/internal/ui/model/statusline_test.go
+++ b/internal/ui/model/statusline_test.go
@@ -1,0 +1,111 @@
+package model
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/crush/internal/ui/common"
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+func newTestStatusLine(width int) *StatusLine {
+	s := NewStatusLine(common.DefaultCommon(nil))
+	s.SetWidth(width)
+	return s
+}
+
+func TestStatusLineDraw(t *testing.T) {
+	s := newTestStatusLine(40)
+	s.SetContent("hello crush")
+	scr := uv.NewScreenBuffer(40, 1)
+	s.Draw(scr, uv.Rect(0, 0, 40, 1))
+	if got := strings.TrimRight(scr.Render(), " "); got != "hello crush" {
+		t.Errorf("expected %q, got %q", "hello crush", got)
+	}
+}
+
+func TestStatusLineDrawEmpty(t *testing.T) {
+	s := newTestStatusLine(40)
+	scr := uv.NewScreenBuffer(40, 1)
+	s.Draw(scr, uv.Rect(0, 0, 40, 1))
+	if got := scr.Render(); strings.TrimSpace(got) != "" {
+		t.Errorf("expected empty screen, got %q", got)
+	}
+}
+
+func TestStatusLineDrawTruncates(t *testing.T) {
+	s := newTestStatusLine(10)
+	s.SetContent("this line is way too long for the status bar")
+	scr := uv.NewScreenBuffer(10, 1)
+	s.Draw(scr, uv.Rect(0, 0, 10, 1))
+	got := scr.Render()
+	if len([]rune(strings.ReplaceAll(got, "…", ""))) > 10 {
+		t.Errorf("expected truncated output, got %q", got)
+	}
+	if !strings.Contains(got, "…") {
+		t.Errorf("expected ellipsis, got %q", got)
+	}
+}
+
+func TestStatusLineDrawFirstLineOnly(t *testing.T) {
+	s := newTestStatusLine(40)
+	s.SetContent("first\nsecond")
+	scr := uv.NewScreenBuffer(40, 1)
+	s.Draw(scr, uv.Rect(0, 0, 40, 1))
+	if got := strings.TrimRight(scr.Render(), " "); got != "first" {
+		t.Errorf("expected only the first line, got %q", got)
+	}
+}
+
+func TestRunStatusLineOutput(t *testing.T) {
+	cmd := runStatusLine("printf 'hello from status line'", []byte(`{}`))
+	msg := cmd()
+	out, ok := msg.(statusLineOutputMsg)
+	if !ok {
+		t.Fatalf("expected statusLineOutputMsg, got %T", msg)
+	}
+	if out.content != "hello from status line" {
+		t.Errorf("unexpected content %q", out.content)
+	}
+}
+
+func TestRunStatusLineReceivesStdin(t *testing.T) {
+	cmd := runStatusLine("cat", []byte(`{"session_id":"abc"}`))
+	msg := cmd()
+	out, ok := msg.(statusLineOutputMsg)
+	if !ok {
+		t.Fatalf("expected statusLineOutputMsg, got %T", msg)
+	}
+	if out.content != `{"session_id":"abc"}` {
+		t.Errorf("unexpected content %q", out.content)
+	}
+}
+
+func TestRunStatusLineErrorShowsStderr(t *testing.T) {
+	cmd := runStatusLine("echo broken >&2; exit 1", []byte(`{}`))
+	msg := cmd()
+	out, ok := msg.(statusLineOutputMsg)
+	if !ok {
+		t.Fatalf("expected statusLineOutputMsg, got %T", msg)
+	}
+	if out.content != "broken" {
+		t.Errorf("expected stderr in content, got %q", out.content)
+	}
+}
+
+func TestStatusLineTick(t *testing.T) {
+	cmd := statusLineTick()
+	// The tick fires after statusLineInterval; just assert it returns a
+	// command that eventually produces a statusLineTickMsg.
+	done := make(chan any, 1)
+	go func() { done <- cmd() }()
+	select {
+	case msg := <-done:
+		if _, ok := msg.(statusLineTickMsg); !ok {
+			t.Errorf("expected statusLineTickMsg, got %T", msg)
+		}
+	case <-time.After(3 * statusLineInterval):
+		t.Fatal("status line tick did not fire")
+	}
+}

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -219,6 +219,8 @@ type UI struct {
 
 	dialog *dialog.Overlay
 	status *Status
+	// statusLine renders the user-configured status line, if any.
+	statusLine *StatusLine
 
 	// isCanceling tracks whether the user has pressed escape once to cancel.
 	isCanceling bool
@@ -475,6 +477,9 @@ func New(com *common.Common, initialSessionID string, continueLast bool) *UI {
 	}
 
 	status := NewStatus(com, ui)
+	if cfg := com.Config(); cfg != nil && cfg.Options != nil && cfg.Options.TUI.StatusLineEnabled() {
+		ui.statusLine = NewStatusLine(com)
+	}
 
 	// Seed the active theme key from the large model provider so the
 	// first model selection can correctly skip a redundant theme swap.
@@ -557,6 +562,9 @@ func (m *UI) Init() tea.Cmd {
 		cmds = append(cmds, cmd)
 	}
 	cmds = append(cmds, m.checkPendingMCPAuth())
+	if m.statusLine != nil {
+		cmds = append(cmds, statusLineTick())
+	}
 	return tea.Batch(cmds...)
 }
 
@@ -1394,6 +1402,12 @@ func (m *UI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, m.handleConnectionEvent(msg)...)
 	case util.ClearStatusMsg:
 		m.status.ClearInfoMsg()
+	case statusLineTickMsg:
+		cmds = append(cmds, m.statusLineRefresh())
+	case statusLineOutputMsg:
+		if m.statusLine != nil {
+			m.statusLine.SetContent(msg.content)
+		}
 	case completions.CompletionItemsLoadedMsg:
 		if m.completionsOpen {
 			m.completions.SetItems(msg.Files, msg.Resources)
@@ -3078,6 +3092,9 @@ func (m *UI) Draw(scr uv.Screen, area uv.Rectangle) *tea.Cursor {
 	// Add status and help layer
 	m.status.SetHideHelp(isOnboarding)
 	m.status.Draw(scr, layout.status)
+	if m.statusLine != nil {
+		m.statusLine.Draw(scr, layout.statusLine)
+	}
 
 	// Draw completions popup if open
 	if !isOnboarding && m.completionsOpen && m.completions.HasItems() {
@@ -3602,6 +3619,9 @@ func (m *UI) updateTextareaWithPrevHeight(msg tea.Msg, prevHeight int) tea.Cmd {
 func (m *UI) updateSize() {
 	// Set status width
 	m.status.SetWidth(m.layout.status.Dx())
+	if m.statusLine != nil {
+		m.statusLine.SetWidth(m.layout.statusLine.Dx())
+	}
 
 	m.chat.SetSize(m.layout.main.Dx(), m.layout.main.Dy())
 	m.textarea.MaxHeight = TextareaMaxHeight
@@ -3675,6 +3695,18 @@ func (m *UI) generateLayout(w, h int) uiLayout {
 	uiLayout := uiLayout{
 		area:   area,
 		status: helpRect,
+	}
+
+	// When a custom status line is configured it gets its own row at the
+	// very bottom of the screen, below the help bar.
+	if m.statusLine != nil && helpRect.Dy() > 1 {
+		var statusLineRect image.Rectangle
+		layout.Vertical(
+			layout.Len(helpRect.Dy()-1),
+			layout.Len(1),
+		).Split(helpRect).Assign(&helpRect, &statusLineRect)
+		uiLayout.status = helpRect
+		uiLayout.statusLine = statusLineRect
 	}
 
 	// Handle different app states
@@ -3844,6 +3876,9 @@ type uiLayout struct {
 
 	// status is the area for the status view.
 	status uv.Rectangle
+
+	// statusLine is the area for the custom status line, when configured.
+	statusLine uv.Rectangle
 
 	// session details is the area for the session details overlay in compact mode.
 	sessionDetails uv.Rectangle

--- a/schema.json
+++ b/schema.json
@@ -792,6 +792,22 @@
         "provider"
       ]
     },
+    "StatusLineConfig": {
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "Shell command that receives the session JSON payload on stdin and prints the status line to stdout",
+          "examples": [
+            "~/bin/statusline.sh"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "command"
+      ]
+    },
     "TUIOptions": {
       "properties": {
         "compact_mode": {
@@ -840,6 +856,10 @@
           ],
           "description": "Exit banner style after quitting Crush",
           "default": "default"
+        },
+        "status_line": {
+          "$ref": "#/$defs/StatusLineConfig",
+          "description": "Custom status line rendered at the bottom of the TUI"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

Adds a user-configurable status line rendered at the very bottom of the TUI, below the help bar. This addresses the bottom-half ask of #2648 (customizable status lines) with a mechanism modeled on Claude Code's `statusLine`, which makes existing status line scripts portable.

## How it works

- Configure with `option ui status-line '<command>'` in `crushrc` (or `options.tui.status_line.command` in JSON config).
- The command re-runs about once a second with a JSON payload on stdin describing the current session:

```json
{
  "session_id": "…",
  "title": "Fix login flow",
  "cwd": "~/dev/app",
  "model": { "id": "…", "display_name": "…", "provider": "…" },
  "workspace": { "current_dir": "…", "project_dir": "…" },
  "context": { "used_tokens": 21043, "context_window": 200000, "percentage": 10.5, "estimated_usage": false },
  "cost": { "total_cost_usd": 0.12 },
  "version": "v0.93.1"
}
```

- The first line of stdout is rendered as the status line, truncated to the available width (ANSI-aware). Empty output hides the line, so a failing or quiet script costs no screen space.
- On non-zero exit the command's stderr is rendered instead, so a broken command is visible rather than silently blank.
- Runs asynchronously via a bubbletea command with a 5s timeout; a slow or hung script never blocks the UI, it just leaves the previous output in place.

## Implementation notes

- New `StatusLine` component in `internal/ui/model/statusline.go` mirrors the existing `Status` bar's draw pattern; `generateLayout` carves one extra row below the help bar only when configured.
- Payload field names follow the Claude Code status line contract where an equivalent exists (`session_id`, `cwd`, `model.display_name`, `workspace.current_dir`, `cost.total_cost_usd`, `context.percentage`), so scripts written for Claude Code port with minimal changes.
- The row is only allocated when the option is set and the help rect is taller than one line, so the default UI is byte-identical.
- `schema.json` regenerated via `go run . schema`; docs updated in `docs/config/README.md`.

## Testing

- `go test ./internal/ui/model/ ./internal/config/ ./internal/shellconfig/` green, including new unit tests for rendering, truncation, first-line-only output, stdin payload round-trip, and stderr-on-failure.
- Manually verified in a live TUI session: footer renders below the help bar, updates each second, and picks up `model.display_name` / `workspace.current_dir` from the payload.

Closes #2648 (bottom bar half; header hiding is left as a separate change).

Generated with Crush