### PR TITLE
fix: allow non-string values in skill metadata

### DIFF
--- a/internal/skills/skills.go
+++ b/internal/skills/skills.go
@@ -36,17 +36,17 @@ var (
 
 // Skill represents a parsed SKILL.md file.
 type Skill struct {
-	Name                   string            `yaml:"name" json:"name"`
-	Description            string            `yaml:"description" json:"description"`
-	UserInvocable          bool              `yaml:"user-invocable" json:"user_invocable"`
-	DisableModelInvocation bool              `yaml:"disable-model-invocation" json:"disable_model_invocation"`
-	License                string            `yaml:"license,omitempty" json:"license,omitempty"`
-	Compatibility          string            `yaml:"compatibility,omitempty" json:"compatibility,omitempty"`
-	Metadata               map[string]string `yaml:"metadata,omitempty" json:"metadata,omitempty"`
-	Instructions           string            `yaml:"-" json:"instructions"`
-	Path                   string            `yaml:"-" json:"path"`
-	SkillFilePath          string            `yaml:"-" json:"skill_file_path"`
-	Builtin                bool              `yaml:"-" json:"builtin"`
+	Name                   string         `yaml:"name" json:"name"`
+	Description            string         `yaml:"description" json:"description"`
+	UserInvocable          bool           `yaml:"user-invocable" json:"user_invocable"`
+	DisableModelInvocation bool           `yaml:"disable-model-invocation" json:"disable_model_invocation"`
+	License                string         `yaml:"license,omitempty" json:"license,omitempty"`
+	Compatibility          string         `yaml:"compatibility,omitempty" json:"compatibility,omitempty"`
+	Metadata               map[string]any `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	Instructions           string         `yaml:"-" json:"instructions"`
+	Path                   string         `yaml:"-" json:"path"`
+	SkillFilePath          string         `yaml:"-" json:"skill_file_path"`
+	Builtin                bool           `yaml:"-" json:"builtin"`
 }
 
 // DiscoveryState represents the outcome of discovering a single skill file.

--- a/internal/skills/skills_test.go
+++ b/internal/skills/skills_test.go
@@ -19,7 +19,7 @@ func TestParse(t *testing.T) {
 		wantDesc    string
 		wantLicense string
 		wantCompat  string
-		wantMeta    map[string]string
+		wantMeta    map[string]any
 		wantTools   string
 		wantInstr   string
 		wantErr     bool
@@ -45,8 +45,32 @@ Use this skill when the user needs to work with PDF files.
 			wantDesc:    "Extracts text and tables from PDF files, fills PDF forms, and merges multiple PDFs.",
 			wantLicense: "Apache-2.0",
 			wantCompat:  "Requires python 3.8+, pdfplumber, pdfrw libraries",
-			wantMeta:    map[string]string{"author": "example-org", "version": "1.0"},
+			wantMeta:    map[string]any{"author": "example-org", "version": "1.0"},
 			wantInstr:   "# PDF Processing\n\n## When to use this skill\nUse this skill when the user needs to work with PDF files.",
+		},
+		{
+			name: "metadata with non-string values",
+			content: `---
+name: ppt-master
+description: AI-driven presentation workflow for generating editable PPTX decks.
+metadata:
+  version: "6.3.2"
+  license: "MIT"
+  sponsors:
+    - "SPONSORS.md"
+    - "SPONSORS_CN.md"
+---
+
+# PPT Master Skill
+`,
+			wantName: "ppt-master",
+			wantDesc: "AI-driven presentation workflow for generating editable PPTX decks.",
+			wantMeta: map[string]any{
+				"version":  "6.3.2",
+				"license":  "MIT",
+				"sponsors": []any{"SPONSORS.md", "SPONSORS_CN.md"},
+			},
+			wantInstr: "# PPT Master Skill",
 		},
 		{
 			name: "minimal skill",


### PR DESCRIPTION
## Summary

- Relax Skill.Metadata from map[string]string to map[string]any.
- Per the Agent Skills spec, metadata values may be lists or nested maps. The previous type rejected spec-compliant skills at discovery time, marking them red in the sidebar. Real-world example: ppt-master SKILL.md carries a sponsors list under metadata and failed with line 16: cannot unmarshal !!seq into string.
- Add a regression case covering list-valued metadata.

## Verification

- go test ./internal/skills -count=1
- go vet ./internal/skills
- Parsed the real-world failing SKILL.md successfully after the change.