### PR TITLE
feat(ui): allow new sessions while the agent is busy

### DIFF
--- a/internal/ui/model/session_busy_test.go
+++ b/internal/ui/model/session_busy_test.go
@@ -45,6 +45,7 @@ type countingWorkspace struct {
 	permSetCalls    int
 	clearQueueCalls int
 	cancelCalls     int
+	lspStopAllCalls int
 	modelCalls      int
 	lspStateCalls   int
 	lspDiagCalls    int
@@ -104,9 +105,19 @@ func (w *countingWorkspace) ListUserMessages(context.Context, string) ([]message
 	return nil, nil
 }
 
+func (w *countingWorkspace) ListAllUserMessages(context.Context) ([]message.Message, error) {
+	return nil, nil
+}
+
 func (w *countingWorkspace) WorkingDir() string { return "" }
 
 func (w *countingWorkspace) LSPStart(context.Context, string) {}
+
+func (w *countingWorkspace) LSPStopAll(context.Context) { w.lspStopAllCalls++ }
+
+func (w *countingWorkspace) SetCurrentSession(context.Context, string) error {
+	return nil
+}
 
 func (w *countingWorkspace) Config() *config.Config { return nil }
 
@@ -123,6 +134,7 @@ func (w *countingWorkspace) resetCounters() {
 	w.readyCalls, w.agentBusyCalls = 0, 0
 	w.queuedCalls, w.queueListCalls, w.permCalls = 0, 0, 0
 	w.permSetCalls, w.clearQueueCalls, w.cancelCalls = 0, 0, 0
+	w.lspStopAllCalls = 0
 	w.modelCalls, w.lspStateCalls, w.lspDiagCalls = 0, 0, 0
 }
 
@@ -777,4 +789,41 @@ func TestRemoteYoloToggleUpdatesEditorPrompt(t *testing.T) {
 	require.False(t, m.yoloModeCached())
 	require.Equal(t, normalPrompt, ansi.Strip(m.textarea.View()),
 		"toggling yolo off must restore the normal editor prompt")
+}
+
+// TestNewSessionWhileAgentBusy pins that ctrl+n starts a new session even
+// while a run is active. Runs are scoped per session, so the previous
+// session's run keeps going in the background; the UI must not block the
+// switch, and must leave the shared LSP servers running for that run.
+func TestNewSessionWhileAgentBusy(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, agentBusy: true}
+	m := newBusyUI(ws)
+	warmCaches(m, true)
+	require.True(t, m.isAgentBusy())
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
+	require.Nil(t, m.session, "ctrl+n must start a new session while the agent is busy")
+
+	runCmds(m, cmd)
+	require.Zero(t, ws.lspStopAllCalls,
+		"the background run may still need the LSP servers; they must not be stopped")
+}
+
+// TestNewSessionWhenIdleStopsLSPs pins the idle half of the same behavior:
+// with no run active, starting a new session still tears down the shared LSP
+// servers.
+func TestNewSessionWhenIdleStopsLSPs(t *testing.T) {
+	pinTTLs(t)
+
+	ws := &countingWorkspace{ready: true, agentBusy: false}
+	m := newBusyUI(ws)
+	warmCaches(m, false)
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl})
+	require.Nil(t, m.session, "ctrl+n must start a new session")
+
+	runCmds(m, cmd)
+	require.Equal(t, 1, ws.lspStopAllCalls, "an idle new session must stop the shared LSP servers")
 }

--- a/internal/ui/model/ui.go
+++ b/internal/ui/model/ui.go
@@ -1941,10 +1941,6 @@ func (m *UI) handleDialogMsg(msg tea.Msg) tea.Cmd {
 		}
 		m.dialog.CloseDialog(dialog.NotificationsID)
 	case dialog.ActionNewSession:
-		if m.isAgentBusy() {
-			cmds = append(cmds, util.ReportWarn("Agent is busy, please wait before starting a new session..."))
-			break
-		}
 		if cmd := m.newSession(); cmd != nil {
 			cmds = append(cmds, cmd)
 		}
@@ -2670,10 +2666,6 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				if !m.hasSession() {
 					break
 				}
-				if m.isAgentBusy() {
-					cmds = append(cmds, util.ReportWarn("Agent is busy, please wait before starting a new session..."))
-					break
-				}
 				if cmd := m.newSession(); cmd != nil {
 					cmds = append(cmds, cmd)
 				}
@@ -2844,10 +2836,6 @@ func (m *UI) handleKeyPressMsg(msg tea.KeyPressMsg) tea.Cmd {
 				}
 			case key.Matches(msg, m.keyMap.Chat.NewSession):
 				if !m.hasSession() {
-					break
-				}
-				if m.isAgentBusy() {
-					cmds = append(cmds, util.ReportWarn("Agent is busy, please wait before starting a new session..."))
 					break
 				}
 				m.focus = uiFocusEditor
@@ -4838,6 +4826,12 @@ func (m *UI) newSession() tea.Cmd {
 		return nil
 	}
 
+	// A run may still be active for the session being left. Backend runs are
+	// scoped per session, so that run keeps going in the background; only tear
+	// down the shared workspace LSP servers once nothing else is using them,
+	// and tell the user where the previous session went.
+	busy := m.isAgentBusy()
+
 	m.session = nil
 	m.sidebarOffset = 0
 	m.sessionFiles = nil
@@ -4856,14 +4850,19 @@ func (m *UI) newSession() tea.Cmd {
 	m.pillsView = ""
 	m.historyReset()
 	agenttools.ResetCache()
-	return tea.Batch(
-		func() tea.Msg {
-			m.com.Workspace.LSPStopAll(context.Background())
-			return nil
-		},
+	cmds := []tea.Cmd{
 		m.loadPromptHistory(),
 		m.reportCurrentSession(""),
-	)
+	}
+	if busy {
+		cmds = append(cmds, util.ReportInfo("Previous session is still working in the background. Press ctrl+s to switch back."))
+	} else {
+		cmds = append(cmds, func() tea.Msg {
+			m.com.Workspace.LSPStopAll(context.Background())
+			return nil
+		})
+	}
+	return tea.Batch(cmds...)
 }
 
 // checkBangModeAfterPaste engages bang mode when pasted text starts with


### PR DESCRIPTION
### What

Removes the "Agent is busy, please wait before starting a new session..." guard, so `ctrl+n` (and the command palette "New Session") starts a new session while a run is still in progress. The previous session's run continues in the background and can be reopened with `ctrl+s`.

### Why

The guard has no documented rationale:

- Added on 2025-07-25 by `ef28817d` ("chore: prevent new sessions when agent busy"), which landed inside PR #301 "Tool improvements". Neither the commit nor the PR gives a reason, and no test covers it.
- Copied to the chat-focused `ctrl+n` path in `698b7c80` (2026-01-22), then carried through the pills refactor and the old-TUI removal without ever being revisited.
- When it was added, the backend already ran one agent loop per session (`activeRequests` keyed by session ID, `IsSessionBusy`) and the message list already filtered events by session, so it never enforced a technical invariant.
- It uses the global busy check ("any session busy"), so it also blocked a new session when the busy run belonged to a different session or a different client.

### Behavior after this change

- `ctrl+n` while busy clears the UI for a new session immediately; the previous session keeps working.
- `LSPStopAll` is skipped while a run is active, since the shared LSP servers may still be needed by that run; they are stopped as before once nothing is running.
- While busy, a short info message points the user to `ctrl+s` to switch back; the existing "Agent's turn completed" notification still fires on completion.

### Tests

`go test ./internal/ui/...` passes. Two new tests in `session_busy_test.go` cover the busy path (new session starts, LSP servers kept alive) and the idle path (LSP servers stopped).

### Question

If there is a reason to keep this guard that isn't captured in the history, I'd be glad to hear it — I couldn't find one.


💘 Generated with Crush