### PR TITLE
Inline local $ref definitions when forwarding MCP tool schemas

### DIFF
--- a/internal/agent/tools/mcp-tools.go
+++ b/internal/agent/tools/mcp-tools.go
@@ -2,8 +2,10 @@ package tools
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 
 	"charm.land/fantasy"
 	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
@@ -86,6 +88,24 @@ func (m *Tool) Info() fantasy.ToolInfo {
 			// Handle case where it's already []string
 			required = reqStr
 		}
+
+		// The ToolInfo pipeline only carries the properties map, so any
+		// $defs/definitions in the original MCP schema are lost, leaving
+		// dangling $ref pointers. Some providers (e.g. Moonshot) validate
+		// tool schemas and reject such requests outright. Inline every
+		// "#/$defs/..." and "#/definitions/..." reference so the forwarded
+		// schema is self-contained.
+		defs := map[string]any{}
+		for _, key := range []string{"$defs", "definitions"} {
+			if d, ok := input[key].(map[string]any); ok {
+				for name, def := range d {
+					defs[name] = def
+				}
+			}
+		}
+		if len(defs) > 0 {
+			parameters = resolveRefs(parameters, defs, 0)
+		}
 	}
 
 	return fantasy.ToolInfo{
@@ -94,6 +114,83 @@ func (m *Tool) Info() fantasy.ToolInfo {
 		Parameters:  parameters,
 		Required:    required,
 	}
+}
+
+const maxRefDepth = 64
+
+// resolveRefs returns a copy of node with local JSON Schema references
+// ("#/$defs/Name" and "#/definitions/Name") replaced by deep copies of their
+// targets. The input MCP schema is cached and shared, so nothing is mutated
+// in place. Depth is capped to guard against cyclic definitions.
+func resolveRefs(node map[string]any, defs map[string]any, depth int) map[string]any {
+	if depth > maxRefDepth {
+		return node
+	}
+	result := make(map[string]any, len(node))
+	for key, value := range node {
+		switch child := value.(type) {
+		case map[string]any:
+			if resolved, ok := resolveRef(child, defs, depth); ok {
+				result[key] = resolved
+				continue
+			}
+			result[key] = resolveRefs(child, defs, depth+1)
+		case []any:
+			items := make([]any, len(child))
+			for i, item := range child {
+				switch elem := item.(type) {
+				case map[string]any:
+					if resolved, ok := resolveRef(elem, defs, depth); ok {
+						items[i] = resolved
+						continue
+					}
+					items[i] = resolveRefs(elem, defs, depth+1)
+				default:
+					items[i] = elem
+				}
+			}
+			result[key] = items
+		default:
+			result[key] = value
+		}
+	}
+	return result
+}
+
+// resolveRef checks whether node is a local reference and, if so, returns a
+// resolved deep copy of its target.
+func resolveRef(node map[string]any, defs map[string]any, depth int) (map[string]any, bool) {
+	ref, ok := node["$ref"].(string)
+	if !ok || len(node) != 1 {
+		return nil, false
+	}
+	var name string
+	for _, prefix := range []string{"#/$defs/", "#/definitions/"} {
+		if strings.HasPrefix(ref, prefix) {
+			name = strings.TrimPrefix(ref, prefix)
+			break
+		}
+	}
+	if name == "" {
+		return nil, false
+	}
+	target, ok := defs[name].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	return resolveRefs(deepCopyMap(target), defs, depth+1), true
+}
+
+func deepCopyMap(source map[string]any) map[string]any {
+	data, err := json.Marshal(source)
+	if err != nil {
+		return map[string]any{}
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return map[string]any{}
+	}
+	return result
 }
 
 func (m *Tool) Run(ctx context.Context, params fantasy.ToolCall) (fantasy.ToolResponse, error) {

--- a/internal/agent/tools/mcp-tools_refs_test.go
+++ b/internal/agent/tools/mcp-tools_refs_test.go
@@ -1,0 +1,124 @@
+package tools
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/tools/mcp"
+)
+
+func TestInfoInlinesDefsRefs(t *testing.T) {
+	inputSchema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"tasks": map[string]any{
+				"type":  "array",
+				"items": map[string]any{"$ref": "#/$defs/OpenTask"},
+			},
+			"filter": map[string]any{"$ref": "#/$defs/Filter"},
+			"legacy": map[string]any{"$ref": "#/definitions/Legacy"},
+		},
+		"required": []any{"tasks"},
+		"$defs": map[string]any{
+			"OpenTask": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"title": map[string]any{"type": "string"},
+					"tags": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"$ref": "#/$defs/Tag"},
+					},
+				},
+			},
+			"Tag":    map[string]any{"type": "string"},
+			"Filter": map[string]any{"type": "string"},
+		},
+		"definitions": map[string]any{
+			"Legacy": map[string]any{"type": "integer"},
+		},
+	}
+
+	tool := &Tool{
+		mcpName: "test",
+		tool:    &mcp.Tool{Name: "batch_add_tasks", InputSchema: inputSchema},
+	}
+	info := tool.Info()
+
+	tasks, ok := info.Parameters["tasks"].(map[string]any)
+	if !ok {
+		t.Fatalf("tasks property missing or wrong type: %#v", info.Parameters["tasks"])
+	}
+	items, ok := tasks["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("tasks.items missing or wrong type: %#v", tasks["items"])
+	}
+	if _, isRef := items["$ref"]; isRef {
+		t.Fatalf("tasks.items still contains an unresolved $ref: %#v", items)
+	}
+	if items["type"] != "object" {
+		t.Fatalf("tasks.items should be the inlined OpenTask object, got %#v", items)
+	}
+	props, ok := items["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("inlined OpenTask missing properties: %#v", items)
+	}
+	tagArray, ok := props["tags"].(map[string]any)
+	if !ok {
+		t.Fatalf("inlined OpenTask missing tags: %#v", props)
+	}
+	if _, isRef := tagArray["items"].(map[string]any)["$ref"]; isRef {
+		t.Fatalf("nested $ref inside inlined def was not resolved: %#v", tagArray["items"])
+	}
+
+	if filter, ok := info.Parameters["filter"].(map[string]any); !ok || filter["type"] != "string" {
+		t.Fatalf("$defs reference not inlined: %#v", info.Parameters["filter"])
+	}
+	if legacy, ok := info.Parameters["legacy"].(map[string]any); !ok || legacy["type"] != "integer" {
+		t.Fatalf("legacy definitions reference not inlined: %#v", info.Parameters["legacy"])
+	}
+
+	if len(info.Required) != 1 || info.Required[0] != "tasks" {
+		t.Fatalf("required mismatch: %#v", info.Required)
+	}
+
+	// The shared original schema must not be mutated.
+	origItems := inputSchema["properties"].(map[string]any)["tasks"].(map[string]any)["items"].(map[string]any)
+	if _, hasRef := origItems["$ref"]; !hasRef {
+		t.Fatalf("original cached schema was mutated: %#v", origItems)
+	}
+}
+
+func TestResolveRefsHandlesCycles(t *testing.T) {
+	defs := map[string]any{
+		"Node": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"child": map[string]any{"$ref": "#/$defs/Node"},
+			},
+		},
+	}
+	node := map[string]any{"$ref": "#/$defs/Node"}
+	_ = resolveRefs(node, defs, 0) // must terminate
+}
+
+func TestResolveRefsLeavesExternalRefsAlone(t *testing.T) {
+	defs := map[string]any{"Known": map[string]any{"type": "string"}}
+	node := map[string]any{
+		"external": map[string]any{"$ref": "https://example.com/schema.json"},
+		"missing":  map[string]any{"$ref": "#/$defs/Unknown"},
+		"described": map[string]any{
+			"$ref":        "#/$defs/Known",
+			"description": "kept alongside ref",
+		},
+	}
+	result := resolveRefs(node, defs, 0)
+	if ext, ok := result["external"].(map[string]any); !ok || ext["$ref"] != "https://example.com/schema.json" {
+		t.Fatalf("external ref should be untouched: %#v", result["external"])
+	}
+	if miss, ok := result["missing"].(map[string]any); !ok || miss["$ref"] != "#/$defs/Unknown" {
+		t.Fatalf("unresolvable local ref should be left as-is: %#v", result["missing"])
+	}
+	// A ref with sibling keywords is not a pure reference; leave it untouched.
+	if d, ok := result["described"].(map[string]any); !ok || d["$ref"] != "#/$defs/Known" {
+		t.Fatalf("ref with siblings should be untouched: %#v", result["described"])
+	}
+}


### PR DESCRIPTION
## Problem

MCP tool schemas that use `\$defs`/`definitions` (e.g. the hosted TickTick MCP server, whose `batch_add_tasks`/`batch_update_tasks` reference `#/\$defs/OpenTask`) are forwarded with those sections stripped: `mcp-tools.go` `Info()` passes only the `properties` and `required` maps through `fantasy.ToolInfo`, and `fantasy` rebuilds the schema as `{type, properties, required}`. The `\$ref` pointers survive while the definitions they point to are deleted.

Providers that validate tool schemas reject the dangling references. Moonshot (Kimi) fails every request with:

```
Invalid request: tools.function.parameters is not a valid moonshot flavored
json schema, details: <At path 'properties.tasks.items.\$ref': \$defs not
found for reference: #/\$defs/OpenTask>
```

This makes Moonshot models unusable whenever such an MCP server is connected, even for requests that never call the affected tool. DeepSeek and Z.AI accept the malformed schema, so the bug is invisible there.

## Solution

Before returning `ToolInfo`, inline every local reference (`#/\$defs/...` and `#/definitions/...`) as a deep copy of its target, producing a self-contained schema that any validator accepts:

- External refs (`https://...`) and unresolvable local refs are left untouched
- A `\$ref` with sibling keywords is left untouched, per JSON Schema spec (it is an annotation, not a pure reference)
- The cached, shared MCP schema is never mutated; resolution builds new maps
- Depth is capped to terminate on cyclic definitions
- Non-object/non-array nodes are passed through by value

## Validation

- New tests: inlining (incl. nested refs inside inlined defs and legacy `definitions`), cycle termination, and untouched external/sibling cases — all pass
- Verified end-to-end against Moonshot `kimi-k3` with the TickTick MCP server connected: previously every request 400'd; with this change tool definitions are accepted and `mcp_ticktick_list_projects` executes correctly

````
 BEHIND-THE-SCENES
````