### PR TITLE
feat: add interactive login TUI and script-friendly auth flow

### DIFF
--- a/internal/cmd/login.go
+++ b/internal/cmd/login.go
@@ -2,21 +2,16 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
 
 	"charm.land/lipgloss/v2"
-	"github.com/charmbracelet/crush/internal/clipboard"
 	"github.com/charmbracelet/crush/internal/config"
-	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/charmbracelet/crush/internal/login"
 	"github.com/charmbracelet/crush/internal/oauth/copilot"
-	"github.com/charmbracelet/crush/internal/oauth/hyper"
-	"github.com/charmbracelet/crush/internal/oauth/openai"
 	"github.com/charmbracelet/crush/internal/workspace"
-	"github.com/charmbracelet/x/exp/charmtone"
-	"github.com/charmbracelet/x/term"
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
@@ -79,8 +74,6 @@ func init() {
 }
 
 func loginHyper(ws workspace.Workspace, force bool) error {
-	ctx := getLoginContext()
-
 	if !force {
 		cfg := ws.Config()
 		if cfg != nil {
@@ -92,45 +85,10 @@ func loginHyper(ws workspace.Workspace, force bool) error {
 		}
 	}
 
-	resp, err := hyper.InitiateDeviceAuth(ctx)
+	ctx := getLoginContext()
+	token, err := login.Run(ctx, login.PlatformHyper)
 	if err != nil {
 		return err
-	}
-
-	clipboard.WriteText(resp.UserCode)
-	fmt.Println("The following code should be on clipboard already:")
-
-	fmt.Println()
-	lipgloss.Println(lipgloss.NewStyle().Bold(true).Render(resp.UserCode))
-	fmt.Println()
-	fmt.Println("Press enter to open this URL, and then paste it there:")
-	fmt.Println()
-	lipgloss.Println(lipgloss.NewStyle().Hyperlink(resp.VerificationURL, "id=hyper").Render(resp.VerificationURL))
-	fmt.Println()
-	waitEnter()
-	if err := browser.OpenURL(resp.VerificationURL); err != nil {
-		fmt.Println("Could not open the URL. You'll need to manually open the URL in your browser.")
-	}
-
-	fmt.Println("Exchanging authorization code...")
-	refreshToken, err := hyper.PollForToken(ctx, resp.DeviceCode, resp.ExpiresIn)
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("Exchanging refresh token for access token...")
-	token, err := hyper.ExchangeToken(ctx, refreshToken)
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("Verifying access token...")
-	introspect, err := hyper.IntrospectToken(ctx, token.AccessToken)
-	if err != nil {
-		return fmt.Errorf("token introspection failed: %w", err)
-	}
-	if !introspect.Active {
-		return fmt.Errorf("access token is not active")
 	}
 
 	if err := ws.SetProviderAPIKey(config.ScopeGlobal, "hyper", token); err != nil {
@@ -143,8 +101,6 @@ func loginHyper(ws workspace.Workspace, force bool) error {
 }
 
 func loginCopilot(ws workspace.Workspace, force bool) error {
-	loginCtx := getLoginContext()
-
 	if !force {
 		cfg := ws.Config()
 		if cfg != nil {
@@ -156,44 +112,25 @@ func loginCopilot(ws workspace.Workspace, force bool) error {
 		}
 	}
 
-	diskToken, hasDiskToken := copilot.RefreshTokenFromDisk()
-	var token *oauth.Token
+	ctx := getLoginContext()
 
-	switch {
-	case hasDiskToken:
+	if diskToken, hasDiskToken := copilot.RefreshTokenFromDisk(); hasDiskToken {
 		fmt.Println("Found existing GitHub Copilot token on disk. Using it to authenticate...")
-
-		t, err := copilot.RefreshToken(loginCtx, diskToken)
+		token, err := copilot.RefreshToken(ctx, diskToken)
 		if err != nil {
 			return fmt.Errorf("unable to refresh token from disk: %w", err)
 		}
-		token = t
-	default:
-		fmt.Println("Requesting device code from GitHub...")
-		dc, err := copilot.RequestDeviceCode(loginCtx)
-		if err != nil {
+		if err := ws.SetProviderAPIKey(config.ScopeGlobal, "copilot", token); err != nil {
 			return err
 		}
+		fmt.Println()
+		fmt.Println("You're now authenticated with GitHub Copilot!")
+		return nil
+	}
 
-		clipboard.WriteText(dc.UserCode)
-		fmt.Println()
-		fmt.Println("The following code should be on clipboard already:")
-		fmt.Println()
-		lipgloss.Println(lipgloss.NewStyle().Bold(true).Render(dc.UserCode))
-		fmt.Println()
-		fmt.Println("Press enter to open this URL and authenticate with GitHub Copilot:")
-		fmt.Println()
-		lipgloss.Println(lipgloss.NewStyle().Hyperlink(dc.VerificationURI, "id=copilot").Render(dc.VerificationURI))
-		fmt.Println()
-		waitEnter()
-		if err := browser.OpenURL(dc.VerificationURI); err != nil {
-			fmt.Println("Could not open the URL. You'll need to manually open the URL in your browser.")
-		}
-
-		fmt.Println("Waiting for authorization...")
-
-		t, err := copilot.PollForToken(loginCtx, dc)
-		if err == copilot.ErrNotAvailable {
+	token, err := login.Run(ctx, login.PlatformCopilot)
+	if err != nil {
+		if errors.Is(err, copilot.ErrNotAvailable) {
 			fmt.Println()
 			fmt.Println("GitHub Copilot is unavailable for this account. To signup, go to the following page:")
 			fmt.Println()
@@ -203,10 +140,7 @@ func loginCopilot(ws workspace.Workspace, force bool) error {
 			fmt.Println()
 			lipgloss.Println(lipgloss.NewStyle().Hyperlink(copilot.FreeURL, "id=copilot-free").Render(copilot.FreeURL))
 		}
-		if err != nil {
-			return err
-		}
-		token = t
+		return err
 	}
 
 	if err := ws.SetProviderAPIKey(config.ScopeGlobal, "copilot", token); err != nil {
@@ -219,8 +153,6 @@ func loginCopilot(ws workspace.Workspace, force bool) error {
 }
 
 func loginOpenAI(ws workspace.Workspace, force bool) error {
-	ctx := getLoginContext()
-
 	if !force {
 		cfg := ws.Config()
 		if cfg != nil {
@@ -232,35 +164,8 @@ func loginOpenAI(ws workspace.Workspace, force bool) error {
 		}
 	}
 
-	flow, err := openai.StartBrowserFlow()
-	if err != nil {
-		return fmt.Errorf("failed to start OAuth flow: %w", err)
-	}
-	defer flow.Close()
-
-	url := flow.StartURL()
-	fmt.Println()
-	lipgloss.Println(
-		lipgloss.NewStyle().Bold(true).Foreground(charmtone.Hazy).Render("Press enter key to open the following ") +
-			lipgloss.NewStyle().Bold(true).Foreground(charmtone.Guac).Render("URL..."),
-	)
-	fmt.Println()
-	lipgloss.Println(lipgloss.NewStyle().Hyperlink(url, "id=openai").Foreground(charmtone.Smoke).Render(url))
-	fmt.Println()
-	fmt.Println(lipgloss.NewStyle().Foreground(charmtone.Squid).Render("enter open · c copy url · esc back · ctrl+c quit"))
-	if !promptLoginKey(url) {
-		fmt.Println("Login cancelled.")
-		return nil
-	}
-	// The handoff page opens the authorization URL in a tab that can close
-	// itself when finished; opening the raw URL would leave the tab behind,
-	// since browsers refuse to close it after a consent flow.
-	if err := browser.OpenURL(url); err != nil {
-		fmt.Println("Could not open the browser. You'll need to manually open the URL above in your browser.")
-	}
-
-	fmt.Println("Waiting for authorization...")
-	token, err := flow.Wait(ctx)
+	ctx := getLoginContext()
+	token, err := login.Run(ctx, login.PlatformOpenAI)
 	if err != nil {
 		return err
 	}
@@ -279,50 +184,6 @@ func getLoginContext() context.Context {
 	go func() {
 		<-ctx.Done()
 		cancel()
-		os.Exit(1)
 	}()
 	return ctx
-}
-
-func waitEnter() {
-	_, _ = fmt.Scanln()
-}
-
-// promptLoginKey reads single keypresses until the user opens the browser
-// with enter, copies the URL with c, or cancels with esc or ctrl+c. It
-// reports whether the browser should be opened.
-func promptLoginKey(url string) bool {
-	if !term.IsTerminal(os.Stdin.Fd()) {
-		waitEnter()
-		return true
-	}
-
-	oldState, err := term.MakeRaw(os.Stdin.Fd())
-	if err != nil {
-		waitEnter()
-		return true
-	}
-	defer func() { _ = term.Restore(os.Stdin.Fd(), oldState) }()
-
-	var buf [1]byte
-	for {
-		if _, err := os.Stdin.Read(buf[:]); err != nil {
-			return true
-		}
-		switch buf[0] {
-		case '\r', '\n':
-			return true
-		case 'c':
-			clipboard.WriteText(url)
-			// Printing needs cooked mode; restore, print, re-raw.
-			_ = term.Restore(os.Stdin.Fd(), oldState)
-			fmt.Println("URL copied to clipboard.")
-			oldState, err = term.MakeRaw(os.Stdin.Fd())
-			if err != nil {
-				return true
-			}
-		case 0x03, 0x1b: // ctrl+c, esc
-			return false
-		}
-	}
 }

--- a/internal/cmd/logout.go
+++ b/internal/cmd/logout.go
@@ -162,7 +162,7 @@ func pickLoggedInProvider(c *client.Client, wsID string) (string, error) {
 	oauthProviders := map[string]string{
 		"hyper":   "Hyper",
 		"copilot": "GitHub Copilot",
-		"openai":  "OpenAI (ChatGPT)",
+		"openai":  "OpenAI",
 	}
 
 	var loggedIn []loggedInProvider

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -1,0 +1,210 @@
+// Package login authenticates Crush with OAuth-capable platforms from the
+// command line. In interactive terminals it runs a small Bubble Tea program
+// that guides the user through opening a browser and waiting for the
+// callback. When stdin is not a terminal, it falls back to a plain,
+// keypress-free flow suitable for scripts and SSH sessions.
+package login
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/charmbracelet/x/term"
+	"github.com/pkg/browser"
+
+	"github.com/charmbracelet/crush/internal/oauth"
+	"github.com/charmbracelet/crush/internal/oauth/copilot"
+	"github.com/charmbracelet/crush/internal/oauth/hyper"
+	"github.com/charmbracelet/crush/internal/oauth/openai"
+)
+
+// Platforms accepted by Run.
+const (
+	PlatformHyper   = "hyper"
+	PlatformCopilot = "copilot"
+	PlatformOpenAI  = "openai"
+)
+
+// startMessages are the first lines printed by the non-interactive flow.
+var startMessages = map[string]string{
+	PlatformHyper:   "Initiating device authorization...",
+	PlatformCopilot: "Requesting device code from GitHub...",
+	PlatformOpenAI:  "Starting browser authorization...",
+}
+
+// titles are the provider names shown in the mini TUI header.
+var titles = map[string]string{
+	PlatformHyper:   "Charm Hyper",
+	PlatformCopilot: "GitHub Copilot",
+	PlatformOpenAI:  "ChatGPT",
+}
+
+// flow is the provider-agnostic surface the login UIs drive. Start is
+// called once to kick off the flow; Wait then blocks until the user
+// completes authorization in the browser, and Close releases any
+// resources the flow holds.
+type flow interface {
+	Start(ctx context.Context) (url string, userCode string, err error)
+	Wait(ctx context.Context) (*oauth.Token, error)
+	Close()
+}
+
+// Run authenticates with the given platform and returns the resulting
+// OAuth token. It runs the mini TUI when stdin is a terminal and the plain
+// non-interactive flow otherwise.
+func Run(ctx context.Context, platform string) (*oauth.Token, error) {
+	newFlow, err := flowFor(platform)
+	if err != nil {
+		return nil, err
+	}
+
+	if term.IsTerminal(os.Stdin.Fd()) {
+		return runTUI(platform, newFlow)
+	}
+	return runCLI(ctx, platform, newFlow)
+}
+
+// runCLI performs the full flow without a TUI and without requiring any
+// keypresses, so it can be driven from scripts and other non-interactive
+// sessions.
+func runCLI(ctx context.Context, platform string, newFlow func() flow) (*oauth.Token, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	f := newFlow()
+
+	fmt.Println(startMessages[platform])
+	url, userCode, err := f.Start(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if userCode != "" {
+		fmt.Printf("Your code: %s\n", userCode)
+	}
+	fmt.Printf("Open this URL and enter the code: %s\n", url)
+
+	openBrowser(url)
+
+	fmt.Println("Waiting for authorization...")
+	token, err := f.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Println("Exchanging token...")
+	return token, nil
+}
+
+// openBrowser opens the given URL in the user's default browser. If the
+// browser can't be opened, the URL is printed for the user to open
+// manually.
+func openBrowser(rawURL string) {
+	if err := browser.OpenURL(rawURL); err != nil {
+		fmt.Printf("Please open this URL to authenticate:\n  %s\n", rawURL)
+	}
+}
+
+// flowFor returns the constructor for the platform's flow.
+func flowFor(platform string) (func() flow, error) {
+	switch platform {
+	case PlatformHyper:
+		return func() flow { return &hyperFlow{} }, nil
+	case PlatformCopilot:
+		return func() flow { return &copilotFlow{} }, nil
+	case PlatformOpenAI:
+		return func() flow { return &openaiFlow{} }, nil
+	default:
+		return nil, fmt.Errorf("unknown platform: %s", platform)
+	}
+}
+
+// hyperFlow runs the Charm Hyper device code flow.
+type hyperFlow struct {
+	deviceCode string
+	expiresIn  int
+}
+
+func (f *hyperFlow) Start(ctx context.Context) (string, string, error) {
+	resp, err := hyper.InitiateDeviceAuth(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	f.deviceCode = resp.DeviceCode
+	f.expiresIn = resp.ExpiresIn
+	return resp.VerificationURL, resp.UserCode, nil
+}
+
+func (f *hyperFlow) Wait(ctx context.Context) (*oauth.Token, error) {
+	refreshToken, err := hyper.PollForToken(ctx, f.deviceCode, f.expiresIn)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := hyper.ExchangeToken(ctx, refreshToken)
+	if err != nil {
+		return nil, err
+	}
+
+	introspect, err := hyper.IntrospectToken(ctx, token.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("token introspection failed: %w", err)
+	}
+	if !introspect.Active {
+		return nil, errors.New("access token is not active")
+	}
+	return token, nil
+}
+
+func (hyperFlow) Close() {}
+
+// copilotFlow runs the GitHub Copilot device code flow.
+type copilotFlow struct {
+	deviceCode *copilot.DeviceCode
+}
+
+func (f *copilotFlow) Start(ctx context.Context) (string, string, error) {
+	dc, err := copilot.RequestDeviceCode(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	f.deviceCode = dc
+	return dc.VerificationURI, dc.UserCode, nil
+}
+
+func (f *copilotFlow) Wait(ctx context.Context) (*oauth.Token, error) {
+	return copilot.PollForToken(ctx, f.deviceCode)
+}
+
+func (copilotFlow) Close() {}
+
+// openaiFlow runs the ChatGPT (OpenAI) authorization code flow with a
+// loopback callback server.
+type openaiFlow struct {
+	f *openai.BrowserFlow
+}
+
+func (f *openaiFlow) Start(_ context.Context) (string, string, error) {
+	bf, err := openai.StartBrowserFlow()
+	if err != nil {
+		return "", "", err
+	}
+	f.f = bf
+	// The handoff page opens the authorization URL in a tab that can close
+	// itself when finished; opening the raw URL would leave the tab behind,
+	// since browsers refuse to close it after a consent flow.
+	return bf.StartURL(), "", nil
+}
+
+func (f *openaiFlow) Wait(ctx context.Context) (*oauth.Token, error) {
+	return f.f.Wait(ctx)
+}
+
+func (f *openaiFlow) Close() {
+	if f.f != nil {
+		f.f.Close()
+	}
+}

--- a/internal/login/styles.go
+++ b/internal/login/styles.go
@@ -1,0 +1,22 @@
+package login
+
+import (
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/exp/charmtone"
+)
+
+var (
+	// trailingSpace is an invisible character that prevents the Bubble Tea
+	// renderer from stripping trailing blank lines. The renderer erases empty
+	// lines after the last non-empty content, so a zero-width space keeps
+	// the line alive without being visible.
+	trailingSpace = "\u200b"
+
+	headerStyle = lipgloss.NewStyle().
+			Bold(true).
+			Foreground(charmtone.Charple)
+	slashStyle = lipgloss.NewStyle().
+			Bold(true)
+	errorStyle = lipgloss.NewStyle().
+			Foreground(charmtone.Coral)
+)

--- a/internal/login/tui.go
+++ b/internal/login/tui.go
@@ -1,0 +1,358 @@
+package login
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/spinner"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/exp/charmtone"
+	"github.com/pkg/browser"
+
+	"github.com/charmbracelet/crush/internal/oauth"
+)
+
+// authState represents the state of the OAuth TUI flow.
+type authState int
+
+const (
+	authStateIntro authState = iota
+	authStatePreparing
+	authStateWaiting
+	authStateExchanging
+	authStateError
+)
+
+// authKeyMap represents the key bindings for the OAuth TUI.
+type authKeyMap struct {
+	Continue key.Binding
+	Cancel   key.Binding
+}
+
+// defaultAuthKeybinds returns the default key bindings for the OAuth TUI.
+func defaultAuthKeybinds() authKeyMap {
+	return authKeyMap{
+		Continue: key.NewBinding(
+			key.WithKeys("enter"),
+			key.WithHelp("enter", "continue"),
+		),
+		Cancel: key.NewBinding(
+			key.WithKeys("ctrl+c", "esc"),
+			key.WithHelp("ctrl+c", "cancel"),
+		),
+	}
+}
+
+// ShortHelp returns the key bindings for the short help screen.
+func (k authKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Continue, k.Cancel}
+}
+
+// FullHelp returns the key bindings for the full help screen.
+func (k authKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{k.Continue, k.Cancel}}
+}
+
+// updateAuthKeymap enables/disables key bindings based on the current state.
+func (m *authModel) updateAuthKeymap() {
+	m.keymap.Continue.SetEnabled(m.state == authStateIntro)
+}
+
+// authModel is the Bubble Tea model for the OAuth authorization flow.
+type authModel struct {
+	platform string
+	newFlow  func() flow
+	flow     flow
+
+	state authState
+
+	spinner spinner.Model
+
+	verificationURL string
+	userCode        string
+	browserFailed   bool
+
+	help   help.Model
+	keymap authKeyMap
+
+	token    *oauth.Token
+	err      error
+	canceled bool
+	quitting bool
+	// blankLines is the height of the last rendered frame, used to blank it
+	// out in the final render on quit.
+	blankLines int
+	width      int
+}
+
+type authReadyMsg struct {
+	flow     flow
+	url      string
+	userCode string
+}
+
+type authTokenMsg struct {
+	token *oauth.Token
+	err   error
+}
+
+type authErrMsg struct {
+	err error
+}
+
+func newAuthModel(platform string, newFlow func() flow) authModel {
+	s := spinner.New(spinner.WithSpinner(spinner.Dot))
+	s.Style = lipgloss.NewStyle().Foreground(charmtone.Julep)
+	m := authModel{
+		platform: platform,
+		newFlow:  newFlow,
+		state:    authStateIntro,
+		spinner:  s,
+		help:     help.New(),
+		keymap:   defaultAuthKeybinds(),
+	}
+	m.updateAuthKeymap()
+	return m
+}
+
+// runTUI runs the OAuth authorization flow with a small TUI that guides
+// the user through opening a browser and waiting for the callback.
+func runTUI(platform string, newFlow func() flow) (*oauth.Token, error) {
+	p := tea.NewProgram(newAuthModel(platform, newFlow))
+	final, err := p.Run()
+	if err != nil {
+		return nil, fmt.Errorf("running auth program: %w", err)
+	}
+	m, ok := final.(authModel)
+	if !ok {
+		return nil, errors.New("unexpected auth program model")
+	}
+	if m.flow != nil {
+		m.flow.Close()
+	}
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.canceled {
+		return nil, errors.New("authentication canceled")
+	}
+	return m.token, nil
+}
+
+// Init initializes the auth TUI.
+func (m authModel) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles messages for the auth TUI.
+func (m authModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case authReadyMsg:
+		m.flow = msg.flow
+		m.verificationURL = msg.url
+		m.userCode = msg.userCode
+		if !m.browserFailed {
+			m.browserFailed = browser.OpenURL(msg.url) != nil
+		}
+		m.state = authStateWaiting
+		m.updateAuthKeymap()
+		cmds := []tea.Cmd{waitCmd(m.flow), m.spinner.Tick}
+		if msg.userCode != "" {
+			cmds = append(cmds, tea.SetClipboard(msg.userCode))
+		}
+		return m, tea.Batch(cmds...)
+
+	case authTokenMsg:
+		if msg.err != nil {
+			m.err = msg.err
+		} else {
+			m.token = msg.token
+		}
+		m.blankLines = m.contentHeight()
+		m.quitting = true
+		return m, tea.Quit
+
+	case authErrMsg:
+		m.err = msg.err
+		m.blankLines = m.contentHeight()
+		m.quitting = true
+		return m, tea.Quit
+
+	case spinner.TickMsg:
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		switch m.state {
+		case authStatePreparing, authStateWaiting, authStateExchanging:
+			return m, cmd
+		default:
+			return m, nil
+		}
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.help.SetWidth(msg.Width)
+		return m, nil
+
+	case tea.KeyPressMsg:
+		switch {
+		case key.Matches(msg, m.keymap.Cancel):
+			m.canceled = true
+			m.blankLines = m.contentHeight()
+			m.quitting = true
+			return m, tea.Quit
+		case key.Matches(msg, m.keymap.Continue):
+			if m.state == authStateIntro {
+				m.state = authStatePreparing
+				m.updateAuthKeymap()
+				return m, tea.Batch(startFlowCmd(m.newFlow), m.spinner.Tick)
+			}
+		}
+		var cmd tea.Cmd
+		m.help, cmd = m.help.Update(msg)
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m authModel) authHeader() string {
+	title := "Let’s authenticate with " + titles[m.platform]
+	w := m.authWidth()
+	if lipgloss.Width(title) > w {
+		title = ansi.Truncate(title, w, "…")
+		return "\n  " + headerStyle.Render(title)
+	}
+	header := headerStyle.Render(title)
+	if remaining := w - lipgloss.Width(title) - 1; remaining > 0 {
+		header += " " + m.slashes(min(remaining, maxHeaderSlashes))
+	}
+	return "\n  " + header
+}
+
+// maxHeaderSlashes caps how wide the decorative slash run can get.
+const maxHeaderSlashes = 50
+
+// slashes renders n diagonal slashes with a horizontal gradient that fades
+// from the header purple to pink, echoing the dialog title treatment.
+func (authModel) slashes(n int) string {
+	ramp := lipgloss.Blend1D(n, charmtone.Charple, charmtone.Dolly)
+	var b strings.Builder
+	for _, c := range ramp {
+		b.WriteString(slashStyle.Foreground(c).Render("╱"))
+	}
+	return b.String()
+}
+
+// authWidth returns the usable text width for the auth TUI, accounting for
+// the 2-space indent. Falls back to 80 when the terminal width is unknown.
+func (m authModel) authWidth() int {
+	const indent = 2
+	w := m.width - indent
+	if w < 20 {
+		w = 80 - indent
+	}
+	return w
+}
+
+// View renders the auth TUI.
+func (m authModel) View() tea.View {
+	if m.quitting {
+		return tea.NewView("")
+	}
+	return tea.NewView(m.content())
+}
+
+// content renders the full auth view. The trailing zero-width space keeps
+// the final blank line alive (the renderer erases trailing empty lines).
+func (m authModel) content() string {
+	var b strings.Builder
+	wrap := lipgloss.NewStyle().MaxWidth(m.authWidth())
+
+	b.WriteString(m.authHeader())
+	b.WriteString("\n\n  ")
+
+	switch m.state {
+	case authStateIntro:
+		b.WriteString(wrap.Render("To authenticate we're going to open the browser. Ready?"))
+	case authStatePreparing:
+		b.WriteString(m.spinner.View())
+		b.WriteString(wrap.Render("Preparing..."))
+	case authStateWaiting:
+		if m.userCode != "" {
+			b.WriteString(wrap.Render("Your code is "))
+			b.WriteString(lipgloss.NewStyle().Foreground(charmtone.Julep).Render(m.userCode))
+			b.WriteString(" ")
+			b.WriteString(lipgloss.NewStyle().Foreground(charmtone.Oyster).Render("copied to clipboard"))
+			b.WriteString("\n\n  ")
+		}
+		urlStyle := lipgloss.NewStyle().
+			Foreground(charmtone.Guac).
+			Underline(true).
+			Hyperlink(m.verificationURL).
+			MaxWidth(m.authWidth())
+		b.WriteString(wrap.Render("Browser not opening? Visit:"))
+		b.WriteString("\n  ")
+		b.WriteString(urlStyle.Render(m.verificationURL))
+		b.WriteString("\n\n  ")
+		b.WriteString(m.spinner.View())
+		b.WriteString(wrap.Render("Waiting for authorization..."))
+	case authStateExchanging:
+		b.WriteString(m.spinner.View())
+		b.WriteString(wrap.Render("Exchanging token..."))
+	case authStateError:
+		b.WriteString(errorStyle.Render(wrap.Render(m.err.Error())))
+	default:
+		return ""
+	}
+
+	b.WriteString("\n\n  ")
+	b.WriteString(m.help.View(m.keymap))
+	b.WriteString("\n")
+	b.WriteString(trailingSpace)
+	return b.String()
+}
+
+// contentHeight returns the height of the current view in lines.
+func (m authModel) contentHeight() int {
+	return lipgloss.Height(m.content())
+}
+
+// startFlowCmd kicks off the platform's OAuth flow and returns the URL to
+// open in the browser along with an optional user code.
+func startFlowCmd(newFlow func() flow) tea.Cmd {
+	return func() tea.Msg {
+		f := newFlow()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		url, userCode, err := f.Start(ctx)
+		if err != nil {
+			return authErrMsg{err: err}
+		}
+
+		return authReadyMsg{
+			flow:     f,
+			url:      url,
+			userCode: userCode,
+		}
+	}
+}
+
+// waitCmd blocks until the user completes authorization in the browser and
+// returns the resulting token.
+func waitCmd(f flow) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+
+		token, err := f.Wait(ctx)
+		return authTokenMsg{token: token, err: err}
+	}
+}

--- a/internal/oauth/callback/page_test.go
+++ b/internal/oauth/callback/page_test.go
@@ -133,14 +133,14 @@ func TestWrite_ContinueHandoff(t *testing.T) {
 
 	var b strings.Builder
 	require.NoError(t, Write(&b, Result{
-		Subject:     "OpenAI (ChatGPT)",
+		Subject:     "OpenAI",
 		ContinueURL: "https://auth.openai.com/oauth/authorize?client_id=x",
 	}))
 	page := b.String()
 
 	require.Contains(t, page, `class="card continue"`)
 	require.Contains(t, page, "One more click")
-	require.Contains(t, page, "OpenAI (ChatGPT)")
+	require.Contains(t, page, "OpenAI")
 	require.Contains(t, page, `id="continue"`)
 	require.Contains(t, page, `href="https://auth.openai.com/oauth/authorize?client_id=x"`)
 	require.Contains(t, page, `target="_blank"`)

--- a/internal/oauth/openai/flow.go
+++ b/internal/oauth/openai/flow.go
@@ -127,7 +127,7 @@ func (f *BrowserFlow) Close() {
 // URL in a self-closable tab.
 func (f *BrowserFlow) handleStart(w http.ResponseWriter, _ *http.Request) {
 	_ = callback.Serve(w, callback.Result{
-		Subject:     "OpenAI (ChatGPT)",
+		Subject:     "OpenAI",
 		ContinueURL: f.authURL,
 	})
 }
@@ -137,7 +137,7 @@ func (f *BrowserFlow) handleStart(w http.ResponseWriter, _ *http.Request) {
 func (f *BrowserFlow) handleCallback(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	result := callback.Result{
-		Subject:          "OpenAI (ChatGPT)",
+		Subject:          "OpenAI",
 		ErrorCode:        query.Get("error"),
 		ErrorDescription: query.Get("error_description"),
 	}


### PR DESCRIPTION
This revision overhauls unifies the various mini OAuth TUIs in Crush. When output is not a TTY these will default to plaintext versions.

<p><img width="700" src="https://github.com/user-attachments/assets/7d52da1e-3d98-403b-b942-88f939b198da" /></p>

<p><img width="700" src="https://github.com/user-attachments/assets/c2616ae7-dcd5-4370-a8d9-b6d823a4c9a5" /></p>
