### PR TITLE
fix(session): prevent concurrent transcript writers

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -567,6 +567,18 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 	if err := ValidateCall(call); err != nil {
 		return nil, err
 	}
+	if err := a.sessions.AcquireWriter(ctx, call.SessionID); err != nil {
+		if call.Accepted != nil {
+			call.Accepted.Close()
+		}
+		a.publishRunComplete(ctx, call, notify.RunComplete{
+			SessionID: call.SessionID,
+			RunID:     call.RunID,
+			Error:     err.Error(),
+			Cancelled: errors.Is(err, context.Canceled),
+		})
+		return nil, err
+	}
 
 	// genCtx/cancel are the run context and its cancel func, created under
 	// the per-session dispatch mutex below so a concurrent Cancel can observe
@@ -1334,6 +1346,9 @@ func (a *sessionAgent) Run(ctx context.Context, call SessionAgentCall) (result *
 }
 
 func (a *sessionAgent) Summarize(ctx context.Context, sessionID string, opts fantasy.ProviderOptions, onAuthRefresh func(context.Context, *fantasy.ProviderError) error) error {
+	if err := a.sessions.AcquireWriter(ctx, sessionID); err != nil {
+		return err
+	}
 	if a.IsSessionBusy(sessionID) {
 		return ErrSessionBusy
 	}

--- a/internal/agent/common_test.go
+++ b/internal/agent/common_test.go
@@ -68,7 +68,8 @@ func testEnv(t *testing.T) fakeEnv {
 	err := os.MkdirAll(workingDir, 0o755)
 	require.NoError(t, err)
 
-	conn, err := db.Connect(t.Context(), t.TempDir())
+	dataDir := t.TempDir()
+	conn, err := db.Connect(t.Context(), dataDir)
 	require.NoError(t, err)
 
 	q := db.New(conn)
@@ -81,7 +82,7 @@ func testEnv(t *testing.T) fakeEnv {
 	lspClients := csync.NewMap[string, *lsp.Client]()
 
 	t.Cleanup(func() {
-		conn.Close()
+		_ = db.Release(dataDir)
 		os.RemoveAll(workingDir)
 	})
 

--- a/internal/agent/writer_test.go
+++ b/internal/agent/writer_test.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/agent/notify"
+	"github.com/charmbracelet/crush/internal/lock"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+type deniedWriterSessions struct {
+	session.Service
+	err error
+}
+
+func (s deniedWriterSessions) AcquireWriter(context.Context, string) error {
+	return s.err
+}
+
+func TestWriterRejectionPublishesTerminalEvent(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		err      error
+		canceled bool
+	}{
+		{"contended", lock.ErrContended, false},
+		{"canceled", context.Canceled, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			a := &sessionAgent{sessions: deniedWriterSessions{err: tc.err}}
+			var completions []notify.RunComplete
+			_, err := a.Run(t.Context(), SessionAgentCall{
+				SessionID: "session", RunID: "run", Prompt: "Continue",
+				OnComplete: func(event notify.RunComplete) { completions = append(completions, event) },
+			})
+			require.ErrorIs(t, err, tc.err)
+			require.Len(t, completions, 1)
+			require.Equal(t, "run", completions[0].RunID)
+			require.Equal(t, tc.canceled, completions[0].Cancelled)
+			require.Equal(t, tc.err.Error(), completions[0].Error)
+		})
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -97,7 +97,7 @@ type App struct {
 func New(ctx context.Context, conn *sql.DB, store *config.ConfigStore, skillsMgr *skills.Manager) (*App, error) {
 	q := db.New(conn)
 	sessions := session.NewService(q, conn)
-	messages := message.NewService(q)
+	messages := message.NewService(q, message.WithWriterGuard(sessions.AcquireWriter))
 	files := history.NewService(q, conn)
 	cfg := store.Config()
 	skipPermissionsRequests := store.Overrides().SkipPermissionRequests

--- a/internal/app/resolve_session_test.go
+++ b/internal/app/resolve_session_test.go
@@ -18,6 +18,10 @@ type mockSessionService struct {
 	created  []session.Session
 }
 
+func (m *mockSessionService) AcquireWriter(context.Context, string) error {
+	return nil
+}
+
 func (m *mockSessionService) Subscribe(context.Context) <-chan pubsub.Event[session.Session] {
 	return make(chan pubsub.Event[session.Session])
 }

--- a/internal/backend/accepted_run_integration_test.go
+++ b/internal/backend/accepted_run_integration_test.go
@@ -44,9 +44,10 @@ func (c *gatedCoordinator) RunAccepted(ctx context.Context, accept *agent.Accept
 // before any model call, so no network I/O happens.
 func newRealCoordinator(t *testing.T) (*gatedCoordinator, session.Service, message.Service) {
 	t.Helper()
-	conn, err := db.Connect(t.Context(), t.TempDir())
+	dataDir := t.TempDir()
+	conn, err := db.Connect(t.Context(), dataDir)
 	require.NoError(t, err)
-	t.Cleanup(func() { conn.Close() })
+	t.Cleanup(func() { _ = db.Release(dataDir) })
 
 	q := db.New(conn)
 	sessions := session.NewService(q, conn)

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -125,12 +125,13 @@ func sessionSetup(cmd *cobra.Command) (context.Context, *sessionServices, func()
 	}
 
 	queries := db.New(conn)
+	sessions := session.NewService(queries, conn)
 	svc := &sessionServices{
-		sessions: session.NewService(queries, conn),
-		messages: message.NewService(queries),
+		sessions: sessions,
+		messages: message.NewService(queries, message.WithWriterGuard(sessions.AcquireWriter)),
 		cfg:      cfg,
 	}
-	return ctx, svc, func() { conn.Close() }, nil
+	return ctx, svc, func() { _ = db.Release(dataDir) }, nil
 }
 
 func runSessionList(cmd *cobra.Command, _ []string) error {

--- a/internal/db/connect.go
+++ b/internal/db/connect.go
@@ -50,6 +50,7 @@ type connEntry struct {
 	db       *sql.DB
 	refCount int
 	lock     *dataDirLock
+	writers  map[string]func()
 }
 
 var (
@@ -196,6 +197,7 @@ func Release(dataDir string) error {
 
 	delete(pool, absPath)
 	closeErr := entry.db.Close()
+	entry.releaseWriters()
 	if entry.lock != nil {
 		entry.lock.release()
 	}
@@ -209,6 +211,7 @@ func ResetPool() {
 	defer poolMu.Unlock()
 	for path, entry := range pool {
 		entry.db.Close()
+		entry.releaseWriters()
 		if entry.lock != nil {
 			entry.lock.release()
 		}

--- a/internal/db/sessionwriter.go
+++ b/internal/db/sessionwriter.go
@@ -1,0 +1,56 @@
+package db
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/charmbracelet/crush/internal/lock"
+)
+
+// AcquireSessionWriter claims a transcript until the pooled connection closes.
+// Ownership persists between turns, including while a local TUI is idle.
+func AcquireSessionWriter(ctx context.Context, conn *sql.DB, id string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	poolMu.Lock()
+	defer poolMu.Unlock()
+	for path, entry := range pool {
+		if entry.db != conn {
+			continue
+		}
+		if _, ok := entry.writers[id]; ok {
+			return nil
+		}
+		directory := filepath.Join(filepath.Dir(path), "session-writers")
+		if err := os.MkdirAll(directory, 0o700); err != nil {
+			return err
+		}
+		name := fmt.Sprintf("%x.lock", sha256.Sum256([]byte(id)))
+		release, err := lock.TryFile(filepath.Join(directory, name))
+		if err != nil {
+			if errors.Is(err, lock.ErrContended) {
+				return fmt.Errorf("session is owned by another Crush process; send input to the owning session: %w", err)
+			}
+			return fmt.Errorf("acquire session writer: %w", err)
+		}
+		if entry.writers == nil {
+			entry.writers = make(map[string]func())
+		}
+		entry.writers[id] = release
+		return nil
+	}
+	return errors.New("session database connection is not pooled")
+}
+
+func (e *connEntry) releaseWriters() {
+	for id, release := range e.writers {
+		release()
+		delete(e.writers, id)
+	}
+}

--- a/internal/message/message.go
+++ b/internal/message/message.go
@@ -127,6 +127,7 @@ func newFlushBaseline(m *Message) flushBaseline {
 }
 
 type service struct {
+	writerGuard func(context.Context, string) error
 	*pubsub.Broker[Message]
 	q        db.Querier
 	debounce time.Duration
@@ -137,6 +138,18 @@ type service struct {
 
 // ServiceOption configures a [Service] at construction.
 type ServiceOption func(*service)
+
+// WithWriterGuard enforces process ownership before any transcript mutation.
+func WithWriterGuard(guard func(context.Context, string) error) ServiceOption {
+	return func(s *service) { s.writerGuard = guard }
+}
+
+func (s *service) checkWriter(ctx context.Context, id string) error {
+	if s.writerGuard != nil {
+		return s.writerGuard(ctx, id)
+	}
+	return nil
+}
 
 // WithDebounce overrides the debounce window for [Service.Update]. A
 // zero or negative value disables debouncing entirely (every update
@@ -165,6 +178,9 @@ func (s *service) Delete(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
+	if err := s.checkWriter(ctx, message.SessionID); err != nil {
+		return err
+	}
 	err = s.q.DeleteMessage(ctx, message.ID)
 	if err != nil {
 		return err
@@ -186,6 +202,9 @@ func (s *service) Delete(ctx context.Context, id string) error {
 }
 
 func (s *service) Create(ctx context.Context, sessionID string, params CreateMessageParams) (Message, error) {
+	if err := s.checkWriter(ctx, sessionID); err != nil {
+		return Message{}, err
+	}
 	if params.Role != Assistant {
 		params.Parts = append(params.Parts, Finish{
 			Reason: "stop",
@@ -222,6 +241,9 @@ func (s *service) Create(ctx context.Context, sessionID string, params CreateMes
 }
 
 func (s *service) DeleteSessionMessages(ctx context.Context, sessionID string) error {
+	if err := s.checkWriter(ctx, sessionID); err != nil {
+		return err
+	}
 	messages, err := s.List(ctx, sessionID)
 	if err != nil {
 		return err
@@ -241,6 +263,9 @@ func (s *service) DeleteSessionMessages(ctx context.Context, sessionID string) e
 // synchronously (terminal updates, debounce <= 0) or buffers it until
 // the next debounce tick. See [Service] for the contract.
 func (s *service) Update(ctx context.Context, msg Message) error {
+	if err := s.checkWriter(ctx, msg.SessionID); err != nil {
+		return err
+	}
 	cloned := msg.Clone()
 
 	// Zero or negative debounce: flush every update synchronously. This

--- a/internal/message/writer_test.go
+++ b/internal/message/writer_test.go
@@ -1,0 +1,32 @@
+package message
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriterGuardBlocksAllTranscriptMutations(t *testing.T) {
+	t.Parallel()
+	blocked := false
+	denial := errors.New("other owner")
+	svc, id := newTestService(t, WithWriterGuard(func(context.Context, string) error {
+		if blocked {
+			return denial
+		}
+		return nil
+	}))
+	msg, err := svc.Create(t.Context(), id, CreateMessageParams{Role: User, Parts: []ContentPart{TextContent{Text: "existing"}}})
+	require.NoError(t, err)
+	blocked = true
+	_, err = svc.Create(t.Context(), id, CreateMessageParams{Role: User})
+	require.ErrorIs(t, err, denial)
+	require.ErrorIs(t, svc.Update(t.Context(), msg), denial)
+	require.ErrorIs(t, svc.Delete(t.Context(), msg.ID), denial)
+	require.ErrorIs(t, svc.DeleteSessionMessages(t.Context(), id), denial)
+	retained, err := svc.List(t.Context(), id)
+	require.NoError(t, err)
+	require.Len(t, retained, 1)
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -63,6 +63,7 @@ type Session struct {
 }
 
 type Service interface {
+	AcquireWriter(ctx context.Context, id string) error
 	pubsub.Subscriber[Session]
 	Create(ctx context.Context, title string) (Session, error)
 	CreateTitleSession(ctx context.Context, parentSessionID string) (Session, error)
@@ -136,6 +137,9 @@ func (s *service) CreateTitleSession(ctx context.Context, parentSessionID string
 }
 
 func (s *service) Delete(ctx context.Context, id string) error {
+	if err := s.AcquireWriter(ctx, id); err != nil {
+		return err
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("beginning transaction: %w", err)
@@ -189,6 +193,9 @@ func (s *service) GetLast(ctx context.Context) (Session, error) {
 }
 
 func (s *service) Save(ctx context.Context, session Session) (Session, error) {
+	if err := s.AcquireWriter(ctx, session.ID); err != nil {
+		return Session{}, err
+	}
 	todosJSON, err := marshalTodos(session.Todos)
 	if err != nil {
 		return Session{}, err
@@ -223,6 +230,9 @@ func (s *service) Save(ctx context.Context, session Session) (Session, error) {
 // UpdateTitleAndUsage updates only the title and usage fields atomically.
 // This is safer than fetching, modifying, and saving the entire session.
 func (s *service) UpdateTitleAndUsage(ctx context.Context, sessionID, title string, promptTokens, completionTokens int64, cost float64) error {
+	if err := s.AcquireWriter(ctx, sessionID); err != nil {
+		return err
+	}
 	if err := s.q.UpdateSessionTitleAndUsage(ctx, db.UpdateSessionTitleAndUsageParams{
 		ID:               sessionID,
 		Title:            title,
@@ -239,6 +249,9 @@ func (s *service) UpdateTitleAndUsage(ctx context.Context, sessionID, title stri
 // Rename updates only the title of a session without touching updated_at or
 // usage fields.
 func (s *service) Rename(ctx context.Context, id string, title string) error {
+	if err := s.AcquireWriter(ctx, id); err != nil {
+		return err
+	}
 	if err := s.q.RenameSession(ctx, db.RenameSessionParams{
 		ID:    id,
 		Title: title,

--- a/internal/session/writer.go
+++ b/internal/session/writer.go
@@ -1,0 +1,12 @@
+package session
+
+import (
+	"context"
+
+	"github.com/charmbracelet/crush/internal/db"
+)
+
+// AcquireWriter prevents independent processes from interleaving a transcript.
+func (s *service) AcquireWriter(ctx context.Context, id string) error {
+	return db.AcquireSessionWriter(ctx, s.db, id)
+}

--- a/internal/session/writer_test.go
+++ b/internal/session/writer_test.go
@@ -1,0 +1,102 @@
+package session_test
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/charmbracelet/crush/internal/db"
+	"github.com/charmbracelet/crush/internal/lock"
+	"github.com/charmbracelet/crush/internal/message"
+	"github.com/charmbracelet/crush/internal/session"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionWriterAcrossProcesses(t *testing.T) {
+	if mode := os.Getenv("CRUSH_TEST_WRITER_MODE"); mode != "" {
+		dataDir := os.Getenv("CRUSH_TEST_WRITER_DIR")
+		id := os.Getenv("CRUSH_TEST_WRITER_ID")
+		conn, err := db.Connect(t.Context(), dataDir)
+		require.NoError(t, err)
+		defer db.Release(dataDir)
+		queries := db.New(conn)
+		sessions := session.NewService(queries, conn)
+		messages := message.NewService(queries, message.WithWriterGuard(sessions.AcquireWriter))
+		if mode == "hold" {
+			require.NoError(t, sessions.AcquireWriter(t.Context(), id))
+			require.NoError(t, sessions.AcquireWriter(t.Context(), id))
+			fmt.Println("ready")
+			_, err := io.Copy(io.Discard, os.Stdin)
+			require.NoError(t, err)
+			return
+		}
+
+		current, err := sessions.Get(t.Context(), id)
+		require.NoError(t, err, "another owner must not block reads")
+		_, err = sessions.Save(t.Context(), current)
+		require.ErrorIs(t, err, lock.ErrContended)
+		require.ErrorIs(t, sessions.Rename(t.Context(), id, "renamed"), lock.ErrContended)
+		require.ErrorIs(t, sessions.UpdateTitleAndUsage(t.Context(), id, "renamed", 1, 1, 1), lock.ErrContended)
+		require.ErrorIs(t, sessions.Delete(t.Context(), id), lock.ErrContended)
+		_, err = messages.Create(t.Context(), id, message.CreateMessageParams{Role: message.User})
+		require.ErrorIs(t, err, lock.ErrContended)
+		retained, err := messages.List(t.Context(), id)
+		require.NoError(t, err)
+		require.Len(t, retained, 1)
+		require.ErrorIs(t, messages.Update(t.Context(), retained[0]), lock.ErrContended)
+		require.ErrorIs(t, messages.Delete(t.Context(), retained[0].ID), lock.ErrContended)
+		require.ErrorIs(t, messages.DeleteSessionMessages(t.Context(), id), lock.ErrContended)
+
+		other, err := sessions.Create(t.Context(), "Independent session")
+		require.NoError(t, err)
+		_, err = messages.Create(t.Context(), other.ID, message.CreateMessageParams{Role: message.User})
+		require.NoError(t, err, "different sessions may have independent owners")
+		return
+	}
+
+	t.Parallel()
+	dataDir := t.TempDir()
+	conn, err := db.Connect(t.Context(), dataDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Release(dataDir)) })
+	queries := db.New(conn)
+	sessions := session.NewService(queries, conn)
+	created, err := sessions.Create(t.Context(), "Existing session")
+	require.NoError(t, err)
+	_, err = message.NewService(queries).Create(t.Context(), created.ID, message.CreateMessageParams{Role: message.User})
+	require.NoError(t, err)
+	command := func(mode string) *exec.Cmd {
+		cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run=^TestSessionWriterAcrossProcesses$")
+		cmd.Env = append(os.Environ(), "CRUSH_TEST_WRITER_MODE="+mode, "CRUSH_TEST_WRITER_DIR="+dataDir, "CRUSH_TEST_WRITER_ID="+created.ID)
+		return cmd
+	}
+	holder := command("hold")
+	stdin, err := holder.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := holder.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, holder.Start())
+	t.Cleanup(func() { _ = holder.Process.Kill() })
+	line, err := bufio.NewReader(stdout).ReadString('\n')
+	require.NoError(t, err)
+	require.Equal(t, "ready\n", line)
+	output, err := command("contend").CombinedOutput()
+	require.NoError(t, err, "%s", output)
+	require.NoError(t, stdin.Close())
+	require.NoError(t, holder.Wait())
+	require.NoError(t, sessions.AcquireWriter(t.Context(), created.ID), "process exit must release ownership")
+	retained, err := sessions.Get(t.Context(), created.ID)
+	require.NoError(t, err)
+	require.Equal(t, created.Title, retained.Title)
+	_, err = db.Connect(t.Context(), dataDir)
+	require.NoError(t, err)
+	require.NoError(t, db.Release(dataDir))
+	output, err = command("contend").CombinedOutput()
+	require.NoError(t, err, "ownership must survive non-final release: %s", output)
+	require.NoError(t, db.Release(dataDir))
+	output, err = command("hold").CombinedOutput()
+	require.NoError(t, err, "final release must permit another writer: %s", output)
+}


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features). Not applicable: bug fix.

Two local Crush processes can resume the same session and interleave assistant/tool messages. SQLite serializes individual writes, but the processes still generate their responses from different snapshots of one transcript. The resulting tool-result order can be rejected by the provider.

Claim an exclusive session writer before agent execution or transcript mutation, using the existing cross-platform `internal/lock` package. Keep ownership between turns until the last pooled database reference is released; process exit also releases the kernel lock. Read-only access and writes to different sessions remain available. This complements the server's opt-in data-directory lock without making local sessions share one directory-wide writer.

Before: with client/server mode disabled, start a prompt in `crush --session <id>`, then run `crush run --session <id> "Continue"` against the same data directory while the first process remains open. Both processes can append to the same transcript.

After: the second writer gets an explicit ownership error before it can append, update or delete transcript messages. Follow-up input can be sent through the owning process, or another process can resume after that owner's database connection closes.

The multi-process regression reproduces the current-main failure: a second process successfully saves a session that the first process is using. With the fix, it verifies rejected session/message mutations, preserved reads, independent-session writes, process-exit recovery, and ownership through pooled reference counting.

Validation:

- `go test ./...`
- `go test -race -failfast ./...`
- `go build -race ./...`
- `./scripts/check_log_capitalization.sh`
- `golangci-lint run --config=.golangci.yml --timeout=5m` (v2.13.1)
