### PR TITLE
fix: always show full bash command in tui, output stays collapsible

### DIFF
--- a/internal/ui/chat/assistant.go
+++ b/internal/ui/chat/assistant.go
@@ -569,7 +569,8 @@ func (a *AssistantMessageItem) renderThinking(thinking string, width int) string
 	switch a.thinkingViewMode {
 	case thinkingCollapsed:
 		totalLines = renderedLines
-		if totalLines > maxCollapsedThinkingHeight {
+		// Avoid hiding a single line; showing it beats the hint.
+		if totalLines > maxCollapsedThinkingHeight+1 {
 			tail, hidden := tailLines(rendered, maxCollapsedThinkingHeight, totalLines)
 			hint := a.sty.Messages.ThinkingTruncationHint.Render(
 				fmt.Sprintf(assistantMessageTruncateFormat, hidden),
@@ -580,7 +581,7 @@ func (a *AssistantMessageItem) renderThinking(thinking string, width int) string
 		}
 	case thinkingTailWindow:
 		totalLines = renderedLines
-		if totalLines > maxExpandedThinkingTailLines {
+		if totalLines > maxExpandedThinkingTailLines+1 {
 			tail, hidden := tailLines(rendered, maxExpandedThinkingTailLines, totalLines)
 			hint := a.sty.Messages.ThinkingTruncationHint.Render(
 				fmt.Sprintf(assistantMessageTailWindowFormat, hidden),

--- a/internal/ui/chat/bash.go
+++ b/internal/ui/chat/bash.go
@@ -33,7 +33,8 @@ func NewBashToolMessageItem(
 	canceled bool,
 	workingDir string,
 ) ToolMessageItem {
-	return newBaseToolMessageItem(sty, toolCall, result, &BashToolRenderContext{workingDir: workingDir}, canceled)
+	base := newBaseToolMessageItem(sty, toolCall, result, &BashToolRenderContext{workingDir: workingDir}, canceled)
+	return &BashToolMessageItem{baseToolMessageItem: base}
 }
 
 // BashToolRenderContext renders bash tool messages.
@@ -65,11 +66,9 @@ func (b *BashToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *
 		return renderJobTool(sty, opts, cappedWidth, "Start", meta.ShellID, description, content)
 	}
 
-	// Regular bash command.
+	// Regular bash command. The command is always rendered expanded
+	// (newlines preserved); expansion only controls the output body.
 	cmd := params.Command
-	if !opts.ExpandedContent {
-		cmd = strings.ReplaceAll(cmd, "\n", " ")
-	}
 	cmd = strings.ReplaceAll(cmd, "\t", "    ")
 	cmd = common.StripBashDisplayPrefix(cmd, b.workingDir)
 	if highlighted, err := common.SyntaxHighlightLexerName(sty, cmd, "bash", nil); err == nil {
@@ -80,7 +79,11 @@ func (b *BashToolRenderContext) RenderTool(sty *styles.Styles, width int, opts *
 		toolParams = append(toolParams, "background", "true")
 	}
 
-	header := toolHeader(sty, opts.Status, "Bash", cappedWidth, opts, toolParams...)
+	// The command is always rendered expanded (wrapped, never
+	// truncated); expansion only controls the output body.
+	headerOpts := *opts
+	headerOpts.ExpandedContent = true
+	header := toolHeader(sty, opts.Status, "Bash", cappedWidth, &headerOpts, toolParams...)
 	if opts.Compact {
 		return header
 	}

--- a/internal/ui/chat/bash_test.go
+++ b/internal/ui/chat/bash_test.go
@@ -101,3 +101,24 @@ func TestBashToolMessageItem_OutputDefaultsCollapsed(t *testing.T) {
 	require.True(t, bash.ToggleExpanded(), "first toggle should report expanded")
 	require.Contains(t, ansi.Strip(bash.RawRender(120)), "line20")
 }
+
+// TestToolOutputPlainContent_SingleHiddenLineShown verifies that
+// collapsing never hides just one line: content one line over the
+// collapsed limit is shown in full, while more over that truncates.
+func TestToolOutputPlainContent_SingleHiddenLineShown(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	var lines []string
+	for i := 1; i <= 11; i++ {
+		lines = append(lines, fmt.Sprintf("line%d", i))
+	}
+	out := ansi.Strip(toolOutputPlainContent(&sty, strings.Join(lines, "\n"), 80, false))
+	require.Contains(t, out, "line11")
+	require.NotContains(t, out, "hidden")
+
+	lines = append(lines, "line12")
+	out = ansi.Strip(toolOutputPlainContent(&sty, strings.Join(lines, "\n"), 80, false))
+	require.NotContains(t, out, "line12")
+	require.Contains(t, out, "2 lines hidden")
+}

--- a/internal/ui/chat/bash_test.go
+++ b/internal/ui/chat/bash_test.go
@@ -1,0 +1,103 @@
+package chat
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/ui/styles"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBashToolMessageItem_CommandAlwaysExpanded guards the contract
+// that the bash command is always rendered expanded (newlines
+// preserved) regardless of the expansion state, while the output body
+// remains expandable and defaults to collapsed.
+func TestBashToolMessageItem_CommandAlwaysExpanded(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	tc := message.ToolCall{
+		ID:       "bash1",
+		Name:     "bash",
+		Input:    `{"command":"echo one\necho two\necho three"}`,
+		Finished: true,
+	}
+
+	render := func(expanded bool) string {
+		ctx := &BashToolRenderContext{}
+		return ctx.RenderTool(&sty, 120, &ToolRenderOpts{
+			ToolCall:        tc,
+			Result:          &message.ToolResult{ToolCallID: "bash1", Content: "out"},
+			Status:          ToolStatusSuccess,
+			ExpandedContent: expanded,
+		})
+	}
+
+	for _, expanded := range []bool{false, true} {
+		out := ansi.Strip(render(expanded))
+		require.Contains(t, out, "echo one")
+		require.Contains(t, out, "echo two")
+		require.Contains(t, out, "echo three")
+	}
+}
+
+// TestBashToolMessageItem_LongCommandNotTruncated verifies that a
+// long bash command wraps in the header instead of being truncated
+// with an ellipsis, even when the output is collapsed.
+func TestBashToolMessageItem_LongCommandNotTruncated(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	longCmd := "echo " + strings.Repeat("a", 200)
+	tc := message.ToolCall{
+		ID:       "bash3",
+		Name:     "bash",
+		Input:    `{"command":"` + longCmd + `"}`,
+		Finished: true,
+	}
+	ctx := &BashToolRenderContext{}
+	out := ansi.Strip(ctx.RenderTool(&sty, 120, &ToolRenderOpts{
+		ToolCall:        tc,
+		Result:          &message.ToolResult{ToolCallID: "bash3", Content: "out"},
+		Status:          ToolStatusSuccess,
+		ExpandedContent: false,
+	}))
+
+	require.NotContains(t, out, "…", "collapsed bash command must not be truncated")
+	require.Contains(t, out, longCmd[strings.LastIndex(longCmd, "a")-10:], "end of command must be visible")
+}
+
+// TestBashToolMessageItem_OutputDefaultsCollapsed verifies that bash
+// output is truncated when collapsed and fully shown when expanded.
+func TestBashToolMessageItem_OutputDefaultsCollapsed(t *testing.T) {
+	t.Parallel()
+
+	sty := styles.CharmtonePantera()
+	tc := message.ToolCall{
+		ID:       "bash2",
+		Name:     "bash",
+		Input:    `{"command":"seq 20"}`,
+		Finished: true,
+	}
+	var lines []string
+	for i := 1; i <= 20; i++ {
+		lines = append(lines, fmt.Sprintf("line%d", i))
+	}
+	result := &message.ToolResult{ToolCallID: "bash2", Content: strings.Join(lines, "\n")}
+
+	item := NewBashToolMessageItem(&sty, tc, result, false, "")
+	bash, ok := item.(*BashToolMessageItem)
+	require.True(t, ok, "NewBashToolMessageItem must return a *BashToolMessageItem")
+	require.False(t, bash.expandedContent, "bash items must default to collapsed")
+
+	renderCollapsed := ansi.Strip(bash.RawRender(120))
+	require.Contains(t, renderCollapsed, "line10")
+	require.NotContains(t, renderCollapsed, "line20")
+	require.Contains(t, renderCollapsed, "… (10 lines hidden)")
+
+	require.True(t, bash.ToggleExpanded(), "first toggle should report expanded")
+	require.Contains(t, ansi.Strip(bash.RawRender(120)), "line20")
+}

--- a/internal/ui/chat/tools.go
+++ b/internal/ui/chat/tools.go
@@ -30,6 +30,16 @@ const responseContextHeight = 10
 // toolBodyLeftPaddingTotal represents the padding that should be applied to each tool body
 const toolBodyLeftPaddingTotal = 2
 
+// collapsedMaxLines returns the number of lines to display when content
+// is collapsed. If collapsing would hide only a single line, all lines
+// are shown instead.
+func collapsedMaxLines(totalLines int) int {
+	if totalLines <= responseContextHeight+1 {
+		return totalLines
+	}
+	return responseContextHeight
+}
+
 // ToolStatus represents the current state of a tool call.
 type ToolStatus int
 
@@ -647,7 +657,7 @@ func toolOutputPlainContent(sty *styles.Styles, content string, width int, expan
 	content = common.RemapANSI16(content, sty.ANSI)
 	lines := strings.Split(content, "\n")
 
-	maxLines := responseContextHeight
+	maxLines := collapsedMaxLines(len(lines))
 	if expanded {
 		maxLines = len(lines) // Show all
 	}
@@ -664,12 +674,12 @@ func toolOutputPlainContent(sty *styles.Styles, content string, width int, expan
 		out = append(out, sty.Tool.ContentLine.Width(width).Render(ln))
 	}
 
-	wasTruncated := len(lines) > responseContextHeight
+	wasTruncated := len(lines) > maxLines
 
 	if !expanded && wasTruncated {
 		out = append(out, sty.Tool.ContentTruncation.
 			Width(width).
-			Render(fmt.Sprintf(assistantMessageTruncateFormat, len(lines)-responseContextHeight)))
+			Render(fmt.Sprintf(assistantMessageTruncateFormat, len(lines)-maxLines)))
 	}
 
 	return strings.Join(out, "\n")
@@ -680,7 +690,7 @@ func toolOutputCodeContent(sty *styles.Styles, path, content string, offset, wid
 	content = stringext.NormalizeSpace(content)
 
 	lines := strings.Split(content, "\n")
-	maxLines := responseContextHeight
+	maxLines := collapsedMaxLines(len(lines))
 	if expanded {
 		maxLines = len(lines)
 	}
@@ -970,7 +980,7 @@ func toolOutputDiffContent(sty *styles.Styles, file, oldContent, newContent stri
 	lines := strings.Split(formatted, "\n")
 
 	// Truncate if needed.
-	maxLines := responseContextHeight
+	maxLines := collapsedMaxLines(len(lines))
 	if expanded {
 		maxLines = len(lines)
 	}
@@ -1020,7 +1030,7 @@ func toolOutputMultiEditDiffContent(sty *styles.Styles, file string, meta tools.
 	lines := strings.Split(formatted, "\n")
 
 	// Truncate if needed.
-	maxLines := responseContextHeight
+	maxLines := collapsedMaxLines(len(lines))
 	if expanded {
 		maxLines = len(lines)
 	}
@@ -1080,7 +1090,7 @@ func toolOutputMarkdownContent(sty *styles.Styles, content string, width int, ex
 	}
 
 	lines := strings.Split(rendered, "\n")
-	maxLines := responseContextHeight
+	maxLines := collapsedMaxLines(len(lines))
 	if expanded {
 		maxLines = len(lines)
 	}

--- a/internal/ui/chat/unified_diff.go
+++ b/internal/ui/chat/unified_diff.go
@@ -157,7 +157,7 @@ func toolOutputDiffContentFromUnified(sty *styles.Styles, content string, width 
 	}
 	combined := strings.Join(blocks, "\n")
 	lines := strings.Split(combined, "\n")
-	maxLines := responseContextHeight
+	maxLines := collapsedMaxLines(len(lines))
 	if expanded {
 		maxLines = len(lines)
 	}

--- a/internal/ui/model/chat.go
+++ b/internal/ui/model/chat.go
@@ -922,9 +922,7 @@ func (m *Chat) MessageItem(id string) chat.MessageItem {
 func (m *Chat) ToggleExpandedSelectedItem() {
 	if expandable, ok := m.list.SelectedItem().(chat.Expandable); ok {
 		wasFollowing := m.follow
-		if !expandable.ToggleExpanded() {
-			m.ScrollToIndex(m.list.Selected())
-		}
+		expandable.ToggleExpanded()
 		if wasFollowing {
 			m.ScrollToBottom()
 		}
@@ -1053,9 +1051,7 @@ func (m *Chat) HandleDelayedClick(msg DelayedClickMsg) bool {
 		if handled {
 			if expandable, ok := selectedItem.(chat.Expandable); ok {
 				wasFollowing := m.follow
-				if !expandable.ToggleExpanded() {
-					m.ScrollToIndex(m.list.Selected())
-				}
+				expandable.ToggleExpanded()
 				if wasFollowing {
 					m.ScrollToBottom()
 				}


### PR DESCRIPTION
* fix: always show full bash command in tui, output stays collapsible
* fix: keep scroll position when expanding or collapsing chat items
* fix: show content in full when collapsing would hide only one line

<details><summary>Before</summary>
<p>

<img width="1272" height="635" alt="Screenshot 2026-09-11 at 14 24 02" src="https://github.com/user-attachments/assets/fe87a314-993c-467d-bc5f-73befa8fed33" />

</p>
</details>

<details><summary>After</summary>
<p>

<img width="1272" height="866" alt="Screenshot 2026-09-11 at 14 24 18" src="https://github.com/user-attachments/assets/a7dff783-b3a5-4a7d-8670-0326a7526557" />

</p>
</details>


